### PR TITLE
fix(weixin): use exponential backoff for rate-limit retries (#77834)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1844,7 +1844,14 @@ class WeixinAdapter(BasePlatformAdapter):
                                 break
                             if attempt >= self._send_chunk_retries:
                                 break
-                            wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
+                            # Exponential backoff for rate limit: 3x, 9x, 27x, ...
+                            # capped at the circuit breaker window so we don't
+                            # sleep longer than the breaker would keep us parked.
+                            cap = max(1.0, self._rate_limit_circuit_window_seconds)
+                            wait = min(
+                                self._send_chunk_retry_delay_seconds * (3 ** (attempt + 1)),
+                                cap,
+                            )
                             logger.warning(
                                 "[%s] rate limited for %s; backing off %.1fs before retry",
                                 self.name, _safe_id(chat_id), wait,


### PR DESCRIPTION
## Summary

Replaces fixed-delay rate-limit retry with exponential backoff in the Weixin (iLink) adapter to break infinite cooldown loops.

## Problem

When iLink returns a rate-limit error (errcode -2) with a 30-second cooldown, the retry logic uses a fixed delay (`send_chunk_retry_delay_seconds * 3`, default 3s). Each retry triggers a fresh 30-second cooldown on the server side, creating an infinite loop:

```
23:37:20  rate limited; cooldown 30.0s
23:40:20  rate limited; cooldown 30.0s  (still 30s)
23:43:20  rate limited; cooldown 30.0s  (still 30s)
...12+ minutes of this
```

## Fix

Change from fixed `delay * 3` to exponential `delay * 3^(attempt+1)`, capped at the circuit breaker window:

| Attempt | Old delay | New delay |
|---------|-----------|-----------|
| 0       | 3s        | 3s        |
| 1       | 3s        | 9s        |
| 2       | 3s        | 27s       |
| 3       | 3s        | 81s (cap) |

The increasing gaps give the server's rate limiter time to fully reset between attempts.

Fixes #77834