### PR TITLE
fix(cron): keep local binary decision terminal and guard embedded-NUL paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -253,36 +253,54 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     return None
 
 
-def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
-    """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+def _read_referenced_script(path: Path) -> tuple[Optional[str], bool, bool]:
+    """Return ``(text, unsafe, found)`` for a referenced script path.
+
+    ``found`` distinguishes a genuinely missing local path (``False`` —
+    the only state allowed to consult ``read_remote_script``) from any
+    locally present file the guard refuses to scan as text (``True``).
+    ``unsafe`` is set (fail closed) whenever the file is present but
+    cannot be safely classified — permission/read errors, non-regular
+    files, and oversized reads must never be revived by the remote
+    fallback (#78197).
+    """
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        return None, False, False
+    except NotADirectoryError:
+        return None, False, False
+    except ValueError:
+        # Embedded NUL inside a tokenized binary path: the local decision
+        # is terminal — never consult the remote fallback for a path the
+        # guard cannot even open (#76762).
+        return None, False, True
+    except PermissionError:
+        return None, True, True
     except OSError:
-        return None, False
+        # Any other open failure (EINVAL, ELOOP, ...): the file is
+        # present but unreadable; fail closed rather than falling back.
+        return None, True, True
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
-            return None, True
-        # Read a bounded chunk first — even for oversized files, the first
-        # chunk tells us if this is a binary (NUL bytes) that should be
-        # skipped as "nothing to scan" rather than failing closed (#76762).
+            return None, True, True
         data = os.read(descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1)
     except OSError:
-        return None, False
+        # Descriptor opened but the read failed: present and unreadable —
+        # fail closed, never fall back.
+        return None, True, True
     finally:
-        os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
     if b"\x00" in data:
-        return None, False
+        return None, False, True
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
-        return None, True
-    return data.decode("utf-8", errors="replace"), False
+        return None, True, True
+    return data.decode("utf-8", errors="replace"), False, True
 
 
 def _contains_unsafe_gateway_action(
@@ -321,11 +339,13 @@ def _contains_unsafe_gateway_action(
         if resolved in visited:
             continue
         visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
+        script_text, unsafe, found = _read_referenced_script(script_path)
         if unsafe:
             return True
-        if script_text is None and read_remote_script is not None:
+        if not found and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
+            # A locally classified binary/unsafe file must NEVER be revived
+            # by the remote fallback (#78197).
             script_text = read_remote_script(str(script_path))
         if not script_text:
             continue
@@ -383,11 +403,12 @@ def _resolve_script_path(script_path: str) -> Path:
 def _read_script_for_scanning(script_path: str) -> str:
     """Read a cron script with the bounded terminal-script scanner.
 
-    Non-regular or oversized inputs fail closed by returning a lifecycle-shaped
-    sentinel, while missing/unreadable paths remain empty so ordinary scheduler
-    path validation can report them.
+    Only genuinely missing paths stay empty (so ordinary scheduler path
+    validation can report them). Locally present files that cannot be
+    scanned — non-regular, oversized, permission/read errors — fail
+    closed by returning a lifecycle-shaped sentinel (#78197).
     """
-    script_text, unsafe = _read_referenced_script(_resolve_script_path(script_path))
+    script_text, unsafe, _found = _read_referenced_script(_resolve_script_path(script_path))
     if unsafe:
         return "hermes gateway restart"
     return script_text or ""

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -857,3 +857,184 @@ class TestCronCreateLifecycleBlockExtra:
         assert rc == 1
         out = capsys.readouterr().out
         assert "Blocked" in out
+
+
+class TestLocalBinaryGuardRegression:
+    """Minimal regression coverage for the on-disk binary → remote revival
+    bypass class that PR #78197 was filed against (#76762 follow-up).
+
+    These tests intentionally exercise only the lifecycle guard module so
+    they fail closed and independent of the unrelated upstream test
+    failures. They do NOT cover cross-backend semantics, two-stage
+    remote reads, envelope formats, deadline budgets, or platform
+    metadata — those are explicitly out of scope for this PR.
+    """
+
+    def test_nul_path_does_not_crash_guard(self, tmp_path):
+        from cron.lifecycle_guard import _read_referenced_script
+        # Simulate a tokenized binary path that contains an embedded NUL.
+        # ``os.open`` raises ``ValueError`` for such paths on POSIX; the
+        # guard must swallow this rather than letting it bubble, and the
+        # local decision must be terminal (found=True) so the remote
+        # fallback is never consulted for an unopenable path.
+        nul_path = tmp_path / "bad\x00name"
+        text, unsafe, found = _read_referenced_script(nul_path)
+        assert text is None
+        assert unsafe is False
+        assert found is True
+
+    def test_embedded_nul_token_never_invokes_remote(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+        calls = []
+
+        def remote(path):
+            calls.append(path)
+            return "hermes gateway restart"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash bad\x00name",
+            cwd=str(tmp_path),
+            read_remote_script=remote,
+        )
+        assert result is False
+        assert calls == []
+
+    def test_local_binary_does_not_invoke_remote(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+        # Incident shape: ``./node.exe`` (a path-bearing direct executable)
+        # must be classified as a local binary and must NOT be revived by
+        # the remote fallback.  On the pre-fix code this test fails: the
+        # binary read returned text=None, the guard treated it as missing,
+        # and the remote callback was invoked.
+        pe = bytearray(4096)
+        pe[:2] = b"MZ"
+        pe[0x3C:0x40] = (0x100).to_bytes(4, "little")
+        pe[0x100:0x104] = b"PE\0\0"
+        binary = tmp_path / "node.exe"
+        binary.write_bytes(pe)
+
+        remote_calls = []
+
+        def remote(path):
+            remote_calls.append(path)
+            # If this were ever called, the guard would be revived by the
+            # remote fallback — that is exactly the bypass we are closing.
+            return "hermes gateway restart"
+
+        cmd = f"ls {tmp_path} && ./{binary.name} --version"
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            cmd,
+            cwd=str(tmp_path),
+            read_remote_script=remote,
+        )
+        assert result is False
+        assert remote_calls == []
+
+    def test_local_missing_still_allows_remote_fallback(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+        remote_calls = []
+
+        def remote(path):
+            remote_calls.append(path)
+            return "hermes gateway restart"
+
+        # Local file does NOT exist; only the basename is referenced so
+        # shlex tokenization yields a single argument.  The local read
+        # returns found=False (FileNotFoundError), so the remote fallback
+        # must be consulted.
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash absent.sh",
+            cwd=str(tmp_path),
+            read_remote_script=remote,
+        )
+        assert result is True
+        assert remote_calls == [str(tmp_path / "absent.sh")]
+
+    def test_explicit_loader_local_binary_does_not_invoke_remote(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+        binary = tmp_path / "node.exe"
+        pe = bytearray(4096)
+        pe[:2] = b"MZ"
+        pe[0x3C:0x40] = (0x100).to_bytes(4, "little")
+        pe[0x100:0x104] = b"PE\0\0"
+        binary.write_bytes(pe)
+
+        def remote(path):
+            raise AssertionError("remote reader must not be called for a "
+                                 "locally classified binary")
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {binary.name}", cwd=str(tmp_path), read_remote_script=remote
+        )
+        assert result is False
+
+    def test_permission_error_fails_closed_without_remote(self, tmp_path, monkeypatch):
+        import cron.lifecycle_guard as lg
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        def denied_open(path, flags, *args, **kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(lg.os, "open", denied_open)
+        calls = []
+
+        def remote(path):
+            calls.append(path)
+            return "hermes gateway restart"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash denied.sh", cwd=str(tmp_path), read_remote_script=remote
+        )
+        assert result is True  # fail closed
+        assert calls == []  # remote must not be consulted
+
+    def test_generic_open_oserror_fails_closed_without_remote(self, tmp_path, monkeypatch):
+        import cron.lifecycle_guard as lg
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        def failing_open(path, flags, *args, **kwargs):
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr(lg.os, "open", failing_open)
+        calls = []
+
+        def remote(path):
+            calls.append(path)
+            return "hermes gateway restart"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash bad.sh", cwd=str(tmp_path), read_remote_script=remote
+        )
+        assert result is True  # fail closed
+        assert calls == []  # remote must not be consulted
+
+    def test_read_error_after_open_fails_closed_without_remote(self, tmp_path, monkeypatch):
+        import cron.lifecycle_guard as lg
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+        script = tmp_path / "r.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+
+        def failing_read(fd, n):
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr(lg.os, "read", failing_read)
+        calls = []
+
+        def remote(path):
+            calls.append(path)
+            return "hermes gateway restart"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {script.name}", cwd=str(tmp_path), read_remote_script=remote
+        )
+        assert result is True  # fail closed
+        assert calls == []  # remote must not be consulted
+
+    def test_safe_text_script_still_scanned(self, tmp_path):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+        script = tmp_path / "safe.sh"
+        script.write_text("#!/bin/bash\necho safe\n")
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {script.name}", cwd=str(tmp_path)
+        )
+        assert result is False


### PR DESCRIPTION
## Fix: keep the local binary decision terminal and guard embedded-NUL paths

### Incident

The guard crashed on a real command chain (`./node.exe`):

1. `./node.exe` (a local PE binary) was opened as if it were a script.
2. The bounded read classified the binary as "no text to scan".
3. Because the read returned `None`, the guard treated the file as *missing* and called the remote backend fallback.
4. The remote read fed the binary bytes back; recursive tokenization produced a path containing an embedded NUL byte.
5. `os.open` raised `ValueError`, escaping the guard.

This PR is the minimal, incident-scoped fix for that chain.

### Change

`cron/lifecycle_guard.py`:

- `_read_referenced_script()` returns a third status (`found`) so the caller can distinguish:
  - **missing** — the local path genuinely does not exist; only this state may use `read_remote_script`;
  - **text** — a bounded script read; scanning continues;
  - **found-unscannable** — the file exists locally but cannot be scanned as text; the remote fallback must never be consulted for it.
- The remote fallback is reached only when `found is False` (locally missing), so a locally classified binary can never be revived by the remote reader — and the tokenized NUL path it produced can never recurse.

Exception classification is precise (no broad `except (OSError, ValueError)` mapping to one state):

| Condition | `(text, unsafe, found)` | Meaning |
|---|---|---|
| `FileNotFoundError` / `NotADirectoryError` | `(None, False, False)` | genuinely missing → remote fallback allowed |
| `ValueError` (embedded NUL) | `(None, False, True)` | local decision terminal → remote never called |
| `PermissionError` / other open `OSError` | `(None, True, True)` | present but unreadable → fail closed |
| `os.read` `OSError` after successful open | `(None, True, True)` | present but unreadable → fail closed |
| binary (NUL content), non-regular, oversize | `(None, True/False, True)` | found → never falls back |

The bounded single read (`os.read(MAX+1)`) and the NUL-census binary heuristic are retained from upstream unchanged. No new budgets, envelopes, platform metadata, deadline framework, magic-number classification, NUL stripping, short-read loops, or explicit-loader semantics are introduced.

### Scope

Explicitly **out of scope** for this PR:

- NUL-padded shell-text bypasses (#77927) and the related magic-signature approach (#77928) — related but separate defects; this PR does not claim to fix NUL-padded scripts, dot-source handling, or all binary-recognition issues.
- Remote binary classification, cross-backend shell semantics, or platform metadata.
- Strict envelope/base64 transport protocols or two-stage remote reads.
- Token/segment/wall-clock budget frameworks.

### Tests

Regression tests in `tests/hermes_cli/test_gateway_restart_loop.py` (`TestLocalBinaryGuardRegression`, 9 tests):

- embedded-NUL token with a remote callback configured: no crash and the callback is not invoked;
- incident shape `./node.exe --version`: the local binary is not recursively scanned and the remote callback is not invoked;
- `bash node.exe` (explicit loader): the remote callback is not invoked for a locally classified binary (pass-through without remote revival; not a fail-closed claim);
- `FileNotFoundError` still reaches the remote fallback;
- `PermissionError`, a generic open `OSError`, and a read-after-open `OSError` (monkeypatched): remote is not consulted and the guard fails closed;
- a normal safe script is still scanned.

Pre-fix verification (the whole class against unmodified upstream `f5be9236e00ddf2f2a412697f267078fc4ee068e`): **7 failed / 2 passed** — the 2 pre-passing tests are missing→remote fallback and safe-text scanning. Post-fix: **9 passed**.

Results (this branch, Windows):

- `TestLocalBinaryGuardRegression`: **9 passed**
- `python -m pytest -q tests/hermes_cli/test_gateway_restart_loop.py`: **83 passed, 8 failed** — the 8 failures are identical to the unmodified upstream baseline (`f5be9236e00ddf2f2a412697f267078fc4ee068e`: 74 passed, 8 failed; 82 collected); they are pre-existing Windows path-format test-environment issues unrelated to this PR.
- `ruff check`: passed; `python -m compileall`: passed; `git diff --check`: passed.

Related: #76762 (crash), #77927 / #77928 (NUL-padded bypass, out of scope here), #78197 (this PR).
