### PR TITLE
fix(gateway): serialize STT/TTS reliability slice behind V6 contract

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1186,6 +1186,9 @@ platform_toolsets:
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
+  # Max seconds the messaging gateway waits for one transcription (including
+  # local fallback) before it releases the chat and surfaces the audio path.
+  gateway_timeout_seconds: 45
   # provider: "local"          # auto-detected if omitted
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo

--- a/contributors/emails/daniubaidillahhusain@gmail.com
+++ b/contributors/emails/daniubaidillahhusain@gmail.com
@@ -1,0 +1,1 @@
+dhansxd

--- a/contributors/emails/mglavinic@gmail.com
+++ b/contributors/emails/mglavinic@gmail.com
@@ -1,0 +1,1 @@
+mglavinic86

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -101,6 +101,12 @@ def _coerce_float(value: Any, default: float) -> float:
         return default
 
 
+def _coerce_positive_float(value: Any, default: float) -> float:
+    """Coerce a positive float, falling back for zero/negative/invalid values."""
+    parsed = _coerce_float(value, default)
+    return parsed if parsed > 0 else default
+
+
 def _coerce_int(value: Any, default: int) -> int:
     """Coerce integer config values, falling back on malformed input."""
     if value is None:
@@ -913,6 +919,9 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    # Hard gateway deadline around the complete STT worker. Provider-level
+    # HTTP/process timeouts are insufficient when setup or cleanup itself hangs.
+    stt_timeout_seconds: float = 45.0
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -1066,6 +1075,7 @@ class GatewayConfig:
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
+            "stt_timeout_seconds": self.stt_timeout_seconds,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -1129,6 +1139,14 @@ class GatewayConfig:
                 if isinstance(data.get("stt"), dict)
                 else None
             )
+        stt_timeout_raw = data.get("stt_timeout_seconds")
+        if stt_timeout_raw is None:
+            stt_timeout_raw = (
+                data.get("stt", {}).get("gateway_timeout_seconds")
+                if isinstance(data.get("stt"), dict)
+                else None
+            )
+        stt_timeout_seconds = _coerce_positive_float(stt_timeout_raw, 45.0)
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -1204,6 +1222,7 @@ class GatewayConfig:
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
+            stt_timeout_seconds=stt_timeout_seconds,
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21367,23 +21367,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return f"{unavailable_note}\n\n{user_text}", []
             return unavailable_note, []
 
+        async def _transcribe_with_local_fallback(path: str):
+            result = await asyncio.to_thread(transcribe_audio, path)
+            if not result.get("success"):
+                fallback = await asyncio.to_thread(
+                    transcribe_audio_local_fallback,
+                    path,
+                )
+                if fallback.get("success"):
+                    logger.info(
+                        "Configured STT failed for %s; recovered with local STT",
+                        path,
+                    )
+                    result = fallback
+            return result
+
         enriched_parts = []
         successful_transcripts: List[str] = []
+        stt_timeout_seconds = getattr(self.config, "stt_timeout_seconds", 45.0)
         for path in audio_paths:
             try:
                 logger.debug("Transcribing user voice: %s", path)
-                result = await asyncio.to_thread(transcribe_audio, path)
-                if not result.get("success"):
-                    fallback = await asyncio.to_thread(
-                        transcribe_audio_local_fallback,
-                        path,
-                    )
-                    if fallback.get("success"):
-                        logger.info(
-                            "Configured STT failed for %s; recovered with local STT",
-                            path,
-                        )
-                        result = fallback
+                result = await asyncio.wait_for(
+                    _transcribe_with_local_fallback(path),
+                    timeout=stt_timeout_seconds,
+                )
                 if result["success"]:
                     transcript = result["transcript"]
                     # Speech-to-text can return success=True with an empty or
@@ -21425,6 +21433,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "[voice message could not be transcribed automatically; "
                         f"the audio is available at: {agent_path}]"
                     )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Voice transcription timed out after %.1fs for %s; continuing fail-open",
