### PR TITLE
fix(terminal): match POSIX docker cwd mount prefixes on Windows

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -143,6 +143,41 @@ class TestCwdHandling:
         assert config["cwd"] == "/workspace"
         assert config["host_cwd"] == "/home/user/project"
 
+    def test_posix_host_cwd_survives_windows_abspath_mangling(self, monkeypatch):
+        """POSIX-style TERMINAL_CWD must not be mangled by abspath on Windows.
+
+        On Windows, os.path.abspath() turns a POSIX-style host path such as
+        /Users/someone/projects into a Windows drive path (D:\\Users\\...),
+        which no longer matches the _HOST_CWD_PREFIXES. Simulate that
+        mangling on any platform by patching os.path.abspath; the expanded
+        (pre-abspath) form must win so host_cwd keeps the real host path.
+        """
+        monkeypatch.setattr(
+            os.path, "abspath",
+            lambda p: "D:\\Users\\someone\\projects" if p == "/Users/someone/projects" else p,
+        )
+        monkeypatch.setattr(os.path, "isdir", lambda _p: False)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", "/Users/someone/projects")
+        monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+        config = _tt_mod._get_env_config()
+        assert config["cwd"] == "/workspace"
+        assert config["host_cwd"] == "/Users/someone/projects", (
+            f"Expected POSIX host cwd, got {config['host_cwd']}. "
+            "abspath-mangled Windows drive form must not leak into host_cwd."
+        )
+
+    def test_windows_host_cwd_resolves_via_abspath_form(self, monkeypatch):
+        """Native Windows drive paths still map to /workspace via abspath form."""
+        monkeypatch.setattr(os.path, "abspath", lambda p: p)
+        monkeypatch.setattr(os.path, "isdir", lambda _p: False)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", "C:\\Users\\alice\\projects")
+        monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+        config = _tt_mod._get_env_config()
+        assert config["cwd"] == "/workspace"
+        assert config["host_cwd"] == "C:\\Users\\alice\\projects"
+
     def test_local_backend_uses_getcwd(self, monkeypatch):
         """Local backend should use os.getcwd(), not /root."""
         monkeypatch.setenv("TERMINAL_ENV", "local")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1486,12 +1486,19 @@ def _get_env_config() -> Dict[str, Any]:
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        expanded = os.path.expanduser(docker_cwd_source)
+        candidate = os.path.abspath(expanded)
+        # On Windows, os.path.abspath() mangles POSIX-style host paths
+        # (/Users/... -> D:\Users\...) so they no longer match the host
+        # prefixes below.  Match against BOTH forms; keep the caller's
+        # original absolute form when it is already a recognizable host
+        # path, otherwise fall back to the resolved absolute path.
         if (
-            any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
+            any(expanded.startswith(p) for p in _HOST_CWD_PREFIXES)
+            or any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
         ):
-            host_cwd = candidate
+            host_cwd = expanded if any(expanded.startswith(p) for p in _HOST_CWD_PREFIXES) else candidate
             cwd = "/workspace"
     elif env_type in _CONTAINER_BACKENDS and cwd:
         # Host paths and relative paths that won't work inside containers

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1628,12 +1628,19 @@ def _get_env_config() -> Dict[str, Any]:
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        expanded = os.path.expanduser(docker_cwd_source)
+        candidate = os.path.abspath(expanded)
+        # On Windows, os.path.abspath() mangles POSIX-style host paths
+        # (/Users/... -> D:\Users\...) so they no longer match the host
+        # prefixes below.  Match against BOTH forms; keep the caller's
+        # original absolute form when it is already a recognizable host
+        # path, otherwise fall back to the resolved absolute path.
         if (
-            any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
+            any(expanded.startswith(p) for p in _HOST_CWD_PREFIXES)
+            or any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
         ):
-            host_cwd = candidate
+            host_cwd = expanded if any(expanded.startswith(p) for p in _HOST_CWD_PREFIXES) else candidate
             cwd = "/workspace"
     elif env_type in _CONTAINER_BACKENDS and cwd:
         # Host paths and relative paths that won't work inside containers


### PR DESCRIPTION
## Problem

On Windows hosts, `os.path.abspath()` mangles POSIX-style paths: `/Users/someone/projects` becomes `D:\Users\someone\projects`. The docker cwd-to-/workspace mount check in `_get_env_config()` then fails to match `_HOST_CWD_PREFIXES` (which contains `/Users/`, `/home/`, `C:\`, `C:/`), so:

- `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true` silently has no effect for POSIX-style `TERMINAL_CWD` values
- `cwd` stays the raw host path instead of `/workspace`
- `host_cwd` stays `None` (the mount never happens)

The fallback condition (`os.path.isabs(candidate) and os.path.isdir(candidate)` and not workspace/root) also fails in test/CI environments where the host directory doesn't exist.

This is platform-specific: on Linux/macOS `abspath` leaves POSIX paths untouched, so the existing tests pass there and CI never catches it.

## Fix

- Match the host-path check against **both** the expanded (pre-`abspath`) form and the resolved form, so POSIX-style paths are recognized on Windows too.
- Keep the caller's original absolute form as `host_cwd` when it is already a recognizable host path (avoids returning the mangled `D:\...` form), falling back to the resolved absolute path for relative inputs.

## Regression tests

Added two tests to `tests/tools/test_modal_sandbox_fixes.py::TestCwdHandling`:

- `test_posix_host_cwd_survives_windows_abspath_mangling` — simulates the Windows `abspath` mangling (`/Users/...` -> `D:\Users\...`) via monkeypatch and asserts `host_cwd` keeps the POSIX form and `cwd` maps to `/workspace`. Fails against the pre-fix code.
- `test_windows_host_cwd_resolves_via_abspath_form` — native Windows drive paths (`C:\Users\...`) still map to `/workspace` via the abspath form (existing behavior preserved).

## Validation

`tests/tools/test_modal_sandbox_fixes.py` — all 32 tests pass (30 existing + 2 new):

- `test_posix_host_cwd_survives_windows_abspath_mangling` ✓
- `test_windows_host_cwd_resolves_via_abspath_form` ✓
- `test_users_path_maps_to_workspace_for_docker_when_enabled` ✓
- `test_docker_default_cwd_maps_current_directory_when_enabled` ✓
- remaining CwdHandling tests ✓

Related: #48137 (Windows Docker cwd path boundary; this PR covers the POSIX-style-path branch of the same mount-cwd-to-workspace code path).
