### PR TITLE
fix(moa): scope the per-slot runtime cache to the active profile

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -162,7 +162,7 @@ _preset_cache_lock = threading.Lock()
 _preset_cache: dict[tuple, Any] = {}
 
 _runtime_cache_lock = threading.Lock()
-_runtime_cache: dict[tuple[str, str], tuple[float, dict[str, Any]]] = {}
+_runtime_cache: dict[tuple[str, str, str], tuple[float, dict[str, Any]]] = {}
 
 # Runtime entries go stale when providers/credentials change (key rotation,
 # base_url edits). Deliberately short-lived: 300s collapses the per-iteration
@@ -346,16 +346,22 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     provider/model on any resolution error so a misconfigured slot still
     attempts the call rather than aborting the whole MoA turn.
 
-    The resolved runtime is cached per (provider, model) with a short TTL
-    (``_RUNTIME_CACHE_TTL_SECONDS``): the resolution does real I/O (catalog
-    query + config read) that used to run serially per create() call before
-    the parallel fan-out could start — the dominant source of MoA cold-start
-    latency (#66793). The TTL bounds credential staleness (key rotation,
-    base_url edits) instead of caching for the process lifetime.
+    The resolved runtime is cached per (hermes_home, provider, model) with a
+    short TTL (``_RUNTIME_CACHE_TTL_SECONDS``): the resolution does real I/O
+    (catalog query + config read) that used to run serially per create() call
+    before the parallel fan-out could start — the dominant source of MoA
+    cold-start latency (#66793). The TTL bounds credential staleness (key
+    rotation, base_url edits) instead of caching for the process lifetime.
+    ``hermes_home`` is part of the key because a multiplex gateway resolves
+    multiple profiles' agents in the same process — without it, one
+    profile's resolved api_key/base_url for a (provider, model) pair would
+    be served to a different profile requesting the same pair.
     """
+    from hermes_constants import get_hermes_home
+
     provider = str(slot.get("provider") or "").strip()
     model = str(slot.get("model") or "").strip()
-    cache_key = (provider, model)
+    cache_key = (str(get_hermes_home()), provider, model)
     now = time.monotonic()
     with _runtime_cache_lock:
         entry = _runtime_cache.get(cache_key)

--- a/tests/agent/test_moa_cold_start_cache_66793.py
+++ b/tests/agent/test_moa_cold_start_cache_66793.py
@@ -181,7 +181,9 @@ def test_slot_runtime_cache_expires_after_ttl(monkeypatch):
     assert calls["n"] == 1
 
     # Age the entry past the TTL and confirm re-resolution.
-    key = ("openai", "gpt-5")
+    from hermes_constants import get_hermes_home
+
+    key = (str(get_hermes_home()), "openai", "gpt-5")
     stamped_at, cached = moa._runtime_cache[key]
     moa._runtime_cache[key] = (
         stamped_at - moa._RUNTIME_CACHE_TTL_SECONDS - 1, cached

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -157,3 +157,52 @@ class TestThreadContextPropagation:
 
         seen = _under_override(prof_b, lambda: asyncio.run(driver()))
         assert seen == str(prof_b)
+
+
+# ---------------------------------------------------------------------------
+# M3 — module-level caches keyed without the profile boundary
+# ---------------------------------------------------------------------------
+
+class TestMoASlotRuntimeCacheIsolation:
+    """agent/moa_loop.py's per-slot runtime cache must not leak credentials
+    resolved for one profile to a MoA call running under a different one.
+
+    The cache used to key on (provider, model) only. A multiplex gateway
+    resolves multiple profiles' agents in the same process, so a MoA slot
+    referencing the same (provider, model) pair in two profiles with
+    different actual credentials for that provider name would have the
+    second profile silently receive the first profile's resolved
+    api_key/base_url for up to _RUNTIME_CACHE_TTL_SECONDS.
+    """
+
+    def test_slot_runtime_does_not_leak_credentials_across_profiles(
+        self, two_profiles, monkeypatch
+    ):
+        prof_a, prof_b = two_profiles
+        import agent.moa_loop as moa
+
+        moa._runtime_cache.clear()
+
+        def fake_resolve(*, requested=None, target_model=None, **_kw):
+            # A realistic resolver reads the active profile's own config for
+            # credentials -- simulated here by keying off the live override.
+            home = str(get_hermes_home())
+            return {
+                "base_url": f"https://{Path(home).name}.example.com/v1",
+                "api_key": f"secret-for-{Path(home).name}",
+                "api_mode": None,
+            }
+
+        import hermes_cli.runtime_provider as rt_mod
+        monkeypatch.setattr(rt_mod, "resolve_runtime_provider", fake_resolve)
+
+        slot = {"provider": "openai", "model": "gpt-4o"}
+        resolved_a = _under_override(prof_a, lambda: moa._slot_runtime(dict(slot)))
+        resolved_b = _under_override(prof_b, lambda: moa._slot_runtime(dict(slot)))
+
+        assert resolved_a["api_key"] == f"secret-for-{prof_a.name}"
+        assert resolved_b["api_key"] == f"secret-for-{prof_b.name}", (
+            "profile B's MoA slot must not receive profile A's cached "
+            "credentials for the same (provider, model) pair"
+        )
+        assert resolved_a["base_url"] != resolved_b["base_url"]


### PR DESCRIPTION
## Summary

`_slot_runtime()`'s per-slot runtime cache (added in #77868, salvage of #66811, to cut MoA cold-start latency) keys the resolved `(api_key, base_url, api_mode)` runtime only on `(provider, model)`. A multiplex gateway resolves multiple profiles' agents in the same OS process (see #77865, #77872 for the same anti-pattern in other modules). If two profiles both use MoA with a slot referencing the same `(provider, model)` pair but have *different* real credentials configured for that provider name, the second profile silently receives the first profile's resolved `api_key`/`base_url` for up to `_RUNTIME_CACHE_TTL_SECONDS` (300s).

Reproduced empirically before writing the fix: resolving a slot under profile A's `HERMES_HOME` override, then under profile B's, returned profile A's cached credentials to profile B.

## Fix

Add the active `hermes_home` to the cache key (`(hermes_home, provider, model)` instead of `(provider, model)`), so each profile resolves and caches its own runtime independently. `_preset_cache` (the sibling cache in the same module) was checked and does **not** have this issue — its key already includes the config file's `st_mtime_ns`, and different profiles have different config file paths, so it self-invalidates correctly across profiles (at the cost of some cache-thrashing under interleaved multi-profile access, which is a missed optimization, not a correctness bug — left untouched to keep this fix minimal).

## Test plan

- [x] Updated the existing TTL-expiry test (`tests/agent/test_moa_cold_start_cache_66793.py`) for the new 3-tuple cache key shape.
- [x] Added `TestMoASlotRuntimeCacheIsolation` to `tests/test_profile_isolation_runtime.py` (the existing dedicated home for this exact bug class), reproducing the cross-profile leak against two real `HERMES_HOME` overrides.
- [x] Mutation-verified: reverting the fix makes the new regression test fail with the exact leaked-credential assertion.
- [x] Full neighboring test sweep (all `*moa*` + profile-isolation test files, 106 tests) passes.
- [x] `ruff check` clean on all changed files.