### PR TITLE
fix(cron): stop lifecycle guard crashing the terminal tool on NUL-bearing and looping script paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,16 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: missing/unreadable path. ValueError: embedded NUL byte —
+        # os.open rejects those before any syscall, so this raises instead of
+        # returning an errno. The NUL arrives the same way #76762 described:
+        # the walk tokenizes a binary's decoded contents and feeds a
+        # NUL-bearing token straight back here, so the skip-binaries intent
+        # of #76762 has to cover the open() call too, not only the later
+        # content check (which this crash never reaches). Fail open like the
+        # OSError case: a NUL-bearing path can never name a real executable
+        # script, so there is nothing to scan and nothing that can run.
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -313,10 +322,14 @@ def _contains_unsafe_gateway_action(
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
         try:
             resolved = script_path.resolve(strict=False)
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             # OSError: unreadable/long paths. ValueError: embedded NUL byte
             # from a binary's decoded contents tokenized as a path — a
             # guarded path must never crash the guard (#76762).
+            # RuntimeError: CPython's pathlib raises it (not OSError) for a
+            # symlink loop, so a self-referential script path crashed the
+            # guard the same way. Keep the unresolved path: the visited-set
+            # de-duplication degrades but the scan still runs.
             resolved = script_path
         if resolved in visited:
             continue

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -170,10 +170,53 @@ def contains_launchctl_submit_command(command: str) -> bool:
     return False
 
 
+def _expanduser_like_shell(candidate: str) -> Path:
+    """Expand ``~``/``~user`` the way a POSIX shell does, without raising.
+
+    ``pathlib.Path.expanduser()`` raises ``RuntimeError("Could not determine
+    home directory.")`` when the tilde prefix names an unknown user, because it
+    treats "``os.path.expanduser`` returned the string unchanged" as an error.
+    ``os.path.expanduser`` itself does NOT raise — it documents "if user or
+    $HOME is unknown, do nothing" and returns the token verbatim.
+
+    The shell agrees with ``os.path``, not with ``pathlib``: ``bash
+    ~nosuchuser/x.sh`` does not fail, it runs the *literal relative path*
+    ``./~nosuchuser/x.sh``. So the unexpanded token is the path that actually
+    executes, and it is exactly what this guard must scan. Using ``os.path``
+    here therefore both removes the crash and keeps the guard aimed at the file
+    the shell would really run — an unknown-user tilde must not become a blind
+    spot, since a script can sit in a literal ``~nosuchuser/`` directory.
+
+    ``ValueError`` (embedded NUL) is caught here rather than left to escape:
+    ``os.path.expanduser`` calls ``pwd.getpwnam()`` for a ``~user`` token, which
+    rejects a NUL *before* this function ever reaches the ``os.open`` guarded by
+    #76762 — so ``bash ~foo\\x00bar/x.sh`` still crashed the guard even with that
+    fix in place. The unexpanded token is returned so the existing
+    ``(OSError, ValueError)`` handling downstream treats it exactly like any
+    other NUL-bearing path: unopenable, unexecutable, nothing to scan.
+    """
+    try:
+        expanded = os.path.expanduser(candidate)
+    except ValueError:
+        expanded = candidate
+    return Path(expanded)
+
+
 def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+    path = _expanduser_like_shell(candidate)
     if not path.is_absolute():
-        path = Path(cwd or Path.cwd()) / path
+        # Path.cwd() raises FileNotFoundError when the process cwd has been
+        # deleted. A guard must not crash its caller, and a deleted cwd is
+        # also unexploitable: the shell cannot execute a relative path from
+        # a cwd that no longer exists (bash exits 127, "getcwd: cannot access
+        # parent directories"), so there is no command to scan and none that
+        # could run. Fall back to the token itself and let the read below
+        # simply fail to find it.
+        try:
+            base = Path(cwd) if cwd else Path.cwd()
+        except OSError:
+            return path
+        path = base / path
     return path
 
 
@@ -322,6 +365,13 @@ def _contains_unsafe_gateway_action(
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
         try:
             resolved = script_path.resolve(strict=False)
+        except RecursionError:
+            # RecursionError subclasses RuntimeError, so the clause below would
+            # silently swallow a genuine stack exhaustion as "unresolvable
+            # path". This walk has its own depth cap
+            # (_MAX_REFERENCED_SCRIPT_DEPTH), so a RecursionError here is a real
+            # interpreter-level fault, not a guarded condition — let it escape.
+            raise
         except (OSError, ValueError, RuntimeError):
             # OSError: unreadable/long paths. ValueError: embedded NUL byte
             # from a binary's decoded contents tokenized as a path — a
@@ -387,7 +437,14 @@ def _resolve_script_path(script_path: str) -> Path:
     """
     from hermes_constants import get_hermes_home
 
-    raw = Path(script_path).expanduser()
+    # os.path.expanduser, not Path.expanduser: the latter raises RuntimeError
+    # for an unknown-user tilde (``~nosuchuser/x.sh``) and would crash the
+    # guard. The scheduler resolves a non-absolute value under
+    # ``<HERMES_HOME>/scripts/`` (cron/scheduler.py), and an unexpanded
+    # ``~nosuchuser/x.sh`` is not absolute — so scanning the same literal
+    # token keeps this resolver mirroring the scheduler exactly, which is the
+    # documented contract above.
+    raw = _expanduser_like_shell(script_path)
     if raw.is_absolute():
         return raw
     return get_hermes_home() / "scripts" / raw

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -18,6 +18,24 @@ from hermes_cli.cron import (
 )
 
 
+def _unknown_user_name() -> str:
+    """Return a username that is guaranteed not to resolve on this machine.
+
+    The precondition is checked through ``os.path.expanduser`` rather than
+    ``pwd`` so it stays portable: that function documents "if user or $HOME is
+    unknown, do nothing", so a token it returns verbatim is one no home
+    directory could be found for — exactly the input that makes
+    ``pathlib.Path.expanduser()`` raise.
+    """
+    for candidate in ("nosuchuser99xyz", "nosuchuser99xyz2", "hermes-no-such-user-31337"):
+        if os.path.expanduser(f"~{candidate}") == f"~{candidate}":
+            return candidate
+    raise RuntimeError("could not find a non-resolving username for the test")
+
+
+_UNKNOWN_USER = _unknown_user_name()
+
+
 # ---------------------------------------------------------------------------
 # Defense 2: _contains_gateway_lifecycle_command pattern tests
 # ---------------------------------------------------------------------------
@@ -768,6 +786,177 @@ class TestLifecycleGuardModule:
             )
             is False
         )
+
+    def test_nul_from_shell_payload_does_not_crash_guard(self):
+        """The payload-recursion route: a NUL-bearing path inside ``sh -c``
+        code reaches the same open() one recursion level down. This route was
+        claimed as covered but had no test until now."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "sh -c 'bash /tmp/inner\x00x.sh'"
+            )
+            is False
+        )
+
+    def test_unknown_user_tilde_path_does_not_crash_public_guard(self):
+        """Same bug class as the NUL path, third exception type.
+
+        ``pathlib.Path.expanduser()`` raises RuntimeError for a tilde naming an
+        unknown user, so ``bash ~nosuchuser/x.sh`` crashed the guard — and with
+        it the terminal tool — exactly like the NUL-bearing path did.
+        ``os.path.expanduser()`` does NOT raise for this input, which is why an
+        audit that probed the ``os.path`` form saw no hole.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash ~{_UNKNOWN_USER}/x.sh"
+            )
+            is False
+        )
+
+    def test_unknown_user_tilde_in_shell_payload_does_not_crash_guard(self):
+        """The payload-recursion route reaches the same expansion."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"sh -c 'bash ~{_UNKNOWN_USER}/x.sh'"
+            )
+            is False
+        )
+
+    def test_unknown_user_tilde_from_script_content_does_not_crash_guard(self, tmp_path):
+        """The reachable route that matters: the token comes from a referenced
+        script's CONTENT — the identical delivery path as the NUL bug."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        outer = tmp_path / "outer.sh"
+        outer.write_text(f"#!/bin/sh\nbash ~{_UNKNOWN_USER}/inner.sh\n")
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {outer}", cwd=str(tmp_path)
+            )
+            is False
+        )
+
+    def test_unknown_user_tilde_cron_script_value_does_not_crash_guard(self):
+        """The cron-creation path resolves the script value through the same
+        expansion, so it crashed identically."""
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        check_gateway_lifecycle("daily ops", f"~{_UNKNOWN_USER}/x.sh")
+
+    def test_unknown_user_tilde_directory_is_still_scanned(self, tmp_path):
+        """The security contract, not just the absence of a crash.
+
+        A POSIX shell does not fail on ``bash ~nosuchuser/x.sh`` — it runs the
+        LITERAL relative path ``./~nosuchuser/x.sh``. So a lifecycle command in
+        a script under a literal ``~nosuchuser/`` directory is genuinely
+        executable, and swallowing the crash as "nothing found" would turn this
+        into a guard bypass. The guard must still detect it.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        literal_dir = tmp_path / f"~{_UNKNOWN_USER}"
+        literal_dir.mkdir()
+        (literal_dir / "x.sh").write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash ~{_UNKNOWN_USER}/x.sh", cwd=str(tmp_path)
+            )
+            is True
+        )
+
+    def test_benign_script_in_unknown_user_tilde_directory_still_passes(self, tmp_path):
+        """The other half of the contract: scanning that literal directory must
+        not turn benign commands into false positives."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        literal_dir = tmp_path / f"~{_UNKNOWN_USER}"
+        literal_dir.mkdir()
+        (literal_dir / "x.sh").write_text("#!/bin/sh\necho hello\n")
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash ~{_UNKNOWN_USER}/x.sh", cwd=str(tmp_path)
+            )
+            is False
+        )
+
+    def test_known_user_tilde_expansion_still_resolves(self, tmp_path, monkeypatch):
+        """Switching to os.path.expanduser must not stop ``~/`` from expanding:
+        a lifecycle command in a script referenced via ``~/`` is still caught."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "restart.sh").write_text("#!/bin/sh\nhermes gateway restart\n")
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "bash ~/restart.sh", cwd=str(tmp_path)
+            )
+            is True
+        )
+
+    def test_nul_inside_tilde_username_does_not_crash_guard(self):
+        """A NUL inside the ``~user`` name is rejected by pwd.getpwnam() during
+        expansion — BEFORE the open() call that the NUL-path fix guards — so it
+        escaped that fix and crashed the guard on its own route."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "bash ~foo\x00bar/x.sh"
+            )
+            is False
+        )
+
+    def test_genuine_recursion_error_is_not_swallowed_as_unresolvable(self):
+        """RecursionError subclasses RuntimeError, so the symlink-loop handler
+        would silently absorb a real stack exhaustion as "unresolvable path".
+        This walk has its own depth cap, so a RecursionError from resolve() is
+        an interpreter-level fault and must propagate."""
+        from pathlib import Path
+
+        import cron.lifecycle_guard as lifecycle_guard
+
+        class _ExplodingPath(type(Path("/tmp"))):
+            def resolve(self, strict=False):
+                raise RecursionError("maximum recursion depth exceeded")
+
+        original = lifecycle_guard._iter_referenced_shell_scripts
+        try:
+            lifecycle_guard._iter_referenced_shell_scripts = (
+                lambda command, *, cwd=None: iter([_ExplodingPath("/tmp/x.sh")])
+            )
+            with pytest.raises(RecursionError):
+                lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+                    "bash /tmp/x.sh"
+                )
+        finally:
+            lifecycle_guard._iter_referenced_shell_scripts = original
 
     def test_classification_of_normal_scripts_is_unchanged(self, tmp_path):
         """The guard must still classify ordinary scripts exactly as before:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,106 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_nul_bearing_path_returns_contract_tuple_instead_of_raising(self):
