### PR TITLE
fix(approval): stop git global options (-C/--git-dir/-c) bypassing the dangerous-command gate

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -880,6 +880,118 @@ class TestGitDestructiveOps:
             assert dangerous is False, cmd
 
 
+class TestGitGlobalOptionsDoNotBypassApproval:
+    """Git global options sit BETWEEN `git` and its subcommand.
+
+    `git -C /repo branch -D main`, `git --git-dir=/x clean -fdx` and
+    `git -c core.pager=cat reset --hard` are the exact same destructive
+    operations as their bare spellings -- `-C` in particular is what an
+    agent naturally emits when operating on a checkout other than its cwd.
+
+    Contract asserted here is a RELATION, not a snapshot: for each
+    destructive operation, the option-prefixed spelling must classify the
+    same as the bare spelling. The bare spelling is looked up at runtime, so
+    these stay meaningful if the underlying patterns or their descriptions
+    are ever rewritten.
+    """
+
+    # Bare spellings whose classification is the reference for the
+    # option-prefixed variants below.
+    DESTRUCTIVE_TAILS = (
+        "branch -D main",
+        "branch -d --force main",
+        "branch --delete --force main",
+        "branch --force --delete main",
+        "reset --hard HEAD~3",
+        "push --force origin main",
+        "push -f origin main",
+        "clean -fdx",
+    )
+
+    # Global-option runs accepted by git's usage line, including the
+    # separated-value spelling (`--git-dir /x`) and a bare VAR=VAL
+    # environment prefix -- both verified to really delete a branch.
+    GLOBAL_OPTION_PREFIXES = (
+        "-C /repo ",
+        "-c core.pager=cat ",
+        "--git-dir=/x --work-tree=/y ",
+        "--git-dir /x --work-tree /y ",
+        "--no-pager ",
+        "--exec-path=/usr/lib/git-core ",
+        "-c a=b -C /repo ",
+    )
+
+    def test_global_options_classify_like_bare_spelling(self):
+        for tail in self.DESTRUCTIVE_TAILS:
+            bare = f"git {tail}"
+            bare_dangerous, _, bare_desc = detect_dangerous_command(bare)
+            # Sanity: the bare spelling is the thing we mirror. If this ever
+            # goes False the reference itself regressed.
+            assert bare_dangerous is True, bare
+            for prefix in self.GLOBAL_OPTION_PREFIXES:
+                cmd = f"git {prefix}{tail}"
+                dangerous, _, desc = detect_dangerous_command(cmd)
+                assert dangerous is True, cmd
+                assert desc == bare_desc, cmd
+
+    def test_env_assignment_prefix_classifies_like_bare_spelling(self):
+        for tail in self.DESTRUCTIVE_TAILS:
+            bare_dangerous, _, bare_desc = detect_dangerous_command(f"git {tail}")
+            assert bare_dangerous is True, tail
+            for cmd in (
+                f"GIT_DIR=/x git -C /repo {tail}",
+                f"GIT_DIR=/x GIT_WORK_TREE=/y git {tail}",
+            ):
+                dangerous, _, desc = detect_dangerous_command(cmd)
+                assert dangerous is True, cmd
+                assert desc == bare_desc, cmd
+
+    def test_global_options_at_chained_command_positions(self):
+        """A real command position is still a command position with options."""
+        for cmd in (
+            "cd /tmp && git -C /repo branch -D main",
+            "cd /tmp; git -C /repo reset --hard",
+            "sudo git -C /repo clean -fdx",
+            "(git -C /repo push -f origin main)",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+
+    def test_read_only_git_ops_with_global_options_not_flagged(self):
+        """Widening the anchor must not gate ordinary read-only work."""
+        for cmd in (
+            "git -C /repo status",
+            "git -C /repo log --oneline",
+            "git -C /repo branch -a",
+            "git -C /repo branch --list",
+            "git -C /repo push origin main",
+            "git -C /repo clean -n",
+            "git -C /repo reset --soft HEAD~1",
+            "git -C /repo reset --help",
+            "git -c user.name=x commit -m 'hello'",
+            "git --no-pager diff",
+            "git --git-dir=/x status",
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
+    def test_quoted_mention_of_option_spelling_is_data_not_command(self):
+        """The load-bearing guard: a wider anchor must not gate quoted DATA.
+
+        DANGEROUS_PATTERNS deliberately anchors to command positions so a
+        destructive spelling quoted inside another command's argument still
+        runs. Widening the git anchor makes this easier to get wrong.
+        """
+        for cmd in (
+            'git commit -m "explain why git -C x branch -D is dangerous"',
+            'git commit -m "port the git -C /repo reset --hard guard"',
+            'gh pr create --body "git --git-dir=/x clean -fdx bypasses the gate"',
+            'git log --grep="git --git-dir /x branch -D"',
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
+
 class TestChmodExecuteCombo:
     """chmod +x && ./ is the two-step social engineering pattern where a
     script is first made executable then immediately run. The script

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -689,6 +689,88 @@ def _sudo_stdin_block_result(description: str) -> dict:
 # Dangerous command patterns
 # =========================================================================
 
+# Git accepts GLOBAL options BETWEEN the program name and the subcommand:
+# `git -C /repo branch -D main`, `git --git-dir=/x --work-tree=/y clean -fdx`,
+# `git -c core.pager=cat reset --hard`, `git --no-pager push -f`. Every git
+# rule below is anchored to `git` immediately followed by its subcommand, so
+# ANY such option slips the whole gate — and `-C` is precisely the spelling an
+# agent emits when it operates on a checkout other than its cwd.
+#
+# Fix shape: keep each bare-spelling rule verbatim (unchanged match behavior,
+# unchanged approval keys) and generate a second, option-tolerant spelling for
+# every one of them, so the hole closes for the whole class rather than for
+# the one subcommand that surfaced it.
+#
+# The generated rule is anchored to _CMDPOS (a real command position) instead
+# of `\b`. That is load-bearing, not decoration: widening the gap between
+# `git` and its subcommand also makes quoted DATA far easier to match, and
+# `git commit -m "why git -C x branch -D is dangerous"` must not trip the
+# gate. _CMDPOS is the same guard the rm hardline rules use for exactly this
+# reason, and _mark_command_starts still exposes genuine chained/subshell
+# command positions to it.
+#
+# The option run accepts only real git global-option shapes, per git's own
+# usage line (`git [-C <path>] [-c <name>=<value>] [--git-dir=<path>] …`):
+# `-c`/`-C` whose value is a separate token, the value-taking long options in
+# either `--opt=value` or `--opt value` spelling, and valueless long/short
+# options. It deliberately does NOT accept arbitrary words, so ordinary prose
+# ("git the branch -d thing") cannot bridge `git` to a subcommand.
+#
+# Verified against git 2.43.0 that the separated-value spelling really runs:
+# `git --git-dir /r/.git --work-tree /r branch -D tmp` deleted the branch.
+_GIT_VALUE_OPTS = r'--(?:git-dir|work-tree|namespace|exec-path|config-env)(?:=[^\s;|&]*|\s+[^\s;|&]+)'
+_GIT_GLOBAL_OPTS = (
+    r'(?:\s+(?:' + _GIT_VALUE_OPTS + r'|-[cC]\s+[^\s;|&]+'
+    r'|--?[a-z][\w-]*(?:=[^\s;|&]*)?))+'
+)
+
+# `GIT_DIR=/x git -C /repo branch -D main` is a real, verified spelling too:
+# a bare VAR=VAL assignment prefix is a command position the shell accepts.
+# _CMDPOS already consumes the `env VAR=VAL` form; extend it locally (rather
+# than widening _CMDPOS itself, which would change the hardline floor's blast
+# radius) so the option-tolerant rule reaches the same commands the bare rule
+# already does — the bare `\bgit\s+…` spelling is unanchored and matches
+# through such a prefix today.
+_GIT_CMD_ANCHOR = _CMDPOS + r'(?:\w+=[^\s;|&]*\s+)*git'
+
+# (subcommand-and-flags tail, description). The bare rule is
+# `\bgit\s+` + tail — byte-identical to the historical literals, so the
+# regex-derived legacy approval keys in _PATTERN_KEY_ALIASES are preserved.
+_GIT_DESTRUCTIVE_RULES = [
+    # `git reset --hard` accepts any unambiguous long-flag prefix (--h,
+    # --ha, --har, --hard) because git's own option parser resolves
+    # abbreviated long flags -- `--hard` is the only `git reset` mode
+    # starting with "h" (siblings are --soft/--mixed/--merge/--keep), so
+    # this cannot collide with another reset mode. It also does not match
+    # `--help`, which git special-cases before mode resolution.
+    (r'reset\s+--h(?:a(?:r(?:d)?)?)?\b', "git reset --hard (destroys uncommitted changes)"),
+    (r'push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
+    (r'push\b.*-f\b', "git force push short flag (rewrites remote history)"),
+    (r'clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
+    (r'branch\s+-D\b', "git branch force delete"),
+    # `-D` is shorthand for `-d --force`; the long-flag spellings
+    # (`--delete`, `--force`) are different tokens entirely, so they slip
+    # past the `-D\b` pattern above even though `git branch -d --force`
+    # and `git branch --delete --force` delete an unmerged branch exactly
+    # like `-D` does. Match delete+force in either order, bounded to the
+    # same command segment (not spanning `;`/`|`/`&`/newline) the same
+    # way the sudo patterns below do, to avoid contaminating an unrelated
+    # later command in the same script.
+    (r'branch\b[^;|&\n]*?(?:-d\b|--delete\b)[^;|&\n]*?(?:-f\b|--force\b)', "git branch force delete (long flags)"),
+    (r'branch\b[^;|&\n]*?(?:-f\b|--force\b)[^;|&\n]*?(?:-d\b|--delete\b)', "git branch force delete (long flags, force-first)"),
+]
+
+# Bare spellings first, in their historical order, so a command that matches
+# today keeps reporting the exact same description; the option-tolerant
+# spellings only ever add matches that were previously missed entirely.
+_GIT_DESTRUCTIVE_PATTERNS = [
+    (r'\bgit\s+' + _tail, _description)
+    for _tail, _description in _GIT_DESTRUCTIVE_RULES
+] + [
+    (_GIT_CMD_ANCHOR + _GIT_GLOBAL_OPTS + r'\s+' + _tail, _description)
+    for _tail, _description in _GIT_DESTRUCTIVE_RULES
+]
+
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
@@ -897,28 +979,12 @@ DANGEROUS_PATTERNS = [
     # a full shell context.
     (r'\b(bash|sh|zsh|ksh)\s+<<', "shell execution via heredoc"),
     # Git destructive operations that can lose uncommitted work or rewrite
-    # shared history. Not captured by rm/chmod/etc patterns.
-    # `git reset --hard` accepts any unambiguous long-flag prefix (--h,
-    # --ha, --har, --hard) because git's own option parser resolves
-    # abbreviated long flags -- `--hard` is the only `git reset` mode
-    # starting with "h" (siblings are --soft/--mixed/--merge/--keep), so
-    # this cannot collide with another reset mode. It also does not match
-    # `--help`, which git special-cases before mode resolution.
-    (r'\bgit\s+reset\s+--h(?:a(?:r(?:d)?)?)?\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
-    (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
-    (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
-    (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
-    # `-D` is shorthand for `-d --force`; the long-flag spellings
-    # (`--delete`, `--force`) are different tokens entirely, so they slip
-    # past the `-D\b` pattern above even though `git branch -d --force`
-    # and `git branch --delete --force` delete an unmerged branch exactly
-    # like `-D` does. Match delete+force in either order, bounded to the
-    # same command segment (not spanning `;`/`|`/`&`/newline) the same
-    # way the sudo patterns below do, to avoid contaminating an unrelated
-    # later command in the same script.
-    (r'\bgit\s+branch\b[^;|&\n]*?(?:-d\b|--delete\b)[^;|&\n]*?(?:-f\b|--force\b)', "git branch force delete (long flags)"),
-    (r'\bgit\s+branch\b[^;|&\n]*?(?:-f\b|--force\b)[^;|&\n]*?(?:-d\b|--delete\b)', "git branch force delete (long flags, force-first)"),
+    # shared history. Not captured by rm/chmod/etc patterns. Each rule is
+    # emitted twice by _GIT_DESTRUCTIVE_PATTERNS above: the historical bare
+    # `git <subcommand>` spelling, plus a command-position-anchored spelling
+    # that tolerates git's global options (`-C`, `--git-dir`, `-c k=v`, …)
+    # sitting between `git` and the subcommand.
+    *_GIT_DESTRUCTIVE_PATTERNS,
     # Script execution after chmod +x — catches the two-step pattern where
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.


### PR DESCRIPTION
## The bug

Every git rule in `DANGEROUS_PATTERNS` is anchored to `\bgit\s+<subcommand>`, but git accepts **global options between the program name and the subcommand**:

```
git -C /repo branch -D main
git --git-dir=/x --work-tree=/y clean -fdx
git -c core.pager=cat reset --hard
```

Any such option slips the entire approval gate. `-C` is precisely the spelling an agent emits when operating on a checkout other than its cwd, so this is the common case rather than an exotic one.

## Whole bug class, measured

This is not one subcommand — it is every git rule in the list. Measured by importing the real `detect_dangerous_command()` (not by reading regexes), 7 patterns × 9 bare spellings × 7 option prefixes on `main` @ 70db671fa:

| command | before | after |
|---|---|---|
| `git branch -D main` | True | True |
| `git branch --delete --force main` | True | True |
| `git -C /repo branch -D main` | **False** | True |
| `git -C /repo branch --delete --force main` | **False** | True |
| `git --git-dir=/x --work-tree=/y branch -D main` | **False** | True |
| `git -c core.pager=cat branch -D feat` | **False** | True |
| `git -C /repo reset --hard HEAD~3` | **False** | True |
| `git -C /repo push --force origin main` | **False** | True |
| `git -C /repo push -f origin main` | **False** | True |
| `git -C /repo clean -fdx` | **False** | True |
| **total bypass holes** | **63** | **0** |

Affected rules (all of them): `git reset --hard`, `git push --force`, `git push -f`, `git clean -f`, `git branch -D`, and both `git branch` long-flag force-delete rules.

Two further spellings were found and **verified against a live git 2.43.0** — each one really deleted a branch in a scratch repo, so they are executable bypasses, not theoretical:

```
git --git-dir /x --work-tree /y branch -D tmp1   # separated option value
GIT_DIR=/x git -C /repo branch -D tmp2           # env assignment prefix
```

Both are closed here too.

## The fix

Each rule is now emitted twice from one source list:

1. the **historical bare spelling, byte-for-byte unchanged** — so match behavior, descriptions, and the regex-derived legacy approval keys in `_PATTERN_KEY_ALIASES` are all preserved;
2. an **option-tolerant spelling** anchored to `_CMDPOS`.

Upstream's own long-flag rules (`git branch force delete (long flags)` / `(long flags, force-first)`) are kept as-is and inherit the widened anchor — this widens the anchor, it does not replace that work.

### The `_CMDPOS` anchor is load-bearing

`DANGEROUS_PATTERNS` deliberately lets a destructive spelling quoted inside another command's argument run (the `gh pr create --title "block rm -rf /"` case documented in the module). Widening the gap between `git` and its subcommand makes quoted **data** much easier to match by accident.

A blanket `\bgit\b[^;|&\n]*?\bbranch\b`-style anchor **does** trip:

```
git commit -m "explain why git -C x branch -D is dangerous"
```

`_CMDPOS` plus a strict git-global-option grammar does not. The option run accepts only real shapes from git's own usage line (`-C <path>`, `-c <name>=<value>`, `--git-dir=<path>` / `--git-dir <path>`, `--no-pager`, …) — never arbitrary words — so prose cannot bridge `git` to a subcommand. This is the same guard the `rm` hardline rules already use, for the same reason.

## Verification

**Differential sweep**, 6192 generated commands (subcommands × option prefixes × env prefixes × command positions × quoted-data wrappers), pristine `upstream/main` vs this branch:

- **2025** previously-missed destructive spellings now gated
- **0** regressions (nothing that was True became False)
- **0** new false positives

Still ungated, as they must be:

```
git -C /repo status / log --oneline / branch -a / branch --list
git -C /repo push origin main / clean -n / reset --soft HEAD~1 / reset --help
git commit -m "explain why git -C x branch -D is dangerous"
gh pr create --body "git --git-dir=/x clean -fdx bypasses the gate"
```

Still gated at real command positions:

```
cd /tmp && git -C /repo branch -D main
sudo git -C /repo clean -fdx
(git -C /repo push -f origin main)
```

## Tests

`TestGitGlobalOptionsDoNotBypassApproval` in `tests/tools/test_approval.py` asserts the **classification relation** — the option-prefixed spelling classifies identically to the bare spelling, description included — resolving the bare spelling at runtime rather than freezing a pattern count or a description string. It stays meaningful if the underlying patterns are ever rewritten, and includes the quoted-data false-positive guard explicitly.

Verified with the canonical runner, not direct pytest:

```
scripts/run_tests.sh tests/tools/test_approval.py          → 99 passed, 0 failed
scripts/run_tests.sh <all 12 approval-touching modules>    → 501 passed, 0 failed
```

Pre-existing, unrelated: `tests/tools/test_voice_mode.py`, `test_voice_wsl_pipewire.py` and `test_termux_api_detection.py` fail identically on pristine `upstream/main` on this host (WSL audio environment) — triaged against the merge-base before touching anything, and untouched by this change.

## Scope

Only `tools/approval.py` and `tests/tools/test_approval.py`. No new env vars, no new tools, no behavior change to any command that is gated today.
