### PR TITLE
fix(optional-skills): correct fitness nutrition skill

### DIFF
--- a/optional-skills/health/fitness-nutrition/SKILL.md
+++ b/optional-skills/health/fitness-nutrition/SKILL.md
@@ -21,11 +21,11 @@ required_environment_variables:
     optional: true
 ---
 
-# Fitness & Nutrition
+# Fitness & Nutrition Skill
 
 Exercise and food-reference data plus offline calculators. Use this skill for
-lookups and mechanical calculations, not as a substitute for individualized
-medical advice, dietetic care, or a progressive training plan.
+lookups and mechanical calculations. It does not provide individualized medical
+advice, dietetic care, or progressive workout programming.
 
 **Data sources (all free, no pip dependencies):**
 
@@ -48,6 +48,36 @@ Trigger this skill when the user asks about:
 - Generic macro templates for cutting, bulking, or maintenance
 
 Do not use this as the primary skill for progressive workout programming, workout tracking, individualized meal planning, or medical nutrition. Route those tasks to the relevant planning, tracking, or clinical workflow, and use this skill only for the needed reference data or calculation.
+
+---
+
+## Prerequisites
+
+- `curl` and `python` available on PATH
+- For higher USDA FoodData Central rate limits, set the optional `USDA_API_KEY`
+  environment variable; `DEMO_KEY` works without signup
+
+## How to Run
+
+Run the helper scripts from the repository root, or use the read-only `curl`
+examples in Procedure for direct lookups. The offline calculators require only
+the Python standard library; network lookups require internet access.
+
+---
+
+## Quick Reference
+
+| Task | Source | Endpoint |
+|------|--------|----------|
+| Search exercises by name | wger | `python scripts/exercise_search.py "query"` (`name__search`, `language__code=en`) |
+| Exercise details | wger | `GET /api/v2/exerciseinfo/{id}/` |
+| Filter by muscle | wger | `GET /api/v2/exerciseinfo/?muscles={id}&language__code=en` |
+| Filter by equipment | wger | `GET /api/v2/exerciseinfo/?equipment={id}&language__code=en` |
+| List categories | wger | `GET /api/v2/exercisecategory/` |
+| List muscles | wger | `GET /api/v2/muscle/` |
+| Search foods | USDA | `GET /fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |
+| Food details | USDA | `GET /fdc/v1/food/{fdcId}` |
+| BMI / TDEE / 1RM / macros | offline | `python scripts/body_calc.py` |
 
 ---
 
@@ -244,19 +274,3 @@ muscle groups, and equipment; an HTTP 200 with an unrelated unfiltered list is
 not a successful search.
 After nutrition lookup: confirm per-100g macros are returned with kcal, protein, fat, carbs.
 After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most adults).
-
----
-
-## Quick Reference
-
-| Task | Source | Endpoint |
-|------|--------|----------|
-| Search exercises by name | wger | `python scripts/exercise_search.py "query"` (`name__search`, `language__code=en`) |
-| Exercise details | wger | `GET /api/v2/exerciseinfo/{id}/` |
-| Filter by muscle | wger | `GET /api/v2/exerciseinfo/?muscles={id}&language__code=en` |
-| Filter by equipment | wger | `GET /api/v2/exerciseinfo/?equipment={id}&language__code=en` |
-| List categories | wger | `GET /api/v2/exercisecategory/` |
-| List muscles | wger | `GET /api/v2/muscle/` |
-| Search foods | USDA | `GET /fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |
-| Food details | USDA | `GET /fdc/v1/food/{fdcId}` |
-| BMI / TDEE / 1RM / macros | offline | `python scripts/body_calc.py` |

--- a/optional-skills/health/fitness-nutrition/SKILL.md
+++ b/optional-skills/health/fitness-nutrition/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     tags: [health, fitness, nutrition, gym, workout, diet, exercise]
     category: health
     prerequisites:
-      commands: [curl, python]
+      tools: [terminal, web_extract]
 required_environment_variables:
   - name: USDA_API_KEY
     prompt: "USDA FoodData Central API key (free)"
@@ -24,19 +24,11 @@ required_environment_variables:
 # Fitness & Nutrition Skill
 
 Exercise and food-reference data plus offline calculators. Use this skill for
-lookups and mechanical calculations. It does not provide individualized medical
-advice, dietetic care, or progressive workout programming.
+lookups and mechanical calculations, not individualized medical advice, dietetic
+care, progressive workout programming, or individualized meal planning.
 
