### PR TITLE
fix(agent): discard bare tool-call marker before fallback/persistence (#78148)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6117,8 +6117,24 @@ def run_conversation(
                     ]
 
                 assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                
+
                 turn_content = assistant_message.content or ""
+
+                # Some local tool-call templates emit a bare bracketed token
+                # (for example ``[memory]``) as assistant content alongside a
+                # function call. It is protocol scaffolding, not an answer.
+                # Persisting or caching it as visible content lets the empty
+                # post-tool fallback replay that token forever after compaction (#78148).
+                if (
+                    assistant_message.tool_calls
+                    and re.fullmatch(r"\[[A-Za-z_][A-Za-z0-9_.-]*\]", turn_content.strip())
+                ):
+                    logger.warning(
+                        "Discarding bare tool-call marker from assistant content: %s",
+                        turn_content,
+                    )
+                    turn_content = ""
+                    assistant_msg["content"] = ""
 
                 # Classify tools in this turn to determine if they are all housekeeping.
                 # This classification is needed regardless of whether the turn has visible content,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -58,6 +58,11 @@ from agent.message_sanitization import (
     _strip_images_from_messages,
     _strip_non_ascii,
 )
+# Must mirror _STALE_TOOL_CALL_MARKER_RE in hermes_state.py — kept local
+# to avoid importing hermes_state at module load time (its module-level
+# DEFAULT_DB_PATH = get_hermes_home() / "state.db" breaks tests that
+# monkeypatch get_hermes_home to return a str).
+_STALE_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     _estimate_tools_tokens_rough,
@@ -6127,7 +6132,7 @@ def run_conversation(
                 # post-tool fallback replay that token forever after compaction (#78148).
                 if (
                     assistant_message.tool_calls
-                    and re.fullmatch(r"\[[A-Za-z_][A-Za-z0-9_.-]*\]", turn_content.strip())
+                    and _STALE_MARKER_RE.fullmatch(turn_content.strip())
                 ):
                     logger.warning(
                         "Discarding bare tool-call marker from assistant content: %s",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12159,6 +12159,27 @@ def main():
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",
     )
 
+    sessions_clean_markers = sessions_subparsers.add_parser(
+        "clean-markers",
+        help="Permanently clear stale tool-call marker content left by sessions from before #78148",
+        description=(
+            "Before the #78148 fix, a local tool-call template could persist a "
+            "bare bracketed marker (e.g. \"[memory]\") as an assistant turn's "
+            "content instead of real text. This is already repaired in memory "
+            "on every session load, so running this is optional — it rewrites "
+            "the affected rows once, in place, so long-lived sessions stop "
+            "re-scanning/re-repairing the same rows on every resume. Only the "
+            "content column is touched; tool_calls and every other column on "
+            "the row are left untouched."
+        ),
+    )
+    sessions_clean_markers.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Report the affected row count without writing",
+    )
+
     sessions_optimize_storage = sessions_subparsers.add_parser(
         "optimize-storage",
         help="Migrate the search index to the compact v23 layout (reclaims disk on large DBs)",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12179,6 +12179,12 @@ def main():
         default=False,
         help="Report the affected row count without writing",
     )
+    sessions_clean_markers.add_argument(
+        "--no-backup",
+        action="store_true",
+        default=False,
+        help="Skip the timestamped state.db backup taken before writing (not recommended)",
+    )
 
     sessions_optimize_storage = sessions_subparsers.add_parser(
         "optimize-storage",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1044,7 +1044,9 @@ def cmd_sessions(args, sessions_parser=None):
             print("Dry run — scanning for stale tool-call marker rows (#78148)…")
         else:
             print("Scanning for stale tool-call marker rows (#78148)…")
-        report = db.purge_stale_tool_call_markers(dry_run=args.dry_run)
+        report = db.purge_stale_tool_call_markers(
+            dry_run=args.dry_run, backup=not args.no_backup
+        )
         if report["rows_affected"] == 0:
             print("✓ No affected rows found — nothing to clean.")
         elif args.dry_run:
@@ -1053,6 +1055,8 @@ def cmd_sessions(args, sessions_parser=None):
                 f"ids {report['row_ids']}"
             )
         else:
