### PR TITLE
fix: execute_code refund only refunded one limiter, default mismatch 90→500

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6154,6 +6154,7 @@ def run_conversation(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
+                    api_call_count -= 1
                 
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the

--- a/run_agent.py
+++ b/run_agent.py
@@ -440,7 +440,7 @@ class AIAgent:
         command: str = None,
         args: list[str] | None = None,
         model: str = "",
-        max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+        max_iterations: int = 500,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = None,  # Deprecated: accepted for compatibility, ignored
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,


### PR DESCRIPTION
The execute_code refund path in conversation_loop.py only called `iteration_budget.refund()` but forgot to decrement `api_call_count`. Every other refund site (ollama context error, compression preflight, redirected/compressed/rebuilt messages retry) correctly decrements both. This meant execute_code-only iterations silently leaked budget through the second limiter.

Also bumped the bare parameter default in `AIAgent.__init__` from 90 to 500 to match the config schema default (`max_turns: 500` in config_defaults.py).

Closes #75097