### PR TITLE
fix(tts): piper lazy-install parity + probe install-safety + null-config guards

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1842,17 +1842,17 @@ def _run_post_setup(post_setup_key: str):
         except ImportError:
             _print_info("    Installing piper-tts (~14MB wheel, voices downloaded on first use)...")
             try:
-                result = _pip_install(["-U", "piper-tts", "--quiet"], timeout=300)
+                result = _pip_install(["-U", "piper-tts==1.4.2", "--quiet"], timeout=300)
                 if result.returncode == 0:
                     _print_success("    piper-tts installed")
                 else:
                     _print_warning("    piper-tts install failed:")
                     _print_info(f"      {(result.stderr or '').strip()[:300]}")
-                    _print_info("    Run manually: uv pip install -U piper-tts")
+                    _print_info("    Run manually: uv pip install -U piper-tts==1.4.2")
                     return
             except subprocess.TimeoutExpired:
                 _print_warning("    piper-tts install timed out (>5min)")
-                _print_info("    Run manually: uv pip install -U piper-tts")
+                _print_info("    Run manually: uv pip install -U piper-tts==1.4.2")
                 return
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick
 # ElevenLabs / OpenAI / MiniMax instead).
 edge-tts = ["edge-tts==7.2.7"]
+# Piper TTS — fully-local neural TTS (OHF-Voice/piper1-gpl). Mirrors the
+# `tts.piper` lazy-install entry in tools/lazy_deps.py; keep pins in sync.
+piper = ["piper-tts==1.4.2"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]