+        """#76762 follow-up: _read_referenced_script must honor its documented
+        ``(text, unsafe)`` contract for a NUL-bearing path.
+
+        os.open() rejects an embedded NUL with ValueError, not OSError, so the
+        original ``except OSError`` let it escape. The #76762 skip-binaries
+        check sits *after* the open() call and was therefore unreachable.
+        """
+        from pathlib import Path
+
+        from cron.lifecycle_guard import _read_referenced_script
+
+        text, unsafe = _read_referenced_script(Path("/tmp/foo\x00bar"))
+        assert text is None
+        assert unsafe is False
+
+    def test_nul_bearing_path_token_does_not_crash_public_guard(self):
+        """End-to-end: the crash escaped through the public entry point, which
+        is what tools/terminal_tool.py calls — so the terminal tool itself
+        failed with a traceback instead of running the command."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "bash /tmp/foo\x00bar.sh", cwd="/tmp"
+            )
+            is False
+        )
+
+    def test_nul_from_remote_script_backend_does_not_crash_guard(self):
+        """The NUL can also arrive from the remote-script backend's text, which
+        the walk re-tokenizes into path tokens."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "bash /remote/deploy.sh",
+                cwd="/tmp",
+                read_remote_script=lambda _p: "bash /opt/tool\x00bin.sh\n",
+            )
+            is False
+        )
+
+    def test_nul_bearing_cron_script_value_does_not_crash_guard(self):
+        """The cron-creation path reaches the same open() via
+        _read_script_for_scanning, so it crashed identically."""
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        check_gateway_lifecycle("daily ops", "/tmp/foo\x00bar.sh")
+
+    def test_symlink_loop_does_not_crash_guard(self, tmp_path):
+        """Same bug class, different exception: CPython's pathlib raises
+        RuntimeError (not OSError) for a symlink loop, so a self-referential
+        script path escaped the resolve() guard and crashed the caller."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        first = tmp_path / "loop.sh"
+        second = tmp_path / "other.sh"
+        first.symlink_to(second)
+        second.symlink_to(first)
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {first}", cwd=str(tmp_path)
+            )
+            is False
+        )
+
+    def test_classification_of_normal_scripts_is_unchanged(self, tmp_path):
+        """The guard must still classify ordinary scripts exactly as before:
+        a lifecycle command in a referenced script is caught, and a benign one
+        is not. Widening an except clause must not weaken detection."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        unsafe_script = tmp_path / "restart.sh"
+        unsafe_script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        benign_script = tmp_path / "benign.sh"
+        benign_script.write_text("#!/bin/bash\necho hello\n")
+
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {unsafe_script}", cwd=str(tmp_path)
+            )
+            is True
+        )
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {benign_script}", cwd=str(tmp_path)
+            )
+            is False
+        )
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## The bug

