### PR TITLE
fix: bump vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7417,9 +7417,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13746,9 +13746,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16621,9 +16621,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17774,7 +17774,7 @@
         "ink-text-input": "6.0.0",
         "nanostores": "1.4.0",
         "react": "19.2.7",
-        "undici": "6.27.0",
+        "undici": "6.28.0",
         "unicode-animations": "1.0.3"
       },
       "devDependencies": {
@@ -17800,9 +17800,9 @@
       }
     },
     "ui-tui/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "4.18.1",
     "yauzl": "^3.3.1",
     "protobufjs": "^8.7.1",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   },
   "engines": {
     "node": ">=22.22.0",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -25,7 +25,7 @@
     "ink-text-input": "6.0.0",
     "nanostores": "1.4.0",
     "react": "19.2.7",
-    "undici": "6.27.0",
+    "undici": "6.28.0",
     "unicode-animations": "1.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- bump the root `brace-expansion` override from 5.0.8 to 5.0.9
- bump the TUI `undici` dependency from 6.27.0 to 6.28.0
- refresh compatible transitive `undici` resolutions to 6.28.0 and 7.29.0
- keep the lockfile diff limited to the affected dependency entries

These patch releases clear the npm security advisories reported by `hermes doctor` across the root/browser, web, and TUI audit scopes.

## Verification

- [x] `npm ci --ignore-scripts`
- [x] `npm run audit:root` — 0 vulnerabilities
- [x] `npm run audit:web` — 0 vulnerabilities
- [x] `npm run audit:tui` — 0 vulnerabilities
- [x] `npm run build --workspace web`
- [x] `npm run check --workspace ui-tui` — 1,527 tests passed, 4 skipped; existing lint warning only
- [x] `./node_modules/.bin/agent-browser --version`
- [x] `git diff --check`
- [x] `hermes doctor` — all checks passed