--- a/tests/agent/test_compression_worker_isolation_76354.py
+++ b/tests/agent/test_compression_worker_isolation_76354.py
@@ -95,7 +95,12 @@ def test_f3_mutating_engine_cannot_touch_live_transcript_after_timeout(
         engine_started.set()
         msgs[:] = [{"role": "assistant", "content": "ENGINE GARBAGE"}]
         mutated_lists.append(msgs)
-        assert release_engine.wait(timeout=30)
+        # Long wait: the host must be able to time out and run its byte-identity
+        # assertions WHILE this worker stays blocked. Under 8-worker CI load the
+        # main thread can be starved past a 30s budget, which fails the
+        # isolation assertions vacuously. 300s keeps the worker blocked for the
+        # entire test while tolerating scheduler starvation.
+        assert release_engine.wait(timeout=300)
         return msgs
 
     agent.context_compressor.compress.side_effect = _mutating_engine
@@ -108,7 +113,9 @@ def test_f3_mutating_engine_cannot_touch_live_transcript_after_timeout(
             live, "sys", approx_tokens=120_000
         )
         # Host timed out and returned while the engine is STILL blocked.
-        assert engine_started.wait(timeout=5)
+        # Generous wait: under loaded CI the worker thread can be delayed
+        # starting; the host's timeout path does not depend on it.
+        assert engine_started.wait(timeout=60)
         assert not release_engine.is_set()
         assert returned is live
         # ── The core assertion, made while the worker keeps running ──────

--- a/tests/agent/test_compression_worker_isolation_76354.py
+++ b/tests/agent/test_compression_worker_isolation_76354.py
@@ -287,3 +287,65 @@ def test_f5_session_contextvar_rebound_after_rotation(
         )
     finally:
         clear_session_vars(tokens)
+
+
+def test_f3_class_worker_stays_blocked_until_explicit_release(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """CLASS regression: a detached compression worker must remain blocked
+    until the host explicitly releases it — never exit on its own timing.
+
+    The original flake (#76354 F3, observed on CI slice 8/8 under 8-worker
+    load) failed because the worker's release wait was a short wall-clock
+    budget that scheduler starvation could exhaust, letting the worker exit
+    and the isolation assertions run vacuously. The class invariant is:
+    worker blocked -> host times out -> host asserts byte-identity WHILE the
+    worker is provably still alive -> only then release. This test asserts
+    the worker is still alive after the host's full assertion pass and does
+    not exit until release_engine is set, independent of any timer.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "F3_CLASS_BLOCKED"
+    db.create_session(session_id, source="cli")
+    agent = _build_agent_with_db(db, session_id)
+    agent._cached_system_prompt = "sys"
+
+    monkeypatch.setattr(
+        "agent.conversation_compression.resolve_context_compression_timeouts",
+        lambda cfg=None: (0.6, 1.2),
+    )
+
+    engine_started = threading.Event()
+    release_engine = threading.Event()
+    worker_alive = threading.Event()
+
+    def _mutating_engine(msgs, **_kwargs):
+        engine_started.set()
+        msgs[:] = [{"role": "assistant", "content": "ENGINE GARBAGE"}]
+        # Must block on the EVENT, not a timer: premature timer expiry is the
+        # bug class. Event.wait without a timeout blocks indefinitely; the
+        # host is the only releaser.
+        release_engine.wait()
+        worker_alive.set()
+
+    agent.context_compressor.compress.side_effect = _mutating_engine
+
+    live = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    baseline = copy.deepcopy(live)
+
+    try:
+        returned, _sp = agent._compress_context(live, "sys", approx_tokens=120_000)
+        assert engine_started.wait(timeout=60)
+        assert not release_engine.is_set()
+        assert returned is live
+        assert live == baseline, "live transcript mutated by detached worker"
+        # The worker is STILL blocked after the host's full assertion pass.
+        assert not worker_alive.is_set(), (
+            "worker exited before the host released it — timing-budget "
+            "flake class: isolation assertions ran against a dead worker"
+        )
+    finally:
+        release_engine.set()
+    # After release the worker completes; transcript still untouched.
+    assert worker_alive.wait(timeout=60)
+    assert live == baseline

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -67,7 +67,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "anthropic", "bedrock",
         "exa", "firecrawl", "parallel-web",
         "fal",
-        "edge-tts", "tts-premium",
+        "edge-tts", "tts-premium", "piper",
         "voice",  # faster-whisper / sounddevice / numpy
         "modal", "daytona", "vercel",
         "messaging", "slack", "matrix", "dingtalk", "feishu",

--- a/tests/tools/test_piper_lazy_install.py
+++ b/tests/tools/test_piper_lazy_install.py
@@ -1,0 +1,96 @@
+"""Tests for piper TTS lazy-install integration (issue #44001).
+
+Verifies that:
+  1. ``tts.piper`` is registered in ``tools/lazy_deps.py`` LAZY_DEPS.
+  2. ``_import_piper()`` calls ``ensure("tts.piper")`` before importing.
+  3. The ``piper`` entry in ``_check_piper_available`` still works when
+     the package IS importable (regression guard).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Feature registration
+# ---------------------------------------------------------------------------
+
+class TestPiperLazyDepsRegistration:
+    """``tts.piper`` must exist in the LAZY_DEPS map."""
+
+    def test_tts_piper_feature_exists(self):
+        from tools.lazy_deps import LAZY_DEPS
+        assert "tts.piper" in LAZY_DEPS
+
+    def test_tts_piper_installs_piper_tts(self):
+        from tools.lazy_deps import LAZY_DEPS
+        pkgs = LAZY_DEPS["tts.piper"]
+        assert any("piper-tts" in p for p in pkgs), (
+            f"Expected 'piper-tts' in tts.piper packages, got {pkgs}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. _import_piper calls ensure()
+# ---------------------------------------------------------------------------
+
+class TestImportPiperLazyInstall:
+    """``_import_piper()`` must call ``ensure("tts.piper")`` before importing."""
+
+    def test_import_piper_calls_ensure(self):
+        """ensure() is invoked with feature='tts.piper' and prompt=False."""
+        mock_ensure = MagicMock()
+        mock_piper_cls = MagicMock()
+
+        with patch("tools.lazy_deps.ensure", mock_ensure), \
+             patch.dict("sys.modules", {"piper": MagicMock(PiperVoice=mock_piper_cls)}):
+            from tools.tts_tool import _import_piper
+            result = _import_piper()
+
+        mock_ensure.assert_called_once_with("tts.piper", prompt=False)
+        assert result is not None
+
+    def test_import_piper_ensure_failure_raises_import_error(self):
+        """If ensure() raises FeatureUnavailable, _import_piper raises ImportError."""
+        from tools.lazy_deps import FeatureUnavailable
+
+        with patch("tools.lazy_deps.ensure", side_effect=FeatureUnavailable("tts.piper", ("piper-tts",), "blocked")):
+            from tools.tts_tool import _import_piper
+            with pytest.raises(ImportError):
+                _import_piper()
+
+    def test_import_piper_ensure_importerror_falls_through(self):
+        """If lazy_deps itself is missing (ImportError), fall through to raw import."""
+        import sys
+        real_module = sys.modules.get("tools.lazy_deps")
+        try:
+            sys.modules["tools.lazy_deps"] = None  # type: ignore[assignment]
+            from tools.tts_tool import _import_piper
+            with pytest.raises((ImportError, AttributeError)):
+                _import_piper()
+        finally:
+            if real_module is not None:
+                sys.modules["tools.lazy_deps"] = real_module
+            else:
+                sys.modules.pop("tools.lazy_deps", None)
+
+
+# ---------------------------------------------------------------------------
+# 3. _check_piper_available regression guard
+# ---------------------------------------------------------------------------
+
+class TestCheckPiperAvailable:
+    """_check_piper_available must still detect importable piper."""
+
+    def test_returns_false_when_piper_not_installed(self):
+        from tools.tts_tool import _check_piper_available
+        # In the test environment piper-tts is not installed,
+        # so this should return False.
+        assert _check_piper_available() is False
+
+    def test_returns_true_when_piper_mocked(self):
+        mock_spec = MagicMock()
+        with patch("importlib.util.find_spec", return_value=mock_spec):
+            from tools.tts_tool import _check_piper_available
+            assert _check_piper_available() is True

--- a/tests/tools/test_piper_lazy_install.py
+++ b/tests/tools/test_piper_lazy_install.py
@@ -30,6 +30,34 @@ class TestPiperLazyDepsRegistration:
             f"Expected 'piper-tts' in tts.piper packages, got {pkgs}"
         )
 
+    def test_tts_piper_pin_matches_pyproject_extra(self):
+        """The lazy pin must agree with the ``piper`` extra in pyproject.toml.
+
+        LAZY_DEPS documents that specs mirror the corresponding extra;
+        a drift means the version a user gets depends on eager vs lazy
+        install. Parsed (not imported) so the test stays free of
+        packaging-runtime side effects.
+        """
+        import re
+        import tomllib
+        from pathlib import Path
+
+        from tools.lazy_deps import LAZY_DEPS
+
+        lazy_spec = LAZY_DEPS["tts.piper"][0]
+        lazy_pin = re.match(r"^piper-tts==([^;\s]+)", lazy_spec).group(1)
+        pyproject = tomllib.loads(
+            Path("pyproject.toml").read_text(encoding="utf-8")
+        )
+        extra_specs = pyproject["project"]["optional-dependencies"]["piper"]
+        assert extra_specs, "pyproject [piper] extra must exist"
+        extra_pin = re.match(r"^piper-tts==([^;\s]+)", extra_specs[0]).group(1)
+        assert lazy_pin == extra_pin, (
+            f"lazy pin piper-tts=={lazy_pin} != pyproject [piper] pin "
+            f"piper-tts=={extra_pin} — the eager and lazy install paths "
+            "would diverge."
+        )
+
 
 # ---------------------------------------------------------------------------
 # 2. _import_piper calls ensure()
@@ -85,9 +113,10 @@ class TestCheckPiperAvailable:
 
     def test_returns_false_when_piper_not_installed(self):
         from tools.tts_tool import _check_piper_available
-        # In the test environment piper-tts is not installed,
-        # so this should return False.
-        assert _check_piper_available() is False
+        # Environment-independent: mock find_spec so the probe reports
+        # "absent" regardless of whether the runner has piper-tts installed.
+        with patch("importlib.util.find_spec", return_value=None):
+            assert _check_piper_available() is False
 
     def test_returns_true_when_piper_mocked(self):
         mock_spec = MagicMock()

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1188,12 +1188,19 @@ class TestRunCommandSttIdleTimeout:
         from tools.transcription_tools import _run_command_stt
 
         script = tmp_path / "progress_then_exit.py"
+        # First tick is emitted immediately and the rest every 50ms — the
+        # total runtime (~400ms) exceeds the 250ms idle window, so passing
+        # depends on the progress extension. The immediate first tick also
+        # keeps the test honest on Windows, where process spawn alone can
+        # exceed a tiny idle window and previously raised TimeoutExpired
+        # before the first chunk was ever read (with all child output intact).
         script.write_text(
             "\n".join([
                 "import sys, time",
-                "for idx in range(4):",
+                "print('tick 0', file=sys.stderr, flush=True)",
+                "for idx in range(1, 9):",
+                "    time.sleep(0.05)",
                 "    print(f'tick {idx}', file=sys.stderr, flush=True)",
-                "    time.sleep(0.04)",
                 "print('done', flush=True)",
             ]),
             encoding="utf-8",
@@ -1201,11 +1208,11 @@ class TestRunCommandSttIdleTimeout:
 
         result = _run_command_stt(
             self._shell_command(sys.executable, "-u", str(script)),
-            timeout=0.1,
+            timeout=0.25,
         )
 
         assert result.returncode == 0
-        assert "tick 3" in result.stderr
+        assert "tick 8" in result.stderr
         assert "done" in result.stdout
 
     def test_silent_stall_still_times_out(self, tmp_path):

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -273,7 +273,10 @@ class TestCheckVoiceRequirements:
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
         monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
                             lambda: {"available": True, "warnings": []})
-        monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
+        monkeypatch.setattr(
+            "tools.transcription_tools._get_provider",
+            lambda cfg, *, install=True: "openai",
+        )
 
         from tools.voice_mode import check_voice_requirements
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -314,6 +314,72 @@ class TestCheckVoiceRequirements:
         assert result["stt_available"] is True
         assert "STT provider: OK (plugin: my-plugin-stt)" in result["details"]
 
+
+    def test_explicit_local_installable_counts_as_ready(self, monkeypatch):
+        """Regression: classic ``/voice on`` gates activation on this probe.
+
+        An explicit ``local`` provider whose faster-whisper isn't installed
+        yet must NOT trigger a lazy pip install from the probe, but must
+        still count as ready when lazy installs are permitted — the install
+        happens at first real transcription. Without this, ``/voice on``
+        rejected an installable provider before the transcription path could
+        install it (#77040 follow-up).
+        """
+        monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
+        monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
+                            lambda: {"available": True, "warnings": []})
+        # Explicit local, faster-whisper absent -> resolver says "none" and
+        # the probe must be called with install=False (no pip from a probe).
+        seen_install_flags = []
+
+        def _fake_get_provider(cfg, *, install=True):
+            seen_install_flags.append(install)
+            return "none"
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._get_provider", _fake_get_provider,
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"enabled": True, "provider": "local", "local": None},
+        )
+        monkeypatch.setattr(
+            "tools.voice_mode._lazy_installs_allowed", lambda: True,
+        )
+
+        from tools.voice_mode import check_voice_requirements
+
+        result = check_voice_requirements()
+        assert seen_install_flags == [False], (
+            "a requirements probe must never request a lazy install"
+        )
+        assert result["stt_available"] is True
+        assert result["available"] is True
+        assert "installs at first use" in result["details"]
+
+    def test_explicit_local_uninstallable_not_ready(self, monkeypatch):
+        """Lazy installs disabled -> explicit uninstalled local is NOT ready."""
+        monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
+        monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
+                            lambda: {"available": True, "warnings": []})
+        monkeypatch.setattr(
+            "tools.transcription_tools._get_provider",
+            lambda cfg, *, install=True: "none",
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"enabled": True, "provider": "local", "local": None},
+        )
+        monkeypatch.setattr(
+            "tools.voice_mode._lazy_installs_allowed", lambda: False,
+        )
+
+        from tools.voice_mode import check_voice_requirements
+
+        result = check_voice_requirements()
+        assert result["stt_available"] is False
+        assert result["available"] is False
+
 # ============================================================================
 # AudioRecorder
 # ============================================================================

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -191,6 +191,35 @@ def test_stt_ready_is_a_probe_never_an_installer(monkeypatch):
     assert ww._stt_ready() is False
 
 
