### PR TITLE
fix(terminal): report background spawn death instead of a fake session id

### DIFF
--- a/tests/tools/test_terminal_background_spawn_death.py
+++ b/tests/tools/test_terminal_background_spawn_death.py
@@ -19,7 +19,9 @@ The assertions target the contract, not message strings:
 
 1. spawn death => an error payload, and no ``session_id`` the caller could
    mistake for a pollable handle;
-2. the surfaced output carries no unredacted credential from the command line;
+2. the surfaced output carries no unredacted credential from the command line —
+   asserted both with the global redaction preference ON and with it OFF, see
+   ``TestSpawnFailureOutputIsRedacted``;
 3. a healthy spawn still returns the normal started payload — without this an
    over-broad guard that fired on every spawn would satisfy (1) and (2).
 """
@@ -31,6 +33,14 @@ import pytest
 import tools.terminal_tool as terminal_tool
 
 
+# A credential-shaped constant: ``sk-`` is a recognised vendor prefix, so this
+# is masked by the PREFIX pass in agent/redact.py — the pass that runs
+# unconditionally, before the ``code_file`` gate. Do NOT swap this for an
+# ENV-assignment shape (``DEPLOY_API_KEY=...``): ``redact_terminal_output``
+# computes ``code_file = not is_env_dump_command(command)``, and the command
+# under test is not an env dump, so the ENV-assignment pass is skipped BY
+# DESIGN. Such a constant leaks against correct production code and would make
+# these tests fail for the wrong reason.
 SECRET = "sk-live-51HxXaMPLe0000000000000000000000000000000000000000"
 COMMAND_WITH_SECRET = f"./deploy.sh --api-key={SECRET}"
 
@@ -60,7 +70,17 @@ class _HealthySpawnEnvironment:
 
 @pytest.fixture
 def background_env(monkeypatch):
-    """Route terminal_tool at a caller-supplied fake non-local environment."""
+    """Route terminal_tool at a caller-supplied fake non-local environment.
+
+    Also cleans up after a *healthy* fake spawn. Such a spawn registers a
+    ``running`` session against a PID that does not exist and starts a
+    ``proc-poller-*`` thread which keeps calling ``execute()`` on the fake
+    environment. Left alone that entry leaks into every later test in the
+    process — ``count_running()``, ``any_running()``, and the checkpoint
+    writer all read the same global registry — so the cleanup below is not
+    cosmetic.
+    """
+    from tools.process_registry import process_registry
 
     def _install(environment, task_id="spawn-contract"):
         monkeypatch.setattr(
@@ -84,7 +104,50 @@ def background_env(monkeypatch):
         monkeypatch.setattr(terminal_tool, "_last_activity", {})
         return task_id
 
-    return _install
+    with process_registry._lock:
+        pre_existing = set(process_registry._running)
+
+    yield _install
+
+    with process_registry._lock:
+        leaked = [
+            process_registry._running.pop(session_id)
+            for session_id in list(process_registry._running)
+            if session_id not in pre_existing
+        ]
+    for session in leaked:
+        # Breaks the poller's ``while not session.exited`` loop; the thread
+        # then returns at the next iteration instead of polling a fake
+        # environment for the lifetime of the test process.
+        session.exited = True
+        thread = getattr(session, "_reader_thread", None)
+        if thread is not None:
+            thread.join(timeout=10)
+            assert not thread.is_alive(), f"poller thread {thread.name} outlived the test"
+
+
+@pytest.fixture
+def redaction_preference_disabled(monkeypatch):
+    """Run with the global ``security.redact_secrets`` preference OFF.
+
+    This is the only condition under which the ``force=True`` argument at the
+    failed-start boundary is observable: ``redact_sensitive_text`` short-circuits
+    on ``if not (force or _REDACT_ENABLED)``, so while the preference is ON the
+    preference alone masks the secret and dropping ``force`` changes nothing.
+
+    ``agent.redact._REDACT_ENABLED`` is snapshotted from ``HERMES_REDACT_SECRETS``
+    / ``security.redact_secrets`` at *import* time — deliberately, so a runtime
+    ``export HERMES_REDACT_SECRETS=false`` cannot disable redaction mid-session.
+    Setting the env var from a test is therefore a no-op: the module is long
+    imported by the time the test runs. Patching the snapshot is the established
+    convention across this suite (``tests/agent/test_redact.py``,
+    ``tests/tools/test_process_registry.py``) and, unlike an
+    ``importlib.reload``, monkeypatch reverts it automatically instead of
+    leaving a rebuilt module behind for every later test.
+    """
+    import agent.redact
+
+    monkeypatch.setattr(agent.redact, "_REDACT_ENABLED", False)
 
 
 class TestSpawnDeathIsReportedAsFailure:
@@ -120,6 +183,36 @@ class TestSpawnDeathIsReportedAsFailure:
 
 class TestSpawnFailureOutputIsRedacted:
     def test_credential_from_command_line_is_not_echoed(self, background_env):
+        task_id = background_env(_BrokenSpawnEnvironment())
+
+        raw = terminal_tool.terminal_tool(
+            command=COMMAND_WITH_SECRET, background=True, task_id=task_id
+        )
+
+        assert SECRET not in raw
+
+    def test_credential_is_not_echoed_when_redaction_preference_is_disabled(
+        self, background_env, redaction_preference_disabled
+    ):
+        """The failed-start payload must stay clean even with redaction OFF.
+
+        A spawn failure is a safety boundary: the captured output echoes the
+        wrapper's own command line, which may carry a credential the operator
+        never intended to surface. That is why the call site passes
+        ``force=True``. This test is what makes ``force=True`` load-bearing —
+        with the preference ON, the sibling test above passes even if ``force``
+        is deleted.
+        """
+        from agent.redact import redact_terminal_output
+
+        # Control: prove the preference really is off, so the assertion below
+        # cannot pass for the wrong reason if this fixture ever stops biting.
+        # A non-forced redaction must pass the secret straight through here.
+        assert SECRET in redact_terminal_output(
+            f"bash: cannot create log file for: {COMMAND_WITH_SECRET}",
+            COMMAND_WITH_SECRET,
+        )
+
         task_id = background_env(_BrokenSpawnEnvironment())
 
         raw = terminal_tool.terminal_tool(

--- a/tests/tools/test_terminal_background_spawn_death.py
+++ b/tests/tools/test_terminal_background_spawn_death.py
@@ -1,0 +1,160 @@
+"""Regression tests: a background spawn that dies must not be reported as started.
+
+``terminal(background=True)`` returned ``"Background process started"`` plus a
+``session_id`` unconditionally — even when the process had already died during
+spawn. On a non-local backend (SSH, Docker, Modal, Daytona) the wrapper can fail
+to produce a PID (unwritable redirect target, broken login shell, transport
+error), and ``ProcessRegistry.spawn_via_env`` marks the session
+``completion_reason == "failed_start"`` and never registers it as running. The
+agent was still handed a handle it could never poll — ``process(action="poll")``
+answers ``not_found`` — so the real failure stayed invisible until someone read
+the logs by hand.
+
+Note the local ``Popen`` path cannot reach this state: it always obtains a PID,
+and a bad command merely exits 127 *after* a successful spawn (a real, pollable
+session). ``failed_start`` is specific to the ``env.execute`` backends, which is
+why these tests drive a fake environment.
+
+The assertions target the contract, not message strings:
+
+1. spawn death => an error payload, and no ``session_id`` the caller could
+   mistake for a pollable handle;
+2. the surfaced output carries no unredacted credential from the command line;
+3. a healthy spawn still returns the normal started payload — without this an
+   over-broad guard that fired on every spawn would satisfy (1) and (2).
+"""
+
+import json
+
+import pytest
+
+import tools.terminal_tool as terminal_tool
+
+
+SECRET = "sk-live-51HxXaMPLe0000000000000000000000000000000000000000"
+COMMAND_WITH_SECRET = f"./deploy.sh --api-key={SECRET}"
+
+
+class _BrokenSpawnEnvironment:
+    """Non-local backend whose background wrapper never emits a PID."""
+
+    env: dict = {}
+
+    def execute(self, command, timeout=None, rewrite_compound_background=False, **kwargs):
+        # Echo the command back the way a failing shell wrapper does, so the
+        # credential on the command line reaches the captured output.
+        return {
+            "output": f"bash: cannot create log file for: {command}",
+            "returncode": 1,
+        }
+
+
+class _HealthySpawnEnvironment:
+    """Non-local backend whose wrapper prints a PID, i.e. a real launch."""
+
+    env: dict = {}
+
+    def execute(self, command, timeout=None, rewrite_compound_background=False, **kwargs):
+        return {"output": "4242", "returncode": 0}
+
+
+@pytest.fixture
+def background_env(monkeypatch):
+    """Route terminal_tool at a caller-supplied fake non-local environment."""
+
+    def _install(environment, task_id="spawn-contract"):
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: {
+                "env_type": "ssh",
+                "cwd": "/tmp",
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+        monkeypatch.setattr(
+            terminal_tool,
+            "_check_all_guards",
+            lambda command, env_type, **kwargs: {"approved": True},
+        )
+        monkeypatch.setattr(
+            terminal_tool, "_active_environments", {task_id: environment}
+        )
+        monkeypatch.setattr(terminal_tool, "_last_activity", {})
+        return task_id
+
+    return _install
+
+
+class TestSpawnDeathIsReportedAsFailure:
+    def test_dead_spawn_does_not_report_success(self, background_env):
+        task_id = background_env(_BrokenSpawnEnvironment())
+
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="./run-server.sh", background=True, task_id=task_id
+            )
+        )
+
+        assert result.get("error")
+        assert result.get("exit_code") != 0
+
+    def test_dead_spawn_hands_back_no_pollable_handle(self, background_env):
+        """A session id the caller cannot poll is worse than no id at all."""
+        from tools.process_registry import process_registry
+
+        task_id = background_env(_BrokenSpawnEnvironment())
+
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="./run-server.sh", background=True, task_id=task_id
+            )
+        )
+
+        session_id = result.get("session_id")
+        if session_id is not None:
+            # If an id is surfaced at all, it must actually resolve.
+            assert process_registry.poll(session_id).get("status") != "not_found"
+
+
+class TestSpawnFailureOutputIsRedacted:
+    def test_credential_from_command_line_is_not_echoed(self, background_env):
+        task_id = background_env(_BrokenSpawnEnvironment())
+
+        raw = terminal_tool.terminal_tool(
+            command=COMMAND_WITH_SECRET, background=True, task_id=task_id
+        )
+
+        assert SECRET not in raw
+
+
+class TestHealthySpawnIsUnaffected:
+    """Load-bearing: an over-broad guard firing on every spawn must fail here."""
+
+    def test_healthy_spawn_still_returns_started_payload(self, background_env):
+        task_id = background_env(_HealthySpawnEnvironment())
+
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="./run-server.sh", background=True, task_id=task_id
+            )
+        )
+
+        assert result.get("error") is None
+        assert result.get("exit_code") == 0
+        assert result.get("session_id")
+
+    def test_healthy_spawn_handle_is_pollable(self, background_env):
+        from tools.process_registry import process_registry
+
+        task_id = background_env(_HealthySpawnEnvironment())
+
+        result = json.loads(
+            terminal_tool.terminal_tool(
+                command="./run-server.sh", background=True, task_id=task_id
+            )
+        )
+
+        polled = process_registry.poll(result["session_id"])
+        assert polled.get("status") != "not_found"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2680,6 +2680,29 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
+                if (
+                    getattr(proc_session, "exited", False)
+                    and getattr(proc_session, "completion_reason", "") == "failed_start"
+                ):
+                    # The process died during spawn. Reporting "started" here
+                    # hands the agent a session id it can never poll, so fail
+                    # loudly instead — and redact, because the captured output
+                    # can echo credentials that were on the command line.
+                    from agent.redact import redact_terminal_output
+
+                    failed_output = redact_terminal_output(
+                        getattr(proc_session, "output_buffer", "") or "",
+                        command,
+                        force=True,
+                    )
+                    failed_exit = getattr(proc_session, "exit_code", -1)
+                    return json.dumps({
+                        "output": failed_output,
+                        "exit_code": -1 if failed_exit is None else failed_exit,
+                        "error": "Failed to start background process",
+                        "status": "error",
+                    }, ensure_ascii=False)
+
                 result_data = {
                     "output": "Background process started",
                     "session_id": proc_session.id,


### PR DESCRIPTION
## The bug

`terminal(background=True)` returns `"Background process started"` plus a `session_id` unconditionally — even when the process already died during spawn.

`tools/process_registry.py` already detects this correctly. `spawn_via_env` marks the session `completion_reason = "failed_start"`, sets `exited = True`, and deliberately does **not** register it in `_running` (lines ~902–915):

```python
if session.pid is None:
    session.exited = True
    session.exit_code = int(result.get("returncode", -1))
    if session.exit_code == 0:
        session.exit_code = -1
    session.completion_reason = "failed_start"
    session.termination_source = "failed_start"
    session.output_buffer = result.get("output", "").strip()
```

`tools/terminal_tool.py` never read that flag:

```
$ grep -c failed_start tools/terminal_tool.py
0
```

So the agent gets a handle it can never poll, and the real failure stays invisible until a human reads the logs.

This is reachable on any non-local backend (SSH, Docker, Modal, Daytona) whenever the background wrapper fails to emit a PID — unwritable redirect target, broken login shell, transport error mid-spawn. The local `Popen` path cannot reach it: it always obtains a PID, and a bad command merely exits 127 *after* a successful spawn, producing a real, pollable session.

## Reproduction on unpatched `main` (70db671f)

Driving the real `terminal_tool` code path in-process against a backend whose wrapper returns no PID:

```
LOADED terminal_tool from: .../tools/terminal_tool.py
grep failed_start in terminal_tool: 0
------------------------------------------------------------------------
terminal_tool(command="./deploy.sh --api-key=sk-live-…", background=True) returned:
{
  "output": "Background process started",
  "session_id": "proc_0e273c8a08f1",
  "pid": null,
  "exit_code": 0,
  "error": null
}

-> session_id handed to the agent: proc_0e273c8a08f1
-> process_registry.poll("proc_0e273c8a08f1") -> {
     "status": "not_found",
     "error": "No process with ID proc_0e273c8a08f1"
   }
-> process_registry.get("proc_0e273c8a08f1") -> None
```

`exit_code: 0`, `error: null`, `pid: null` — and the id it just handed out does not resolve. Note the caller has no way to infer failure from `pid: null` either, since the local backend legitimately reports a pid while non-local sessions are identified by session id.

After the fix, same input:

```
{
  "output": "bash: /sandbox/tmp/hermes_bg_x.log: Read-only file system",
  "exit_code": 1,
  "error": "Failed to start background process",
  "status": "error"
}
```

## The fix

Check `completion_reason` at the background return point and return `status=error` with the captured spawn output. 23 lines in `tools/terminal_tool.py`, no behavior change on the healthy path.

The captured output is passed through `agent.redact.redact_terminal_output(..., force=True)` **before** it is returned. This is not incidental: a failing wrapper echoes its own command line back (`bash: cannot create log file for: ./deploy.sh --api-key=…`), so surfacing the raw buffer would turn a visibility fix into a credential leak. `force=True` bypasses the `security.redact_secrets` preference, consistent with the other safety boundaries that must never emit raw credentials.

## Whole bug class: `lost` and `already_exited`

`process_registry` defines other `completion_reason` values. I checked whether they share the reporting hole; they do not, and the change stays scoped to `failed_start`:

- **`lost`** (`_env_poller_loop`, ~line 1125, set when the sandbox is reaped mid-run) is set **asynchronously by the poller thread**, long after `terminal_tool` has returned. It is not observable at the spawn return point, so no guard there could act on it. It *is* surfaced today — `poll()` reports `status: "exited"` with `completion_reason: "lost"` and `termination_source: "backend_lost"`. Verified:
  ```
  poll() -> {"status": "exited", "exit_code": -1,
             "completion_reason": "lost", "termination_source": "backend_lost"}
  ```
- **`already_exited`** is not a `completion_reason` at all — it's a *status* returned by `kill_process()` / `write_stdin()`, and it already carries `exit_code`, `completion_reason`, `termination_source` and `output`. Verified:
  ```
  kill_process() -> {"status": "already_exited", "exit_code": 0,
                     "completion_reason": "exited", "output": ""}
  ```

`failed_start` is the only `completion_reason` that can be true at `terminal_tool`'s background return, because it is the only one `spawn_via_env` sets synchronously — hence the only one this guard can act on.

## Tests

`tests/tools/test_terminal_background_spawn_death.py` drives the real `terminal_tool` entry point against a fake non-local environment, and asserts the **contract**, not message strings:

1. a dead spawn produces an error payload (`error` set, `exit_code != 0`);
2. any `session_id` surfaced must actually resolve via `process_registry.poll()` — an unpollable handle is worse than none;
3. the returned JSON contains no unredacted credential from the command line;
4. **load-bearing:** a healthy spawn still returns the normal started payload with a pollable handle. Without this, an over-broad guard that fired on *every* spawn would satisfy 1–3 and pass the suite.

Verified genuinely RED before the fix — reverting only `tools/terminal_tool.py` and keeping the new test:

```
FAILED ...::test_dead_spawn_does_not_report_success
FAILED ...::test_dead_spawn_hands_back_no_pollable_handle
        AssertionError: assert 'not_found' != 'not_found'
========================= 2 failed, 3 passed =========================
```

The 3 that pass unpatched are the healthy-spawn and redaction cases, which is the point — they are the guard against overcorrecting.

Green with the fix, via the canonical runner from the worktree root:

```
$ ./scripts/run_tests.sh tests/tools/test_terminal*.py tests/tools/test_process*.py \
    tests/tools/test_notify_on_complete.py tests/tools/test_threaded_process_handle.py \
    tests/tools/test_zombie_process_cleanup.py tests/tools/test_subprocess_stdin_guard.py

=== Summary: 23 files, 243 tests passed, 0 failed (100% complete) in 6.9s ===
```

## Scope

Two files: `tools/terminal_tool.py` (+23) and the new test (+160). No new env vars, no new tools, no changes outside the terminal tool and its tests.