+                    stt_timeout_seconds,
+                    path,
+                )
+                from tools.credential_files import to_agent_visible_cache_path
+
+                agent_path = to_agent_visible_cache_path(os.path.abspath(path))
+                enriched_parts.append(
+                    "[voice message could not be transcribed automatically; "
+                    f"the audio is available at: {agent_path}]"
+                )
             except Exception as e:
                 logger.error("Transcription error: %s", e)
                 from tools.credential_files import to_agent_visible_cache_path

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1499,10 +1499,12 @@ def _collect_auto_append_media_tags(
         if msg.get("role") not in ("tool", "function"):
             continue
         call_id = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(call_id) not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
+        tool_name = tool_name_by_call_id.get(call_id) or str(
+            msg.get("tool_name") or msg.get("name") or ""
+        )
+        if tool_name not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
             continue
         content = str(msg.get("content") or "")
-        tool_name = tool_name_by_call_id.get(call_id)
         # JSON-payload tools (image_generate) return a local-file path in a
         # known field rather than a MEDIA: tag. Extract it so delivery is
         # deterministic even when the model omits the path from its reply.
@@ -19075,7 +19077,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
-                await adapter.send_voice(**send_kwargs)
+                send_result = await adapter.send_voice(**send_kwargs)
+                if send_result is not None and not getattr(send_result, "success", True):
+                    logger.warning(
+                        "Auto voice reply delivery failed: %s",
+                        getattr(send_result, "error", "send returned success=False"),
+                    )
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
@@ -21406,6 +21413,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "words. Do not guess at the content; ask the user "
                             "to resend or type it out.]"
                         )
+
                         continue
                     successful_transcripts.append(transcript)
                     # Pass the transcript through as a plain quoted line. The

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1507,6 +1507,9 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
+        # Hard deadline for one gateway voice transcription, including local fallback.
+        # Prevents a stuck provider/setup path from holding the chat lock indefinitely.
+        "gateway_timeout_seconds": 45.0,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -138,6 +138,163 @@ caption
         assert tags == []
         assert voice is False
 
+    def test_gateway_auto_append_keeps_real_tts_media_tag(self):
+        """TTS tool media tags are still auto-appended when the model omits them."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {"role": "user", "content": "Say this as audio"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_tts", "function": {"name": "text_to_speech"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_tts",
+                "content": '{"success": true, "media_tag": "[[audio_as_voice]]\\nMEDIA:/tmp/voice.ogg"}',
+            },
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/tmp/voice.ogg"]
+        assert voice is True
+
+    @pytest.mark.parametrize("field", ["tool_name", "name"])
+    def test_gateway_auto_append_uses_explicit_tool_result_name(self, field):
+        """Persisted tool rows may name their producer without assistant tool_calls."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "tool",
+                field: "text_to_speech",
+                "content": '[[audio_as_voice]]\nMEDIA:/tmp/voice.ogg',
+            },
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/tmp/voice.ogg"]
+        assert voice is True
+
+    @pytest.mark.parametrize("field", ["tool_name", "name"])
+    def test_gateway_auto_append_rejects_unallowed_explicit_tool_name(self, field):
+        """Explicit producer metadata must not bypass automatic-delivery allowlist."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "tool",
+                field: "terminal",
+                "content": "MEDIA:/tmp/private.txt",
+            },
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == []
+        assert voice is False
+
+    def test_gateway_auto_append_image_generate_json_path(self):
+        """image_generate returns a local path in JSON (no MEDIA: tag); it is
+        auto-appended so delivery doesn't depend on the model restating it."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {"role": "user", "content": "Make me a cat"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_img", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": '{"success": true, "image": "/tmp/gen/cat.png", "agent_visible_image": "/tmp/gen/cat.png"}',
+            },
+            {"role": "assistant", "content": "Here's your cat."},
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/tmp/gen/cat.png"]
+        assert voice is False
+
+    def test_gateway_auto_append_image_generate_prefers_host_path(self):
+        """When host and sandbox paths differ, the host-deliverable path wins."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {"role": "user", "content": "Make me a dog"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_img", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": '{"success": true, "host_image": "/host/dog.jpg", "image": "/host/dog.jpg", "agent_visible_image": "/sandbox/dog.jpg"}',
+            },
+        ]
+
+        tags, _ = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/host/dog.jpg"]
+
+    def test_gateway_auto_append_image_generate_failure_and_url_ignored(self):
+        """Failed generations and remote URLs are not auto-delivered."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        def _img_msgs(content):
+            return [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "c", "function": {"name": "image_generate"}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c", "content": content},
+            ]
+
+        # Failed generation
+        tags, _ = _collect_auto_append_media_tags(
+            _img_msgs('{"success": false, "image": null, "error": "boom"}'),
+            history_offset=0,
+        )
+        assert tags == []
+
+        # Remote URL is not a local file path
+        tags, _ = _collect_auto_append_media_tags(
+            _img_msgs('{"success": true, "image": "https://fal.media/x/cat.png"}'),
+            history_offset=0,
+        )
+        assert tags == []
+
+    def test_gateway_auto_append_image_generate_dedupes_history(self):
+        """A generated image path already in history is not re-sent."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "c", "function": {"name": "image_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": '{"success": true, "image": "/tmp/gen/cat.png"}',
+            },
+        ]
+
+        tags, _ = _collect_auto_append_media_tags(
+            messages, history_offset=0, history_media_paths={"/tmp/gen/cat.png"}
+        )
+        assert tags == []
+
 
     def test_collect_history_media_paths_includes_image_generate_json(self):
         """Regression for #46627: the history media-path collector must pick up

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -1,5 +1,7 @@
-"""Gateway STT config tests — honor stt.enabled: false from config.yaml."""
+"""Gateway STT config tests — config bridging and fail-open voice handling."""
 
