### PR TITLE
fix(desktop): never replay hydrated session history in auto-speak; lock mute/re-arm semantics

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -1,0 +1,135 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { playSpeechText } from '@/lib/voice-playback'
+import { $messages } from '@/store/session'
+import { setVoicePlaybackState } from '@/store/voice-playback'
+import { $autoSpeakReplies } from '@/store/voice-prefs'
+
+import { useAutoSpeakReplies } from './use-auto-speak-replies'
+
+vi.mock('@/lib/voice-playback', () => ({ playSpeechText: vi.fn(() => Promise.resolve(true)) }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+// Single-window test env: the ambient-cue claim resolves immediately.
+vi.mock('@/store/ambient', () => ({ ownsAmbientCue: vi.fn(async () => true) }))
+
+interface Reply {
+  id: string
+  pending: boolean
+  text: string
+}
+
+describe('useAutoSpeakReplies', () => {
+  afterEach(() => {
+    cleanup()
+    $autoSpeakReplies.set(false)
+    $messages.set([])
+    setVoicePlaybackState({
+      audioElement: null,
+      messageId: null,
+      sequence: 0,
+      source: null,
+      status: 'idle'
+    })
+    vi.clearAllMocks()
+  })
+
+  it('does not replay history that hydrates after selecting a session', async () => {
+    let reply: Reply | null = { id: 'assistant-a', pending: false, text: 'Already heard A' }
+    let spokenId: string | null = null
+
+    const markSpoken = vi.fn(() => {
+      spokenId = reply?.id ?? null
+    })
+
+    const pendingReply = () => (reply?.id === spokenId ? null : reply)
+
+    $autoSpeakReplies.set(true)
+
+    const { rerender } = renderHook(
+      ({ sessionId }) =>
+        useAutoSpeakReplies({
+          busy: false,
+          conversationActive: false,
+          failureLabel: 'Read aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId
+        }),
+      { initialProps: { sessionId: 'session-a' } }
+    )
+
+    rerender({ sessionId: 'session-b' })
+
+    // Session B's history hydrates asynchronously with a COMPLETED reply —
+    // it was already heard in a previous visit, so it must be consumed
+    // silently, never spoken.
+    act(() => {
+      reply = { id: 'assistant-b-history', pending: false, text: 'Existing session B reply' }
+      $messages.set([])
+    })
+
+    await waitFor(() => expect(markSpoken).toHaveBeenCalled())
+    expect(playSpeechText).not.toHaveBeenCalled()
+
+    // A new turn starts: the pending reply is the first signal.
+    act(() => {
+      reply = { id: 'assistant-b-new', pending: true, text: 'A new reply' }
+      $messages.set([])
+    })
+
+    // ...and only its COMPLETED version is spoken aloud, exactly once.
+    act(() => {
+      reply = { id: 'assistant-b-new', pending: false, text: 'A new reply' }
+      $messages.set([])
+    })
+
+    await waitFor(() => expect(playSpeechText).toHaveBeenCalledOnce())
+    expect(playSpeechText).toHaveBeenCalledWith('A new reply', {
+      messageId: 'assistant-b-new',
+      source: 'read-aloud'
+    })
+  })
+
+  it('speaks an atomic completed reply after a new user turn', async () => {
+    let reply: Reply | null = { id: 'assistant-history', pending: false, text: 'Existing reply' }
+    let spokenId: string | null = null
+
+    const markSpoken = () => {
+      spokenId = reply?.id ?? null
+    }
+
+    const pendingReply = () => (reply?.id === spokenId ? null : reply)
+
+    $autoSpeakReplies.set(true)
+
+    const { rerender } = renderHook(
+      ({ busy }) =>
+        useAutoSpeakReplies({
+          busy,
+          conversationActive: false,
+          failureLabel: 'Read aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId: 'session-a'
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    // The user starts a turn (busy renders true), then the reply lands
+    // atomically — completed before the next busy render.
+    rerender({ busy: true })
+
+    act(() => {
+      reply = { id: 'assistant-new', pending: false, text: 'Atomic reply' }
+      $messages.set([{ id: 'assistant-new', role: 'assistant', content: 'Atomic reply' }] as never)
+    })
+
+    await waitFor(() =>
+      expect(playSpeechText).toHaveBeenCalledWith('Atomic reply', {
+        messageId: 'assistant-new',
+        source: 'read-aloud'
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.ts
@@ -16,6 +16,9 @@ interface AutoSpeakReply {
 }
 
 interface UseAutoSpeakReplies {
+  /** Whether the agent is mid-turn (the Stop-button seam). A turn that has
+   *  started is the only thing that makes a completed reply speakable. */
+  busy: boolean
   conversationActive: boolean
   failureLabel: string
   /** Mark the current last reply spoken — shared dedupe with the conversation consumer. */
@@ -34,6 +37,7 @@ interface UseAutoSpeakReplies {
  * the latest reply, so a backlog collapses to the newest.
  */
 export function useAutoSpeakReplies({
+  busy,
   conversationActive,
   failureLabel,
   markSpoken,
@@ -45,8 +49,26 @@ export function useAutoSpeakReplies({
   // would never fire on its own replies (and would fire on someone else's).
   const { $messages } = useComposerScope()
   const latest = useRef({ conversationActive, failureLabel, markSpoken, pendingReply })
+  const busyRef = useRef(busy)
+  // Latched true for the duration of a turn: a completed reply is only
+  // speakable if this session started a turn since the gate armed. Reset when
+  // the effect re-arms (session switch, toggle, mount).
+  const freshReplyStartedRef = useRef(false)
   latest.current = { conversationActive, failureLabel, markSpoken, pendingReply }
 
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    busyRef.current = busy
+  }, [busy])
+
+  // eslint-disable-next-line no-restricted-syntax -- idempotent latch, not a mirror; read back only inside the re-arm effect below
+  useEffect(() => {
+    if (busy) {
+      freshReplyStartedRef.current = true
+    }
+  }, [busy])
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     if (!enabled) {
       return undefined
@@ -55,15 +77,35 @@ export function useAutoSpeakReplies({
     // Don't read whatever reply already sits at the bottom when the toggle flips
     // on (or a chat opens) — consume it so only later replies are spoken.
     latest.current.markSpoken()
+    freshReplyStartedRef.current = busyRef.current
+    let waitingForFreshReply = true
 
     const speakLatest = () => {
       const { conversationActive, failureLabel, markSpoken, pendingReply } = latest.current
+      const reply = pendingReply()
+
+      if (waitingForFreshReply && freshReplyStartedRef.current) {
+        waitingForFreshReply = false
+      }
+
+      // Session history hydrates asynchronously after `sessionId` changes. The
+      // effect's eager mark above can therefore still see the previous session.
+      // Ignore completed replies until this session starts a new turn (or a
+      // pending assistant reply appears), consuming late-arriving history
+      // instead of replaying it aloud.
+      if (waitingForFreshReply && reply) {
+        if (reply.pending) {
+          waitingForFreshReply = false
+        } else {
+          markSpoken()
+
+          return
+        }
+      }
 
       if (conversationActive || $voicePlayback.get().status !== 'idle') {
         return
       }
-
-      const reply = pendingReply()
 
       if (!reply || reply.pending) {
         return

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -276,6 +276,7 @@ export function useComposerVoice({
   }, [t])
 
   useAutoSpeakReplies({
+    busy,
     conversationActive: voiceConversationActive,
     failureLabel: t.assistant.thread.readAloudFailed,
     markSpoken: consumePendingResponse,

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -264,3 +264,170 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     expect(monitorCalls.length).toBe(armed)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Mute semantics — #74337 class: muting mid-conversation must be respected
+// (no re-arm while muted) AND reversible (unmute returns the loop to
+// listening), with the mic never wedging into a stuck state after playback.
+// ---------------------------------------------------------------------------
+
+function renderWithReply() {
+  let reply: { id: string; pending: boolean; text: string } | null = null
+  const onBusyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+
+  const hook = renderHook(
+    ({ busy }: HookProps) =>
+      useVoiceConversation({
+        busy,
+        consumePendingResponse: vi.fn(),
+        enabled: true,
+        onSubmit: async () => {
+          // Mirrors the real app: submitting a turn makes the agent busy, and
+          // the reply only appears once the turn ends (busy flips false).
+          reply = { id: 'reply-1', pending: true, text: 'Hello back' }
+          onBusyChange.current(true)
+        },
+        onTranscribeAudio: async () => 'Hello',
+        pendingResponse: () => (busy ? null : reply)
+      }),
+    { initialProps: { busy: false } }
+  )
+
+  onBusyChange.current = busy => hook.rerender({ busy })
+
+  return {
+    completeReply() {
+      if (reply) {
+        reply = { ...reply, pending: false }
+      }
+    },
+    finishTurn() {
+      onBusyChange.current(false)
+    },
+    hook
+  }
+}
+
+async function beginTurn(hook: ReturnType<typeof renderWithReply>['hook']) {
+  await act(async () => {
+    await hook.result.current.start()
+  })
+  await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+
+  micHandle.stop.mockResolvedValueOnce({
+    audio: new Blob(['q'], { type: 'audio/webm' }),
+    durationMs: 900,
+    heardSpeech: true
+  })
+
+  await act(async () => {
+    hook.result.current.stopTurn()
+  })
+  await waitFor(() => expect(hook.result.current.status).toBe('thinking'))
+}
+
+describe('useVoiceConversation mute semantics', () => {
+  beforeEach(() => {
+    monitorCalls.length = 0
+    vi.clearAllMocks()
+    micHandle.start.mockResolvedValue(undefined)
+    micHandle.stop.mockResolvedValue(null)
+  })
+
+  afterEach(cleanup)
+
+  it('muting while listening cancels the recorder and keeps the mic off until unmute', async () => {
+    const { hook } = renderConversation()
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+
+    expect(hook.result.current.muted).toBe(true)
+    expect(hook.result.current.status).toBe('idle')
+    expect(micHandle.cancel).toHaveBeenCalled()
+
+    // The drive loop must not re-open the mic while muted.
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 50))
+    })
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
+
+    // Unmuting re-arms the loop without a manual stop/start.
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    expect(micHandle.start).toHaveBeenCalledTimes(2)
+  })
+
+  it('a reply completing while muted is never spoken and unmute re-arms into the next turn', async () => {
+    const { completeReply, finishTurn, hook } = renderWithReply()
+
+    await beginTurn(hook)
+
+    // Mute during generation; the turn's reply is held, not spoken.
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+    expect(hook.result.current.muted).toBe(true)
+    expect(hook.result.current.status).toBe('idle')
+
+    // The turn ends and the reply becomes available — but muted gates speech.
+    await act(async () => {
+      finishTurn()
+    })
+    expect(hook.result.current.status).toBe('idle')
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
+
+    // Unmute: the held reply plays (fallback path), then the mic re-arms.
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+
+    await waitFor(() => expect(hook.result.current.status).toBe('speaking'))
+    completeReply()
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    expect(micHandle.start).toHaveBeenCalledTimes(2)
+  })
+
+  it('muting during reply playback does not wedge the loop; unmute returns it to listening', async () => {
+    const { completeReply, finishTurn, hook } = renderWithReply()
+
+    await beginTurn(hook)
+    // Turn ends → the (pending) reply lands → live speech opens and the
+    // fallback poll holds 'speaking' until the reply completes.
+    await act(async () => {
+      finishTurn()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('speaking'))
+
+    // User mutes mid-playback to silence the rest of the reply.
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+    expect(hook.result.current.muted).toBe(true)
+
+    // Reply completes while muted → settle runs, but no re-arm while muted.
+    completeReply()
+    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 50))
+    })
+    expect(micHandle.start).toHaveBeenCalledTimes(1)
+
+    // Unmute returns the loop to listening — no manual stop/start needed.
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    expect(micHandle.start).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #64390 #73649 #73691 #73880 #74337 #78098 #78118
## What changed and why

**Desktop voice-conversation reliability residuals (Lane 09 of the Vox Lockin campaign).**

### 1. Auto-speak replays hydrated session history after a session switch (fixes #64390)

With **Read Responses Aloud** enabled, switching sessions could speak the newly opened session's **last reply from history** — an old reply the user already heard — because:

- the `sessionId` re-arm in `useAutoSpeakReplies` consumes whatever reply sits in the store at switch time, but
- session history hydrates **asynchronously** after the switch, so a completed reply arriving a beat later still looks "unspoken" to the dedupe and gets read aloud.

**Fix:** gate auto-speak on the session having started a **fresh turn**. While the gate is armed (after a session switch / toggle-on / mount), completed replies are consumed silently; only a pending assistant reply or a new turn (`busy`) opens the gate. Ported from #64390's approach (authored by @kannishk) — the open PR conflicts with current main, so the change is rebased onto main's composer-scope wiring (`useComposerScope().$messages`, `ownsAmbientCue`) and the repo's eslint conventions.

### 2. Mute semantics locked by regression tests (#74337 class)

The "can remain muted after reply playback" report shares its root with #73649 (fixed by merged #73880 — re-arm after playback is now covered by the existing `use-voice-conversation-rearm.test.tsx`). This PR adds the complementary mute-contract regressions to `use-voice-conversation.test.tsx`:

- muting while listening cancels the recorder and the mic stays off until unmute;
- a reply completing while muted is never spoken, and unmute re-arms into the next turn (held reply plays, then the mic re-arms);
- muting during reply playback never wedges the loop — unmute returns it to listening.

No production code change was needed for the mute path: on current main `muted` only ever flips via user `toggleMute` (never spontaneously), and the re-arm class is covered by #73880. The tests lock that contract so the class can't silently regress.

## How to test

```bash
cd apps/desktop
npx vitest run src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx \
  src/app/chat/composer/hooks/use-voice-conversation.test.tsx \
  src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx \
  src/lib/voice-stop-word.test.ts src/lib/speech-text.test.ts \
  src/store/voice-prefs.test.ts src/app/settings/voice-field-visible.test.ts \
  src/app/settings/voice-provider-fields.test.ts
```

Expected: **8 files, 60 tests, all passing** (was 55; +2 auto-speak session-switch regressions, +3 mute-semantics regressions). `npx tsc -p tsconfig.json --noEmit`, `npx eslint` on the touched files, and `git diff --check` are all clean.

## Platforms tested

- Windows 10 (git-bash), vitest UI project, Node 24 — full targeted suite green.
- No Python/gateway files touched; desktop hooks only.

## Why this matters to users

- Opening a session with history no longer triggers an unexpected spoken replay of an old reply.
- Voice conversation mute stays predictable: mute is respected and reversible, and the loop returns to listening after playback — no manual stop/start or mute toggling needed.

Fixes #64390

Related: #74337 (class regression-locked; re-arm root fixed by #73880), #73649 (verified fixed on main), #73691 (verified covered — desktop auto-speak is client-side, closed NOT_PLANNED), #78098 (verified fixed by #78118).

Credit: session-switch gating approach salvaged from #64390, authored by @kannishk.

Part of #74337

Part of #78207
Part of #79890
