### PR TITLE
feat(desktop): add completion sound volume control and custom audio

### DIFF
--- a/apps/desktop/src/app/settings/notifications-settings.tsx
+++ b/apps/desktop/src/app/settings/notifications-settings.tsx
@@ -1,14 +1,22 @@
 import { useStore } from '@nanostores/react'
 import type { ReactNode } from 'react'
+import { useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Slider } from '@/components/ui/slider'
 import { useI18n } from '@/i18n'
-import { COMPLETION_SOUND_VARIANTS, previewCompletionSound } from '@/lib/completion-sound'
+import {
+  CUSTOM_AUDIO_VARIANT_ID,
+  COMPLETION_SOUND_VARIANTS,
+  getCustomAudioDataUrl,
+  previewCompletionSound,
+  setCustomAudioDataUrl
+} from '@/lib/completion-sound'
 import { triggerHaptic } from '@/lib/haptics'
 import { Bell, Play } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $completionSoundVariantId, setCompletionSoundVariantId } from '@/store/completion-sound'
+import { $completionSoundVariantId, $completionSoundVolume, setCompletionSoundVariantId, setCompletionSoundVolume } from '@/store/completion-sound'
 import {
   $nativeNotifyPrefs,
   NATIVE_NOTIFICATION_KINDS,
@@ -27,16 +35,75 @@ function Caption({ children, className }: { children: ReactNode; className?: str
   return <p className={cn(CAPTION, className)}>{children}</p>
 }
 
+function fileNameFromDataUrl(dataUrl: string): string {
+  try {
+    const parsed = new URL(dataUrl)
+    const name = parsed.searchParams.get('name')
+
+    return name || 'custom-audio'
+  } catch {
+    return 'custom-audio'
+  }
+}
+
 export function NotificationsSettings() {
   const { t } = useI18n()
   const prefs = useStore($nativeNotifyPrefs)
   const completionSoundVariantId = useStore($completionSoundVariantId)
+  const completionSoundVolume = useStore($completionSoundVolume)
   const copy = t.settings.notifications
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [customAudioName, setCustomAudioName] = useState<string | null>(() => {
+    const dataUrl = getCustomAudioDataUrl()
+
+    return dataUrl ? fileNameFromDataUrl(dataUrl) : null
+  })
+  // Draft volume (percent) tracked locally so the thumb follows the pointer
+  // while dragging. The store is only written on commit to avoid replaying the
+  // sound on every pixel of movement.
+  const [draftVolumePercent, setDraftVolumePercent] = useState(() => Math.round(completionSoundVolume * 100))
+
+  const isCustomSelected = completionSoundVariantId === CUSTOM_AUDIO_VARIANT_ID
 
   const runTest = async () => {
     triggerHaptic('open')
     const ok = await sendTestNativeNotification(copy.testTitle, copy.testBody)
     notify({ kind: ok ? 'info' : 'error', message: ok ? copy.testSent : copy.testUnsupported })
+  }
+
+  const handleCustomFile = async (file: File) => {
+    // localStorage holds the file as a base64 data URL; cap the payload so a
+    // giant file can't silently fail the quota. ~2MB of audio → ~2.7MB base64.
+    if (file.size > 2 * 1024 * 1024) {
+      notify({ kind: 'error', message: copy.completionSoundCustomTooLarge })
+
+      return
+    }
+
+    try {
+      const dataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+
+        reader.onload = () => resolve(String(reader.result))
+        reader.onerror = () => reject(reader.error)
+        reader.readAsDataURL(file)
+      })
+
+      setCustomAudioDataUrl(dataUrl)
+      setCustomAudioName(file.name)
+
+      // Preview the freshly loaded file immediately so the user hears it.
+      previewCompletionSound(CUSTOM_AUDIO_VARIANT_ID)
+      notify({ kind: 'info', message: copy.completionSoundCustomLoaded(file.name) })
+    } catch {
+      notify({ kind: 'error', message: copy.testUnsupported })
+    }
+  }
+
+  const removeCustomAudio = () => {
+    setCustomAudioDataUrl(null)
+    setCustomAudioName(null)
+    triggerHaptic('selection')
   }
 
   return (
@@ -85,6 +152,7 @@ export function NotificationsSettings() {
                     {variant.name}
                   </SelectItem>
                 ))}
