### PR TITLE
fix(acp): honor HERMES_ACP_SKIP_CONFIGURED_MCP at the session-build site

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -674,15 +674,22 @@ class SessionManager:
         # ``mcp_discovery_timeout`` (config.yaml, default ~1.5s) so a dead
         # server can't block — servers that miss the bound are picked up by
         # the automatic late-refresh (see HermesACPAgent._schedule_mcp_late_refresh).
-        try:
-            from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
+        # Honor the host's opt-out here too.  ``entry.py`` gates the
+        # spawn-time discovery on HERMES_ACP_SKIP_CONFIGURED_MCP, but this
+        # site would (re)start the very work the host asked us to skip --
+        # just later, and inside session construction instead of at process
+        # start.  A metadata-only host that sets the flag and supplies its
+        # servers through session/new got configured-MCP startup anyway.
+        if os.environ.get("HERMES_ACP_SKIP_CONFIGURED_MCP", "").strip() != "1":
+            try:
+                from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
 
-            ensure_mcp_discovery_before_agent_build(
-                logger=logger,
-                thread_name="acp-mcp-discovery",
-            )
-        except Exception:
-            logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
+                ensure_mcp_discovery_before_agent_build(
+                    logger=logger,
+                    thread_name="acp-mcp-discovery",
+                )
+            except Exception:
+                logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
         agent = AIAgent(**kwargs)
         # Codex app-server sessions are spawned lazily on the first turn. Stamp

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -662,15 +662,22 @@ class SessionManager:
         # ``mcp_discovery_timeout`` (config.yaml, default ~1.5s) so a dead
         # server can't block — servers that miss the bound are picked up by
         # the automatic late-refresh (see HermesACPAgent._schedule_mcp_late_refresh).
-        try:
-            from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
+        # Honor the host's opt-out here too.  ``entry.py`` gates the
+        # spawn-time discovery on HERMES_ACP_SKIP_CONFIGURED_MCP, but this
+        # site would (re)start the very work the host asked us to skip --
+        # just later, and inside session construction instead of at process
+        # start.  A metadata-only host that sets the flag and supplies its
+        # servers through session/new got configured-MCP startup anyway.
+        if os.environ.get("HERMES_ACP_SKIP_CONFIGURED_MCP", "").strip() != "1":
+            try:
+                from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
 
-            ensure_mcp_discovery_before_agent_build(
-                logger=logger,
-                thread_name="acp-mcp-discovery",
-            )
-        except Exception:
-            logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
+                ensure_mcp_discovery_before_agent_build(
+                    logger=logger,
+                    thread_name="acp-mcp-discovery",
+                )
+            except Exception:
+                logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
         agent = AIAgent(**kwargs)
         # Codex app-server sessions are spawned lazily on the first turn. Stamp

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,6 +1,7 @@
 """Tests for acp_adapter.entry startup wiring."""
 
 import sys
+from unittest.mock import MagicMock, patch
 
 import acp
 import pytest
@@ -88,3 +89,39 @@ def test_main_setup_browser_propagates_browser_failure(monkeypatch):
     with pytest.raises(SystemExit) as excinfo:
         entry.main(["--setup-browser"])
     assert excinfo.value.code == 1
+
+
+def test_skip_configured_mcp_is_honored_at_the_session_build_site(monkeypatch):
+    """The flag must gate BOTH discovery sites, not just the spawn-time one.
+
+    ``entry.py`` checks it before the JSON-RPC loop, but ``_make_agent`` used
+    to call ``ensure_mcp_discovery_before_agent_build`` unconditionally — and
+    that helper *starts* discovery, not just joins it. A metadata-only host
+    that set the flag and supplied its servers through ``session/new`` got the
+    configured-MCP startup anyway, inside session construction (block/buzz#4098,
+    the recurrence of block/buzz#3355 one protocol step on).
+    """
+    import acp_adapter.session as session_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **kwargs: calls.append("started"),
+    )
+    manager = session_mod.SessionManager(agent_factory=None)
+    monkeypatch.setattr(
+        session_mod.SessionManager,
+        "_build_agent_kwargs",
+        lambda self, **kwargs: {},
+        raising=False,
+    )
+
+    monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")
+    with patch("run_agent.AIAgent", MagicMock()):
+        manager._make_agent(session_id="s1", cwd=".")
+    assert calls == [], "flag set — discovery must not be (re)started here"
+
+    monkeypatch.delenv("HERMES_ACP_SKIP_CONFIGURED_MCP", raising=False)
+    with patch("run_agent.AIAgent", MagicMock()):
+        manager._make_agent(session_id="s2", cwd=".")
+    assert calls == ["started"], "flag unset — normal behavior must be unchanged"


### PR DESCRIPTION
`HERMES_ACP_SKIP_CONFIGURED_MCP` is documented as the opt-out for ACP hosts that supply their MCP servers through `session/new` and don't want Hermes starting every profile-configured server on their behalf. It's checked in exactly one place — `acp_adapter/entry.py:258`, gating the spawn-time discovery thread.

But `SessionManager._make_agent` then calls `ensure_mcp_discovery_before_agent_build()` unconditionally (`acp_adapter/session.py:665-671`), and that helper **starts** discovery rather than only joining an existing run:

```python
# hermes_cli/mcp_startup.py:251-255
start_background_mcp_discovery(logger=logger, thread_name=thread_name)
wait_for_mcp_discovery(timeout=timeout, single_query=single_query)
```

Its own docstring calls that site "self-sufficient" — which is correct for the case it was written for, and defeats the flag for the case it wasn't.

**The effect:** a host that sets the flag still gets configured-MCP startup. It's just moved out of process launch and into session construction, where it runs inside the client's `session/new` budget instead of its connect budget.

This is the same class as [block/buzz#3355](https://github.com/block/buzz/issues/3355), one protocol step later. Buzz sets the flag (`crates/buzz-acp/src/config.rs`, whose comment cites #3355 by number), passes `mcpServers: []`, and still observes its managed Hermes child doing MCP work before answering — now during `session/new` rather than `initialize`.

**The change** guards the second site with the same check `entry.py` uses. Hosts that pass servers via `session/new` are unaffected: those are registered separately in `_register_session_mcp_servers`, and the automatic late-refresh still covers stragglers.

**Test** asserts discovery is not restarted when the host opted out, and still runs when it did not.

126 tests pass in `tests/acp/`. (One pre-existing failure in `test_ping_suppression.py` reproduces on untouched `main` on Windows — unrelated to this change.)

---

Filing a separate issue with the analysis of the larger problem this sits next to: `session/new` runs agent construction on the event loop, which is why a slow boot presents to hosts as a completely unresponsive connection rather than a slow one. That one needs a design decision, not a patch, so it isn't in this PR.

Signed-off-by: SmokeDev