### PR TITLE
fix(update): classify venv holders on the full cmdline, truncate only for display

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -144,7 +144,7 @@ def main() -> None:
         {
             "pid": pid,
             "name": name,
-            "cmdline": _redact_sensitive_cmdline(cmdline),
+            "cmdline": _redact_sensitive_cmdline(cmdline)[:120],
         }
         for pid, name, cmdline in matches
         if not _is_pausable_gateway(cmdline)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2911,7 +2911,14 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
-        matches.append((int(pid), str(name), cmdline_raw[:120]))
+        # Full cmdline — callers classify on it (the pausable-gateway
+        # exemption) before anyone displays it. Truncating at capture broke
+        # that: a long ``.hermes-runtime`` interpreter path pushes ``gateway
+        # run`` past 120 chars, so the matcher saw no subcommand and the
+        # Desktop preflight reported a pausable gateway as an unpausable
+        # blocker, dead-ending every update. Truncation belongs at the
+        # display sites.
+        matches.append((int(pid), str(name), cmdline_raw))
     return matches
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -2926,7 +2933,7 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
             hint = "  ← Hermes Desktop backend (close the desktop app)"
         elif "gateway" in low:
             hint = "  ← gateway"
-        lines.append(f"  PID {pid}  {name}  {cmdline}{hint}")
+        lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
     lines.append("")
