### PR TITLE
fix(mattermost): preserve Unicode upload filenames

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -60,6 +60,18 @@ logger = logging.getLogger(__name__)
 # practical limit for readable messages — matching OpenClaw's choice).
 MAX_POST_LENGTH = 4000
 
+
+def _new_file_upload_form():
+    """Create multipart data without percent-encoding Unicode filenames.
+
+    Mattermost stores the multipart ``filename`` parameter verbatim. The
+    aiohttp default (``quote_fields=True``) percent-encodes non-ASCII names,
+    leaving users with attachment names such as ``%E9%AB%98...docx``.
+    """
+    import aiohttp
+
+    return aiohttp.FormData(quote_fields=False)
+
 # Channel type codes returned by the Mattermost API.
 _CHANNEL_TYPE_MAP = {
     "D": "dm",
@@ -285,7 +297,7 @@ class MattermostAdapter(BasePlatformAdapter):
         import aiohttp
 
         url = f"{self._base_url}/api/v4/files"
-        form = aiohttp.FormData()
+        form = _new_file_upload_form()
         form.add_field("channel_id", channel_id)
         form.add_field(
             "files",
@@ -1091,7 +1103,7 @@ async def _standalone_send(
                 file_path = media.get("path") if isinstance(media, dict) else media
                 if not file_path or not os.path.exists(file_path):
                     continue
-                form = aiohttp.FormData()
+                form = _new_file_upload_form()
                 # Mattermost requires channel_id on file uploads so the
                 # server can attribute them.
                 form.add_field("channel_id", chat_id)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -404,6 +404,40 @@ class TestMattermostFileUpload:
         self.adapter._session = MagicMock()
 
     @pytest.mark.asyncio
+    async def test_upload_preserves_unicode_filename(self):
+        """Mattermost should receive readable Unicode multipart filenames."""
+        filename = "质量审查报告.docx"
+        captured = {}
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 201
+        mock_resp.json = AsyncMock(return_value={
+            "file_infos": [{"id": "file_unicode"}]
+        })
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        def capture_upload(*args, **kwargs):
+            payload = kwargs["data"]()
+            file_part = payload._parts[1][0]
+            captured["content_disposition"] = file_part.headers["Content-Disposition"]
+            return mock_resp
+
+        self.adapter._session.post = MagicMock(side_effect=capture_upload)
+
+        file_id = await self.adapter._upload_file(
+            "channel_1",
+            b"document-data",
+            filename,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+        assert file_id == "file_unicode"
+        assert f'filename="{filename}"' in captured["content_disposition"]
+        assert "%E9" not in captured["content_disposition"]
+
+    @pytest.mark.asyncio
     @patch("tools.url_safety.is_safe_url", return_value=True)
     async def test_send_image_downloads_and_uploads(self, _mock_safe):
         """send_image should download the URL, upload via /api/v4/files, then post."""


### PR DESCRIPTION
## Summary

- construct Mattermost multipart forms with `quote_fields=False` so Unicode filenames remain readable
- apply the fix to both live-adapter uploads and standalone/cron uploads
- add a regression test covering the actual multipart `Content-Disposition` header

## Reproduction

With aiohttp's default `FormData()`, uploading a file named `质量审查报告.docx` produces a percent-encoded `filename` parameter such as:

```text
filename="%E8%B4%A8%E9%87%8F...docx"
```

Mattermost stores that value literally. With `FormData(quote_fields=False)`, the multipart header keeps the original Unicode filename.

## Test plan

- `scripts/run_tests.sh tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py -q` (25 passed)
- `.venv/bin/ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`
- `git diff --check origin/main...HEAD`

## Live verification

A Mattermost upload using the corrected multipart form was followed by `GET /api/v4/files/{file_id}/info`; the server returned the original Unicode filename unchanged.
