### PR TITLE
feat(providers): send app attribution headers to Infersia

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -918,6 +918,18 @@ _AI_GATEWAY_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
+# Infersia app attribution headers. Infersia reads OpenRouter's header names —
+# X-OpenRouter-Title, with X-Title accepted as the older spelling — and shows
+# the result in the customer's activity log. Without them Hermes traffic is
+# attributed to the OpenAI SDK, so a user sees "OpenAI/Python" rather than the
+# agent that made the call.
+# Documented at https://infersia.com/docs/app-attribution
+_INFERSIA_HEADERS = {
+    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+    "X-OpenRouter-Title": "Hermes Agent",
+    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+}
+
 # Nous Portal extra_body for product attribution.
 # Callers should pass this as extra_body in chat.completions.create()
 # when the auxiliary client is backed by Nous Portal.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -918,15 +918,15 @@ _AI_GATEWAY_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
-# Infersia app attribution headers. Infersia reads OpenRouter's header names —
-# X-OpenRouter-Title, with X-Title accepted as the older spelling — and shows
-# the result in the customer's activity log. Without them Hermes traffic is
-# attributed to the OpenAI SDK, so a user sees "OpenAI/Python" rather than the
-# agent that made the call.
+# Infersia app attribution headers. Infersia accepts either spelling of the
+# title header, so this uses `X-Title` to match what this file already sends to
+# OpenRouter and the AI gateway rather than introducing a third variant.
+# Without attribution Hermes traffic is recorded against the OpenAI SDK, so a
+# user sees "OpenAI/Python" rather than the agent that made the call.
 # Documented at https://infersia.com/docs/app-attribution
 _INFERSIA_HEADERS = {
     "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-    "X-OpenRouter-Title": "Hermes Agent",
+    "X-Title": "Hermes Agent",
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5599,6 +5599,7 @@ class AIAgent:
     ) -> None:
         from agent.auxiliary_client import (
             _AI_GATEWAY_HEADERS,
+            _INFERSIA_HEADERS,
             build_nvidia_nim_headers,
             build_or_headers,
         )
@@ -5607,6 +5608,8 @@ class AIAgent:
             self._client_kwargs["default_headers"] = build_or_headers()
         elif base_url_host_matches(base_url, "ai-gateway.vercel.sh"):
             self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
+        elif base_url_host_matches(base_url, "api.infersia.com"):
+            self._client_kwargs["default_headers"] = dict(_INFERSIA_HEADERS)
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)
         elif base_url_host_matches(base_url, "api.routermint.com"):

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -214,3 +214,41 @@ def test_openrouter_headers_no_cache_when_disabled(mock_openai):
     assert "X-OpenRouter-Cache-TTL" not in headers
 
 
+
+
+@patch("run_agent.OpenAI")
+def test_infersia_base_url_applies_attribution_headers(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.infersia.com/v1",
+        model="deepseek/deepseek-v4-flash-0731",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.infersia.com/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-OpenRouter-Title"] == "Hermes Agent"
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
+def test_unknown_base_url_sends_no_attribution_headers(mock_openai):
+    """A host with no policy must not inherit another provider's attribution."""
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.infersia.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://unknown.example/v1")
+
+    assert "default_headers" not in agent._client_kwargs

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -232,7 +232,7 @@ def test_infersia_base_url_applies_attribution_headers(mock_openai):
 
     headers = agent._client_kwargs["default_headers"]
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
-    assert headers["X-OpenRouter-Title"] == "Hermes Agent"
+    assert headers["X-Title"] == "Hermes Agent"
     assert headers["User-Agent"].startswith("HermesAgent/")
 
 


### PR DESCRIPTION
## What does this PR do?

Adds Infersia to the base-URL attribution dispatch in `_apply_client_headers_for_base_url`, so Hermes identifies itself to that provider the way it already does for OpenRouter, Vercel AI Gateway, NVIDIA, Routermint, Copilot, Kimi, Qwen, ChatGPT and x.ai.

**The problem.** Infersia reads OpenRouter's attribution header names and shows the result in the user's activity log. Hermes currently sends nothing to it, because any host outside the built-in list falls to the `else` branch and `default_headers` is popped. The user-visible effect is that Hermes traffic is attributed to the OpenAI SDK — the activity log reads `OpenAI/Python 2.24.0`, which is true and tells them nothing about which tool spent their money.

I confirmed this against a live endpoint rather than inferring it: across a full capture of Hermes' request headers, the complete set is standard HTTP plus the SDK's own `x-stainless-*` family. There is no `X-Title`, no `HTTP-Referer`, and the user agent is the SDK default.

**Why this approach.** It mirrors the existing `ai-gateway.vercel.sh` case exactly, which is the closest analogue — a provider whose entry exists purely for attribution. The header values are the same ones Hermes already sends elsewhere: `HTTP-Referer: https://hermes-agent.nousresearch.com`, the product name, and the `HermesAgent/{version}` user agent.

**On special-casing.** CONTRIBUTING.md is clear that third-party products should widen a generic surface rather than be special-cased in core. I read that as scoped to `plugins/`, and this dispatch is existing core machinery carrying nine providers on the same pattern — but if you'd rather this list became data-driven (a `HOST -> headers` mapping the nine current branches also fold into), I'm happy to rewrite it that way instead. That would be a genuine improvement to the generic surface and I'd rather do it than add a tenth branch you don't want.

Users can already set these by hand via `model.default_headers`; this PR is about the default, so that no user has to know the header names exist.

## Related Issue

Related to #12785 (configurable default headers / User-Agent for third-party APIs). Not a fix for it — that issue asks for a general configuration surface, this adds one provider's default.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/auxiliary_client.py` — adds `_INFERSIA_HEADERS`, beside `_AI_GATEWAY_HEADERS` and with the same shape.
- `run_agent.py` — imports it and adds one `elif base_url_host_matches(base_url, "api.infersia.com")` branch.
- `tests/run_agent/test_provider_attribution_headers.py` — two tests: one asserting the headers are applied for an Infersia base URL, one asserting an unknown host still gets no attribution headers.

Purely additive: +53 / -0. No existing branch, header value or provider is touched.

## How to Test

1. Point Hermes at Infersia in `~/.hermes/config.yaml`:
   ```yaml
   model:
     default: deepseek/deepseek-v4-flash-0731
     provider: custom
     base_url: https://api.infersia.com/v1
     api_key: isk-v1-...
   ```
2. Run `hermes chat` and send any prompt.
3. Before this change the provider's activity log attributes the request to `OpenAI/Python`; after it, to `Hermes Agent`.

Or just the unit tests:

```bash
pytest tests/run_agent/test_provider_attribution_headers.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **not done, and I'd rather say so than tick it.** I validated that all three files parse and wrote the new tests to mirror the existing ones in that file exactly, but I have not run your full suite locally. Please let CI be the judge.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64), CPython 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; the new constant is commented in place and links the provider's spec
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture change
- [x] I've considered cross-platform impact — N/A, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A, no tool behaviour change

## Reference

The provider's attribution spec, including the header names and the request to scope them by hostname: https://infersia.com/docs/app-attribution

---

Prepared with Claude Code. Every claim above about Hermes' current behaviour was verified by reading this repository and by capturing Hermes' real request headers at the receiving end.