+import asyncio
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -11,16 +13,36 @@ from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    """Wait without consuming another executor thread."""
+    for _ in range(200):
+        if event.is_set():
+            return
+        await asyncio.sleep(0.001)
+    raise AssertionError("worker thread did not start")
+
+
 def test_gateway_config_stt_disabled_from_dict_nested():
     config = GatewayConfig.from_dict({"stt": {"enabled": False}})
     assert config.stt_enabled is False
+
+
+def test_gateway_config_stt_timeout_defaults_and_accepts_nested_override():
+    assert GatewayConfig.from_dict({}).stt_timeout_seconds == 45.0
+    config = GatewayConfig.from_dict({"stt": {"gateway_timeout_seconds": 12.5}})
+    assert config.stt_timeout_seconds == 12.5
+
+
+def test_gateway_config_stt_timeout_rejects_invalid_values():
+    assert GatewayConfig.from_dict({"stt": {"gateway_timeout_seconds": 0}}).stt_timeout_seconds == 45.0
+    assert GatewayConfig.from_dict({"stt": {"gateway_timeout_seconds": "bad"}}).stt_timeout_seconds == 45.0
 
 
 def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text(
-        yaml.dump({"stt": {"enabled": False}}),
+        yaml.dump({"stt": {"enabled": False, "gateway_timeout_seconds": 7.5}}),
         encoding="utf-8",
     )
 
@@ -30,6 +52,188 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     config = load_gateway_config()
 
     assert config.stt_enabled is False
