### PR TITLE
fix(voice): resolve Porcupine wake-word key through the credential resolver

### DIFF
--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -624,3 +624,93 @@ def test_machine_lock_is_released_when_owner_process_exits(tmp_path):
         if process.is_alive():
             process.terminate()
         process.join(10)
+
+
+# ── Porcupine access-key resolution (credential-pool class, #68003) ──────
+
+
+def _fake_pool_with_key(key: str):
+    """Stand-in for ``agent.credential_pool.CredentialPool`` (peek-only)."""
+    from types import SimpleNamespace
+
+    entry = (
+        SimpleNamespace(runtime_api_key=key, access_token=key) if key else None
+    )
+    return SimpleNamespace(
+        has_credentials=lambda: bool(key),
+        peek=lambda: entry,
+    )
+
+
+class TestPorcupineCredentialResolution:
+    """The Porcupine wake-word key resolves through the shared voice-key
+    resolver (env / ~/.hermes/.env, then the credential pool) instead of a
+    raw ``os.getenv`` — the last voice credential read still bypassing the
+    #68003 fix."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        """Keep the developer's real env / ~/.hermes/.env out of these tests."""
+        import hermes_cli.config as config_mod
+
+        monkeypatch.delenv("PORCUPINE_ACCESS_KEY", raising=False)
+        monkeypatch.setattr(config_mod, "load_env", lambda: {})
+        yield
+
+    def test_pooled_key_resolves_when_env_empty(self):
+        from unittest.mock import patch
+
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=_fake_pool_with_key("pool-porcupine-key"),
+        ):
+            assert ww._resolve_porcupine_access_key() == "pool-porcupine-key"
+
+    def test_env_wins_over_pool(self, monkeypatch):
+        from unittest.mock import patch
+
+        monkeypatch.setenv("PORCUPINE_ACCESS_KEY", "env-key")
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=_fake_pool_with_key("pool-porcupine-key"),
+        ) as lp:
+            assert ww._resolve_porcupine_access_key() == "env-key"
+        lp.assert_not_called()
+
+    def test_no_key_anywhere_returns_empty(self):
+        from unittest.mock import patch
+
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=_fake_pool_with_key(""),
+        ):
+            assert ww._resolve_porcupine_access_key() == ""
+
+    def test_requirements_gate_sees_pooled_key(self, monkeypatch):
+        """check_wake_word_requirements must agree with the engine: a pooled
+        key counts as configured (previously only raw env was consulted)."""
+        from unittest.mock import patch
+
+        _voice_loop_ready(monkeypatch)
+        monkeypatch.setattr(ww, "_audio_available", lambda: True)
+        monkeypatch.setattr("tools.lazy_deps.is_available", lambda f: True)
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=_fake_pool_with_key("pool-porcupine-key"),
+        ):
+            r = ww.check_wake_word_requirements({"provider": "porcupine"})
+        assert r["available"] is True
+
+    def test_requirements_gate_flags_missing_key(self, monkeypatch):
+        from unittest.mock import patch
+
+        _voice_loop_ready(monkeypatch)
+        monkeypatch.setattr(ww, "_audio_available", lambda: True)
+        monkeypatch.setattr("tools.lazy_deps.is_available", lambda f: True)
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=_fake_pool_with_key(""),
+        ):
+            r = ww.check_wake_word_requirements({"provider": "porcupine"})
+        assert r["available"] is False
+        assert "PORCUPINE_ACCESS_KEY" in r["hint"]

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -673,6 +673,23 @@ class _SherpaKwsEngine(_Engine):
             pass
 
 
+def _resolve_porcupine_access_key() -> str:
+    """Resolve the Porcupine wake-word access key through the shared voice-key resolver.
+
+    Delegates to ``tools.tool_backend_helpers.resolve_provider_secret`` — the
+    single owner of STT/TTS/wake credential resolution (config > env/.env >
+    the credential pool, scope-aware under multiplexed gateway turns).
+    Previously this was a raw ``os.getenv`` read, so a key stored in
+    ``~/.hermes/.env`` (the standard Hermes location) or in the auth store
+    never reached the wake-word engine (#68003 class).
+    """
+    try:
+        from tools.tool_backend_helpers import resolve_provider_secret
+    except ImportError:  # pragma: no cover — helpers are in-repo
+        return (os.getenv("PORCUPINE_ACCESS_KEY") or "").strip()
+    return resolve_provider_secret("PORCUPINE_ACCESS_KEY", "porcupine")
+
+
 class _PorcupineEngine(_Engine):
     """Picovoice Porcupine — premium, on-device, needs an access key."""
 
@@ -683,7 +700,7 @@ class _PorcupineEngine(_Engine):
 
         import pvporcupine
 