`cron/lifecycle_guard.py` makes filesystem probes on behalf of a security guard, and several of them raise exception types the guard does not catch. Each one escapes through `contains_gateway_lifecycle_command_or_referenced_script` into `tools/terminal_tool.py:2560`, so **in a gateway session (`_HERMES_GATEWAY=1`) the terminal tool itself fails with a traceback instead of running the command** — and every retry of that command shape fails identically, so the agent loses its shell for that call. `check_gateway_lifecycle` (the cron-creation path) reaches the same probes and crashes the same way.

Two distinct crashes are fixed here.

### 1. `os.open()` raises `ValueError` on a NUL-bearing path

`_read_referenced_script()` wraps `os.open()` in `except OSError`, but a path token carrying a NUL byte makes `os.open` raise **`ValueError`**:

```
  File "cron/lifecycle_guard.py", line 260, in _read_referenced_script
    descriptor = os.open(path, flags)
ValueError: embedded null byte
```

**How the NUL gets there** is exactly the path #76762 described: `_contains_unsafe_gateway_action` recurses into a referenced script, reads its *text*, and extracts path tokens from it. A script whose text contains a NUL byte yields a token with an embedded NUL, which is fed straight back into `os.open`.

This is a follow-up to #76762, not a contradiction of it. That fix hardened this function to *"skip NUL-bearing binaries rather than failing closed"* — but the check sits **after** the `os.open` call:

