### PR TITLE
fix(buzz): require explicit @mention in mention-gated channels

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1032,8 +1032,10 @@ class BuzzAdapter(BasePlatformAdapter):
         is_dm = state["chat_type"] == "dm"
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        # DMs always dispatch. An explicit mention (npub, hex, or @display
+        # name) is required — a bare display-name word in prose does NOT
+        # count, matching Discord/Slack/Chatto mention semantics.
+        if not is_dm and self.require_mention and not self._is_explicitly_mentioned(content):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1124,7 +1126,10 @@ class BuzzAdapter(BasePlatformAdapter):
         if not p_tagged_to_self:
             return False
         content = event.get("content")
-        return isinstance(content, str) and not self._is_mentioned(content)
+        # Loose check on purpose: a p-tagged message whose text visibly
+        # addresses us (bare name OR @name) is a channel message, not a
+        # structural DM — only a p-tag WITHOUT any visible address latches.
+        return isinstance(content, str) and not self._mentions_us_loose(content)
 
     def _maybe_latch_dm(self, channel_id: str, state: dict, event: dict) -> None:
         """Latch a group conversation to chat_type="dm" once any direct
@@ -1136,8 +1141,15 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_names.setdefault(channel_id, "DM")
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
-    def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+    def _mentions_us_loose(self, content: str) -> bool:
+        """True when the message text visibly addresses this agent in any form:
+        npub, hex pubkey, or display name with OR without a leading ``@``.
+
+        Used for DM-vs-channel classification, where the question is "did the
+        author visibly address us" — a bare name still counts as addressing,
+        so a p-tagged message saying our name is a channel message, not a
+        structural DM.
+        """
         lowered = content.lower()
         if self._self_pubkey and self._self_pubkey in lowered:
             return True
@@ -1145,6 +1157,27 @@ class BuzzAdapter(BasePlatformAdapter):
             return True
         if self._display_name:
             pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            if re.search(pattern, lowered):
+                return True
+        return False
+
+    def _is_explicitly_mentioned(self, content: str) -> bool:
+        """True when the message explicitly mentions this agent: npub, hex
+        pubkey, or ``@display name``.
+
+        Requires the ``@`` for the display name — a bare name in prose (e.g.
+        "max volume") does NOT count. This mirrors Discord (``<@id>`` tokens),
+        Slack (``<@uid>``), and Chatto (``@login``/``@displayName``) mention
+        semantics: an explicit address is required to wake the bot in
+        mention-gated channels.
+        """
+        lowered = content.lower()
+        if self._self_pubkey and self._self_pubkey in lowered:
+            return True
+        if self._self_npub and self._self_npub in lowered:
+            return True
+        if self._display_name:
+            pattern = rf"(?<!\w)@{re.escape(self._display_name.lower())}(?!\w)"
             if re.search(pattern, lowered):
                 return True
         return False


### PR DESCRIPTION
## What
Aligns Buzz mention gating with Discord, Slack, and Chatto: an explicit address (npub, hex pubkey, or **@display name**) is required to wake the agent in `require_mention` channels. A bare display-name word in prose no longer counts as a mention.

## Why
Buzz was the outlier among the official connectors:

| Connector | Mention detection | "Are you here, Max?" counts? |
|---|---|---|
| Discord | Literal `<@id>` token (or resolved mentions) | No |
| Slack | Literal `<@uid>` token | No |
| Chatto | `@login` / `@displayName` — **@ required** | No |
| Buzz (before) | Plain display name, `@` optional | **Yes** |

In practice this meant a message in a mention-gated channel that merely contained the bot's display name in prose woke the bot, even though the author never addressed it explicitly — surprising for users who expect @-mention semantics like every other connector.

**Counter-examples (the false positives this fixes):** with a display name like "Max", *any* sentence containing the word would wake the bot in mention-gated channels — e.g. "**max** volume", "**maximum**", "set it to **max**", or "**Max** is away this week" all counted as mentions even though the author was not addressing the agent.

## Implementation
Splits mention detection into two checks with different purposes:

- **`_is_explicitly_mentioned()`** — used by the mention gate. Requires the `@` for the display name; npub/hex still match bare (unambiguous long-form addresses).
- **`_mentions_us_loose()`** — used by DM-vs-channel classification (`_is_direct_message_event`). Bare name still counts as "visibly addressing us", so a p-tagged message that says our name stays a channel message instead of wrongly latching the channel as a DM (which would then dispatch everything without mention).

## Testing
- `py_compile` clean
- Behavior matrix verified:
  - Gate: "Are you here, Max?" -> False (bare name), "max volume" -> False, "maximum" -> False, "@Max check this" -> True, "@max hello" -> True, npub -> True
  - DM classification: "Are you here, Max?" -> still loose-True (no accidental DM latch)