### PR TITLE
fix(context_breakdown): search the volatile tier for the skills index

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -99,14 +99,17 @@ def compute_session_context_breakdown(
     context = parts.get("context", "") or ""
     volatile = parts.get("volatile", "") or ""
 
-    skills_match = _SKILLS_BLOCK_RE.search(stable)
+    # Skills index lives in the volatile tier (moved from stable so skill
+    # edits don't invalidate the cached identity prefix — #37117). Fall back
+    # to stable for sessions whose cached prompt predates that move.
+    skills_match = _SKILLS_BLOCK_RE.search(volatile) or _SKILLS_BLOCK_RE.search(stable)
     skills_index = skills_match.group(0) if skills_match else ""
 
     memory_block, user_block = _memory_blocks(agent)
     memory_text = "\n\n".join(part for part in (memory_block, user_block) if part).strip()
 
     system_core = _strip_blocks(stable, skills_index)
-    system_tail = _strip_blocks(volatile, memory_block, user_block)
+    system_tail = _strip_blocks(volatile, skills_index, memory_block, user_block)
     system_prompt_text = "\n\n".join(part for part in (system_core, system_tail) if part).strip()
 
     tools = list(getattr(agent, "tools", None) or [])
@@ -204,7 +207,10 @@ def compute_context_details(agent: Any) -> Dict[str, Any]:
 
     parts = build_system_prompt_parts(agent)
     stable = parts.get("stable", "") or ""
-    skills_match = _SKILLS_BLOCK_RE.search(stable)
+    volatile = parts.get("volatile", "") or ""
+    # Skills index lives in the volatile tier (#37117); fall back to stable
+    # for sessions whose cached prompt predates that move.
+    skills_match = _SKILLS_BLOCK_RE.search(volatile) or _SKILLS_BLOCK_RE.search(stable)
     skills_block = skills_match.group(0) if skills_match else ""
 
     skills: List[Dict[str, Any]] = []

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from agent.context_breakdown import compute_session_context_breakdown
+from agent.context_breakdown import _chars_to_tokens, compute_session_context_breakdown
 
 
 def _make_agent(
@@ -32,12 +32,13 @@ def _make_agent(
 
 
 def test_breakdown_includes_major_categories():
-    stable = (
-        "base guidance\n"
-        "<available_skills>\n  demo:\n    - hello: hi\n</available_skills>"
-    )
+    # Skills index lives in the volatile tier (#37117), not stable.
+    stable = "base guidance"
     context = "# Project Context\nFollow AGENTS.md"
-    volatile = "Current time: now"
+    volatile = (
+        "<available_skills>\n  demo:\n    - hello: hi\n</available_skills>\n\n"
+        "Current time: now"
+    )
     history = [{"role": "user", "content": "hello there"}]
     agent, parts = _make_agent(stable=stable, context=context, volatile=volatile)
 
@@ -48,6 +49,59 @@ def test_breakdown_includes_major_categories():
     assert {"system_prompt", "tool_definitions", "rules", "skills", "mcp", "subagent_definitions", "conversation"} <= ids
     assert data["context_max"] == 200_000
     assert data["estimated_total"] > 0
+
+
+def test_skills_index_falls_back_to_stable_for_legacy_sessions():
+    """A session whose cached system prompt predates #37117 (skills still in
+    the stable tier) must still attribute a "skills" category."""
+    stable = (
+        "base guidance\n"
+        "<available_skills>\n  demo:\n    - hello: hi\n</available_skills>"
+    )
+    volatile = "Current time: now"
+    agent, parts = _make_agent(stable=stable, volatile=volatile)
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    ids = {item["id"] for item in data["categories"]}
+    assert "skills" in ids
+
+
+def test_skills_index_not_double_counted_in_system_prompt():
+    """The skills block must be attributed only to the "skills" category,
+    not also folded into "system_prompt" via the volatile tail."""
+    skills_block = "<available_skills>\n  demo:\n    - hello: hi\n</available_skills>"
+    stable = "base guidance"
+    remainder = "Current time: now"
+    volatile = f"{skills_block}\n\n{remainder}"
+    agent, parts = _make_agent(stable=stable, volatile=volatile)
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, [])
+
+    by_id = {item["id"]: item["tokens"] for item in data["categories"]}
+    expected_system_prompt = _chars_to_tokens(
+        "\n\n".join((stable, remainder))
+    )
+    assert by_id["system_prompt"] == expected_system_prompt
+    assert by_id["skills"] == _chars_to_tokens(skills_block)
+
+
+def test_context_details_finds_skills_in_volatile_tier():
+    """compute_context_details() (the /context all per-skill listing) must
+    also look in the volatile tier, not just stable."""
+    from agent.context_breakdown import compute_context_details
+
+    stable = "base guidance"
+    volatile = "<available_skills>\n  demo:\n    - hello: hi\n</available_skills>"
+    agent, parts = _make_agent(stable=stable, volatile=volatile)
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        details = compute_context_details(agent)
+
+    names = {entry["name"] for entry in details["skills"]}
+    assert names == {"hello"}
 
 
 


### PR DESCRIPTION
## Summary

#37117 (salvaged and merged today as #77696) moved the `<available_skills>` block from the stable band of the system prompt to the volatile band, so skill edits don't invalidate the cached identity prefix. A same-day CI-caught follow-up fixed `hermes_cli/prompt_size.py`'s `compute_prompt_breakdown()` for this move.

`agent/context_breakdown.py` — which powers the `/context` and `/context all` commands (shipped via #72242) — has its own independent copy of the same `_SKILLS_BLOCK_RE` regex, used in two places (`compute_session_context_breakdown()`, `compute_context_details()`), and both were missed by the follow-up fix: they still search only the stable tier.

Empirically confirmed before writing the fix: with a skill loaded, `/context`'s "Skills" category is silently absent from the breakdown, and `/context all` lists zero skills.

## Fix

- Both functions now search the volatile tier first, falling back to stable for sessions whose cached prompt predates #37117 (mirrors `prompt_size.py`'s fix).
- `compute_session_context_breakdown()` also now strips the found skills block out of the volatile tail before folding it into the `system_prompt` text, so skills tokens are attributed only to their own category rather than double-counted once they're found (a bug that would otherwise have been introduced by fixing the lookup alone).

## Test plan

- [x] Updated `test_breakdown_includes_major_categories`'s fixture to place `<available_skills>` in the volatile tier (matching current production reality) rather than stable — this is why the bug wasn't caught: the existing test's mock reflected the pre-#37117 layout.
- [x] Added `test_skills_index_falls_back_to_stable_for_legacy_sessions` for the legacy fallback path.
- [x] Added `test_skills_index_not_double_counted_in_system_prompt` proving the volatile-tail stripping fix.
- [x] Added `test_context_details_finds_skills_in_volatile_tier` — `compute_context_details()` had no prior direct behavioral test coverage at all.
- [x] Mutation-verified: reverting the fix makes all three new/updated assertions fail with the exact symptom described above.
- [x] Full neighboring test sweep (context breakdown, prompt_size, system_prompt, status command — 61 tests) passes.
- [x] `ruff check` clean on all changed files.