### PR TITLE
chore: add contributor email mapping for johnrazmus

### DIFF
--- a/contributors/emails/jr.razmus@gmail.com
+++ b/contributors/emails/jr.razmus@gmail.com
@@ -1,0 +1,1 @@
+johnrazmus


### PR DESCRIPTION
Attribution mapping for @johnrazmus (jr.razmus@gmail.com), needed by the #65260 salvage.