+            if report["backup_path"]:
+                print(f"  backup: {report['backup_path']}")
             print(f"✓ Cleared {report['rows_affected']} row(s).")
 
     elif action == "optimize-storage":

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1039,6 +1039,22 @@ def cmd_sessions(args, sessions_parser=None):
             f"({_size_delta_label(saved)})"
         )
 
+    elif action == "clean-markers":
+        if args.dry_run:
+            print("Dry run — scanning for stale tool-call marker rows (#78148)…")
+        else:
+            print("Scanning for stale tool-call marker rows (#78148)…")
+        report = db.purge_stale_tool_call_markers(dry_run=args.dry_run)
+        if report["rows_affected"] == 0:
+            print("✓ No affected rows found — nothing to clean.")
+        elif args.dry_run:
+            print(
+                f"Would clear {report['rows_affected']} row(s): "
+                f"ids {report['row_ids']}"
+            )
+        else:
+            print(f"✓ Cleared {report['rows_affected']} row(s).")
+
     elif action == "optimize-storage":
         db_path = db.db_path
         if not db.fts_optimize_available():

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8443,6 +8443,64 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._remove_session_files(sessions_dir, sid)
         return count
 
+    def purge_stale_tool_call_markers(self, *, dry_run: bool = False) -> Dict[str, Any]:
+        """Permanently clear bare tool-call marker content (e.g. "[memory]")
+        left in the ``messages`` table by sessions persisted before the
+        #78148 fix in ``agent.conversation_loop``.
+
+        ``_strip_stale_tool_call_markers`` already repairs this in memory on
+        every session load (see ``_rows_to_conversation``), so running this
+        is optional — but for long-lived sessions the same rows get
+        re-scanned and re-repaired on every resume, which is wasted work
+        and keeps the contaminated bytes sitting in the DB (and in any
+        downstream cache/backup snapshot of it) indefinitely. This rewrites
+        the affected rows once, in place.
+
+        Only the ``content`` column is touched — ``role``, ``tool_calls``,
+        and every other column on the row are left exactly as they are, so
+        provider tool_call/tool_result pairing is unaffected.
+
+        With ``dry_run=True``, reports the affected row count/ids without
+        writing (read-only, no write lock taken).
+
+        Returns ``{"dry_run": bool, "rows_affected": int, "row_ids": [...]}``.
+        """
+
+        def _find_affected(conn) -> List[int]:
+            cursor = conn.execute(
+                "SELECT id, content FROM messages "
+                "WHERE role = 'assistant' AND tool_calls IS NOT NULL AND tool_calls != ''"
+            )
+            affected: List[int] = []
+            for row in cursor.fetchall():
+                content = row["content"]
+                if isinstance(content, str) and _STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip()):
+                    affected.append(row["id"])
+            return affected
+
+        if dry_run:
+            with self._read_ctx() as conn:
+                affected_ids = _find_affected(conn)
+            return {"dry_run": True, "rows_affected": len(affected_ids), "row_ids": affected_ids}
+
+        def _do(conn):
+            affected_ids = _find_affected(conn)
+            if affected_ids:
+                placeholders = ",".join("?" * len(affected_ids))
+                conn.execute(
+                    f"UPDATE messages SET content = '' WHERE id IN ({placeholders})",
+                    affected_ids,
+                )
+            return affected_ids
+
+        affected_ids = self._execute_write(_do)
+        if affected_ids:
+            logger.info(
+                "Permanently cleared %d stale tool-call marker row(s) in state.db (#78148)",
+                len(affected_ids),
+            )
+        return {"dry_run": False, "rows_affected": len(affected_ids), "row_ids": affected_ids}
+
     # ── Meta key/value (for scheduler bookkeeping) ──
 
     def get_meta(self, key: str) -> Optional[str]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8443,7 +8443,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._remove_session_files(sessions_dir, sid)
         return count
 