+                <SelectItem value={String(CUSTOM_AUDIO_VARIANT_ID)}>{copy.completionSoundCustom}</SelectItem>
               </SelectContent>
             </Select>
 
@@ -106,6 +174,83 @@ export function NotificationsSettings() {
         description={copy.completionSoundDesc}
         title={copy.completionSoundTitle}
       />
+
+      <ListRow
+        action={
+          <div className="flex w-full min-w-56 items-center gap-3 @2xl:w-72">
+            <Slider
+              aria-label={copy.completionSoundVolumeLabel}
+              max={400}
+              min={0}
+              onValueChange={([value]) => setDraftVolumePercent(value)}
+              onValueCommit={([value]) => {
+                setCompletionSoundVolume(value / 100)
+                setDraftVolumePercent(value)
+                previewCompletionSound()
+                triggerHaptic('selection')
+              }}
+              step={5}
+              value={[draftVolumePercent]}
+            />
+            <span className="w-10 shrink-0 text-right tabular-nums text-[length:var(--conversation-caption-font-size)] text-(--ui-text-secondary)">
+              {draftVolumePercent}%
+            </span>
+          </div>
+        }
+        description={copy.completionSoundVolumeDesc(draftVolumePercent)}
+        title={copy.completionSoundVolumeLabel}
+      />
+
+      {isCustomSelected && (
+        <ListRow
+          action={
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <input
+                accept="audio/*,.mp3,.wav,.ogg,.m4a,.flac"
+                className="hidden"
+                onChange={event => {
+                  const file = event.target.files?.[0]
+
+                  if (file) {
+                    void handleCustomFile(file)
+                  }
+
+                  event.target.value = ''
+                }}
+                ref={fileInputRef}
+                type="file"
+              />
+              <Button
+                onClick={() => fileInputRef.current?.click()}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                {copy.completionSoundCustomChoose}
+              </Button>
+              {customAudioName && (
+                <Button
+                  onClick={removeCustomAudio}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  {copy.completionSoundCustomRemove}
+                </Button>
+              )}
+            </div>
+          }
+          below={
+            customAudioName ? (
+              <div className="mt-1 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                {copy.completionSoundCustomLoaded(customAudioName)}
+              </div>
+            ) : null
+          }
+          description={copy.completionSoundCustomDesc}
+          title={copy.completionSoundCustom}
+        />
+      )}
 
       <div className="mt-4 flex flex-col gap-2">
         <Button className="self-start" onClick={() => void runTest()} size="sm" type="button" variant="outline">

--- a/apps/desktop/src/components/ui/slider.tsx
+++ b/apps/desktop/src/components/ui/slider.tsx
@@ -1,0 +1,27 @@
+import { Slider as SliderPrimitive } from 'radix-ui'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Slider({
+  className,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  return (
+    <SliderPrimitive.Root
+      className={cn(
+        'relative flex w-full touch-none select-none items-center data-[orientation=vertical]:h-full data-[orientation=vertical]:w-3 data-[orientation=vertical]:flex-col',
+        className
+      )}
+      data-slot="slider"
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-[color-mix(in_srgb,var(--dt-foreground)_14%,transparent)] data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5">
+        <SliderPrimitive.Range className="absolute h-full bg-primary data-[orientation=vertical]:w-full" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block size-4 rounded-full border border-[color-mix(in_srgb,var(--dt-foreground)_20%,transparent)] bg-foreground shadow-[0_0.0625rem_0.1875rem_color-mix(in_srgb,var(--dt-background)_50%,transparent)] transition-colors focus-visible:outline-none focus-visible:ring-[0.1875rem] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -404,7 +404,15 @@ export const en: Translations = {
       testUnsupported: 'This system does not support native notifications.',
       completionSoundTitle: 'Completion Sound',
       completionSoundDesc: 'Plays when an agent turn finishes. Pick a preset and preview it here.',
-      completionSoundPreview: 'Preview'
+      completionSoundPreview: 'Preview',
+      completionSoundVolumeLabel: 'Volume',
+      completionSoundVolumeDesc: percent => `Loudness: ${percent}% of the designed level`,
+      completionSoundCustom: 'Custom audio',
+      completionSoundCustomDesc: 'Use your own sound file (mp3, wav, ogg, m4a). It is stored locally in this app.',
+      completionSoundCustomChoose: 'Choose audio file…',
+      completionSoundCustomRemove: 'Remove custom audio',
+      completionSoundCustomLoaded: name => `Loaded: ${name}`,
+      completionSoundCustomTooLarge: 'Audio file too large (max 2 MB).'
     },
     sections: {
       model: 'Model',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -335,6 +335,14 @@ export interface Translations {
       completionSoundTitle: string
       completionSoundDesc: string
       completionSoundPreview: string
+      completionSoundVolumeLabel: string
+      completionSoundVolumeDesc: (percent: number) => string
+      completionSoundCustom: string
+      completionSoundCustomDesc: string
+      completionSoundCustomChoose: string
+      completionSoundCustomRemove: string
+      completionSoundCustomLoaded: (name: string) => string
+      completionSoundCustomTooLarge: string
     }
     sections: Record<string, string>
     searchPlaceholder: Record<'about' | 'config' | 'gateway' | 'keys' | 'mcp' | 'sessions', string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -272,7 +272,15 @@ export const zhHant = defineLocale({
       testUnsupported: '此系統不支援原生通知。',
       completionSoundTitle: '完成提示音',
       completionSoundDesc: '代理回合結束時播放。可在此選擇預設並預覽。',
-      completionSoundPreview: '預覽'
+      completionSoundPreview: '預覽',
+      completionSoundVolumeLabel: '音量',
+      completionSoundVolumeDesc: percent => `響度：設計音量的 ${percent}%`,
+      completionSoundCustom: '自訂音訊',
+      completionSoundCustomDesc: '使用你自己的提示音檔案（mp3、wav、ogg、m4a）。檔案僅保存在本機。',
+      completionSoundCustomChoose: '選擇音訊檔案…',
+      completionSoundCustomRemove: '移除自訂音訊',
+      completionSoundCustomLoaded: name => `已載入：${name}`,
+      completionSoundCustomTooLarge: '音訊檔案過大（上限 2 MB）。'
     },
     sections: {
       model: '模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -396,7 +396,15 @@ export const zh: Translations = {
       testUnsupported: '此系统不支持原生通知。',
       completionSoundTitle: '完成提示音',
       completionSoundDesc: '智能体回合结束时播放。可在此选择预设并预览。',
-      completionSoundPreview: '预览'
+      completionSoundPreview: '预览',
+      completionSoundVolumeLabel: '音量',
+      completionSoundVolumeDesc: percent => `响度：设计音量的 ${percent}%`,
+      completionSoundCustom: '自定义音频',
+      completionSoundCustomDesc: '使用你自己的提示音文件（mp3、wav、ogg、m4a）。文件仅保存在本机。',
+      completionSoundCustomChoose: '选择音频文件…',
+      completionSoundCustomRemove: '移除自定义音频',
+      completionSoundCustomLoaded: name => `已加载：${name}`,
+      completionSoundCustomTooLarge: '音频文件过大（上限 2 MB）。'
     },
     sections: {
       model: '模型',

--- a/apps/desktop/src/lib/completion-sound.ts
+++ b/apps/desktop/src/lib/completion-sound.ts
@@ -2,8 +2,9 @@
 // Fourteen curated presets for A/B in Settings → Appearance. Default is variant 1.
 
 import { ownsAmbientCue } from '@/store/ambient'
-import { $completionSoundVariantId, resolveCompletionSoundVariantId } from '@/store/completion-sound'
+import { $completionSoundVariantId, $completionSoundVolume, resolveCompletionSoundVariantId } from '@/store/completion-sound'
 import { $hapticsMuted } from '@/store/haptics'
+import { readKey, writeKey } from '@/lib/storage'
 
 type OscType = OscillatorType
 
@@ -410,12 +411,88 @@ export const COMPLETION_SOUND_VARIANTS: readonly CompletionSoundVariant[] = [
   }
 ] as const
 
-function playVariant(variantId: number) {
-  const variant = COMPLETION_SOUND_VARIANTS.find(v => v.id === variantId)
+// Custom audio support: user-supplied audio file (id 15). The audio bytes are
+// stored as a base64 data URL in localStorage by the settings panel; we decode
+// them on demand and play the buffer through the master bus.
+const CUSTOM_AUDIO_STORAGE_KEY = 'hermes.desktop.completionSoundCustomAudio'
 
-  if (!variant) {
+let customAudioBuffer: AudioBuffer | null = null
+let customAudioSource: AudioBufferSourceNode | null = null
+
+export function getCustomAudioDataUrl(): string | null {
+  const raw = readKey(CUSTOM_AUDIO_STORAGE_KEY)
+
+  if (!raw) {
+    return null
+  }
+
+  // Guard against localStorage clutter: only accept data: URLs of audio type.
+  return /^data:audio\/[a-zA-Z0-9.+-]+;base64,/.test(raw) ? raw : null
+}
+
+export function setCustomAudioDataUrl(dataUrl: string | null) {
+  customAudioBuffer = null
+  customAudioSource = null
+
+  if (dataUrl === null) {
+    writeKey(CUSTOM_AUDIO_STORAGE_KEY, null)
+  } else {
+    writeKey(CUSTOM_AUDIO_STORAGE_KEY, dataUrl)
+  }
+}
+
+// Virtual variant id reserved for the user-supplied audio file. It is not part
+// of COMPLETION_SOUND_VARIANTS (which only holds the synthesized presets) —
+// the settings UI appends it as an extra "Custom audio" entry.
+export const CUSTOM_AUDIO_VARIANT_ID = 15
+
+async function decodeCustomAudio(ac: AudioContext, dataUrl: string): Promise<AudioBuffer | null> {
+  try {
+    const response = await fetch(dataUrl)
+    const arrayBuffer = await response.arrayBuffer()
+    const decoded = await ac.decodeAudioData(arrayBuffer)
+
+    return decoded
+  } catch {
+    return null
+  }
+}
+
+// Plays the user-supplied audio file. Falls back silently when nothing is set
+// or the file can't be decoded. A short fade avoids clicks at the edges.
+async function playCustomAudio(ac: AudioContext, master: GainNode, t0: number) {
+  const dataUrl = getCustomAudioDataUrl()
+
+  if (!dataUrl) {
     return
   }
+
+  if (!customAudioBuffer) {
+    customAudioBuffer = await decodeCustomAudio(ac, dataUrl)
+
+    if (!customAudioBuffer) {
+      return
+    }
+  }
+
+  const source = ac.createBufferSource()
+  source.buffer = customAudioBuffer
+
+  const env = ac.createGain()
+  const fade = Math.min(0.03, customAudioBuffer.duration / 2)
+  env.gain.setValueAtTime(0.0001, t0)
+  env.gain.exponentialRampToValueAtTime(1, t0 + fade)
+  env.gain.setValueAtTime(1, t0 + Math.max(0, customAudioBuffer.duration - fade))
+  env.gain.exponentialRampToValueAtTime(0.0001, t0 + customAudioBuffer.duration)
+
+  source.connect(env)
+  env.connect(master)
+  source.start(t0)
+  customAudioSource = source
+}
+
+function playVariant(variantId: number) {
+  const variant = COMPLETION_SOUND_VARIANTS.find(v => v.id === variantId)
 
   const ac = getCtx()
 
@@ -429,7 +506,11 @@ function playVariant(variantId: number) {
   tone.type = 'lowpass'
   tone.frequency.setValueAtTime(3800, ac.currentTime)
   tone.Q.setValueAtTime(0.32, ac.currentTime)
-  master.gain.setValueAtTime(0.48, ac.currentTime)
+
+  // User volume multiplier (0–4, default 2) scales the designed level so the
+  // cues are clearly audible. Applied to the master bus, not per-voice.
+  const volume = $completionSoundVolume.get()
+  master.gain.setValueAtTime(0.48 * volume, ac.currentTime)
   master.connect(tone)
 
   const dry = ac.createGain()
@@ -443,6 +524,16 @@ function playVariant(variantId: number) {
   tone.connect(reverb)
   reverb.connect(wet)
   wet.connect(ac.destination)
+
+  if (variantId === CUSTOM_AUDIO_VARIANT_ID) {
+    void playCustomAudio(ac, master, ac.currentTime + 0.01)
+
+    return
+  }
+
+  if (!variant) {
+    return
+  }
 
   variant.play(ac, master, ac.currentTime + 0.01)
 }

--- a/apps/desktop/src/store/completion-sound.ts
+++ b/apps/desktop/src/store/completion-sound.ts
@@ -3,18 +3,33 @@ import { atom } from 'nanostores'
 import { persistString, storedString } from '@/lib/storage'
 
 const STORAGE_KEY = 'hermes.desktop.completionSoundVariantId'
+const VOLUME_STORAGE_KEY = 'hermes.desktop.completionSoundVolume'
 
 export const DEFAULT_COMPLETION_SOUND_VARIANT_ID = 1
+
+// Default loudness as a linear multiplier applied on top of the baked-in
+// synthesis gains. 1 = the level the sounds were originally designed at
+// (master 0.48 → dry 0.88 ≈ audible but quiet). 0.5 halves it, 2 doubles it.
+export const DEFAULT_COMPLETION_SOUND_VOLUME = 2
 
 // Range mirrors COMPLETION_SOUND_VARIANTS in lib/completion-sound.ts. Validating
 // by range (not membership) keeps this store free of a dependency on the lib,
 // which imports the atom back — a membership check would close that cycle.
-const VARIANT_COUNT = 14
+const VARIANT_COUNT = 15
 
 export function resolveCompletionSoundVariantId(variantId: number): number {
   return Number.isInteger(variantId) && variantId >= 1 && variantId <= VARIANT_COUNT
     ? variantId
     : DEFAULT_COMPLETION_SOUND_VARIANT_ID
+}
+
+export function resolveCompletionSoundVolume(value: number): number {
+  // Clamp to a sane audible range: 0 (mute) … 4× the designed level.
+  if (!Number.isFinite(value)) {
+    return DEFAULT_COMPLETION_SOUND_VOLUME
+  }
+
+  return Math.min(4, Math.max(0, value))
 }
 
 function load(): number {
@@ -23,10 +38,24 @@ function load(): number {
   return stored ? resolveCompletionSoundVariantId(Number.parseInt(stored, 10)) : DEFAULT_COMPLETION_SOUND_VARIANT_ID
 }
 
+function loadVolume(): number {
+  const stored = storedString(VOLUME_STORAGE_KEY)
+
+  return stored ? resolveCompletionSoundVolume(Number.parseFloat(stored)) : DEFAULT_COMPLETION_SOUND_VOLUME
+}
+
 export const $completionSoundVariantId = atom(load())
 
 $completionSoundVariantId.subscribe(id => persistString(STORAGE_KEY, String(id)))
 
 export function setCompletionSoundVariantId(variantId: number) {
   $completionSoundVariantId.set(resolveCompletionSoundVariantId(variantId))
+}
+
+export const $completionSoundVolume = atom(loadVolume())
+
+$completionSoundVolume.subscribe(volume => persistString(VOLUME_STORAGE_KEY, String(volume)))
+
+export function setCompletionSoundVolume(volume: number) {
+  $completionSoundVolume.set(resolveCompletionSoundVolume(volume))
 }


### PR DESCRIPTION
The completion sound was synthesized at a very conservative level (master gain 0.48 x dry 0.88) with no way for users to adjust it. This adds:

- Volume control: a user-scalable multiplier (0-4x, default 2x) applied to the master bus, persisted as hermes.desktop.completionSoundVolume, and a slider in Settings -> Notifications with live preview on release.
- Custom audio: a 15th 'Custom audio' variant that plays a user-supplied audio file (mp3/wav/ogg/m4a/flac) stored as a base64 data URL in localStorage. Files are capped at 2MB, fade in/out to avoid clicks, and can be removed from the settings panel.
- i18n: added volume/custom-audio copy to en, zh, zh-hant (types updated).

The volume multiplier defaults to 2x so the cues are clearly audible out of the box while staying below clipping.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

