### PR TITLE
Add governed evidence-learning ledger and skill routing safeguards

### DIFF
--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -388,7 +388,7 @@ Cómo confirma el agente que funcionó.
 
 Todo skill nuevo o modernizado — incluido, opcional o contribuido — debe cumplir estos estándares antes del merge:
 
-1. **`description` ≤ 60 caracteres, una oración, termina con punto.** Las descripciones largas saturan la UI de listado de habilidades. Indica la capacidad, no la implementación. Sin palabras de marketing ("potente", "completo", "fluido", "avanzado").
+1. **La pista `routing` debe tener ≤ 60 caracteres, ser una oración y terminar en punto.** Usa el campo opcional `routing:` del frontmatter para el índice del system prompt. Mantén `description:` completa y legible (hasta 1024 caracteres); con `routing:` presente no se trunca silenciosamente. Si falta `routing:`, las habilidades antiguas usan el comportamiento heredado de truncar `description:`.
 
 2. **Las herramientas referenciadas en el cuerpo de SKILL.md deben ser herramientas nativas de Hermes o servidores MCP que la habilidad espere explícitamente.** Usa los nombres de herramientas en comillas invertidas: `` `terminal` ``, `` `web_extract` ``, `` `web_search` ``, `` `read_file` ``, `` `write_file` ``, etc.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,13 +566,12 @@ See `skills/gifs/gif-search/` and `skills/email/himalaya/` for examples.
 
 Every new or modernized skill — bundled, optional, or contributed — must meet these standards before merge. Reviewers reject PRs that violate them.
 
-1. **`description` ≤ 60 characters, one sentence, ends with a period.** Long descriptions bloat the skill listing UI and dilute the model's attention when many skills are loaded. State the capability, not the implementation. No marketing words ("powerful", "comprehensive", "seamless", "advanced"). Don't repeat the skill name. Verify with:
+1. **The `routing` hint must be ≤ 60 characters, one sentence, and end with a period.** Use the optional frontmatter `routing:` field for the system-prompt skill index. Keep `description:` human-readable and complete (up to 1024 characters); it is not silently truncated when `routing:` is present. State the capability, not the implementation. No marketing words ("powerful", "comprehensive", "seamless", "advanced"). Don't repeat the skill name. If `routing:` is absent, legacy skills fall back to truncated `description:` behavior. Verify with:
    ```python
-   import re, pathlib
-   m = re.search(r'^description: (.*)$',
-                 pathlib.Path('skills/<cat>/<name>/SKILL.md').read_text(),
-                 re.MULTILINE)
-   assert len(m.group(1)) <= 60, len(m.group(1))
+   import re, pathlib, yaml
+   fm = pathlib.Path('skills/<cat>/<name>/SKILL.md').read_text()
+   data = yaml.safe_load(fm.split('---', 2)[1])
+   assert len(data.get('routing', data['description'])) <= 60
    ```
 
    Good: `Search arXiv papers by keyword, author, category, or ID.`

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -922,15 +922,26 @@ def _run_review_in_thread(
                     _digest_history(messages_snapshot) if _routed
                     else messages_snapshot
                 )
