### PR TITLE
fix(terminal): bootstrap configured Windows network drives

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3210,6 +3210,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+    "windows_network_drives": "TERMINAL_WINDOWS_NETWORK_DRIVES",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
 }
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -252,6 +252,10 @@ DEFAULT_CONFIG = {
         "backend": "local",
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
+        # Opt-in SMB mappings applied to every newly-created Windows local terminal
+        # environment. Each entry is {"drive": "E", "remote": "\\\\server\\share"}.
+        # Authentication is delegated to Windows Credential Manager.
+        "windows_network_drives": [],
         # Terminal font family for the desktop app's embedded xterm.js terminal.
         # When set (e.g. "'CaskaydiaCoveNerdFont', 'JetBrains Mono', monospace"),
         # the desktop terminal uses this as the CSS font-family value, with the

--- a/tests/tools/test_windows_network_drives.py
+++ b/tests/tools/test_windows_network_drives.py
@@ -1,0 +1,97 @@
+"""Tests for opt-in SMB drive bootstrap in the Windows local terminal backend."""
+
+import subprocess
+
+from tools.environments import local as local_mod
+
+
+def test_windows_network_drive_mapping_runs_once_per_environment(monkeypatch):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+
+    local_mod.ensure_windows_network_drives(
+        [
+            {"drive": "e", "remote": r"\\fileserver\engineering"},
+            {"drive": "D:", "remote": r"\\fileserver\documents"},
+        ]
+    )
+
+    assert [call[0] for call in calls] == [
+        ["net", "use", "E:", "/delete", "/y"],
+        ["net", "use", "E:", r"\\fileserver\engineering", "/persistent:no"],
+        ["net", "use", "D:", "/delete", "/y"],
+        ["net", "use", "D:", r"\\fileserver\documents", "/persistent:no"],
+    ]
+    assert all(call[1]["check"] is False for call in calls)
+    assert all(call[1]["timeout"] == 15 for call in calls)
+
+
+def test_windows_network_drive_mapping_ignores_invalid_entries(monkeypatch):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    calls = []
+    monkeypatch.setattr(
+        local_mod.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(args) or subprocess.CompletedProcess(args, 0),
+    )
+
+    local_mod.ensure_windows_network_drives(
+        [
+            {"drive": "invalid", "remote": r"\\server\share"},
+            {"drive": "F", "remote": "not-a-unc-path"},
+            "E: \\server\share",
+            {"drive": "G", "remote": r"\\server\share"},
+        ]
+    )
+
+    assert calls == [
+        ["net", "use", "G:", "/delete", "/y"],
+        ["net", "use", "G:", r"\\server\share", "/persistent:no"],
+    ]
+
+
+def test_windows_network_drive_mapping_is_noop_off_windows(monkeypatch):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+    monkeypatch.setattr(
+        local_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+
+    local_mod.ensure_windows_network_drives(
+        [{"drive": "E", "remote": r"\\fileserver\engineering"}]
+    )
+
+
+def test_local_environment_bootstraps_configured_windows_drives(monkeypatch, tmp_path):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    mappings = [{"drive": "E", "remote": r"\\fileserver\engineering"}]
+    observed = []
+    monkeypatch.setattr(
+        local_mod,
+        "ensure_windows_network_drives",
+        lambda value: observed.append(value),
+    )
+    monkeypatch.setattr(local_mod.LocalEnvironment, "init_session", lambda self: None)
+
+    local_mod.LocalEnvironment(cwd=str(tmp_path), windows_network_drives=mappings)
+
+    assert observed == [mappings]
+
+
+def test_local_environment_does_not_bootstrap_without_mappings(monkeypatch, tmp_path):
+    monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+    monkeypatch.setattr(
+        local_mod,
+        "ensure_windows_network_drives",
+        lambda value: (_ for _ in ()).throw(AssertionError("must not run")),
+    )
+    monkeypatch.setattr(local_mod.LocalEnvironment, "init_session", lambda self: None)
+
+    local_mod.LocalEnvironment(cwd=str(tmp_path))

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -22,6 +22,41 @@ _IS_WINDOWS = platform.system() == "Windows"
 logger = logging.getLogger(__name__)
 
 
+def ensure_windows_network_drives(mappings: object) -> None:
+    """Connect configured SMB mappings for a newly-created local environment."""
+    if not _IS_WINDOWS or not isinstance(mappings, list):
+        return
+    for entry in mappings:
+        if not isinstance(entry, Mapping):
+            logger.warning("Ignoring invalid terminal.windows_network_drives entry: expected mapping")
+            continue
+        drive = str(entry.get("drive", "")).strip().upper().rstrip(":")
+        remote = str(entry.get("remote", "")).strip()
+        if not re.fullmatch(r"[A-Z]", drive) or not remote.startswith("\\\\"):
+            logger.warning("Ignoring invalid terminal.windows_network_drives entry for drive %r; use a single drive letter and a UNC path.", entry.get("drive"))
+            continue
+        try:
+            # Clear a stale/disconnected mapping first: otherwise hidden Windows
+            # processes may receive an unanswerable System error 1223 prompt.
+            subprocess.run(
+                ["net", "use", f"{drive}:", "/delete", "/y"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=15, check=False, creationflags=windows_hide_flags(),
+            )
+            result = subprocess.run(
+                ["net", "use", f"{drive}:", remote, "/persistent:no"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=15, check=False, creationflags=windows_hide_flags(),
+            )
+            if result.returncode:
+                detail = (result.stderr or result.stdout).strip().replace("\n", " ")
+                logger.warning("Could not map %s: to %s (exit %s): %s", drive, remote, result.returncode, detail[:300])
+            else:
+                logger.info("Mapped Windows drive %s: to %s for Hermes terminal environment", drive, remote)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning("Could not map Windows drive %s: to %s: %s", drive, remote, exc)
+
+
 def _msys_to_windows_path(cwd: str) -> str:
     """Translate a Git Bash / MSYS-style POSIX path (``/c/Users/x``) to the
     native Windows form (``C:\\Users\\x``) so ``os.path.isdir`` and
@@ -1421,7 +1456,10 @@ class LocalEnvironment(BaseEnvironment):
 
     _profile_scoped_passthrough = True
 
-    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
+    def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None,
+                 windows_network_drives: object = None):
+        if windows_network_drives:
+            ensure_windows_network_drives(windows_network_drives)
         cwd = _resolve_local_initial_cwd(cwd)
         super().__init__(cwd=cwd, timeout=timeout, env=env)
         self.init_session()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1484,6 +1484,13 @@ def _get_env_config() -> Dict[str, Any]:
         docker_extra_args = []
         docker_shm_size = "1g"
 
+    windows_network_drives = _parse_env_var(
+        "TERMINAL_WINDOWS_NETWORK_DRIVES", "[]", json.loads, "valid JSON"
+    )
+    if not isinstance(windows_network_drives, list):
+        logger.warning("TERMINAL_WINDOWS_NETWORK_DRIVES must be a JSON list; ignoring it")
+        windows_network_drives = []
+
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
     # else starts in the backend's default root-like cwd.
@@ -1548,6 +1555,7 @@ def _get_env_config() -> Dict[str, Any]:
             os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
         "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "windows_network_drives": windows_network_drives,
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
@@ -1622,7 +1630,11 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        return _LocalEnvironment(
+            cwd=cwd,
+            timeout=timeout,
+            windows_network_drives=(local_config or {}).get("windows_network_drives"),
+        )
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -2446,6 +2458,7 @@ def terminal_tool(
                         if env_type == "local":
                             local_config = {
                                 "persistent": config.get("local_persistent", False),
+                                "windows_network_drives": config.get("windows_network_drives", []),
                             }
 
                         new_env = _create_environment(


### PR DESCRIPTION
## Summary

- add opt-in `terminal.windows_network_drives` for the Windows local terminal backend
- clear stale mappings before reconnecting configured UNC paths
- rely on Windows Credential Manager; no credentials or host-specific shares are added
- add focused coverage for valid, invalid, and non-Windows behavior

## Validation

- `venv/Scripts/python.exe -m pytest tests/tools/test_windows_network_drives.py -q`

Closes #78241