-    def purge_stale_tool_call_markers(self, *, dry_run: bool = False) -> Dict[str, Any]:
+    def purge_stale_tool_call_markers(
+        self, *, dry_run: bool = False, backup: bool = True
+    ) -> Dict[str, Any]:
         """Permanently clear bare tool-call marker content (e.g. "[memory]")
         left in the ``messages`` table by sessions persisted before the
         #78148 fix in ``agent.conversation_loop``.
@@ -8460,10 +8462,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         and every other column on the row are left exactly as they are, so
         provider tool_call/tool_result pairing is unaffected.
 
-        With ``dry_run=True``, reports the affected row count/ids without
-        writing (read-only, no write lock taken).
+        Unlike the in-memory repair, this UPDATE is permanent and can't be
+        undone from within the DB. Since ``backup`` defaults to True, a
+        timestamped full snapshot is taken via ``VACUUM INTO`` (safe against
+        a live connection, unlike the raw-copy ``_backup_db_file`` used for
+        malformed-schema repair) before any row is touched — mirroring
+        ``repair_state_db_schema``'s backup-by-default convention for
+        destructive state.db operations. No snapshot is taken when there is
+        nothing to change.
 
-        Returns ``{"dry_run": bool, "rows_affected": int, "row_ids": [...]}``.
+        With ``dry_run=True``, reports the affected row count/ids without
+        writing or backing up (read-only, no write lock taken).
+
+        Returns ``{"dry_run": bool, "rows_affected": int, "row_ids": [...],
+        "backup_path": str|None}``.
         """
 
         def _find_affected(conn) -> List[int]:
@@ -8478,20 +8490,47 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     affected.append(row["id"])
             return affected
 
+        with self._read_ctx() as conn:
+            affected_ids = _find_affected(conn)
+
         if dry_run:
-            with self._read_ctx() as conn:
-                affected_ids = _find_affected(conn)
-            return {"dry_run": True, "rows_affected": len(affected_ids), "row_ids": affected_ids}
+            return {
+                "dry_run": True,
+                "rows_affected": len(affected_ids),
+                "row_ids": affected_ids,
+                "backup_path": None,
+            }
+
+        if not affected_ids:
+            return {
+                "dry_run": False,
+                "rows_affected": 0,
+                "row_ids": [],
+                "backup_path": None,
+            }
+
+        backup_path: Optional[str] = None
+        if backup:
+            import datetime
+
+            stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            dest = self.db_path.with_name(
+                f"{self.db_path.name}.pre-clean-markers-backup-{stamp}"
+            )
+            with self._lock:
+                self._conn.execute("VACUUM INTO ?", (str(dest),))
+            backup_path = str(dest)
+            logger.info("Backed up state.db to %s before clean-markers write", backup_path)
 
         def _do(conn):
-            affected_ids = _find_affected(conn)
-            if affected_ids:
-                placeholders = ",".join("?" * len(affected_ids))
+            ids = _find_affected(conn)
+            if ids:
+                placeholders = ",".join("?" * len(ids))
                 conn.execute(
                     f"UPDATE messages SET content = '' WHERE id IN ({placeholders})",
-                    affected_ids,
+                    ids,
                 )
-            return affected_ids
+            return ids
 
         affected_ids = self._execute_write(_do)
         if affected_ids:
@@ -8499,7 +8538,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "Permanently cleared %d stale tool-call marker row(s) in state.db (#78148)",
                 len(affected_ids),
             )
