### PR TITLE
fix(media): media-delivery denylist is inert on Windows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1205,6 +1205,33 @@ _MEDIA_DELIVERY_DENIED_PREFIXES = (
     "/var/run",
 )
 
+# Windows has no equivalent of the POSIX paths above, and they do not degrade
+# gracefully: ``Path("/etc").resolve()`` becomes ``C:\etc`` on the current
+# drive, which does not exist, so every entry above is inert on Windows and the
+# non-strict denylist is effectively empty there. These are resolved from the
+# environment rather than hard-coded, because Windows need not be on C: and a
+# roaming profile need not be under C:\Users.
+_MEDIA_DELIVERY_DENIED_WINDOWS_ENV_ROOTS = (
+    "SystemRoot",    # C:\Windows — system binaries, config, SAM/SYSTEM hives
+    "ProgramData",   # machine-wide application state, incl. credential stores
+)
+
+# Windows credential stores that live under the user profile. The POSIX
+# dotfile equivalents (.aws, .ssh, .azure, .gcloud …) use the same names on
+# Windows and are already covered by _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS;
+# these are the locations that have no POSIX counterpart.
+#
+# AppData is deliberately NOT denied wholesale: %LOCALAPPDATA%\Temp is a normal
+# place for generated artifacts, so a blanket rule would break legitimate media
+# delivery. Only the credential subtrees are listed.
+_MEDIA_DELIVERY_DENIED_WINDOWS_HOME_SUBPATHS = (
+    "AppData/Roaming/Microsoft/Credentials",
+    "AppData/Local/Microsoft/Credentials",
+    "AppData/Roaming/Microsoft/Protect",  # DPAPI master keys
+    "AppData/Roaming/Microsoft/Crypto",
+    "AppData/Local/Microsoft/Vault",
+)
+
 # Within $HOME we additionally deny common credential / config directories.
 # Resolved at check time against the live $HOME so containers and alt-home
 # setups work correctly.
@@ -1336,6 +1363,15 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
+    if os.name == "nt":
+        # The POSIX prefixes above are inert here (see the constant's comment),
+        # so add the real system roots for this platform.
+        for env_name in _MEDIA_DELIVERY_DENIED_WINDOWS_ENV_ROOTS:
+            root = os.environ.get(env_name)
+            if root:
+                denied.append(Path(root))
+        for sub in _MEDIA_DELIVERY_DENIED_WINDOWS_HOME_SUBPATHS:
+            denied.append(home / sub)
     # The active Hermes profile and shared Hermes root both contain control
     # files and credentials. Only cache subdirectories under them are
     # explicitly allowlisted above (matched BEFORE this denylist in

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -770,6 +770,46 @@ _MEDIA_DELIVERY_TRUST_RECENT_DEFAULT_SECONDS = 600
 _MEDIA_DELIVERY_DENIED_PREFIXES = (
     "/etc", "/proc", "/sys", "/dev", "/root", "/boot", "/var/log", "/var/lib", "/var/run")
 
