### PR TITLE
fix(cli): recognize mcp-<server> prefixed toolset names in startup validation (#78102)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4463,7 +4463,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # live registry aliases (registered during discover_mcp_tools),
             # but discovery hasn't run yet at this point, so exclude them.
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
-            invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
+            invalid = [t for t in toolsets if not validate_toolset(t)
+                       and t not in mcp_names
+                       and not (t.startswith("mcp-") and t[4:] in mcp_names)]
             if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         


### PR DESCRIPTION
## Summary

Fixes false-positive "Unknown toolsets: mcp-<server>" warning at startup when MCP toolset names are configured using the canonical `mcp-<server_name>` form.

## Problem

The startup toolset validator in `cli.py` (line ~4465) builds a set of known MCP names from `mcp_servers` config keys (bare names like `codegraph`), but user-configured toolset names use the prefixed form `mcp-codegraph`. Since `mcp-codegraph` is neither a registered toolset nor a bare MCP server name, it's flagged as unknown — even though it's the canonical toolset name for that MCP server.

## Fix

Add a prefix-aware check: if a toolset name starts with `mcp-` and the suffix matches a configured MCP server name, accept it as valid.

```python
# Before
invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]

# After
invalid = [t for t in toolsets if not validate_toolset(t)
           and t not in mcp_names
           and not (t.startswith("mcp-") and t[4:] in mcp_names)]
```

## Testing

1. Configure any MCP server in `config.yaml`:
   ```yaml
   mcp_servers:
     codegraph:
       command: codegraph
       args: [serve, --mcp]
       enabled: true
   ```
2. Add its toolset name to `platform_toolsets.cli`:
   ```yaml
   platform_toolsets:
     cli:
       - hermes-cli
       - mcp-codegraph
   ```
3. Run `hermes` — no warning should appear.

Fixes #78102