```python
descriptor = os.open(path, flags)   # ← ValueError raised HERE
...
if b"\x00" in data:                 # ← #76762's check, never reached
    return None, False
```

### 2. `pathlib.Path.expanduser()` raises `RuntimeError` on an unknown-user tilde

`_resolve_terminal_script_path()` expands path tokens with `Path(candidate).expanduser()`, which raises when the tilde names a user that does not resolve:

```
  File "cron/lifecycle_guard.py", line 174, in _resolve_terminal_script_path
    path = Path(candidate).expanduser()
RuntimeError: Could not determine home directory.
```

**`os.path.expanduser()` does NOT raise for this input.** It documents *"if user or $HOME is unknown, do nothing"* and returns the token verbatim; only `pathlib` treats that as an error. The two APIs agree on `~/`, `~root/`, absolute and relative tokens — they differ **only** on the unknown-user form:

```
>>> os.path.expanduser('~nosuchuser99xyz/x.sh')
'~nosuchuser99xyz/x.sh'
>>> Path('~nosuchuser99xyz/x.sh').expanduser()
RuntimeError: Could not determine home directory.
```

An earlier revision of this PR's audit table claimed this site was clean. That claim was made against the `os.path` form and generalised — it was wrong, and the table below is corrected and re-verified by execution.

### 3. A NUL *inside* the `~user` name — a route the NUL fix alone did not close

