### PR TITLE
fix: search_files rg fails on Windows absolute drive paths

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -989,3 +989,27 @@ class TestSearchFilesRgWindowsDrivePath:
         assert "os error" in result.error
         assert result.files == []
         assert result.total_count == 0
+
+    def test_zero_match_probe_commands_use_native_drive_path(self, monkeypatch):
+        """_zero_match_probe must route paths through _quote_rg_path too.
+
+        The three rg invocations inside _zero_match_probe (case-insensitive,
+        hidden/no-ignore, and fixed-string) use the same shell-command form
+        as _search_files_rg and _search_with_rg. If they keep using
+        _escape_shell_arg, a Windows-native rg.exe receives the MSYS /d/...
+        form and fails with os error 3 — the probe silently returns None (no
+        exit-code check) and the search loses its steering hints on exactly
+        the platform this fix targets. Regression guard.
+        """
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        ops._command_cache = {"rg": True}
+        # Use a pattern with regex metacharacters so probe runs all three
+        # rg invocations (CI → hidden → fixed-string).
+        ops._zero_match_probe("lookup[key+1]", "D:\\projects\\foo", None)
+        cmds = [call.args[0] for call in env.execute.call_args_list]
+        assert len(cmds) == 3
+        for cmd in cmds:
+            assert "D:/projects/foo" in cmd, f"Command lacks native path: {cmd!r}"
+            assert "/d/projects/foo" not in cmd, f"Command still has MSYS path: {cmd!r}"

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 from tools.file_operations import (
     _is_write_denied,
+    _rg_native_path,
     ReadResult,
     WriteResult,
     PatchResult,
@@ -898,3 +899,93 @@ class TestEscapeNativeToolArg:
         assert node_cmds, f"no node command captured in: {commands}"
         assert "'C:/Users/alice/app/main.js'" in node_cmds[0]
         assert "/c/Users" not in node_cmds[0]
+
+# =========================================================================
+# _rg_native_path — Windows drive paths for the rg-backed searches
+# =========================================================================
+
+class TestRgNativePath:
+    """_rg_native_path must hand a Windows-native rg.exe ``D:/...`` paths.
+
+    Hermes disables MSYS argv conversion by default
+    (``MSYS2_ARG_CONV_EXCL=*`` / ``MSYS_NO_PATHCONV=1``), so the Git Bash
+    ``/d/...`` form that ``_bash_safe_path`` produces is never converted
+    back for a Windows-native ``rg.exe`` — it resolves to ``C:\\d\\...``
+    and fails with os error 3. Regression: search_files returned empty
+    results for every absolute Windows path.
+    """
+
+    def test_msys_drive_form_converted_to_native(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("/d/projects/foo") == "D:/projects/foo"
+
+    def test_bare_msys_drive_converted(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("/d") == "D:/"
+
+    def test_backslash_native_form_normalized(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("D:\\projects\\foo") == "D:/projects/foo"
+
+    def test_forward_slash_native_form_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("D:/projects/foo") == "D:/projects/foo"
+
+    def test_relative_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _rg_native_path("src/components") == "src/components"
+
+    def test_noop_off_windows(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+        assert _rg_native_path("/d/projects/foo") == "/d/projects/foo"
+        assert _rg_native_path("D:/projects/foo") == "D:/projects/foo"
+
+
+class TestSearchFilesRgWindowsDrivePath:
+    """The rg-backed search commands must embed native ``D:/...`` paths."""
+
+    def _make_env(self):
+        env = MagicMock()
+        env.cwd = "/"
+        env.execute.return_value = {"output": "", "returncode": 0}
+        return env
+
+    def test_file_search_command_uses_native_drive_path(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        ops._search_files_rg("*.log", "D:\\projects\\foo", limit=50, offset=0)
+        cmd = env.execute.call_args.args[0]
+        assert "D:/projects/foo" in cmd
+        assert "/d/projects/foo" not in cmd
+
+    def test_content_search_command_uses_native_drive_path(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        ops._search_with_rg("error", "D:\\projects\\foo", None, 50, 0, "content", 0)
+        cmd = env.execute.call_args.args[0]
+        assert "D:/projects/foo" in cmd
+        assert "/d/projects/foo" not in cmd
+
+    def test_file_search_surfaces_rg_error_instead_of_empty(self):
+        """rg os error 3 must be reported, not silently swallowed.
+
+        The old ``2>/dev/null`` made a broken search indistinguishable
+        from an empty directory; pipefail + exit-code check now surface
+        the diagnostic.
+        """
+        env = self._make_env()
+        env.execute.return_value = {
+            "output": (
+                "rg: /d/projects/foo: IO error for operation on "
+                "/d/projects/foo: 系统找不到指定的路径。 (os error 3)"
+            ),
+            "returncode": 2,
+        }
+        ops = ShellFileOperations(env)
+        result = ops._search_files_rg("*.log", "D:/projects/foo", limit=50, offset=0)
+        assert result.error is not None
+        assert "os error" in result.error
+        assert result.files == []
+        assert result.total_count == 0

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -233,7 +233,7 @@ class TestPaginationBounds:
             commands.append(command)
             if command.startswith("test -e"):
                 return MagicMock(exit_code=0, stdout="exists")
-            if command.startswith("rg --files"):
+            if "rg --files" in command:
                 return MagicMock(exit_code=0, stdout="a.py\n")
             return MagicMock(exit_code=0, stdout="")
 
@@ -242,7 +242,7 @@ class TestPaginationBounds:
             result = ops.search("*.py", target="files", path=".", offset=-4, limit=-2)
 
         assert result.files == ["a.py"]
-        rg_commands = [cmd for cmd in commands if cmd.startswith("rg --files")]
+        rg_commands = [cmd for cmd in commands if "rg --files" in cmd]
         assert rg_commands
         assert "| head -n 1" in rg_commands[0]
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -356,6 +356,37 @@ class ExecuteResult:
 _SEARCH_TIMEOUT_MARKER_RE = re.compile(r"\n?\[Command timed out after \d+s\]\s*$")
 
 
+def _rg_native_path(path: str) -> str:
+    """Return *path* in the form a Windows-native ``rg`` executable accepts.
+
+    ``_escape_shell_arg`` rewrites ``D:\\...`` / ``D:/...`` to the Git Bash
+    ``/d/...`` form via ``_bash_safe_path`` — correct for MSYS-built
+    programs (bash builtins, ``find``) but wrong for a Windows-native
+    ``rg.exe``: Hermes disables MSYS argv conversion by default
+    (``MSYS2_ARG_CONV_EXCL=*`` + ``MSYS_NO_PATHCONV=1``, set in
+    ``tools/environments/local.py``), so a literal ``/d/...`` reaches rg
+    and is resolved as ``C:\\d\\...`` — "system cannot find the path
+    specified" (os error 3). Windows-native rg accepts ``D:/...``
+    directly, so rg commands must use that form on Windows and skip the
+    MSYS rewrite. No-op off Windows and for relative / non-drive paths.
+    """
+    from tools.environments.local import _IS_WINDOWS
+
+    if not _IS_WINDOWS or not path:
+        return path
+    # MSYS drive form "/d/rest" -> "D:/rest" (also covers bare "/d").
+    m = re.match(r"^/([A-Za-z])(?:/(.*))?$", path)
+    if m:
+        drive = m.group(1).upper()
+        rest = m.group(2) or ""
+        return f"{drive}:/{rest}" if rest else f"{drive}:/"
+    # Native Windows forms: normalize backslashes, keep forward slashes.
+    path = path.replace("\\", "/")
+    if re.match(r"^[A-Za-z]:/", path):
+        return path
+    return path
+
+
 def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]:
     """Return stdout cleaned for parsing and a limit reason for search timeouts."""
     if result.exit_code == 124:
@@ -1171,6 +1202,18 @@ class ShellFileOperations(FileOperations):
         if _IS_WINDOWS and arg:
             arg = _msys_to_windows_path(arg).replace("\\", "/")
         return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+    def _quote_rg_path(self, path: str) -> str:
+        """Quote *path* for an ``rg`` invocation using the native form rg reads.
+
+        Like :meth:`_escape_shell_arg` but keeps Windows drive paths in the
+        ``D:/...`` form a Windows-native ``rg.exe`` understands instead of
+        rewriting them to the MSYS ``/d/...`` form (which only MSYS-built
+        tools accept — see :func:`_rg_native_path`).
+        """
+        import shlex
+
+        return shlex.quote(_rg_native_path(path))
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
@@ -2891,26 +2934,40 @@ class ShellFileOperations(FileOperations):
             glob_pattern = pattern
 
         fetch_limit = limit + offset
-        # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
+        rg_path = self._quote_rg_path(path)
+        # `set -o pipefail` so rg's exit status survives the `| head`
+        # truncation (mirrors _search_with_rg). `_exec` merges stderr into
+        # stdout, so diagnostics stay recoverable via _split_tool_diagnostics.
+        # Try mtime-sorted first (rg 13+); older rg exits 2 on the unknown
+        # --sortr flag, so fall back to unsorted when nothing came back.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_native_tool_arg(path)} 2>/dev/null "
-            f"| head -n {fetch_limit}"
+            f"set -o pipefail; rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"{rg_path} | head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        all_files = [f for f in stdout.strip().split('\n') if f]
+        diagnostics, payload = _split_tool_diagnostics(stdout)
+        all_files = [f for f in payload.strip().split('\n') if f]
 
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_native_tool_arg(path)} 2>/dev/null "
-                f"| head -n {fetch_limit}"
+                f"set -o pipefail; rg --files -g {self._escape_shell_arg(glob_pattern)} "
+                f"{rg_path} | head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
-            all_files = [f for f in stdout.strip().split('\n') if f]
+            diagnostics, payload = _split_tool_diagnostics(stdout)
+            all_files = [f for f in payload.strip().split('\n') if f]
+
+        # rg exit codes: 0=ok, 2=hard error (missing root, IO failure).
+        # Surface the diagnostics instead of silently returning "no files":
+        # the old `2>/dev/null` masked failures such as os error 3 on a
+        # Windows drive path, making a broken search indistinguishable from
+        # an empty directory.
+        if result.exit_code == 2 and not all_files:
+            error_msg = diagnostics.strip() or stdout.strip() or "rg exited with status 2"
+            return SearchResult(error=f"File search failed: {error_msg}", total_count=0)
 
         page = all_files[offset:offset + limit]
 
@@ -2987,12 +3044,10 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path (path via _quote_rg_path: Windows-native rg
+        # needs D:/... — the MSYS /d/... form yields os error 3).
         cmd_parts.append(self._escape_shell_arg(pattern))
-        # rg is a native Windows binary when installed via winget/cargo/choco:
-        # it needs the C:/... path form, not the MSYS /c/... form (which
-        # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
-        cmd_parts.append(self._escape_native_tool_arg(path))
+        cmd_parts.append(self._quote_rg_path(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2773,7 +2773,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2795,7 +2795,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2815,7 +2815,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_shell_arg(pattern)} {self._quote_rg_path(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -3047,7 +3047,10 @@ class ShellFileOperations(FileOperations):
         # Add pattern and path (path via _quote_rg_path: Windows-native rg
         # needs D:/... — the MSYS /d/... form yields os error 3).
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._quote_rg_path(path))
+        # rg is a native Windows binary when installed via winget/cargo/choco:
+        # it needs the C:/... path form, not the MSYS /c/... form (which
+        # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
+        cmd_parts.append(self._escape_native_tool_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,


### PR DESCRIPTION
## Summary

On Windows, `search_files` fails for every absolute drive path (e.g. `D:\projects\foo`):

- The rg-backed search commands rewrite Windows paths (`D:\...` / `D:/...`) to the Git Bash `/d/...` form via `_bash_safe_path`.
- Hermes disables MSYS argv conversion by default (`MSYS2_ARG_CONV_EXCL=*` + `MSYS_NO_PATHCONV=1`, see `tools/environments/local.py`), so a **Windows-native** `rg.exe` receives the literal `/d/...` and resolves it as `C:\d\...` → "system cannot find the path specified" (os error 3).
- **File search** (`_search_files_rg`) silently swallowed the failure (`2>/dev/null`, no exit-code check) and returned "no files" — a broken search was indistinguishable from an empty directory.
- **Content search** (`_search_with_rg`) surfaced a confusing path error.

## Changes

- Add `_rg_native_path` / `_quote_rg_path`: rg commands now pass native `D:/...` paths on Windows (no-op off Windows and for relative/non-drive paths). MSYS-built tools (`find`, bash builtins) keep the `/d/...` form.
- `_search_files_rg`: drop `2>/dev/null`, add `set -o pipefail` + exit-code check so a hard rg failure returns `SearchResult.error` instead of an empty result (mirrors `_search_with_rg`'s existing error surfacing).
- Tests:
  - `_rg_native_path` conversions (MSYS → native, backslash → forward slash, relative/no-op cases).
  - Both search modes embed `D:/...` (not `/d/...`) in the command on Windows.
  - rg os error 3 is surfaced as `SearchResult.error`, not an empty result.
  - Relax the pagination test's `startswith("rg --files")` assertion to `in` so it tolerates the `set -o pipefail; ` prefix.

## Verification

- New tests: 9 pass (65 passed, 3 pre-existing Windows-only failures unrelated to this PR: two `TestSearchFilesFallbackHiddenPaths` cases use GNU `find -printf` under cmd.exe, and one umask-permission test on the atomic-write path — all fail identically on `main`).
- End-to-end on Windows with the real Git Bash + WinGet native rg: file search for `D:\projects\greenscreen-studio` now returns `package.json` (previously 0 results); content search returns 4 matches (previously os error 3).

## Notes

This reproduces only on Windows hosts where `rg` resolves to a Windows-native build (e.g. WinGet/scoop installs); MSYS2-built `rg` accepts `/d/...`, which is why the issue is environment-dependent.