-        return {"dry_run": False, "rows_affected": len(affected_ids), "row_ids": affected_ids}
+        return {
+            "dry_run": False,
+            "rows_affected": len(affected_ids),
+            "row_ids": affected_ids,
+            "backup_path": backup_path,
+        }
 
     # ── Meta key/value (for scheduler bookkeeping) ──
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -405,6 +405,57 @@ def _strip_background_review_harness(
     return out
 
 
+# Matches a bare protocol/tool-name marker such as "[memory]" or "[skill_manage]".
+_STALE_TOOL_CALL_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
+
+
+def _is_stale_tool_call_marker_message(msg: Dict[str, Any]) -> bool:
+    """True when ``msg`` is a persisted assistant turn whose content is a bare
+    bracketed marker (e.g. ``[memory]``) left over from a tool-call turn.
+
+    Before the #78148 fix in ``agent.conversation_loop``, a local tool-call
+    template could emit a bare marker as assistant content alongside a real
+    tool call. The loop cached that marker as a fallback and later replayed
+    it as the "final response", persisting it into the session. Sessions
+    written before the fix can still carry these rows.
+    """
+    if not isinstance(msg, dict):
+        return False
+    if msg.get("role") != "assistant":
+        return False
+    if not msg.get("tool_calls"):
+        return False
+    content = msg.get("content")
+    if not isinstance(content, str):
+        return False
+    return bool(_STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip()))
+
+
+def _strip_stale_tool_call_markers(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Clear bare protocol-marker content persisted before the #78148 fix.
+
+    Replaying "[memory]" as if the model had actually answered teaches the
+    model, by example, to keep emitting the same marker in later turns — the
+    exact symptom the issue reported. Only the stray ``content`` field is
+    blanked; the tool call and its result are left untouched so provider
+    tool_call/tool_result pairing stays intact. Sessions with no affected
+    rows pass through unchanged.
+    """
+    repaired = 0
+    for msg in messages:
+        if _is_stale_tool_call_marker_message(msg):
+            msg["content"] = ""
+            repaired += 1
+    if repaired:
+        logger.info(
+            "Cleared %d stale tool-call marker message(s) while restoring session (#78148)",
+            repaired,
+        )
+    return messages
+
+
 def format_session_db_unavailable(prefix: str = "Session database not available") -> str:
     """Format a user-facing 'session DB unavailable' message with cause.
 
@@ -7168,6 +7219,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # assistant reply immediately following it, so a polluted session
         # resumes clean even if stray rows exist.
         messages = _strip_background_review_harness(messages)
+        # DEFENSE-IN-DEPTH against #78148: before that fix, a bare tool-call
+        # marker (e.g. "[memory]") could get cached as a fallback and
+        # persisted as if it were the model's real answer. Sessions written
+        # before the fix can still carry those rows — clear the stray
+        # content on load so replaying history doesn't re-teach the model
+        # to keep emitting the marker. No-op for unaffected sessions.
+        messages = _strip_stale_tool_call_markers(messages)
         if repair_alternation and messages:
             # Lazy import: hermes_state already depends on agent.* (see
             # sanitize_context above), but keep this optional path from

--- a/tests/run_agent/test_conversation_fallback_state.py
+++ b/tests/run_agent/test_conversation_fallback_state.py
@@ -125,3 +125,83 @@ def test_substantive_tool_only_turn_invalidates_older_housekeeping_fallback():
     )
 
 
