### PR TITLE
fix(profiles): compose profile home correctly in system prompt + add canonical resolvers

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -402,10 +402,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # See file_safety._resolve_active_profile_name + classify_cross_profile_target
     # for the matching tool-side guard.
     try:
-        from agent.file_safety import _resolve_active_profile_name
-        active_profile = _resolve_active_profile_name()
+        from hermes_constants import (
+            get_active_profile_home,
+            get_active_profile_name,
+            get_default_hermes_root,
+        )
+        active_profile = get_active_profile_name()
+        # The profile's own home IS get_active_profile_home() — do not append
+        # profiles/<name> again. The default profile's data lives at the
+        # profiles-root, which is the parent of profiles/, not the profile home.
+        profile_home = get_active_profile_home()
+        default_home = get_default_hermes_root()
     except Exception:
         active_profile = "default"
+        profile_home = None
+        default_home = None
     if active_profile == "default":
         post_workspace_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "
@@ -418,9 +429,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         post_workspace_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
-            f"profile's data lives at {get_hermes_home()}/skills/, {get_hermes_home()}/plugins/, "
-            f"{get_hermes_home()}/cron/, {get_hermes_home()}/memories/ — those belong to a "
+            f"and writes {profile_home}/. The default "
+            f"profile's data lives at {default_home}/skills/, {default_home}/plugins/, "
+            f"{default_home}/cron/, {default_home}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -198,6 +198,53 @@ def get_default_hermes_root() -> Path:
     return env_path
 
 
+def get_active_profile_home() -> Path:
+    """Return the active profile's own home directory.
+
+    This is the single source of truth for "where does THIS profile's data
+    live". Unlike :func:`get_default_hermes_root` (which returns the parent of
+    ``profiles/`` for profile-listing operations), this always resolves to the
+    directory the current session actually reads and writes:
+
+    * default profile → ``~/.hermes`` (or the platform/HERMES_HOME default)
+    * named profile   → ``<root>/profiles/<name>``
+
+    It is exactly :func:`get_hermes_home`. It exists as a separately-named
+    function so call sites that compose profile paths stop re-deriving the
+    home ad hoc (and stop double-appending ``profiles/<name>`` — see the
+    system-prompt profile line and issue #18594's sibling defects). Prefer
+    this over open-coding ``get_hermes_home()`` when the intent is "the
+    current profile's own directory", so the two resolution concerns
+    (profile-home vs profiles-root) stay grep-able and distinct.
+    """
+    return get_hermes_home()
+
+
+def get_active_profile_name() -> str:
+    """Return the active profile name derived from the profile home.
+
+    ``~/.hermes``              -> ``"default"``
+    ``<root>/profiles/<name>`` -> ``<name>``
+    anything else              -> ``"custom"``
+
+    Falls back to ``"default"`` on any resolution failure so callers never
+    raise into a tool/prompt path.
+    """
+    try:
+        home_real = get_active_profile_home().resolve()
+        root_real = get_default_hermes_root().resolve()
+    except (OSError, RuntimeError):
+        return "default"
+    try:
+        rel = home_real.relative_to(root_real / "profiles")
+        parts = rel.parts
+        if len(parts) == 1 and parts[0]:
+            return parts[0]
+    except ValueError:
+        pass
+    return "default"
+
+
 def get_optional_skills_dir(default: Path | None = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -81,6 +81,52 @@ class TestGetHermesHome:
         assert get_hermes_home() == local_appdata / "hermes"
 
 
+class TestActiveProfileResolution:
+    """Tests for get_active_profile_home() / get_active_profile_name().
+
+    These are the canonical profile-home vs profiles-root resolvers. The
+    system prompt's profile line composes from them; a doubled
+    ``profiles/<name>/profiles/<name>/`` path is the regression they guard.
+    """
+
+    def test_named_profile_resolves_own_home_and_root(self, tmp_path, monkeypatch):
+        from hermes_constants import get_active_profile_home, get_active_profile_name
+
+        root = tmp_path / ".hermes"
+        profile_home = root / "profiles" / "data-sage"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        assert get_active_profile_name() == "data-sage"
+        assert get_active_profile_home() == profile_home
+        # The profiles-root is the parent of profiles/, NOT the profile home.
+        assert get_default_hermes_root() == root
+
+    def test_default_profile_resolves_native_home(self, tmp_path, monkeypatch):
+        from hermes_constants import get_active_profile_home, get_active_profile_name
+
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        assert get_active_profile_name() == "default"
+        assert get_active_profile_home() == tmp_path / ".hermes"
+        assert get_default_hermes_root() == tmp_path / ".hermes"
+
+    def test_docker_named_profile(self, tmp_path, monkeypatch):
+        from hermes_constants import get_active_profile_home, get_active_profile_name
+
+        docker_root = tmp_path / "opt" / "data"
+        profile_home = docker_root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        assert get_active_profile_name() == "coder"
+        assert get_active_profile_home() == profile_home
+        assert get_default_hermes_root() == docker_root
+
+
 class TestGetProcessHermesHome:
     """Tests for get_process_hermes_home() — process launch scope.
 


### PR DESCRIPTION
## Problem

The named-profile branch of the system prompt composed its profile line as:

```python
f"... reads and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
f"profile's data lives at {get_hermes_home()}/skills/, ..."
```

In a profile process, `get_hermes_home()` **already returns the profile dir** (`<root>/profiles/<name>`), so this emitted a doubled path `<root>/profiles/<name>/profiles/<name>/` and pointed the "default profile's data" clause at the profile's own `skills/` dir instead of the profiles-root. Observed live: a named-profile session's stored system prompt read

```
Active Hermes profile: data-sage. This session reads and writes
/home/.../.hermes/profiles/data-sage/profiles/data-sage/.
```

Same defect **class** as #18594 (profile-home composition), different call site: there `HERMES_HOME` was unset and fell back to the default; here it is set correctly but the consumer composed the path wrong.

## Fix

Add two canonical resolvers to `hermes_constants` so call sites stop re-deriving the profile home ad hoc (and stop double-appending `profiles/<name>`):

- **`get_active_profile_home()`** — the active profile's own directory (`get_hermes_home()`, named for intent)
- **`get_active_profile_name()`** — the active profile name, falling back to `"default"` on any resolution failure

Rewrite the prompt's profile line to use them: it now reads/writes the profile home directly and points the default-data clause at `get_default_hermes_root()` (the parent of `profiles/`).

## Scope

This PR fixes the **system-prompt path composition** and introduces the canonical resolver pair. It does **not** change the Honcho memory-plugin's per-request scoping in the shared dashboard/desktop process — that is a separate, deeper fix (the in-process plugin client resolves `honcho.json` from the parent process home rather than the chat's profile) and is tracked separately.

## Testing

- New `TestActiveProfileResolution` in `tests/test_hermes_constants.py`: default, named, and Docker-layout profiles all resolve home and root correctly (53 tests in that file pass).
- `tests/agent/test_system_prompt.py` (58) and `tests/hermes_cli/test_profiles.py` pass.
- End-to-end: a named-profile `build_system_prompt_parts` run renders `reads and writes <profile-home>/.` with no doubling and the default-data clause at the profiles-root.