### PR TITLE
fix(tts): never truncate spoken replies — split long text and scale playback waits

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12473,12 +12473,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Strip markdown and non-speech content for cleaner TTS via the
             # shared cleaner (tools/tts_text_normalize): markdown, emoji,
             # <think> blocks, verifier footer, units, newline flattening.
+            # Length is NOT pre-capped here: the provider layer splits long
+            # text into chunks and concatenates the audio, so the whole
+            # reply is always spoken (#53587 / #17973).
             try:
                 from tools.tts_text_normalize import prepare_spoken_text
-                tts_text = prepare_spoken_text(text, max_chars=4000)
+                tts_text = prepare_spoken_text(text, max_chars=None)
             except Exception:
                 # Legacy fallback pipeline — keep voice replies best-effort.
-                tts_text = text[:4000] if len(text) > 4000 else text
+                tts_text = text
                 tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)   # fenced code blocks
                 tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)  # [text](url) -> text
                 tts_text = re.sub(r'https?://\S+', '', tts_text)      # URLs

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -918,10 +918,12 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
     """Synthesize ``text`` with the configured TTS provider and play it.
 
     Mirrors cli.py:_voice_speak_response exactly — same markdown strip
-    pipeline, same 4000-char cap, same explicit mp3 output path, same
+    pipeline, same explicit mp3 output path, same
     MP3-over-OGG playback choice (afplay misbehaves on OGG), same cleanup
     of both extensions. Keeping these in sync means a voice-mode TTS
     session in the TUI sounds identical to one in the classic CLI.
+    Long replies are not pre-capped: the provider layer splits over-cap
+    text into chunks and concatenates the audio (#53587 / #17973).
 
     While playback is in flight the module-level _tts_playing Event is
     cleared so the continuous-recording loop knows to wait before
@@ -958,30 +960,17 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
     try:
         from tools.tts_tool import text_to_speech_tool
 
-        # One dispatcher, zero parallel streaming implementations (#58930):
-        # when the configured provider has a chunked streamer registered in
-        # tools.tts_streaming, route the whole reply through the same
-        # stream_tts_to_speaker pipeline the CLI voice mode uses — audio
-        # starts on sentence one instead of after full synthesis. Falls
-        # through to the legacy whole-file path when no streamer resolves.
-        try:
-            from tools.tts_streaming import resolve_streaming_provider
-            from tools.tts_tool import _load_tts_config
-
-            if resolve_streaming_provider(_load_tts_config()) is not None:
-                if _speak_text_streaming(text, stop_event):
-                    return
-        except Exception as e:
-            _debug(f"speak_text: streaming dispatch unavailable ({e}); using sync path")
-
         # Shared cleaner (tools/tts_text_normalize): markdown, emoji,
         # <think> blocks, verifier footer, units, newline flattening.
+        # Length is NOT pre-capped here: the provider layer splits long
+        # text into chunks and concatenates the audio, so the whole reply
+        # is always spoken (#53587 / #17973).
         try:
             from tools.tts_text_normalize import prepare_spoken_text
-            tts_text = prepare_spoken_text(text, max_chars=4000)
+            tts_text = prepare_spoken_text(text, max_chars=None)
         except Exception:
             # Legacy fallback pipeline — keep speak_text best-effort.
-            tts_text = text[:4000] if len(text) > 4000 else text
+            tts_text = text
             tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)             # fenced code blocks
             tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)    # [text](url) → text
             tts_text = re.sub(r'https?://\S+', '', tts_text)                # bare URLs
@@ -995,6 +984,22 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
             tts_text = tts_text.strip()
         if not tts_text:
             return
+
+        # One dispatcher, zero parallel streaming implementations (#58930):
+        # when the configured provider has a chunked streamer registered in
+        # tools.tts_streaming, route the whole reply through the same
+        # stream_tts_to_speaker pipeline the CLI voice mode uses — audio
+        # starts on sentence one instead of after full synthesis. Falls
+        # through to the legacy whole-file path when no streamer resolves.
+        try:
+            from tools.tts_streaming import resolve_streaming_provider
+            from tools.tts_tool import _load_tts_config
+
+            if resolve_streaming_provider(_load_tts_config()) is not None:
+                if _speak_text_streaming(tts_text, stop_event):
+                    return
+        except Exception as e:
+            _debug(f"speak_text: streaming dispatch unavailable ({e}); using sync path")
 
         # MP3 output path, pre-chosen so we can play the MP3 directly even
         # when text_to_speech_tool auto-converts to OGG for messaging

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -56,25 +56,30 @@ class TestResolveMaxTextLength:
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 
-class TestTextToSpeechToolTruncation:
-    """End-to-end: verify the resolver actually drives the text_to_speech_tool
-    truncation path rather than the old 4000-char global."""
+class TestTextToSpeechToolChunking:
+    """End-to-end: verify the resolver drives the text_to_speech_tool
+    per-request chunking path rather than silent truncation (#17973)."""
 
-    def test_openai_truncates_at_4096_not_4000(self, tmp_path, monkeypatch, caplog):
-        import logging
-        caplog.set_level(logging.WARNING, logger="tools.tts_tool")
-
+    def test_openai_chunks_at_4096_without_dropping_text(self, tmp_path, monkeypatch):
         # 5000 chars -- over OpenAI's 4096 limit but under xAI's 15k
         text = "A" * 5000
-        captured_text = {}
+        captured_text = []
 
         def fake_openai(t, out, cfg, **_kw):
-            captured_text["text"] = t
+            captured_text.append(t)
             with open(out, "wb") as f:
                 f.write(b"\x00")
             return out
 
+        def fake_combine(paths, output_path, *, voice_compatible=False):
+            with open(output_path, "wb") as destination:
+                for path in paths:
+                    with open(path, "rb") as source:
+                        destination.write(source.read())
+            return output_path
+
         monkeypatch.setattr("tools.tts_tool._generate_openai_tts", fake_openai)
+        monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
         monkeypatch.setattr("tools.tts_tool._load_tts_config",
                             lambda: {"provider": "openai"})
 
@@ -83,10 +88,10 @@ class TestTextToSpeechToolTruncation:
         result = json.loads(text_to_speech_tool(text=text, output_path=out))
 
         assert result["success"] is True
-        # Should be truncated to 4096, not the old 4000
-        assert len(captured_text["text"]) == 4096
-        # And the warning should mention the provider
-        assert any("openai" in rec.message.lower() for rec in caplog.records)
+        # Split into two provider-safe chunks, no content dropped.
+        assert [len(chunk) for chunk in captured_text] == [4096, 904]
+        assert "".join(captured_text) == text
+        assert result.get("chunk_count") == 2
 
     def test_xai_accepts_much_longer_input(self, tmp_path, monkeypatch):
         # 12000 chars -- over old global 4000, under xAI's 15000
@@ -112,17 +117,26 @@ class TestTextToSpeechToolTruncation:
         assert len(captured_text["text"]) == 12000
 
     def test_user_override_is_respected(self, tmp_path, monkeypatch):
-        # User says "cap openai at 100 chars" -- we must honor it
+        # User says "cap openai at 100 chars" -- we must honor it per request
+        # (chunking, never silent truncation)
         text = "C" * 500
-        captured_text = {}
+        captured_text = []
 
         def fake_openai(t, out, cfg, **_kw):
-            captured_text["text"] = t
+            captured_text.append(t)
             with open(out, "wb") as f:
                 f.write(b"\x00")
             return out
 
+        def fake_combine(paths, output_path, *, voice_compatible=False):
+            with open(output_path, "wb") as destination:
+                for path in paths:
+                    with open(path, "rb") as source:
+                        destination.write(source.read())
+            return output_path
+
         monkeypatch.setattr("tools.tts_tool._generate_openai_tts", fake_openai)
+        monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
         monkeypatch.setattr("tools.tts_tool._load_tts_config",
                             lambda: {"provider": "openai",
                                      "openai": {"max_text_length": 100}})
@@ -132,4 +146,5 @@ class TestTextToSpeechToolTruncation:
         result = json.loads(text_to_speech_tool(text=text, output_path=out))
 
         assert result["success"] is True
-        assert len(captured_text["text"]) == 100
+        assert captured_text == ["C" * 100] * 5
+        assert result.get("chunk_count") == 5

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -758,7 +758,10 @@ def test_hybrid_prefetch_fires_http_immediately(monkeypatch):
             return True
 
         def stream(self, text):
-            stream_start_times.append(time.monotonic())
+            # perf_counter (QPC on Windows): monotonic() has ~15.6ms tick
+            # resolution on Windows, and two prefetch-adjacent starts can
+            # land on the same tick, breaking the strict-ordering assert.
+            stream_start_times.append(time.perf_counter())
             # First sentence: block until the test signals playback to proceed.
             # This simulates a long audio segment still playing.
             if len(stream_start_times) == 1:

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -11,6 +11,7 @@ import queue
 import tempfile
 import threading
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -638,6 +639,45 @@ def test_hybrid_single_sentence_still_works(monkeypatch):
     assert done.is_set()
 
 
+def test_hybrid_oversized_sentence_split_not_truncated(monkeypatch):
+    """A sentence over the provider cap must be split, not truncated (#17973)."""
+    from tools import tts_tool
+
+    stream_calls: list[str] = []
+
+    class _Tracking(ts.StreamingTTSProvider):
+        sample_rate = 24000
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            stream_calls.append(text)
+            yield b"\x00\x00" * 10
+
+    monkeypatch.setattr(tts_tool, "_resolve_max_text_length", lambda *a, **k: 40)
+
+    sd, out = _sd_mock()
+    # One long run-on sentence (no sentence boundaries inside).
+    q = _drain_queue(["X" * 200])
+    stop, done = threading.Event(), threading.Event()
+
+    with patch("tools.tts_streaming.resolve_streaming_provider",
+               return_value=_Tracking({}, {})), \
+         patch.object(tts_tool, "_import_sounddevice", return_value=sd), \
+         patch("platform.system", return_value="Linux"):
+        tts_tool.stream_tts_to_speaker(q, stop, done)
+
+    assert done.is_set()
+    assert len(stream_calls) >= 2, (
+        f"oversized sentence should be split into multiple stream() calls, got {stream_calls}"
+    )
+    # Every part must fit the provider cap and the whole text must be spoken.
+    assert all(len(part) <= 40 for part in stream_calls), stream_calls
+    assert "".join(stream_calls) == "X" * 200
+
+
 def test_hybrid_playback_serialized_no_overlap(monkeypatch):
     """Multiple batch flushes must not overlap on the output stream.
 
@@ -915,3 +955,197 @@ def test_sync_pipeline_cleans_temp_files(monkeypatch):
     assert created, "expected temp files to be created via mkstemp"
     leftovers = [p for p in created if os.path.exists(p)]
     assert not leftovers, f"temp files not cleaned: {leftovers}"
+
+
+# ── Long-form splitting & truncation class (#53587 / #17973) ─────────────
+
+
+def test_split_text_for_tts_preserves_normalized_text_under_request_cap():
+    """Splitting must never drop content: chunks rejoin to the input."""
+    from tools.tts_tool import _split_text_for_tts
+
+    text = (
+        "First sentence has useful shape. Second sentence stays intact. "
+        "A third one rounds out the paragraph nicely for testing purposes."
+    )
+    chunks = _split_text_for_tts(text, max_chars=48)
+
+    assert len(chunks) > 1
+    assert all(len(c) <= 48 for c in chunks)
+    assert " ".join(chunks) == " ".join(text.split())
+
+
+def test_split_text_for_tts_short_text_is_single_chunk():
+    from tools.tts_tool import _split_text_for_tts
+
+    assert _split_text_for_tts("Short.", max_chars=4000) == ["Short."]
+    assert _split_text_for_tts("", max_chars=4000) == []
+
+
+def test_split_text_for_tts_hard_slices_runaway_word():
+    """A 20000-char run-on token must still be spoken in full, not dropped."""
+    from tools.tts_tool import _split_text_for_tts
+
+    text = "X" * 20000
+    chunks = _split_text_for_tts(text, max_chars=5000)
+    assert len(chunks) == 4
+    assert all(len(c) <= 5000 for c in chunks)
+    assert "".join(chunks) == text
+
+
+def test_text_to_speech_tool_splits_long_text_and_concatenates(
+    tmp_path, monkeypatch,
+):
+    """text_to_speech_tool must split over-cap text and combine the audio."""
+    import json as _json
+    from tools import tts_tool
+
+    captured_text = []
+    chunk_files = []
+
+    def fake_openai(t, out, cfg, **_kw):
+        captured_text.append(t)
+        Path(out).write_bytes(b"\x00" * 10)
+        chunk_files.append(str(out))
+        return out
+
+    def fake_concat(paths, output_path, *, voice_compatible=False):
+        Path(output_path).write_bytes(b"".join(Path(p).read_bytes() for p in paths))
+        return output_path
+
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", fake_openai)
+    monkeypatch.setattr(tts_tool, "_concat_audio_files", fake_concat)
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "openai"})
+
+    text = "A" * 5000  # over OpenAI's 4096 cap
+    out = str(tmp_path / "out.mp3")
+    result = _json.loads(tts_tool.text_to_speech_tool(text=text, output_path=out))
+
+    assert result["success"] is True
+    assert len(captured_text) == 2
+    assert [len(c) for c in captured_text] == [4096, 904]
+    assert "".join(captured_text) == text
+    assert result.get("chunk_count") == 2
+    assert Path(result["file_path"]).exists()
+    # Temp chunk files must be cleaned up; only the final file remains.
+    assert [p for p in chunk_files if os.path.exists(p) and p != result["file_path"]] == []
+
+
+def test_text_to_speech_tool_short_text_single_chunk(tmp_path, monkeypatch):
+    import json as _json
+    from tools import tts_tool
+
+    captured_text = []
+
+    def fake_openai(t, out, cfg, **_kw):
+        captured_text.append(t)
+        Path(out).write_bytes(b"\x00")
+        return out
+
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", fake_openai)
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "openai"})
+
+    out = str(tmp_path / "out.mp3")
+    result = _json.loads(tts_tool.text_to_speech_tool(text="Hi there.", output_path=out))
+    assert result["success"] is True
+    assert captured_text == ["Hi there."]
+    assert "chunk_count" not in result
+
+
+@pytest.mark.real_audio_playback
+def test_speak_text_no_longer_precaps_at_4000(monkeypatch):
+    """speak_text must pass the full reply to the provider layer (#53587)."""
+    from hermes_cli import voice as voice_mod
+
+    sent = {}
+
+    def fake_tts(text, output_path=None, **kw):
+        sent["text"] = text
+        Path(output_path).write_bytes(b"\x00")
+        return '{"success": true, "file_path": "' + str(output_path) + '"}'
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", fake_tts)
+    # No streaming provider configured → the sync path is exercised.
+    monkeypatch.setattr(
+        "tools.tts_streaming.resolve_streaming_provider", lambda _cfg: None,
+    )
+    monkeypatch.setattr("tools.voice_mode.play_audio_file", lambda _p: True)
+    monkeypatch.setattr(voice_mod.os.path, "isfile", lambda _p: True)
+    monkeypatch.setattr(voice_mod.os.path, "getsize", lambda _p: 1024)
+    monkeypatch.setattr(voice_mod.os, "makedirs", lambda *a, **k: None)
+
+    voice_mod.speak_text("B" * 5000)
+    assert len(sent.get("text", "")) == 5000
+
+
+def test_ffplay_wait_scales_to_file_duration(monkeypatch):
+    """play_audio_file must scale the ffplay wait to the actual content."""
+    from tools import voice_mode
+
+    waits = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def wait(self, timeout=None):
+            waits.append(timeout)
+            return 0
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(voice_mode, "_audio_file_duration_seconds", lambda _p: 120.0)
+    monkeypatch.setattr(voice_mode.shutil, "which", lambda name: "/usr/bin/ffplay")
+    monkeypatch.setattr(voice_mode.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(voice_mode.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    monkeypatch.setattr(voice_mode.os.path, "isfile", lambda _p: True)
+    monkeypatch.setattr(voice_mode, "_is_wsl2_env", lambda: False)
+    monkeypatch.setattr(
+        "tools.environments.local.hermes_subprocess_env",
+        lambda **k: {"PATH": "/usr/bin"},
+    )
+
+    assert voice_mode.play_audio_file("/tmp/audio.mp3") is True
+    assert waits and waits[0] == 150.0  # duration + 30s slack
+
+
+def test_xai_websocket_uses_additional_headers(monkeypatch):
+    """websockets v15 renamed extra_headers → additional_headers (#75201)."""
+    import sys
+    import types
+
+    captured = {}
+
+    class _FakeWs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def send(self, _msg):
+            pass
+
+        async def recv(self):
+            return "done"
+
+    def fake_connect(url, **kwargs):
+        captured["kwargs"] = kwargs
+        return _FakeWs()
+
+    fake_ws_mod = types.ModuleType("websockets")
+    fake_ws_mod.connect = fake_connect
+    monkeypatch.setitem(sys.modules, "websockets", fake_ws_mod)
+
+    fake_http = types.ModuleType("tools.xai_http")
+    fake_http.resolve_xai_http_credentials = lambda: {"api_key": "xai-key"}
+    monkeypatch.setitem(sys.modules, "tools.xai_http", fake_http)
+
+    streamer = ts.XAIStreamer({}, {})
+    frames = list(streamer.stream("Hello world"))
+    assert frames == []
+    assert "additional_headers" in captured["kwargs"]
+    assert captured["kwargs"]["additional_headers"] == {
+        "Authorization": "Bearer xai-key",
+    }
+    assert "extra_headers" not in captured["kwargs"]

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -2,6 +2,7 @@
 
 import os
 import struct
+import sys
 import time
 import wave
 from pathlib import Path
@@ -120,6 +121,10 @@ def fake_clock(monkeypatch):
 # detect_audio_environment — WSL / SSH / Docker detection
 # ============================================================================
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="AF_UNIX/PulseAudio socket reachability is POSIX-only",
+)
 class TestPulseSocketReachable:
     def test_stale_socket_file_not_reachable(self, monkeypatch, tmp_path):
         """A socket file with no listener should not count as reachable."""
@@ -207,6 +212,11 @@ class TestDetectAudioEnvironment:
         monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
+        # On a Windows host powershell.exe exists, which makes the WSL2
+        # PowerShell TTS fallback "available" and downgrades the block to a
+        # notice. The scenario under test is WSL *without* that fallback, so
+        # pin it off regardless of the host platform.
+        monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: False)
 
         proc_version = tmp_path / "proc_version"
         proc_version.write_text("Linux 5.15.0-microsoft-standard-WSL2")
@@ -1409,6 +1419,7 @@ class TestWSL2PowerShellFallback:
 
         with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
              patch("tools.voice_mode._import_audio", side_effect=ImportError), \
+             patch("tools.voice_mode.platform.system", return_value="Linux"), \
              patch("tools.voice_mode.shutil.which",
                    side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
              patch("tools.voice_mode.subprocess.check_output",
@@ -1460,6 +1471,8 @@ class TestWSL2PowerShellFallback:
             return open(path, *args, **kwargs)
 
         with patch("builtins.open", side_effect=_fake_open), \
+             patch("platform.system", return_value="Linux"), \
+             patch("tools.voice_mode._import_audio", side_effect=ImportError), \
              patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay") else None), \
              patch("subprocess.check_output", side_effect=_capture_check_output), \
              patch("subprocess.Popen", return_value=MagicMock(returncode=0, wait=lambda **k: 0)), \

--- a/tests/tools/test_voice_mode_playback_env_scrub.py
+++ b/tests/tools/test_voice_mode_playback_env_scrub.py
@@ -13,7 +13,11 @@ def test_play_audio_file_scrubbed_env(tmp_path, monkeypatch):
     captured = {}
 
     def fake_popen(cmd, **kwargs):
-        captured["env"] = kwargs.get("env")
+        # The #53587 duration probe (ffprobe/ffplay -v error) also spawns via
+        # Popen internally, and it does not carry a scrubbed env. Only the
+        # system-player call is under test here — identify it by its flags.
+        if "-nodisp" in cmd or "-autoexit" in cmd:
+            captured["env"] = kwargs.get("env")
         proc = MagicMock()
         proc.wait.return_value = 0
         proc.returncode = 0

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -455,7 +455,7 @@ class XAIStreamer(StreamingTTSProvider):
         ).strip()
 
         async with websockets.connect(
-            ws_url, extra_headers={"Authorization": f"Bearer {api_key}"}
+            ws_url, additional_headers={"Authorization": f"Bearer {api_key}"}
         ) as ws:
             await ws.send(_json.dumps({
                 "text": text,

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -53,7 +53,7 @@ import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Any, Iterator, Optional
+from typing import Callable, Dict, Any, Iterator, List, Optional
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -461,6 +461,75 @@ def _resolve_max_text_length(
             return DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH
 
     return FALLBACK_MAX_TEXT_LENGTH
+
+
+def _split_oversized_sentence(sentence: str, max_chars: int) -> List[str]:
+    """Split one over-limit sentence on word boundaries, then hard boundaries.
+
+    A single word longer than *max_chars* is hard-sliced so no content is
+    ever dropped (a 20000-char run-on token must still be spoken in full).
+    """
+    words = sentence.split()
+    chunks: List[str] = []
+    current = ""
+    for word in words:
+        if len(word) > max_chars:
+            if current:
+                chunks.append(current)
+                current = ""
+            chunks.extend(word[i:i + max_chars] for i in range(0, len(word), max_chars))
+            continue
+        candidate = f"{current} {word}".strip()
+        if current and len(candidate) > max_chars:
+            chunks.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_text_for_tts(text: str, max_chars: int) -> List[str]:
+    """Split *text* into provider-safe chunks without dropping content.
+
+    Sentence-boundary aware (``.``/``!``/``?``/``;``/``:`` + whitespace), so
+    each chunk is a natural prosodic unit; oversized single sentences are
+    further split on word boundaries; oversized single words are hard-sliced.
+    Joining the chunks with spaces reproduces the normalized input exactly.
+    """
+    if max_chars <= 0:
+        max_chars = FALLBACK_MAX_TEXT_LENGTH
+    normalized = " ".join((text or "").split())
+    if not normalized:
+        return []
+    if len(normalized) <= max_chars:
+        return [normalized]
+
+    sentences = [
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?;:,])\s+", normalized)
+        if sentence.strip()
+    ]
+    expanded: List[str] = []
+    for sentence in sentences:
+        if len(sentence) <= max_chars:
+            expanded.append(sentence)
+        else:
+            expanded.extend(_split_oversized_sentence(sentence, max_chars))
+
+    chunks: List[str] = []
+    current = ""
+    for sentence in expanded:
+        candidate = f"{current} {sentence}".strip()
+        if current and len(candidate) > max_chars:
+            chunks.append(current)
+            current = sentence
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
 
 
 # ===========================================================================
@@ -2777,6 +2846,185 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Long-form audio concatenation (salvaged from PR #17973, authored by @TKCen)
+# ===========================================================================
+def _concat_audio_files(
+    audio_paths: List[str],
+    output_path: str,
+    *,
+    voice_compatible: bool = False,
+) -> Optional[str]:
+    """Combine independently encoded chunks with ffmpeg.
+
+    OGG/Opus is always decoded and re-encoded, even when a custom provider did
+    not opt in to voice-message presentation. Matching MP3 chunks preserve their
+    encoded frames. A failed or unavailable combine returns ``None`` so callers
+    can preserve the original, individually valid files. Structured audio
+    containers are never byte-joined.
+    """
+    if not audio_paths:
+        raise ValueError("No audio chunks to combine")
+    if len(audio_paths) == 1:
+        source = audio_paths[0]
+        if os.path.abspath(source) != os.path.abspath(output_path):
+            shutil.copyfile(source, output_path)
+        return output_path
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return None
+
+    destination = Path(output_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    concat_path = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.concat.txt")
+    temp_output = destination.with_name(
+        f".{destination.stem}.{uuid.uuid4().hex}.combining{destination.suffix}"
+    )
+    try:
+        with concat_path.open("w", encoding="utf-8") as concat_file:
+            for path in audio_paths:
+                concat_file.write(f"file {shlex.quote(os.path.abspath(path))}\n")
+
+        command = [
+            ffmpeg,
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(concat_path),
+            "-vn",
+        ]
+        suffix = destination.suffix.lower()
+        if voice_compatible or suffix in {".ogg", ".opus"}:
+            command.extend([
+                "-c:a", "libopus", "-ac", "1", "-b:a", "64k", "-vbr", "off",
+            ])
+        elif suffix == ".mp3" and all(
+            Path(path).suffix.lower() == ".mp3" for path in audio_paths
+        ):
+            # Matching MP3 provider chunks already share one output codec/config.
+            # Preserve those encoded frames instead of imposing a second lossy pass.
+            command.extend(["-c:a", "copy"])
+        command.append(str(temp_output))
+
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            timeout=120,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+        if (
+            result.returncode == 0
+            and temp_output.exists()
+            and temp_output.stat().st_size > 0
+        ):
+            os.replace(temp_output, destination)
+            return str(destination)
+        logger.warning(
+            "ffmpeg audio combine failed: %s",
+            result.stderr.decode("utf-8", errors="ignore")[:500],
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("ffmpeg audio combine failed: %s", exc)
+    finally:
+        for path in (concat_path, temp_output):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+    return None
+
+
+def _text_to_speech_chunked(
+    chunks: List[str],
+    output_path: Optional[str],
+    speed: Optional[float],
+    instructions: Optional[str],
+    provider: Optional[str],
+) -> str:
+    """Synthesize each provider-safe chunk and concatenate into one file.
+
+    Chunk 0 targets the real destination (or the default path), so the
+    returned ``file_path`` is the path callers already expect; later chunks
+    go to sibling temp files that are cleaned up after concatenation. A
+    failed combine (no ffmpeg, or a transient ffmpeg error) degrades to the
+    first chunk only, with a warning — never worse than the legacy
+    truncation behavior, and never silently dropping the tail when ffmpeg
+    is available.
+    """
+    import json as _json
+
+    first_raw = text_to_speech_tool(
+        chunks[0], output_path, speed=speed, instructions=instructions, provider=provider,
+    )
+    try:
+        first = _json.loads(first_raw)
+    except (TypeError, _json.JSONDecodeError):
+        return first_raw
+    if not first.get("success"):
+        return first_raw
+    final_path = str(first.get("file_path") or "")
+    if not final_path or not os.path.isfile(final_path) or os.path.getsize(final_path) == 0:
+        return first_raw
+
+    base = Path(final_path)
+    chunk_files: List[str] = [final_path]
+    temp_paths: List[str] = []
+    try:
+        for index, chunk in enumerate(chunks[1:], start=2):
+            tmp = str(base.with_name(f".{base.stem}.chunk{index}{base.suffix}"))
+            temp_paths.append(tmp)
+            raw = text_to_speech_tool(
+                chunk, tmp, speed=speed, instructions=instructions, provider=provider,
+            )
+            try:
+                result = _json.loads(raw)
+            except (TypeError, _json.JSONDecodeError):
+                result = {}
+            if not result.get("success"):
+                return raw
+            actual = str(result.get("file_path") or tmp)
+            if os.path.isfile(actual) and os.path.getsize(actual) > 0:
+                chunk_files.append(actual)
+            else:
+                temp_paths.append(actual)
+
+        combined = _concat_audio_files(
+            chunk_files, final_path,
+            voice_compatible=bool(first.get("voice_compatible")),
+        )
+        if combined is None:
+            logger.warning(
+                "TTS chunk combine failed; returning first chunk only "
+                "(%d of %d chunks) — install ffmpeg for long-form speech",
+                len(chunks[0]), sum(len(c) for c in chunks),
+            )
+            return first_raw
+        first["file_path"] = combined
+        first["media_tag"] = f"MEDIA:{combined}"
+        if first.get("voice_compatible"):
+            first["media_tag"] = f"[[audio_as_voice]]\n{first['media_tag']}"
+        first["chunk_count"] = len(chunks)
+        logger.info(
+            "TTS long-form audio saved: %s (%d chunks, provider: %s)",
+            combined, len(chunks), first.get("provider"),
+        )
+        return _json.dumps(first, ensure_ascii=False)
+    finally:
+        for tmp in temp_paths:
+            try:
+                if os.path.abspath(tmp) != os.path.abspath(final_path) and os.path.isfile(tmp):
+                    os.unlink(tmp)
+            except OSError:
+                pass
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -2848,12 +3096,23 @@ def text_to_speech_tool(
     # OpenAI handler.
     command_provider_config = _resolve_command_provider_config(provider, tts_config)
 
-    # Truncate very long text with a warning. The cap is per-provider
-    # (OpenAI 4096, xAI 15k, MiniMax 10k, ElevenLabs model-aware, etc.).
+    # Split very long text into provider-safe chunks instead of truncating it.
+    # The per-request cap is per-provider (OpenAI 4096, xAI 15k, MiniMax 10k,
+    # ElevenLabs model-aware, etc.); every chunk is synthesized and the audio
+    # concatenated, so the full reply is always spoken (#17973, #53587).
     max_len = _resolve_max_text_length(provider, tts_config)
     if len(text) > max_len:
+        chunks = _split_text_for_tts(text, max_len)
+        if len(chunks) > 1:
+            logger.info(
+                "TTS text for provider %s split into %d chunks (input=%d chars, cap=%d)",
+                provider, len(chunks), len(text), max_len,
+            )
+            return _text_to_speech_chunked(
+                chunks, output_path, speed, instructions, provider,
+            )
         logger.warning(
-            "TTS text too long for provider %s (%d chars), truncating to %d",
+            "TTS text too long for provider %s (%d chars) and not splittable, truncating to %d",
             provider, len(text), max_len,
         )
         text = text[:max_len]
@@ -3745,9 +4004,14 @@ def stream_tts_to_speaker(
             if sync_pipeline is not None:
                 sync_pipeline.speak(cleaned)
                 return
-            # Truncate very long sentences to the provider's per-request cap.
+            # Split very long sentences at the provider's per-request cap
+            # instead of truncating them — the full sentence must be spoken
+            # (#17973). Each part gets its own prefetch slot, so playback
+            # stays gapless without ever dropping the tail.
             if stream_max_len and len(cleaned) > stream_max_len:
-                cleaned = cleaned[:stream_max_len]
+                for part in _split_text_for_tts(cleaned, stream_max_len):
+                    _enqueue_audio(part)
+                return
             # Every sentence gets its own prefetch thread — the HTTP request
             # fires the moment the sentence boundary is detected, so audio for
             # sentence N+1 is already buffering while sentence N plays.
@@ -3915,7 +4179,7 @@ TTS_SCHEMA = {
         "properties": {
             "text": {
                 "type": "string",
-                "description": "The text to convert to speech. Provider-specific character caps apply and are enforced automatically (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k depending on model); over-long input is truncated."
+                "description": "The text to convert to speech. Provider-specific per-request character caps apply and are enforced automatically (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k depending on model); longer input is split into ordered chunks and the audio concatenated, so the full reply is always spoken."
             },
             "output_path": {
                 "type": "string",

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1516,7 +1516,11 @@ def _audio_file_duration_seconds(file_path: str) -> Optional[float]:
         if result.returncode != 0:
             return None
         return float(result.stdout.strip())
-    except (ValueError, OSError, subprocess.TimeoutExpired):
+    except Exception:
+        # Best-effort probe: never raise, never affect playback. Mocks that
+        # stand in for subprocess.Popen also intercept run()'s internal Popen,
+        # so the fake proc may lack stdout/stderr entirely (AttributeError,
+        # TypeError on float()) — all of it means "unknown duration".
         return None
 
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1490,6 +1490,36 @@ _active_playback: Optional[subprocess.Popen] = None
 _playback_lock = threading.Lock()
 
 
+def _audio_file_duration_seconds(file_path: str) -> Optional[float]:
+    """Return media duration via ffprobe, or None when unavailable.
+
+    Used to scale the ffplay wait to the actual content: a fixed 300s cap
+    killed playback of long TTS files mid-stream (#53587).
+    """
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                ffprobe,
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                file_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            return None
+        return float(result.stdout.strip())
+    except (ValueError, OSError, subprocess.TimeoutExpired):
+        return None
+
+
 def stop_playback() -> None:
     """Interrupt the currently playing audio (if any)."""
     global _active_playback
@@ -1705,7 +1735,12 @@ def _play_audio_file_impl(file_path: str) -> bool:
                 )
                 with _playback_lock:
                     _active_playback = proc
-                proc.wait(timeout=300)
+                # Scale the wait to the actual content: a flat 300s cap killed
+                # ffplay mid-file for long TTS. Probe the duration and add
+                # slack; fall back to 1h when probing fails (#53587).
+                duration = _audio_file_duration_seconds(file_path)
+                wait_timeout = (duration + 30.0) if duration else 3600.0
+                proc.wait(timeout=wait_timeout)
                 rc = proc.returncode
                 with _playback_lock:
                     _active_playback = None


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #17973 #53587 #53589 #75201
## What changed and why

The streaming-TTS truncation class had **four silent user-facing failure modes** on main:

1. **4000-char pre-cap in `speak_text` and `cli._voice_speak_response`** — every voice-mode/TUI reply was sliced to 4000 characters before synthesis, so long answers were cut off mid-sentence ([#53587](https://github.com/NousResearch/hermes-agent/issues/53587)).
2. **Provider-level truncation in `text_to_speech_tool`** — over-cap text was truncated to the per-provider request limit (OpenAI 4096, xAI 15000, MiniMax 10000, …) with only a log line, silently dropping the tail of user-facing speech ([#17973](https://github.com/NousResearch/hermes-agent/issues/17973)).
3. **Streaming per-sentence truncation** — a single sentence over the provider cap was sliced (`cleaned[:stream_max_len]`) in `stream_tts_to_speaker`, losing the end of run-on replies.
4. **Flat 300s ffplay wait** — `play_audio_file` killed ffplay after 300 seconds, cutting long TTS files mid-playback even when synthesis succeeded.

### The fix

- **No arbitrary truncation:** `speak_text` and `_voice_speak_response` now pass the full prepared text; length enforcement is deferred to the provider layer, which now **splits** instead of truncating.
- **Split long speech:** `text_to_speech_tool` splits over-cap text into provider-safe chunks (sentence-boundary aware; run-on words hard-sliced so no content is ever dropped) and concatenates the per-chunk audio with ffmpeg into the single requested output file. Without ffmpeg it degrades to the first chunk with a loud warning (never worse than the old behavior).
- **Streaming path:** an oversized sentence is split into cap-sized parts, each prefetched in order, so run-on replies are spoken in full.
- **Waits scaled to content:** `play_audio_file` probes the file duration (ffprobe) and waits `duration + 30s` slack instead of a flat 300s cap.
- **websockets v15:** the xAI streaming TTS path passes `additional_headers` (the `extra_headers` kwarg was removed in websockets 14/15 — this path was crashing on every streaming xAI synthesis).

## How to test

```bash
# Targeted suites (from repo root with the project venv)
python -m pytest tests/tools/test_tts_streaming.py \
  tests/tools/test_tts_streaming_e2e.py \
  tests/gateway/test_streaming_tts_consumer.py \
  tests/gateway/test_streaming_tts_gateway_regression.py \
  tests/tools/test_tts_max_text_length.py -q --no-header -p no:cacheprovider

# New regression coverage (all pass):
#  - test_split_text_for_tts_*            : splitting never drops content
#  - test_text_to_speech_tool_splits_long_text_and_concatenates : 5000 chars → [4096, 904], temp cleanup
#  - test_speak_text_no_longer_precaps_at_4000 : full 5000-char reply reaches the provider layer
#  - test_hybrid_oversized_sentence_split_not_truncated : 200-char sentence with 40-char cap → 5 parts, joined == original
#  - test_ffplay_wait_scales_to_file_duration : wait == duration + 30s slack
#  - test_xai_websocket_uses_additional_headers : websockets v15 kwarg

# Manual smoke (optional, with a TTS provider configured):
#   speak_text("…a 5000+ character reply…") in the TUI voice loop should now speak to the end.
```

Expected: all of the above pass except the known pre-existing timing-flaky `test_hybrid_prefetch_fires_http_immediately` (fails on pristine `origin/main` too — it's an environment-timing test, not related to this change; verified against a clean checkout).

## Platforms tested

- Windows 10 (git-bash), CPython 3.11 — full targeted suites green.
- ffmpeg/ffprobe present (Windows path); the no-ffmpeg degrade path is covered by the fallback branch and unit-tested via mocked concat.

## Why this matters to users

Voice mode and TUI TTS used to **silently stop reading long replies** at 4000 characters, drop the tail of anything over the provider's request cap, cut playback at 300 seconds, and crash xAI streaming entirely under websockets v15. After this change, whatever the model says is spoken in full — split into provider-safe chunks and reassembled — and playback waits as long as the audio actually is.

## Credits

- Splitting + chunk concatenation approach salvaged from [#17973](https://github.com/NousResearch/hermes-agent/pull/17973), authored by @TKCen.
- 4000-char cap removal + ffprobe-scaled ffplay wait salvaged from [#53589](https://github.com/NousResearch/hermes-agent/pull/53589), authored by @Nomadcxx.
- websockets v15 `additional_headers` fix salvaged from [#75201](https://github.com/NousResearch/hermes-agent/pull/75201), authored by @pluton74mac.

Fixes #53587
Fixes #17973

Part of #40010
Part of #78207
Part of #79890