-                review_agent.run_conversation(
-                    user_message=(
-                        prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
-                        "at runtime — do not attempt them."
-                    ),
-                    conversation_history=_review_history,
+                from agent.learning_context import (
+                    build_learning_metadata,
+                    learning_metadata_scope,
                 )
+
+                _learning_metadata = build_learning_metadata(
+                    messages_snapshot,
+                    session_id=agent.session_id or "",
+                    platform=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                )
+                with learning_metadata_scope(_learning_metadata):
+                    review_agent.run_conversation(
+                        user_message=(
+                            prompt
+                            + "\n\nYou can only call memory and skill "
+                            "management tools. Other tools will be denied "
+                            "at runtime — do not attempt them."
+                        ),
+                        conversation_history=_review_history,
+                    )
             finally:
                 clear_thread_tool_whitelist()
 

--- a/agent/context_health.py
+++ b/agent/context_health.py
@@ -1,0 +1,143 @@
+"""Deterministic audit of durable context and measured learning state."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+def _finding(kind: str, severity: str, subject: str, message: str) -> dict[str, str]:
+    return {
+        "kind": kind,
+        "severity": severity,
+        "subject": subject,
+        "message": message,
+    }
+
+
+def _memory_findings() -> tuple[list[dict[str, str]], dict[str, int]]:
+    findings: list[dict[str, str]] = []
+    stats = {"memory_chunks": 0, "memory_chars": 0}
+    base = get_hermes_home() / "memories"
+    normalized: list[str] = []
+    for name in ("MEMORY.md", "USER.md"):
+        path = base / name
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        stats["memory_chars"] += len(text)
+        for chunk in (part.strip() for part in text.split("\n§\n")):
+            if not chunk:
+                continue
+            stats["memory_chunks"] += 1
+            normalized.append(" ".join(chunk.lower().split()))
+    for text, count in Counter(normalized).items():
+        if count < 2:
+            continue
+        subject = "memory:" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+        findings.append(
+            _finding(
+                "duplicate_memory",
+                "medium",
+                subject,
+                f"The same durable memory appears {count} times.",
+            )
+        )
+    return findings, stats
+
+
+def _candidate_findings() -> tuple[list[dict[str, str]], dict[str, int]]:
+    from agent import learning_ledger
+
+    findings: list[dict[str, str]] = []
+    candidates = learning_ledger.list_candidates()
+    stats = {
+        "candidates": len(candidates),
+        "pending_candidates": 0,
+        "validated_candidates": 0,
+    }
+    stale_before = datetime.now(timezone.utc) - timedelta(days=7)
+    for candidate in candidates:
+        candidate_id = candidate["candidate_id"]
+        status = candidate["status"]
+        events = learning_ledger.list_events(candidate_id=candidate_id)
+        outcomes = [event for event in events if event["event"].startswith("outcome_")]
+        if status in {"pending", "applying"}:
+            stats["pending_candidates"] += 1
+            try:
+                created = datetime.fromisoformat(str(candidate["created_at"]).replace("Z", "+00:00"))
+            except Exception:
+                created = None
+            if created is not None and created < stale_before:
+                findings.append(
+                    _finding("stale_candidate", "medium", candidate_id, "Learning candidate has awaited disposition for more than seven days.")
+                )
+        if status == "validated":
+            stats["validated_candidates"] += 1
+        if status == "active" and not outcomes:
+            findings.append(
+                _finding("unvalidated_learning", "medium", candidate_id, "Applied learning has no recorded outcome evidence.")
+            )
+        failed = [
+            event for event in outcomes
+            if event["event"] in {"outcome_verification_failed", "outcome_user_corrected", "outcome_retry_failed"}
+        ]
+        if failed:
+            findings.append(
+                _finding("failed_learning_outcome", "high", candidate_id, f"Applied learning has {len(failed)} negative outcome receipt(s).")
+            )
+    return findings, stats
+
+
+def audit_context() -> dict[str, Any]:
+    findings, stats = _memory_findings()
+    candidate_findings, candidate_stats = _candidate_findings()
+    findings.extend(candidate_findings)
+    stats.update(candidate_stats)
+    try:
+        from agent.trace_compiler import discover_compilation_proposals
+
+        proposals = discover_compilation_proposals()
+    except Exception:
+        proposals = []
+    stats["compilation_candidates"] = len(proposals)
+    for proposal in proposals:
+        findings.append(
+            _finding(
+                "compilation_candidate",
+                "low",
+                proposal["id"],
+                "Repeated successful deterministic workflow is ready for human review.",
+            )
+        )
+    weights = {"low": 3, "medium": 10, "high": 20}
+    score = max(0, 100 - sum(weights.get(item["severity"], 5) for item in findings))
+    findings.sort(key=lambda item: ({"high": 0, "medium": 1, "low": 2}.get(item["severity"], 3), item["kind"], item["subject"]))
+    return {"score": score, "findings": findings, "stats": stats}
+
+
+def format_context_audit() -> str:
+    result = audit_context()
+    lines = [
+        f"Context Health: score={result['score']}/100, findings={len(result['findings'])}",
+        (
+            f"Memory: {result['stats']['memory_chunks']} chunks / "
+            f"{result['stats']['memory_chars']} chars · "
+            f"Learning: {result['stats']['candidates']} candidates, "
+            f"{result['stats']['validated_candidates']} validated"
+        ),
+    ]
+    if not result["findings"]:
+        lines.append("No deterministic context-health issues found.")
+    else:
+        for item in result["findings"]:
+            lines.append(
+                f"- [{item['severity']}] {item['kind']} ({item['subject']}): {item['message']}"
+            )
+    return "\n".join(lines)

--- a/agent/learning_context.py
+++ b/agent/learning_context.py
@@ -1,0 +1,84 @@
+"""Context-local provenance for autonomous learning proposals.
+
+Background review binds one bounded evidence envelope before its tool loop.
+Memory and skill staging consume it without changing model-visible tool schemas.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Sequence
+
+from agent.redact import redact_sensitive_text
+
+_MAX_EXCERPT_CHARS = 500
+_learning_metadata: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
+    "learning_metadata", default={}
+)
+
+
+def _message_text(message: Mapping[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            str(block.get("text") or "")
+            for block in content
+            if isinstance(block, Mapping) and block.get("type") in {None, "text"}
+        )
+    return ""
+
+
+def _trigger_for(text: str) -> str:
+    lowered = text.lower()
+    if any(marker in lowered for marker in ("remember", "i prefer", "please always", "please never", "my preference")):
+        return "preference"
+    if any(marker in lowered for marker in ("that's wrong", "that is wrong", "instead", "correction", "don't do that")):
+        return "correction"
+    return "workflow_observation"
+
+
+def build_learning_metadata(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    session_id: str = "",
+    platform: str = "",
+) -> dict[str, Any]:
+    excerpt = ""
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            excerpt = _message_text(message).strip()
+            if excerpt:
+                break
+    excerpt = redact_sensitive_text(excerpt, force=True)[:_MAX_EXCERPT_CHARS]
+    return {
+        "source": {
+            "session_id": session_id,
+            "platform": platform,
+            "trust": "user_supplied_unverified",
+        },
+        "evidence": {
+            "status": "captured" if excerpt else "missing",
+            "trigger": _trigger_for(excerpt) if excerpt else "unknown",
+            "source_trust": "user_supplied_unverified",
+            "excerpt": excerpt,
+            "hypothesis": "Applying this proposal should reduce repeated correction on similar future tasks.",
+            "risk": "unknown",
+            "confidence": "unknown",
+        },
+    }
+
+
+def current_learning_metadata() -> dict[str, Any]:
+    return dict(_learning_metadata.get())
+
+
+@contextmanager
+def learning_metadata_scope(metadata: Mapping[str, Any]) -> Iterator[None]:
+    token = _learning_metadata.set(dict(metadata))
+    try:
+        yield
+    finally:
+        _learning_metadata.reset(token)

--- a/agent/learning_evaluation.py
+++ b/agent/learning_evaluation.py
@@ -1,0 +1,412 @@
+"""Deterministic regression checks for proposed skill mutations.
+
+V1 manifests are data, not prompts.  They assert mechanical properties of the
+candidate text and compare those results with the exact reviewed baseline.
+Qualitative model judging can be layered on later without weakening these hard
+contracts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write, atomic_write_text
+
+_SAFE_CANDIDATE_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _snapshot_dir(candidate_id: str) -> Path:
+    home = get_hermes_home()
+    learning = home / "learning"
+    root = learning / "snapshots"
+    directory = root / candidate_id
+    if (root.exists() and root.is_symlink()) or (
+        directory.exists() and directory.is_symlink()
+    ):
+        raise ValueError("evaluation snapshot directory must not be a symlink")
+    if learning.is_symlink():
+        raise ValueError("evaluation snapshot parent must not be a symlink")
+    return directory
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _snapshot_fingerprint(manifest: Mapping[str, Any]) -> str:
+    return _sha256_hex(_canonical_json(manifest))
+
+
+def _persist_snapshot_manifest(candidate_id: str, manifest: Mapping[str, Any]) -> None:
+    directory = _snapshot_dir(candidate_id)
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    snapshot = directory / "snapshot.json"
+    atomic_json_write(snapshot, manifest, mode=0o600)
+
+
+def _load_snapshot_manifest(candidate_id: str) -> dict[str, Any]:
+    snapshot = _snapshot_dir(candidate_id) / "snapshot.json"
+    if snapshot.is_symlink() or not snapshot.is_file():
+        raise ValueError("candidate has no usable evaluation snapshot")
+    data = json.loads(snapshot.read_text(encoding="utf-8"))
+    if data.get("candidate_id") != candidate_id:
+        raise ValueError("evaluation snapshot candidate identity mismatch")
+    return data
+
+
+def _evaluate_text(text: str, manifest: Mapping[str, Any]) -> dict[str, Any]:
+    if int(manifest.get("version", 0)) != 1:
+        raise ValueError("evaluation manifest version must be 1")
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("evaluation manifest requires at least one case")
+
+    passed = 0
+    failures: list[dict[str, Any]] = []
+    case_results: list[dict[str, Any]] = []
+    for index, raw_case in enumerate(cases):
+        if not isinstance(raw_case, Mapping):
+            raise ValueError(f"evaluation case {index} must be an object")
+        name = str(raw_case.get("name") or f"case-{index + 1}")
+        reasons: list[str] = []
+        case_sensitive = bool(raw_case.get("case_sensitive", False))
+        haystack = text if case_sensitive else text.lower()
+        for required in raw_case.get("must_contain") or []:
+            needle = str(required) if case_sensitive else str(required).lower()
+            if needle not in haystack:
+                reasons.append(f"missing required text: {required}")
+        for forbidden in raw_case.get("must_not_contain") or []:
+            needle = str(forbidden) if case_sensitive else str(forbidden).lower()
+            if needle in haystack:
+                reasons.append(f"contains forbidden text: {forbidden}")
+        max_chars = raw_case.get("max_chars")
+        if isinstance(max_chars, int) and len(text) > max_chars:
+            reasons.append(f"exceeds max_chars={max_chars}")
+        min_chars = raw_case.get("min_chars")
+        if isinstance(min_chars, int) and len(text) < min_chars:
+            reasons.append(f"below min_chars={min_chars}")
+        ok = not reasons
+        case_results.append({"case": name, "passed": ok, "reasons": reasons})
+        if ok:
+            passed += 1
+        else:
+            failures.append({"case": name, "reasons": reasons})
+    return {
+        "passed": passed,
+        "total": len(cases),
+        "failures": failures,
+        "cases": case_results,
+    }
+
+
+def compare_texts(*, baseline: str, candidate: str, manifest: Mapping[str, Any]) -> dict[str, Any]:
+    baseline_result = _evaluate_text(baseline, manifest)
+    candidate_result = _evaluate_text(candidate, manifest)
+    baseline_passed = {
+        item["case"] for item in baseline_result["cases"] if item["passed"]
+    }
+    candidate_passed = {
+        item["case"] for item in candidate_result["cases"] if item["passed"]
+    }
+    if baseline_passed - candidate_passed:
+        verdict = "regressed"
+    elif candidate_result["passed"] > baseline_result["passed"]:
+        verdict = "improved"
+    elif candidate_result["passed"] == candidate_result["total"]:
+        verdict = "passed"
+    else:
+        verdict = "unchanged"
+    return {
+        "verdict": verdict,
+        "baseline": baseline_result,
+        "candidate": candidate_result,
+    }
+
+
+def simulate_candidate_text(baseline: str, payload: Mapping[str, Any]) -> str:
+    action = str(payload.get("action") or "")
+    if action in {"create", "edit"}:
+        content = payload.get("content")
+        if not isinstance(content, str):
+            raise ValueError(f"{action} candidate requires content")
+        return content
+    if action == "patch":
+        old = payload.get("old_string")
+        new = payload.get("new_string")
+        if not isinstance(old, str) or not old:
+            raise ValueError("patch candidate requires old_string")
+        if not isinstance(new, str):
+            raise ValueError("patch candidate requires new_string")
+        occurrences = baseline.count(old)
+        if occurrences == 0:
+            raise ValueError("reviewed baseline no longer contains old_string")
+        replace_all = bool(payload.get("replace_all"))
+        if occurrences > 1 and not replace_all:
+            raise ValueError("reviewed baseline contains a non-unique old_string")
+        return baseline.replace(old, new) if replace_all else baseline.replace(old, new, 1)
+    if action == "delete":
+        return ""
+    raise ValueError(f"unsupported deterministic evaluation action: {action}")
+
+
+def evaluate_pending_skill(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate a pending skill payload against its colocated manifest."""
+    payload = dict(record.get("payload") or {})
+    name = str(payload.get("name") or "")
+    if not name:
+        raise ValueError("pending skill candidate has no name")
+    from tools.skill_manager_tool import _find_skill, _validate_file_path
+
+    found = _find_skill(name)
+    action = str(payload.get("action") or "")
+    if found is None and action != "create":
+        raise ValueError(f"skill '{name}' is no longer available")
+    skill_dir = Path(found["path"]) if found is not None else None
+    target_file = "SKILL.md"
+    requested_file = payload.get("file_path")
+    if requested_file:
+        path_error = _validate_file_path(str(requested_file))
+        if path_error:
+            raise ValueError(path_error)
+        target_file = str(requested_file)
+    baseline_path = skill_dir / target_file if skill_dir is not None else None
+    if baseline_path is not None and baseline_path.is_symlink():
+        raise ValueError("evaluated skill target must not be a symlink")
+    if skill_dir is not None and baseline_path is not None:
+        try:
+            baseline_path.resolve().relative_to(skill_dir.resolve())
+        except ValueError as exc:
+            raise ValueError("evaluated skill target escapes its skill directory") from exc
+    baseline = baseline_path.read_text(encoding="utf-8") if baseline_path and baseline_path.exists() else ""
+    manifest_path = skill_dir / "evals" / "manifest.json" if skill_dir is not None else None
+    if manifest_path is None or not manifest_path.exists():
+        return {"verdict": "no_manifest", "baseline": None, "candidate": None}
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if action not in {"edit", "patch"}:
+        raise ValueError("deterministic skill evaluation supports edit and patch candidates")
+    candidate = simulate_candidate_text(baseline, payload)
+    candidate_id = str(record.get("candidate_id") or record.get("id") or "")
+    if candidate_id:
+        if not _SAFE_CANDIDATE_ID.fullmatch(candidate_id):
+            raise ValueError("invalid candidate id for baseline snapshot")
+        # Bind skill identity into the ledger so rollback can verify it later.
+        # Skip when the candidate has no ledger row (e.g. standalone evaluation).
+        from agent import learning_ledger
+
+        if learning_ledger.ledger_exists():
+            learning_ledger.update_candidate_proposal_fields(
+                candidate_id,
+                {"skill_name": name, "target_file": target_file},
+            )
+        directory = _snapshot_dir(candidate_id)
+        directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+        baseline_path = directory / "baseline.txt"
+        atomic_write_text(baseline_path, baseline)
+        _persist_snapshot_manifest(
+            candidate_id,
+            {
+                "version": 1,
+                "candidate_id": candidate_id,
+                "skill_name": name,
+                "target_file": target_file,
+                "baseline_sha256": _sha256_text(baseline),
+                "candidate_sha256": _sha256_text(candidate),
+                "rollback_action": "edit" if target_file == "SKILL.md" else "write_file",
+                "manifest_fingerprint": _snapshot_fingerprint(manifest),
+            },
+        )
+        try:
+            baseline_path.chmod(0o600)
+        except OSError:
+            pass
+    return compare_texts(baseline=baseline, candidate=candidate, manifest=manifest)
+
+
+def _sha256_text(text: str) -> str:
+    import hashlib
+
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def prepare_evaluated_skill_rollback(candidate_id: str) -> dict[str, Any]:
+    """Build a rollback payload after proving the evaluated target is unchanged.
+
+    This function is read-only. The caller must execute the returned payload via
+    ``apply_skill_pending`` so the existing skill mutation handler remains the
+    sole mutation engine.
+    """
+    if not _SAFE_CANDIDATE_ID.fullmatch(candidate_id):
+        raise ValueError("invalid candidate id for rollback")
+    from agent import learning_ledger
+    from tools.skill_manager_tool import _find_skill, _validate_file_path
+
+    candidate = learning_ledger.get_candidate(candidate_id)
+    if candidate is None or candidate.get("subsystem") != "skills":
+        raise ValueError("unknown evaluated skill candidate")
+    if candidate.get("status") not in {"active", "validated", "rolling_back"}:
+        raise ValueError("only active, validated, or rolling_back candidates can be rolled back")
+    metadata = _load_snapshot_manifest(candidate_id)
+    if metadata.get("version") != 1:
+        raise ValueError("evaluation snapshot metadata does not match candidate")
+    name = str(metadata.get("skill_name") or "")
+    if not name:
+        raise ValueError("evaluation snapshot is missing skill identity")
+    # Verify snapshot identity against the skill_name stored in the ledger
+    # at evaluation time.  A mismatch means the snapshot was retargeted.
+    proposal = dict(candidate.get("proposal") or {})
+    proposal_name = str(proposal.get("skill_name") or "")
+    if proposal_name and proposal_name != name:
+        raise ValueError("evaluation snapshot skill identity does not match candidate")
+    # Also verify target_file if it was stored.
+    proposal_target = str(proposal.get("target_file") or "")
+    if proposal_target:
+        metadata_target = str(metadata.get("target_file") or "SKILL.md")
+        if proposal_target != metadata_target:
+            raise ValueError("evaluation snapshot target file does not match candidate")
+    found = _find_skill(name)
+    if found is None:
+        raise ValueError("evaluated skill target no longer exists")
+    target_file = str(metadata.get("target_file") or "SKILL.md")
+    if target_file != "SKILL.md":
+        path_error = _validate_file_path(target_file)
+        if path_error:
+            raise ValueError(path_error)
+    skill_dir = Path(found["path"])
+    current_path = skill_dir / target_file
+    try:
+        current_path.resolve().relative_to(skill_dir.resolve())
+    except ValueError as exc:
+        raise ValueError("evaluated skill target escapes its skill directory") from exc
+    if current_path.is_symlink() or not current_path.is_file():
+        raise ValueError("evaluated skill target is not a regular file")
+    current = current_path.read_text(encoding="utf-8")
+    if _sha256_text(current) != metadata.get("candidate_sha256"):
+        raise ValueError("skill changed after evaluated candidate was applied")
+    baseline_path = _snapshot_dir(candidate_id) / "baseline.txt"
+    baseline = baseline_path.read_text(encoding="utf-8")
+    if _sha256_text(baseline) != metadata.get("baseline_sha256"):
+        raise ValueError("evaluation snapshot baseline is corrupted")
+    manifest_path = skill_dir / "evals" / "manifest.json"
+    if manifest_path.exists():
+        current_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if _snapshot_fingerprint(current_manifest) != metadata.get("manifest_fingerprint"):
+            raise ValueError("evaluation manifest changed after snapshot was taken")
+    if target_file == "SKILL.md":
+        return {"action": "edit", "name": name, "content": baseline}
+    return {
+        "action": "write_file",
+        "name": name,
+        "file_path": target_file,
+        "file_content": baseline,
+    }
+
+
+def evaluate_pending_memory(record: Mapping[str, Any], store) -> dict[str, Any]:
+    """Simulate a memory mutation and enforce deterministic store invariants."""
+    payload = dict(record.get("payload") or {})
+    target = str(payload.get("target") or "memory")
+    baseline = list(store._entries_for(target))
+    candidate = list(baseline)
+
+    def apply_one(operation: Mapping[str, Any]) -> None:
+        action = str(operation.get("action") or "")
+        content = operation.get("content")
+        old_text = operation.get("old_text")
+        if action == "add":
+            if not isinstance(content, str) or not content.strip():
+                raise ValueError("memory add requires non-empty content")
+            if content not in candidate:
+                candidate.append(content)
+        elif action == "replace":
+            needle = str(old_text or "")
+            matches = [i for i, entry in enumerate(candidate) if needle and needle in entry]
+            if len({candidate[i] for i in matches}) != 1 or not isinstance(content, str) or not content.strip():
+                raise ValueError("memory replace target is stale or replacement is empty")
+            candidate[matches[0]] = content
+        elif action == "remove":
+            needle = str(old_text or "")
+            matches = [i for i, entry in enumerate(candidate) if needle and needle in entry]
+            if len({candidate[i] for i in matches}) != 1:
+                raise ValueError("memory remove target is stale")
+            candidate.pop(matches[0])
+        else:
+            raise ValueError(f"unsupported memory evaluation action: {action}")
+
+    if payload.get("action") == "batch":
+        for operation in payload.get("operations") or []:
+            apply_one(operation)
+    else:
+        apply_one(payload)
+
+    limit = store.user_char_limit if target == "user" else store.memory_char_limit
+    checks = {
+        "nonempty_entries": all(isinstance(item, str) and item.strip() for item in candidate),
+        "no_duplicates": len(candidate) == len(set(candidate)),
+        "within_char_limit": sum(len(item) for item in candidate) <= limit,
+    }
+    candidate_id = str(record.get("candidate_id") or record.get("id") or "")
+    if candidate_id:
+        if not _SAFE_CANDIDATE_ID.fullmatch(candidate_id):
+            raise ValueError("invalid candidate id for memory snapshot")
+        snapshot = _snapshot_dir(candidate_id) / "memory.json"
+        atomic_json_write(
+            snapshot,
+            {
+                "version": 1,
+                "candidate_id": candidate_id,
+                "target": target,
+                "baseline": baseline,
+                "candidate": candidate,
+            },
+            mode=0o600,
+        )
+    passed = sum(bool(value) for value in checks.values())
+    return {
+        "verdict": "passed" if passed == len(checks) else "regressed",
+        "baseline": {"entries": len(baseline)},
+        "candidate": {"passed": passed, "total": len(checks), "checks": checks},
+    }
+
+
+def prepare_evaluated_memory_rollback(candidate_id: str, store) -> dict[str, Any]:
+    """Build an exact batch rollback after proving evaluated memory is unchanged."""
+    if not _SAFE_CANDIDATE_ID.fullmatch(candidate_id):
+        raise ValueError("invalid candidate id for rollback")
+    from agent import learning_ledger
+
+    candidate_record = learning_ledger.get_candidate(candidate_id)
+    if candidate_record is None or candidate_record.get("subsystem") != "memory":
+        raise ValueError("unknown evaluated memory candidate")
+    if candidate_record.get("status") not in {"active", "validated", "rolling_back"}:
+        raise ValueError("only active, validated, or rolling_back candidates can be rolled back")
+    snapshot = _snapshot_dir(candidate_id) / "memory.json"
+    if snapshot.is_symlink() or not snapshot.is_file():
+        raise ValueError("candidate has no usable memory evaluation snapshot")
+    data = json.loads(snapshot.read_text(encoding="utf-8"))
+    if data.get("version") != 1 or data.get("candidate_id") != candidate_id:
+        raise ValueError("memory evaluation snapshot does not match candidate")
+    target = str(data.get("target") or "memory")
+    baseline = data.get("baseline")
+    expected = data.get("candidate")
+    if not isinstance(baseline, list) or not all(isinstance(item, str) for item in baseline):
+        raise ValueError("memory evaluation baseline is malformed")
+    if not isinstance(expected, list) or not all(isinstance(item, str) for item in expected):
+        raise ValueError("memory evaluation candidate is malformed")
+    current = list(store._entries_for(target))
+    if current != expected:
+        raise ValueError("memory changed after evaluated candidate was applied")
+    operations = [
+        {"action": "remove", "old_text": entry}
+        for entry in sorted(current, key=len, reverse=True)
+    ]
+    operations.extend({"action": "add", "content": entry} for entry in baseline)
+    return {"action": "batch", "target": target, "operations": operations}

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -251,6 +251,43 @@ def _skill_roots() -> list[tuple[str, Path]]:
     return [("base", repo / "skills"), ("profile", home_skills)]
 
 
+def _learning_candidates() -> list[dict[str, Any]]:
+    try:
+        from agent import learning_ledger
+
+        projected: list[dict[str, Any]] = []
+        for candidate in learning_ledger.list_candidates():
+            outcomes = []
+            for event in learning_ledger.list_events(candidate_id=candidate["candidate_id"]):
+                if not event["event"].startswith("outcome_"):
+                    continue
+                outcomes.append(
+                    {
+                        "outcome": event["event"].removeprefix("outcome_"),
+                        "detail": event.get("detail", {}),
+                        "timestamp": event.get("occurred_at"),
+                    }
+                )
+            projected.append(
+                {
+                    "id": candidate["candidate_id"],
+                    "subsystem": candidate["subsystem"],
+                    "action": candidate["action"],
+                    "status": candidate["status"],
+                    "summary": candidate.get("proposal", {}).get("summary", ""),
+                    "risk": candidate.get("evidence", {}).get("risk", "unknown"),
+                    "hypothesis": candidate.get("evidence", {}).get("hypothesis", ""),
+                    "source": candidate.get("source", {}),
+                    "createdAt": candidate.get("created_at"),
+                    "updatedAt": candidate.get("updated_at"),
+                    "outcomes": outcomes,
+                }
+            )
+        return projected
+    except Exception:
+        return []
+
+
 def build_learning_graph() -> dict[str, Any]:
     """Full payload for the desktop learning panel.
 
@@ -268,6 +305,7 @@ def build_learning_graph() -> dict[str, Any]:
     skill_edges = build_edges(learned_skills)
     memory_cards = _memory_cards()
     memory_edges = _memory_skill_edges(memory_cards, list(learned_skills.values()))
+    candidates = _learning_candidates()
 
     edges = skill_edges + memory_edges
     clusters: dict[str, int] = {}
@@ -314,11 +352,14 @@ def build_learning_graph() -> dict[str, Any]:
             for c, n in sorted(clusters.items(), key=lambda kv: -kv[1])
         ],
         "memory": memory_cards,
+        "candidates": candidates,
         "stats": {
             **density_stats(learned_skills, skill_edges),
             "memory_nodes": len(memory_cards),
             "memory_skill_edges": len(memory_edges),
             "learned_skills": len(learned_skills),
+            "learning_candidates": len(candidates),
+            "validated_candidates": sum(1 for candidate in candidates if candidate["status"] == "validated"),
         },
     }
 

--- a/agent/learning_ledger.py
+++ b/agent/learning_ledger.py
@@ -27,7 +27,10 @@ _MAX_EVIDENCE_CHARS = 500
 _MAX_JSON_CHARS = 16_384
 _RISKS = {"low", "medium", "high", "unknown"}
 _CONFIDENCE = {"low", "medium", "high", "unknown"}
-_CANDIDATE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+# Candidate IDs may be namespaced (for example ``pastoral:<uuid>``).
+# Keep the namespace separator explicit rather than permitting arbitrary
+# punctuation in IDs used by paths and CLI surfaces.
+_CANDIDATE_ID_RE = re.compile(r"^(?:[A-Za-z0-9_-]+:)?[A-Za-z0-9_-]{1,64}$")
 _VALID_STATUSES = {"pending", "applying", "active", "validated", "rolling_back", "rolled_back", "rejected"}
 _VALID_TRANSITIONS = {
     "pending": {"applying", "active", "rejected"},

--- a/agent/learning_ledger.py
+++ b/agent/learning_ledger.py
@@ -1,0 +1,644 @@
+"""Profile-scoped evidence ledger for learned memory and skill changes.
+
+The ledger is deliberately separate from the session database.  A mutable
+candidate row provides transactional status and deduplication while an
+append-only event table preserves the lifecycle audit trail.  Pending JSON
+files in :mod:`tools.write_approval` remain the replay payload; this module
+never applies memory or skill mutations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Optional
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_VERSION = 1
+_MAX_EVIDENCE_CHARS = 500
+_MAX_JSON_CHARS = 16_384
+_RISKS = {"low", "medium", "high", "unknown"}
+_CONFIDENCE = {"low", "medium", "high", "unknown"}
+_CANDIDATE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_VALID_STATUSES = {"pending", "applying", "active", "validated", "rolling_back", "rolled_back", "rejected"}
+_VALID_TRANSITIONS = {
+    "pending": {"applying", "active", "rejected"},
+    "applying": {"pending", "active", "rejected"},
+    "active": {"validated", "rolling_back"},
+    "validated": {"rolling_back"},
+    "rolling_back": {"rolled_back", "active", "validated"},
+    "rolled_back": set(),
+    "rejected": set(),
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ledger_path() -> Path:
+    return get_hermes_home() / "learning" / "ledger.db"
+
+
+def _validate_candidate_id(candidate_id: str) -> str:
+    value = str(candidate_id or "")
+    if not _CANDIDATE_ID_RE.fullmatch(value):
+        raise ValueError("candidate id contains invalid characters")
+    return value
+
+
+def ledger_exists() -> bool:
+    path = _ledger_path()
+    return path.exists() and path.is_file() and not path.is_symlink()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _bounded_json(value: Any, *, label: str) -> str:
+    text = _canonical_json(value)
+    if len(text) > _MAX_JSON_CHARS:
+        raise ValueError(f"{label} exceeds {_MAX_JSON_CHARS} characters")
+    return text
+
+
+def canonical_payload_fingerprint(subsystem: str, payload: Mapping[str, Any]) -> str:
+    material = _canonical_json({"subsystem": subsystem, "payload": dict(payload)})
+    return "sha256:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def candidate_dedup_key(subsystem: str, payload: Mapping[str, Any]) -> str:
+    """Return an exact deterministic mutation identity.
+
+    Only mutation semantics are included.  Presentation/provenance fields such
+    as summaries, timestamps, candidate IDs, and evidence are intentionally
+    absent because they must not make an equivalent proposal look new.
+    """
+
+    if subsystem == "memory":
+        semantic_keys = ("action", "target", "content", "old_text", "operations")
+    elif subsystem == "skills":
+        semantic_keys = (
+            "action",
+            "name",
+            "content",
+            "old_string",
+            "new_string",
+            "replace_all",
+            "file_path",
+            "file_content",
+            "absorbed_into",
+        )
+    else:
+        semantic_keys = tuple(sorted(payload))
+    semantic = {key: payload.get(key) for key in semantic_keys if key in payload}
+    return canonical_payload_fingerprint(subsystem, semantic)
+
+
+def sanitize_evidence(evidence: Optional[Mapping[str, Any]]) -> dict[str, Any]:
+    from agent.redact import redact_sensitive_text
+
+    raw = dict(evidence or {})
+    raw_excerpt = str(raw.get("excerpt") or "")
+    excerpt_hash = "sha256:" + hashlib.sha256(raw_excerpt.encode("utf-8")).hexdigest()
+    trust = str(raw.get("source_trust") or raw.get("trust") or "unknown")[:64]
+    try:
+        excerpt = redact_sensitive_text(raw_excerpt, force=True)
+        hypothesis = redact_sensitive_text(str(raw.get("hypothesis") or ""), force=True)
+    except Exception:
+        excerpt = ""
+        hypothesis = ""
+    if trust in {"untrusted_external", "user_supplied_unverified", "unknown"}:
+        excerpt = ""
+    risk = str(raw.get("risk") or "unknown").lower()
+    confidence = str(raw.get("confidence") or "unknown").lower()
+    return {
+        "status": str(raw.get("status") or "missing")[:64],
+        "trigger": str(raw.get("trigger") or "unknown")[:64],
+        "source_trust": trust,
+        "excerpt": excerpt[:_MAX_EVIDENCE_CHARS],
+        "excerpt_hash": excerpt_hash,
+        "hypothesis": hypothesis[:_MAX_EVIDENCE_CHARS],
+        "risk": risk if risk in _RISKS else "unknown",
+        "confidence": confidence if confidence in _CONFIDENCE else "unknown",
+    }
+
+
+def _connect() -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = _ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.parent.is_symlink() or (path.exists() and path.is_symlink()):
+        raise RuntimeError("learning ledger path must not be a symlink")
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    conn = sqlite3.connect(path, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if current > SCHEMA_VERSION:
+            raise RuntimeError(
+                f"learning ledger uses newer schema {current}; this runtime supports {SCHEMA_VERSION}"
+            )
+        # Set the lock wait before journal-mode negotiation: two fresh
+        # processes can initialize the same profile concurrently, and the WAL
+        # pragma itself needs to honor the wait rather than fail immediately.
+        conn.execute("PRAGMA busy_timeout=5000")
+        apply_wal_with_fallback(conn, db_label="learning/ledger.db")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA synchronous=FULL")
+        conn.execute("BEGIN IMMEDIATE")
+        _ensure_schema(conn)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(str(path) + suffix)
+            if sidecar.exists():
+                try:
+                    sidecar.chmod(0o600)
+                except OSError:
+                    pass
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current > SCHEMA_VERSION:
+        raise RuntimeError(
+            f"learning ledger uses newer schema {current}; this runtime supports {SCHEMA_VERSION}"
+        )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS learning_candidates (
+            candidate_id TEXT PRIMARY KEY,
+            subsystem TEXT NOT NULL,
+            action TEXT NOT NULL,
+            status TEXT NOT NULL,
+            payload_fingerprint TEXT NOT NULL,
+            dedup_key TEXT NOT NULL,
+            pending_relpath TEXT,
+            proposal_json TEXT NOT NULL,
+            source_json TEXT NOT NULL,
+            evidence_json TEXT NOT NULL,
+            precondition_json TEXT NOT NULL,
+            revision INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS learning_dedup_latches (
+            dedup_key TEXT PRIMARY KEY,
+            candidate_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(candidate_id) REFERENCES learning_candidates(candidate_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS learning_events (
+            event_id TEXT PRIMARY KEY,
+            candidate_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            event_json TEXT NOT NULL,
+            occurred_at TEXT NOT NULL,
+            FOREIGN KEY(candidate_id) REFERENCES learning_candidates(candidate_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_learning_candidates_dedup
+        ON learning_candidates(dedup_key, status)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_learning_events_candidate
+        ON learning_events(candidate_id, occurred_at, event_id)
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS learning_events_no_update
+        BEFORE UPDATE ON learning_events
+        BEGIN SELECT RAISE(ABORT, 'learning events are immutable'); END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS learning_events_no_delete
+        BEFORE DELETE ON learning_events
+        BEGIN SELECT RAISE(ABORT, 'learning events are immutable'); END
+        """
+    )
+    if current == 0:
+        conn.execute(f"PRAGMA user_version={SCHEMA_VERSION}")
+    conn.commit()
+
+
+@contextmanager
+def _transaction(*, immediate: bool = False) -> Iterator[sqlite3.Connection]:
+    conn = _connect()
+    try:
+        if immediate:
+            conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except Exception:
+            conn.rollback()
+            raise
+        else:
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def _event_row(
+    candidate_id: str,
+    event: str,
+    detail: Optional[Mapping[str, Any]] = None,
+    *,
+    event_id: Optional[str] = None,
+) -> tuple[str, str, str, str, str]:
+    if not event:
+        raise ValueError("event is required")
+    occurred_at = _utc_now()
+    from agent.redact import redact_sensitive_text
+
+    def clean(value: Any, *, depth: int = 0) -> Any:
+        if depth > 6:
+            return "[TRUNCATED]"
+        if isinstance(value, str):
+            return redact_sensitive_text(value, force=True)[:_MAX_EVIDENCE_CHARS]
+        if isinstance(value, Mapping):
+            return {
+                str(key)[:128]: clean(item, depth=depth + 1)
+                for key, item in list(value.items())[:64]
+            }
+        if isinstance(value, (list, tuple)):
+            return [clean(item, depth=depth + 1) for item in list(value)[:64]]
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        return redact_sensitive_text(str(value), force=True)[:_MAX_EVIDENCE_CHARS]
+
+    body = clean(dict(detail or {}))
+    return event_id or uuid.uuid4().hex, candidate_id, event, _bounded_json(body, label="event detail"), occurred_at
+
+
+def create_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    item = dict(candidate)
+    candidate_id = _validate_candidate_id(str(item.get("candidate_id") or "").strip())
+    subsystem = str(item.get("subsystem") or "").strip()
+    action = str(item.get("action") or "").strip()
+    if not subsystem or not action:
+        raise ValueError("subsystem and action are required")
+    now = _utc_now()
+    evidence = sanitize_evidence(item.get("evidence"))
+    proposal = dict(item.get("proposal") or {})
+    source = dict(item.get("source") or {})
+    precondition = dict(item.get("precondition") or {})
+    status = str(item.get("status") or "pending")
+    fingerprint = str(item.get("payload_fingerprint") or "")
+    dedup_key = str(item.get("dedup_key") or fingerprint)
+    pending_relpath = item.get("pending_relpath")
+
+    with _transaction(immediate=True) as conn:
+        conn.execute(
+            """
+            INSERT INTO learning_candidates(
+                candidate_id, subsystem, action, status, payload_fingerprint,
+                dedup_key, pending_relpath, proposal_json, source_json,
+                evidence_json, precondition_json, revision, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+            """,
+            (
+                candidate_id,
+                subsystem,
+                action,
+                status,
+                fingerprint,
+                dedup_key,
+                str(pending_relpath) if pending_relpath else None,
+                _bounded_json(proposal, label="proposal"),
+                _bounded_json(source, label="source"),
+                _bounded_json(evidence, label="evidence"),
+                _bounded_json(precondition, label="precondition"),
+                now,
+                now,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO learning_events(event_id, candidate_id, event, event_json, occurred_at) VALUES (?, ?, ?, ?, ?)",
+            _event_row(candidate_id, "candidate_created", {"status": status}),
+        )
+        if str(source.get("origin") or "") == "background_review":
+            conn.execute(
+                "INSERT INTO learning_dedup_latches(dedup_key, candidate_id, created_at) VALUES (?, ?, ?)",
+                (dedup_key, candidate_id, now),
+            )
+    created = get_candidate(candidate_id)
+    if created is None:  # pragma: no cover - defensive
+        raise RuntimeError("candidate transaction committed but row is unavailable")
+    return created
+
+
+def transition_candidate(
+    candidate_id: str,
+    *,
+    from_status: str,
+    to_status: str,
+    event: str,
+    detail: Optional[Mapping[str, Any]] = None,
+) -> Optional[dict[str, Any]]:
+    candidate_id = _validate_candidate_id(candidate_id)
+    event_row = _event_row(candidate_id, event, detail)
+    now = _utc_now()
+    with _transaction(immediate=True) as conn:
+        if from_status not in _VALID_STATUSES or to_status not in _VALID_STATUSES:
+            raise ValueError(f"invalid status: {from_status} -> {to_status}")
+        if to_status not in _VALID_TRANSITIONS.get(from_status, set()):
+            raise ValueError(f"invalid transition: {from_status} -> {to_status}")
+        cursor = conn.execute(
+            """
+            UPDATE learning_candidates
+            SET status = ?, revision = revision + 1, updated_at = ?
+            WHERE candidate_id = ? AND status = ?
+            """,
+            (to_status, now, candidate_id, from_status),
+        )
+        if cursor.rowcount != 1:
+            return None
+        conn.execute(
+            "INSERT INTO learning_events(event_id, candidate_id, event, event_json, occurred_at) VALUES (?, ?, ?, ?, ?)",
+            event_row,
+        )
+    return get_candidate(candidate_id)
+
+
+def _candidate_from_row(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "candidate_id": row["candidate_id"],
+        "subsystem": row["subsystem"],
+        "action": row["action"],
+        "status": row["status"],
+        "payload_fingerprint": row["payload_fingerprint"],
+        "dedup_key": row["dedup_key"],
+        "pending_relpath": row["pending_relpath"],
+        "proposal": json.loads(row["proposal_json"]),
+        "source": json.loads(row["source_json"]),
+        "evidence": json.loads(row["evidence_json"]),
+        "precondition": json.loads(row["precondition_json"]),
+        "revision": row["revision"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def get_candidate(candidate_id: str) -> Optional[dict[str, Any]]:
+    candidate_id = _validate_candidate_id(candidate_id)
+    if not ledger_exists():
+        return None
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM learning_candidates WHERE candidate_id = ?",
+            (candidate_id,),
+        ).fetchone()
+    return _candidate_from_row(row) if row is not None else None
+
+
+def list_candidates(*, statuses: Optional[Iterable[str]] = None) -> list[dict[str, Any]]:
+    if not ledger_exists():
+        return []
+    params: list[Any] = []
+    where = ""
+    if statuses is not None:
+        wanted = list(statuses)
+        if not wanted:
+            return []
+        where = " WHERE status IN (" + ",".join("?" for _ in wanted) + ")"
+        params.extend(wanted)
+    with _transaction() as conn:
+        rows = conn.execute(
+            "SELECT * FROM learning_candidates" + where + " ORDER BY created_at, candidate_id",
+            params,
+        ).fetchall()
+    return [_candidate_from_row(row) for row in rows]
+
+
+def find_candidate_by_dedup(
+    dedup_key: str,
+    *,
+    statuses: Optional[Iterable[str]] = None,
+) -> Optional[dict[str, Any]]:
+    if not ledger_exists():
+        return None
+    params: list[Any] = [dedup_key]
+    where = "dedup_key = ?"
+    if statuses is not None:
+        wanted = list(statuses)
+        if not wanted:
+            return None
+        where += " AND status IN (" + ",".join("?" for _ in wanted) + ")"
+        params.extend(wanted)
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM learning_candidates WHERE " + where
+            + " ORDER BY updated_at DESC, candidate_id DESC LIMIT 1",
+            params,
+        ).fetchone()
+    return _candidate_from_row(row) if row is not None else None
+
+
+_OUTCOMES = {
+    "verification_succeeded",
+    "verification_failed",
+    "user_corrected",
+    "retry_failed",
+    "rolled_back",
+    "goal_completed",
+    "repeated_error_reduced",
+}
+
+
+def record_outcome(
+    candidate_id: str,
+    outcome: str,
+    *,
+    detail: Optional[Mapping[str, Any]] = None,
+    attempt_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Append an outcome receipt and apply only explicit lifecycle effects."""
+    if outcome not in _OUTCOMES:
+        raise ValueError(f"unsupported learning outcome: {outcome}")
+    candidate_id = _validate_candidate_id(candidate_id)
+    stable_event_id = None
+    if attempt_id:
+        stable_event_id = "outcome-" + hashlib.sha256(
+            f"{candidate_id}\0{outcome}\0{attempt_id}".encode("utf-8")
+        ).hexdigest()
+    event_row = _event_row(
+        candidate_id,
+        f"outcome_{outcome}",
+        detail,
+        event_id=stable_event_id,
+    )
+    with _transaction(immediate=True) as conn:
+        if stable_event_id and conn.execute(
+            "SELECT 1 FROM learning_events WHERE event_id = ?", (stable_event_id,)
+        ).fetchone() is not None:
+            row = conn.execute(
+                "SELECT * FROM learning_candidates WHERE candidate_id = ?", (candidate_id,)
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"unknown learning candidate: {candidate_id}")
+            return _candidate_from_row(row)
+        row = conn.execute(
+            "SELECT status FROM learning_candidates WHERE candidate_id = ?",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown learning candidate: {candidate_id}")
+        current = str(row["status"])
+        new_status = current
+        if outcome == "verification_succeeded" and current == "active":
+            new_status = "validated"
+        elif outcome == "rolled_back" and current in {"active", "validated", "rolling_back"}:
+            new_status = "rolled_back"
+        conn.execute(
+            """
+            UPDATE learning_candidates
+            SET status = ?, revision = revision + 1, updated_at = ?
+            WHERE candidate_id = ?
+            """,
+            (new_status, event_row[4], candidate_id),
+        )
+        conn.execute(
+            "INSERT INTO learning_events(event_id, candidate_id, event, event_json, occurred_at) VALUES (?, ?, ?, ?, ?)",
+            event_row,
+        )
+    candidate = get_candidate(candidate_id)
+    if candidate is None:  # pragma: no cover
+        raise RuntimeError("outcome committed but candidate is unavailable")
+    return candidate
+
+
+def list_events(*, candidate_id: Optional[str] = None, limit: Optional[int] = None) -> list[dict[str, Any]]:
+    if not ledger_exists():
+        return []
+    where = ""
+    params: list[Any] = []
+    if candidate_id is not None:
+        candidate_id = _validate_candidate_id(candidate_id)
+        where = " WHERE candidate_id = ?"
+        params.append(candidate_id)
+    query = (
+        "SELECT event_id, candidate_id, event, event_json, occurred_at "
+        "FROM learning_events" + where + " ORDER BY occurred_at, event_id"
+    )
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(max(0, int(limit)))
+    with _transaction() as conn:
+        rows = conn.execute(query, params).fetchall()
+    return [
+        {
+            "event_id": row["event_id"],
+            "candidate_id": row["candidate_id"],
+            "event": row["event"],
+            "detail": json.loads(row["event_json"]),
+            "occurred_at": row["occurred_at"],
+        }
+        for row in rows
+    ]
+
+
+def purge_candidate_evidence(candidate_id: str, *, reason: str = "retention") -> bool:
+    """Remove persisted excerpts/hypotheses while retaining their digest and labels."""
+    candidate_id = _validate_candidate_id(candidate_id)
+    with _transaction(immediate=True) as conn:
+        row = conn.execute(
+            "SELECT evidence_json FROM learning_candidates WHERE candidate_id = ?", (candidate_id,)
+        ).fetchone()
+        if row is None:
+            return False
+        evidence = json.loads(row["evidence_json"])
+        evidence["excerpt"] = ""
+        evidence["hypothesis"] = ""
+        evidence["status"] = "purged"
+        now = _utc_now()
+        conn.execute(
+            "UPDATE learning_candidates SET evidence_json = ?, revision = revision + 1, updated_at = ? WHERE candidate_id = ?",
+            (_bounded_json(evidence, label="evidence"), now, candidate_id),
+        )
+        conn.execute(
+            "INSERT INTO learning_events(event_id, candidate_id, event, event_json, occurred_at) VALUES (?, ?, ?, ?, ?)",
+            _event_row(candidate_id, "candidate_evidence_purged", {"reason": reason}),
+        )
+    return True
+
+
+def purge_expired_evidence(*, retention_days: int = 30) -> int:
+    """Apply the bounded local evidence-retention policy on explicit audit/review."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max(0, int(retention_days)))
+    purged = 0
+    for candidate in list_candidates():
+        try:
+            created = datetime.fromisoformat(str(candidate["created_at"]).replace("Z", "+00:00"))
+        except Exception:
+            continue
+        evidence = candidate.get("evidence", {})
+        if created < cutoff and (evidence.get("excerpt") or evidence.get("hypothesis")):
+            purged += int(purge_candidate_evidence(candidate["candidate_id"], reason="retention_expired"))
+    return purged
+
+
+def update_candidate_proposal_fields(
+    candidate_id: str,
+    fields: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Merge additional identity fields into a candidate's proposal JSON.
+
+    Used by evaluation to bind skill_name and target_file into the ledger so
+    rollback can verify snapshot identity after the pending JSON is deleted.
+    """
+    candidate_id = _validate_candidate_id(candidate_id)
+    now = _utc_now()
+    with _transaction(immediate=True) as conn:
+        row = conn.execute(
+            "SELECT proposal_json FROM learning_candidates WHERE candidate_id = ?",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        proposal = json.loads(str(row["proposal_json"]))
+        proposal.update(fields)
+        conn.execute(
+            """
+            UPDATE learning_candidates
+            SET proposal_json = ?, revision = revision + 1, updated_at = ?
+            WHERE candidate_id = ?
+            """,
+            (_bounded_json(proposal, label="proposal"), now, candidate_id),
+        )
+    return get_candidate(candidate_id)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -839,9 +839,20 @@ def _normalize_skill_description(frontmatter: Dict[str, Any]) -> str:
     return str(raw_desc).strip().strip("'\"") if raw_desc else ""
 
 
+def _normalize_skill_routing(frontmatter: Dict[str, Any]) -> str:
+    """Normalize the optional short routing hint from frontmatter."""
+    raw_routing = frontmatter.get("routing", "")
+    return str(raw_routing).strip().strip("'\"") if raw_routing else ""
+
+
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a system-prompt-length description from parsed frontmatter."""
-    desc = _normalize_skill_description(frontmatter)
+    """Extract the short routing hint used in the system-prompt skill index.
+
+    ``routing`` is preferred when present so a detailed human-facing
+    ``description`` can remain intact without consuming prompt budget.
+    Legacy skills continue to use ``description`` and are truncated as before.
+    """
+    desc = _normalize_skill_routing(frontmatter) or _normalize_skill_description(frontmatter)
     if not desc:
         return ""
     if len(desc) > SKILL_PROMPT_DESC_LIMIT:
@@ -850,8 +861,8 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 
 
 def is_skill_description_truncated_for_prompt(frontmatter: Dict[str, Any]) -> bool:
-    """True when the description will be truncated in the system prompt skill index."""
-    desc = _normalize_skill_description(frontmatter)
+    """True when the effective routing hint is truncated in the system prompt."""
+    desc = _normalize_skill_routing(frontmatter) or _normalize_skill_description(frontmatter)
     return len(desc) > SKILL_PROMPT_DESC_LIMIT
 
 

--- a/agent/trace_compiler.py
+++ b/agent/trace_compiler.py
@@ -1,0 +1,150 @@
+"""Human-reviewed proposals for compiling stable deterministic traces.
+
+The compiler never writes a script or creates a cron job.  It only produces a
+bounded proposal after repeated successful evidence across distinct sessions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+_CONTROL = set(";&|><`$\n\r")
+_SECRET_FLAGS = {
+    "--api-key",
+    "--apikey",
+    "--password",
+    "--token",
+    "--secret",
+    "-p",
+}
+_SAFE_KINDS = {"test", "lint", "typecheck", "build"}
+_SAFE_PACKAGE_TASKS = {"test", "check", "lint", "typecheck", "build"}
+
+
+def _safe_argv(command: str) -> list[str] | None:
+    if not command or any(char in command for char in _CONTROL):
+        return None
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        return None
+    if not argv or len(argv) > 40:
+        return None
+    lowered = [token.lower() for token in argv]
+    if any(token in _SECRET_FLAGS for token in lowered):
+        return None
+    if any(any(marker in token for marker in ("api_key=", "token=", "password=", "secret=")) for token in lowered):
+        return None
+    executable = lowered[0]
+    if executable in {"npm", "pnpm", "yarn"}:
+        task = next((token for token in lowered[1:] if not token.startswith("-")), "")
+        if task == "run":
+            index = lowered.index("run") + 1
+            task = lowered[index] if index < len(lowered) else ""
+        if task not in _SAFE_PACKAGE_TASKS:
+            return None
+    elif executable in {"pytest", "py.test", "scripts/run_tests.sh"}:
+        pass
+    elif executable in {"python", "python3"}:
+        if len(lowered) < 3 or lowered[1:3] not in (["-m", "pytest"], ["-m", "ruff"]):
+            return None
+    elif executable == "uv":
+        if "pytest" not in lowered and "ruff" not in lowered:
+            return None
+    else:
+        return None
+    return argv
+
+
+def _script_preview(argv: list[str]) -> str:
+    return (
+        "#!/usr/bin/env python3\n"
+        "import subprocess\n\n"
+        f"raise SystemExit(subprocess.run({argv!r}, check=False).returncode)\n"
+    )
+
+
+def propose_compilations(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    min_successes: int = 3,
+    min_sessions: int = 3,
+) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[Mapping[str, Any]]] = defaultdict(list)
+    for event in events:
+        root = str(event.get("root") or "")
+        command = str(event.get("canonical_command") or "")
+        if root and command:
+            groups[(root, command)].append(event)
+
+    proposals: list[dict[str, Any]] = []
+    for (root, command), records in sorted(groups.items()):
+        argv = _safe_argv(command)
+        if argv is None:
+            continue
+        if any(str(record.get("status")) != "passed" for record in records):
+            continue
+        successes = len(records)
+        sessions = {str(record.get("session_id") or "") for record in records}
+        if successes < min_successes or len(sessions) < min_sessions:
+            continue
+        digest = hashlib.sha256(f"{root}\0{command}".encode("utf-8")).hexdigest()[:16]
+        summaries = {str(record.get("output_summary") or "") for record in records}
+        kinds = {str(record.get("kind") or "") for record in records}
+        stable_output = len(summaries) == 1
+        proposals.append(
+            {
+                "id": f"trace-{digest}",
+                "root": root,
+                "canonical_command": command,
+                "argv": argv,
+                "successes": successes,
+                "distinct_sessions": len(sessions),
+                "stable_output": stable_output,
+                "script_preview": _script_preview(argv),
+                "user_review_required": True,
+                "no_agent_eligible": stable_output and len(kinds) == 1 and kinds <= _SAFE_KINDS,
+                "schedule": None,
+                "next_action": "Review the script, choose a destination and schedule, then create it through the existing script/cron approval path.",
+            }
+        )
+    return proposals
+
+
+def discover_compilation_proposals() -> list[dict[str, Any]]:
+    """Project stable proposals from the profile's verification evidence DB."""
+    try:
+        from agent.verification_evidence import _connect
+
+        conn = _connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT session_id, root, canonical_command, command, kind, status, output_summary
+                FROM verification_events
+                ORDER BY id DESC
+                LIMIT 1000
+                """
+            ).fetchall()
+            events = [dict(row) for row in rows]
+        finally:
+            conn.close()
+    except Exception:
+        return []
+    return propose_compilations(events)
+
+
+def format_compilation_proposals() -> str:
+    proposals = discover_compilation_proposals()
+    if not proposals:
+        return "Trace compilation: no workflow has enough stable successful receipts yet."
+    lines = [f"Trace compilation: {len(proposals)} human-review proposal(s)"]
+    for proposal in proposals:
+        lines.append(
+            f"- {proposal['id']}: {proposal['canonical_command']} "
+            f"({proposal['successes']} successes across {proposal['distinct_sessions']} sessions; no schedule inferred)"
+        )
+    return "\n".join(lines)

--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -465,6 +465,7 @@ def record_terminal_result(
     session_id: str | None,
     exit_code: int,
     output: str = "",
+    candidate_id: str | None = None,
 ) -> Optional[dict[str, Any]]:
     """Record a foreground terminal result when it is verification evidence."""
 
@@ -520,7 +521,39 @@ def record_terminal_result(
             _prune_old_events(conn, session_id=evidence.session_id, root=evidence.root)
             conn.commit()
 
-    return {"id": event_id, **evidence.__dict__, "created_at": created_at}
+    result = {
+        "id": event_id,
+        **evidence.__dict__,
+        "created_at": created_at,
+        "candidate_outcome_recorded": False,
+    }
+    # Closed-loop receipts require an explicit candidate identity and durable
+    # outcome linkage. Session coincidence is not causal linkage: one session
+    # can contain many unrelated memory, skill, and coding tasks.
+    if not candidate_id:
+        return result
+    from agent import learning_ledger
+
+    if not learning_ledger.ledger_exists():
+        raise RuntimeError("learning ledger is unavailable for candidate verification")
+    outcome = "verification_succeeded" if evidence.status == "passed" else "verification_failed"
+    candidate = learning_ledger.get_candidate(candidate_id)
+    if candidate is None or candidate.get("status") != "active":
+        raise RuntimeError("learning candidate is no longer active")
+    recorded = learning_ledger.record_outcome(
+        candidate_id,
+        outcome,
+        detail={
+            "verification_event_id": event_id,
+            "kind": evidence.kind,
+            "scope": evidence.scope,
+        },
+        attempt_id=f"verification:{event_id}",
+    )
+    if recorded is None:
+        raise RuntimeError("learning candidate outcome was not persisted")
+    result["candidate_outcome_recorded"] = True
+    return result
 
 
 def mark_workspace_edited(

--- a/apps/desktop/src/app/starmap/index.test.tsx
+++ b/apps/desktop/src/app/starmap/index.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { StarmapGraph } from '../../types/hermes'
+
+import { LearningCandidates } from './learning-candidates'
+
+const ledgerOnlyGraph: StarmapGraph = {
+  nodes: [],
+  edges: [],
+  clusters: [],
+  memory: [],
+  stats: {},
+  candidates: [
+    {
+      id: 'candidate-1',
+      subsystem: 'skills',
+      action: 'patch',
+      status: 'active',
+      summary: 'Verified retry procedure',
+      risk: 'low',
+      hypothesis: 'Fewer repeat failures',
+      source: {},
+      outcomes: []
+    }
+  ]
+}
+
+describe('LearningCandidates', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders a ledger-only candidate instead of a blank journey', () => {
+    render(<LearningCandidates graph={ledgerOnlyGraph} />)
+
+    expect(screen.getByRole('region', { name: 'Learning candidates' })).toBeTruthy()
+    expect(screen.getByText('Verified retry procedure')).toBeTruthy()
+    expect(screen.getByText('active')).toBeTruthy()
+    expect(screen.getByText('skills · patch · risk low')).toBeTruthy()
+  })
+
+  it('renders nothing when there are no candidates', () => {
+    const { container } = render(
+      <LearningCandidates graph={{ ...ledgerOnlyGraph, candidates: [] }} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/starmap/index.test.tsx
+++ b/apps/desktop/src/app/starmap/index.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { StarmapGraph } from '../../types/hermes'
 
 import { LearningCandidates } from './learning-candidates'
+import { StarmapView } from './index'
 
 const ledgerOnlyGraph: StarmapGraph = {
   nodes: [],
@@ -27,6 +28,49 @@ const ledgerOnlyGraph: StarmapGraph = {
   ]
 }
 
+// Mock the store module so StarmapView composition tests don't pull in the
+// @/-aliased dependency chain (only resolvable under the desktop vite config).
+// The factory is hoisted, so atoms are created inside and re-imported below.
+vi.mock('../../store/starmap', async () => {
+  const { atom } = await import('nanostores')
+  return {
+    $starmapGraph: atom(null),
+    $starmapLoading: atom(false),
+    $starmapError: atom(null),
+    loadStarmapGraph: vi.fn(),
+  }
+})
+
+// Import the mocked module to control atom values per test.
+import { $starmapGraph as $mockGraph, $starmapLoading as $mockLoading, $starmapError as $mockError } from '../../store/starmap'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      starmap: {
+        close: 'Close',
+        loadFailed: 'Load failed',
+        loading: 'Loading',
+        emptyDesc: 'Nothing learned yet',
+        emptyTitle: 'Empty journey',
+      }
+    }
+  })
+}))
+
+vi.mock('@/components/page-loader', () => ({
+  PageLoader: () => <div data-testid="page-loader">Loading...</div>,
+}))
+
+vi.mock('../overlays/panel', () => ({
+  Panel: ({ children }: { children: React.ReactNode }) => <div data-testid="panel">{children}</div>,
+  PanelEmpty: ({ title }: { title: string }) => <div data-testid="panel-empty">{title}</div>,
+}))
+
+vi.mock('./star-map', () => ({
+  StarMap: () => <div data-testid="star-map" />,
+}))
+
 describe('LearningCandidates', () => {
   afterEach(() => {
     cleanup()
@@ -46,5 +90,26 @@ describe('LearningCandidates', () => {
       <LearningCandidates graph={{ ...ledgerOnlyGraph, candidates: [] }} />
     )
     expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('StarmapView composition', () => {
+  afterEach(() => {
+    cleanup()
+    $mockGraph.set(null)
+    $mockLoading.set(false)
+    $mockError.set(null)
+  })
+
+  it('mounts LearningCandidates and does not show the empty state for a ledger-only graph', () => {
+    $mockGraph.set(ledgerOnlyGraph)
+
+    render(<StarmapView onClose={() => undefined} />)
+
+    // The candidate section is actually mounted (not dropped from composition).
+    expect(screen.getByRole('region', { name: 'Learning candidates' })).toBeTruthy()
+    expect(screen.getByText('Verified retry procedure')).toBeTruthy()
+    // The empty-state gate treats ledger-only content as real content.
+    expect(screen.queryByTestId('panel-empty')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/starmap/index.tsx
+++ b/apps/desktop/src/app/starmap/index.tsx
@@ -8,7 +8,9 @@ import type { StarmapGraph } from '@/types/hermes'
 
 import { Panel, PanelEmpty } from '../overlays/panel'
 
+import { LearningCandidates } from './learning-candidates'
 import { StarMap } from './star-map'
+import { hasStarmapContent } from './starmap-content'
 
 // Star map overlay: a top-down map of what Hermes has learned for a profile,
 // over a radial time axis. Data is fetched on demand into the $starmap* atoms;
@@ -43,15 +45,20 @@ export function StarmapView({ onClose }: { onClose: () => void }) {
         <PanelEmpty description={error} icon="warning" title={t.starmap.loadFailed} />
       ) : !shown && loading ? (
         <PageLoader aria-label={t.starmap.loading} className="min-h-0 flex-1" />
-      ) : shown && shown.nodes.length === 0 && !imported ? (
+      ) : shown && !hasStarmapContent(shown) && !imported ? (
         <PanelEmpty description={t.starmap.emptyDesc} icon="lightbulb" title={t.starmap.emptyTitle} />
       ) : shown ? (
-        <StarMap
-          graph={shown}
-          imported={imported !== null}
-          onImport={setImported}
-          onResetMap={() => setImported(null)}
-        />
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!imported && <LearningCandidates graph={shown} />}
+          {shown.nodes.length > 0 ? (
+            <StarMap
+              graph={shown}
+              imported={imported !== null}
+              onImport={setImported}
+              onResetMap={() => setImported(null)}
+            />
+          ) : null}
+        </div>
       ) : null}
     </Panel>
   )

--- a/apps/desktop/src/app/starmap/learning-candidates.tsx
+++ b/apps/desktop/src/app/starmap/learning-candidates.tsx
@@ -1,0 +1,32 @@
+import type { StarmapGraph } from '@/types/hermes'
+
+export function LearningCandidates({ graph }: { graph: StarmapGraph }) {
+  const candidates = graph.candidates ?? []
+
+  if (candidates.length === 0) {
+    return null
+  }
+
+  return (
+    <section aria-label="Learning candidates" className="max-h-48 shrink-0 overflow-y-auto border-b border-border/60 bg-background/95 p-3">
+      <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Evidence ledger · {candidates.length} candidate{candidates.length === 1 ? '' : 's'}
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+        {candidates.map(candidate => (
+          <article className="rounded-md border border-border/70 bg-muted/30 p-2" key={candidate.id}>
+            <div className="flex items-center justify-between gap-2 text-sm font-medium">
+              <span className="truncate">{candidate.summary}</span>
+              <span className="shrink-0 rounded bg-background px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                {candidate.status}
+              </span>
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {candidate.subsystem} · {candidate.action} · risk {candidate.risk}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/desktop/src/app/starmap/starmap-content.test.ts
+++ b/apps/desktop/src/app/starmap/starmap-content.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasStarmapContent } from './starmap-content'
+
+describe('hasStarmapContent', () => {
+  it('treats ledger-only candidates as visible learning content', () => {
+    expect(hasStarmapContent({ candidates: [{ id: 'candidate' }], nodes: [] })).toBe(true)
+  })
+
+  it('keeps a genuinely empty projection empty', () => {
+    expect(hasStarmapContent({ candidates: [], nodes: [] })).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/starmap/starmap-content.ts
+++ b/apps/desktop/src/app/starmap/starmap-content.ts
@@ -1,0 +1,8 @@
+interface StarmapContentShape {
+  candidates?: readonly unknown[]
+  nodes: readonly unknown[]
+}
+
+export function hasStarmapContent(graph: StarmapContentShape) {
+  return graph.nodes.length > 0 || (graph.candidates?.length ?? 0) > 0
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -675,11 +675,31 @@ export interface StarmapMemoryCard {
   body: string
 }
 
+/** Read-only projection of one evidence-ledger candidate. */
+export interface StarmapLearningCandidate {
+  id: string
+  subsystem: string
+  action: string
+  status: string
+  summary: string
+  risk: string
+  hypothesis: string
+  source: Record<string, unknown>
+  createdAt?: null | string
+  updatedAt?: null | string
+  outcomes: Array<{
+    outcome: string
+    detail: Record<string, unknown>
+    timestamp?: null | string
+  }>
+}
+
 export interface StarmapGraph {
   nodes: StarmapNode[]
   edges: StarmapEdge[]
   clusters: StarmapCluster[]
   memory: StarmapMemoryCard[]
+  candidates?: StarmapLearningCandidate[]
   stats: Record<string, unknown>
 }
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3434,15 +3434,20 @@ class GatewaySlashCommandsMixin:
         Gate changes persist to config.yaml and evict the cached agent so the
         new setting takes effect on the next message.
         """
-        from gateway.run import _hermes_home
+        from hermes_constants import get_hermes_home
         from hermes_cli.write_approval_commands import handle_pending_subcommand
         from tools import write_approval as wa
         from tools.memory_tool import load_on_disk_store
 
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
+        if not self._resume_caller_is_admin(event.source):
+            return (
+                "Memory learning review is profile-global and requires an explicitly "
+                "configured slash-command admin. Use the local CLI or configure an admin ID."
+            )
         session_key = self._session_key_for_source(event.source)
-        config_path = _hermes_home / "config.yaml"
+        config_path = get_hermes_home() / "config.yaml"
 
         def _set_approval(enabled: bool):
             # Write-back round-trip: raw read is correct (merged defaults must
@@ -3483,18 +3488,27 @@ class GatewaySlashCommandsMixin:
         the write-approval ``diff <id>``; the CLI also has an unrelated
         ``hermes skills diff <name>`` that diffs a bundled skill vs stock.)
         """
-        from gateway.run import _hermes_home
+        from hermes_constants import get_hermes_home
         from hermes_cli.write_approval_commands import handle_pending_subcommand
         from tools import write_approval as wa
 
         raw_args = event.get_command_args().strip()
         args = raw_args.split() if raw_args else []
+        if not self._resume_caller_is_admin(event.source):
+            return (
+                "Skill learning review is profile-global and requires an explicitly "
+                "configured slash-command admin. Use the local CLI or configure an admin ID."
+            )
         session_key = self._session_key_for_source(event.source)
-        config_path = _hermes_home / "config.yaml"
+        config_path = get_hermes_home() / "config.yaml"
 
         gate_on = wa.write_approval_enabled(wa.SKILLS)
         wants_toggle = bool(args) and args[0].lower() in {"approval", "mode"}
-        if not gate_on and not wants_toggle and wa.pending_count(wa.SKILLS) == 0:
+        read_only_learning = bool(args) and args[0].lower() in {
+            "history", "ledger", "audit", "compile", "compilations", "eval", "evaluate",
+            "rollback",
+        }
+        if not gate_on and not wants_toggle and not read_only_learning and wa.pending_count(wa.SKILLS) == 0:
             return ("Skill write approval is off (skills.write_approval). "
                     "Enable it with /skills approval on, then review staged "
                     "writes here with /skills pending.")

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1772,7 +1772,10 @@ class CLICommandsMixin:
         parts = cmd.strip().split()
         args = parts[1:] if len(parts) > 1 else []
         if args and args[0].lower() in {"pending", "approve", "apply", "reject",
-                                        "deny", "drop", "diff", "approval", "mode"}:
+                                        "deny", "drop", "diff", "approval", "mode",
+                                        "history", "ledger", "audit", "compile",
+                                        "compilations", "eval", "evaluate", "rollback",
+                                        "reconcile"}:
             from hermes_cli.write_approval_commands import handle_pending_subcommand
             from tools import write_approval as wa
             out = handle_pending_subcommand(

--- a/hermes_cli/context_cmd.py
+++ b/hermes_cli/context_cmd.py
@@ -1,0 +1,98 @@
+"""Deterministic context-health and workflow-compilation CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shlex
+import subprocess
+
+
+def build_parser(subparsers) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(
+        "context",
+        help="Audit durable context and inspect deterministic workflow proposals",
+    )
+    actions = parser.add_subparsers(dest="context_action")
+    actions.add_parser("audit", help="Run the deterministic Context Health Audit")
+    actions.add_parser(
+        "compile-proposals",
+        aliases=["compile"],
+        help="Show human-reviewed stable trace-to-script proposals",
+    )
+    verify = actions.add_parser(
+        "verify",
+        help="Run an allowlisted deterministic check linked to one learning candidate",
+    )
+    verify.add_argument("candidate_id")
+    verify.add_argument("verify_argv", nargs=argparse.REMAINDER)
+    return parser
+
+
+def cmd_context(args) -> int:
+    action = getattr(args, "context_action", None)
+    if action == "audit":
+        from agent.context_health import format_context_audit
+
+        print(format_context_audit())
+        return 0
+    if action in {"compile-proposals", "compile"}:
+        from agent.trace_compiler import format_compilation_proposals
+
+        print(format_compilation_proposals())
+        return 0
+    if action == "verify":
+        from agent import learning_ledger
+        from agent.trace_compiler import _safe_argv
+        from agent.verification_evidence import record_terminal_result
+
+        candidate_id = str(args.candidate_id)
+        candidate = learning_ledger.get_candidate(candidate_id)
+        if candidate is None or candidate.get("status") != "active":
+            print("Verification requires a known active learning candidate.")
+            return 2
+        raw = list(args.verify_argv or [])
+        if raw and raw[0] == "--":
+            raw = raw[1:]
+        command = shlex.join(raw)
+        argv = _safe_argv(command)
+        if argv is None:
+            print("Verification command is not an allowlisted deterministic check.")
+            return 2
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        output = (completed.stdout or "") + (completed.stderr or "")
+        try:
+            receipt = record_terminal_result(
+                command=command,
+                cwd=Path.cwd(),
+                session_id=f"context-verify:{candidate_id}",
+                exit_code=completed.returncode,
+                output=output,
+                candidate_id=candidate_id,
+            )
+        except Exception:
+            if output:
+                print(output[-4000:].rstrip())
+            print("Verification ran, but its candidate outcome could not be persisted.")
+            return 2
+        if output:
+            print(output[-4000:].rstrip())
+        if receipt is None:
+            print("Command ran but is not a recognized project verification command; no learning outcome was recorded.")
+            return 2
+        if not receipt.get("candidate_outcome_recorded"):
+            print("Verification ran, but its candidate outcome could not be persisted.")
+            return 2
+        print(
+            f"Candidate {candidate_id} verification "
+            f"{'passed' if completed.returncode == 0 else 'failed'} (exit {completed.returncode})."
+        )
+        return completed.returncode
+    print("Usage: hermes context <audit|compile-proposals|verify>")
+    return 2

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11482,6 +11482,13 @@ def main():
     project_parser.set_defaults(func=cmd_project)
 
     # =========================================================================
+    # context command — deterministic health audit + compilation proposals
+    from hermes_cli.context_cmd import build_parser as _build_context_parser, cmd_context
+
+    context_parser = _build_context_parser(subparsers)
+    context_parser.set_defaults(func=cmd_context)
+
+    # =========================================================================
     # hooks command — shell-hook inspection and management
     # =========================================================================
     # hooks command  (parser built in hermes_cli/subcommands/hooks.py)

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -31,6 +31,8 @@ def _fmt_state(subsystem: str) -> str:
 # ---------------------------------------------------------------------------
 
 def _fmt_pending_list(subsystem: str) -> str:
+    from agent import learning_ledger
+
     records = wa.list_pending(subsystem)
     if not records:
         return f"No pending {subsystem} writes."
@@ -38,12 +40,47 @@ def _fmt_pending_list(subsystem: str) -> str:
     for r in records:
         origin = r.get("origin", "foreground")
         tag = " [auto]" if origin == "background_review" else ""
-        lines.append(f"  {r['id']}{tag}  {r.get('summary', '')}")
+        candidate = learning_ledger.get_candidate(str(r.get("candidate_id") or r["id"]))
+        risk = (candidate or {}).get("evidence", {}).get("risk", "unknown")
+        lines.append(f"  {r['id']}{tag}  {r.get('summary', '')}  risk={risk}")
+        if candidate:
+            evidence = candidate.get("evidence", {})
+            excerpt = str(evidence.get("excerpt") or "")[:200]
+            hypothesis = str(evidence.get("hypothesis") or "")[:200]
+            if excerpt:
+                lines.append(f"    Evidence: {excerpt}")
+            if hypothesis:
+                lines.append(f"    Hypothesis: {hypothesis}")
     where = "/{s} approve <id>".format(s=subsystem)
     lines.append("")
     lines.append(f"Apply: {where}   Reject: /{subsystem} reject <id>")
     if subsystem == wa.SKILLS:
         lines.append("Review full diff: /skills diff <id>")
+    return "\n".join(lines)
+
+
+def _fmt_history(subsystem: str) -> str:
+    from agent import learning_ledger
+
+    candidates = [
+        item for item in learning_ledger.list_candidates()
+        if item.get("subsystem") == subsystem
+    ]
+    if not candidates:
+        return f"No {subsystem} learning history."
+    lines = [f"{subsystem.capitalize()} learning history ({len(candidates)}):"]
+    for candidate in candidates:
+        reason = ""
+        events = learning_ledger.list_events(candidate_id=candidate["candidate_id"])
+        for event in reversed(events):
+            if event["event"] in {"candidate_rejected", "candidate_rolled_back"}:
+                reason = str(event.get("detail", {}).get("reason") or "")
+                break
+        suffix = f" — {reason}" if reason else ""
+        lines.append(
+            f"  {candidate['candidate_id']}  {candidate['status']}  "
+            f"{candidate.get('proposal', {}).get('summary', '')}{suffix}"
+        )
     return "\n".join(lines)
 
 
@@ -84,6 +121,28 @@ def handle_pending_subcommand(
     if sub == "pending":
         return _fmt_pending_list(subsystem)
 
+    if sub in {"history", "ledger"}:
+        return _fmt_history(subsystem)
+
+    if sub == "audit":
+        from agent.context_health import format_context_audit
+
+        return format_context_audit()
+
+    if sub in {"compile", "compilations"}:
+        from agent.trace_compiler import format_compilation_proposals
+
+        return format_compilation_proposals()
+
+    if sub == "reconcile":
+        return _reconcile(subsystem, rest)
+
+    if sub in {"eval", "evaluate"}:
+        return _evaluate_skill(rest) if subsystem == wa.SKILLS else _evaluate_memory(rest, memory_store)
+
+    if sub == "rollback":
+        return _rollback_skill(rest) if subsystem == wa.SKILLS else _rollback_memory(rest, memory_store)
+
     if sub in {"approve", "apply"}:
         return _approve(subsystem, rest, memory_store)
 
@@ -122,13 +181,72 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
             return f"No pending {subsystem} write with id '{target}'."
         targets = [rec]
 
+    from agent import learning_ledger
+
     applied, failed = 0, []
     for rec in targets:
-        ok, msg = _apply_one(subsystem, rec, memory_store)
+        if target.lower() == "all":
+            candidate = learning_ledger.get_candidate(str(rec.get("candidate_id") or rec["id"]))
+            if (candidate or {}).get("evidence", {}).get("risk") == "high":
+                failed.append(f"{rec['id']}: high-risk candidate requires explicit approval by id")
+                continue
+        claim = wa.claim_pending(subsystem, rec["id"])
+        if claim is None:
+            failed.append(f"{rec['id']}: already claimed or no longer pending")
+            continue
+        candidate = wa.ensure_candidate_for_record(claim)
+        if candidate is None:
+            wa.release_claim(subsystem, claim, restore=True)
+            failed.append(f"{rec['id']}: learning ledger unavailable")
+            continue
+        reviewed_ok, reviewed_error = wa.verify_reviewed_payload(
+            subsystem, claim, candidate, memory_store=memory_store
+        )
+        if not reviewed_ok:
+            wa.release_claim(subsystem, claim, restore=True)
+            failed.append(f"{rec['id']}: stale review — {reviewed_error}")
+            continue
+        started = learning_ledger.transition_candidate(
+            rec["id"],
+            from_status="pending",
+            to_status="applying",
+            event="candidate_apply_started",
+            detail={"claim_id": claim.get("_claim_id")},
+        )
+        if started is None:
+            wa.release_claim(subsystem, claim, restore=True)
+            failed.append(f"{rec['id']}: candidate is no longer pending")
+            continue
+
+        try:
+            ok, msg = _apply_one(subsystem, claim, memory_store)
+        except Exception:
+            # The canonical mutation handler may have completed its durable
+            # side effect before losing its result.  Replaying automatically
+            # would violate exactly-once semantics, so preserve both the
+            # applying lifecycle and claim for explicit reconciliation.
+            failed.append(f"{rec['id']}: apply result is uncertain; needs reconciliation")
+            continue
         if ok:
-            wa.discard_pending(subsystem, rec["id"])
-            applied += 1
+            terminal = learning_ledger.transition_candidate(
+                rec["id"],
+                from_status="applying",
+                to_status="active",
+                event="candidate_activated",
+            )
+            if terminal is not None and wa.release_claim(subsystem, claim, restore=False):
+                applied += 1
+            else:
+                failed.append(f"{rec['id']}: applied but lifecycle finalization needs reconciliation")
         else:
+            learning_ledger.transition_candidate(
+                rec["id"],
+                from_status="applying",
+                to_status="pending",
+                event="candidate_apply_failed",
+                detail={"error": msg},
+            )
+            wa.release_claim(subsystem, claim, restore=True)
             failed.append(f"{rec['id']}: {msg}")
 
     out = [f"Approved {applied} {subsystem} write(s)."]
@@ -140,34 +258,139 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
 
 def _apply_one(subsystem: str, rec, memory_store):
     payload = rec.get("payload", {})
-    try:
-        if subsystem == wa.MEMORY:
-            if memory_store is None:
-                return False, "memory store unavailable"
-            from tools.memory_tool import apply_memory_pending
-            result = apply_memory_pending(payload, memory_store)
-            return bool(result.get("success")), result.get("error", "")
-        else:
-            from tools.skill_manager_tool import apply_skill_pending
-            result = json.loads(apply_skill_pending(payload))
-            return bool(result.get("success")), result.get("error", "")
-    except Exception as e:
-        return False, str(e)
+    if subsystem == wa.MEMORY:
+        if memory_store is None:
+            return False, "memory store unavailable"
+        from tools.memory_tool import apply_memory_pending
+        result = apply_memory_pending(payload, memory_store)
+        return bool(result.get("success")), result.get("error", "")
+    from tools.skill_manager_tool import apply_skill_pending
+    result = json.loads(apply_skill_pending(payload))
+    return bool(result.get("success")), result.get("error", "")
 
 
 def _reject(subsystem: str, rest: List[str]) -> str:
     target, err = _resolve_one(subsystem, rest)
     if err or target is None:
         return err or f"Usage: /{subsystem} reject <id>"
+    from agent import learning_ledger
+
+    reason = " ".join(rest[1:]).strip()
+    records = wa.list_pending(subsystem)
     if target.lower() == "all":
-        n = 0
-        for rec in wa.list_pending(subsystem):
-            if wa.discard_pending(subsystem, rec["id"]):
-                n += 1
-        return f"Rejected {n} pending {subsystem} write(s)."
-    if wa.discard_pending(subsystem, target):
+        targets = records
+    else:
+        record = wa.get_pending(subsystem, target)
+        if record is None:
+            return f"No pending {subsystem} write with id '{target}'."
+        targets = [record]
+
+    rejected = 0
+    for record in targets:
+        claim = wa.claim_pending(subsystem, record["id"])
+        if claim is None:
+            continue
+        candidate = wa.ensure_candidate_for_record(claim)
+        if candidate is None:
+            # A crash may leave exact replay JSON durable before its ledger row.
+            # Explicit human rejection must still be able to discard that
+            # non-executable orphan instead of restoring it forever.
+            if wa.release_claim(subsystem, claim, restore=False):
+                rejected += 1
+            continue
+        transitioned = None
+        transitioned = learning_ledger.transition_candidate(
+            record["id"],
+            from_status="pending",
+            to_status="rejected",
+            event="candidate_rejected",
+            detail={"reason": reason},
+        )
+        if transitioned is not None and not learning_ledger.purge_candidate_evidence(
+            record["id"], reason="candidate_rejected"
+        ):
+            transitioned = None
+        if transitioned is not None and wa.release_claim(subsystem, claim, restore=False):
+            rejected += 1
+        else:
+            wa.release_claim(subsystem, claim, restore=True)
+
+    if target.lower() == "all":
+        return f"Rejected {rejected} pending {subsystem} write(s)."
+    if rejected:
         return f"Rejected pending {subsystem} write '{target}'."
-    return f"No pending {subsystem} write with id '{target}'."
+    return f"Could not reject pending {subsystem} write '{target}'."
+
+
+def _reconcile(subsystem: str, rest: List[str]) -> str:
+    """Expose interrupted claims; resolution is always an explicit human choice."""
+    from agent import learning_ledger
+
+    claims = wa.list_claims(subsystem)
+    if not rest:
+        if not claims:
+            return f"No interrupted {subsystem} claims."
+        lines = [f"Interrupted {subsystem} claims ({len(claims)}):"]
+        for claim in claims:
+            candidate = learning_ledger.get_candidate(str(claim.get("candidate_id") or claim["id"]))
+            lines.append(
+                f"  {claim['id']}  status={(candidate or {}).get('status', 'unknown')}  "
+                f"age={int(claim.get('_claim_age_seconds', 0))}s"
+            )
+        lines.append(
+            f"Resolve explicitly: /{subsystem} reconcile <id> <restore|mark-applied|discard-claim>"
+        )
+        return "\n".join(lines)
+    if len(rest) != 2 or rest[1] not in {"restore", "mark-applied", "discard-claim"}:
+        return f"Usage: /{subsystem} reconcile <id> <restore|mark-applied|discard-claim>"
+    pending_id, resolution = rest
+    claim = next((item for item in claims if str(item.get("id")) == pending_id), None)
+    if claim is None:
+        return f"No interrupted {subsystem} claim with id '{pending_id}'."
+    candidate = learning_ledger.get_candidate(str(claim.get("candidate_id") or pending_id))
+    if candidate is None:
+        return f"Claim '{pending_id}' has no matching candidate; inspect it manually."
+    if resolution == "discard-claim":
+        if candidate.get("status") not in {"active", "rejected", "rolled_back", "validated"}:
+            return f"Claim '{pending_id}' is not terminal; choose restore or mark-applied instead."
+        return (
+            f"Discarded finalized claim '{pending_id}'."
+            if wa.release_claim(subsystem, claim, restore=False)
+            else f"Could not discard finalized claim '{pending_id}'."
+        )
+    if candidate.get("status") not in {"pending", "applying", "active"}:
+        return f"Claim '{pending_id}' is not pending/applying/active; inspect it manually."
+    if resolution == "restore":
+        if candidate.get("status") == "active":
+            return f"Claim '{pending_id}' is already active and cannot be restored to pending."
+        transitioned = candidate
+        if candidate.get("status") == "applying":
+            transitioned = learning_ledger.transition_candidate(
+                pending_id,
+                from_status="applying",
+                to_status="pending",
+                event="candidate_reconciled_pending",
+                detail={"resolution": "human_confirmed_not_applied"},
+            )
+        released = transitioned is not None and wa.release_claim(subsystem, claim, restore=True)
+        return (
+            f"Restored '{pending_id}' to pending review."
+            if released else f"Could not restore interrupted claim '{pending_id}'."
+        )
+    transitioned = candidate
+    if candidate.get("status") in {"pending", "applying"}:
+        transitioned = learning_ledger.transition_candidate(
+            pending_id,
+            from_status=str(candidate["status"]),
+            to_status="active",
+            event="candidate_reconciled_active",
+            detail={"resolution": "human_confirmed_applied"},
+        )
+    released = transitioned is not None and wa.release_claim(subsystem, claim, restore=False)
+    return (
+        f"Marked '{pending_id}' applied and removed its claim."
+        if released else f"Could not finalize interrupted claim '{pending_id}'."
+    )
 
 
 def _diff(rest: List[str]) -> str:
@@ -179,6 +402,208 @@ def _diff(rest: List[str]) -> str:
     diff = wa.skill_pending_diff(rec)
     header = f"# Pending skill write {rec['id']}: {rec.get('summary', '')}\n"
     return header + "\n" + diff
+
+
+def _evaluate_skill(rest: List[str]) -> str:
+    if not rest:
+        return "Usage: /skills eval <id>"
+    record = wa.get_pending(wa.SKILLS, rest[0])
+    if record is None:
+        return f"No pending skill write with id '{rest[0]}'."
+    try:
+        from agent import learning_ledger
+        from agent.learning_evaluation import evaluate_pending_skill
+
+        result = evaluate_pending_skill(record)
+        verdict = result["verdict"]
+        if verdict == "no_manifest":
+            return f"Candidate {record['id']}: no evals/manifest.json; no evaluation recorded."
+        outcome = "verification_succeeded" if verdict in {"improved", "passed"} else "verification_failed"
+        learning_ledger.record_outcome(
+            str(record.get("candidate_id") or record["id"]),
+            outcome,
+            detail={
+                "verdict": verdict,
+                "baseline_passed": result["baseline"]["passed"],
+                "candidate_passed": result["candidate"]["passed"],
+                "total": result["candidate"]["total"],
+            },
+        )
+        return (
+            f"Candidate {record['id']} evaluation: {verdict} "
+            f"(baseline {result['baseline']['passed']}/{result['baseline']['total']}, "
+            f"candidate {result['candidate']['passed']}/{result['candidate']['total']})."
+        )
+    except Exception as e:
+        return f"Candidate {record['id']} evaluation failed: {e}"
+
+
+def _evaluate_memory(rest: List[str], memory_store) -> str:
+    if not rest:
+        return "Usage: /memory eval <id>"
+    record = wa.get_pending(wa.MEMORY, rest[0])
+    if record is None:
+        return f"No pending memory write with id '{rest[0]}'."
+    if memory_store is None:
+        return "Memory store unavailable."
+    try:
+        from agent import learning_ledger
+        from agent.learning_evaluation import evaluate_pending_memory
+
+        result = evaluate_pending_memory(record, memory_store)
+        outcome = "verification_succeeded" if result["verdict"] == "passed" else "verification_failed"
+        learning_ledger.record_outcome(
+            str(record.get("candidate_id") or record["id"]),
+            outcome,
+            detail={"verdict": result["verdict"], "checks": result["candidate"]["checks"]},
+            attempt_id=f"memory-eval:{record.get('payload_fingerprint', '')}",
+        )
+        return (
+            f"Candidate {record['id']} evaluation: {result['verdict']} "
+            f"({result['candidate']['passed']}/{result['candidate']['total']} invariants)."
+        )
+    except Exception as e:
+        return f"Candidate {record['id']} evaluation failed: {e}"
+
+
+def _rollback_skill(rest: List[str]) -> str:
+    if not rest:
+        return "Usage: /skills rollback <candidate-id>"
+    candidate_id = rest[0]
+    try:
+        from agent import learning_ledger
+        from agent.learning_evaluation import prepare_evaluated_skill_rollback
+        from tools.skill_manager_tool import apply_skill_pending
+
+        candidate = learning_ledger.get_candidate(candidate_id)
+        if candidate is None or candidate.get("subsystem") != "skills":
+            return f"Unknown skill candidate '{candidate_id}'."
+        if candidate.get("status") == "rolling_back":
+            if len(rest) == 2 and rest[1] == "mark-rolled-back":
+                transitioned = learning_ledger.transition_candidate(
+                    candidate_id,
+                    from_status="rolling_back",
+                    to_status="rolled_back",
+                    event="rollback_reconciled",
+                    detail={"resolution": "human_confirmed_rolled_back"},
+                )
+                if transitioned:
+                    return f"Marked '{candidate_id}' rolled back."
+                return f"Could not reconcile rollback for '{candidate_id}'."
+            return (
+                f"Candidate '{candidate_id}' is in rolling_back state. "
+                "Inspect the skill file, then run: /skills rollback <id> mark-rolled-back"
+            )
+        if candidate.get("status") not in {"active", "validated"}:
+            return f"Candidate '{candidate_id}' is not active or validated."
+
+        transitioned = learning_ledger.transition_candidate(
+            candidate_id,
+            from_status=str(candidate["status"]),
+            to_status="rolling_back",
+            event="rollback_started",
+            detail={"subsystem": "skills"},
+        )
+        if transitioned is None:
+            return f"Candidate '{candidate_id}' could not enter rolling_back state."
+
+        payload = prepare_evaluated_skill_rollback(candidate_id)
+        result = json.loads(apply_skill_pending(payload))
+        if not result.get("success"):
+            learning_ledger.transition_candidate(
+                candidate_id,
+                from_status="rolling_back",
+                to_status=str(candidate["status"]),
+                event="rollback_failed",
+                detail={"error": str(result.get("error", "unknown"))[:200]},
+            )
+            return f"Candidate {candidate_id} rollback failed: {result.get('error', 'unknown error')}"
+        try:
+            learning_ledger.record_outcome(
+                candidate_id,
+                "rolled_back",
+                detail={"rollback": "evaluated_snapshot"},
+                attempt_id="evaluated-snapshot-rollback",
+            )
+        except Exception as receipt_error:
+            return (
+                f"Candidate {candidate_id} rollback mutation succeeded but receipt failed: {receipt_error}. "
+                f"Candidate needs reconciliation: /skills rollback {candidate_id} mark-rolled-back"
+            )
+        return f"Rolled back evaluated skill candidate '{candidate_id}'."
+    except Exception as e:
+        return f"Candidate {candidate_id} rollback failed: {e}"
+
+
+def _rollback_memory(rest: List[str], memory_store) -> str:
+    if not rest:
+        return "Usage: /memory rollback <candidate-id>"
+    if memory_store is None:
+        return "Memory store unavailable for rollback."
+    candidate_id = rest[0]
+    try:
+        from agent import learning_ledger
+        from agent.learning_evaluation import prepare_evaluated_memory_rollback
+        from tools.memory_tool import apply_memory_pending
+
+        candidate = learning_ledger.get_candidate(candidate_id)
+        if candidate is None or candidate.get("subsystem") != "memory":
+            return f"Unknown memory candidate '{candidate_id}'."
+        if candidate.get("status") == "rolling_back":
+            if len(rest) == 2 and rest[1] == "mark-rolled-back":
+                transitioned = learning_ledger.transition_candidate(
+                    candidate_id,
+                    from_status="rolling_back",
+                    to_status="rolled_back",
+                    event="rollback_reconciled",
+                    detail={"resolution": "human_confirmed_rolled_back"},
+                )
+                if transitioned:
+                    return f"Marked '{candidate_id}' rolled back."
+                return f"Could not reconcile rollback for '{candidate_id}'."
+            return (
+                f"Candidate '{candidate_id}' is in rolling_back state. "
+                "Inspect the memory file, then run: /memory rollback <id> mark-rolled-back"
+            )
+        if candidate.get("status") not in {"active", "validated"}:
+            return f"Candidate '{candidate_id}' is not active or validated."
+
+        transitioned = learning_ledger.transition_candidate(
+            candidate_id,
+            from_status=str(candidate["status"]),
+            to_status="rolling_back",
+            event="rollback_started",
+            detail={"subsystem": "memory"},
+        )
+        if transitioned is None:
+            return f"Candidate '{candidate_id}' could not enter rolling_back state."
+
+        payload = prepare_evaluated_memory_rollback(candidate_id, memory_store)
+        result = apply_memory_pending(payload, memory_store)
+        if not result.get("success"):
+            learning_ledger.transition_candidate(
+                candidate_id,
+                from_status="rolling_back",
+                to_status=str(candidate["status"]),
+                event="rollback_failed",
+                detail={"error": str(result.get("error", "unknown"))[:200]},
+            )
+            return f"Candidate {candidate_id} rollback failed: {result.get('error', 'unknown error')}"
+        try:
+            learning_ledger.record_outcome(
+                candidate_id,
+                "rolled_back",
+                detail={"rollback": "evaluated_memory_snapshot"},
+                attempt_id="evaluated-memory-snapshot-rollback",
+            )
+        except Exception as receipt_error:
+            return (
+                f"Candidate {candidate_id} rollback mutation succeeded but receipt failed: {receipt_error}. "
+                f"Candidate needs reconciliation: /memory rollback {candidate_id} mark-rolled-back"
+            )
+        return f"Rolled back evaluated memory candidate '{candidate_id}'."
+    except Exception as e:
+        return f"Candidate {candidate_id} rollback failed: {e}"
 
 
 def _set_approval(subsystem: str, rest: List[str], set_mode_fn) -> str:

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -90,7 +90,10 @@ FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
         "tier": "cheap",
         "text_endpoint": "fal-ai/pixverse/v6/text-to-video",
         "image_endpoint": "fal-ai/pixverse/v6/image-to-video",
-        "aspect_ratios": None,
+        "aspect_ratios": ("16:9", "4:3", "1:1", "3:4", "9:16", "2:3", "3:2", "21:9"),
+        # The v6 image-to-video endpoint inherits the source image's shape and
+        # rejects aspect_ratio; only text-to-video accepts it.
+        "aspect_ratio_t2v_only": True,
         "resolutions": ("360p", "540p", "720p", "1080p"),
         "durations": (1, 15),
         "audio": True,
@@ -264,7 +267,7 @@ def _build_payload(
     if seed is not None:
         payload["seed"] = seed
 
-    if family.get("aspect_ratios"):
+    if family.get("aspect_ratios") and not (image_url and family.get("aspect_ratio_t2v_only")):
         if aspect_ratio in family["aspect_ratios"]:
             payload["aspect_ratio"] = aspect_ratio
         # otherwise let the endpoint auto-crop / use its default

--- a/tests/agent/test_context_health.py
+++ b/tests/agent/test_context_health.py
@@ -1,0 +1,67 @@
+"""Deterministic context-health audit contracts."""
+
+from __future__ import annotations
+
+
+def _candidate(candidate_id: str, status: str = "active") -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "subsystem": "skills",
+        "action": "patch",
+        "status": status,
+        "payload_fingerprint": f"sha256:{candidate_id}",
+        "dedup_key": f"sha256:{candidate_id}",
+        "proposal": {"summary": "Improve workflow"},
+        "source": {"origin": "background_review"},
+        "evidence": {"status": "captured", "risk": "medium"},
+        "precondition": {},
+    }
+
+
+def test_audit_finds_duplicate_memory_and_unvalidated_learning(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    memories = home / "memories"
+    memories.mkdir(parents=True)
+    (memories / "MEMORY.md").write_text(
+        "Project uses pytest\n§\nProject uses pytest\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent import learning_ledger
+    from agent.context_health import audit_context
+
+    learning_ledger.create_candidate(_candidate("candidate-1"))
+    result = audit_context()
+
+    kinds = {finding["kind"] for finding in result["findings"]}
+    assert "duplicate_memory" in kinds
+    assert "unvalidated_learning" in kinds
+    assert 0 <= result["score"] < 100
+
+
+def test_failed_outcome_is_reported_as_quality_risk(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from agent import learning_ledger
+    from agent.context_health import audit_context
+
+    learning_ledger.create_candidate(_candidate("candidate-1"))
+    learning_ledger.record_outcome(
+        "candidate-1", "verification_failed", detail={"reason": "fixture failed"}
+    )
+
+    result = audit_context()
+
+    finding = next(item for item in result["findings"] if item["kind"] == "failed_learning_outcome")
+    assert finding["subject"] == "candidate-1"
+    assert finding["severity"] == "high"
+
+
+def test_audit_text_is_shared_cli_friendly(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from agent.context_health import format_context_audit
+
+    text = format_context_audit()
+
+    assert text.startswith("Context Health:")
+    assert "score=" in text

--- a/tests/agent/test_learning_context.py
+++ b/tests/agent/test_learning_context.py
@@ -1,0 +1,32 @@
+"""Evidence-context contracts for autonomous background learning."""
+
+from __future__ import annotations
+
+
+def test_build_learning_metadata_uses_bounded_redacted_user_evidence():
+    from agent.learning_context import build_learning_metadata
+
+    messages = [
+        {"role": "system", "content": "secret system text"},
+        {"role": "user", "content": "Please remember this Authorization: Bearer " + "a" * 80 + " " + "x" * 1000},
+        {"role": "assistant", "content": "Understood"},
+    ]
+
+    metadata = build_learning_metadata(messages, session_id="session-1", platform="cli")
+
+    assert metadata["source"]["session_id"] == "session-1"
+    assert metadata["source"]["trust"] == "user_supplied_unverified"
+    assert metadata["evidence"]["trigger"] == "preference"
+    assert "a" * 80 not in metadata["evidence"]["excerpt"]
+    assert len(metadata["evidence"]["excerpt"]) <= 500
+    assert "system text" not in metadata["evidence"]["excerpt"]
+
+
+def test_learning_metadata_scope_is_context_local():
+    from agent.learning_context import current_learning_metadata, learning_metadata_scope
+
+    assert current_learning_metadata() == {}
+    metadata = {"source": {"session_id": "s"}, "evidence": {"status": "captured"}}
+    with learning_metadata_scope(metadata):
+        assert current_learning_metadata() == metadata
+    assert current_learning_metadata() == {}

--- a/tests/agent/test_learning_evaluation.py
+++ b/tests/agent/test_learning_evaluation.py
@@ -1,0 +1,324 @@
+"""Deterministic candidate-versus-baseline evaluation contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_candidate_improves_baseline_on_fixture_manifest():
+    from agent.learning_evaluation import compare_texts
+
+    manifest = {
+        "version": 1,
+        "cases": [
+            {"name": "documents retry", "must_contain": ["retry", "verify"]},
+            {"name": "rejects secret", "must_not_contain": ["API_KEY=plaintext"]},
+        ],
+    }
+
+    result = compare_texts(
+        baseline="Retry the command.",
+        candidate="Retry the command, then verify the result.",
+        manifest=manifest,
+    )
+
+    assert result["baseline"]["passed"] == 1
+    assert result["candidate"]["passed"] == 2
+    assert result["verdict"] == "improved"
+
+
+def test_candidate_regression_is_detected_without_model_judge():
+    from agent.learning_evaluation import compare_texts
+
+    manifest = {
+        "version": 1,
+        "cases": [{"name": "keeps safety", "must_contain": ["approval", "rollback"]}],
+    }
+
+    result = compare_texts(
+        baseline="Require approval and keep rollback.",
+        candidate="Apply automatically.",
+        manifest=manifest,
+    )
+
+    assert result["verdict"] == "regressed"
+    assert result["candidate"]["failures"][0]["case"] == "keeps safety"
+
+
+def test_simulate_patch_requires_exact_reviewed_baseline():
+    from agent.learning_evaluation import simulate_candidate_text
+
+    payload = {
+        "action": "patch",
+        "old_string": "old procedure",
+        "new_string": "new verified procedure",
+    }
+    assert simulate_candidate_text("Use the old procedure.", payload) == "Use the new verified procedure."
+
+    try:
+        simulate_candidate_text("The target changed.", payload)
+    except ValueError as exc:
+        assert "reviewed baseline" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("stale baseline must fail")
+
+
+def test_evaluated_skill_can_rollback_through_existing_mutation_handler(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_dir = home / "skills" / "demo"
+    (skill_dir / "evals").mkdir(parents=True)
+    baseline = "---\nname: demo\ndescription: demo skill\n---\n\nRequire approval.\n"
+    candidate_text = baseline.replace("Require approval.", "Require approval and rollback.")
+    (skill_dir / "SKILL.md").write_text(baseline)
+    (skill_dir / "evals" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "cases": [
+                    {"name": "keeps approval", "must_contain": ["approval"]},
+                    {"name": "adds rollback", "must_contain": ["rollback"]},
+                ],
+            }
+        )
+    )
+    from agent import learning_ledger
+    from agent.learning_evaluation import evaluate_pending_skill
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.SKILLS,
+        {"action": "edit", "name": "demo", "content": candidate_text},
+        summary="add rollback contract",
+        origin="foreground",
+    )
+    assert evaluate_pending_skill(record)["verdict"] == "improved"
+    approved = handle_pending_subcommand(
+        wa.SKILLS, ["approve", record["id"]]
+    )
+    assert approved is not None
+    assert "Approved 1" in approved
+    assert (skill_dir / "SKILL.md").read_text() == candidate_text
+
+    rolled_back = handle_pending_subcommand(
+        wa.SKILLS, ["rollback", record["id"]]
+    )
+
+    assert rolled_back == f"Rolled back evaluated skill candidate '{record['id']}'."
+    assert (skill_dir / "SKILL.md").read_text() == baseline
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None
+    assert candidate["status"] == "rolled_back"
+
+
+def test_evaluated_memory_can_rollback_through_existing_mutation_handler(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from agent import learning_ledger
+    from agent.learning_evaluation import evaluate_pending_memory
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore
+
+    store = MemoryStore()
+    baseline = "User prefers concise technical answers"
+    replacement = "User prefers concise verified answers"
+    assert store.add("memory", baseline)["success"]
+    record = wa.stage_write(
+        wa.MEMORY,
+        {
+            "action": "replace",
+            "target": "memory",
+            "old_text": "concise technical",
+            "content": replacement,
+        },
+        summary="replace preference",
+        origin="foreground",
+    )
+    assert evaluate_pending_memory(record, store)["verdict"] == "passed"
+    approved = handle_pending_subcommand(
+        wa.MEMORY, ["approve", record["id"]], memory_store=store
+    )
+    assert approved is not None and "Approved 1" in approved
+    assert store.memory_entries == [replacement]
+
+    rolled_back = handle_pending_subcommand(
+        wa.MEMORY, ["rollback", record["id"]], memory_store=store
+    )
+
+    assert rolled_back == f"Rolled back evaluated memory candidate '{record['id']}'."
+    assert store.memory_entries == [baseline]
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None
+    assert candidate["status"] == "rolled_back"
+
+
+def test_evaluated_support_file_patch_rolls_back_the_reviewed_file(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_dir = home / "skills" / "demo"
+    (skill_dir / "evals").mkdir(parents=True)
+    (skill_dir / "references").mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: demo skill\n---\n"
+    )
+    baseline = "Retry the operation.\n"
+    candidate_text = "Retry and verify the operation.\n"
+    support_path = skill_dir / "references" / "guide.md"
+    support_path.write_text(baseline)
+    (skill_dir / "evals" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "cases": [
+                    {"name": "keeps retry", "must_contain": ["retry"]},
+                    {"name": "adds verification", "must_contain": ["verify"]},
+                ],
+            }
+        )
+    )
+    from agent.learning_evaluation import evaluate_pending_skill
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.SKILLS,
+        {
+            "action": "patch",
+            "name": "demo",
+            "file_path": "references/guide.md",
+            "old_string": "Retry the operation.",
+            "new_string": "Retry and verify the operation.",
+        },
+        summary="verify support-file procedure",
+        origin="foreground",
+    )
+
+    assert evaluate_pending_skill(record)["verdict"] == "improved"
+    approved = handle_pending_subcommand(wa.SKILLS, ["approve", record["id"]])
+    assert approved is not None and "Approved 1" in approved
+    assert support_path.read_text() == candidate_text
+    rolled_back = handle_pending_subcommand(wa.SKILLS, ["rollback", record["id"]])
+    assert rolled_back == f"Rolled back evaluated skill candidate '{record['id']}'."
+    assert support_path.read_text() == baseline
+
+
+def test_skill_rollback_rejects_retargeted_snapshot_metadata(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for name in ("a", "b"):
+        skill_dir = home / "skills" / name
+        (skill_dir / "evals").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Demo skill {name}\n---\n\nRequire approval for {name}.\n"
+        )
+        (skill_dir / "evals" / "manifest.json").write_text(
+            json.dumps({"version": 1, "cases": [{"name": "rollback", "must_contain": ["rollback"]}]})
+        )
+    from agent.learning_evaluation import evaluate_pending_skill, prepare_evaluated_skill_rollback
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.SKILLS,
+        {
+            "action": "patch",
+            "name": "a",
+            "old_string": "Require approval for a.",
+            "new_string": "Require approval and rollback for a.",
+        },
+        summary="add rollback",
+        origin="foreground",
+    )
+    assert evaluate_pending_skill(record)["verdict"] == "improved"
+    approved = handle_pending_subcommand(wa.SKILLS, ["approve", record["id"]])
+    assert approved is not None and "Approved 1" in approved
+    metadata_path = home / "learning" / "snapshots" / record["id"] / "snapshot.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["skill_name"] = "b"
+    metadata_path.write_text(json.dumps(metadata))
+
+    with pytest.raises(ValueError, match="snapshot.*candidate|identity|manifest"):
+        prepare_evaluated_skill_rollback(record["id"])
+
+
+def test_evaluation_rejects_symlinked_learning_parent(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (home / "learning").symlink_to(outside, target_is_directory=True)
+    skill_dir = home / "skills" / "demo"
+    (skill_dir / "evals").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Retry.\n")
+    (skill_dir / "evals" / "manifest.json").write_text(
+        json.dumps({"version": 1, "cases": [{"name": "verify", "must_contain": ["verify"]}]})
+    )
+    from agent.learning_evaluation import evaluate_pending_skill
+
+    record = {
+        "id": "snapshot-symlink",
+        "candidate_id": "snapshot-symlink",
+        "payload": {
+            "action": "patch",
+            "name": "demo",
+            "old_string": "Retry.",
+            "new_string": "Retry and verify.",
+        },
+    }
+
+    with pytest.raises(ValueError, match="snapshot|symlink|profile"):
+        evaluate_pending_skill(record)
+    assert list(outside.iterdir()) == []
+
+
+def test_skill_rollback_receipt_failure_requires_explicit_reconciliation(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    skill_dir = home / "skills" / "demo"
+    (skill_dir / "evals").mkdir(parents=True)
+    baseline = "---\nname: demo\ndescription: Demo skill\n---\n\nRequire approval.\n"
+    candidate_text = "---\nname: demo\ndescription: Demo skill\n---\n\nRequire approval and rollback.\n"
+    (skill_dir / "SKILL.md").write_text(baseline)
+    (skill_dir / "evals" / "manifest.json").write_text(
+        json.dumps({"version": 1, "cases": [{"name": "rollback", "must_contain": ["rollback"]}]})
+    )
+    from agent import learning_ledger
+    from agent.learning_evaluation import evaluate_pending_skill
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.SKILLS,
+        {"action": "edit", "name": "demo", "content": candidate_text},
+        summary="add rollback",
+        origin="foreground",
+    )
+    assert evaluate_pending_skill(record)["verdict"] == "improved"
+    approved = handle_pending_subcommand(wa.SKILLS, ["approve", record["id"]])
+    assert approved is not None and "Approved 1" in approved
+    original_record_outcome = learning_ledger.record_outcome
+    monkeypatch.setattr(
+        learning_ledger,
+        "record_outcome",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("receipt unavailable")),
+    )
+
+    first = handle_pending_subcommand(wa.SKILLS, ["rollback", record["id"]])
+
+    assert first is not None and "needs reconciliation" in first
+    assert (skill_dir / "SKILL.md").read_text() == baseline
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None and candidate["status"] == "rolling_back"
+    monkeypatch.setattr(learning_ledger, "record_outcome", original_record_outcome)
+
+    reconciled = handle_pending_subcommand(
+        wa.SKILLS, ["rollback", record["id"], "mark-rolled-back"]
+    )
+
+    assert reconciled is not None and "Marked" in reconciled
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None and candidate["status"] == "rolled_back"

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -79,3 +79,40 @@ def test_full_payload_shape_and_edge_integrity(tmp_path):
     assert graph["stats"]["nodes"] == len(skill_nodes)
     assert graph["stats"]["memory_nodes"] == len(graph["memory"])
     assert all("timestamp" in n for n in graph["nodes"])
+
+
+def test_graph_projects_learning_candidates_without_changing_node_kinds(tmp_path):
+    from agent import learning_ledger
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+    try:
+        learning_ledger.create_candidate(
+            {
+                "candidate_id": "candidate-journey",
+                "subsystem": "skills",
+                "action": "patch",
+                "status": "active",
+                "payload_fingerprint": "sha256:p",
+                "dedup_key": "sha256:d",
+                "proposal": {"summary": "Improve retry guidance"},
+                "source": {"origin": "background_review"},
+                "evidence": {
+                    "status": "captured",
+                    "risk": "medium",
+                    "hypothesis": "Fewer repeated retry failures",
+                },
+                "precondition": {},
+            }
+        )
+        learning_ledger.record_outcome(
+            "candidate-journey", "verification_failed", detail={"reason": "fixture failed"}
+        )
+        graph = learning_graph.build_learning_graph()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert {node["kind"] for node in graph["nodes"]} <= {"skill", "memory"}
+    assert graph["candidates"][0]["id"] == "candidate-journey"
+    assert graph["candidates"][0]["outcomes"][0]["outcome"] == "verification_failed"

--- a/tests/agent/test_learning_ledger.py
+++ b/tests/agent/test_learning_ledger.py
@@ -1,0 +1,326 @@
+"""Behavior contracts for the profile-scoped learning ledger."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _create_same_dedup_candidate(home: str, candidate_id: str, queue) -> None:
+    os.environ["HERMES_HOME"] = home
+    from agent import learning_ledger
+
+    try:
+        learning_ledger.create_candidate(_candidate(candidate_id))
+        queue.put("created")
+    except sqlite3.IntegrityError:
+        queue.put("duplicate")
+
+
+def _candidate(candidate_id: str = "candidate-1") -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "subsystem": "memory",
+        "action": "add",
+        "status": "pending",
+        "payload_fingerprint": "sha256:payload",
+        "dedup_key": "sha256:dedup",
+        "pending_relpath": f"pending/memory/{candidate_id}.json",
+        "proposal": {"summary": "Remember the preference"},
+        "source": {"origin": "background_review", "trust": "user_explicit"},
+        "evidence": {
+            "status": "captured",
+            "excerpt": "Use token sk-secret-example in the setup",
+            "hypothesis": "Remembering this avoids repeated correction",
+            "risk": "low",
+            "confidence": "high",
+        },
+        "precondition": {},
+    }
+
+
+def test_create_candidate_persists_current_state_and_creation_event(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent import learning_ledger
+
+    created = learning_ledger.create_candidate(_candidate())
+
+    assert created["candidate_id"] == "candidate-1"
+    assert created["status"] == "pending"
+    assert learning_ledger.get_candidate("candidate-1")["proposal"]["summary"] == "Remember the preference"
+    events = learning_ledger.list_events(candidate_id="candidate-1")
+    assert [event["event"] for event in events] == ["candidate_created"]
+    assert (home / "learning" / "ledger.db").exists()
+
+
+def test_transition_is_compare_and_swap_and_appends_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(_candidate())
+    transitioned = learning_ledger.transition_candidate(
+        "candidate-1",
+        from_status="pending",
+        to_status="applying",
+        event="candidate_apply_started",
+        detail={"claim_id": "claim-1"},
+    )
+    stale = learning_ledger.transition_candidate(
+        "candidate-1",
+        from_status="pending",
+        to_status="rejected",
+        event="candidate_rejected",
+    )
+
+    assert transitioned is not None
+    assert transitioned["status"] == "applying"
+    assert stale is None
+    assert [event["event"] for event in learning_ledger.list_events(candidate_id="candidate-1")] == [
+        "candidate_created",
+        "candidate_apply_started",
+    ]
+
+
+def test_failed_transition_transaction_leaves_state_and_events_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(_candidate())
+    with pytest.raises(ValueError, match="event"):
+        learning_ledger.transition_candidate(
+            "candidate-1",
+            from_status="pending",
+            to_status="applying",
+            event="",
+        )
+
+    assert learning_ledger.get_candidate("candidate-1")["status"] == "pending"
+    assert len(learning_ledger.list_events(candidate_id="candidate-1")) == 1
+
+
+def test_profile_switch_after_import_is_isolated(tmp_path, monkeypatch):
+    from agent import learning_ledger
+
+    home_a = tmp_path / "a"
+    home_b = tmp_path / "b"
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    learning_ledger.create_candidate(_candidate("a-candidate"))
+
+    monkeypatch.setenv("HERMES_HOME", str(home_b))
+    assert learning_ledger.list_candidates() == []
+    learning_ledger.create_candidate(_candidate("b-candidate"))
+
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    assert [item["candidate_id"] for item in learning_ledger.list_candidates()] == ["a-candidate"]
+
+
+def test_payload_fingerprint_is_stable_but_semantic_change_changes_it():
+    from agent.learning_ledger import canonical_payload_fingerprint
+
+    left = {"action": "add", "target": "user", "content": "concise"}
+    reordered = {"content": "concise", "target": "user", "action": "add"}
+    changed = {"action": "add", "target": "user", "content": "verbose"}
+
+    assert canonical_payload_fingerprint("memory", left) == canonical_payload_fingerprint("memory", reordered)
+    assert canonical_payload_fingerprint("memory", left) != canonical_payload_fingerprint("memory", changed)
+
+
+def test_evidence_is_redacted_and_bounded():
+    from agent.learning_ledger import sanitize_evidence
+
+    evidence = sanitize_evidence(
+        {
+            "excerpt": "Authorization: Bearer " + "a" * 80 + " " + "x" * 1000,
+            "hypothesis": "h" * 1000,
+            "risk": "unexpected",
+            "confidence": 0.99,
+            "status": "captured",
+        }
+    )
+
+    assert "a" * 80 not in evidence["excerpt"]
+    assert len(evidence["excerpt"]) <= 500
+    assert len(evidence["hypothesis"]) <= 500
+    assert evidence["risk"] == "unknown"
+    assert evidence["confidence"] == "unknown"
+
+
+def test_schema_version_is_initialized_and_future_version_fails_closed(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(_candidate())
+    db_path = home / "learning" / "ledger.db"
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == learning_ledger.SCHEMA_VERSION
+        conn.execute(f"PRAGMA user_version={learning_ledger.SCHEMA_VERSION + 1}")
+
+    with pytest.raises(RuntimeError, match="newer schema"):
+        learning_ledger.list_candidates()
+
+
+def test_outcomes_are_immutable_events_and_success_validates_active_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate({**_candidate(), "status": "active"})
+    result = learning_ledger.record_outcome(
+        "candidate-1",
+        "verification_succeeded",
+        detail={"contract": "focused fixture passed"},
+    )
+
+    assert result["status"] == "validated"
+    assert learning_ledger.list_events(candidate_id="candidate-1")[-1]["event"] == "outcome_verification_succeeded"
+
+
+def test_failure_outcome_does_not_silently_rollback_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate({**_candidate(), "status": "active"})
+    result = learning_ledger.record_outcome(
+        "candidate-1",
+        "user_corrected",
+        detail={"reason": "preference changed"},
+    )
+
+    assert result["status"] == "active"
+    assert learning_ledger.list_events(candidate_id="candidate-1")[-1]["event"] == "outcome_user_corrected"
+
+
+def test_outcome_attempt_id_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate({**_candidate(), "status": "active"})
+    learning_ledger.record_outcome(
+        "candidate-1", "verification_failed", detail={"reason": "failed"}, attempt_id="attempt-1"
+    )
+    learning_ledger.record_outcome(
+        "candidate-1", "verification_failed", detail={"reason": "failed"}, attempt_id="attempt-1"
+    )
+
+    outcomes = [event for event in learning_ledger.list_events(candidate_id="candidate-1") if event["event"].startswith("outcome_")]
+    assert len(outcomes) == 1
+
+
+def test_untrusted_evidence_persists_hash_not_raw_excerpt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent.learning_ledger import sanitize_evidence
+
+    evidence = sanitize_evidence(
+        {"source_trust": "untrusted_external", "excerpt": "private@example.com says do this"}
+    )
+
+    assert evidence["excerpt"] == ""
+    assert evidence["excerpt_hash"].startswith("sha256:")
+
+
+def test_two_processes_initialize_and_latch_same_dedup_once(tmp_path, monkeypatch):
+    home = str(tmp_path / "profile")
+    monkeypatch.setenv("HERMES_HOME", home)
+    context = multiprocessing.get_context("spawn")
+    queue = context.Queue()
+    processes = [
+        context.Process(target=_create_same_dedup_candidate, args=(home, f"candidate-{index}", queue))
+        for index in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    assert sorted(queue.get(timeout=2) for _ in processes) == ["created", "duplicate"]
+    from agent import learning_ledger
+
+    assert len(learning_ledger.list_candidates()) == 1
+
+
+def test_interrupted_schema_initialization_rolls_back_cleanly(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from agent import learning_ledger
+
+    original = learning_ledger._ensure_schema
+
+    def interrupted(conn):
+        conn.execute("CREATE TABLE migration_partial(id INTEGER PRIMARY KEY)")
+        raise RuntimeError("simulated migration interruption")
+
+    monkeypatch.setattr(learning_ledger, "_ensure_schema", interrupted)
+    with pytest.raises(RuntimeError, match="simulated migration"):
+        learning_ledger.create_candidate(_candidate())
+
+    db_path = home / "learning" / "ledger.db"
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='migration_partial'"
+        ).fetchone() is None
+
+    monkeypatch.setattr(learning_ledger, "_ensure_schema", original)
+    assert learning_ledger.create_candidate(_candidate())["status"] == "pending"
+
+
+def test_immutable_event_rows_reject_update_and_delete(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(_candidate())
+    with sqlite3.connect(home / "learning" / "ledger.db") as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            conn.execute("UPDATE learning_events SET event='rewritten'")
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            conn.execute("DELETE FROM learning_events")
+
+
+def test_ledger_path_must_not_be_symlink(tmp_path, monkeypatch):
+    home = tmp_path / "profile"
+    learning_dir = home / "learning"
+    learning_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.db"
+    outside.touch()
+    (learning_dir / "ledger.db").symlink_to(outside)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from agent import learning_ledger
+
+    with pytest.raises(RuntimeError, match="must not be a symlink"):
+        learning_ledger.create_candidate(_candidate())
+
+
+def test_candidate_ids_are_bounded_and_path_safe(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    with pytest.raises(ValueError, match="invalid characters"):
+        learning_ledger.create_candidate({**_candidate(), "candidate_id": "../escape"})
+    with pytest.raises(ValueError, match="invalid characters"):
+        learning_ledger.get_candidate("x" * 65)
+
+
+def test_event_details_are_bounded_and_redacted(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(_candidate())
+    secret = "sk-1234567890abcdefghijklmnopqrstuvwxyz"
+    learning_ledger.record_outcome(
+        "candidate-1",
+        "verification_failed",
+        detail={"error": f"OPENAI_API_KEY={secret}", "long": "x" * 2_000},
+    )
+
+    detail = learning_ledger.list_events(candidate_id="candidate-1")[-1]["detail"]
+    serialized = str(detail)
+    assert secret not in serialized
+    assert len(detail["long"]) <= 500

--- a/tests/agent/test_learning_ledger.py
+++ b/tests/agent/test_learning_ledger.py
@@ -12,13 +12,28 @@ import pytest
 
 def _create_same_dedup_candidate(home: str, candidate_id: str, queue) -> None:
     os.environ["HERMES_HOME"] = home
+    import time
+
     from agent import learning_ledger
 
-    try:
-        learning_ledger.create_candidate(_candidate(candidate_id))
-        queue.put("created")
-    except sqlite3.IntegrityError:
-        queue.put("duplicate")
+    # Two fresh processes can race schema initialization on the same new
+    # profile; a lock timeout there is contention, not a behavioral result.
+    # Retry briefly, then classify the dedup outcome.
+    last_error: Exception | None = None
+    for _ in range(20):
+        try:
+            learning_ledger.create_candidate(_candidate(candidate_id))
+            queue.put("created")
+            return
+        except sqlite3.IntegrityError:
+            queue.put("duplicate")
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower():
+                raise
+            last_error = exc
+            time.sleep(0.1)
+    raise last_error  # type: ignore[misc]
 
 
 def _candidate(candidate_id: str = "candidate-1") -> dict:

--- a/tests/agent/test_learning_ledger.py
+++ b/tests/agent/test_learning_ledger.py
@@ -74,6 +74,19 @@ def test_create_candidate_persists_current_state_and_creation_event(tmp_path, mo
     assert (home / "learning" / "ledger.db").exists()
 
 
+def test_namespaced_candidate_id_round_trips_through_ledger(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    from agent import learning_ledger
+
+    candidate_id = "pastoral:edaca6a49a734f408dd9fbad1f5408af"
+    learning_ledger.create_candidate(_candidate(candidate_id))
+
+    candidate = learning_ledger.get_candidate(candidate_id)
+    assert candidate is not None
+    assert candidate["candidate_id"] == candidate_id
+    assert learning_ledger.list_events(candidate_id=candidate_id)[0]["candidate_id"] == candidate_id
+
+
 def test_transition_is_compare_and_swap_and_appends_event(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
     from agent import learning_ledger

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -12,6 +12,8 @@ from agent.skill_utils import (
     is_skill_support_path,
     iter_skill_index_files,
     parse_frontmatter,
+    extract_skill_description,
+    is_skill_description_truncated_for_prompt,
     resolve_skill_config_values,
     skill_matches_platform,
     skill_matches_platform_list,
@@ -28,7 +30,24 @@ from agent.skill_utils import (
 
 
 
-def test_skill_config_helpers_share_raw_config_parse_cache(tmp_path, monkeypatch):
+def test_skill_prompt_uses_short_routing_field_for_long_description():
+    frontmatter = {
+        "description": "A detailed description that is intentionally much longer than the prompt routing budget and remains available in the skill metadata.",
+        "routing": "Use for Sion elder financial reports.",
+    }
+
+    assert extract_skill_description(frontmatter) == "Use for Sion elder financial reports."
+    assert is_skill_description_truncated_for_prompt(frontmatter) is False
+
+
+def test_legacy_long_description_still_truncates_without_routing_field():
+    frontmatter = {"description": "A" * 80}
+
+    assert extract_skill_description(frontmatter).endswith("...")
+    assert is_skill_description_truncated_for_prompt(frontmatter) is True
+
+
+def test_skill_config_helpers_share_raw_config_cache(tmp_path, monkeypatch):
     """Repeated skill config helpers should parse config.yaml only once."""
     from agent import skill_utils
 

--- a/tests/agent/test_trace_compiler.py
+++ b/tests/agent/test_trace_compiler.py
@@ -1,0 +1,58 @@
+"""Stable trace-to-script proposal contracts."""
+
+from __future__ import annotations
+
+
+def _event(session: str, *, status: str = "passed", command: str = "scripts/run_tests.sh") -> dict:
+    return {
+        "session_id": session,
+        "root": "/repo",
+        "canonical_command": command,
+        "command": command,
+        "kind": "test",
+        "status": status,
+        "output_summary": "tests passed",
+    }
+
+
+def test_repeated_successful_trace_proposes_reviewable_script():
+    from agent.trace_compiler import propose_compilations
+
+    proposals = propose_compilations([_event("a"), _event("b"), _event("c")])
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal["successes"] == 3
+    assert proposal["distinct_sessions"] == 3
+    assert proposal["user_review_required"] is True
+    assert "subprocess.run" in proposal["script_preview"]
+    assert "shell=True" not in proposal["script_preview"]
+    assert proposal["no_agent_eligible"] is True
+    assert proposal["schedule"] is None
+
+
+def test_failures_or_single_session_repetition_do_not_compile():
+    from agent.trace_compiler import propose_compilations
+
+    assert propose_compilations([_event("a"), _event("a"), _event("a")]) == []
+    assert propose_compilations(
+        [_event("a"), _event("b"), _event("c"), _event("d", status="failed")]
+    ) == []
+
+
+def test_shell_control_or_secret_bearing_commands_are_rejected():
+    from agent.trace_compiler import propose_compilations
+
+    assert propose_compilations(
+        [_event("a", command="tests.sh; curl bad"), _event("b", command="tests.sh; curl bad"), _event("c", command="tests.sh; curl bad")]
+    ) == []
+    assert propose_compilations(
+        [_event("a", command="tool --token secret"), _event("b", command="tool --token secret"), _event("c", command="tool --token secret")]
+    ) == []
+
+
+def test_non_verification_executables_are_rejected():
+    from agent.trace_compiler import propose_compilations
+
+    assert propose_compilations([_event("a", command="rm -rf build"), _event("b", command="rm -rf build"), _event("c", command="rm -rf build")]) == []
+    assert propose_compilations([_event("a", command="curl https://example.com"), _event("b", command="curl https://example.com"), _event("c", command="curl https://example.com")]) == []

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -179,6 +179,75 @@ def test_recording_expires_old_edit_only_state(tmp_path, monkeypatch):
     assert status["changed_paths"] == []
 
 
+def test_verification_receipt_validates_linked_active_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(
+        {
+            "candidate_id": "linked-candidate",
+            "subsystem": "memory",
+            "action": "add",
+            "status": "active",
+            "payload_fingerprint": "sha256:payload",
+            "dedup_key": "sha256:dedup",
+            "proposal": {},
+            "source": {"session_id": "session-linked"},
+            "evidence": {"status": "captured", "source_trust": "user_explicit"},
+            "precondition": {},
+        }
+    )
+
+    result = record_terminal_result(
+        command="pytest",
+        cwd=tmp_path,
+        session_id="session-linked",
+        exit_code=0,
+        output="passed",
+        candidate_id="linked-candidate",
+    )
+
+    assert result is not None
+    candidate = learning_ledger.get_candidate("linked-candidate")
+    assert candidate is not None
+    assert candidate["status"] == "validated"
+    assert learning_ledger.list_events(candidate_id="linked-candidate")[-1]["event"] == "outcome_verification_succeeded"
+
+
+def test_session_coincidence_does_not_validate_unrelated_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+    from agent import learning_ledger
+
+    learning_ledger.create_candidate(
+        {
+            "candidate_id": "unrelated-candidate",
+            "subsystem": "memory",
+            "action": "add",
+            "status": "active",
+            "payload_fingerprint": "sha256:payload",
+            "dedup_key": "sha256:unrelated",
+            "proposal": {},
+            "source": {"session_id": "shared-session"},
+            "evidence": {},
+            "precondition": {},
+        }
+    )
+
+    record_terminal_result(
+        command="pytest",
+        cwd=tmp_path,
+        session_id="shared-session",
+        exit_code=0,
+        output="passed",
+    )
+
+    candidate = learning_ledger.get_candidate("unrelated-candidate")
+    assert candidate is not None
+    assert candidate["status"] == "active"
+
+
 def test_windows_backslash_ad_hoc_script_path_is_matched(tmp_path, monkeypatch):
     """Ad-hoc verification scripts with Windows backslash paths must be
     matched by ``_find_ad_hoc_match`` trying ``posix=False`` in addition to

--- a/tests/gateway/test_learning_review_authorization.py
+++ b/tests/gateway/test_learning_review_authorization.py
@@ -1,0 +1,84 @@
+"""Authorization contracts for profile-global learning review commands."""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="ordinary-user",
+            chat_id="room",
+        ),
+    )
+
+
+def _runner(*, admin: bool):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._resume_caller_is_admin = lambda source: admin
+    runner._session_key_for_source = lambda source: "test-session"
+    runner._evict_cached_agent = lambda session_key: None
+    return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler", "command"),
+    [
+        ("_handle_memory_command", "/memory pending"),
+        ("_handle_skills_command", "/skills pending"),
+    ],
+)
+async def test_non_admin_cannot_access_profile_global_learning_queue(
+    tmp_path, monkeypatch, handler, command
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    result = await getattr(_runner(admin=False), handler)(_event(command))
+
+    assert "admin" in result.lower()
+    assert "pending" not in result.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "subcommand",
+    ["history", "ledger", "audit", "compile", "compilations", "eval missing", "evaluate missing", "rollback missing"],
+)
+async def test_admin_can_reach_each_learning_command_with_skill_gate_off(
+    tmp_path, monkeypatch, subcommand
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    result = await _runner(admin=True)._handle_skills_command(
+        _event(f"/skills {subcommand}")
+    )
+
+    assert "approval is off" not in result.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler", "command"),
+    [
+        ("_handle_memory_command", "/memory approval on"),
+        ("_handle_skills_command", "/skills approval on"),
+    ],
+)
+async def test_gateway_toggle_writes_active_profile_config(
+    tmp_path, monkeypatch, handler, command
+):
+    profile_home = tmp_path / ".hermes" / "profiles" / "other"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    result = await getattr(_runner(admin=True), handler)(_event(command))
+
+    assert "on" in result.lower()
+    assert (profile_home / "config.yaml").exists()
+    assert not (tmp_path / ".hermes" / "config.yaml").exists()

--- a/tests/hermes_cli/test_context_cmd.py
+++ b/tests/hermes_cli/test_context_cmd.py
@@ -1,0 +1,151 @@
+from argparse import Namespace
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+
+def test_context_verify_links_allowlisted_check_to_active_candidate(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from agent import learning_ledger
+    from hermes_cli.context_cmd import cmd_context
+
+    learning_ledger.create_candidate(
+        {
+            "candidate_id": "verify-candidate",
+            "subsystem": "skills",
+            "action": "edit",
+            "status": "pending",
+            "payload_fingerprint": "sha256:" + "a" * 64,
+            "dedup_key": "verify-candidate",
+            "proposal": {"name": "demo"},
+        }
+    )
+    learning_ledger.transition_candidate(
+        "verify-candidate",
+        from_status="pending",
+        to_status="active",
+        event="candidate_applied",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.context_cmd.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="1 passed\n", stderr=""),
+    )
+
+    result = cmd_context(
+        Namespace(
+            context_action="verify",
+            candidate_id="verify-candidate",
+            verify_argv=["--", "pytest", "tests/agent/test_learning_ledger.py"],
+        )
+    )
+
+    assert result == 0
+    assert "verification passed" in capsys.readouterr().out
+    candidate = learning_ledger.get_candidate("verify-candidate")
+    assert candidate is not None
+    assert candidate["status"] == "validated"
+
+
+def test_context_verify_rejects_non_allowlisted_command(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from agent import learning_ledger
+    from hermes_cli.context_cmd import cmd_context
+
+    learning_ledger.create_candidate(
+        {
+            "candidate_id": "unsafe-candidate",
+            "subsystem": "memory",
+            "action": "add",
+            "status": "active",
+            "payload_fingerprint": "sha256:" + "b" * 64,
+            "dedup_key": "unsafe-candidate",
+            "proposal": {"target": "memory"},
+        }
+    )
+
+    result = cmd_context(
+        Namespace(
+            context_action="verify",
+            candidate_id="unsafe-candidate",
+            verify_argv=["--", "sh", "-c", "echo nope"],
+        )
+    )
+
+    assert result == 2
+    assert "not an allowlisted" in capsys.readouterr().out
+
+
+def test_context_verify_fails_closed_when_outcome_is_not_durable(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from agent import learning_ledger
+    from hermes_cli.context_cmd import cmd_context
+
+    learning_ledger.create_candidate(
+        {
+            "candidate_id": "durability-candidate",
+            "subsystem": "skills",
+            "action": "edit",
+            "status": "pending",
+            "payload_fingerprint": "sha256:" + "d" * 64,
+            "dedup_key": "durability-candidate",
+            "proposal": {"name": "demo"},
+        }
+    )
+    learning_ledger.transition_candidate(
+        "durability-candidate",
+        from_status="pending",
+        to_status="active",
+        event="candidate_applied",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.context_cmd.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="1 passed\n", stderr=""),
+    )
+    monkeypatch.setattr(
+        learning_ledger,
+        "record_outcome",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("disk unavailable")),
+    )
+
+    result = cmd_context(
+        Namespace(
+            context_action="verify",
+            candidate_id="durability-candidate",
+            verify_argv=["--", "pytest", "tests/agent/test_learning_ledger.py"],
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert result == 2
+    assert "could not be persisted" in output
+    assert "verification passed" not in output
+    candidate = learning_ledger.get_candidate("durability-candidate")
+    assert candidate is not None and candidate["status"] == "active"
+
+
+def test_context_verify_cli_preserves_top_level_command_dispatch(tmp_path):
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path / ".hermes")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "context",
+            "verify",
+            "missing-candidate",
+            "--",
+            "pytest",
+            "tests/hermes_cli/test_context_cmd.py",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "known active learning candidate" in completed.stdout
+    assert "unhashable type" not in completed.stderr

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -147,6 +147,44 @@ class TestFamilyRouting:
 
 
 class TestPayloadBuilder:
+    def test_pixverse_t2v_passes_vertical_aspect_ratio(self):
+        """PixVerse v6 text-to-video supports 9:16 and must not silently
+        fall back to its 16:9 API default."""
+        from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+        p = _build_payload(
+            FAL_FAMILIES["pixverse-v6"],
+            prompt="x",
+            image_url=None,
+            duration=5,
+            aspect_ratio="9:16",
+            resolution="540p",
+            negative_prompt=None,
+            audio=False,
+            seed=None,
+        )
+
+        assert p["aspect_ratio"] == "9:16"
+
+    def test_pixverse_i2v_omits_unsupported_aspect_ratio(self):
+        """PixVerse v6 image-to-video inherits the source image shape and its
+        endpoint schema does not accept aspect_ratio."""
+        from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+        p = _build_payload(
+            FAL_FAMILIES["pixverse-v6"],
+            prompt="x",
+            image_url="https://example.com/frame.png",
+            duration=5,
+            aspect_ratio="9:16",
+            resolution="540p",
+            negative_prompt=None,
+            audio=False,
+            seed=None,
+        )
+
+        assert "aspect_ratio" not in p
+
     def test_drops_unsupported_keys(self):
         """Veo enum-clamps duration, supports aspect+resolution+audio+neg."""
         from plugins.video_gen.fal import FAL_FAMILIES, _build_payload

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -114,6 +114,17 @@ class TestValidateFrontmatter:
     def test_invalid_yaml(self):
         content = "---\n: invalid: yaml: {{{\n---\n\nBody.\n"
         assert "YAML frontmatter parse error" in _validate_frontmatter(content)
+    def test_long_description_with_routing_field_is_valid_for_new_skill(self):
+        content = "---\nname: long-desc\ndescription: " + ("A" * 120) + "\nrouting: Use for long descriptions.\n---\n\nBody.\n"
+        assert _validate_frontmatter(content, new_skill=True) is None
+
+    def test_long_description_without_routing_field_is_rejected_for_new_skill(self):
+        content = "---\nname: long-desc\ndescription: " + ("A" * 120) + "\n---\n\nBody.\n"
+        assert "system-prompt skill index" in _validate_frontmatter(content, new_skill=True)
+
+    def test_routing_field_must_fit_prompt_budget(self):
+        content = "---\nname: long-desc\ndescription: Full description.\nrouting: " + ("A" * 61) + "\n---\n\nBody.\n"
+        assert "routing" in _validate_frontmatter(content, new_skill=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -197,6 +197,38 @@ def test_stage_write_creates_linked_learning_candidate(hermes_home):
     assert candidate["evidence"]["excerpt"] == "Keep it concise"
 
 
+def test_pending_id_accepts_migrated_namespace(hermes_home):
+    from tools import write_approval as wa
+
+    candidate_id = "pastoral:edaca6a49a734f408dd9fbad1f5408af"
+    assert wa._validate_pending_id(candidate_id) == candidate_id
+
+
+def test_migrated_namespaced_pending_record_round_trips(hermes_home):
+    from tools import write_approval as wa
+
+    candidate_id = "pastoral:edaca6a49a734f408dd9fbad1f5408af"
+    pending_dir = Path(hermes_home) / "pending" / "memory"
+    pending_dir.mkdir(parents=True)
+    record = {
+        "id": candidate_id,
+        "candidate_id": candidate_id,
+        "subsystem": "memory",
+        "action": "add",
+        "summary": "migrated record",
+        "payload": {"action": "add", "target": "memory", "content": "test"},
+        "created_at": 1,
+    }
+    (pending_dir / "pastoral-edaca6a49a734f408dd9fbad1f5408af.json").write_text(
+        json.dumps(record), encoding="utf-8"
+    )
+
+    assert wa.list_pending("memory")[0]["id"] == candidate_id
+    fetched = wa.get_pending("memory", candidate_id)
+    assert fetched is not None
+    assert fetched["id"] == candidate_id
+
+
 def test_claim_pending_has_one_winner_and_can_restore(hermes_home):
     from tools import write_approval as wa
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -229,6 +229,31 @@ def test_migrated_namespaced_pending_record_round_trips(hermes_home):
     assert fetched["id"] == candidate_id
 
 
+def test_namespaced_claim_uses_encoded_filename_and_releases(hermes_home):
+    from tools import write_approval as wa
+
+    candidate_id = "pastoral:edaca6a49a734f408dd9fbad1f5408af"
+    pending_dir = Path(hermes_home) / "pending" / "memory"
+    pending_dir.mkdir(parents=True)
+    record = {
+        "id": candidate_id,
+        "candidate_id": candidate_id,
+        "subsystem": "memory",
+        "action": "add",
+        "summary": "migrated claim",
+        "payload": {"action": "add", "target": "memory", "content": "test"},
+        "created_at": 1,
+    }
+    (pending_dir / "pastoral-edaca6a49a734f408dd9fbad1f5408af.json").write_text(
+        json.dumps(record), encoding="utf-8"
+    )
+
+    claim = wa.claim_pending("memory", candidate_id)
+    assert claim is not None
+    assert "pastoral-edaca6a49a734f408dd9fbad1f5408af.json.applying" in claim["_claim_path"]
+    assert wa.release_claim("memory", claim, restore=False) is True
+
+
 def test_claim_pending_has_one_winner_and_can_restore(hermes_home):
     from tools import write_approval as wa
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -8,11 +8,28 @@ subcommand dispatch.
 """
 
 import json
+import multiprocessing
 import os
 import tempfile
 import shutil
+from pathlib import Path
 
 import pytest
+
+
+def _approve_pending_worker(home: str, pending_id: str, queue) -> None:
+    os.environ["HERMES_HOME"] = home
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import load_on_disk_store
+
+    queue.put(
+        handle_pending_subcommand(
+            wa.MEMORY,
+            ["approve", pending_id],
+            memory_store=load_on_disk_store(),
+        )
+    )
 
 
 @pytest.fixture
@@ -148,6 +165,504 @@ _SKILL = (
 # ---------------------------------------------------------------------------
 # Pending store CRUD
 # ---------------------------------------------------------------------------
+
+
+def test_stage_write_creates_linked_learning_candidate(hermes_home):
+    from agent import learning_ledger
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        "memory",
+        {"action": "add", "target": "user", "content": "prefers concise answers"},
+        summary="prefers concise answers",
+        origin="background_review",
+        metadata={
+            "source": {"session_id": "session-1", "trust": "user_explicit"},
+            "evidence": {
+                "status": "captured",
+                "source_trust": "user_explicit",
+                "excerpt": "Keep it concise",
+                "hypothesis": "Avoid repeated verbosity corrections",
+                "risk": "low",
+                "confidence": "high",
+            },
+        },
+    )
+
+    candidate = learning_ledger.get_candidate(record["candidate_id"])
+    assert record["candidate_id"] == record["id"]
+    assert record["ledger_recorded"] is True
+    assert candidate is not None
+    assert candidate["pending_relpath"] == f"pending/memory/{record['id']}.json"
+    assert candidate["evidence"]["excerpt"] == "Keep it concise"
+
+
+def test_claim_pending_has_one_winner_and_can_restore(hermes_home):
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        "memory",
+        {"action": "add", "target": "user", "content": "one"},
+        summary="one",
+        origin="foreground",
+    )
+
+    first = wa.claim_pending("memory", record["id"])
+    second = wa.claim_pending("memory", record["id"])
+
+    assert first is not None
+    assert second is None
+    assert wa.get_pending("memory", record["id"]) is None
+    assert wa.release_claim("memory", first, restore=True) is True
+    assert wa.get_pending("memory", record["id"]) is not None
+
+
+def test_approve_transitions_candidate_and_removes_pending(hermes_home):
+    from agent import learning_ledger
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools.memory_tool import MemoryStore
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        "memory",
+        {"action": "add", "target": "user", "content": "approved learning"},
+        summary="approved learning",
+        origin="background_review",
+    )
+    store = MemoryStore(); store.load_from_disk()
+
+    out = handle_pending_subcommand(wa.MEMORY, ["approve", record["id"]], memory_store=store)
+
+    assert "Approved 1" in out
+    assert wa.get_pending("memory", record["id"]) is None
+    assert learning_ledger.get_candidate(record["id"])["status"] == "active"
+    assert [event["event"] for event in learning_ledger.list_events(candidate_id=record["id"])][-2:] == [
+        "candidate_apply_started",
+        "candidate_activated",
+    ]
+
+
+def test_reject_preserves_reason_in_ledger(hermes_home):
+    from agent import learning_ledger
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        "skills",
+        {"action": "delete", "name": "example"},
+        summary="delete example",
+        origin="background_review",
+    )
+
+    out = handle_pending_subcommand(
+        wa.SKILLS,
+        ["reject", record["id"], "too", "risky"],
+    )
+
+    assert "Rejected" in out
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate["status"] == "rejected"
+    rejection = next(
+        event
+        for event in learning_ledger.list_events(candidate_id=record["id"])
+        if event["event"] == "candidate_rejected"
+    )
+    assert rejection["detail"]["reason"] == "too risky"
+
+
+def test_background_write_stages_when_approval_config_is_on(hermes_home, monkeypatch):
+    from tools import write_approval as wa
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: True)
+    token = set_current_write_origin(BACKGROUND_REVIEW)
+    try:
+        decision = wa.evaluate_gate(wa.MEMORY)
+    finally:
+        reset_current_write_origin(token)
+
+    assert decision.stage is True
+    assert decision.allow is False
+
+
+def test_equivalent_rejected_background_proposal_is_suppressed(hermes_home):
+    from agent import learning_ledger
+    from tools import write_approval as wa
+
+    payload = {"action": "add", "target": "user", "content": "stable preference"}
+    first = wa.stage_write(
+        "memory", payload, summary="stable preference", origin="background_review"
+    )
+    assert learning_ledger.transition_candidate(
+        first["id"],
+        from_status="pending",
+        to_status="rejected",
+        event="candidate_rejected",
+        detail={"reason": "not durable"},
+    ) is not None
+    assert wa.discard_pending("memory", first["id"])
+
+    duplicate = wa.stage_write(
+        "memory", payload, summary="same words, same mutation", origin="background_review"
+    )
+
+    assert duplicate["suppressed"] is True
+    assert duplicate["candidate_id"] == first["id"]
+    assert wa.pending_count("memory") == 0
+
+
+def test_pending_list_surfaces_evidence_risk_and_hypothesis(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    wa.stage_write(
+        "skills",
+        {"action": "patch", "name": "demo", "old_string": "a", "new_string": "b"},
+        summary="patch demo",
+        origin="background_review",
+        metadata={
+            "evidence": {
+                "status": "captured",
+                "source_trust": "review_observed",
+                "excerpt": "The previous procedure failed",
+                "hypothesis": "This patch prevents the same failure",
+                "risk": "medium",
+                "confidence": "medium",
+            }
+        },
+    )
+
+    out = handle_pending_subcommand("skills", ["pending"])
+
+    assert "risk=medium" in out
+    assert "The previous procedure failed" in out
+    assert "This patch prevents the same failure" in out
+
+
+def test_approve_all_skips_high_risk_candidate(hermes_home):
+    from agent import learning_ledger
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        "skills",
+        {"action": "delete", "name": "dangerous"},
+        summary="delete dangerous",
+        origin="background_review",
+    )
+
+    out = handle_pending_subcommand("skills", ["approve", "all"])
+
+    assert "requires explicit approval" in out
+    assert wa.get_pending("skills", record["id"]) is not None
+    assert learning_ledger.get_candidate(record["id"])["status"] == "pending"
+
+
+def test_history_surfaces_rejection_reason(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        "memory",
+        {"action": "add", "target": "user", "content": "temporary detail"},
+        summary="temporary detail",
+        origin="background_review",
+    )
+    handle_pending_subcommand("memory", ["reject", record["id"], "temporary"])
+
+    out = handle_pending_subcommand("memory", ["history"])
+
+    assert record["id"] in out
+    assert "rejected" in out
+    assert "temporary" in out
+
+
+def test_skill_eval_compares_baseline_and_records_outcome(hermes_home):
+    from pathlib import Path
+
+    from agent import learning_ledger
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    skill_dir = Path(hermes_home) / "skills" / "demo"
+    (skill_dir / "evals").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Retry the command.\n", encoding="utf-8")
+    (skill_dir / "evals" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "cases": [{"name": "verified retry", "must_contain": ["retry", "verify"]}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    record = wa.stage_write(
+        "skills",
+        {
+            "action": "patch",
+            "name": "demo",
+            "old_string": "Retry the command.",
+            "new_string": "Retry the command, then verify the result.",
+        },
+        summary="add verification",
+        origin="background_review",
+    )
+
+    out = handle_pending_subcommand("skills", ["eval", record["id"]])
+
+    assert "improved" in out
+    assert (Path(hermes_home) / "learning" / "snapshots" / record["id"] / "baseline.txt").exists()
+    assert learning_ledger.list_events(candidate_id=record["id"])[-1]["event"] == "outcome_verification_succeeded"
+
+
+def test_stage_failure_is_not_reported_as_staged(hermes_home, monkeypatch):
+    from tools import write_approval as wa
+
+    monkeypatch.setattr(wa, "_atomic_pending_json_write", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")))
+    result = wa.stage_write(
+        "memory",
+        {"action": "add", "target": "user", "content": "x"},
+        summary="x",
+        origin="foreground",
+    )
+
+    assert result["success"] is False
+    assert result["staged"] is False
+
+
+def test_pending_public_apis_reject_path_traversal(hermes_home):
+    import pytest
+
+    from tools import write_approval as wa
+
+    with pytest.raises(ValueError):
+        wa.get_pending("memory", "../other-profile")
+    with pytest.raises(ValueError):
+        wa.list_pending("../memory")
+
+
+def test_untrusted_background_review_context_forces_staging_when_gate_off(hermes_home, monkeypatch):
+    from agent.learning_context import learning_metadata_scope
+    from tools import write_approval as wa
+    from tools.skill_provenance import BACKGROUND_REVIEW, reset_current_write_origin, set_current_write_origin
+
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: False)
+    token = set_current_write_origin(BACKGROUND_REVIEW)
+    try:
+        with learning_metadata_scope(
+            {"evidence": {"status": "captured", "source_trust": "user_supplied_unverified", "risk": "medium"}}
+        ):
+            decision = wa.evaluate_gate("memory")
+    finally:
+        reset_current_write_origin(token)
+
+    assert decision.stage is True
+
+
+def test_approval_rejects_tampered_replay_payload(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import load_on_disk_store
+
+    record = wa.stage_write(
+        "memory",
+        {"action": "add", "target": "user", "content": "reviewed"},
+        summary="reviewed",
+        origin="foreground",
+    )
+    path = wa._pending_dir("memory") / f"{record['id']}.json"
+    body = json.loads(path.read_text())
+    body["payload"]["content"] = "tampered"
+    path.write_text(json.dumps(body))
+
+    out = handle_pending_subcommand(
+        "memory", ["approve", record["id"]], memory_store=load_on_disk_store()
+    )
+
+    assert "stale review" in out
+    assert wa.get_pending("memory", record["id"]) is not None
+
+
+def test_approval_rejects_changed_memory_target(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import load_on_disk_store
+
+    store = load_on_disk_store()
+    assert store.add("memory", "old fact")["success"]
+    record = wa.stage_write(
+        "memory",
+        {"action": "replace", "target": "memory", "old_text": "old fact", "content": "new fact"},
+        summary="replace fact",
+        origin="foreground",
+        metadata={"precondition": {"old_texts": ["old fact"]}},
+    )
+    assert store.remove("memory", "old fact")["success"]
+
+    out = handle_pending_subcommand("memory", ["approve", record["id"]], memory_store=store)
+
+    assert "memory target changed" in out
+    assert wa.get_pending("memory", record["id"]) is not None
+
+
+def test_two_process_approval_applies_exactly_once(hermes_home):
+    from agent import learning_ledger
+    from tools import write_approval as wa
+    from tools.memory_tool import load_on_disk_store
+
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "one durable entry"},
+        summary="concurrent approval",
+        origin="background_review",
+    )
+    context = multiprocessing.get_context("spawn")
+    queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_approve_pending_worker,
+            args=(hermes_home, record["id"], queue),
+        )
+        for _ in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    results = [queue.get(timeout=2) for _ in processes]
+    assert sum("Approved 1" in result for result in results) == 1, results
+    assert load_on_disk_store()._entries_for("memory") == ["one durable entry"]
+    assert wa.get_pending(wa.MEMORY, record["id"]) is None
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None
+    assert candidate["status"] == "active"
+
+
+def test_interrupted_claim_requires_explicit_reconciliation(hermes_home):
+    from agent import learning_ledger
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "recoverable"},
+        summary="reconcile interrupted approval",
+        origin="background_review",
+    )
+    claim = wa.claim_pending(wa.MEMORY, record["id"])
+    assert claim is not None
+    assert learning_ledger.transition_candidate(
+        record["id"],
+        from_status="pending",
+        to_status="applying",
+        event="candidate_apply_started",
+        detail={"claim_id": claim["_claim_id"]},
+    ) is not None
+
+    listing = handle_pending_subcommand(wa.MEMORY, ["reconcile"])
+    assert record["id"] in listing
+    restored = handle_pending_subcommand(
+        wa.MEMORY, ["reconcile", record["id"], "restore"]
+    )
+
+    assert restored is not None
+    assert "Restored" in restored
+    assert wa.get_pending(wa.MEMORY, record["id"]) is not None
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None
+    assert candidate["status"] == "pending"
+    assert wa.list_claims(wa.MEMORY) == []
+
+
+def test_staging_fails_closed_when_ledger_write_fails(hermes_home, monkeypatch):
+    from agent import learning_ledger
+    from tools import write_approval as wa
+
+    monkeypatch.setattr(
+        learning_ledger,
+        "create_candidate",
+        lambda _candidate: (_ for _ in ()).throw(OSError("ledger unavailable")),
+    )
+    result = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "must not orphan"},
+        summary="ledger failure",
+        origin="foreground",
+    )
+
+    assert result["success"] is False
+    assert result["staged"] is False
+    assert wa.pending_count(wa.MEMORY) == 0
+
+
+def test_pending_envelope_id_must_match_filename(hermes_home):
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "original"},
+        summary="tamper envelope",
+        origin="foreground",
+    )
+    path = Path(hermes_home) / "pending" / "memory" / f"{record['id']}.json"
+    body = json.loads(path.read_text())
+    body["id"] = "different-id"
+    path.write_text(json.dumps(body))
+
+    assert wa.get_pending(wa.MEMORY, record["id"]) is None
+    assert wa.list_pending(wa.MEMORY) == []
+    assert wa.claim_pending(wa.MEMORY, record["id"]) is None
+
+
+def test_pending_subsystem_directory_must_not_be_symlink(hermes_home):
+    from tools import write_approval as wa
+
+    outside = Path(hermes_home).parent / "outside"
+    outside.mkdir()
+    pending = Path(hermes_home) / "pending"
+    pending.mkdir()
+    (pending / "memory").symlink_to(outside, target_is_directory=True)
+
+    result = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "escape"},
+        summary="symlink escape",
+        origin="foreground",
+    )
+    assert result["success"] is False
+    assert result["staged"] is False
+    assert list(outside.iterdir()) == []
+
+
+def test_staging_rejects_preexisting_pending_record_symlink(hermes_home, monkeypatch):
+    from types import SimpleNamespace
+    from tools import write_approval as wa
+
+    pending_id = "fixed-pending-id"
+    outside = Path(hermes_home).parent / "outside.json"
+    outside.write_text("unchanged")
+    pending_dir = Path(hermes_home) / "pending" / wa.MEMORY
+    pending_dir.mkdir(parents=True)
+    (pending_dir / f"{pending_id}.json").symlink_to(outside)
+    monkeypatch.setattr(wa.uuid, "uuid4", lambda: SimpleNamespace(hex=pending_id))
+
+    result = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "must stay local"},
+        summary="symlink target",
+        origin="foreground",
+    )
+
+    assert result["success"] is False
+    assert result["staged"] is False
+    assert outside.read_text() == "unchanged"
 
 
 # ---------------------------------------------------------------------------
@@ -286,3 +801,139 @@ class TestSkillGist:
         assert wa.skill_gist("remove_file", "demo", file_path="a.py") == "remove a.py from 'demo'"
         assert wa.skill_gist("delete", "demo") == "delete skill 'demo'"
         assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"
+
+
+def test_pending_candidate_relink_is_not_listed(hermes_home):
+    from tools import write_approval as wa
+
+    first = wa.stage_write(wa.MEMORY, {"action": "add", "target": "memory", "content": "first"}, summary="first", origin="foreground")
+    second = wa.stage_write(wa.MEMORY, {"action": "add", "target": "memory", "content": "second"}, summary="second", origin="foreground")
+    path = Path(hermes_home) / "pending" / "memory" / f"{first['id']}.json"
+    envelope = json.loads(path.read_text())
+    envelope["candidate_id"] = second["id"]
+    envelope["payload"] = second["payload"]
+    path.write_text(json.dumps(envelope))
+
+    assert wa.get_pending(wa.MEMORY, first["id"]) is None
+    assert all(item["id"] != first["id"] for item in wa.list_pending(wa.MEMORY))
+
+
+def test_legacy_pending_record_without_candidate_id_is_migratable(hermes_home):
+    from tools import write_approval as wa
+
+    pending_id = "legacy123"
+    path = Path(hermes_home) / "pending" / "memory" / f"{pending_id}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "id": pending_id,
+                "subsystem": wa.MEMORY,
+                "action": "add",
+                "summary": "private legacy detail that must not persist",
+                "payload": {"action": "add", "target": "memory", "content": "legacy"},
+            }
+        )
+    )
+
+    record = wa.get_pending(wa.MEMORY, pending_id)
+
+    assert record is not None
+    assert record["candidate_id"] == pending_id
+    candidate = wa.ensure_candidate_for_record(record)
+    assert candidate is not None
+    assert candidate["candidate_id"] == pending_id
+    assert candidate["proposal"]["summary"] == "memory add candidate"
+    assert "private legacy" not in json.dumps(candidate)
+
+
+def test_ambiguous_apply_exception_requires_reconciliation_without_replay(hermes_home, monkeypatch):
+    from agent import learning_ledger
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore
+
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "exactly once"},
+        summary="ambiguous application",
+        origin="foreground",
+    )
+    side_effects = []
+
+    def mutate_then_raise(payload, store):
+        side_effects.append(payload["content"])
+        raise RuntimeError("receipt lost after mutation")
+
+    monkeypatch.setattr("tools.memory_tool.apply_memory_pending", mutate_then_raise)
+    store = MemoryStore()
+
+    first = handle_pending_subcommand(
+        wa.MEMORY, ["approve", record["id"]], memory_store=store
+    )
+    second = handle_pending_subcommand(
+        wa.MEMORY, ["approve", record["id"]], memory_store=store
+    )
+
+    assert first is not None and "needs reconciliation" in first
+    assert second is not None and "No pending" in second
+    assert side_effects == ["exactly once"]
+    candidate = learning_ledger.get_candidate(record["id"])
+    assert candidate is not None and candidate["status"] == "applying"
+    assert len(wa.list_claims(wa.MEMORY)) == 1
+
+
+def test_memory_substring_precondition_preserves_existing_semantics(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore, memory_tool
+
+    store = MemoryStore()
+    assert store.add("memory", "User prefers concise technical answers")["success"]
+    _set_approval(wa.MEMORY, True)
+    staged = json.loads(memory_tool(action="replace", target="memory", old_text="concise technical", content="User prefers concise verified answers", store=store))
+    assert staged["staged"] is True
+    result = handle_pending_subcommand(wa.MEMORY, ["approve", staged["pending_id"]], memory_store=store)
+
+    assert result is not None and "Approved 1" in result
+    assert store.memory_entries == ["User prefers concise verified answers"]
+
+
+def test_long_lived_ledger_does_not_copy_raw_memory_summary(hermes_home):
+    from agent import learning_ledger
+    from tools import write_approval as wa
+
+    secret_text = "private family detail that belongs only in pending replay"
+    record = wa.stage_write(wa.MEMORY, {"action": "add", "target": "memory", "content": secret_text}, summary=f"add to memory: {secret_text}", origin="foreground")
+    candidate = learning_ledger.get_candidate(record["id"])
+
+    assert candidate is not None
+    assert secret_text not in json.dumps(candidate)
+
+
+def test_invalid_skill_path_is_rejected_before_staging_or_diff(hermes_home, tmp_path):
+    from tools import write_approval as wa
+    from tools.skill_manager_tool import skill_manage
+
+    skill_dir = Path(hermes_home) / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\ndescription: demo\n---\n")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("must not be disclosed")
+    _set_approval(wa.SKILLS, True)
+    result = json.loads(skill_manage(action="write_file", name="demo", file_path=str(secret), file_content="x"))
+
+    assert result["success"] is False
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_explicit_rejection_discards_orphan_pending_record(hermes_home, monkeypatch):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    record = wa.stage_write(wa.MEMORY, {"action": "add", "target": "memory", "content": "orphan"}, summary="orphan", origin="foreground")
+    monkeypatch.setattr(wa, "ensure_candidate_for_record", lambda _record: None)
+    result = handle_pending_subcommand(wa.MEMORY, ["reject", record["id"]])
+
+    assert result == f"Rejected pending memory write '{record['id']}'."
+    assert wa.get_pending(wa.MEMORY, record["id"]) is None

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,6 +23,7 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
+import hashlib
 import json
 import logging
 import time
@@ -909,7 +910,7 @@ def load_on_disk_store() -> "MemoryStore":
 
 
 def _apply_write_gate(action: str, target: str, content: Optional[str],
-                      old_text: Optional[str]) -> Optional[str]:
+                      old_text: Optional[str], store: "MemoryStore") -> Optional[str]:
     """Evaluate the memory write gate. Returns a JSON tool-result string when
     the write should NOT proceed normally (blocked or staged), or None when the
     caller should perform the real write.
@@ -953,11 +954,29 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
         "content": content,
         "old_text": old_text,
     }
+    entries = store._entries_for(target)
+    target_fingerprint = hashlib.sha256(
+        json.dumps(entries, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
     record = wa.stage_write(
         wa.MEMORY, payload,
         summary=f"{summary}: {detail[:120]}",
         origin=wa.current_origin(),
+        metadata={"precondition": {"target_fingerprint": target_fingerprint}},
     )
+    if record.get("staged") is False:
+        return tool_error("Failed to persist pending memory write; nothing was saved.", success=False)
+    if record.get("suppressed"):
+        return json.dumps(
+            {
+                "success": True,
+                "staged": False,
+                "deduplicated": True,
+                "candidate_id": record["candidate_id"],
+                "message": "Equivalent learning candidate already exists; no duplicate was staged.",
+            },
+            ensure_ascii=False,
+        )
     return json.dumps(
         {"success": True, "staged": True, "pending_id": record["id"],
          "message": decision.message},
@@ -965,7 +984,8 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
     )
 
 
-def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Optional[str]:
+def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]],
+                            store: "MemoryStore") -> Optional[str]:
     """Evaluate the write gate for a batch of memory operations.
 
     Returns a JSON tool-result string when the batch should NOT proceed
@@ -1000,11 +1020,29 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
         return tool_error(decision.message, success=False)
 
     payload = {"action": "batch", "target": target, "operations": operations}
+    entries = store._entries_for(target)
+    target_fingerprint = hashlib.sha256(
+        json.dumps(entries, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
     record = wa.stage_write(
         wa.MEMORY, payload,
         summary=f"{summary}: {detail[:120]}",
         origin=wa.current_origin(),
+        metadata={"precondition": {"target_fingerprint": target_fingerprint}},
     )
+    if record.get("staged") is False:
+        return tool_error("Failed to persist pending memory write; nothing was saved.", success=False)
+    if record.get("suppressed"):
+        return json.dumps(
+            {
+                "success": True,
+                "staged": False,
+                "deduplicated": True,
+                "candidate_id": record["candidate_id"],
+                "message": "Equivalent learning candidate already exists; no duplicate was staged.",
+            },
+            ensure_ascii=False,
+        )
     return json.dumps(
         {"success": True, "staged": True, "pending_id": record["id"],
          "message": decision.message},
@@ -1078,7 +1116,7 @@ def memory_tool(
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
-        gate_result = _apply_batch_write_gate(target, operations)
+        gate_result = _apply_batch_write_gate(target, operations, store)
         if gate_result is not None:
             return gate_result
         result = store.apply_batch(target, operations)
@@ -1103,7 +1141,7 @@ def memory_tool(
 
     # Approval gate: when on, stages the write (background/gateway) or prompts
     # inline (interactive CLI); when off (default) passes straight through.
-    gate_result = _apply_write_gate(action, target, content, old_text)
+    gate_result = _apply_write_gate(action, target, content, old_text, store)
     if gate_result is not None:
         return gate_result
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1431,6 +1431,20 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
         new_string=payload_kwargs.get("new_string") or "",
     )
     record = wa.stage_write(wa.SKILLS, payload, summary=gist, origin=wa.current_origin())
+    if record.get("staged") is False:
+        return tool_error("Failed to persist pending skill write; nothing was saved.", success=False)
+    if record.get("suppressed"):
+        return json.dumps(
+            {
+                "success": True,
+                "staged": False,
+                "deduplicated": True,
+                "candidate_id": record["candidate_id"],
+                "gist": gist,
+                "message": "Equivalent learning candidate already exists; no duplicate was staged.",
+            },
+            ensure_ascii=False,
+        )
     return json.dumps(
         {"success": True, "staged": True, "pending_id": record["id"],
          "gist": gist, "message": decision.message},
@@ -1530,6 +1544,14 @@ def skill_manage(
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)
+
+    # Validate file targets before the review gate serializes or previews them.
+    # Otherwise an invalid absolute/traversal path can become a read primitive
+    # through `/skills diff` even though the eventual mutation would reject it.
+    if action in {"write_file", "remove_file"} or (action == "patch" and file_path):
+        path_error = _validate_file_path(file_path or "")
+        if path_error:
+            return tool_error(path_error, success=False)
 
     # Approval gate: when on, stages the write for review (skills are too large
     # to review inline, so they always stage regardless of origin); when off

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -604,13 +604,17 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
     desc = str(parsed["description"])
     if len(desc) > MAX_DESCRIPTION_LENGTH:
         return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
-    if new_skill and len(desc.strip().strip("'\"")) > SKILL_PROMPT_DESC_LIMIT:
+    routing = str(parsed.get("routing", "")).strip().strip("'\"")
+    if routing and len(routing) > SKILL_PROMPT_DESC_LIMIT:
         return (
-            f"Description is {len(desc.strip())} chars — new skills must fit the "
-            f"{SKILL_PROMPT_DESC_LIMIT}-char system-prompt budget (one sentence, "
-            f"trigger first, ends with a period). The skill index truncates "
-            f"longer descriptions to {SKILL_PROMPT_DESC_LIMIT - 3} chars + '...', "
-            f"destroying the routing signal. Move detail into the skill body."
+            f"Routing description exceeds {SKILL_PROMPT_DESC_LIMIT} characters; "
+            "keep the routing hint short and move detail into 'description' or the skill body."
+        )
+    if new_skill and len(desc.strip().strip("'\"")) > SKILL_PROMPT_DESC_LIMIT and not routing:
+        return (
+            f"Description is {len(desc.strip())} chars — add a short 'routing' "
+            f"field of {SKILL_PROMPT_DESC_LIMIT} characters or fewer for the "
+            "system-prompt skill index."
         )
 
     body = content[end_match.end() + 3:].strip()

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -97,7 +97,9 @@ def _atomic_pending_json_write(path: Path, data: Mapping[str, Any], *, create: b
 MEMORY = "memory"
 SKILLS = "skills"
 _SUBSYSTEMS = (MEMORY, SKILLS)
-_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+# Pending IDs may be namespaced when records are migrated from another
+# profile (for example ``pastoral:<uuid>``). Keep the separator explicit.
+_ID_RE = re.compile(r"^(?:[A-Za-z0-9_-]+:)?[A-Za-z0-9_-]{1,64}$")
 
 # Config key (per subsystem). A single boolean: the approval gate is OFF by
 # default (writes flow freely, the pre-gate behaviour), and ON means stage /
@@ -164,6 +166,20 @@ def _validate_pending_id(pending_id: str) -> str:
     if not _ID_RE.fullmatch(value):
         raise ValueError("pending id contains invalid characters")
     return value
+
+
+def _pending_filename_id(pending_id: str) -> str:
+    """Encode a logical ID for a safe pending filename.
+
+    Migrated records historically encoded the single namespace separator as a
+    hyphen in filenames while retaining ``namespace:<id>`` in the envelope.
+    Preserve that on-disk compatibility without weakening ID validation.
+    """
+    return pending_id.replace(":", "-", 1)
+
+
+def _pending_path(subsystem: str, pending_id: str) -> Path:
+    return _pending_dir(subsystem) / f"{_pending_filename_id(pending_id)}.json"
 
 
 def _risk_for(subsystem: str, action: str) -> str:
@@ -415,7 +431,7 @@ def _read_pending_record(
         if not isinstance(record, dict):
             return None
         record_id = _validate_pending_id(str(record.get("id") or ""))
-        if record_id != expected_id:
+        if record_id != expected_id and _pending_filename_id(record_id) != expected_id:
             return None
         raw_candidate_id = record.get("candidate_id")
         if raw_candidate_id in {None, ""}:
@@ -459,16 +475,17 @@ def list_pending(subsystem: str) -> List[Dict[str, Any]]:
 def get_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
     """Return a single pending record by id, or None."""
     pending_id = _validate_pending_id(pending_id)
-    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    path = _pending_path(subsystem, pending_id)
     if not path.exists():
         return None
-    return _read_pending_record(path, subsystem=subsystem, expected_id=pending_id)
+    expected_id = _pending_filename_id(pending_id)
+    return _read_pending_record(path, subsystem=subsystem, expected_id=expected_id)
 
 
 def discard_pending(subsystem: str, pending_id: str) -> bool:
     """Delete a pending record. Returns True if it existed."""
     pending_id = _validate_pending_id(pending_id)
-    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    path = _pending_path(subsystem, pending_id)
     try:
         if path.exists():
             path.unlink()
@@ -481,7 +498,7 @@ def discard_pending(subsystem: str, pending_id: str) -> bool:
 def claim_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
     """Atomically claim one pending payload for apply/reject."""
     pending_id = _validate_pending_id(pending_id)
-    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    path = _pending_path(subsystem, pending_id)
     if path.is_symlink() or (path.exists() and not path.is_file()):
         return None
     claim_id = uuid.uuid4().hex
@@ -516,12 +533,12 @@ def release_claim(subsystem: str, claim: Mapping[str, Any], *, restore: bool) ->
         or claim_path.is_symlink()
         or not claim_path.is_file()
         or claim_path.parent.resolve() != expected_parent
-        or not claim_path.name.startswith(f"{pending_id}.json.applying.")
+        or not claim_path.name.startswith(f"{_pending_filename_id(pending_id)}.json.applying.")
     ):
         return False
     try:
         if restore:
-            canonical = _pending_dir(subsystem) / f"{pending_id}.json"
+            canonical = _pending_path(subsystem, pending_id)
             # Never overwrite a fresh canonical proposal created while this
             # claim was in flight.  A failed restore remains an explicit claim
             # for reconciliation instead of losing either payload.

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -43,21 +43,61 @@ web dashboard.
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import os
+import re
+import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
+
+def _atomic_pending_json_write(path: Path, data: Mapping[str, Any], *, create: bool = False) -> None:
+    """Write pending JSON without ever following the destination symlink."""
+    if path.parent.is_symlink() or not path.parent.is_dir():
+        raise ValueError("pending directory is not a regular local directory")
+    if path.is_symlink() or (create and os.path.lexists(path)):
+        raise FileExistsError("pending record path already exists or is a symlink")
+    if path.exists() and not path.is_file():
+        raise ValueError("pending record path is not a regular file")
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.stem}_", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.is_symlink():
+            raise FileExistsError("pending record path became a symlink")
+        # Replace the directory entry itself; never redirect through a symlink.
+        os.replace(tmp_path, path)
+        try:
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            pass
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
 # Subsystem identifiers
 MEMORY = "memory"
 SKILLS = "skills"
 _SUBSYSTEMS = (MEMORY, SKILLS)
+_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 # Config key (per subsystem). A single boolean: the approval gate is OFF by
 # default (writes flow freely, the pre-gate behaviour), and ON means stage /
@@ -108,11 +148,119 @@ def _normalize_enabled(value: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 def _pending_dir(subsystem: str) -> Path:
-    return get_hermes_home() / "pending" / subsystem
+    if subsystem not in _SUBSYSTEMS:
+        raise ValueError(f"invalid pending subsystem: {subsystem!r}")
+    root = get_hermes_home() / "pending"
+    directory = root / subsystem
+    if (root.exists() and root.is_symlink()) or (
+        directory.exists() and directory.is_symlink()
+    ):
+        raise RuntimeError("pending write directory must not be a symlink")
+    return directory
 
 
-def stage_write(subsystem: str, payload: Dict[str, Any],
-                *, summary: str, origin: str) -> Dict[str, Any]:
+def _validate_pending_id(pending_id: str) -> str:
+    value = str(pending_id or "")
+    if not _ID_RE.fullmatch(value):
+        raise ValueError("pending id contains invalid characters")
+    return value
+
+
+def _risk_for(subsystem: str, action: str) -> str:
+    if action in {"delete", "remove", "remove_file"}:
+        return "high"
+    if subsystem == SKILLS and action in {"edit", "patch", "write_file"}:
+        return "medium"
+    if subsystem == MEMORY and action in {"replace", "batch"}:
+        return "medium"
+    return "low"
+
+
+def _capture_skill_precondition(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    """Fingerprint the exact existing skill target without changing it."""
+    try:
+        from tools.skill_manager_tool import _find_skill
+
+        found = _find_skill(str(payload.get("name") or ""))
+        action = str(payload.get("action") or "")
+        if found is None:
+            return {"target_exists": False}
+        skill_dir = Path(found["path"])
+        skill_root = skill_dir.resolve()
+        if action in {"write_file", "remove_file"}:
+            target = skill_dir / str(payload.get("file_path") or "")
+        else:
+            target = skill_dir / "SKILL.md"
+        try:
+            target.resolve(strict=False).relative_to(skill_root)
+        except (OSError, ValueError):
+            return {"capture_failed": True}
+        if not target.exists() or target.is_symlink() or not target.is_file():
+            return {"target_exists": False}
+        digest = hashlib.sha256(target.read_bytes()).hexdigest()
+        return {"target_exists": True, "target_sha256": digest}
+    except Exception:
+        return {"capture_failed": True}
+
+
+def verify_reviewed_payload(
+    subsystem: str,
+    record: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    memory_store=None,
+) -> tuple[bool, str]:
+    """Reject changed replay payloads or targets after human review."""
+    from agent import learning_ledger
+
+    record_id = str(record.get("id") or "")
+    candidate_id = str(record.get("candidate_id") or "")
+    ledger_id = str(candidate.get("candidate_id") or "")
+    if not record_id or record_id != candidate_id or record_id != ledger_id:
+        return False, "pending record is not linked to its reviewed candidate"
+    if str(record.get("subsystem") or "") != subsystem or str(candidate.get("subsystem") or "") != subsystem:
+        return False, "pending subsystem does not match its reviewed candidate"
+    payload = dict(record.get("payload") or {})
+    fingerprint = learning_ledger.canonical_payload_fingerprint(subsystem, payload)
+    if fingerprint != str(candidate.get("payload_fingerprint") or ""):
+        return False, "reviewed payload changed after staging"
+    precondition = dict(record.get("precondition") or candidate.get("precondition") or {})
+    if not precondition:
+        return True, ""
+    if precondition.get("capture_failed"):
+        return False, "target precondition could not be captured"
+    if subsystem == MEMORY:
+        if memory_store is None:
+            return False, "memory store unavailable"
+        entries = memory_store._entries_for(str(payload.get("target") or "memory"))
+        target_fingerprint = precondition.get("target_fingerprint")
+        if target_fingerprint:
+            actual = hashlib.sha256(
+                json.dumps(entries, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if actual != target_fingerprint:
+                return False, "memory target changed after staging"
+            return True, ""
+        for old_text in precondition.get("old_texts", []):
+            if not any(str(old_text) in entry for entry in entries):
+                return False, "memory target changed after staging"
+        return True, ""
+    current = _capture_skill_precondition(payload)
+    if current != precondition:
+        return False, "skill target changed after staging"
+    return True, ""
+
+
+def stage_write(
+    subsystem: str,
+    payload: Dict[str, Any],
+    *,
+    summary: str,
+    origin: str,
+    metadata: Optional[Mapping[str, Any]] = None,
+    candidate_id: Optional[str] = None,
+    dedup_key: Optional[str] = None,
+) -> Dict[str, Any]:
     """Persist a pending write and return a short record describing it.
 
     Args:
@@ -125,30 +273,166 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
             entry text itself.
         origin: ``foreground`` or ``background_review`` — recorded for audit.
 
-    Returns a dict with ``id`` and metadata. Best-effort: on disk failure it
-    logs and still returns a record (the write is simply lost, which is the
-    safe failure for an approval gate — nothing is silently committed).
+    Returns a dict with ``id`` and metadata. Staging fails closed unless both
+    the exact replay payload and its ledger lifecycle row are durable.
     """
-    pid = uuid.uuid4().hex[:8]
+    from agent import learning_ledger
+
+    if subsystem not in _SUBSYSTEMS:
+        raise ValueError(f"invalid pending subsystem: {subsystem!r}")
+    pid = _validate_pending_id(candidate_id or uuid.uuid4().hex)
+    meta: Dict[str, Any] = {}
+    if (origin or "") == "background_review":
+        try:
+            from agent.learning_context import current_learning_metadata
+
+            meta = current_learning_metadata()
+        except Exception:
+            meta = {}
+    meta.update(dict(metadata or {}))
+    if subsystem == SKILLS and not meta.get("precondition"):
+        meta["precondition"] = _capture_skill_precondition(payload)
+    payload_fingerprint = learning_ledger.canonical_payload_fingerprint(subsystem, payload)
+    resolved_dedup_key = dedup_key or learning_ledger.candidate_dedup_key(subsystem, payload)
+    if (origin or "") == "background_review":
+        existing = learning_ledger.find_candidate_by_dedup(
+            resolved_dedup_key,
+            statuses={"pending", "applying", "active", "validated", "rejected", "rolled_back"},
+        )
+        if existing is not None:
+            return {
+                "id": existing["candidate_id"],
+                "candidate_id": existing["candidate_id"],
+                "subsystem": subsystem,
+                "action": payload.get("action", ""),
+                "summary": (summary or "").strip(),
+                "origin": origin,
+                "ledger_recorded": True,
+                "suppressed": True,
+                "deduplicated": True,
+                "existing_status": existing["status"],
+            }
+    evidence = dict(meta.get("evidence") or {})
+    if str(evidence.get("risk") or "unknown") == "unknown":
+        evidence["risk"] = _risk_for(subsystem, str(payload.get("action") or ""))
     record = {
         "id": pid,
+        "candidate_id": pid,
+        "schema_version": 2,
         "subsystem": subsystem,
         "action": payload.get("action", ""),
         "summary": (summary or "").strip(),
         "origin": origin or "foreground",
         "created_at": time.time(),
         "payload": payload,
+        "payload_fingerprint": payload_fingerprint,
+        "dedup_key": resolved_dedup_key,
+        "precondition": dict(meta.get("precondition") or {}),
+        "ledger_recorded": False,
+        "success": True,
+        "staged": True,
     }
     try:
         d = _pending_dir(subsystem)
-        d.mkdir(parents=True, exist_ok=True)
+        d.mkdir(parents=True, exist_ok=True, mode=0o700)
         path = d / f"{pid}.json"
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        _atomic_pending_json_write(path, record, create=True)
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
+        record["success"] = False
+        record["staged"] = False
+        return record
+
+    try:
+        source = {"origin": record["origin"], **dict(meta.get("source") or {})}
+        learning_ledger.create_candidate(
+            {
+                "candidate_id": pid,
+                "subsystem": subsystem,
+                "action": record["action"],
+                "status": "pending",
+                "payload_fingerprint": payload_fingerprint,
+                "dedup_key": resolved_dedup_key,
+                "pending_relpath": f"pending/{subsystem}/{pid}.json",
+                "proposal": {
+                    # Pending JSON is the exact, reviewable replay envelope.
+                    # The long-lived ledger keeps only a non-content-bearing gist.
+                    "summary": f"{subsystem} {record['action']} candidate",
+                    "target": payload.get("target"),
+                    "name": payload.get("name"),
+                    "file_path": payload.get("file_path"),
+                },
+                "source": source,
+                "evidence": evidence,
+                "precondition": record["precondition"],
+            }
+        )
+        record["ledger_recorded"] = True
+        _atomic_pending_json_write(path, record)
+    except Exception as e:
+        # A competing process may have latched the same autonomous proposal
+        # after our optimistic pre-check.  The SQLite latch is authoritative;
+        # remove this orphan replay payload and report the existing candidate.
+        if (origin or "") == "background_review":
+            try:
+                existing = learning_ledger.find_candidate_by_dedup(resolved_dedup_key)
+                if existing is not None and existing["candidate_id"] != pid:
+                    path.unlink(missing_ok=True)
+                    return {
+                        "id": existing["candidate_id"],
+                        "candidate_id": existing["candidate_id"],
+                        "subsystem": subsystem,
+                        "action": payload.get("action", ""),
+                        "summary": (summary or "").strip(),
+                        "origin": origin,
+                        "ledger_recorded": True,
+                        "success": True,
+                        "staged": False,
+                        "suppressed": True,
+                        "deduplicated": True,
+                        "existing_status": existing["status"],
+                    }
+            except Exception:
+                pass
+        logger.error("Failed to record learning candidate %s: %s", pid, e, exc_info=True)
+        path.unlink(missing_ok=True)
+        record["success"] = False
+        record["staged"] = False
     return record
+
+
+def _read_pending_record(
+    path: Path,
+    *,
+    subsystem: str,
+    expected_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Read one pending record only when its envelope matches its path."""
+    if path.is_symlink() or not path.is_file():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(record, dict):
+            return None
+        record_id = _validate_pending_id(str(record.get("id") or ""))
+        if record_id != expected_id:
+            return None
+        raw_candidate_id = record.get("candidate_id")
+        if raw_candidate_id in {None, ""}:
+            # Pre-ledger records had no candidate_id. Bind them to their
+            # immutable filename/id so migration never trusts a mutable link.
+            candidate_id = record_id
+            record["candidate_id"] = record_id
+        else:
+            candidate_id = _validate_pending_id(str(raw_candidate_id))
+            if candidate_id != record_id:
+                return None
+        record_subsystem = str(record.get("subsystem") or subsystem)
+        if record_subsystem != subsystem:
+            return None
+        return record
+    except Exception:
+        return None
 
 
 def list_pending(subsystem: str) -> List[Dict[str, Any]]:
@@ -158,9 +442,15 @@ def list_pending(subsystem: str) -> List[Dict[str, Any]]:
         return []
     records: List[Dict[str, Any]] = []
     for p in d.glob("*.json"):
+        expected_id = p.name.removesuffix(".json")
         try:
-            records.append(json.loads(p.read_text(encoding="utf-8")))
-        except Exception:
+            expected_id = _validate_pending_id(expected_id)
+        except ValueError:
+            continue
+        record = _read_pending_record(p, subsystem=subsystem, expected_id=expected_id)
+        if record is not None:
+            records.append(record)
+        else:
             logger.warning("Skipping unreadable pending record: %s", p)
     records.sort(key=lambda r: r.get("created_at", 0))
     return records
@@ -168,17 +458,16 @@ def list_pending(subsystem: str) -> List[Dict[str, Any]]:
 
 def get_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
     """Return a single pending record by id, or None."""
+    pending_id = _validate_pending_id(pending_id)
     path = _pending_dir(subsystem) / f"{pending_id}.json"
     if not path.exists():
         return None
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return None
+    return _read_pending_record(path, subsystem=subsystem, expected_id=pending_id)
 
 
 def discard_pending(subsystem: str, pending_id: str) -> bool:
     """Delete a pending record. Returns True if it existed."""
+    pending_id = _validate_pending_id(pending_id)
     path = _pending_dir(subsystem) / f"{pending_id}.json"
     try:
         if path.exists():
@@ -187,6 +476,125 @@ def discard_pending(subsystem: str, pending_id: str) -> bool:
     except Exception as e:  # pragma: no cover
         logger.error("Failed to discard pending %s/%s: %s", subsystem, pending_id, e)
     return False
+
+
+def claim_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
+    """Atomically claim one pending payload for apply/reject."""
+    pending_id = _validate_pending_id(pending_id)
+    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        return None
+    claim_id = uuid.uuid4().hex
+    claim_path = path.with_name(f"{pending_id}.json.applying.{claim_id}")
+    try:
+        os.replace(path, claim_path)
+        record = _read_pending_record(
+            claim_path,
+            subsystem=subsystem,
+            expected_id=pending_id,
+        )
+        if record is None:
+            claim_path.unlink(missing_ok=True)
+            return None
+        record["_claim_path"] = str(claim_path)
+        record["_claim_id"] = claim_id
+        return record
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        logger.error("Failed to claim pending %s/%s: %s", subsystem, pending_id, e)
+        return None
+
+
+def release_claim(subsystem: str, claim: Mapping[str, Any], *, restore: bool) -> bool:
+    """Restore or delete a claimed payload after a decision."""
+    pending_id = _validate_pending_id(str(claim.get("id") or ""))
+    claim_path = Path(str(claim.get("_claim_path") or ""))
+    expected_parent = _pending_dir(subsystem).resolve()
+    if (
+        not claim_path.exists()
+        or claim_path.is_symlink()
+        or not claim_path.is_file()
+        or claim_path.parent.resolve() != expected_parent
+        or not claim_path.name.startswith(f"{pending_id}.json.applying.")
+    ):
+        return False
+    try:
+        if restore:
+            canonical = _pending_dir(subsystem) / f"{pending_id}.json"
+            # Never overwrite a fresh canonical proposal created while this
+            # claim was in flight.  A failed restore remains an explicit claim
+            # for reconciliation instead of losing either payload.
+            os.link(claim_path, canonical, follow_symlinks=False)
+            if canonical.is_symlink() or not canonical.is_file():
+                canonical.unlink(missing_ok=True)
+                return False
+            claim_path.unlink()
+        else:
+            claim_path.unlink()
+        return True
+    except Exception as e:
+        logger.error("Failed to release pending claim %s/%s: %s", subsystem, pending_id, e)
+        return False
+
+
+def list_claims(subsystem: str) -> List[Dict[str, Any]]:
+    """List interrupted claims without replaying or resolving them."""
+    d = _pending_dir(subsystem)
+    if not d.exists():
+        return []
+    claims: List[Dict[str, Any]] = []
+    for path in d.glob("*.json.applying.*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            pending_id = _validate_pending_id(str(record.get("id") or ""))
+            if not path.name.startswith(f"{pending_id}.json.applying."):
+                continue
+            record["_claim_path"] = str(path)
+            record["_claim_id"] = path.name.rsplit(".", 1)[-1]
+            record["_claim_age_seconds"] = max(0.0, time.time() - path.stat().st_mtime)
+            claims.append(record)
+        except Exception:
+            logger.warning("Skipping unreadable pending claim: %s", path)
+    claims.sort(key=lambda item: (-float(item.get("_claim_age_seconds", 0)), str(item.get("id", ""))))
+    return claims
+
+
+def ensure_candidate_for_record(record: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return or create a ledger candidate for a legacy pending record."""
+    from agent import learning_ledger
+
+    candidate_id = str(record.get("candidate_id") or record.get("id") or "")
+    if not candidate_id:
+        return None
+    existing = learning_ledger.get_candidate(candidate_id)
+    if existing is not None:
+        return existing
+    subsystem = str(record.get("subsystem") or "")
+    payload = dict(record.get("payload") or {})
+    try:
+        return learning_ledger.create_candidate(
+            {
+                "candidate_id": candidate_id,
+                "subsystem": subsystem,
+                "action": str(record.get("action") or payload.get("action") or "legacy"),
+                "status": "pending",
+                "payload_fingerprint": learning_ledger.canonical_payload_fingerprint(subsystem, payload),
+                "dedup_key": learning_ledger.candidate_dedup_key(subsystem, payload),
+                "pending_relpath": f"pending/{subsystem}/{candidate_id}.json",
+                "proposal": {
+                    "summary": f"{subsystem} {str(record.get('action') or payload.get('action') or 'legacy')} candidate"
+                },
+                "source": {"origin": str(record.get("origin") or "legacy")},
+                "evidence": {"status": "legacy_missing"},
+                "precondition": {},
+            }
+        )
+    except Exception as e:
+        logger.error("Failed to create ledger entry for legacy pending %s: %s", candidate_id, e)
+        return None
 
 
 def pending_count(subsystem: str) -> int:
@@ -271,10 +679,35 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
     delays a write for approval, never silently refuses it. ``blocked`` is
     still produced when the user *actively denies* an inline prompt.
     """
+    background = is_background()
+
+    # A real background-review run binds a trusted metadata envelope.  Missing
+    # context here means a legacy/internal caller, whose existing gate-off
+    # behavior remains unchanged for compatibility.
+    if background:
+        try:
+            from agent.learning_context import current_learning_metadata
+
+            evidence = dict(current_learning_metadata().get("evidence") or {})
+        except Exception:
+            evidence = {}
+        if evidence:
+            trust = str(evidence.get("source_trust") or "unknown")
+            status = str(evidence.get("status") or "missing")
+            risk = str(evidence.get("risk") or "unknown")
+            if (
+                trust in {"untrusted_external", "user_supplied_unverified", "unknown"}
+                or status in {"missing", "malformed", "unverified"}
+                or risk == "high"
+            ):
+                where = "/skills pending" if subsystem == SKILLS else "/memory pending"
+                return GateDecision(
+                    stage=True,
+                    message=f"Untrusted or high-risk learning candidate staged for review with {where}.",
+                )
+
     if not write_approval_enabled(subsystem):
         return GateDecision(allow=True)
-
-    background = is_background()
 
     # Skills always stage — a SKILL.md is too large to review inline, and a
     # background skill write happens in a daemon thread with no user present.
@@ -444,9 +877,10 @@ def skill_pending_diff(record: Dict[str, Any]) -> str:
 
     # Resolve current on-disk content for diffable actions.
     try:
-        from tools.skill_manager_tool import _find_skill
+        from tools.skill_manager_tool import _find_skill, _validate_file_path
     except Exception:
         _find_skill = None  # type: ignore
+        _validate_file_path = None  # type: ignore
 
     current = ""
     target_label = "SKILL.md"
@@ -458,14 +892,19 @@ def skill_pending_diff(record: Dict[str, Any]) -> str:
                 p = base / "SKILL.md"
             elif action in {"patch", "write_file"}:
                 rel = payload.get("file_path") or "SKILL.md"
+                path_error = _validate_file_path(str(rel)) if _validate_file_path is not None else "validator unavailable"
+                if path_error:
+                    return f"invalid staged skill path: {path_error}"
                 p = base / rel
                 target_label = rel
             else:
                 p = base / "SKILL.md"
             try:
-                if p.exists():
+                base_resolved = Path(base).resolve()
+                p.resolve(strict=False).relative_to(base_resolved)
+                if p.exists() and not p.is_symlink() and p.is_file():
                     current = p.read_text(encoding="utf-8")
-            except Exception:
+            except (OSError, ValueError):
                 current = ""
 
     if action == "edit":

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -502,7 +502,7 @@ def claim_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
     if path.is_symlink() or (path.exists() and not path.is_file()):
         return None
     claim_id = uuid.uuid4().hex
-    claim_path = path.with_name(f"{pending_id}.json.applying.{claim_id}")
+    claim_path = path.with_name(f"{_pending_filename_id(pending_id)}.json.applying.{claim_id}")
     try:
         os.replace(path, claim_path)
         record = _read_pending_record(
@@ -533,7 +533,10 @@ def release_claim(subsystem: str, claim: Mapping[str, Any], *, restore: bool) ->
         or claim_path.is_symlink()
         or not claim_path.is_file()
         or claim_path.parent.resolve() != expected_parent
-        or not claim_path.name.startswith(f"{_pending_filename_id(pending_id)}.json.applying.")
+        or not any(
+            claim_path.name.startswith(f"{prefix}.json.applying.")
+            for prefix in (_pending_filename_id(pending_id), pending_id)
+        )
     ):
         return False
     try:
@@ -567,7 +570,10 @@ def list_claims(subsystem: str) -> List[Dict[str, Any]]:
         try:
             record = json.loads(path.read_text(encoding="utf-8"))
             pending_id = _validate_pending_id(str(record.get("id") or ""))
-            if not path.name.startswith(f"{pending_id}.json.applying."):
+            if not any(
+                path.name.startswith(f"{prefix}.json.applying.")
+                for prefix in (_pending_filename_id(pending_id), pending_id)
+            ):
                 continue
             record["_claim_path"] = str(path)
             record["_claim_id"] = path.name.rsplit(".", 1)[-1]


### PR DESCRIPTION
## Summary

This PR adds a governed, profile-scoped evidence-learning ledger and improves the safety and observability of Hermes learning and skill-management workflows.

### What changed

- Added a profile-scoped learning ledger with lifecycle and audit events.
- Added bounded, redacted evidence envelopes at staging time.
- Added deterministic evaluation, causal verification, and crash-safe rollback.
- Added context-health checks and proposal-only trace compilation.
- Added authorized gateway and CLI review surfaces for learning candidates.
- Added desktop Learning Journey rendering for evidence-ledger candidates.
- Added regression coverage for two-process deduplication under schema-init contention.
- Added support for namespaced learning candidate IDs.
- Fixed migrated pending-write lookup and claim cleanup for namespaced IDs.
- Added separate short `routing` metadata for skills while preserving full descriptions.
- Fixed PixVerse v6 aspect-ratio handling for text-to-video and image-to-video requests.

### Compatibility and safety

- Existing skills without a `routing` field retain legacy behavior.
- Learning changes remain proposal- and approval-oriented.
- Candidate evidence is bounded and redacted before persistence.
- Rollback and claim cleanup paths are covered by tests.
- No upstream branches were modified.

### Testing

Focused regression suite:

```text
162 passed in 5.02s


Test areas include:

- Learning ledger
- Evidence context
- Learning evaluation
- Context health
- Trace compilation
- CLI context commands
- Gateway review authorization
- Write approval and claim lifecycle
- Skill routing metadata
- Skill-manager validation

### Review notes

The branch was rebased onto the current upstream `main` before publishing. The changes are available from:

`laiglesiasion:feat/learning-ledger-governance`

If GitHub offers the choice, mark it as a **Draft pull request** for now. The branch contains several related commits and still deserves maintainer review before being presented as ready to merge.