### PR TITLE
test(stt): stabilize idle-timeout progress test against spawn latency (pre-existing flake on Windows + loaded CI)

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1188,12 +1188,19 @@ class TestRunCommandSttIdleTimeout:
         from tools.transcription_tools import _run_command_stt
 
         script = tmp_path / "progress_then_exit.py"
+        # First tick is emitted immediately and the rest every 50ms — the
+        # total runtime (~400ms) exceeds the 250ms idle window, so passing
+        # depends on the progress extension. The immediate first tick also
+        # keeps the test honest on Windows, where process spawn alone can
+        # exceed a tiny idle window and previously raised TimeoutExpired
+        # before the first chunk was ever read (with all child output intact).
         script.write_text(
             "\n".join([
                 "import sys, time",
-                "for idx in range(4):",
+                "print('tick 0', file=sys.stderr, flush=True)",
+                "for idx in range(1, 9):",
+                "    time.sleep(0.05)",
                 "    print(f'tick {idx}', file=sys.stderr, flush=True)",
-                "    time.sleep(0.04)",
                 "print('done', flush=True)",
             ]),
             encoding="utf-8",
@@ -1201,11 +1208,11 @@ class TestRunCommandSttIdleTimeout:
 
         result = _run_command_stt(
             self._shell_command(sys.executable, "-u", str(script)),
-            timeout=0.1,
+            timeout=0.25,
         )
 
         assert result.returncode == 0
-        assert "tick 3" in result.stderr
+        assert "tick 8" in result.stderr
         assert "done" in result.stdout
 
     def test_silent_stall_still_times_out(self, tmp_path):


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #78191 #78196 #78202 #78207
## What & why

`test_stderr_progress_extends_beyond_timeout` in `tests/tools/test_transcription_tools.py` is broken by design on slow-spawn platforms and flaky under CI load. It used a **0.1s idle timeout with ticks every 0.04s** — shorter than Windows process spawn latency, so the first stderr chunk could never arrive inside the idle window. The runner then killed the child and raised `TimeoutExpired` with *all* child output captured.

Proof it is pre-existing (not caused by any PR in flight):
- Fails identically on a pristine `origin/main` worktree (`942ff91f21`) on Windows — deterministic.
- Fails on Linux CI only under 8-worker load (seen on #78202's run); sibling PRs #78191 / #78196 passed the same slice 3/8.
- Probe: child emitted `tick 0..3` + `done`, runner still raised `TimeoutExpired` at `tools/transcription_tools.py:785`.

## The fix

- First tick emitted **immediately** (before any sleep) — kills the spawn race.
- Ticks every 50ms for ~400ms total runtime; idle window 250ms (5× tick period) — tolerant of real scheduling latency.
- Total runtime still exceeds the idle window, so the pass **depends on the progress extension** — the test's intent is preserved (mirrors `_run_command_tts` timing conventions in `test_tts_command_providers.py`).

## How to test

```
pytest tests/tools/test_transcription_tools.py::TestRunCommandSttIdleTimeout -q
```

Expected: `2 passed` (repeatable — 3/3 green locally on Windows; full file 50/50).

## Platforms tested

Windows (native, this box) — 3 consecutive runs of the class + full file. Linux CI hermetic slice will exercise the loaded-runner case.

## Why this matters to users

A timing test that deterministically fails on Windows and randomly on loaded CI blocks every PR that touches the STT surface — including the Vox Lockin campaign PRs eliminating the STT/TTS bug class. This unblocks them and stops the flake class at the root.

Part of #78207

Part of #79890