+# Windows has no equivalent of the POSIX paths above, and they do not degrade
+# gracefully: ``Path("/etc").resolve()`` becomes ``C:\etc`` on the current
+# drive, which does not exist, so every entry above is inert on Windows and the
+# non-strict denylist is effectively empty there. The system roots below are
+# resolved from the environment rather than hard-coded, because Windows need
+# not be on C: and a roaming profile need not be under C:\Users.
+_MEDIA_DELIVERY_DENIED_WINDOWS_ENV_ROOTS = (
+    "SystemRoot",    # C:\Windows — system binaries, config, SAM/SYSTEM hives
+    "ProgramData",   # machine-wide application state, incl. credential stores
+)
+
+# Windows credential stores that live under the user profile. The POSIX
+# dotfile equivalents (.aws, .ssh, .azure, .gcloud …) use the same names on
+# Windows and are already covered by _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS;
+# these are the locations that have no POSIX counterpart.
+#
+# AppData is deliberately NOT denied wholesale: %LOCALAPPDATA%\Temp is a normal
+# place for generated artifacts, so a blanket rule would break legitimate media
+# delivery. Only the credential subtrees are listed.
+#
+# Split by which AppData root they live under, because that root is NOT always
+# ``home / "AppData/Roaming"`` / ``home / "AppData/Local"``: Windows Known
+# Folder redirection (roaming profiles, Folder Redirection GPOs) can point
+# %APPDATA% / %LOCALAPPDATA% at a path outside %USERPROFILE% entirely, e.g.
+# %USERPROFILE%=C:\Users\svc but %APPDATA%=Z:\RoamingProfile\svc. Deriving
+# these paths from home alone denies the default-layout credential store but
+# not the redirected one — the actual live location on a redirected machine.
+# _media_delivery_denied_paths() below resolves both the home-relative form
+# (matches the common case with zero env dependency) AND the env-derived form
+# (matches the redirected case) so either layout is covered.
+_MEDIA_DELIVERY_DENIED_WINDOWS_ROAMING_SUBPATHS = (
+    "Microsoft/Credentials",
+    "Microsoft/Protect",  # DPAPI master keys
+    "Microsoft/Crypto",
+)
+_MEDIA_DELIVERY_DENIED_WINDOWS_LOCAL_SUBPATHS = (
+    "Microsoft/Credentials",
+    "Microsoft/Vault",
+)
+
 # Credential / config dirs denied under $HOME (Library/Keychains = macOS), resolved at check time.
 _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS = (
     ".ssh", ".aws", ".gnupg", ".kube", ".docker", ".config", ".azure", ".gcloud",
@@ -880,8 +920,30 @@ def _kanban_board_db_paths() -> List[Path]:
 def _media_delivery_denied_paths() -> List[Path]:
     """Return absolute denylist paths under which delivery is never allowed."""
     home = Path(os.path.expanduser("~"))
-    return [*map(Path, _MEDIA_DELIVERY_DENIED_PREFIXES),
-            *(home / sub for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS),
+    denied = [*map(Path, _MEDIA_DELIVERY_DENIED_PREFIXES),
+              *(home / sub for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS)]
+    if os.name == "nt":
+        # The POSIX prefixes above are inert here (see the constants' comment),
+        # so add the real system roots for this platform.
+        for env_name in _MEDIA_DELIVERY_DENIED_WINDOWS_ENV_ROOTS:
+            root = os.environ.get(env_name)
+            if root:
+                denied.append(Path(root))
+        # Roaming/Local AppData credential subtrees: deny BOTH the
+        # home-relative form (correct on the common, non-redirected layout,
+        # and a fail-closed fallback when %APPDATA%/%LOCALAPPDATA% are unset)
+        # and the env-derived form (correct when Known Folder redirection
+        # points the real root outside %USERPROFILE%). See the subpaths'
+        # constant comment above.
+        roaming_root = Path(os.environ.get("APPDATA") or (home / "AppData" / "Roaming"))
+        local_root = Path(os.environ.get("LOCALAPPDATA") or (home / "AppData" / "Local"))
+        for sub in _MEDIA_DELIVERY_DENIED_WINDOWS_ROAMING_SUBPATHS:
+            denied.append(home / "AppData" / "Roaming" / sub)
+            denied.append(roaming_root / sub)
+        for sub in _MEDIA_DELIVERY_DENIED_WINDOWS_LOCAL_SUBPATHS:
+            denied.append(home / "AppData" / "Local" / sub)
+            denied.append(local_root / sub)
+    return [*denied,
             *(r / rel for r in _credential_home_roots() for rel in _ROOT_CREDENTIAL_PATHS),
             *_kanban_board_db_paths()]
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1117,3 +1117,77 @@ class TestMediaFallbackDoesNotLeakHostPath:
         sent_text = adapter.sent[0]["content"]
         assert "Here's the daily summary." in sent_text
         assert self.SENSITIVE_PATH not in sent_text
+
+
+class TestMediaDeliveryWindowsSystemPaths:
+    r"""The non-strict denylist must actually cover something on Windows.
+
+    ``_MEDIA_DELIVERY_DENIED_PREFIXES`` is POSIX-only, and the entries do not
+    degrade gracefully: ``Path("/etc").resolve()`` becomes ``C:\etc`` on the
+    current drive, which does not exist. Every entry is therefore inert on
+    Windows, leaving the default-mode denylist effectively empty -- so
+    ``C:\Windows\win.ini`` was deliverable as a gateway attachment.
+    """
+
+    def _denied_str(self):
+        import gateway.platforms.base as base
+
+        return [str(p) for p in base._media_delivery_denied_paths()]
+
+    def _is_covered(self, probe):
+        rp = os.path.normcase(os.path.abspath(probe))
+        for d in self._denied_str():
+            nd = os.path.normcase(os.path.abspath(d))
+            if rp == nd or rp.startswith(nd + os.sep):
+                return True
+        return False
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    @pytest.mark.parametrize("env_name", ["SystemRoot", "ProgramData"])
+    def test_windows_system_roots_are_denied(self, env_name):
+        root = os.environ.get(env_name)
+        if not root:
+            pytest.skip(f"%{env_name}% not set on this host")
+        assert self._is_covered(root), (
+            f"%{env_name}% ({root}) must be on the media-delivery denylist"
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            r"AppData\Roaming\Microsoft\Credentials",
+            r"AppData\Local\Microsoft\Credentials",
+            r"AppData\Roaming\Microsoft\Protect",
+        ],
+    )
+    def test_windows_credential_stores_are_denied(self, rel):
+        probe = os.path.join(os.path.expanduser("~"), rel)
+        assert self._is_covered(probe), f"{rel} must be denied"
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    @pytest.mark.parametrize("rel", [r"AppData\Local\Temp", "Pictures", "Downloads"])
+    def test_ordinary_user_dirs_are_not_denied(self, rel):
+        r"""AppData must NOT be denied wholesale.
+
+        %LOCALAPPDATA%\Temp is a normal home for generated artifacts; a blanket
+        AppData rule would break legitimate media delivery.
+        """
+        probe = os.path.join(os.path.expanduser("~"), rel)
+        assert not self._is_covered(probe), (
+            f"{rel} is an ordinary directory and must stay deliverable"
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    def test_system_file_is_refused_end_to_end(self, monkeypatch):
+        """The guard itself, not just the denylist, must refuse a system file."""
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", ()
+        )
+        monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
+        import gateway.platforms.base as base
+
+        probe = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "win.ini")
+        if not os.path.exists(probe):
+            pytest.skip("win.ini not present on this host")
+        assert base.validate_media_delivery_path(probe) is None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1619,3 +1619,75 @@ class TestPlatformLockTakeoverGovernance:
         assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
         assert len(takeover_calls) == 1
         assert adapter._platform_lock_takeover_attempted is True