+    assert config.stt_timeout_seconds == 7.5
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_surfaces_path_when_stt_disabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=False)
+    runner._has_setup_skill = lambda: True  # Should NOT be consulted in disabled branch.
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("transcribe_audio should not be called when STT is disabled"),
+    ), patch(
+        "gateway.run._probe_audio_duration",
+        new=AsyncMock(return_value="0:12"),
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "caption",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "voice.ogg" in result
+    assert "voice message" in result.lower()
+    assert "(duration: 0:12)" in result
+    assert "caption" in result
+    assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_omits_duration_on_probe_failure():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=False)
+
+    with patch(
+        "gateway.run._probe_audio_duration",
+        new=AsyncMock(return_value=None),
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "voice.ogg" in result
+    assert "duration" not in result.lower()
+    assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_avoids_bogus_no_provider_message_for_backend_key_errors():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": False, "error": "VOICE_TOOLS_OPENAI_KEY not set"},
+    ), patch(
+        "tools.transcription_tools.transcribe_audio_local_fallback",
+        return_value={"success": False, "error": "not installed"},
+    ):
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "caption",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert "No STT provider is configured" not in result
+    assert "voice message could not be transcribed automatically" in result
+    assert "voice.ogg" in result
+    # The opaque backend cause must NOT leak into the LLM-visible prompt.
+    assert "VOICE_TOOLS_OPENAI_KEY" not in result
+    assert "caption" in result
+    assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_falls_back_to_installed_local_stt():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": False, "error": "configured provider unavailable"},
+    ), patch(
+        "tools.transcription_tools.transcribe_audio_local_fallback",
+        return_value={
+            "success": True,
+            "transcript": "recovered locally",
+            "provider": "local",
+        },
+    ) as local_fallback:
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "",
+            ["/tmp/voice.ogg"],
+        )
+
+    assert result == '"recovered locally"'
+    assert transcripts == ["recovered locally"]
+    local_fallback.assert_called_once_with("/tmp/voice.ogg")
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_times_out_fail_open():
+    """A stuck STT worker must not hold the gateway/chat lock indefinitely."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_timeout_seconds=0.2)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def stuck_transcription(_path):
+        worker_started.set()
+        release_worker.wait(timeout=5)
+        return {"success": True, "transcript": "too late"}
+
+    try:
+        with patch(
+            "tools.transcription_tools.transcribe_audio",
+            side_effect=stuck_transcription,
+        ):
+            transcription_task = asyncio.create_task(
+                runner._enrich_message_with_transcription(
+                    "caption",
+                    ["/tmp/stuck-voice.ogg"],
+                )
+            )
+            await _wait_for_thread_event(worker_started)
+            result, transcripts = await transcription_task
+    finally:
+        release_worker.set()
+
+    assert "voice message could not be transcribed automatically" in result
+    assert "stuck-voice.ogg" in result
+    assert "caption" in result
+    assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_bounds_local_fallback_too():
+    """The same gateway deadline must cover a stuck local fallback."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_timeout_seconds=0.2)
+    fallback_started = threading.Event()
+    release_worker = threading.Event()
+
+    def stuck_local_fallback(_path):
+        fallback_started.set()
+        release_worker.wait(timeout=5)
+        return {"success": True, "transcript": "too late"}
+
+    try:
+        with patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": False, "error": "configured provider unavailable"},
+        ), patch(
+            "tools.transcription_tools.transcribe_audio_local_fallback",
+            side_effect=stuck_local_fallback,
+        ) as local_fallback:
+            transcription_task = asyncio.create_task(
+                runner._enrich_message_with_transcription(
+                    "",
+                    ["/tmp/stuck-fallback.ogg"],
+                )
+            )
+            await _wait_for_thread_event(fallback_started)
+            result, transcripts = await transcription_task
+            local_fallback.assert_called_once_with("/tmp/stuck-fallback.ogg")
+    finally:
+        release_worker.set()
+
+    assert "voice message could not be transcribed automatically" in result
+    assert "stuck-fallback.ogg" in result
+    assert transcripts == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -177,6 +177,42 @@ async def test_non_streaming_media_failure_notifies_user(tmp_path, monkeypatch):
     assert adapter.notices == ["⚠️ Couldn't deliver the video attachment."]
 
 