+def test_stt_ready_does_not_arm_unbacked_local_command(monkeypatch):
+    """Explicit local_command with no command and no whisper is NOT ready.
+
+    The resolver never lazy-installs faster-whisper for local_command
+    (transcription_tools._get_provider returns "none" for a missing
+    explicit command without installing), so treating it as ready would
+    arm the wake word on an unusable STT backend — even when lazy
+    installs are allowed.
+    """
+    monkeypatch.setattr(
+        ww, "_stt_ready", ww.__dict__["_stt_ready"]
+    )  # use the real implementation
+
+    def _fake_get_provider(cfg, *, install=True):
+        # faster-whisper absent, no HERMES_LOCAL_STT_COMMAND, no command
+        # provider configured → resolver says "none" and installs nothing.
+        return "none"
+
+    fake_stt = types.SimpleNamespace(
+        _get_provider=_fake_get_provider,
+        _load_stt_config=lambda: {"enabled": True, "provider": "local_command"},
+        is_stt_enabled=lambda cfg: bool(cfg.get("enabled")),
+    )
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_stt)
+
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+    assert ww._stt_ready() is False
+
+
 def test_requirements_fresh_install_lazy_allowed(monkeypatch):
     """Deps missing + lazy installs allowed → available, so /wake on can
     reach the engine constructor's ``lazy_deps.ensure()`` call.

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -146,6 +146,51 @@ def test_tts_ready_is_a_probe_never_an_installer(monkeypatch):
     assert ww._tts_ready() is True
 
 
+def test_stt_ready_is_a_probe_never_an_installer(monkeypatch):
+    """_stt_ready must NOT trigger lazy pip installs from a status poll.
+
+    Regression: _get_provider resolved an explicit 'local' provider by
+    lazy-installing faster-whisper (lazy_deps.ensure → pip install), which
+    froze the TUI's wake.start handshake — and wake.status — for the length
+    of a pip install. Uninstalled-but-lazy-installable counts as ready
+    WITHOUT calling _try_lazy_install_stt / ensure.
+    """
+    monkeypatch.setattr(
+        ww, "_stt_ready", ww.__dict__["_stt_ready"]
+    )  # use the real implementation
+    install_seen: list = []
+
+    def _fake_get_provider(cfg, *, install=True):
+        install_seen.append(install)
+        # faster-whisper absent, no cloud keys → resolves to nothing
+        return "none"
+
+    fake_stt = types.SimpleNamespace(
+        _get_provider=_fake_get_provider,
+        _load_stt_config=lambda: {"enabled": True, "provider": "local"},
+        is_stt_enabled=lambda cfg: bool(cfg.get("enabled")),
+    )
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_stt)
+
+    # Deps missing + lazy installs allowed → ready (installs at first use),
+    # and the probe must never pass install=True into the resolver.
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+    assert ww._stt_ready() is True
+    assert install_seen == [False]
+
+    # Deps missing + lazy installs disabled → not ready.
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: False)
+    assert ww._stt_ready() is False
+
+    # A cloud provider resolves → ready without needing the lazy install.
+    fake_stt._get_provider = lambda cfg, *, install=True: "groq"
+    assert ww._stt_ready() is True
+
+    # STT disabled → never ready.
+    fake_stt._load_stt_config = lambda: {"enabled": False, "provider": "local"}
+    assert ww._stt_ready() is False
+
+
 def test_requirements_fresh_install_lazy_allowed(monkeypatch):
     """Deps missing + lazy installs allowed → available, so /wake on can
     reach the engine constructor's ``lazy_deps.ensure()`` call.

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -140,6 +140,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tts.mistral": ("mistralai==2.4.8",),
     "tts.edge": ("edge-tts==7.2.7",),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
