### PR TITLE
fix: proactively guard exhausted rate limits

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -27,6 +27,9 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional
 
 
+_DEFAULT_THROTTLE_FLOOR_SECONDS = 1.0
+
+
 @dataclass
 class RateLimitBucket:
     """One rate-limit window (e.g. requests per minute)."""
@@ -51,6 +54,11 @@ class RateLimitBucket:
         """Estimated seconds remaining until reset, adjusted for elapsed time."""
         elapsed = time.time() - self.captured_at
         return max(0.0, self.reset_seconds - elapsed)
+
+    @property
+    def is_exhausted(self) -> bool:
+        """Whether this bucket has a known zero/negative remaining quota."""
+        return self.limit > 0 and self.remaining <= 0
 
 
 @dataclass
@@ -127,6 +135,36 @@ def parse_rate_limit_headers(
         captured_at=now,
         provider=provider,
     )
+
+
+def throttle_seconds_from_state(
+    state: Optional[RateLimitState],
+    *,
+    floor_seconds: float = _DEFAULT_THROTTLE_FLOOR_SECONDS,
+) -> Optional[float]:
+    """Return a pre-call throttle delay derived from captured rate-limit state.
+
+    Providers can return ``x-ratelimit-*`` headers on successful responses where
+    the just-finished call consumed the last request/token in a bucket.  A next
+    immediate request would predictably 429.  Treat exhausted buckets as a local
+    circuit breaker until the longest exhausted reset window expires.
+    """
+    if state is None or not state.has_data:
+        return None
+
+    waits = [
+        bucket.remaining_seconds_now
+        for bucket in (
+            state.requests_min,
+            state.requests_hour,
+            state.tokens_min,
+            state.tokens_hour,
+        )
+        if bucket.is_exhausted and bucket.remaining_seconds_now > 0
+    ]
+    if not waits:
+        return None
+    return max(floor_seconds, max(waits))
 
 
 # ── Formatting ──────────────────────────────────────────────────────────

--- a/run_agent.py
+++ b/run_agent.py
@@ -3110,10 +3110,19 @@ class AIAgent:
         if not headers:
             return
         try:
-            from agent.rate_limit_tracker import parse_rate_limit_headers
+            from agent.rate_limit_tracker import (
+                parse_rate_limit_headers,
+                throttle_seconds_from_state,
+            )
             state = parse_rate_limit_headers(headers, provider=self.provider)
             if state is not None:
                 self._rate_limit_state = state
+                if self.provider == "nous" and throttle_seconds_from_state(state) is not None:
+                    try:
+                        from agent.nous_rate_guard import record_nous_rate_limit
+                        record_nous_rate_limit(headers=headers)
+                    except Exception:
+                        pass
         except Exception:
             pass  # Never let header parsing break the agent loop
 

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -8,6 +8,7 @@ from agent.rate_limit_tracker import (
     parse_rate_limit_headers,
     format_rate_limit_display,
     format_rate_limit_compact,
+    throttle_seconds_from_state,
     _fmt_count,
     _fmt_seconds,
     _bar,
@@ -112,6 +113,57 @@ class TestBucket:
     def test_remaining_seconds_expired(self):
         b = RateLimitBucket(limit=800, remaining=795, reset_seconds=30.0, captured_at=time.time() - 60)
         assert b.remaining_seconds_now == 0.0
+
+    def test_is_exhausted_only_when_known_quota_empty(self):
+        assert RateLimitBucket(limit=100, remaining=0).is_exhausted
+        assert RateLimitBucket(limit=100, remaining=-1).is_exhausted
+        assert not RateLimitBucket(limit=100, remaining=1).is_exhausted
+        assert not RateLimitBucket(limit=0, remaining=0).is_exhausted
+
+
+class TestProactiveThrottle:
+    def test_no_throttle_when_capacity_remains(self):
+        state = parse_rate_limit_headers(NOUS_HEADERS, provider="nous")
+        assert throttle_seconds_from_state(state) is None
+
+    def test_throttle_when_success_headers_show_exhausted_request_bucket(self):
+        state = parse_rate_limit_headers(
+            {
+                **NOUS_HEADERS,
+                "x-ratelimit-remaining-requests": "0",
+                "x-ratelimit-reset-requests": "12",
+            },
+            provider="nous",
+        )
+        assert state is not None
+        assert throttle_seconds_from_state(state) == pytest.approx(12, abs=1)
+
+    def test_throttle_uses_longest_exhausted_bucket(self):
+        state = parse_rate_limit_headers(
+            {
+                **NOUS_HEADERS,
+                "x-ratelimit-remaining-requests": "0",
+                "x-ratelimit-reset-requests": "12",
+                "x-ratelimit-remaining-tokens-1h": "0",
+                "x-ratelimit-reset-tokens-1h": "120",
+            },
+            provider="nous",
+        )
+        assert state is not None
+        assert throttle_seconds_from_state(state) == pytest.approx(120, abs=1)
+
+    def test_no_throttle_for_expired_exhausted_bucket(self):
+        state = RateLimitState(
+            requests_min=RateLimitBucket(
+                limit=100,
+                remaining=0,
+                reset_seconds=1,
+                captured_at=time.time() - 2,
+            ),
+            captured_at=time.time() - 2,
+            provider="nous",
+        )
+        assert throttle_seconds_from_state(state) is None
 
 
 class TestFormatting:


### PR DESCRIPTION
## Summary
- derive proactive throttle windows from captured x-ratelimit headers when a response consumes the last bucket quota
- record exhausted Nous headers into the existing cross-session guard so the next turn skips Nous before making another doomed request
- cover exhausted, longest-window, and expired-window behavior in rate-limit tracker tests

## Tests
- python3 -m pytest tests/agent/test_rate_limit_tracker.py tests/agent/test_nous_rate_guard.py tests/run_agent/test_nous_429_fallback_reentry.py
- python3 -m py_compile agent/rate_limit_tracker.py run_agent.py tests/agent/test_rate_limit_tracker.py