-        access_key = (os.getenv("PORCUPINE_ACCESS_KEY") or "").strip()
+        access_key = _resolve_porcupine_access_key()
         if not access_key:
             raise RuntimeError(
                 "Porcupine wake word requires PORCUPINE_ACCESS_KEY "
@@ -831,7 +848,7 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
         if framework == "tflite":
             tflite_ok = ensure_tflite_runtime() or lazy_deps.is_available("wake.openwakeword.tflite") or lazy_ok
 
-    if provider == "porcupine" and not (os.getenv("PORCUPINE_ACCESS_KEY") or "").strip():
+    if provider == "porcupine" and not _resolve_porcupine_access_key():
         key_ok = False
         hint = "Set PORCUPINE_ACCESS_KEY (free key at https://console.picovoice.ai)."
     elif not deps_ok and not lazy_ok:


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #68003 #77840 #77843
## What changed and why

The wake-word engine read `PORCUPINE_ACCESS_KEY` with a bare `os.getenv`, so a key stored in `~/.hermes/.env` (the standard Hermes secret location) or in the credential pool / auth store never reached it — a wake word that always reported "no key" despite a valid configured credential. It was the **last voice-tool credential read still bypassing** the shared resolver added for #68003 (`tools.tool_backend_helpers.resolve_provider_secret`, commit `c136400c9e`), which migrated every STT/TTS key lookup but left the Porcupine wake-word path on raw `os.getenv`.

This PR routes both Porcupine credential reads through `resolve_provider_secret` — the single owner of voice credential resolution (config > env / `~/.hermes/.env` > credential pool, scope-aware under multiplexed gateway turns):

- `tools/wake_word.py`
  - new `_resolve_porcupine_access_key()` helper delegating to `resolve_provider_secret("PORCUPINE_ACCESS_KEY", "porcupine")` (lazy import + `os.getenv` fallback, same pattern as `_resolve_provider_key` in the STT/TTS tools)
  - `_PorcupineEngine.__init__` now resolves the key through the helper (RuntimeError behavior unchanged)
  - `check_wake_word_requirements` now gates on the same helper, so the readiness probe agrees with the engine about pooled/`.env` keys
- `tests/tools/test_wake_word.py`
  - `TestPorcupineCredentialResolution`: pooled key resolves when env empty; env wins over pool; empty when nowhere; requirements gate sees pooled keys and flags missing keys

## How to test

```bash
# from the repo root
python -m pytest tests/tools/test_wake_word.py tests/tools/test_voice_credential_pool_resolution.py tests/tools/test_tool_backend_helpers.py -q --no-header -p no:cacheprovider
# -> 62 passed (5 new Porcupine tests included)

# wider credential-path suite
python -m pytest tests/tools/test_transcription_dotenv_fallback.py tests/tools/test_tts_dotenv_fallback.py tests/tools/test_credential_pool_env_fallback.py -q --no-header -p no:cacheprovider
# -> 26 passed
```

Expected: all targeted suites green. (One pre-existing Windows flake, `test_transcription_tools.py::TestRunCommandSttIdleTimeout::test_stderr_progress_extends_beyond_timeout`, fails identically on pristine `main` — a 0.1 s subprocess timing test, unrelated to this change.)

Manual check: with `PORCUPINE_ACCESS_KEY` set only in `~/.hermes/.env` (not exported), `check_wake_word_requirements` (wake.status) reports Porcupine available, and the engine constructor accepts the key.

## Platforms tested

Windows 10 (git-bash), Python 3.11 venv. No network, no audio — all tests are monkeypatched.

## Why this matters to users

Users who configure Porcupine ("Hey Hermes" premium wake word) the standard Hermes way — `~/.hermes/.env` or the credential pool — currently get a hard "Porcupine wake word requires PORCUPINE_ACCESS_KEY" failure at engine construction and a permanently unavailable wake word in status checks. After this change the wake-word engine honors the same credential resolution every other voice tool uses, including scope-safe reads under multiplexed gateway turns and any future pooled Porcupine entries.

## Class verification (this lane)

- #68003's core fix is on `main` (`c136400c9e`, merged, issue closed). All STT/TTS provider keys (groq, mistral, elevenlabs, deepinfra, gemini, minimax, openai, xai) resolve through the shared resolver with pool fallback; this PR completes the class by migrating the last raw-env voice credential read (Porcupine wake word).
- #77843 (Codex OAuth for STT) is implemented by the open PR #77840, which is pooled (`load_pool("openai-codex")`) and exhaustion-handled (`mark_exhausted_and_rotate`, `select_excluding`, refresh-retry); verification comment posted there.

Part of #78207

Part of #79890