@@ -3026,9 +3033,10 @@ def _leftover_pausable_gateway_pids(
     to exempt them (``_is_pausable_gateway``), so the preflight's exemption
     and this guard's tolerance cannot drift apart — matcher drift between
     two views of the same process table is what produced the launcher/worker
-    dead-end fixed above. The scan captures only a 120-char cmdline prefix,
-    so the live argv is re-read where psutil allows; an unreadable argv
-    falls back to the captured prefix.
+    dead-end fixed above. The scan captures the full argv, but it is re-read
+    live where psutil allows so a process that re-execed since the scan is
+    classified on what it is running now; an unreadable argv falls back to
+    the captured cmdline.
 
     Returns ``None`` when any holder is not a pausable gateway — an operator
     REPL, a stray script, or the Desktop backend has no pause machinery

--- a/tests/hermes_cli/test_venv_holder_cmdline_not_truncated.py
+++ b/tests/hermes_cli/test_venv_holder_cmdline_not_truncated.py
@@ -1,0 +1,61 @@
+"""Regression: venv-holder detection must not truncate cmdline before classification.
+
+A gateway launched through the long ``.hermes-runtime`` interpreter path has
+``gateway run`` sitting past character 120.  While
+``_detect_venv_python_processes`` truncated to 120 chars at capture time, the
+pausable-gateway matcher saw no subcommand, so the Desktop update preflight
+reported that gateway as an *unpausable* blocker and aborted every update with
+"another Hermes process is using this installation".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import update_cmd
+from hermes_cli._scan_venv_blockers import _is_pausable_gateway
+from hermes_cli.update_cmd import _format_venv_python_holders_message
+
+LONG_RUNTIME_GATEWAY = (
+    r"C:\Users\someone\AppData\Local\hermes\hermes-agent\.hermes-runtime\python"
+    r"\generation-1785635064-16968-cb2f7f1f\cpython-3.11-windows-x86_64-none"
+    r"\python.exe -m hermes_cli.main gateway run"
+)
+
+
+def test_long_gateway_cmdline_is_pausable_only_when_untruncated():
+    assert len(LONG_RUNTIME_GATEWAY) > 120, "fixture must exceed the old cut"
+    assert _is_pausable_gateway(LONG_RUNTIME_GATEWAY) is True
+    # The bug: the 120-char prefix loses `gateway run`.
+    assert _is_pausable_gateway(LONG_RUNTIME_GATEWAY[:120]) is False
+
+
+def test_detect_returns_untruncated_cmdline(monkeypatch):
+    """The detector hands callers the full argv, not a 120-char prefix."""
+    psutil = pytest.importorskip("psutil")
+    if not update_cmd._m()._is_windows():
+        pytest.skip("Windows-only detector")
+
+    venv_python = str(update_cmd._m().PROJECT_ROOT / "venv" / "Scripts" / "python.exe")
+    argv = [venv_python, "-m", "hermes_cli.main", "gateway", "run", "x" * 200]
+
+    class FakeProc:
+        info = {
+            "pid": 999999,
+            "exe": venv_python,
+            "name": "python.exe",
+            "cmdline": argv,
+            "cwd": "",
+        }
+
+    monkeypatch.setattr(psutil, "process_iter", lambda *_a, **_k: [FakeProc()])
+
+    matches = update_cmd._detect_venv_python_processes()
+    assert matches, "fake venv holder should be detected"
+    assert matches[0][2] == " ".join(argv)
+
+
+def test_holder_message_still_truncates():
+    msg = _format_venv_python_holders_message([(1, "python.exe", "z" * 500)])
+    assert "z" * 120 in msg
+    assert "z" * 121 not in msg


### PR DESCRIPTION
## Symptom

Every Hermes Desktop update aborts:

```
[updates] venv-blocked: 1 process(es) hold the install
[updates] error: Update aborted: another Hermes process is using this installation.

These processes must be stopped before updating:

  PID 6988  python.exe  C:\...\hermes-agent\.hermes-runtime\python\generation-1785635064-16968-cb2f7f1f\cpython-3.1
```

The reported process **is a gateway** — exactly the kind the pause machinery exists to stop.

## Root cause

`_detect_venv_python_processes()` truncates at capture time:

```python
matches.append((int(pid), str(name), cmdline_raw[:120]))
```

Every consumer classifies on that string *before* anything displays it. A gateway launched through the managed runtime has an interpreter path long enough that `gateway run` falls past the 120-char cut:

```
...\.hermes-runtime\python\generation-<id>\cpython-3.11-windows-x86_64-none\python.exe -m hermes_cli.main gateway run
                                                                             ^ char 120
```

`_is_pausable_gateway()` sees no subcommand → not exempt → `blocked`.

Observed on a real install, both halves of one gateway (parent/child):

```
5944  venv\Scripts\python.exe -m hermes_cli.main gateway run   → exempt=True   ✅
6988  ...\generation-...\cpython-3.1                           → exempt=False  ❌
```

The scan's own diagnostic contradicted its verdict: `{"blocked": true, "pausable_gateways": 1}`.

Because the Desktop preflight aborts *before* spawning `hermes-setup`, the CLI updater's `_pause_windows_gateways_for_update()` never runs — the dead-end the exemption was added to prevent. No path forward except stopping the gateway by hand, every single update.

## Fix

Truncation moves from capture to the two display sites:

- `_detect_venv_python_processes()` returns the full argv
- `_format_venv_python_holders_message()` truncates for the CLI message
- `_scan_venv_blockers` truncates in its JSON payload

One change at the source fixes all three consumers (`_is_pausable_gateway`, `_leftover_pausable_gateway_pids`, `managed_uv._windows_runtime_holders`) rather than patching each.

Also corrects the now-stale `_leftover_pausable_gateway_pids` docstring: the psutil re-read is no longer compensating for a truncated prefix, it handles re-exec since the scan.

## Verification

New regression test `tests/hermes_cli/test_venv_holder_cmdline_not_truncated.py`, including an explicit reproduction of the old behavior:

```python
assert _is_pausable_gateway(LONG_RUNTIME_GATEWAY) is True
assert _is_pausable_gateway(LONG_RUNTIME_GATEWAY[:120]) is False  # the bug
```

```
tests/hermes_cli/test_venv_holder_cmdline_not_truncated.py
tests/hermes_cli/test_scan_venv_blockers.py
tests/hermes_cli/test_update_venv_health.py          → 31 passed
tests/hermes_cli/test_update_gateway_launcher_refresh.py
tests/hermes_cli/test_update_import_guard.py         → 22 passed
```

On the affected machine, with the gateway still running:

```
before: {"ok": true, "blocked": true,  "processes": [{"pid": 6988, ...}], "pausable_gateways": 1}
after:  {"ok": true, "blocked": false, "processes": [],                   "pausable_gateways": 2}
```

Windows 10, Python 3.11.