`os.path.expanduser` calls `pwd.getpwnam()` for a `~user` token, which rejects a NUL **before** control ever reaches the `os.open()` that fix #1 guards. So `bash ~foo\x00bar/x.sh` still crashed the guard with fix #1 in place. Found while verifying fix #2.

## Fail-open vs fail-closed — a different answer for each crash

**NUL-bearing paths: fail open** (`return None, False`), matching what this function already does for an unopenable path. A NUL-bearing path is unexecutable by construction — `os.execv`, `subprocess.run`, and `open()` all reject an embedded NUL with `ValueError`, and `execve(2)` cannot carry one in `argv` — so there is no file to scan and no command that could ever run. Fail-closed would re-introduce the exact #76762 false positive as a hard block instead of a crash.

**Unknown-user tilde: fail open would have been a REAL BYPASS.** A POSIX shell does not fail on `bash ~nosuchuser/x.sh` — it executes the **literal relative path** `./~nosuchuser/x.sh`:

```
$ mkdir '~nosuchuser99xyz' && echo 'hermes gateway restart' > '~nosuchuser99xyz/x.sh'
$ bash ~nosuchuser99xyz/x.sh
✗ Refusing to restart the gateway from inside the gateway process.
```

The unexpanded token *is* the path that executes, so simply swallowing the crash would have created a blind spot the shell walks straight through. The fix uses `os.path.expanduser`, which both removes the crash **and** keeps the guard aimed at the file the shell would really run. This also keeps `_resolve_script_path` mirroring the scheduler (`cron/scheduler.py:2248-2252`), which resolves a non-absolute value under `<HERMES_HOME>/scripts/` — an unexpanded `~nosuchuser/x.sh` is not absolute, so scan and run reach the same file with no desync.

## Reproduction — every row below was executed, not read

Crash routes for the NUL path, on `main` @ `70db671fa`:

| input to `contains_gateway_lifecycle_command_or_referenced_script` | `main` @ `70db671fa` | this PR |
|---|---|---|
| `bash /tmp/foo\x00bar.sh` | `ValueError: embedded null byte` | `False` |
| `sh -c 'bash /tmp/inner\x00x.sh'` (payload recursion) | `ValueError: embedded null byte` | `False` |
| `bash /remote/deploy.sh` + `read_remote_script` returning NUL-bearing text | `ValueError: embedded null byte` | `False` |
| `check_gateway_lifecycle("daily ops", "/tmp/foo\x00bar.sh")` (cron path) | `ValueError: embedded null byte` | returns cleanly |

Crash routes for the unknown-user tilde, measured against this PR's own previous head (`563626236`) — i.e. these were still broken *after* the NUL fix:

| input | at `563626236` | this PR |
|---|---|---|
| `bash ~nosuchuser99xyz/x.sh` | `RuntimeError: Could not determine home directory.` | `False` |
| `sh -c 'bash ~nosuchuser99xyz/x.sh'` (payload recursion) | `RuntimeError` | `False` |
| referenced script whose **CONTENT** contains `bash ~nosuchuser99xyz/inner.sh` | `RuntimeError` | `False` |
| `check_gateway_lifecycle("daily ops", "~nosuchuser99xyz/x.sh")` (cron path) | `RuntimeError` | returns cleanly |
| `bash ~foo\x00bar/x.sh` (NUL inside the `~user` name) | `ValueError: embedded null byte` | `False` |

Controls, same run: `bash ~/normal.sh` → `False`, `bash /tmp/plain.sh` → `False`, `bash ~root/x.sh` → `False`, `hermes gateway restart` → `True`. The crash is specific to the `~unknownuser` form.

Detection is preserved where it matters — a lifecycle command inside a literal `~nosuchuser/` directory is **still caught** (`True`), and a benign script there still passes (`False`).

## Whole bug class — every site, re-verified by execution

Every row below corresponds to a command actually run against both the unpatched and patched trees. Sites I could not verify by execution are not listed.

