### PR TITLE
fix: respect tirith_fail_open in circuit breaker path

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -750,6 +750,9 @@ def check_command_security(command: str) -> dict:
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
     # (issue #41400).
     if _circuit_open:
+        fail_open = cfg.get("tirith_fail_open", True)
+        if not fail_open:
+            return {"action": "block", "findings": [], "summary": "tirith disabled (circuit breaker, fail-closed)"}
         return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and


### PR DESCRIPTION
The tirith circuit breaker at `check_command_security()` always returned `"allow"` when the breaker was open, ignoring the user's `tirith_fail_open` configuration. The three operational failure handlers (OSError, timeout, unknown exit code) all correctly check fail_open — the circuit breaker was the one path that missed it.

Now reads fail_open from config and returns `"block"` when fail_open is false (fail-closed), matching the other failure handlers.

Closes #74922