+class TestMediaDeliveryWindowsSystemPaths:
+    r"""The non-strict denylist must actually cover something on Windows.
+
+    ``_MEDIA_DELIVERY_DENIED_PREFIXES`` is POSIX-only, and the entries do not
+    degrade gracefully: ``Path("/etc").resolve()`` becomes ``C:\etc`` on the
+    current drive, which does not exist. Every entry is therefore inert on
+    Windows, leaving the default-mode denylist effectively empty -- so
+    ``C:\Windows\win.ini`` was deliverable as a gateway attachment.
+    """
+
+    def _denied_str(self):
+        import gateway.platforms.base as base
+
+        return [str(p) for p in base._media_delivery_denied_paths()]
+
+    def _is_covered(self, probe):
+        rp = os.path.normcase(os.path.abspath(probe))
+        for d in self._denied_str():
+            nd = os.path.normcase(os.path.abspath(d))
+            if rp == nd or rp.startswith(nd + os.sep):
+                return True
+        return False
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    @pytest.mark.parametrize("env_name", ["SystemRoot", "ProgramData"])
+    def test_windows_system_roots_are_denied(self, env_name):
+        root = os.environ.get(env_name)
+        if not root:
+            pytest.skip(f"%{env_name}% not set on this host")
+        assert self._is_covered(root), (
+            f"%{env_name}% ({root}) must be on the media-delivery denylist"
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            r"AppData\Roaming\Microsoft\Credentials",
+            r"AppData\Local\Microsoft\Credentials",
+            r"AppData\Roaming\Microsoft\Protect",
+        ],
+    )
+    def test_windows_credential_stores_are_denied(self, rel):
+        probe = os.path.join(os.path.expanduser("~"), rel)
+        assert self._is_covered(probe), f"{rel} must be denied"
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    @pytest.mark.parametrize("rel", [r"AppData\Local\Temp", "Pictures", "Downloads"])
+    def test_ordinary_user_dirs_are_not_denied(self, rel):
+        r"""AppData must NOT be denied wholesale.
+
+        %LOCALAPPDATA%\Temp is a normal home for generated artifacts; a blanket
+        AppData rule would break legitimate media delivery.
+        """
+        probe = os.path.join(os.path.expanduser("~"), rel)
+        assert not self._is_covered(probe), (
+            f"{rel} is an ordinary directory and must stay deliverable"
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows-only denylist entries")
+    def test_system_file_is_refused_end_to_end(self, monkeypatch):
+        """The guard itself, not just the denylist, must refuse a system file."""
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", ()
+        )
+        monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
+        import gateway.platforms.base as base
+
+        probe = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "win.ini")
+        if not os.path.exists(probe):
+            pytest.skip("win.ini not present on this host")
+        assert base.validate_media_delivery_path(probe) is None


