### PR TITLE
feat: add SambaNova model provider (OpenAI-compatible)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -402,6 +402,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("KILOCODE_API_KEY",),
         base_url_env_var="KILOCODE_BASE_URL",
     ),
+    "sambanova": ProviderConfig(
+        id="sambanova",
+        name="SambaNova",
+        auth_type="api_key",
+        inference_base_url="https://api.sambanova.ai/v1",
+        api_key_env_vars=("SAMBANOVA_API_KEY",),
+        base_url_env_var="SAMBANOVA_BASE_URL",
+    ),
     "huggingface": ProviderConfig(
         id="huggingface",
         name="Hugging Face",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3474,6 +3474,7 @@ def select_provider_and_model(args=None):
         "arcee",
         "gmi",
         "nvidia",
+        "sambanova",
         "ollama-cloud",
         "tencent-tokenhub",
         "lmstudio",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -440,8 +440,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4",
     ],
     "sambanova": [
-        "Meta-Llama-3.3-70B-Instruct",
-        "Qwen2.5-72B-Instruct",
+        "MiniMax-M2.7",
+        "gemma-4-31B-it",
+        "gpt-oss-120b",
     ],
     "opencode-zen": [
         "kimi-k2.5",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -439,6 +439,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
     ],
+    "sambanova": [
+        "Meta-Llama-3.3-70B-Instruct",
+        "Qwen2.5-72B-Instruct",
+    ],
     "opencode-zen": [
         "kimi-k2.5",
         "kimi-k2.6",
@@ -1358,6 +1362,8 @@ _PROVIDER_ALIASES = {
     "nvidia-nim": "nvidia",
     "build-nvidia": "nvidia",
     "nemotron": "nvidia",
+    "sambanova-ai": "sambanova",
+    "sambanovaai": "sambanova",
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
     "lm_studio": "lmstudio",

--- a/plugins/model-providers/sambanova/__init__.py
+++ b/plugins/model-providers/sambanova/__init__.py
@@ -16,6 +16,7 @@ SAMBA_NOVA_MODELS_URL = "https://api.sambanova.ai/v1/models"
 
 sambanova = ProviderProfile(
     name="sambanova",
+    aliases=("sambanova-ai", "sambanovaai"),
     env_vars=("SAMBANOVA_API_KEY",),
     display_name="SambaNova",
     description="SambaNova — AI acceleration platform with OpenAI-compatible API",

--- a/plugins/model-providers/sambanova/__init__.py
+++ b/plugins/model-providers/sambanova/__init__.py
@@ -1,0 +1,32 @@
+"""SambaNova provider profile.
+
+SambaNova provides an OpenAI-compatible API endpoint for their AI models.
+This profile enables users to use SambaNova as a model provider in Hermes.
+"""
+
+from __future__ import annotations
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+# SambaNova API endpoints
+SAMBA_NOVA_BASE_URL = "https://api.sambanova.ai/v1"
+SAMBA_NOVA_MODELS_URL = "https://api.sambanova.ai/v1/models"
+
+
+sambanova = ProviderProfile(
+    name="sambanova",
+    env_vars=("SAMBANOVA_API_KEY",),
+    display_name="SambaNova",
+    description="SambaNova — AI acceleration platform with OpenAI-compatible API",
+    signup_url="https://cloud.sambanova.ai/",
+    base_url=SAMBA_NOVA_BASE_URL,
+    models_url=SAMBA_NOVA_MODELS_URL,
+    fallback_models=(
+        "Meta-Llama-3.3-70B-Instruct",
+        "Qwen2.5-72B-Instruct",
+    ),
+    supports_vision=False,
+)
+
+register_provider(sambanova)

--- a/plugins/model-providers/sambanova/__init__.py
+++ b/plugins/model-providers/sambanova/__init__.py
@@ -9,25 +9,22 @@ from __future__ import annotations
 from providers import register_provider
 from providers.base import ProviderProfile
 
-# SambaNova API endpoints
-SAMBA_NOVA_BASE_URL = "https://api.sambanova.ai/v1"
-SAMBA_NOVA_MODELS_URL = "https://api.sambanova.ai/v1/models"
-
-
 sambanova = ProviderProfile(
     name="sambanova",
     aliases=("sambanova-ai", "sambanovaai"),
-    env_vars=("SAMBANOVA_API_KEY",),
+    env_vars=("SAMBANOVA_API_KEY", "SAMBANOVA_BASE_URL"),
     display_name="SambaNova",
     description="SambaNova — AI acceleration platform with OpenAI-compatible API",
     signup_url="https://cloud.sambanova.ai/",
-    base_url=SAMBA_NOVA_BASE_URL,
-    models_url=SAMBA_NOVA_MODELS_URL,
+    base_url="https://api.sambanova.ai/v1",
+    models_url="https://api.sambanova.ai/v1/models",
+    auth_type="api_key",
+    default_aux_model="gemma-4-31B-it",
     fallback_models=(
-        "Meta-Llama-3.3-70B-Instruct",
-        "Qwen2.5-72B-Instruct",
+        "MiniMax-M2.7",
+        "gemma-4-31B-it",
+        "gpt-oss-120b",
     ),
-    supports_vision=False,
 )
 
 register_provider(sambanova)

--- a/plugins/model-providers/sambanova/plugin.yaml
+++ b/plugins/model-providers/sambanova/plugin.yaml
@@ -1,0 +1,5 @@
+name: sambanova-provider
+kind: model-provider
+version: 1.0.0
+description: SambaNova — AI acceleration platform with OpenAI-compatible API
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -43,6 +43,7 @@ class TestProviderRegistry:
         ("ai-gateway", "Vercel AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
         ("gmi", "GMI Cloud", "api_key"),
+        ("sambanova", "SambaNova", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -97,6 +98,11 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["gmi"]
         assert pconfig.api_key_env_vars == ("GMI_API_KEY",)
         assert pconfig.base_url_env_var == "GMI_BASE_URL"
+
+    def test_sambanova_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["sambanova"]
+        assert pconfig.api_key_env_vars == ("SAMBANOVA_API_KEY",)
+        assert pconfig.base_url_env_var == "SAMBANOVA_BASE_URL"
 
     def test_huggingface_env_vars(self):
         pconfig = PROVIDER_REGISTRY["huggingface"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -51,6 +51,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Qwen OAuth** | `hermes model` → "Qwen OAuth" (provider: `qwen-oauth`; browser PKCE login) |
 | **MiniMax OAuth** | `hermes model` → "MiniMax (OAuth)" (provider: `minimax-oauth`; browser PKCE login) |
 | **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`) |
+| **SambaNova** | `SAMBANOVA_API_KEY` in `~/.hermes/.env` (provider: `sambanova`; aliases: `sambanova-ai`, `sambanovaai`; base models: MiniMax-M2.7, gemma-4-31B-it, gpt-oss-120b) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
 


### PR DESCRIPTION
## Summary

Add SambaNova as a model provider in Hermes Agent using the OpenAI-compatible plugin path.

### Changes

- Added new provider plugin at 
-  - Provider metadata (name, kind, version, description)
-  - Provider profile configuration:
  - Base URL: 
  - Environment variable: 
  - OpenAI-compatible API
  - Fallback models: Meta-Llama-3.3-70B-Instruct, Qwen2.5-72B-Instruct

### Context

SambaNova provides an OpenAI-compatible API for their AI acceleration platform. This allows Hermes users to use SambaNova as a model provider by simply setting the  environment variable.

### Related

- Jira: CP-3007