### PR TITLE
fix(openviking): strip PYTHONPATH from autostarted server child env (#78153)

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1505,6 +1505,17 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
     log_path = _openviking_server_log_path()
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Do not let the server child inherit this process's PYTHONPATH.
+        # On a Hermes install PYTHONPATH points at the Hermes venv
+        # site-packages, so openviking-server would import aiohttp and
+        # friends from the Hermes venv instead of its own (its venv's
+        # site-packages are shadowed because PYTHONPATH precedes them) —
+        # and on Windows the loaded DLLs then lock the Hermes venv,
+        # aborting `hermes update` with access-denied on .pyd files.
+        # Strip PYTHONPATH so the server resolves packages from its own
+        # venv. (#78153)
+        child_env = os.environ.copy()
+        child_env.pop("PYTHONPATH", None)
         with log_path.open("ab") as log_file:
             subprocess.Popen(
                 [server_cmd, "--host", host, "--port", str(port)],
@@ -1512,6 +1523,7 @@ def _start_local_openviking_server(endpoint: str) -> tuple[str, str]:
                 stderr=log_file,
                 stdin=subprocess.DEVNULL,
                 start_new_session=True,
+                env=child_env,
             )
     except Exception as e:
         return _LOCAL_SERVER_FAILED, f"Could not start openviking-server: {e}"

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -392,6 +392,35 @@ def test_start_local_openviking_server_uses_endpoint_host_and_port(monkeypatch):
     assert kwargs["start_new_session"] is True
 
 
+def test_start_local_openviking_server_strips_pythonpath_from_child_env(monkeypatch):
+    """The spawned server must not inherit Hermes's PYTHONPATH (#78153).
+
+    Inheriting it makes openviking-server import packages from the Hermes
+    venv instead of its own, and on Windows locks Hermes venv DLLs so the
+    venv cannot be rebuilt during `hermes update`.
+    """
+    popen_calls = []
+
+    def fake_popen(args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return object()
+
+    monkeypatch.setattr(openviking_module, "_local_openviking_port_is_open", lambda host, port: False)
+    monkeypatch.setattr(openviking_module.shutil, "which", lambda name: "/usr/local/bin/openviking-server")
+    monkeypatch.setattr(openviking_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("PYTHONPATH", "/opt/hermes/.venv/Lib/site-packages")
+    monkeypatch.setenv("HERMES_PROFILE", "test-profile")
+
+    state, _message = openviking_module._start_local_openviking_server("http://127.0.0.1:1934")
+
+    assert state == openviking_module._LOCAL_SERVER_STARTED
+    _, kwargs = popen_calls[0]
+    child_env = kwargs["env"]
+    assert child_env is not None
+    assert "PYTHONPATH" not in child_env
+    assert child_env.get("HERMES_PROFILE") == "test-profile"
+
+
 def test_start_local_openviking_server_does_not_spawn_when_port_already_open(monkeypatch):
     """A live listener means a second server would just die on DataDirectoryLocked."""
     probed = []


### PR DESCRIPTION
## Summary

Fixes #78153.

`_start_local_openviking_server()` in `plugins/memory/openviking/__init__.py` spawns `openviking-server` via `subprocess.Popen` without an explicit `env`, so the child inherits the parent's `PYTHONPATH`. On a Hermes install `PYTHONPATH` points at the Hermes venv site-packages, which shadows the server's own venv (`PYTHONPATH` precedes venv site-packages in import resolution). That causes:

1. **Import pollution** — the OV process imports aiohttp and friends from the Hermes venv instead of its own `ov-venv`.
2. **DLL locking blocks updates on Windows** — loaded DLLs (e.g. `mask.cp311-win_amd64.pyd`) lock the Hermes venv, so `hermes update` aborts with access-denied while rebuilding the venv.

## Fix

Pass an explicit child env built from `os.environ.copy()` with `PYTHONPATH` removed, so the server resolves packages from its own venv. All other env vars are preserved.

## Tests

- New regression test `test_start_local_openviking_server_strips_pythonpath_from_child_env` asserting the Popen env has no `PYTHONPATH` while other vars survive.
- Full OpenViking plugin suite: 65 passed.
