### PR TITLE
fix: close the Codex app-server session on agent teardown (salvage #65260)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4274,6 +4274,21 @@ class AIAgent:
         except Exception:
             pass
 
+        # 6c. Close the Codex app-server session. The runtime already drops
+        # it on turn crash / retirement (agent/codex_runtime.py), but hard
+        # teardown had no owner — a /new, /reset, or session expiry left the
+        # app-server child process running until interpreter exit. Clear the
+        # attribute BEFORE close() so a concurrent reader can't grab a
+        # half-closed session, and so a raising close() can't strand a stale
+        # reference behind.
+        try:
+            codex_session = getattr(self, "_codex_session", None)
+            if codex_session is not None:
+                self._codex_session = None
+                codex_session.close()
+        except Exception:
+            pass
+
         # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
         # boundaries (/new, /reset, session expiry), so the message list won't

--- a/tests/run_agent/test_codex_app_server_lifecycle.py
+++ b/tests/run_agent/test_codex_app_server_lifecycle.py
@@ -1,0 +1,82 @@
+"""Codex app-server session lifecycle on hard agent teardown (#65260).
+
+The Codex runtime drops ``agent._codex_session`` on turn crash and on
+retirement (agent/codex_runtime.py), but ``AIAgent.close()`` — the hard
+teardown for /new, /reset, and session expiry — had no owner for it, so
+the app-server child process survived until interpreter exit.
+"""
+
+import threading
+
+from run_agent import AIAgent
+
+
+class _FakeCodexSession:
+    def __init__(self, raises: bool = False):
+        self.close_calls = 0
+        self._raises = raises
+
+    def close(self):
+        self.close_calls += 1
+        if self._raises:
+            raise RuntimeError("app-server already dead")
+
+
+def _bare_agent(session_id: str) -> AIAgent:
+    """Minimal agent shell exercising close() without a real build."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = session_id
+    agent.client = None
+    agent._active_children_lock = threading.Lock()
+    agent._active_children = set()
+    agent._end_session_on_close = False
+    agent._session_messages = ["retained"]
+    return agent
+
+
+def test_agent_close_releases_codex_app_server_session(monkeypatch):
+    agent = _bare_agent("test-codex-lifecycle")
+    codex_session = _FakeCodexSession()
+    agent._codex_session = codex_session
+
+    monkeypatch.setattr("run_agent.cleanup_vm", lambda _task_id: None)
+    monkeypatch.setattr("run_agent.cleanup_browser", lambda _task_id: None)
+
+    agent.close()
+    agent.close()
+
+    # Idempotent: the second close must not re-close a released session.
+    assert codex_session.close_calls == 1
+    assert agent._codex_session is None
+    assert agent._session_messages == []
+
+
+def test_close_clears_reference_even_when_session_close_raises(monkeypatch):
+    """A wedged app-server must not strand a stale session reference.
+
+    The attribute is cleared BEFORE close() precisely so a raising close
+    can't leave a dead session attached to the agent.
+    """
+    agent = _bare_agent("test-codex-lifecycle-raises")
+    codex_session = _FakeCodexSession(raises=True)
+    agent._codex_session = codex_session
+
+    monkeypatch.setattr("run_agent.cleanup_vm", lambda _task_id: None)
+    monkeypatch.setattr("run_agent.cleanup_browser", lambda _task_id: None)
+
+    agent.close()
+
+    assert codex_session.close_calls == 1
+    assert agent._codex_session is None
+
+
+def test_close_without_codex_session_is_a_noop(monkeypatch):
+    """Non-Codex sessions (the common case) must be unaffected."""
+    agent = _bare_agent("test-no-codex")
+
+    monkeypatch.setattr("run_agent.cleanup_vm", lambda _task_id: None)
+    monkeypatch.setattr("run_agent.cleanup_browser", lambda _task_id: None)
+
+    agent.close()
+
+    assert getattr(agent, "_codex_session", None) is None


### PR DESCRIPTION
Salvages the Codex-teardown commit (b7d7cfd0e) of #65260 by @johnrazmus — ported with authorship preserved.

## Context — what this fixes, for whom

Anyone running the Codex app-server runtime in a long-lived process (gateway, desktop, TUI): `agent/codex_runtime.py` already drops `_codex_session` on turn crash and on retirement, but `AIAgent.close()` — the HARD teardown path for `/new`, `/reset`, and session expiry — had no owner for it. Verified on current main: `close()` has zero `_codex_session` references, so every ended Codex session leaks its app-server child process until interpreter exit. A gateway that cycles sessions all day accumulates them.

## Port notes

- Ported rather than cherry-picked: the PR's `close()` predates ~4,000 commits of teardown-step churn (main's close() now runs through step 7 with computer-use release and a cached-client close at 6b). The hunk is re-anchored as step 6c; the author's logic is unchanged.
- Ordering preserved from the original: the attribute is cleared BEFORE `close()` so a concurrent reader can't observe a half-closed session and a raising `close()` can't strand a stale reference.
- Test file extends the author's original lifecycle test with two cases the port made worth pinning: a raising `close()` must still clear the reference, and a non-Codex agent must be unaffected.

## Verification

- `tests/run_agent/test_codex_app_server_lifecycle.py`: 3 passed
- Codex sweep (`tests/run_agent/ -k codex`): 149 passed, 1 failed — `test_manual_approvals_keep_codex_server_requests_fail_closed`, confirmed PRE-EXISTING on clean `upstream/main` (reproduced in a fresh worktree at the same SHA), unrelated to this diff
- Mutation check: revert run_agent.py to main → 2 of 3 fail; restore → 3 pass
- ruff clean

## Scope

This is one commit out of #65260's ten. The rest of that PR is being adjudicated separately — the state-growth core (SessionPolicy, per-source retention, trigram toggle, finalize-stale) has real value but needs its own vehicle plus the review fixes; several Codex/Discord commits are still under evaluation. This one had the clearest bug, a self-contained diff, and no interaction with in-flight work.