| # | Site | Exception that escapes | Status |
|---|---|---|---|
| 1 | `_read_referenced_script` → `os.open(path, flags)` | `ValueError` (embedded NUL) | **Fixed** (earlier commit on this branch) |
| 2 | `_contains_unsafe_gateway_action` → `Path.resolve(strict=False)` | `RuntimeError` (symlink loop) | **Fixed** (earlier commit on this branch) |
| 3 | `_read_referenced_script` → `os.fstat` / `os.read` | none — operate on an `int` fd, no path parsing. Exercised on a FIFO → `(None, True)` and a regular file → `("echo hi\n", False)` | No hole (executed) |
| 4 | `_resolve_terminal_script_path` → **`pathlib.Path.expanduser()`** | **`RuntimeError`** for `~unknownuser`; **`ValueError`** for a NUL inside the `~user` name. Tolerates a missing `HOME` (both APIs return the same result). | **Fixed here** — previously and wrongly listed as "No hole" |
| 5 | `_resolve_terminal_script_path` → `Path.cwd()` | `FileNotFoundError` when the process cwd has been deleted | **Fixed here** (see below) |
| 6 | `_resolve_script_path` → `pathlib.Path.expanduser()` (cron path) | `RuntimeError` for `~unknownuser` | **Fixed here** |
| 7 | `_resolve_script_directory` → `_resolve_script_path` | already `except Exception`; `'/tmp/foo\x00bar.sh'` → `'/tmp'`, `'~nosuchuser/x.sh'` → resolved under the scripts dir | Already covered (executed) |
| 8 | `contains_launchctl_submit_command` | pure token inspection, no filesystem call. NUL and `~unknownuser` inputs both return `True`; a real `launchctl submit` still returns `True` | No hole (executed) |

## Two lower-severity fixes in the same functions

**`Path.cwd()` with a deleted cwd** (row 5) raised `FileNotFoundError` straight out of the public guard when `cwd=None`. Verified escaping; now falls back to the bare token. This is not attacker-controlled, and a deleted cwd is unexploitable — a shell cannot execute a relative path from it (`bash` exits 127, `getcwd: cannot access parent directories`) — so there is nothing to scan and nothing that can run. Fixed rather than deferred because it is one line inside a function this PR already touches, and a guard must never crash its caller.

**`except RuntimeError` was over-broad.** `RecursionError` subclasses `RuntimeError`, so the symlink-loop handler silently absorbed a genuine stack exhaustion as "unresolvable path" (verified: a `resolve()` that raises `RecursionError` returned `False` instead of propagating). This walk has its own depth cap (`_MAX_REFERENCED_SCRIPT_DEPTH = 8`), so a `RecursionError` here is an interpreter-level fault, not a guarded condition. It is now re-raised ahead of the symlink-loop clause.

## Tests

Sixteen behavior-contract tests in `TestLifecycleGuardModule` (no frozen strings, no change-detectors), covering:

- the documented `(text, unsafe)` tuple returned instead of raising
- the NUL crash at the **public entry point `terminal_tool` actually calls**, plus the remote-script-backend, cron-script-value, and `sh -c` payload-recursion routes — **all five NUL routes now have tests.** An earlier revision of this body claimed five covered routes when the payload-recursion one had none; that test is added here rather than the claim being dropped.
- all four unknown-user-tilde routes, plus the NUL-in-username route
- **the security contract in both directions:** a lifecycle command inside a literal `~nosuchuser/` directory is still detected (`True`), and a benign script there still passes (`False`) — this is what makes the fix a fix rather than a crash suppression
- `~/` expansion still resolving and still detecting, so the `os.path` switch cannot silently disable tilde handling
- `RecursionError` propagating instead of being swallowed
- the symlink loop, and `test_classification_of_normal_scripts_is_unchanged` pinning the invariant that widening an `except` clause must not weaken detection

The unknown-user name is discovered at import time via `os.path.expanduser` rather than hardcoded, so the tests stay correct on a machine where any given name happens to exist.

Verified with the canonical runner, from the worktree root:

```
$ ./scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py
# on this branch before the tilde patch:  8 failed, 90 passed   ← RED
# with the patch:                         98 passed, 0 failed   ← GREEN

$ ./scripts/run_tests.sh tests/cron/ tests/tools/test_terminal_tool.py
=== Summary: 37 files, 400 tests passed, 0 failed (100% complete) ===
```

Two of the new tests pass on the unpatched branch by design: the `sh -c` NUL route (a coverage gap, not a bug) and `~/` expansion (a regression guard for the `os.path` switch).

## Scope

Two files across the branch: `cron/lifecycle_guard.py` and `tests/hermes_cli/test_gateway_restart_loop.py`. No new `HERMES_*` env vars, no new core tools, no snapshot/change-detector tests, no prompt-caching surface touched.
