### PR TITLE
fix(mcp): seed OAuth mtime baseline on first read to prevent spurious invalidation (#77369)

### DIFF
--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -661,6 +661,14 @@ class MCPOAuthManager:
             except (FileNotFoundError, OSError):
                 return False
 
+            if entry.last_mtime_ns == 0:
+                # First read — seed the baseline without invalidating.
+                # A freshly created _ProviderEntry starts at 0; treating
+                # the initial read as a "change" forces a spurious
+                # re-initialization that regularly exceeds connect_timeout
+                # on hosted OAuth servers (#77369).
+                entry.last_mtime_ns = mtime_ns
+                return False
             if mtime_ns != entry.last_mtime_ns:
                 old = entry.last_mtime_ns
                 entry.last_mtime_ns = mtime_ns


### PR DESCRIPTION
## Summary

Fixes spurious OAuth re-initialization caused by `invalidate_if_disk_changed()` treating the very first mtime read as an external file change.

## Problem

`_ProviderEntry.last_mtime_ns` defaults to `0` (documented as "never read"). On the first call to `invalidate_if_disk_changed()`, `mtime_ns != 0` is always true, so the entry is always invalidated — even when the tokens file hasn't changed.

Each false invalidation sets `provider._initialized = False`, forcing a full OAuth re-initialization. On hosted MCP servers this regularly exceeds `connect_timeout`, producing parking cycles. Observed: 18 spurious invalidations vs 2 genuine ones over 40 minutes, with ~32% availability.

## Fix

When `entry.last_mtime_ns == 0`, seed it with the current mtime and return `False` (no invalidation). This is a first read, not an external change.

```python
if entry.last_mtime_ns == 0:
    # First read — seed the baseline without invalidating.
    entry.last_mtime_ns = mtime_ns
    return False
```

## Testing

1. Configure an MCP server with OAuth
2. Verify first connection succeeds without spurious re-initialization
3. Manually modify the tokens file and verify the next call DOES invalidate

Fixes #77369