### PR TITLE
fix(cron): enforce profile cap for review dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8617,8 +8617,19 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if _per_profile_cap is not None:
+            current = _per_profile_running.get(row["assignee"], 0)
+            if current >= _per_profile_cap:
+                result.skipped_per_profile_capped.append(
+                    (row["id"], row["assignee"], current)
+                )
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            if _per_profile_cap is not None:
+                _per_profile_running[row["assignee"]] = (
+                    _per_profile_running.get(row["assignee"], 0) + 1
+                )
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8663,6 +8674,10 @@ def _dispatch_once_locked(
                 _set_worker_pid(conn, claimed.id, int(pid))
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            if _per_profile_cap is not None and claimed.assignee:
+                _per_profile_running[claimed.assignee] = (
+                    _per_profile_running.get(claimed.assignee, 0) + 1
+                )
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -98,3 +98,42 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert res2.spawned[0][0] != spawned_id  # different task this time
 
 
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_review_dispatch_shares_profile_cap(
+    isolated_kanban_home_with_profiles, dry_run
+):
+    """Ready and review workers share one per-profile concurrency cap."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_id = kb.create_task(conn, title="running", assignee="alpha")
+        ready_id = kb.create_task(conn, title="ready", assignee="alpha")
+        review_ids = [
+            kb.create_task(conn, title=f"review-{i}", assignee="alpha")
+            for i in range(3)
+        ]
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running' WHERE id = ?",
+                (running_id,),
+            )
+            conn.executemany(
+                "UPDATE tasks SET status = 'review' WHERE id = ?",
+                [(task_id,) for task_id in review_ids],
+            )
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=dry_run,
+            max_in_progress_per_profile=3,
+        )
+
+    spawned_ids = [task_id for task_id, _, _ in res.spawned]
+    capped_ids = [task_id for task_id, _, _ in res.skipped_per_profile_capped]
+    assert spawned_ids[0] == ready_id
+    assert len(spawned_ids) == 2
+    assert len(set(spawned_ids).intersection(review_ids)) == 1
+    assert set(capped_ids) == set(review_ids) - set(spawned_ids)
+    assert all(count == 3 for _, _, count in res.skipped_per_profile_capped)


### PR DESCRIPTION
## What does this PR do?

Apply the per-profile concurrency cap to review dispatch.

## Related Issue

Fixes #78123

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Review workers now check and update the shared per-profile running count in dry-run and real dispatch. Added regression coverage mixing running, ready, and review tasks.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_per_profile_cap.py`
2. `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_per_profile_cap.py`
3. `python scripts/check-windows-footguns.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_per_profile_cap.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