+    "tts.piper": ("piper-tts==1.4.2",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -965,12 +965,18 @@ def _transcribe_command_stt(
     }
 
 
-def _get_provider(stt_config: dict) -> str:
+def _get_provider(stt_config: dict, *, install: bool = True) -> str:
     """Determine which STT provider to use.
 
     When ``stt.provider`` is explicitly set in config, that choice is
     honoured — no silent cloud fallback.  When no provider is configured,
     auto-detect tries: local > groq (free) > openai (paid).
+
+    ``install`` controls whether resolving an uninstalled ``local`` provider
+    may trigger a lazy faster-whisper install.  Probe callers (wake-word and
+    voice requirements checks) pass ``install=False`` so a slow pip install
+    can never freeze a startup handshake or status poll — the install then
+    happens lazily at first real transcription instead.
     """
     if not is_stt_enabled(stt_config):
         return "none"
@@ -986,8 +992,9 @@ def _get_provider(stt_config: dict) -> str:
                 return "local"
             if _has_local_command():
                 return "local_command"
-            # Try lazy-install before giving up
-            if _try_lazy_install_stt():
+            # Try lazy-install before giving up (probe callers skip this —
+            # an uninstalled local provider is resolved lazily at first use)
+            if install and _try_lazy_install_stt():
                 return "local"
             logger.warning(
                 "STT provider 'local' configured but unavailable "
@@ -1073,7 +1080,8 @@ def _get_provider(stt_config: dict) -> str:
     if _has_local_command():
         return "local_command"
     # Try lazy-install before falling through to cloud providers
-    if _try_lazy_install_stt():
+    # (probe callers skip this — uninstalled local resolves lazily at first use)
+    if install and _try_lazy_install_stt():
         return "local"
     if _HAS_OPENAI and _resolve_provider_key("GROQ_API_KEY", "groq"):
         logger.info("No local STT available, using Groq Whisper API")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2747,7 +2747,9 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
         Path to the saved audio file.
     """
     KittenTTS = _import_kittentts()
-    kt_config = tts_config.get("kittentts", {})
+    # Null-safe subsection read (issue #47318): `tts.kittentts: null` in
+    # config.yaml yields None, not {} — coalesce so .get() doesn't crash.
+    kt_config = tts_config.get("kittentts") or {}
     model_name = kt_config.get("model", DEFAULT_KITTENTTS_MODEL)
     voice = kt_config.get("voice", DEFAULT_KITTENTTS_VOICE)
     speed = kt_config.get("speed", 1.0)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -197,7 +197,18 @@ def _import_piper():
     Open Home Foundation). ``pip install piper-tts`` provides cross-platform
     wheels (Linux / macOS / Windows, x86_64 + ARM64) with embedded espeak-ng.
     Voice models (.onnx + .onnx.json) are downloaded on first use.
+
+    Calls :func:`tools.lazy_deps.ensure` first so ``piper-tts`` gets installed
+    on demand — matching the lazy-install pattern used by Edge TTS, ElevenLabs,
+    and Mistral TTS providers.
     """
+    try:
+        from tools.lazy_deps import FeatureUnavailable, ensure
+        ensure("tts.piper", prompt=False)
+    except ImportError:
+        pass
+    except Exception as e:
+        raise ImportError(str(e))
     from piper import PiperVoice
     return PiperVoice
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -120,6 +120,21 @@ def _default_input_samplerate(sd) -> int:
 from hermes_constants import is_termux as _is_termux_environment
 
 
+def _lazy_installs_allowed() -> bool:
+    """Return whether lazy pip installs are permitted in this environment.
+
+    Mirrors ``wake_word._stt_ready``'s gate: probes must never run pip
+    themselves, but an *installable* provider still counts as ready so
+    activation gates (``/voice on``) don't reject a backend that will be
+    installed at first real use.
+    """
+    try:
+        from tools.lazy_deps import _allow_lazy_installs
+        return _allow_lazy_installs()
+    except Exception:
+        return False
+
+
 def _voice_capture_install_hint() -> str:
     if _is_termux_environment():
         return "pkg install python-numpy portaudio && python -m pip install sounddevice"
@@ -2193,6 +2208,19 @@ def check_voice_requirements() -> Dict[str, Any]:
     # lazy faster-whisper install here would freeze /voice status (and the
     # TUI's voice.toggle status RPC) for the length of a pip install.
     stt_provider = _get_provider(stt_config, install=False)
+    # Explicit ``local`` whose faster-whisper isn't installed yet: the probe
+    # must NOT install, but classic ``/voice on`` gates activation on this
+    # result (cli.py), so a lazy-installable local still counts as ready —
+    # the pip fetch happens at first real transcription, exactly like
+    # ``wake_word._stt_ready``. Without this the gate would reject an
+    # installable provider before the transcription path could install it.
+    lazy_local_pending = (
+        stt_provider == "none"
+        and stt_enabled
+        and "provider" in stt_config
+        and stt_config.get("provider") == "local"
+        and _lazy_installs_allowed()
+    )
     native_stt_available = stt_provider in {
         "local",
         "local_command",
@@ -2212,6 +2240,7 @@ def check_voice_requirements() -> Dict[str, Any]:
             plugin_stt_available = _check_plugin_stt_provider(stt_provider)
     stt_available = stt_enabled and (
         native_stt_available
+        or lazy_local_pending
         or command_stt_config is not None
         or plugin_stt_available
     )
@@ -2252,6 +2281,10 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (xAI Grok STT)")
     elif stt_provider == "elevenlabs":
         details_parts.append("STT provider: OK (ElevenLabs Scribe)")
+    elif lazy_local_pending:
+        details_parts.append(
+            "STT provider: OK (local faster-whisper — installs at first use)"
+        )
     elif command_stt_config is not None:
         details_parts.append(f"STT provider: OK (command: {stt_provider})")
     elif plugin_stt_available:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -2189,7 +2189,10 @@ def check_voice_requirements() -> Dict[str, Any]:
     )
     stt_config = _load_stt_config()
     stt_enabled = is_stt_enabled(stt_config)
-    stt_provider = _get_provider(stt_config)
+    # install=False: this is a status probe, not a transcription path — a
+    # lazy faster-whisper install here would freeze /voice status (and the
+    # TUI's voice.toggle status RPC) for the length of a pip install.
+    stt_provider = _get_provider(stt_config, install=False)
     native_stt_available = stt_provider in {
         "local",
         "local_command",

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -739,12 +739,33 @@ def _stt_ready() -> bool:
     A wake without STT arms the mic but every captured utterance dies at
     transcription — a useless (and confusing) experience. Same standard as
     voice mode's ``check_voice_requirements``: enabled + a real provider.
+
+    PROBE, not an installer: ``_get_provider`` resolves an explicit
+    ``local`` provider by lazy-installing faster-whisper via
+    ``lazy_deps.ensure`` — running that inside the wake.start handshake /
+    wake.status froze the TUI for the length of a pip install. We resolve
+    with ``install=False``; an uninstalled-but-installable local provider
+    still counts as ready ("installs at first transcription"), mirroring
+    ``_tts_ready``.
     """
     try:
+        from tools import lazy_deps
         from tools.transcription_tools import _get_provider, _load_stt_config, is_stt_enabled
 
         stt_config = _load_stt_config()
-        return is_stt_enabled(stt_config) and _get_provider(stt_config) != "none"
+        if not is_stt_enabled(stt_config):
+            return False
+
+        provider = _get_provider(stt_config, install=False)
+        if provider != "none":
+            return True
+
+        # Explicit local / local_command that isn't installed yet: ready iff
+        # a lazy install is permitted — the pip fetch happens at first
+        # transcription, never from a status poll / startup handshake.
+        if "provider" in stt_config and stt_config.get("provider") in ("local", "local_command"):
+            return lazy_deps._allow_lazy_installs()
+        return False
     except Exception:
         return False
 

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -760,10 +760,14 @@ def _stt_ready() -> bool:
         if provider != "none":
             return True
 
-        # Explicit local / local_command that isn't installed yet: ready iff
-        # a lazy install is permitted — the pip fetch happens at first
-        # transcription, never from a status poll / startup handshake.
-        if "provider" in stt_config and stt_config.get("provider") in ("local", "local_command"):
+        # Explicit local that isn't installed yet: ready iff a lazy install
+        # is permitted — the pip fetch happens at first transcription,
+        # never from a status poll / startup handshake. local_command is
+        # deliberately NOT included: the resolver never lazy-installs
+        # faster-whisper for it (transcription_tools._get_provider returns
+        # "none" for a missing explicit command without installing), so
+        # arming the wake word on it would be unbacked.
+        if "provider" in stt_config and stt_config.get("provider") == "local":
             return lazy_deps._allow_lazy_installs()
         return False
     except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T16:38:42.729819205Z"
+exclude-newer = "2026-07-21T05:16:26.2434185Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1720,6 +1720,9 @@ otlp = [
 parallel-web = [
     { name = "parallel-web" },
 ]
+piper = [
+    { name = "piper-tts" },
+]
 slack = [
     { name = "aiohttp" },
     { name = "slack-bolt" },
@@ -1887,6 +1890,7 @@ requires-dist = [
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.3.0" },
+    { name = "piper-tts", marker = "extra == 'piper'", specifier = "==1.4.2" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'", specifier = ">=0.7.0,<1" },
@@ -1936,7 +1940,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "piper", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3061,6 +3065,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3101,6 +3114,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
     { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
+]
+
+[[package]]
+name = "piper-tts"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime" },
+    { name = "pathvalidate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/53/3c636c4250e8cb489c50c6dda9d64400518e8c6600576850104b3232b562/piper_tts-1.4.2.tar.gz", hash = "sha256:dbe7e5391d7657f8a5f2b7ce7cdbafc5bbc559de2af15e5299ce298323eade51", size = 4364835, upload-time = "2026-04-02T21:17:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/27/5e309f1218296118e8e9ac22eeeddb0bb9a17095bd9eedcd26603eea7bf5/piper_tts-1.4.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d996f9139c44a0bedb6a9ed45805c429a827c56ef9213933859349801fa7f4e1", size = 13822408, upload-time = "2026-04-02T21:16:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e1/84fcb36c7ac413bb22eb3bdda5f21861f02d0f436df0a9090949c9fec032/piper_tts-1.4.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:138e6adf26a8e796f53866770ea30b666b65432a5e94857c2d9a8c473a8a1f90", size = 13830417, upload-time = "2026-04-02T21:17:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1c/260c65320df47fee582d78ad52d49d4195c5439a77b62e73306c2de835ea/piper_tts-1.4.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6736329f1ef58c39272215849dffdacae601201480b08a0c892938fa4d7c8c67", size = 13841991, upload-time = "2026-04-02T21:17:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/58/7b7cbd7e570ac6eb8dbfc22de94d1457863b97876c1cb6a926e959423fb2/piper_tts-1.4.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b17184a664bd9431ce95c138f4bfb3025e1280cf26075a703dbfdcab989b8ee3", size = 13841872, upload-time = "2026-04-02T21:17:06.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5a/fda959ca07554a8ec3e380b168e79fff16f3020f4956c356a613616c1994/piper_tts-1.4.2-cp39-abi3-win_amd64.whl", hash = "sha256:9c4a3a11f5889ea9d0df4414dce2bd9bee5ce7d9cf604c8fd5e307441d4c031f", size = 13831944, upload-time = "2026-04-02T21:17:08.755Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #44001 #44010 #47318 #61799 #77040 #77932
## What changed and why

This PR completes the **provider registry & lazy-install consistency** bug class: built-in providers must be lazy-installable on fresh installs, requirements probes must never trigger pip installs, and provider fallback/readiness reporting must be truthful. It salvages and completes two open PRs (authorship preserved, see credits) plus the remaining null-config gap.

### 1. Piper TTS is now lazy-installable (issue #44001)

- `tools/lazy_deps.py`: added the missing `tts.piper` feature entry (was absent — fresh installs with `tts.provider: piper` failed with a manual-install error while edge/elevenlabs/mistral auto-installed).
- `tools/tts_tool.py::_import_piper`: calls `lazy_deps.ensure("tts.piper")` before importing, matching the Edge/ElevenLabs/Mistral pattern.
- **Pin parity** (maintainer-flagged gap in #44010): `piper-tts==1.4.2` is now pinned in all three places — the new `[piper]` extra in `pyproject.toml`, the `tts.piper` lazy entry, and the `hermes tools` post-setup installer (previously unpinned `-U piper-tts`, which could install a newer version and then get **downgraded** by the lazy pin on first use). `uv.lock` regenerated (adds `piper-tts` + `pathvalidate`).
- `tests/test_project_metadata.py`: `[piper]` added to the lazy-covered-extras contract so it can't leak into `[all]`.
- `tests/tools/test_piper_lazy_install.py`: environment-independent (mocks `find_spec` instead of assuming piper is absent) and asserts the lazy pin matches the pyproject extra.

### 2. Requirements probes never lazy-install (follow-up to #77040)

- `tools/transcription_tools.py::_get_provider`: new `install: bool = True` kwarg; probe callers pass `install=False` so a bare status check can never freeze on a pip install.
- `tools/voice_mode.py::check_voice_requirements` and `tools/wake_word.py::_stt_ready` call it with `install=False`.
- **Activation gate preserved** (maintainer-flagged gap in #77040): an explicit uninstalled `local` STT provider now counts as *ready* when lazy installs are permitted — so classic `/voice on` still activates and the install happens at first real transcription, instead of rejecting an installable provider before the transcription path could install it. The probe itself never runs pip (regression test asserts `install=False` is passed).
- **`local_command` exception removed** (maintainer-flagged gap): the wake probe previously treated explicit `local_command` as ready whenever lazy installs were allowed, but the resolver never lazy-installs faster-whisper for `local_command` — arming the wake word on it would be unbacked. The readiness exception is now restricted to `local` only, with a regression test.

### 3. Null-config crash-proofing parity (issue #47318)

- `tools/tts_tool.py::_generate_kittentts`: the `kittentts` subsection read was the last TTS provider section not null-coalesced (`tts.kittentts: null` in config.yaml would yield `None`). Now uses the `(x or {})` pattern already applied everywhere else on main (the core #47318 fix landed earlier via #61799; this closes the remaining site).

## How to test

```bash
# Targeted suites (venv python from the main checkout):
python -m pytest tests/agent/test_tts_registry.py \
  tests/hermes_cli/test_plugins_tts_registration.py \
  tests/tools/test_tts_container_repair.py \
  tests/tools/test_piper_lazy_install.py \
  tests/tools/test_wake_word.py tests/tools/test_voice_mode.py \
  tests/test_packaging_metadata.py tests/test_project_metadata.py \
  -q --no-header -p no:cacheprovider
# → 140 passed (6 deselected = pre-existing Windows env failures, identical on main)
```

Behavioral probes run during development:

- **Piper registry parity**: `tools.lazy_deps.LAZY_DEPS["tts.piper"]` exists; `_import_piper()` calls `ensure("tts.piper", prompt=False)`.
- **Probe has no install side effect**: `_get_provider({"enabled": True, "provider": "local", ...}, install=False)` makes 0 calls to `_try_lazy_install_stt`, while `install=True` makes exactly 1.
- **Unknown provider reports truthfully** (already merged via #77932, verified against this branch): `provider: "edge"` + `fallback_from: "missing-provider"` instead of masquerading as the unknown name.
- **Null config**: config.yaml with `stt.local: null` / `tts.edge: null` / `tts.kittentts: null` loads and both TTS generation and STT provider resolution complete without `'NoneType' object has no attribute 'get'`.

## Platforms tested

- Windows 10 (git-bash), CPython 3.11 — full targeted suites + behavioral probes.
- `git diff origin/main --check` clean; `scripts/check-windows-footguns.py` clean on all touched files (only pre-existing WSL-gated test line flagged, not touched by this PR).

## Why this matters to users

- **Fresh installs** can pick Piper TTS without manual `pip install piper-tts` — it now auto-installs on first use like every other built-in provider, at a version consistent with `hermes tools` (no surprise downgrades).
- **`/voice on`, `wake.status`, and TUI status polls never hang on pip installs** — but an installable local STT provider still activates correctly and installs at first transcription.
- **Null provider sections in config.yaml** (which setup flows can produce) no longer crash STT/TTS.
- **Config still wins**: unknown provider names fall back to Edge but the tool result says so truthfully (`fallback_from`), so agents/users aren't silently misled about which engine produced the audio.

Fixes #44001

## Credits

- Salvaged from #44010 (piper lazy-install registry), authored by @liuhao1024 — commit `fdccbd6431`.
- Salvaged from #77040 (probe install-safety), authored by @Limkyy — commit `f576f7b907`.
- Completion work (pin parity, pyproject `[piper]` extra + lockfile, activation-gate preservation, `local_command` exception removal, null-coalesce for kittentts, tests) by @andrexibiza — commit `e35c25ff69`.
- #47318 was fixed on main earlier via #61799; this PR closes the one remaining unguarded subsection read and adds regression coverage.

Part of #65160
Part of #78207
Part of #79890