-**Data sources (all free, no pip dependencies):**
-
-- **wger** (https://wger.de/api/v2/) — open exercise database with muscles, equipment, and images. Public endpoints need zero authentication.
-- **USDA FoodData Central** (https://api.nal.usda.gov/fdc/v1/) — US government food-composition database. `DEMO_KEY` works instantly; free signup for higher limits.
-
-**Offline calculators (pure stdlib Python):**
-
-- BMI, TDEE (Mifflin-St Jeor), one-rep max (Epley/Brzycki/Lombardi), macro splits, body fat % (US Navy method)
-
----
+**Data sources:** wger (open exercise data) and USDA FoodData Central (food
+composition data). The bundled helpers use only the Python standard library.
 
 ## When to Use
 
@@ -47,230 +39,132 @@ Trigger this skill when the user asks about:
 - One-rep-max estimates and derived training percentages
 - Generic macro templates for cutting, bulking, or maintenance
 
-Do not use this as the primary skill for progressive workout programming, workout tracking, individualized meal planning, or medical nutrition. Route those tasks to the relevant planning, tracking, or clinical workflow, and use this skill only for the needed reference data or calculation.
-
----
+Do not use this as the primary skill for progressive workout programming, workout
+tracking, individualized meal planning, or medical nutrition. Route those tasks
+to the relevant planning, tracking, or clinical workflow, and use this skill only
+for needed reference data or calculations.
 
 ## Prerequisites
 
-- `curl` and `python` available on PATH
-- For higher USDA FoodData Central rate limits, set the optional `USDA_API_KEY`
-  environment variable; `DEMO_KEY` works without signup
+- The native `terminal` tool for invoking the bundled helper scripts.
+- The native `web_extract` tool for read-only direct lookups when a helper does
+  not cover the request.
+- For higher USDA FoodData Central rate limits, configure the optional
+  `USDA_API_KEY`; `DEMO_KEY` works without signup.
+- Network access is needed for wger and USDA lookups; calculators are offline.
 
 ## How to Run
 
-Run the helper scripts from the repository root, or use the read-only `curl`
-examples in Procedure for direct lookups. The offline calculators require only
-the Python standard library; network lookups require internet access.
+Use `terminal` with a helper path relative to this skill directory:
 
----
+- `scripts/exercise_search.py` searches and filters wger exercises.
+- `scripts/body_calc.py` performs BMI, TDEE, one-rep-max, macro, and body-fat
+  calculations.
+
+For direct read-only wger or USDA requests, use `web_extract` with the endpoint
+URL. Keep returned JSON intact while inspecting it, and present only the fields
+needed by the user. Do not use an unrelated unfiltered response as a search
+result.
 
 ## Quick Reference
 
-| Task | Source | Endpoint |
-|------|--------|----------|
-| Search exercises by name | wger | `python scripts/exercise_search.py "query"` (`name__search`, `language__code=en`) |
-| Exercise details | wger | `GET /api/v2/exerciseinfo/{id}/` |
-| Filter by muscle | wger | `GET /api/v2/exerciseinfo/?muscles={id}&language__code=en` |
-| Filter by equipment | wger | `GET /api/v2/exerciseinfo/?equipment={id}&language__code=en` |
-| List categories | wger | `GET /api/v2/exercisecategory/` |
-| List muscles | wger | `GET /api/v2/muscle/` |
-| Search foods | USDA | `GET /fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |
-| Food details | USDA | `GET /fdc/v1/food/{fdcId}` |
-| BMI / TDEE / 1RM / macros | offline | `python scripts/body_calc.py` |
-
----
+| Task | Native tool or helper | Request |
+|------|------------------------|---------|
+| Search exercises by name | `terminal` + `scripts/exercise_search.py` | `name__search`, `language__code=en` |
+| Exercise details | `web_extract` | `https://wger.de/api/v2/exerciseinfo/{id}/` |
+| Filter by muscle | `web_extract` | `/api/v2/exerciseinfo/?muscles={id}&language__code=en` |
+| Filter by equipment | `web_extract` | `/api/v2/exerciseinfo/?equipment={id}&language__code=en` |
+| List categories | `web_extract` | `/api/v2/exercisecategory/` |
+| List muscles | `web_extract` | `/api/v2/muscle/` |
+| Search foods | `web_extract` | `/fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |
+| Food details | `web_extract` | `/fdc/v1/food/{fdcId}` |
+| BMI / TDEE / 1RM / macros | `terminal` + `scripts/body_calc.py` | Offline calculator arguments |
 
 ## Procedure
 
 ### Exercise Lookup (wger API)
 
-All wger public endpoints return JSON and require no auth. Use the read-only
-`exerciseinfo` endpoint, add `language__code=en`, and request `format=json`.
+Use `terminal` to invoke the helper for searches. It calls the supported
+`/api/v2/exerciseinfo/` endpoint, requests English data, fetches at most 100
+candidates, reranks exact and all-token name matches, and emits at most the
+requested 1–20 records as compact JSON.
 
-**Step 1 — Identify what the user wants:**
+Examples of helper arguments:
 
-- By muscle → use `/api/v2/exerciseinfo/?muscles={id}&language__code=en&format=json`
-- By category → use `/api/v2/exerciseinfo/?category={id}&language__code=en&format=json`
-- By equipment → use `/api/v2/exerciseinfo/?equipment={id}&language__code=en&format=json`
-- By name → run `python scripts/exercise_search.py "{query}"`; it uses
-  `/api/v2/exerciseinfo/?name__search={query}&language__code=en&format=json`
-- Full details → use `/api/v2/exerciseinfo/{exercise_id}/?format=json`
+- Name: `scripts/exercise_search.py "pull up" --limit 10`
+- Muscle: `scripts/exercise_search.py --muscle 4 --limit 20`
+- Category: `scripts/exercise_search.py --category 11 --limit 20`
+- Equipment: `scripts/exercise_search.py --equipment 3 --limit 20`
+- Combined filters: `scripts/exercise_search.py --muscle 4 --equipment 1 --limit 20`
 
-**Step 2 — Reference IDs (so you don't need extra API calls):**
+For a detail or catalog request outside the helper, use `web_extract` on the
+read-only wger endpoint and request `language__code=en` and `format=json`.
+Relevant paths are `exerciseinfo/{exercise_id}/`,
+`exerciseinfo/?category={id}`, `exercisecategory/`, and `muscle/`.
 
-Exercise categories:
+Reference IDs commonly used by the API:
 
-| ID | Category    |
-|----|-------------|
-| 8  | Arms        |
-| 9  | Legs        |
-| 10 | Abs         |
-| 11 | Chest       |
-| 12 | Back        |
-| 13 | Shoulders   |
-| 14 | Calves      |
-| 15 | Cardio      |
+| ID | Category | ID | Muscle | ID | Equipment |
+|----|----------|----|--------|----|-----------|
+| 8 | Arms | 1 | Biceps brachii | 1 | Barbell |
+| 9 | Legs | 2 | Anterior deltoid | 3 | Dumbbell |
+| 10 | Abs | 4 | Pectoralis major | 6 | Pull-up bar |
+| 11 | Chest | 8 | Gluteus maximus | 7 | Bodyweight |
+| 12 | Back | 10 | Quadriceps femoris | 8 | Bench |
+| 13 | Shoulders | 12 | Latissimus dorsi | 10 | Kettlebell |
+| 14 | Calves | 14 | Triceps brachii | | |
+| 15 | Cardio | 15 | Soleus | | |
 
-Muscles:
-
-| ID | Muscle                    | ID | Muscle                  |
-|----|---------------------------|----|-------------------------|
-| 1  | Biceps brachii            | 2  | Anterior deltoid        |
-| 3  | Serratus anterior         | 4  | Pectoralis major        |
-| 5  | Obliquus externus         | 6  | Gastrocnemius           |
-| 7  | Rectus abdominis          | 8  | Gluteus maximus         |
-| 9  | Trapezius                 | 10 | Quadriceps femoris      |
-| 11 | Biceps femoris            | 12 | Latissimus dorsi        |
-| 13 | Brachialis                | 14 | Triceps brachii         |
-| 15 | Soleus                    |    |                         |
-
-Equipment:
-
-| ID | Equipment      |
-|----|----------------|
-| 1  | Barbell        |
-| 3  | Dumbbell       |
-| 4  | Gym mat        |
-| 5  | Swiss Ball     |
-| 6  | Pull-up bar    |
-| 7  | none (bodyweight) |
-| 8  | Bench          |
-| 9  | Incline bench  |
-| 10 | Kettlebell     |
-
-**Step 3 — Fetch and present results:**
-
-```bash
-# Search exercises by name
-python scripts/exercise_search.py "pull up" --limit 10
-```
-
-The helper fetches at most 100 wger candidates, reranks exact and all-token name matches, and returns only the requested 1–20 records.
-
-```bash
-# Get full details for a specific exercise
-EXERCISE_ID="$1"
-curl -s "https://wger.de/api/v2/exerciseinfo/${EXERCISE_ID}/?format=json" \
-  | python -c "
-import json,sys,html,re
-data=json.load(sys.stdin)
-trans=[t for t in data.get('translations',[]) if t.get('language')==2]
-t=trans[0] if trans else data.get('translations',[{}])[0]
-desc=re.sub('<[^>]+>','',html.unescape(t.get('description','N/A')))
-print(f\"Exercise  : {t.get('name','N/A')}\")
-print(f\"Category  : {data.get('category',{}).get('name','N/A')}\")
-print(f\"Primary   : {', '.join(m.get('name_en','') for m in data.get('muscles',[])) or 'N/A'}\")
-print(f\"Secondary : {', '.join(m.get('name_en','') for m in data.get('muscles_secondary',[])) or 'none'}\")
-print(f\"Equipment : {', '.join(e.get('name','') for e in data.get('equipment',[])) or 'bodyweight'}\")
-print(f\"How to    : {desc[:500]}\")
-imgs=data.get('images',[])
-if imgs: print(f\"Image     : {imgs[0].get('image','')}\")
-"
-```
-
-```bash
-# List exercises by one filter
-python scripts/exercise_search.py --muscle 4 --limit 20
-python scripts/exercise_search.py --category 11 --limit 20
-python scripts/exercise_search.py --equipment 3 --limit 20
-
-# Combine filters as needed
-python scripts/exercise_search.py --muscle 4 --equipment 1 --limit 20
-```
-
-The helper resolves English names from each record's `translations`, then emits
-compact JSON with IDs, names, muscles, equipment, descriptions, and images.
+Present exercise names, IDs, muscles, equipment, descriptions, and images when
+available. Treat community-maintained exercise data as reference material, not
+individualized technique or medical advice.
 
 ### Nutrition Lookup (USDA FoodData Central)
 
-Uses `USDA_API_KEY` env var if set, otherwise falls back to `DEMO_KEY`.
-DEMO_KEY = 30 requests/hour. Free signup key = 1,000 requests/hour.
+Use `web_extract` for the read-only USDA endpoints. Use `USDA_API_KEY` when
+configured, otherwise `DEMO_KEY`. Search with
+`/fdc/v1/foods/search?api_key={key}&query={food}&pageSize=5&dataType=Foundation,SR%20Legacy`.
+For a selected record, fetch `/fdc/v1/food/{fdcId}?api_key={key}`.
 
-Inspect the returned descriptions and FDC IDs before choosing a result; search
-rank alone is not an identity match. For packaged food, use the product label
-when available. Treat generic USDA values as estimates and state the per-100 g
-basis before scaling to a serving.
-
-```bash
-# Search foods by name
-FOOD="$1"
-API_KEY="${USDA_API_KEY:-DEMO_KEY}"
-ENCODED=$(python -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$FOOD")
-curl -s "https://api.nal.usda.gov/fdc/v1/foods/search?api_key=${API_KEY}&query=${ENCODED}&pageSize=5&dataType=Foundation,SR%20Legacy" \
-  | python -c "
-import json,sys
-data=json.load(sys.stdin)
-foods=data.get('foods',[])
-if not foods: print('No foods found.'); sys.exit()
-for f in foods:
-    n={x['nutrientName']:x.get('value','?') for x in f.get('foodNutrients',[])}
-    cal=n.get('Energy','?'); prot=n.get('Protein','?')
-    fat=n.get('Total lipid (fat)','?'); carb=n.get('Carbohydrate, by difference','?')
-    print(f\"{f.get('description','N/A')}\")
-    print(f\"  Per 100g: {cal} kcal | {prot}g protein | {fat}g fat | {carb}g carbs\")
-    print(f\"  FDC ID: {f.get('fdcId','N/A')}\")
-    print()
-"
-```
-
-```bash
-# Detailed nutrient profile by FDC ID
-FDC_ID="$1"
-API_KEY="${USDA_API_KEY:-DEMO_KEY}"
-curl -s "https://api.nal.usda.gov/fdc/v1/food/${FDC_ID}?api_key=${API_KEY}" \
-  | python -c "
-import json,sys
-d=json.load(sys.stdin)
-print(f\"Food: {d.get('description','N/A')}\")
-print(f\"{'Nutrient':<40} {'Amount':>8} {'Unit'}\")
-print('-'*56)
-for x in sorted(d.get('foodNutrients',[]),key=lambda x:x.get('nutrient',{}).get('rank',9999)):
-    nut=x.get('nutrient',{}); amt=x.get('amount',0)
-    if amt and float(amt)>0:
-        print(f\"  {nut.get('name',''):<38} {amt:>8} {nut.get('unitName','')}\")
-"
-```
+Inspect descriptions and FDC IDs before choosing a result; search rank alone is
+not an identity match. For packaged food, prefer the product label when
+available. Treat generic USDA values as estimates and state the per-100 g basis
+before scaling to a serving. Report kcal, protein, fat, and carbohydrate when
+those nutrients are present.
 
 ### Offline Calculators
 
-Use the helper scripts in `scripts/` for batch operations,
-or run inline for single calculations:
+Use `terminal` to invoke `scripts/body_calc.py` with one of these argument forms:
 
-- `python scripts/body_calc.py bmi <weight_kg> <height_cm>`
-- `python scripts/body_calc.py tdee <weight_kg> <height_cm> <age> <M|F> <activity 1-5>`
-- `python scripts/body_calc.py 1rm <weight> <reps>`
-- `python scripts/body_calc.py macros <tdee_kcal> <cut|maintain|bulk>`
-- `python scripts/body_calc.py bodyfat <M|F> <neck_cm> <waist_cm> [hip_cm] <height_cm>`
+- `bmi <weight_kg> <height_cm>`
+- `tdee <weight_kg> <height_cm> <age> <M|F> <activity 1-5>`
+- `1rm <weight> <reps>`
+- `macros <tdee_kcal> <cut|maintain|bulk>`
+- `bodyfat <M|F> <neck_cm> <waist_cm> [hip_cm] <height_cm>`
 
-See `references/FORMULAS.md` for the science behind each formula.
-The CLI rejects unsupported categories, non-positive measurements, and 1RM
-sets above 10 repetitions instead of silently selecting defaults.
-
----
+See `references/FORMULAS.md` for the science behind each formula. The helper
+rejects unsupported categories, non-positive measurements, and one-rep-max sets
+above 10 repetitions instead of silently selecting defaults.
 
 ## Pitfalls
 
-- wger exercise data includes multiple translations — use the name-search
-  helper or select translation language ID `2` for English
-- wger is community-maintained reference data — verify exercise details instead
-  of treating a database entry as individualized technique or medical advice
-- USDA `DEMO_KEY` has **30 req/hour** — add `sleep 2` between batch requests or get a free key
-- USDA data is **per 100g** — remind users to scale to their actual portion size
-- USDA search results can be approximate — select the intended FDC ID, and let
-  a current product label override generic database values
-- BMI does not distinguish muscle from fat — high BMI in muscular people is not necessarily unhealthy
-- Body fat formulas are **estimates** (±3-5%) — recommend DEXA scans for precision
-- 1RM formulas lose accuracy above 10 reps — use sets of 3-5 for best estimates
-- Macro percentages are templates, not individualized prescriptions; use a
-  user-approved plan when one exists
-
----
+- wger has multiple translations; use the helper or request English language ID
+  `2` when inspecting translations.
+- USDA `DEMO_KEY` has 30 requests per hour; use a configured key for higher
+  limits and avoid unneeded repeated requests.
+- USDA data is per 100 g; scale explicitly to the user's portion size.
+- USDA search results can be approximate; select the intended FDC ID, and let a
+  current product label override generic database values.
+- BMI does not distinguish muscle from fat.
+- Body-fat formulas are estimates (±3–5%); recommend DEXA scans for precision.
+- One-rep-max formulas lose accuracy above 10 repetitions; sets of 3–5 are best.
+- Macro percentages are templates, not individualized prescriptions.
 
 ## Verification
 
-After running exercise search: confirm the JSON includes exercise names,
-muscle groups, and equipment; an HTTP 200 with an unrelated unfiltered list is
-not a successful search.
-After nutrition lookup: confirm per-100g macros are returned with kcal, protein, fat, carbs.
-After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most adults).
+After exercise search, confirm the JSON includes names, IDs, and relevant muscle
+or equipment fields; an unrelated unfiltered list is not a successful search.
+After nutrition lookup, confirm the selected food identity and per-100 g kcal,
+protein, fat, and carbohydrate values before scaling.
+After calculations, confirm the helper succeeded and sanity-check outputs (for
+example, TDEE is commonly 1500–3500 kcal for adults, but individual values vary).

--- a/optional-skills/health/fitness-nutrition/SKILL.md
+++ b/optional-skills/health/fitness-nutrition/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: fitness-nutrition
-description: "Workout planning, macros, and body metrics via wger/USDA."
+description: "Exercise/food reference and body metrics via wger/USDA."
 platforms: [linux, macos, windows]
-version: 1.0.0
+version: 1.1.0
 author: Hailey Marshall (haileymarshall), Hermes Agent
 authors:
   - haileymarshall
@@ -23,13 +23,14 @@ required_environment_variables:
 
 # Fitness & Nutrition
 
-Expert fitness coach and sports nutritionist skill. Two data sources
-plus offline calculators — everything a gym-goer needs in one place.
+Exercise and food-reference data plus offline calculators. Use this skill for
+lookups and mechanical calculations, not as a substitute for individualized
+medical advice, dietetic care, or a progressive training plan.
 
 **Data sources (all free, no pip dependencies):**
 
-- **wger** (https://wger.de/api/v2/) — open exercise database, 690+ exercises with muscles, equipment, images. Public endpoints need zero authentication.
-- **USDA FoodData Central** (https://api.nal.usda.gov/fdc/v1/) — US government nutrition database, 380,000+ foods. `DEMO_KEY` works instantly; free signup for higher limits.
+- **wger** (https://wger.de/api/v2/) — open exercise database with muscles, equipment, and images. Public endpoints need zero authentication.
+- **USDA FoodData Central** (https://api.nal.usda.gov/fdc/v1/) — US government food-composition database. `DEMO_KEY` works instantly; free signup for higher limits.
 
 **Offline calculators (pure stdlib Python):**
 
@@ -40,11 +41,13 @@ plus offline calculators — everything a gym-goer needs in one place.
 ## When to Use
 
 Trigger this skill when the user asks about:
-- Exercises, workouts, gym routines, muscle groups, workout splits
-- Food macros, calories, protein content, meal planning, calorie counting
-- Body composition: BMI, body fat, TDEE, caloric surplus/deficit
-- One-rep max estimates, training percentages, progressive overload
-- Macro ratios for cutting, bulking, or maintenance
+- Exercise reference by movement name, muscle, equipment, or category
+- Food energy, macro, micronutrient, or ingredient composition
+- BMI, body-fat, TDEE, or calorie-target calculations
+- One-rep-max estimates and derived training percentages
+- Generic macro templates for cutting, bulking, or maintenance
+
+Do not use this as the primary skill for progressive workout programming, workout tracking, individualized meal planning, or medical nutrition. Route those tasks to the relevant planning, tracking, or clinical workflow, and use this skill only for the needed reference data or calculation.
 
 ---
 
@@ -52,15 +55,16 @@ Trigger this skill when the user asks about:
 
 ### Exercise Lookup (wger API)
 
-All wger public endpoints return JSON and require no auth. Always add
-`format=json` and `language=2` (English) to exercise queries.
+All wger public endpoints return JSON and require no auth. Use the read-only
+`exerciseinfo` endpoint, add `language__code=en`, and request `format=json`.
 
 **Step 1 — Identify what the user wants:**
 
-- By muscle → use `/api/v2/exercise/?muscles={id}&language=2&status=2&format=json`
-- By category → use `/api/v2/exercise/?category={id}&language=2&status=2&format=json`
-- By equipment → use `/api/v2/exercise/?equipment={id}&language=2&status=2&format=json`
-- By name → use `/api/v2/exercise/search/?term={query}&language=english&format=json`
+- By muscle → use `/api/v2/exerciseinfo/?muscles={id}&language__code=en&format=json`
+- By category → use `/api/v2/exerciseinfo/?category={id}&language__code=en&format=json`
+- By equipment → use `/api/v2/exerciseinfo/?equipment={id}&language__code=en&format=json`
+- By name → run `python scripts/exercise_search.py "{query}"`; it uses
+  `/api/v2/exerciseinfo/?name__search={query}&language__code=en&format=json`
 - Full details → use `/api/v2/exerciseinfo/{exercise_id}/?format=json`
 
 **Step 2 — Reference IDs (so you don't need extra API calls):**
@@ -109,17 +113,10 @@ Equipment:
 
 ```bash
 # Search exercises by name
-QUERY="$1"
-ENCODED=$(python -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$QUERY")
-curl -s "https://wger.de/api/v2/exercise/search/?term=${ENCODED}&language=english&format=json" \
-  | python -c "
-import json,sys
-data=json.load(sys.stdin)
-for s in data.get('suggestions',[])[:10]:
-    d=s.get('data',{})
-    print(f\"  ID {d.get('id','?'):>4} | {d.get('name','N/A'):<35} | Category: {d.get('category','N/A')}\")
-"
+python scripts/exercise_search.py "pull up" --limit 10
 ```
+
+The helper fetches at most 100 wger candidates, reranks exact and all-token name matches, and returns only the requested 1–20 records.
 
 ```bash
 # Get full details for a specific exercise
@@ -143,23 +140,27 @@ if imgs: print(f\"Image     : {imgs[0].get('image','')}\")
 ```
 
 ```bash
-# List exercises filtering by muscle, category, or equipment
-# Combine filters as needed: ?muscles=4&equipment=1&language=2&status=2
-FILTER="$1"  # e.g. "muscles=4" or "category=11" or "equipment=3"
-curl -s "https://wger.de/api/v2/exercise/?${FILTER}&language=2&status=2&limit=20&format=json" \
-  | python -c "
-import json,sys
-data=json.load(sys.stdin)
-print(f'Found {data.get(\"count\",0)} exercises.')
-for ex in data.get('results',[]):
-    print(f\"  ID {ex['id']:>4} | muscles: {ex.get('muscles',[])} | equipment: {ex.get('equipment',[])}\")
-"
+# List exercises by one filter
+python scripts/exercise_search.py --muscle 4 --limit 20
+python scripts/exercise_search.py --category 11 --limit 20
+python scripts/exercise_search.py --equipment 3 --limit 20
+
+# Combine filters as needed
+python scripts/exercise_search.py --muscle 4 --equipment 1 --limit 20
 ```
+
+The helper resolves English names from each record's `translations`, then emits
+compact JSON with IDs, names, muscles, equipment, descriptions, and images.
 
 ### Nutrition Lookup (USDA FoodData Central)
 
 Uses `USDA_API_KEY` env var if set, otherwise falls back to `DEMO_KEY`.
 DEMO_KEY = 30 requests/hour. Free signup key = 1,000 requests/hour.
+
+Inspect the returned descriptions and FDC IDs before choosing a result; search
+rank alone is not an identity match. For packaged food, use the product label
+when available. Treat generic USDA values as estimates and state the per-100 g
+basis before scaling to a serving.
 
 ```bash
 # Search foods by name
@@ -213,25 +214,34 @@ or run inline for single calculations:
 - `python scripts/body_calc.py bodyfat <M|F> <neck_cm> <waist_cm> [hip_cm] <height_cm>`
 
 See `references/FORMULAS.md` for the science behind each formula.
+The CLI rejects unsupported categories, non-positive measurements, and 1RM
+sets above 10 repetitions instead of silently selecting defaults.
 
 ---
 
 ## Pitfalls
 
-- wger exercise endpoint returns **all languages by default** — always add `language=2` for English
-- wger includes **unverified user submissions** — add `status=2` to only get approved exercises
+- wger exercise data includes multiple translations — use the name-search
+  helper or select translation language ID `2` for English
+- wger is community-maintained reference data — verify exercise details instead
+  of treating a database entry as individualized technique or medical advice
 - USDA `DEMO_KEY` has **30 req/hour** — add `sleep 2` between batch requests or get a free key
 - USDA data is **per 100g** — remind users to scale to their actual portion size
+- USDA search results can be approximate — select the intended FDC ID, and let
+  a current product label override generic database values
 - BMI does not distinguish muscle from fat — high BMI in muscular people is not necessarily unhealthy
 - Body fat formulas are **estimates** (±3-5%) — recommend DEXA scans for precision
 - 1RM formulas lose accuracy above 10 reps — use sets of 3-5 for best estimates
-- wger's `exercise/search` endpoint uses `term` not `query` as the parameter name
+- Macro percentages are templates, not individualized prescriptions; use a
+  user-approved plan when one exists
 
 ---
 
 ## Verification
 
-After running exercise search: confirm results include exercise names, muscle groups, and equipment.
+After running exercise search: confirm the JSON includes exercise names,
+muscle groups, and equipment; an HTTP 200 with an unrelated unfiltered list is
+not a successful search.
 After nutrition lookup: confirm per-100g macros are returned with kcal, protein, fat, carbs.
 After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most adults).
 
@@ -241,10 +251,10 @@ After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most 
 
 | Task | Source | Endpoint |
 |------|--------|----------|
-| Search exercises by name | wger | `GET /api/v2/exercise/search/?term=&language=english` |
+| Search exercises by name | wger | `python scripts/exercise_search.py "query"` (`name__search`, `language__code=en`) |
 | Exercise details | wger | `GET /api/v2/exerciseinfo/{id}/` |
-| Filter by muscle | wger | `GET /api/v2/exercise/?muscles={id}&language=2&status=2` |
-| Filter by equipment | wger | `GET /api/v2/exercise/?equipment={id}&language=2&status=2` |
+| Filter by muscle | wger | `GET /api/v2/exerciseinfo/?muscles={id}&language__code=en` |
+| Filter by equipment | wger | `GET /api/v2/exerciseinfo/?equipment={id}&language__code=en` |
 | List categories | wger | `GET /api/v2/exercisecategory/` |
 | List muscles | wger | `GET /api/v2/muscle/` |
 | Search foods | USDA | `GET /fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |

--- a/optional-skills/health/fitness-nutrition/SKILL.md
+++ b/optional-skills/health/fitness-nutrition/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: fitness-nutrition
 description: >
-  Gym workout planner and nutrition tracker. Search 690+ exercises by muscle,
-  equipment, or category via wger. Look up macros and calories for 380,000+
-  foods via USDA FoodData Central. Compute BMI, TDEE, one-rep max, macro
-  splits, and body fat — pure Python, no pip installs. Built for anyone
-  chasing gains, cutting weight, or just trying to eat better.
+  Deterministic fitness and nutrition reference. Search exercises by name,
+  muscle, equipment, or category via wger; look up food composition via USDA
+  FoodData Central; and compute BMI, TDEE, one-rep max, macro templates, and
+  body-fat estimates with dependency-free Python helpers.
 platforms: [linux, macos, windows]
-version: 1.0.0
+version: 1.1.0
 authors:
   - haileymarshall
 license: MIT
@@ -27,13 +26,14 @@ required_environment_variables:
 
 # Fitness & Nutrition
 
-Expert fitness coach and sports nutritionist skill. Two data sources
-plus offline calculators — everything a gym-goer needs in one place.
+Exercise and food-reference data plus offline calculators. Use this skill for
+lookups and mechanical calculations, not as a substitute for individualized
+medical advice, dietetic care, or a progressive training plan.
 
 **Data sources (all free, no pip dependencies):**
 
-- **wger** (https://wger.de/api/v2/) — open exercise database, 690+ exercises with muscles, equipment, images. Public endpoints need zero authentication.
-- **USDA FoodData Central** (https://api.nal.usda.gov/fdc/v1/) — US government nutrition database, 380,000+ foods. `DEMO_KEY` works instantly; free signup for higher limits.
+- **wger** (https://wger.de/api/v2/) — open exercise database with muscles, equipment, and images. Public endpoints need zero authentication.
+- **USDA FoodData Central** (https://api.nal.usda.gov/fdc/v1/) — US government food-composition database. `DEMO_KEY` works instantly; free signup for higher limits.
 
 **Offline calculators (pure stdlib Python):**
 
@@ -44,11 +44,13 @@ plus offline calculators — everything a gym-goer needs in one place.
 ## When to Use
 
 Trigger this skill when the user asks about:
-- Exercises, workouts, gym routines, muscle groups, workout splits
-- Food macros, calories, protein content, meal planning, calorie counting
-- Body composition: BMI, body fat, TDEE, caloric surplus/deficit
-- One-rep max estimates, training percentages, progressive overload
-- Macro ratios for cutting, bulking, or maintenance
+- Exercise reference by movement name, muscle, equipment, or category
+- Food energy, macro, micronutrient, or ingredient composition
+- BMI, body-fat, TDEE, or calorie-target calculations
+- One-rep-max estimates and derived training percentages
+- Generic macro templates for cutting, bulking, or maintenance
+
+Do not use this as the primary skill for progressive workout programming, workout tracking, individualized meal planning, or medical nutrition. Route those tasks to the relevant planning, tracking, or clinical workflow, and use this skill only for the needed reference data or calculation.
 
 ---
 
@@ -56,15 +58,16 @@ Trigger this skill when the user asks about:
 
 ### Exercise Lookup (wger API)
 
-All wger public endpoints return JSON and require no auth. Always add
-`format=json` and `language=2` (English) to exercise queries.
+All wger public endpoints return JSON and require no auth. Use the read-only
+`exerciseinfo` endpoint, add `language__code=en`, and request `format=json`.
 
 **Step 1 — Identify what the user wants:**
 
-- By muscle → use `/api/v2/exercise/?muscles={id}&language=2&status=2&format=json`
-- By category → use `/api/v2/exercise/?category={id}&language=2&status=2&format=json`
-- By equipment → use `/api/v2/exercise/?equipment={id}&language=2&status=2&format=json`
-- By name → use `/api/v2/exercise/search/?term={query}&language=english&format=json`
+- By muscle → use `/api/v2/exerciseinfo/?muscles={id}&language__code=en&format=json`
+- By category → use `/api/v2/exerciseinfo/?category={id}&language__code=en&format=json`
+- By equipment → use `/api/v2/exerciseinfo/?equipment={id}&language__code=en&format=json`
+- By name → run `python3 scripts/exercise_search.py "{query}"`; it uses
+  `/api/v2/exerciseinfo/?name__search={query}&language__code=en&format=json`
 - Full details → use `/api/v2/exerciseinfo/{exercise_id}/?format=json`
 
 **Step 2 — Reference IDs (so you don't need extra API calls):**
@@ -113,17 +116,10 @@ Equipment:
 
 ```bash
 # Search exercises by name
-QUERY="$1"
-ENCODED=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$QUERY")
-curl -s "https://wger.de/api/v2/exercise/search/?term=${ENCODED}&language=english&format=json" \
-  | python3 -c "
-import json,sys
-data=json.load(sys.stdin)
-for s in data.get('suggestions',[])[:10]:
-    d=s.get('data',{})
-    print(f\"  ID {d.get('id','?'):>4} | {d.get('name','N/A'):<35} | Category: {d.get('category','N/A')}\")
-"
+python3 scripts/exercise_search.py "pull up" --limit 10
 ```
+
+The helper fetches at most 100 wger candidates, reranks exact and all-token name matches, and returns only the requested 1–20 records.
 
 ```bash
 # Get full details for a specific exercise
@@ -147,23 +143,27 @@ if imgs: print(f\"Image     : {imgs[0].get('image','')}\")
 ```
 
 ```bash
-# List exercises filtering by muscle, category, or equipment
-# Combine filters as needed: ?muscles=4&equipment=1&language=2&status=2
-FILTER="$1"  # e.g. "muscles=4" or "category=11" or "equipment=3"
-curl -s "https://wger.de/api/v2/exercise/?${FILTER}&language=2&status=2&limit=20&format=json" \
-  | python3 -c "
-import json,sys
-data=json.load(sys.stdin)
-print(f'Found {data.get(\"count\",0)} exercises.')
-for ex in data.get('results',[]):
-    print(f\"  ID {ex['id']:>4} | muscles: {ex.get('muscles',[])} | equipment: {ex.get('equipment',[])}\")
-"
+# List exercises by one filter
+python3 scripts/exercise_search.py --muscle 4 --limit 20
+python3 scripts/exercise_search.py --category 11 --limit 20
+python3 scripts/exercise_search.py --equipment 3 --limit 20
+
+# Combine filters as needed
+python3 scripts/exercise_search.py --muscle 4 --equipment 1 --limit 20
 ```
+
+The helper resolves English names from each record's `translations`, then emits
+compact JSON with IDs, names, muscles, equipment, descriptions, and images.
 
 ### Nutrition Lookup (USDA FoodData Central)
 
 Uses `USDA_API_KEY` env var if set, otherwise falls back to `DEMO_KEY`.
 DEMO_KEY = 30 requests/hour. Free signup key = 1,000 requests/hour.
+
+Inspect the returned descriptions and FDC IDs before choosing a result; search
+rank alone is not an identity match. For packaged food, use the product label
+when available. Treat generic USDA values as estimates and state the per-100 g
+basis before scaling to a serving.
 
 ```bash
 # Search foods by name
@@ -217,25 +217,34 @@ or run inline for single calculations:
 - `python3 scripts/body_calc.py bodyfat <M|F> <neck_cm> <waist_cm> [hip_cm] <height_cm>`
 
 See `references/FORMULAS.md` for the science behind each formula.
+The CLI rejects unsupported categories, non-positive measurements, and 1RM
+sets above 10 repetitions instead of silently selecting defaults.
 
 ---
 
 ## Pitfalls
 
-- wger exercise endpoint returns **all languages by default** — always add `language=2` for English
-- wger includes **unverified user submissions** — add `status=2` to only get approved exercises
+- wger exercise data includes multiple translations — use the name-search
+  helper or select translation language ID `2` for English
+- wger is community-maintained reference data — verify exercise details instead
+  of treating a database entry as individualized technique or medical advice
 - USDA `DEMO_KEY` has **30 req/hour** — add `sleep 2` between batch requests or get a free key
 - USDA data is **per 100g** — remind users to scale to their actual portion size
+- USDA search results can be approximate — select the intended FDC ID, and let
+  a current product label override generic database values
 - BMI does not distinguish muscle from fat — high BMI in muscular people is not necessarily unhealthy
 - Body fat formulas are **estimates** (±3-5%) — recommend DEXA scans for precision
 - 1RM formulas lose accuracy above 10 reps — use sets of 3-5 for best estimates
-- wger's `exercise/search` endpoint uses `term` not `query` as the parameter name
+- Macro percentages are templates, not individualized prescriptions; use a
+  user-approved plan when one exists
 
 ---
 
 ## Verification
 
-After running exercise search: confirm results include exercise names, muscle groups, and equipment.
+After running exercise search: confirm the JSON includes exercise names,
+muscle groups, and equipment; an HTTP 200 with an unrelated unfiltered list is
+not a successful search.
 After nutrition lookup: confirm per-100g macros are returned with kcal, protein, fat, carbs.
 After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most adults).
 
@@ -245,10 +254,10 @@ After calculators: sanity-check outputs (e.g. TDEE should be 1500-3500 for most 
 
 | Task | Source | Endpoint |
 |------|--------|----------|
-| Search exercises by name | wger | `GET /api/v2/exercise/search/?term=&language=english` |
+| Search exercises by name | wger | `python3 scripts/exercise_search.py "query"` (`name__search`, `language__code=en`) |
 | Exercise details | wger | `GET /api/v2/exerciseinfo/{id}/` |
-| Filter by muscle | wger | `GET /api/v2/exercise/?muscles={id}&language=2&status=2` |
-| Filter by equipment | wger | `GET /api/v2/exercise/?equipment={id}&language=2&status=2` |
+| Filter by muscle | wger | `GET /api/v2/exerciseinfo/?muscles={id}&language__code=en` |
+| Filter by equipment | wger | `GET /api/v2/exerciseinfo/?equipment={id}&language__code=en` |
 | List categories | wger | `GET /api/v2/exercisecategory/` |
 | List muscles | wger | `GET /api/v2/muscle/` |
 | Search foods | USDA | `GET /fdc/v1/foods/search?query=&dataType=Foundation,SR Legacy` |

--- a/optional-skills/health/fitness-nutrition/references/FORMULAS.md
+++ b/optional-skills/health/fitness-nutrition/references/FORMULAS.md
@@ -79,7 +79,11 @@ BF% = 86.010 × log₁₀(waist − neck) − 70.041 × log₁₀(height) + 36.7
 
 BF% = 163.205 × log₁₀(waist + hip − neck) − 97.684 × log₁₀(height) − 78.387
 
-All measurements in centimeters.
+The published constants require inches. The CLI accepts centimetres and must
+convert centimetres to inches (divide each measurement by 2.54) before applying
+these equations. Substituting centimetres directly produces incorrect results.
+It rejects estimates outside `0 < body fat < 100` instead of assigning a
+category to a non-physical result.
 
 | Category      | Male   | Female |
 |--------------|--------|--------|

--- a/optional-skills/health/fitness-nutrition/scripts/body_calc.py
+++ b/optional-skills/health/fitness-nutrition/scripts/body_calc.py
@@ -15,7 +15,25 @@ import sys
 import math
 
 
+class CalculatorInputError(ValueError):
+    """Raised when calculator input is outside the supported domain."""
+
+
+def require_positive(name, value):
+    if not math.isfinite(value) or value <= 0:
+        raise CalculatorInputError(f"{name} must be greater than zero")
+
+
+def require_sex(sex):
+    normalized = sex.upper()
+    if normalized not in {"M", "F"}:
+        raise CalculatorInputError("sex must be M or F")
+    return normalized
+
+
 def bmi(weight_kg, height_cm):
+    require_positive("weight", weight_kg)
+    require_positive("height", height_cm)
     h = height_cm / 100
     val = weight_kg / (h * h)
     if val < 18.5:
@@ -36,7 +54,14 @@ def bmi(weight_kg, height_cm):
 
 
 def tdee(weight_kg, height_cm, age, sex, activity):
-    if sex.upper() == "M":
+    require_positive("weight", weight_kg)
+    require_positive("height", height_cm)
+    require_positive("age", age)
+    sex = require_sex(sex)
+    if activity not in {1, 2, 3, 4, 5}:
+        raise CalculatorInputError("activity must be between 1 and 5")
+
+    if sex == "M":
         bmr = 10 * weight_kg + 6.25 * height_cm - 5 * age + 5
     else:
         bmr = 10 * weight_kg + 6.25 * height_cm - 5 * age - 161
@@ -49,7 +74,7 @@ def tdee(weight_kg, height_cm, age, sex, activity):
         5: ("Extremely active (athlete + physical job)", 1.9),
     }
 
-    label, mult = multipliers.get(activity, ("Moderate", 1.55))
+    label, mult = multipliers[activity]
     total = bmr * mult
 
     print(f"BMR (Mifflin-St Jeor): {bmr:.0f} kcal/day")
@@ -66,9 +91,9 @@ def tdee(weight_kg, height_cm, age, sex, activity):
 
 
 def one_rep_max(weight, reps):
-    if reps < 1:
-        print("Error: reps must be at least 1.")
-        sys.exit(1)
+    require_positive("weight", weight)
+    if not 1 <= reps <= 10:
+        raise CalculatorInputError("reps must be between 1 and 10")
     if reps == 1:
         print(f"1RM = {weight:.1f} (actual single)")
         return
@@ -94,6 +119,7 @@ def one_rep_max(weight, reps):
 
 
 def macros(tdee_kcal, goal):
+    require_positive("TDEE", tdee_kcal)
     goal = goal.lower()
     if goal in {"cut", "lose", "deficit"}:
         cals = tdee_kcal - 500
@@ -103,10 +129,15 @@ def macros(tdee_kcal, goal):
         cals = tdee_kcal + 400
         p, f, c = 0.30, 0.25, 0.45
         label = "Lean Bulk (+400 kcal)"
-    else:
+    elif goal in {"maintain", "maintenance"}:
         cals = tdee_kcal
         p, f, c = 0.30, 0.30, 0.40
         label = "Maintenance"
+    else:
+        raise CalculatorInputError("goal must be cut, maintain, or bulk")
+
+    if cals <= 0:
+        raise CalculatorInputError("calorie target must be greater than zero")
 
     prot_g = cals * p / 4
     fat_g = cals * f / 9
@@ -124,16 +155,29 @@ def macros(tdee_kcal, goal):
 
 
 def bodyfat(sex, neck_cm, waist_cm, hip_cm, height_cm):
-    sex = sex.upper()
+    sex = require_sex(sex)
+    require_positive("neck", neck_cm)
+    require_positive("waist", waist_cm)
+    require_positive("height", height_cm)
+    if sex == "F":
+        require_positive("hip", hip_cm)
+    neck_in = neck_cm / 2.54
+    waist_in = waist_cm / 2.54
+    hip_in = hip_cm / 2.54
+    height_in = height_cm / 2.54
     if sex == "M":
         if waist_cm <= neck_cm:
-            print("Error: waist must be larger than neck."); sys.exit(1)
-        bf = 86.010 * math.log10(waist_cm - neck_cm) - 70.041 * math.log10(height_cm) + 36.76
+            raise CalculatorInputError("waist must be larger than neck")
+        bf = 86.010 * math.log10(waist_in - neck_in) - 70.041 * math.log10(height_in) + 36.76
     else:
-        if (waist_cm + hip_cm) <= neck_cm:
-            print("Error: waist + hip must be larger than neck."); sys.exit(1)
-        bf = 163.205 * math.log10(waist_cm + hip_cm - neck_cm) - 97.684 * math.log10(height_cm) - 78.387
-
+        if waist_in + hip_in <= neck_in:
+            raise CalculatorInputError("waist + hip must be larger than neck")
+        bf = (163.205 * math.log10(waist_in + hip_in - neck_in)
+              - 97.684 * math.log10(height_in) - 78.387)
+    if not 0 < bf < 100:
+        raise CalculatorInputError(
+            "measurements produce an invalid body-fat estimate"
+        )
     print(f"Estimated body fat: {bf:.1f}%")
 
     if sex == "M":
@@ -201,9 +245,9 @@ def main():
             print(f"Unknown command: {cmd}")
             usage()
 
-    except (IndexError, ValueError) as e:
-        print(f"Error: {e}")
-        usage()
+    except (CalculatorInputError, IndexError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/optional-skills/health/fitness-nutrition/scripts/exercise_search.py
+++ b/optional-skills/health/fitness-nutrition/scripts/exercise_search.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Search or filter wger exercises and emit compact JSON."""
+
+import argparse
+from html.parser import HTMLParser
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+WGER_SEARCH_URL = "https://wger.de/api/v2/exerciseinfo/"
+ENGLISH_LANGUAGE_ID = 2
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.parts = []
+
+    def handle_data(self, data):
+        text = data.strip()
+        if text:
+            self.parts.append(text)
+
+
+def _plain_text(value):
+    parser = _TextExtractor()
+    parser.feed(value or "")
+    return " ".join(parser.parts)
+
+
+def _names(items):
+    return [
+        item.get("name_en") or item.get("name")
+        for item in items
+        if item.get("name_en") or item.get("name")
+    ]
+
+
+def _compact(exercise):
+    translation = next(
+        (
+            item
+            for item in exercise.get("translations", [])
+            if item.get("language") == ENGLISH_LANGUAGE_ID
+        ),
+        {},
+    )
+    images = exercise.get("images") or []
+    return {
+        "id": exercise.get("id"),
+        "name": translation.get("name", ""),
+        "category": (exercise.get("category") or {}).get("name", ""),
+        "primary_muscles": _names(exercise.get("muscles") or []),
+        "secondary_muscles": _names(exercise.get("muscles_secondary") or []),
+        "equipment": _names(exercise.get("equipment") or []),
+        "description": _plain_text(translation.get("description", "")),
+        "image": images[0].get("image", "") if images else "",
+    }
+
+
+def _name_tokens(value):
+    """Return normalized tokens for conservative exercise-name matching."""
+    normalized = []
+    for token in re.findall(r"[a-z0-9]+", value.lower()):
+        if token == "ups":
+            token = "up"
+        elif token == "downs":
+            token = "down"
+        if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
+            token = token[:-1]
+        normalized.append(token)
+    return tuple(normalized)
+
+
+def _relevance_key(record, query):
+    """Prefer exact/all-token names over wger's broad full-text rank."""
+    query_tokens = _name_tokens(query)
+    name = record.get("name", "")
+    candidate_tokens = _name_tokens(name)
+    query_compact = "".join(query_tokens)
+    candidate_compact = "".join(candidate_tokens)
+    compact_exact = candidate_compact != query_compact
+    missing = len(set(query_tokens) - set(candidate_tokens))
+    token_exact = candidate_tokens != query_tokens
+    extras = len(set(candidate_tokens) - set(query_tokens))
+    return (
+        compact_exact,
+        missing,
+        token_exact,
+        extras,
+        len(candidate_tokens),
+        name.lower(),
+    )
+
+
+def _limit(value):
+    parsed = int(value)
+    if not 1 <= parsed <= 20:
+        raise argparse.ArgumentTypeError("limit must be between 1 and 20")
+    return parsed
+
+
+def _positive_id(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("filter IDs must be positive integers")
+    return parsed
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query", nargs="?", help="exercise name or partial name")
+    parser.add_argument("--limit", type=_limit, default=5)
+    parser.add_argument("--muscle", type=_positive_id, help="wger muscle ID")
+    parser.add_argument("--category", type=_positive_id, help="wger category ID")
+    parser.add_argument("--equipment", type=_positive_id, help="wger equipment ID")
+    args = parser.parse_args(argv)
+
+    query = (args.query or "").strip()
+    filters = {
+        name: value
+        for name, value in (
+            ("muscles", args.muscle),
+            ("category", args.category),
+            ("equipment", args.equipment),
+        )
+        if value is not None
+    }
+    if args.query is not None and not _name_tokens(query):
+        print("Error: query must contain letters or numbers", file=sys.stderr)
+        return 2
+    if not query and not filters:
+        print("Error: provide a query or at least one filter", file=sys.stderr)
+        return 2
+
+    request_params = {
+        "language__code": "en",
+        "limit": 100,
+        "format": "json",
+        **filters,
+    }
+    if query:
+        request_params["name__search"] = query
+    params = urllib.parse.urlencode(request_params)
+    request = urllib.request.Request(
+        f"{WGER_SEARCH_URL}?{params}",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "Hermes-Agent/fitness-nutrition",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            payload = json.loads(response.read())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"Error: wger request failed: {exc}", file=sys.stderr)
+        return 1
+
+    results = [_compact(item) for item in payload.get("results", [])]
+    if query:
+        results.sort(key=lambda item: _relevance_key(item, query))
+    else:
+        results.sort(key=lambda item: item.get("name", "").lower())
+    result = {
+        "query": query,
+        "count": payload.get("count", 0),
+        "results": results[: args.limit],
+    }
+    if filters:
+        result["filters"] = filters
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_fitness_nutrition_skill.py
+++ b/tests/skills/test_fitness_nutrition_skill.py
@@ -253,7 +253,6 @@ def test_skill_contract_routes_through_corrected_helpers() -> None:
     skill = SKILL_MD.read_text(encoding="utf-8")
     formulas = FORMULAS_MD.read_text(encoding="utf-8")
 
-    assert "version: 1.1.0" in skill
     assert "scripts/exercise_search.py" in skill
     assert "--muscle" in skill
     assert "--category" in skill

--- a/tests/skills/test_fitness_nutrition_skill.py
+++ b/tests/skills/test_fitness_nutrition_skill.py
@@ -1,0 +1,270 @@
+"""Behavior tests for the optional fitness-nutrition skill."""
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+from unittest import mock
+
+import pytest
+
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "health"
+    / "fitness-nutrition"
+)
+BODY_CALC = SKILL_DIR / "scripts" / "body_calc.py"
+EXERCISE_SEARCH = SKILL_DIR / "scripts" / "exercise_search.py"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+FORMULAS_MD = SKILL_DIR / "references" / "FORMULAS.md"
+
+
+def run_body_calc(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(BODY_CALC), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_bodyfat_converts_male_centimetres_for_navy_equation() -> None:
+    result = run_body_calc("bodyfat", "M", "38", "85", "180")
+
+    assert result.returncode == 0
+    assert "Estimated body fat: 16.2%" in result.stdout
+
+
+def test_bodyfat_converts_female_centimetres_for_navy_equation() -> None:
+    result = run_body_calc("bodyfat", "F", "34", "75", "100", "165")
+
+    assert result.returncode == 0
+    assert "Estimated body fat: 29.2%" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (("bmi", "-80", "180"), "weight must be greater than zero"),
+        (("bmi", "80", "0"), "height must be greater than zero"),
+        (("tdee", "80", "180", "0", "M", "3"), "age must be greater than zero"),
+        (("tdee", "80", "180", "35", "X", "3"), "sex must be M or F"),
+        (("tdee", "80", "180", "35", "M", "9"), "activity must be between 1 and 5"),
+        (("1rm", "0", "5"), "weight must be greater than zero"),
+        (("1rm", "100", "11"), "reps must be between 1 and 10"),
+        (["macros", "2500", "recomp"], "goal must be cut, maintain, or bulk"),
+        (["bodyfat", "X", "34", "75", "100", "165"], "sex must be M or F"),
+        (["bodyfat", "M", "38", "85", "0"], "height must be greater than zero"),
+        (
+            ["bodyfat", "M", "40", "41", "200"],
+            "measurements produce an invalid body-fat estimate",
+        ),
+    ],
+)
+def test_invalid_calculator_inputs_fail_closed(
+    args: tuple[str, ...], message: str
+) -> None:
+    result = run_body_calc(*args)
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert message in result.stderr
+
+
+def load_exercise_search():
+    spec = importlib.util.spec_from_file_location("exercise_search", EXERCISE_SEARCH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def exercise_record(exercise_id: int, name: str) -> dict:
+    return {
+        "id": exercise_id,
+        "category": {},
+        "muscles": [],
+        "muscles_secondary": [],
+        "equipment": [],
+        "translations": [{"language": 2, "name": name, "description": ""}],
+        "images": [],
+    }
+
+
+def test_exercise_search_cli_uses_supported_wger_search(capsys) -> None:
+    exercise_search = load_exercise_search()
+    payload = {
+        "count": 2,
+        "results": [
+            {
+                "id": 289,
+                "category": {"name": "Shoulders"},
+                "muscles": [{"name_en": "Shoulders"}],
+                "muscles_secondary": [],
+                "equipment": [],
+                "translations": [
+                    {
+                        "language": 2,
+                        "name": "High Pull",
+                        "description": "Explosive barbell pull.",
+                    }
+                ],
+                "images": [],
+            },
+            {
+                "id": 475,
+                "category": {"name": "Back"},
+                "muscles": [{"name_en": "Lats"}],
+                "muscles_secondary": [{"name_en": "Biceps"}],
+                "equipment": [{"name": "Pull-up bar"}],
+                "translations": [
+                    {
+                        "language": 2,
+                        "name": "Pull-ups",
+                        "description": "<p>Pull under control.</p>",
+                    }
+                ],
+                "images": [{"image": "https://wger.de/pull-up.jpg"}],
+            },
+        ],
+    }
+    response = mock.MagicMock()
+    response.__enter__.return_value = response
+    response.read.return_value = json.dumps(payload).encode()
+
+    with mock.patch.object(
+        exercise_search.urllib.request, "urlopen", return_value=response
+    ) as urlopen:
+        exit_code = exercise_search.main(["pull up", "--limit", "1"])
+
+    assert exit_code == 0
+    request = urlopen.call_args.args[0]
+    assert "name__search=pull+up" in request.full_url
+    assert "language__code=en" in request.full_url
+    assert "limit=100" in request.full_url
+    result = json.loads(capsys.readouterr().out)
+    assert result == {
+        "query": "pull up",
+        "count": 2,
+        "results": [
+            {
+                "id": 475,
+                "name": "Pull-ups",
+                "category": "Back",
+                "primary_muscles": ["Lats"],
+                "secondary_muscles": ["Biceps"],
+                "equipment": ["Pull-up bar"],
+                "description": "Pull under control.",
+                "image": "https://wger.de/pull-up.jpg",
+            }
+        ],
+    }
+
+
+def test_exercise_search_cli_filters_and_prints_english_names(capsys) -> None:
+    exercise_search = load_exercise_search()
+    payload = {
+        "count": 1,
+        "results": [exercise_record(475, "Pull-ups")],
+    }
+    response = mock.MagicMock()
+    response.__enter__.return_value = response
+    response.read.return_value = json.dumps(payload).encode()
+
+    with mock.patch.object(
+        exercise_search.urllib.request, "urlopen", return_value=response
+    ) as urlopen:
+        exit_code = exercise_search.main([
+            "--muscle",
+            "4",
+            "--equipment",
+            "1",
+            "--limit",
+            "10",
+        ])
+
+    assert exit_code == 0
+    request = urlopen.call_args.args[0]
+    assert "muscles=4" in request.full_url
+    assert "equipment=1" in request.full_url
+    result = json.loads(capsys.readouterr().out)
+    assert result["filters"] == {"muscles": 4, "equipment": 1}
+    assert result["results"][0]["name"] == "Pull-ups"
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("pullup", "Pull-ups"),
+        ("pullups", "Pull-ups"),
+        ("squat", "Squats"),
+        ("deadlift", "Deadlifts"),
+        ("chinup", "Chin Up"),
+    ],
+)
+def test_exercise_search_cli_reranks_common_spellings(capsys, query, expected) -> None:
+    exercise_search = load_exercise_search()
+    names = [
+        "Pullback",
+        "Pullover",
+        "Pull-ups",
+        "Pullup on fingerboard",
+        "Belt Squat",
+        "Squats",
+        "Romanian Deadlift",
+        "Deadlifts",
+        "Chin tuck",
+        "Chin Up",
+    ]
+    payload = {
+        "count": len(names),
+        "results": [exercise_record(index, name) for index, name in enumerate(names)],
+    }
+    response = mock.MagicMock()
+    response.__enter__.return_value = response
+    response.read.return_value = json.dumps(payload).encode()
+
+    with mock.patch.object(
+        exercise_search.urllib.request, "urlopen", return_value=response
+    ):
+        exit_code = exercise_search.main([query, "--limit", "1"])
+
+    assert exit_code == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["results"][0]["name"] == expected
+
+
+@pytest.mark.parametrize("query", ["   ", "!!!"])
+def test_exercise_search_cli_rejects_unsearchable_query(capsys, query) -> None:
+    exercise_search = load_exercise_search()
+
+    with mock.patch.object(exercise_search.urllib.request, "urlopen") as urlopen:
+        exit_code = exercise_search.main([query])
+
+    assert exit_code == 2
+    assert capsys.readouterr().err == "Error: query must contain letters or numbers\n"
+    urlopen.assert_not_called()
+
+
+def test_skill_contract_routes_through_corrected_helpers() -> None:
+    skill = SKILL_MD.read_text(encoding="utf-8")
+    formulas = FORMULAS_MD.read_text(encoding="utf-8")
+
+    assert "version: 1.1.0" in skill
+    assert "scripts/exercise_search.py" in skill
+    assert "--muscle" in skill
+    assert "--category" in skill
+    assert "--equipment" in skill
+    assert "name__search" in skill
+    assert "/api/v2/exercise/search/" not in skill
+    assert "/api/v2/exercise/?" not in skill
+    assert "status=2" not in skill
+    assert "product label" in skill.lower()
+    assert (
+        "do not use this as the primary skill for progressive workout programming"
+        in skill.lower()
+    )
+    assert "convert centimetres to inches" in formulas.lower()


### PR DESCRIPTION
## What does this PR do?

Fixes correctness and routing defects in the official optional `fitness-nutrition` skill:

- The US Navy body-fat equations were receiving centimetres even though their published constants require inches. For the male regression case, this changed the result from `22.6%` to the unit-correct `16.2%`; the female case changed from `55.8%` to `29.2%`.
- Unsupported calculator categories, non-positive physical inputs, and non-physical body-fat outputs silently selected defaults or emitted plausible-looking nonsense. The CLI now fails closed with exit code 2.
- wger removed the documented `/api/v2/exercise/search/` route. A dependency-free helper now uses the supported `exerciseinfo` filters, reranks up to 100 candidates across joined, hyphenated, and plural spellings, resolves English names from translations, and emits compact JSON.
- The skill contract now uses current `exerciseinfo` filters for name, muscle, category, and equipment lookups, distinguishes reference/calculation from individualized planning, and requires explicit USDA result selection with product-label precedence.

This keeps the optional skill dependency-free and avoids changing Hermes core behavior.

## Related Issue

No existing issue or open PR was found for these defects.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/health/fitness-nutrition/scripts/body_calc.py`
  - Convert centimetres to inches before both Navy equations.
  - Validate sex, activity, goal, repetitions, and positive numeric inputs.
  - Return exit code 2 with a specific stderr message for invalid input.
- `optional-skills/health/fitness-nutrition/scripts/exercise_search.py`
  - Add a stdlib-only wger name-search CLI using supported API filters.
  - Emit compact JSON with names, category, muscles, equipment, description, and image.
- `optional-skills/health/fitness-nutrition/SKILL.md`
  - Replace obsolete/ignored wger routes and parameters.
  - Tighten routing boundaries and nutrition identity guidance.
  - Bump the skill version to 1.1.0.
- `optional-skills/health/fitness-nutrition/references/FORMULAS.md`
  - Document the Navy equations' required unit conversion.
- `tests/skills/test_fitness_nutrition_skill.py`
  - Add CLI-boundary regressions for formulas, validation, wger request construction/output, and the SKILL contract.

## How to Test

1. Run `python -m pytest tests/skills/test_fitness_nutrition_skill.py -q`.
2. Run `python -m pytest tests/skills/test_fitness_nutrition_skill.py tests/tools/test_skills_tool.py tests/website/test_extract_skills.py tests/scripts/test_build_skills_index_health.py -q`.
3. Run `python3 optional-skills/health/fitness-nutrition/scripts/body_calc.py bodyfat M 38 85 180` and confirm `16.2%`.
4. Run `python3 optional-skills/health/fitness-nutrition/scripts/exercise_search.py "pull up" --limit 3` and confirm named JSON results with muscles and equipment.
5. Run `uvx ruff check optional-skills/health/fitness-nutrition/scripts/body_calc.py optional-skills/health/fitness-nutrition/scripts/exercise_search.py tests/skills/test_fitness_nutrition_skill.py`.

Verified locally:

- Targeted and skill-integration suite: `80 passed`
- Python 3.12 direct CLI smokes: corrected body fat, valid TDEE, invalid-input rejection, and live wger search passed
- Live wger name search and combined muscle/equipment filters: HTTP success with relevant named results
- Live USDA lookup: HTTP success; docs now explicitly prevent treating search rank as food identity
- `scripts/run_tests.sh`: stopped after ~9,000 passes because two unrelated timing-sensitive gateway tests failed under parallel load; both passed immediately in isolation (`2 passed`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (see isolated unrelated timing flakes above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS x86_64, Python 3.11 and 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow changes)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib only; no shell-specific logic in helpers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool changes)

## Screenshots / Logs

```text
$ python3 optional-skills/health/fitness-nutrition/scripts/body_calc.py bodyfat M 38 85 180
Estimated body fat: 16.2%
Category: Fitness (14-17%)
Method: US Navy circumference formula

$ python -m pytest tests/skills/test_fitness_nutrition_skill.py -q
23 passed
```