+@pytest.mark.asyncio
+async def test_auto_voice_reply_logs_unsuccessful_send_result(tmp_path, monkeypatch, caplog):
+    """A failed auto voice-reply delivery must be logged, not silently ignored."""
+    import json as _json
+    import os as _os
+    import tempfile as _tempfile
+    from types import SimpleNamespace as _SimpleNamespace
+
+    monkeypatch.setattr(_tempfile, "gettempdir", lambda: str(tmp_path))
+
+    def _fake_text_to_speech_tool(*, text, output_path, **_kwargs):
+        _os.makedirs(_os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as fh:
+            fh.write(b"\x00" * 32)
+        return _json.dumps({"success": True, "file_path": output_path})
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", _fake_text_to_speech_tool)
+    monkeypatch.setattr("tools.tts_tool._strip_markdown_for_tts", lambda text: text)
+
+    runner = object.__new__(GatewayRunner)
+    adapter = _SimpleNamespace(
+        send_voice=AsyncMock(
+            return_value=SendResult(success=False, error="chat unavailable")
+        ),
+        is_in_voice_channel=lambda *_a, **_k: False,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    event = _event()
+
+    with caplog.at_level("WARNING"):
+        await runner._send_voice_reply(event, "Hello there.")
+
+    assert "Auto voice reply delivery failed" in caplog.text
+    assert "chat unavailable" in caplog.text
+
+
 class _DiscordMediaFailureAdapter(BasePlatformAdapter):
     """Minimal adapter to exercise non-streaming MEDIA failure notification."""
 


### PR DESCRIPTION
## Current disposition — `candidate_blocked` (Discord V6)

Canonical campaign authority: #90321, validated by the generic ledger contract in #90307.

Exact current head: `8e5cf6e57ca547da5a7b79a445cf5b66c426d9e0`.

This branch contains real STT/TTS reliability fixes, but it is **not the complete V6 publication authority by itself**. V6 remains a paired/collision gap: open #78180 changes adjacent Discord voice config, persistence, command, `gateway/run.py`, and adapter surfaces. The campaign needs an explicit addendum and serialized composition rather than merging two locally coherent voice trains and discovering the contract afterward.

## What this branch proves

### 1. Bounded stalled transcription

Salvaged from #74051, authored by @mglavinic86:

- wraps the complete configured-provider plus local-fallback sequence in a gateway-level deadline;
- defaults `stt_timeout_seconds` to 45 seconds;
- fails open with an audio-path marker instead of pinning the chat lock forever.

### 2. Media-producer recovery and delivery visibility

Residual work from #65745, authored by @dhansxd:

- recovers producer identity from explicit tool-result `tool_name` / `name` fields when the paired assistant `tool_calls` row is absent;
- restores automatic delivery eligibility for reconstructed/persisted TTS/audio results;
- logs unsuccessful voice-reply `SendResult` values instead of silently discarding the failure.

Historical focused verification reported 61 passing tests on Windows plus clean diff/footgun checks. That evidence remains useful for this head; it is not exact-current-main acceptance.

## V6 collision / contract gap

#78180 independently introduces per-chat transcribe-only mode, transcript destinations, persisted voice preferences, slash-command behavior, and additional STT drop-point logging. It touches the same broad voice-control surfaces while representing different product semantics.

Before either train is promoted as V6 completion, the paired addendum must decide:

- which behaviors are one capability versus separately reviewable slices;
- config and persistence ownership;
- handler/command sequencing and compatibility;
- attribution and merge order;
- exact negative behavior for stalled STT, passive transcription, file-only transcripts, media delivery, and disabled agent turns.

## Required before merge

1. Publish the V6 paired addendum that serializes #78196 and #78180 without collapsing distinct behaviors into one unreviewable train.
2. Preserve @mglavinic86 and @dhansxd provenance on the salvaged fixes.
3. Rebase the selected slice onto current main and resolve overlapping voice config/handler/persistence ownership deliberately.
4. Run exact-head STT timeout, transcript-mode, TTS/media routing, busy-session, voice-command, persistence, and cross-platform tests.
5. Reconcile the authoritative publication state in #90321 only after the composed contract is real.

## Historical relationships

- #74051 — bounded voice transcription stalls.
- #65745 — silent-audio/media-producer residuals.
- #74928 — verified fixed on current main by prior work; no code carried here for that issue.
- #11349 D2 — verified absent; no documentation drift introduced.
- Part of #78207.
- Part of #79890.

This PR is implementation evidence pending V6 composition. It is ready for review, but not merge-authorized until the paired V6 contract above is satisfied.