### PR TITLE
fix(buzz): preserve canonical inbound thread roots

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1056,6 +1056,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=self._thread_id_from_event(event),
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1210,6 +1211,32 @@ class BuzzAdapter(BasePlatformAdapter):
             state["seen"][event_id] = None
             self._trim_seen(state)
 
+    @staticmethod
+    def _thread_id_from_event(event: dict) -> Optional[str]:
+        """Return the canonical Buzz thread anchor from Nostr ``e`` tags."""
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return None
+
+        root = None
+        reply = None
+        fallback = None
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) < 2 or tag[0] != "e":
+                continue
+            target = str(tag[1] or "").strip()
+            if not target:
+                continue
+            if fallback is None:
+                fallback = target
+            marker = str(tag[3] or "").strip().lower() if len(tag) > 3 else ""
+            if marker == "root" and root is None:
+                root = target
+            elif marker == "reply" and reply is None:
+                reply = target
+
+        return root or reply or fallback
+
     async def _dispatch_message(
         self,
         text: str,
@@ -1219,6 +1246,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1230,6 +1258,7 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -261,9 +261,11 @@ class TestMentionGating:
 
 
 def _tagged_event(event_id, channel, *, content, pubkey=OTHER_PUBKEY,
-                  created_at=1000, kind=9, p=None, reply_to=None):
+                  created_at=1000, kind=9, p=None, root=None, reply_to=None):
     """Event with the tag shapes observed on a live relay (h/p/e tags)."""
     tags = [["h", channel]]
+    if root:
+        tags.append(["e", root, "", "root"])
     if reply_to:
         tags.append(["e", reply_to, "", "reply"])
     if p:
@@ -335,6 +337,7 @@ class TestDmClassification:
         assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
         # It carried a mention, so it dispatches — but as a group message.
         assert [d["chat_type"] for d in adapter._dispatched] == ["group"]
+        assert adapter._dispatched[0]["thread_id"] == "root-event"
 
         # And once the mention is absent, the channel gate drops the message
         # even though the earlier reply p-tagged us.
@@ -344,6 +347,20 @@ class TestDmClassification:
         )
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_nested_channel_reply_preserves_canonical_root(self, adapter):
+        await self._poll_with(
+            adapter, CHANNEL,
+            _tagged_event(
+                "e1",
+                CHANNEL,
+                content="@chip nested reply",
+                root="thread-root",
+                reply_to="immediate-parent",
+            ),
+        )
+
+        assert adapter._dispatched[0]["thread_id"] == "thread-root"
 
     @pytest.mark.asyncio
     async def test_channel_like_metadata_blocks_latch_even_without_mention(self, adapter):
@@ -379,6 +396,26 @@ class TestDmClassification:
         assert a._may_reclassify_as_dm(DM_CHANNEL) is True
         assert CHANNEL not in a._channel_state
         assert a._may_reclassify_as_dm(CHANNEL) is False
+
+
+class TestThreadAnchorExtraction:
+
+    def test_prefers_root_over_reply_regardless_of_tag_order(self):
+        event = {
+            "tags": [
+                ["e", "immediate-parent", "", "reply"],
+                ["e", "thread-root", "", "root"],
+            ]
+        }
+        assert BuzzAdapter._thread_id_from_event(event) == "thread-root"
+
+    def test_falls_back_to_reply_then_first_unmarked_event(self):
+        assert BuzzAdapter._thread_id_from_event(
+            {"tags": [["e", "reply-anchor", "", "reply"]]}
+        ) == "reply-anchor"
+        assert BuzzAdapter._thread_id_from_event(
+            {"tags": [["e", "legacy-anchor"]]}
+        ) == "legacy-anchor"
 
 
 # ── Sending ───────────────────────────────────────────────────────────────
@@ -536,5 +573,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
-


### PR DESCRIPTION
## What does this PR do?

Preserves the canonical Buzz thread root on inbound native Buzz events. The adapter now reads Nostr `e` tags, prefers a `root` marker over an immediate `reply` marker, falls back to the reply marker for older events, and carries the result into `SessionSource.thread_id`.

This complements #77080 rather than duplicating it: #77080 supplies a synthetic thread anchor for top-level Buzz messages, while this PR preserves the real canonical root when a user triggers Hermes from an existing or nested Buzz thread.

## Related Issue

Related: #77080

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Parse inbound Nostr `e` tags in `plugins/platforms/buzz/adapter.py`.
- Prefer canonical `root`, then `reply`, then the first legacy unmarked event tag.
- Pass the resolved root into `build_source(thread_id=...)`.
- Add adapter dispatch and extraction regressions for reply-only, nested root+reply, reversed marker order, and legacy tags.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py`.
2. Send a native Buzz message inside a nested thread with both `root` and `reply` `e` tags.
3. Confirm the dispatched source uses the canonical root rather than the immediate parent.

Validation on macOS:

- Adapter suite: 26 passed.
- Full current-upstream gateway package: 4,829 passed, with two unrelated macOS baseline failures reproduced unchanged on untouched `origin/main` (`test_shutdown_forensics` subprocess spawn and `test_systemd_notify` Linux abstract socket binding).
- Windows footgun scan: clean for both changed files.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs and documented the non-overlapping relationship to #77080.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — the full gateway package has two unrelated macOS baseline failures noted above.
- [x] I've added tests for the bug fix.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation updates are N/A; no user-facing config or command changes.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A.
- [x] I've considered cross-platform impact and ran the repository Windows footgun scan.
- [x] Tool descriptions/schemas updates are N/A.

## Screenshots / Logs

The regression tests model live native Buzz event shapes:

- first-level reply: `e` tag marked `reply`
- nested reply: canonical `root` plus immediate-parent `reply`
- reversed marker order: `reply` before `root` still resolves to canonical `root`