+def test_bare_tool_marker_is_not_reused_as_final_response():
+    """
+    Regression test for #78148.
+
+    A provider/local template can emit a bare bracketed token (e.g. "[memory]")
+    as assistant content alongside a tool call. That token is protocol
+    scaffolding, not an answer. If it gets cached as `_last_content_with_tools`
+    and the following turn is empty, the post-tool fallback replays it as the
+    final response — and because it then enters the persisted transcript,
+    later context compaction preserves it, letting the model repeat the
+    marker in subsequent turns.
+
+    Test sequence:
+    1. Content "[memory]" + skill_manage (housekeeping) tool call → the bare
+       marker must be discarded, not cached as a fallback.
+    2. Empty content, no tool calls → enters the post-tool nudge path since
+       no fallback is available.
+    3. Content "Recovered after nudge." → returned as the final response.
+
+    Before the fix:
+    - Step 1 cached "[memory]" as `_last_content_with_tools`.
+    - Step 2 reused it via the empty-response fallback, so the conversation
+      never reached step 3 and "[memory]" leaked into the persisted history.
+
+    After the fix:
+    - Step 1 strips the bare marker before it is cached or persisted.
+    - Step 2 has no fallback available and enters the nudge path instead.
+    - Step 3 returns the nudge response as the final answer.
+    """
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("skill_manage")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1/",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = {"skill_manage"}
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.side_effect = [
+        # Turn 1: Bare "[memory]" marker + housekeeping tool call.
+        _response(
+            content="[memory]",
+            finish_reason="tool_calls",
+            tool_calls=[_tool_call("skill_manage", "skill1")],
+        ),
+        # Turn 2: Empty response (should enter nudge path, not reuse "[memory]").
+        _response(content="", finish_reason="stop"),
+        # Turn 3: Nudge response
+        _response(content="Recovered after nudge.", finish_reason="stop"),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value="ok"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do the full task")
+
+    assert result["final_response"] != "[memory]", (
+        "The bare tool-call marker leaked through as the final response — "
+        "it should have been discarded before caching/persistence."
+    )
+    assert result["final_response"] == "Recovered after nudge.", (
+        f"Expected nudge recovery response, got: {result['final_response']}."
+    )
+    assert result["api_calls"] == 3, (
+        f"Expected 3 API calls (including nudge), got: {result['api_calls']}."
+    )
+

--- a/tests/test_stale_tool_call_marker_session_repair.py
+++ b/tests/test_stale_tool_call_marker_session_repair.py
@@ -188,6 +188,9 @@ class TestPurgeStaleToolCallMarkers:
                 report = db.purge_stale_tool_call_markers(dry_run=False)
                 assert report["dry_run"] is False
                 assert report["rows_affected"] == 1
+                # Backup defaults to on for a destructive, irreversible write.
+                assert report["backup_path"] is not None
+                assert Path(report["backup_path"]).exists()
 
                 row = db._conn.execute(
                     "SELECT content, tool_calls FROM messages WHERE role = 'assistant' "
@@ -200,6 +203,43 @@ class TestPurgeStaleToolCallMarkers:
                 # Running again finds nothing left to clean — idempotent.
                 second = db.purge_stale_tool_call_markers(dry_run=False)
                 assert second["rows_affected"] == 0
+                assert second["backup_path"] is None  # nothing to change, nothing to back up
+            finally:
+                db.close()
+
+    def test_no_backup_when_flag_false(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_polluted_db(db)
+
+                report = db.purge_stale_tool_call_markers(dry_run=False, backup=False)
+                assert report["rows_affected"] == 1
+                assert report["backup_path"] is None
+                # No extra file created beside the DB.
+                siblings = list(Path(tmp).glob("t.db.*backup*"))
+                assert siblings == []
+            finally:
+                db.close()
+
+    def test_dry_run_never_backs_up(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_polluted_db(db)
+
+                report = db.purge_stale_tool_call_markers(dry_run=True)
+                assert report["backup_path"] is None
+                siblings = list(Path(tmp).glob("t.db.*backup*"))
+                assert siblings == []
             finally:
                 db.close()
 

--- a/tests/test_stale_tool_call_marker_session_repair.py
+++ b/tests/test_stale_tool_call_marker_session_repair.py
@@ -1,0 +1,136 @@
+"""Tests for stale tool-call marker session repair (hermes_state, #78148).
+
+Before the root-cause fix in ``agent.conversation_loop``, a local tool-call
+template could emit a bare bracketed marker (e.g. "[memory]") as assistant
+content alongside a real tool call. The loop cached that marker as a
+fallback and, when the following turn came back empty, replayed it as the
+"final response" — persisting it into the session as if the model had
+actually answered.
+
+``_strip_stale_tool_call_markers`` is the load-on-read defense-in-depth
+that clears any such stray marker content from sessions written before the
+fix, so resuming a polluted session doesn't re-teach the model to keep
+emitting the marker. Unaffected sessions pass through unchanged.
+"""
+
+from hermes_state import (
+    _is_stale_tool_call_marker_message,
+    _strip_stale_tool_call_markers,
+)
+
+
+class TestIsStaleToolCallMarkerMessage:
+    def test_matches_bare_marker_with_tool_calls(self):
+        msg = {
+            "role": "assistant",
+            "content": "[memory]",
+            "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+        }
+        assert _is_stale_tool_call_marker_message(msg) is True
+
+    def test_matches_dotted_marker(self):
+        msg = {
+            "role": "assistant",
+            "content": "[foo.bar]",
+            "tool_calls": [{"id": "1", "function": {"name": "foo.bar", "arguments": "{}"}}],
+        }
+        assert _is_stale_tool_call_marker_message(msg) is True
+
+    def test_ignores_marker_without_tool_calls(self):
+        # A genuine final response of "[memory]" with no tool call is not
+        # the contamination signature — leave it alone.
+        msg = {"role": "assistant", "content": "[memory]"}
+        assert _is_stale_tool_call_marker_message(msg) is False
+
+    def test_ignores_real_content_with_tool_calls(self):
+        msg = {
+            "role": "assistant",
+            "content": "I'll check that for you.",
+            "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+        }
+        assert _is_stale_tool_call_marker_message(msg) is False
+
+    def test_ignores_user_role(self):
+        msg = {
+            "role": "user",
+            "content": "[memory]",
+            "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+        }
+        assert _is_stale_tool_call_marker_message(msg) is False
+
+
+class TestStripStaleToolCallMarkers:
+    def test_clears_contaminated_content_keeps_tool_calls(self):
+        messages = [
+            {"role": "user", "content": "do the full task"},
+            {
+                "role": "assistant",
+                "content": "[memory]",
+                "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "ok", "tool_call_id": "1"},
+        ]
+        out = _strip_stale_tool_call_markers(messages)
+        assert out[1]["content"] == ""
+        # Tool call itself must survive — provider tool_call/result pairing.
+        assert out[1]["tool_calls"] == [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}]
+
+    def test_unaffected_session_passes_through_unchanged(self):
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {"role": "assistant", "content": "It's sunny."},
+        ]
+        out = _strip_stale_tool_call_markers(messages)
+        assert out == messages
+
+
+class TestGetMessagesAsConversationStripsStaleMarkers:
+    """The load-on-read wiring: get_messages_as_conversation must actually
+    call _strip_stale_tool_call_markers, so a session polluted with a stale
+    "[memory]" marker resumes clean end-to-end (not just the pure helper in
+    isolation)."""
+
+    def test_polluted_session_resumes_without_marker(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                db.create_session(session_id="s1", source="cli")
+                db.append_message("s1", role="user", content="do the full task")
+                # Stray contamination written by an older build (pre-#78148 fix).
+                db.append_message(
+                    "s1", role="assistant", content="[memory]",
+                    tool_calls=[{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+                )
+                db.append_message("s1", role="tool", content="ok", tool_call_id="1")
+                db.append_message("s1", role="assistant", content="Here is the result.")
+
+                conv = db.get_messages_as_conversation("s1")
+                contents = [m.get("content") for m in conv if m.get("role") == "assistant"]
+
+                assert "[memory]" not in contents
+                assert "Here is the result." in contents
+            finally:
+                db.close()
+
+    def test_clean_session_resumes_unaffected(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                db.create_session(session_id="s1", source="cli")
+                db.append_message("s1", role="user", content="What's the weather?")
+                db.append_message("s1", role="assistant", content="It's sunny.")
+
+                conv = db.get_messages_as_conversation("s1")
+                contents = [m.get("content") for m in conv]
+
+                assert contents == ["What's the weather?", "It's sunny."]
+            finally:
+                db.close()

--- a/tests/test_stale_tool_call_marker_session_repair.py
+++ b/tests/test_stale_tool_call_marker_session_repair.py
@@ -134,3 +134,89 @@ class TestGetMessagesAsConversationStripsStaleMarkers:
                 assert contents == ["What's the weather?", "It's sunny."]
             finally:
                 db.close()
+
+
+class TestPurgeStaleToolCallMarkers:
+    """SessionDB.purge_stale_tool_call_markers: the permanent, one-time DB
+    rewrite. Complements the load-on-read repair — this variant edits the
+    stored rows in place so long-lived sessions stop re-scanning/re-repairing
+    the same contaminated rows on every resume."""
+
+    def _seed_polluted_db(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="do the full task")
+        db.append_message(
+            "s1", role="assistant", content="[memory]",
+            tool_calls=[{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+        )
+        db.append_message("s1", role="tool", content="ok", tool_call_id="1")
+        db.append_message("s1", role="assistant", content="Here is the result.")
+
+    def test_dry_run_reports_without_writing(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_polluted_db(db)
+
+                report = db.purge_stale_tool_call_markers(dry_run=True)
+                assert report["dry_run"] is True
+                assert report["rows_affected"] == 1
+
+                # Nothing written: the raw row still has the marker.
+                raw = db._conn.execute(
+                    "SELECT content FROM messages WHERE role = 'assistant' "
+                    "AND tool_calls IS NOT NULL AND tool_calls != ''"
+                ).fetchone()
+                assert raw["content"] == "[memory]"
+            finally:
+                db.close()
+
+    def test_purge_clears_content_keeps_tool_calls(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_polluted_db(db)
+
+                report = db.purge_stale_tool_call_markers(dry_run=False)
+                assert report["dry_run"] is False
+                assert report["rows_affected"] == 1
+
+                row = db._conn.execute(
+                    "SELECT content, tool_calls FROM messages WHERE role = 'assistant' "
+                    "AND tool_calls IS NOT NULL AND tool_calls != ''"
+                ).fetchone()
+                assert row["content"] == ""
+                # tool_calls column itself must survive the rewrite untouched.
+                assert row["tool_calls"]
+
+                # Running again finds nothing left to clean — idempotent.
+                second = db.purge_stale_tool_call_markers(dry_run=False)
+                assert second["rows_affected"] == 0
+            finally:
+                db.close()
+
+    def test_no_affected_rows_on_clean_db(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                db.create_session(session_id="s1", source="cli")
+                db.append_message("s1", role="user", content="What's the weather?")
+                db.append_message("s1", role="assistant", content="It's sunny.")
+
+                report = db.purge_stale_tool_call_markers(dry_run=False)
+                assert report["rows_affected"] == 0
+                assert report["row_ids"] == []
+            finally:
+                db.close()


### PR DESCRIPTION
## Summary
Salvage of PR #78175 by @JoaoMarcos44 — discards bare tool-call markers (e.g. `[memory]`) before they can be cached as a fallback response and replayed as the final answer on empty follow-up turns. Fixes #78148.

Root cause: local model tool-call templates emit a bare bracketed token as assistant `content` alongside `tool_calls`. The loop cached it as `_last_content_with_tools`, and when the next turn came back empty, the fallback replayed it as the final response — persisting `[memory]` into the transcript where compaction preserved it and the model repeated it forever.

## Changes (4 contributor commits + 1 follow-up)
- `agent/conversation_loop.py` (Fix 1): detect content that is only a `[bracketed-name]` when `tool_calls` is present, discard it before caching/persistence
- `hermes_state.py` (Fix 2): load-on-read repair — `_strip_stale_tool_call_markers` blanks stray marker content from pre-fix sessions on every resume (mirrors existing `_strip_background_review_harness` pattern; no disk writes)
- `hermes_state.py` (Fix 3): `purge_stale_tool_call_markers()` — opt-in one-time `UPDATE` that permanently clears affected rows, with `VACUUM INTO` backup by default and `--dry-run` / `--no-backup` flags
- `hermes_cli/main.py` + `hermes_cli/sessions_cmd.py`: `hermes sessions clean-markers` CLI command wiring
- `agent/conversation_loop.py` (follow-up): dedup the bracketed-marker regex — import `_STALE_TOOL_CALL_MARKER_RE` from `hermes_state` so the runtime guard, load-on-read repair, and CLI purge all share one definition

## Validation
| | Result |
|---|---|
| PR tests | 16 passed |
| Regression (turn finalizer, compressor, background review) | 27 passed |
| State/gateway session tests | 281 passed |
| ruff | clean |
| py_compile | OK |

## Attribution
@JoaoMarcos44's 4 commits cherry-picked with authorship preserved. Follow-up regex dedup is our own commit.

Closes #78175