### PR DESCRIPTION
## The bug

`_MEDIA_DELIVERY_DENIED_PREFIXES` is POSIX-only, and the entries **don't degrade gracefully**. `Path("/etc").resolve()` becomes `C:\etc` on the current drive — which doesn't exist. So on Windows every entry in that tuple is inert and the default-mode denylist is effectively empty.

Measured against unmodified `main` on Windows:

```
/etc     -> C:\etc      exists=False
/sys     -> C:\sys      exists=False
/root    -> C:\root     exists=False
...all nine resolve to nonexistent paths

C:\Windows      covered=False
C:\ProgramData  covered=False
```

Verified end-to-end through the guard itself, not just the constant:

```python
validate_media_delivery_path(r"C:\Windows\win.ini")
  before -> <path>   # deliverable as a gateway attachment
  after  -> None     # refused
```

**Strict mode was unaffected** — the `~/.ssh` denial works, because those entries are built from the live `$HOME` rather than hard-coded POSIX roots. This is the *default* (non-strict) path, which is what most operators run.

## The fix

Two Windows-specific lists:

**System roots**, resolved from `%SystemRoot%` and `%ProgramData%` — read from the environment rather than hard-coded, because Windows needn't live on `C:` and a roaming profile needn't sit under `C:\Users`.

**Credential stores under the user profile** that have no POSIX counterpart: `Microsoft\Credentials` (roaming and local), `Microsoft\Protect` (DPAPI master keys), `Microsoft\Crypto`, `Local\Microsoft\Vault`. The POSIX dotfile equivalents (`.aws`, `.ssh`, `.azure`, `.gcloud`) use the same names on Windows and are already covered by `_MEDIA_DELIVERY_DENIED_HOME_SUBPATHS`.

**AppData is deliberately not denied wholesale.** `%LOCALAPPDATA%\Temp` is a normal home for generated artifacts, so a blanket rule would break legitimate media delivery. A test asserts `Temp`, `Pictures` and `Downloads` stay deliverable.

## Verification (Windows)

- **9 new tests. 6 fail when the production change is reverted** — so the coverage pins real behaviour rather than passing vacuously. The 3 that pass either way are the must-stay-deliverable assertions.
- `tests/gateway/test_platform_base.py`: 2 failed before, 2 failed after. **Set-diff of failure names is empty** — nothing newly broken. Those 2 are unrelated pre-existing failures.
- `ruff check` clean.

## Relationship to #52045

Complementary, not overlapping. #52045 rewrites the *comparison* helpers to be case-insensitive (`_path_compare_key`, `_path_under_or_equal`); this fixes *what is in the list* to compare against. Different hunks in the same file — #52045 touches the helpers around :52 and `_path_under_denied_prefix` at :1134, this touches the constants at :1196 and `_media_delivery_denied_paths` at :1333.

Both are needed: case-folding a denylist that contains only nonexistent paths still denies nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
