### PR TITLE
fix(agent): reset rate-limit backoff counter on manual model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2746,6 +2746,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Reset fallback state ──
     agent._fallback_activated = False
     agent._fallback_index = 0
+    # A manual model switch establishes a new primary, same as a successful
+    # restore_primary_runtime() does — reset the rate-limit backoff counter
+    # too, or the new primary's first 429 inherits the escalated cooldown
+    # from whatever provider the user just switched away from instead of
+    # the intended 60s first-hit cooldown (try_activate_fallback).
+    agent._rate_limit_backoff_count = 0
 
     # When the user deliberately swaps primary providers (e.g. openrouter
     # → anthropic), drop any fallback entries that target the OLD primary

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -93,3 +93,21 @@ def test_switch_within_same_provider_preserves_chain():
         )
 
     assert agent._fallback_chain == chain
+
+
+def test_switch_model_resets_rate_limit_backoff_counter():
+    """A manual /model switch establishes a new primary. Without a reset,
+    the new primary's first 429 would inherit the escalated backoff count
+    from whatever provider the user just switched away from — reintroducing
+    the exact "first rate-limit benches the primary for a long cooldown"
+    regression restore_primary_runtime's own reset exists to prevent.
+    """
+    agent = _make_agent([])
+    agent._fallback_activated = True
+    agent._fallback_index = 2
+    agent._rate_limit_backoff_count = 3
+    agent._rate_limited_until = 99999999999.0
+
+    _switch_to_anthropic(agent)
+
+    assert agent._rate_limit_backoff_count == 0


### PR DESCRIPTION
## Summary

Today's rate-limit backoff-escalation fix keeps a 60s first-hit cooldown and escalates only on *consecutive* rate-limits (60s → 2m → 4m → ... capped at 4h), resetting `_rate_limit_backoff_count` in `restore_primary_runtime()` when the primary comes back healthy — explicitly to avoid re-benching the primary for a long cooldown on its first 429.

`switch_model()` is a second, independent code path that establishes a new "primary": when the user manually swaps models via `/model`, it already resets `_fallback_activated`/`_fallback_index` and the stale-call circuit breaker, and it updates `_primary_runtime` to the newly selected model/provider — but it does not reset `_rate_limit_backoff_count`.

Empirically confirmed before writing the fix: after 3 consecutive rate-limits on provider A (backoff_count=3), manually switching to provider B via `switch_model()` left `_rate_limit_backoff_count` at 3. Provider B's first rate-limit then computes `60 * 2**3 = 480s` instead of the intended 60s first-hit cooldown — reintroducing the exact regression today's fix addressed, via a different path.

## Fix

Reset `_rate_limit_backoff_count = 0` alongside the existing `_fallback_activated`/`_fallback_index` reset in `switch_model()`, mirroring `restore_primary_runtime()`'s reset.

## Test plan

- [x] Added `test_switch_model_resets_rate_limit_backoff_counter` to `tests/run_agent/test_switch_model_fallback_prune.py` (the existing home for `switch_model()`'s fallback-state-reset regression tests).
- [x] Mutation-verified: reverting the fix makes the new test fail (`3 == 0` assertion fails, counter stays at 3).
- [x] Full neighboring test sweep: all `switch_model`/`fallback`/`restore_primary` test files (34 tests) pass. Two pre-existing failures in `test_switch_model_reasoning_override.py` were confirmed unrelated — they fail identically with or without this change, due to the `anthropic` package not being installed in this environment (`ModuleNotFoundError: No module named 'anthropic'`), not this fix.
- [x] `ruff check` clean on all changed files.