### PR TITLE
fix(yuanbao): let group mentions interrupt active turns

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2990,7 +2990,17 @@ class DispatchMiddleware(InboundMiddleware):
                         del cache[k]
             await adapter.handle_message(event)
 
-        if ctx.chat_type == "group":
+        # Addressed group messages must reach BasePlatformAdapter immediately so
+        # its busy-input policy can interrupt or steer an active turn.  The
+        # default pipeline stops unaddressed group traffic in GroupAtGuard, but
+        # keep the queue fallback for custom pipelines that call dispatch
+        # directly.
+        direct_group_input = ctx.chat_type == "group" and (
+            bool(ctx.owner_command)
+            or GroupAtGuardMiddleware._is_at_bot(ctx.msg_body, adapter._bot_id)
+        )
+
+        if ctx.chat_type == "group" and not direct_group_input:
             is_new = _sk not in adapter._group_queues
             queue = adapter._group_queues.setdefault(_sk, asyncio.Queue())
             queue.put_nowait(_dispatch_inbound_event)

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -641,6 +641,61 @@ class TestGroupAtGuardMiddleware:
         next_fn.assert_awaited_once()
 
 
+class TestDispatchMiddleware:
+    @pytest.mark.asyncio
+    async def test_addressed_group_message_bypasses_serial_queue(self):
+        """A second @bot turn must reach busy-input handling immediately."""
+        adapter = make_adapter()
+        adapter._bot_id = "bot_123"
+        first_started = asyncio.Event()
+        second_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def handle_message(event):
+            if event.message_id == "first":
+                first_started.set()
+                await release_first.wait()
+            elif event.message_id == "second":
+                second_started.set()
+
+        adapter.handle_message = handle_message
+        source = adapter.build_source(
+            chat_id="group:grp-1",
+            chat_type="group",
+            user_id="alice",
+            user_name="Alice",
+            thread_id="main",
+        )
+        mention = {
+            "msg_type": "TIMCustomElem",
+            "msg_content": {
+                "data": json.dumps({"elem_type": 1002, "text": "@bot", "user_id": "bot_123"})
+            },
+        }
+
+        def addressed_context(message_id):
+            return make_ctx(
+                adapter=adapter,
+                chat_type="group",
+                chat_id="group:grp-1",
+                msg_body=[mention],
+                msg_id=message_id,
+                raw_text=f"message {message_id}",
+                source=source,
+            )
+
+        middleware = DispatchMiddleware()
+        await middleware(addressed_context("first"), AsyncMock())
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        await middleware(addressed_context("second"), AsyncMock())
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+
+        assert not adapter._group_queues
+        release_first.set()
+        await asyncio.gather(*list(adapter._inbound_tasks))
+
+
 class TestAutoSetHomeAfterGroupAtGuard:
     @pytest.mark.asyncio
     async def test_unaddressed_group_does_not_set_home(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- dispatch addressed Yuanbao group messages immediately instead of serializing them behind the current turn
- preserve the existing queue fallback for unaddressed group traffic and custom pipelines
- let the shared gateway busy-input policy handle group @mentions and owner commands the same way as DMs

## Regression coverage

The new test starts one blocked group @mention, sends a second @mention, and proves the second reaches `handle_message` before the first completes. Reverting the dispatch change makes the test fail with a timeout because the second message remains in the group queue.

## Tests

- `python -m pytest tests/test_yuanbao_pipeline.py tests/test_yuanbao_integration.py tests/test_yuanbao_shutdown.py -q` (90 passed)
- `ruff check gateway/platforms/yuanbao.py tests/test_yuanbao_pipeline.py`

Fixes #78134