### PR TITLE
fix(security): fail closed for NUL shell scripts

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -389,7 +389,12 @@ def _read_script_for_scanning(script_path: str) -> str:
     sentinel, while missing/unreadable paths remain empty so ordinary scheduler
     path validation can report them.
     """
-    script_text, unsafe = _read_referenced_script(_resolve_script_path(script_path))
+    resolved_script = _resolve_script_path(script_path)
+    shell_invoked = resolved_script.suffix.lower() in {".sh", ".bash"}
+    script_text, unsafe = _read_referenced_script(
+        resolved_script,
+        shell_invoked=shell_invoked,
+    )
     if unsafe:
         return "hermes gateway restart"
     return script_text or ""

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -181,8 +181,8 @@ def _iter_referenced_shell_scripts(
     command: str,
     *,
     cwd: Optional[str] = None,
-) -> Iterator[Path]:
-    """Yield scripts executed directly or through a POSIX shell."""
+) -> Iterator[tuple[Path, bool]]:
+    """Yield ``(script, shell_invoked)`` references from a command."""
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -192,7 +192,7 @@ def _iter_referenced_shell_scripts(
 
         if executable_name in {".", "source"}:
             if len(segment) > index + 1:
-                yield _resolve_terminal_script_path(segment[index + 1], cwd)
+                yield _resolve_terminal_script_path(segment[index + 1], cwd), True
             continue
 
         if executable_name in _SHELL_EXECUTABLES:
@@ -216,7 +216,7 @@ def _iter_referenced_shell_scripts(
                 "-c",
                 "--command",
             }:
-                yield _resolve_terminal_script_path(arguments[arg_index], cwd)
+                yield _resolve_terminal_script_path(arguments[arg_index], cwd), True
             continue
 
         # A bare "/" token is pathlib's division operator in Python sources
@@ -226,7 +226,7 @@ def _iter_referenced_shell_scripts(
         # (#77131). Skip pure-separator tokens.
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+                yield _resolve_terminal_script_path(executable, cwd), False
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
@@ -253,11 +253,15 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     return None
 
 
-def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
+def _read_referenced_script(path: Path, *, shell_invoked: bool = False) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
+    except ValueError:
+        # An embedded NUL path cannot be read safely and must not fall through
+        # to a remote callback.
+        return None, True
     except OSError:
         return None, False
     try:
@@ -272,14 +276,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     finally:
         os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
+    # A NUL-bearing shebang file (or a file passed to a shell) is still a
+    # shell script: bash/sh can execute its suffix. Native executables are not.
     if b"\x00" in data:
-        return None, False
+        return None, shell_invoked or data.startswith(b"#!")
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
     return data.decode("utf-8", errors="replace"), False
@@ -310,7 +310,7 @@ def _contains_unsafe_gateway_action(
         ):
             return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    for script_path, shell_invoked in _iter_referenced_shell_scripts(command, cwd=cwd):
         try:
             resolved = script_path.resolve(strict=False)
         except (OSError, ValueError):
@@ -321,12 +321,14 @@ def _contains_unsafe_gateway_action(
         if resolved in visited:
             continue
         visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
+        script_text, unsafe = _read_referenced_script(script_path, shell_invoked=shell_invoked)
         if unsafe:
             return True
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+            if script_text is not None and "\x00" in script_text:
+                return shell_invoked or script_text.startswith("#!")
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -724,6 +724,24 @@ class TestLifecycleGuardModule:
         script.write_bytes(b"#!/bin/bash\n\x00printf safe\n")
         assert contains_gateway_lifecycle_command_or_referenced_script(str(script)) is True
 
+    def test_plain_shell_script_with_nul_fails_closed(self, tmp_path):
+        """Cron treats .sh/.bash as shell scripts even without a shebang."""
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+        script = tmp_path / "plain-nul.sh"
+        script.write_bytes(b"printf safe\n\x00hermes gateway restart\n")
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("clean prompt", str(script))
+
+    def test_remote_plain_shell_script_with_nul_fails_closed(self):
+        """Remote reads must also fail closed for shell-invoked scripts."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "/bin/bash /remote/plain-nul.sh",
+            read_remote_script=lambda _path: "printf safe\n\x00hermes gateway restart\n",
+        ) is True
+
     def test_remote_nul_bearing_shell_script_fails_closed(self):
         """Remote script reads follow the same NUL fail-closed rule."""
         from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -516,6 +516,27 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 0
         assert calls == [command]
 
+    def test_remote_nul_bearing_script_is_blocked(self, monkeypatch):
+        """Terminal remote fallback preserves NUL shell content for the guard."""
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            cwd = "/remote"
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "#!/bin/bash\n\x00printf safe\n", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        result = json.loads(tt.terminal_tool(command="/bin/bash remote-nul.sh"))
+
+        assert result["exit_code"] == 1
+        assert "referenced script" in result["error"]
+        assert calls == ["cat /remote/remote-nul.sh"]
+
     def test_safe_referenced_script_passes_through(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt
 
@@ -694,6 +715,51 @@ class TestLifecycleGuardModule:
             '/usr/bin/python3 -c "print(1)"'
         )
         assert result is False
+
+    def test_nul_bearing_shell_script_fails_closed(self, tmp_path):
+        """bash/sh can execute content after a NUL byte."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        script = tmp_path / "nul-shell.sh"
+        script.write_bytes(b"#!/bin/bash\n\x00printf safe\n")
+        assert contains_gateway_lifecycle_command_or_referenced_script(str(script)) is True
+
+    def test_remote_nul_bearing_shell_script_fails_closed(self):
+        """Remote script reads follow the same NUL fail-closed rule."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "/remote/nul-shell.sh",
+            read_remote_script=lambda _path: "#!/bin/bash\n\x00printf safe\n",
+        ) is True
+
+    def test_nul_path_blocks_without_remote_fallback(self):
+        """NUL paths must not crash or re-enter the remote callback."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        reads = []
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "/remote/nul\x00shell.sh", read_remote_script=lambda path: reads.append(path)
+        ) is True
+        assert reads == []
+
+    def test_native_executable_with_nul_is_not_a_shell_script(self, tmp_path):
+        """A direct native executable remains allowed despite NUL bytes."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        binary = tmp_path / "tool"
+        binary.write_bytes(b"\x7fELF\x02\x01\x00\x00")
+        assert contains_gateway_lifecycle_command_or_referenced_script(str(binary)) is False
+
+    def test_remote_binary_fallback_remains_safe(self):
+        """#77729 regression: remote binary bytes do not crash or block."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        binary_blob = "\x7fELF\x01\x01\n/opt/bin/tool\x00\x01 --run\n"
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "/home/zedi/venv/bin/python --version",
+            read_remote_script=lambda _path: binary_blob,
+        ) is False
 
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:


### PR DESCRIPTION
## What

Fail closed for NUL-bearing shell scripts in the cron guard. This keeps `.sh` / `.bash` scripts unsafe even without a shebang, matching the scheduler's `bash` execution path.

## Why

The earlier NUL handling fix was still bypassable for cron-created shell scripts without `#!`. This change routes cron `.sh` / `.bash` scripts through the shared guard with `shell_invoked=True` and adds regressions for:
- plain `.sh` with NUL in the body
- remote shell-invoked script with NUL and no shebang

## Tests

- `python -m compileall -q cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check`
- `python -m pytest -p no:cacheprovider tests/hermes_cli/test_gateway_restart_loop.py -k 'not test_cronjob_tool_surfaces_block_as_error'`
- full file: `89 passed, 1 failed` where the single failure is the existing `croniter` dependency blocker in `test_cronjob_tool_surfaces_block_as_error`