### PR TITLE
fix(file-ops): stop reading CJK text as binary at the sniff boundary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -16,6 +16,8 @@ from tools.file_operations import (
     SearchMatch,
     LintResult,
     ShellFileOperations,
+    BINARY_SNIFF_BYTES,
+    BINARY_SNIFF_LOOKAHEAD,
     MAX_LINE_LENGTH,
     normalize_read_pagination,
     normalize_search_pagination,
@@ -250,6 +252,11 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     intercepted by a bare MagicMock.  ``include_stderr`` folds stderr
     into ``output`` for tests that surface shell error text; leave it
     off for tests that parse structured stdout (e.g. find results).
+
+    Decodes with ``errors="replace"`` to match the real environments
+    (``tools/environments/base.py``), which hand file ops a lossy string
+    rather than raising on undecodable bytes.  Anything that inspects
+    U+FFFD — the binary sniff — only behaves like production under this.
     """
     env = MagicMock()
     env.cwd = cwd
@@ -259,6 +266,8 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
             command,
             shell=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             input=kwargs.get("stdin_data"),
         )
@@ -302,10 +311,12 @@ class TestShellFileOpsHelpers:
 
         def side_effect(command, **kwargs):
             commands.append(command)
+            if command.startswith("command -v base64"):
+                return {"output": "yes\n", "returncode": 0}
             if command.startswith("wc -c"):
                 return {"output": "5\n", "returncode": 0}
             if command.startswith("head -c"):
-                return {"output": "hello", "returncode": 0}
+                return {"output": "aGVsbG8=", "returncode": 0}  # b64 of "hello"
             if command.startswith("sed -n"):
                 return {"output": "hello\n", "returncode": 0}
             if command.startswith("wc -l"):
@@ -317,10 +328,16 @@ class TestShellFileOpsHelpers:
         result = ops.read_file(r"C:\Users\alice\notes.txt")
 
         assert result.error is None
-        assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
-        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+        safe = "'/c/Users/alice/notes.txt'"
+        want = BINARY_SNIFF_BYTES + BINARY_SNIFF_LOOKAHEAD + 1
+        # The base64 probe carries no path; everything that names the file has
+        # to use the bash-safe form.
+        assert [c for c in commands if "notes.txt" in c] == [
+            f"wc -c < {safe} 2>/dev/null",
+            f"head -c {want} < {safe} 2>/dev/null | base64 | tr -d '\\n'",
+            f"sed -n '1,2000p' {safe}",
+            f"wc -l < {safe}",
+        ]
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
@@ -673,3 +690,186 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+
+def _write_split_boundary_file(path: Path, tail: str = "다" * 200) -> str:
+    """Write a valid UTF-8 file whose BINARY_SNIFF_BYTES boundary splits a char.
+
+    Pads with ASCII so the multi-byte character straddles the window cut.
+    Returns the text written.
+    """
+    pad = "a" * (BINARY_SNIFF_BYTES - 2)          # bytes 1..998
+    text = pad + "가" + tail + "\n"               # "가" spans bytes 999..1001
+    path.write_text(text, encoding="utf-8")
+    assert path.stat().st_size > BINARY_SNIFF_BYTES, "file must exceed the window"
+    head = path.read_bytes()[:BINARY_SNIFF_BYTES]
+    assert head.decode("utf-8", errors="replace").endswith("�"), (
+        "fixture must actually split a character at the window boundary"
+    )
+    return text
+
+
+class TestBinarySniffTruncationBoundary:
+    """A character split by the sniff window is not evidence of binary.
+
+    Regression: the sniff judges BINARY_SNIFF_BYTES *bytes*, so on CJK text the
+    cut routinely lands inside a multi-byte character. Environments decode with
+    errors="replace" and flush at command end, so that dangling prefix reached
+    the guard as U+FFFD and read as undecodable bytes — making ordinary Korean
+    notes unreadable ("Binary file - cannot display as text") once they grew
+    past the window.
+
+    The sample is therefore taken as raw bytes and decoded here, incrementally
+    and without a final flush, so a split character stays buffered instead of
+    becoming U+FFFD. BINARY_SNIFF_LOOKAHEAD extra bytes keep that exact: a lone
+    0xE9 ending the window is a valid UTF-8 lead byte, and only the bytes after
+    it show whether anything completes it.
+    """
+
+    def test_split_boundary_file_reads_as_text(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "korean.md"
+        _write_split_boundary_file(target)
+
+        result = ops.read_file(str(target))
+
+        assert result.is_binary is False, result.error
+        assert result.error is None
+        assert "가" in result.content
+        assert "�" not in result.content
+
+    def test_split_boundary_file_reads_raw_as_text(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "korean.md"
+        text = _write_split_boundary_file(target)
+
+        result = ops.read_file_raw(str(target))
+
+        assert result.is_binary is False, result.error
+        assert result.content == text
+
+    def test_undecodable_bytes_midsample_still_binary(self, tmp_path):
+        """The guard's real target — invalid bytes away from the cut — stands."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "latin1.md"
+        target.write_bytes(b"caf\xe9 r\xe9sum\xe9\n" + b"a" * 2000)
+
+        assert ops.read_file(str(target)).is_binary is True
+        assert ops.read_file_raw(str(target)).is_binary is True
+
+    def test_undecodable_byte_exactly_at_the_boundary_still_binary(self, tmp_path):
+        """The ambiguous case the lookahead exists to settle.
+
+        0xE9 on the window's last byte is a valid UTF-8 lead byte, so on the
+        window alone it is indistinguishable from a character the cut split.
+        The following bytes are what prove nothing completes it.
+        """
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "boundary-latin1.md"
+        target.write_bytes(b"a" * (BINARY_SNIFF_BYTES - 1) + b"\xe9" + b"r" * 2000)
+
+        assert ops.read_file(str(target)).is_binary is True
+        assert ops.read_file_raw(str(target)).is_binary is True
+
+    def test_trailing_undecodable_byte_at_eof_still_binary(self, tmp_path):
+        """At EOF nothing can complete a dangling sequence, so it counts."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        short = tmp_path / "short.md"
+        short.write_bytes(b"plain text\n" + b"\xe9")
+        assert short.stat().st_size <= BINARY_SNIFF_BYTES
+        assert ops.read_file(str(short)).is_binary is True
+
+        # Same thing just past the window, where the lookahead hits EOF.
+        past = tmp_path / "past-window.md"
+        past.write_bytes(b"a" * (BINARY_SNIFF_BYTES + 2) + b"\xe9")
+        assert ops.read_file(str(past)).is_binary is True
+
+    def test_four_byte_char_split_by_window_reads_as_text(self, tmp_path):
+        """The lookahead has to cover the longest UTF-8 sequence, not just 3."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "emoji.md"
+        target.write_bytes(b"a" * (BINARY_SNIFF_BYTES - 2) + "🙂".encode() + b"tail\n")
+
+        result = ops.read_file(str(target))
+
+        assert result.is_binary is False, result.error
+        assert "🙂" in result.content
+
+    @pytest.mark.parametrize("offset_from_window", [-3, -2, -1, 0])
+    def test_every_split_offset_reads_as_text(self, tmp_path, offset_from_window):
+        """Where the character starts must not change the verdict."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / f"split{offset_from_window}.md"
+        pad = b"a" * (BINARY_SNIFF_BYTES + offset_from_window)
+        target.write_bytes(pad + "각".encode() + "나".encode() * 400)
+
+        assert ops.read_file(str(target)).is_binary is False
+
+    def test_short_korean_file_unaffected(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "short-korean.md"
+        target.write_text("회의 용어집\n두 번째 줄\n", encoding="utf-8")
+
+        result = ops.read_file(str(target))
+
+        assert result.is_binary is False, result.error
+        assert "회의 용어집" in result.content
+
+    def test_ascii_file_unaffected(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        target = tmp_path / "notes.md"
+        target.write_text("hello\n" * 500, encoding="utf-8")
+
+        result = ops.read_file(str(target))
+
+        assert result.is_binary is False, result.error
+        assert "hello" in result.content
+
+
+class TestBinarySniffWithoutBase64:
+    """Fallback for environments with no base64 to carry raw bytes back.
+
+    Without it the sample can only arrive as the env's lossy string, where a
+    split character and an undecodable byte both look like a trailing U+FFFD.
+    The fallback resolves that the only way it can — by whether the file
+    outran the window — so it is deliberately less precise than the byte path.
+    """
+
+    @staticmethod
+    def _ops_without_base64(cwd):
+        ops = ShellFileOperations(make_real_subprocess_env(cwd))
+        ops._command_cache['base64'] = False
+        return ops
+
+    def test_split_boundary_file_still_reads_as_text(self, tmp_path):
+        ops = self._ops_without_base64(str(tmp_path))
+        target = tmp_path / "korean.md"
+        _write_split_boundary_file(target)
+
+        result = ops.read_file(str(target))
+
+        assert result.is_binary is False, result.error
+        assert "가" in result.content
+
+    def test_mojibake_still_binary(self, tmp_path):
+        ops = self._ops_without_base64(str(tmp_path))
+        target = tmp_path / "latin1.md"
+        target.write_bytes(b"caf\xe9 r\xe9sum\xe9\n" + b"a" * 2000)
+
+        assert ops.read_file(str(target)).is_binary is True
+
+    def test_truncation_allowance_is_exactly_one_trailing_char(self):
+        """Only a single trailing U+FFFD is excused, and only when truncated."""
+        ops = ShellFileOperations(MagicMock())
+
+        assert ops._is_likely_binary(
+            "notes.md", "ok�", sample_truncated=True) is False
+        # Same sample, untruncated caller: still binary.
+        assert ops._is_likely_binary(
+            "notes.md", "ok�", sample_truncated=False) is True
+        # Two at the tail can't come from one split character.
+        assert ops._is_likely_binary(
+            "notes.md", "ok��", sample_truncated=True) is True
+        # Interior replacement chars are never excused.
+        assert ops._is_likely_binary(
+            "notes.md", "o�k�", sample_truncated=True) is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,8 @@ Usage:
 
 import os
 import re
+import base64
+import codecs
 import difflib
 import hashlib
 from abc import ABC, abstractmethod
@@ -725,6 +727,13 @@ _FAIL_CLOSED_INPROC_EXTS = frozenset({'.json', '.yaml', '.yml', '.toml'})
 MAX_LINES = 2000
 MAX_LINE_LENGTH = 2000
 MAX_FILE_SIZE = 50 * 1024  # 50KB
+# Bytes of a file that decide binary-vs-text.
+BINARY_SNIFF_BYTES = 1000
+# Fetched past that window so a character starting on its last byte can still
+# be completed (UTF-8 tops out at 4 bytes), which is what separates "the cut
+# split a character" from "these bytes are undecodable". One more byte on top
+# tells "the file ends inside the window" from "there is more after it".
+BINARY_SNIFF_LOOKAHEAD = 3
 DEFAULT_READ_OFFSET = 1
 DEFAULT_READ_LIMIT = 2000
 DEFAULT_SEARCH_OFFSET = 0
@@ -887,11 +896,86 @@ class ShellFileOperations(FileOperations):
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
-    def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
+    def _read_sniff_sample(self, path: str) -> Optional[bytes]:
+        """Fetch the binary-sniff window as raw bytes, or None if unavailable.
+
+        Raw bytes, not the env's decoded stdout: environments decode with
+        ``errors="replace"`` and flush at command end, so a character split by
+        the byte cut arrives as U+FFFD — indistinguishable from a genuinely
+        undecodable byte. base64 carries the sample across that transport
+        intact. ``-w0`` is GNU-only, hence the ``tr``; the input redirect keeps
+        a leading-dash path out of argv.
+        """
+        if not self._has_command('base64'):
+            return None
+        want = BINARY_SNIFF_BYTES + BINARY_SNIFF_LOOKAHEAD + 1
+        quoted = self._escape_shell_arg(path)
+        result = self._exec(
+            f"head -c {want} < {quoted} 2>/dev/null | base64 | tr -d '\\n'")
+        if result.exit_code != 0:
+            return None
+        encoded = "".join(_strip_terminal_fence_leaks(result.stdout).split())
+        try:
+            return base64.b64decode(encoded, validate=True)
+        except Exception:
+            return None
+
+    def _sample_is_binary(self, path: str, sample: bytes) -> bool:
+        """Binary-vs-text verdict for a raw sniff window."""
+        if os.path.splitext(path)[1].lower() in BINARY_EXTENSIONS:
+            return True
+        if not sample:
+            return False
+
+        # Incremental decode with no final flush: a character the window cut in
+        # half stays buffered rather than becoming U+FFFD, so only bytes that
+        # are actually undecodable produce one. The lookahead is what makes
+        # that exact — a lone 0xE9 at the end of a latin-1 file is a valid
+        # UTF-8 lead byte, and only the bytes after it reveal that nothing
+        # completes it. When the sample reached EOF there is nothing more
+        # coming, so flush and let a dangling sequence count against the file.
+        at_eof = len(sample) <= BINARY_SNIFF_BYTES + BINARY_SNIFF_LOOKAHEAD
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        text = decoder.decode(sample, final=at_eof)
+
+        # Undecodable bytes mean a read→edit→write round-trip would write the
+        # lossy text back over the original bytes, so such a file is read-only
+        # as far as the agent is concerned. U+FFFD is "printable", so the
+        # ratio below never catches it; legitimate UTF-8 effectively never
+        # contains one.
+        if "�" in text:
+            return True
+        if not text:
+            return False
+        non_printable = sum(1 for c in text if ord(c) < 32 and c not in '\n\r\t')
+        return non_printable / len(text) > 0.30
+
+    def _detect_binary(self, path: str, file_size: int) -> bool:
+        """Decide binary-vs-text, preferring the byte-exact sample."""
+        if os.path.splitext(path)[1].lower() in BINARY_EXTENSIONS:
+            return True
+        sample = self._read_sniff_sample(path)
+        if sample is not None:
+            return self._sample_is_binary(path, sample)
+        # No base64 in the environment: fall back to the env's decoded sample,
+        # which cannot tell a split character from an undecodable byte except
+        # by whether the file outran the window.
+        result = self._exec(
+            f"head -c {BINARY_SNIFF_BYTES} {self._escape_shell_arg(path)} 2>/dev/null")
+        return self._is_likely_binary(
+            path, _strip_terminal_fence_leaks(result.stdout),
+            sample_truncated=file_size > BINARY_SNIFF_BYTES)
+
+    def _is_likely_binary(self, path: str, content_sample: str = None,
+                          sample_truncated: bool = False) -> bool:
         """
         Check if a file is likely binary.
         
         Uses extension check (fast) + content analysis (fallback).
+
+        ``sample_truncated`` says the caller cut ``content_sample`` at a byte
+        offset (file longer than BINARY_SNIFF_BYTES), which makes a single
+        trailing U+FFFD ambiguous — see below.
         """
         ext = os.path.splitext(path)[1].lower()
         if ext in BINARY_EXTENSIONS:
@@ -899,6 +983,18 @@ class ShellFileOperations(FileOperations):
         
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
+            sample = content_sample[:BINARY_SNIFF_BYTES]
+            # A byte-sliced sample can cut a multi-byte character in half, and
+            # the env's decoder flushes that dangling prefix as U+FFFD. The
+            # artifact is always exactly one U+FFFD and always the final char
+            # (a truncated sequence decodes as a single maximal subpart), so
+            # dropping one trailing replacement char is what separates "sample
+            # ended mid-character" from "file holds undecodable bytes" — every
+            # other U+FFFD still trips the check below. Without this, any text
+            # file whose byte BINARY_SNIFF_BYTES lands inside a multi-byte
+            # character — routine for CJK — reads back as unreadable binary.
+            if sample_truncated and sample.endswith("�"):
+                sample = sample[:-1]
             # Undecodable bytes: the terminal env decodes stdout with
             # errors="replace", so any non-UTF-8 byte arrives here already
             # turned into U+FFFD. That char is "printable" (ord 65533), so the
@@ -908,11 +1004,11 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            if "\ufffd" in sample:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in content_sample[:BINARY_SNIFF_BYTES]
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(content_sample), BINARY_SNIFF_BYTES) > 0.30
         
         return False
     
@@ -1179,12 +1275,8 @@ class ShellFileOperations(FileOperations):
                 ),
             )
         
-        # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        
-        if self._is_likely_binary(path, sample_output):
+        # Sample the head of the file to check for binary content
+        if self._detect_binary(path, file_size):
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
@@ -1298,9 +1390,7 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        if self._is_likely_binary(path, sample_output):
+        if self._detect_binary(path, file_size):
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."


### PR DESCRIPTION
## Problem

`read_file` rejects ordinary UTF-8 text as binary once the file grows past the
binary-sniff window, for any script that uses multi-byte characters.

The sniff judges a fixed number of *bytes* (`head -c 1000`), so the cut lands
wherever it lands — routinely inside a character on CJK text. Environments
decode subprocess output with `errors="replace"` and flush at command end
(`tools/environments/base.py`), so that split character arrives at the guard as
U+FFFD. The non-UTF-8 guard added in 021a0768 reads it as undecodable bytes:

```
Binary file - cannot display as text. Use appropriate tools to handle this file type.
```

The file is valid UTF-8 and perfectly readable; only the sample was cut mid-character.

Measured on a Korean Markdown vault: **19 of 42** files over the window were
unreadable. Whether a given file trips depends only on where byte 1000 lands,
so it looks arbitrary from the outside.

## Fix

The sample is now taken as **raw bytes** (base64 across the transport, as
`tools/image_source.py` already does) instead of the environment's decoded
string, and decoded here with an incremental decoder and **no final flush**. A
character the window split stays buffered rather than becoming U+FFFD, so only
genuinely undecodable bytes produce one.

The window alone cannot settle every case: a lone `0xE9` ending it is a valid
UTF-8 lead byte, indistinguishable from a split character until you see whether
anything completes it. So the read takes `BINARY_SNIFF_LOOKAHEAD` bytes past the
window, plus one more to distinguish "the file ends inside the window" from
"there is more after it" — at EOF the decoder is flushed and a dangling
sequence does count against the file.

That makes the two cases exact rather than heuristic, so the read→edit→write
corruption the guard exists to prevent stays covered, **including at the
boundary**. It also drops the sniff's dependence on a separate `wc -c` for the
decision, which removes both a TOCTOU window and a silent failure mode where an
unparseable size would have quietly changed the verdict.

Environments with no `base64` fall back to the previous string sample, which can
only separate the two cases by whether the file outran the window.

## Tests

`TestBinarySniffTruncationBoundary` in `tests/tools/test_file_operations.py`:

- a valid UTF-8 file whose window boundary splits a character reads as text,
  through both `read_file` and `read_file_raw`, with content intact
- the same for a 4-byte character, and for every start offset across the boundary
- an undecodable byte landing *exactly* on the window's last byte is still
  binary — the case the lookahead exists to settle
- a dangling sequence at EOF is still binary, both below the window and just past it
- undecodable bytes away from the cut, PNG, raw-byte and latin-1 fixtures stay binary
- short CJK and ASCII files are unaffected

`TestBinarySniffWithoutBase64` covers the fallback path.

`make_real_subprocess_env` now decodes with `errors="replace"` to match the real
environments. Without that the helper raises on undecodable bytes instead of
producing the lossy string the sniff is written against, so tests could not
reproduce production behavior.

Verified against the reported corpus: 19 previously-unreadable files → 0, with
`read_file_raw` output byte-identical to disk.
