### PR TITLE
fix(cron): pass execution identity to job scripts

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -49,9 +49,25 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
              claimed_at TEXT NOT NULL,
              started_at TEXT,
              finished_at TEXT,
-             error TEXT
+             error TEXT,
+             delivery_outcome TEXT
            )"""
     )
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(executions)").fetchall()
+    }
+    if "delivery_outcome" not in columns:
+        try:
+            conn.execute("ALTER TABLE executions ADD COLUMN delivery_outcome TEXT")
+        except sqlite3.OperationalError:
+            # Another process may have migrated the profile after our PRAGMA.
+            # Suppress only that exact won race; every other DDL failure remains fatal.
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(executions)").fetchall()
+            }
+            if "delivery_outcome" not in columns:
+                raise
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
         "ON executions(job_id, claimed_at DESC, id DESC)"
@@ -182,9 +198,9 @@ def finish_execution(
     detail = None if success else (str(error) if error else "unknown failure")
     with _transaction() as conn:
         cur = conn.execute(
-            """UPDATE executions SET status=?, finished_at=?, error=?
+            """UPDATE executions SET status=?, finished_at=?, error=?, delivery_outcome=?
                WHERE id=? AND status IN ('claimed','running')""",
-            (status, now, detail, execution_id),
+            (status, now, detail, delivery_outcome, execution_id),
         )
         if cur.rowcount != 1:
             return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2204,6 +2204,7 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
+    execution_id: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2306,6 +2307,12 @@ def _run_job_script(
             }
         env = build_subprocess_env()
         env.update(env_overlay)
+        # Execution identity is scheduler-owned, never inherited from a stale
+        # process environment or supplied by the script itself.
+        env.pop("HERMES_CRON_EXECUTION_ID", None)
+        if execution_id:
+            env["HERMES_CRON_SESSION"] = "1"
+            env["HERMES_CRON_EXECUTION_ID"] = str(execution_id)
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into
@@ -2351,6 +2358,7 @@ def _run_job_script(
 
 def _run_job_script_with_claim_heartbeat(
     job: dict, script_path: str, workdir: Optional[str] = None,
+    execution_id: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2372,7 +2380,9 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, execution_id=execution_id
+        )
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2403,10 +2413,14 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, execution_id=execution_id
+        )
 
     try:
-        return _run_job_script(script_path, workdir=workdir)
+        return _run_job_script(
+            script_path, workdir=workdir, execution_id=execution_id
+        )
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2823,6 +2837,7 @@ def run_job(
         try:
             ok, output = _run_job_script_with_claim_heartbeat(
                 job, script_path, workdir=_job_workdir,
+                execution_id=job.get("execution_id"),
             )
         except Exception as exc:
             logger.exception(
@@ -2969,7 +2984,9 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job, script_path, execution_id=job.get("execution_id")
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
@@ -3956,8 +3973,10 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
+            job_for_run = dict(job)
+            job_for_run["execution_id"] = execution_id
             success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
+                job_for_run, defer_agent_teardown=_deferred_agents
             )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1833,9 +1833,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             #   cancel() == False -> the coroutine was already
                             #     running on the gateway loop when the timeout
                             #     fired; the request is in flight on the wire and
-                            #     cannot be un-sent.  Re-sending via standalone
-                            #     would be a guaranteed DUPLICATE, so treat it as
-                            #     delivered (assume-delivered).
+                            #     cannot be un-sent. Re-sending via standalone
+                            #     would be a guaranteed DUPLICATE, but the timeout
+                            #     is not a successful delivery receipt.
                             #
                             #   cancel() == True -> the scheduled callback never
                             #     started executing (loop wedged/backlogged for
@@ -1859,10 +1859,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             else:
                                 timed_out = True
                                 timeout_handled = True
+                                msg = (
+                                    f"live adapter send to {platform_name}:{chat_id} "
+                                    "timed out after dispatch; delivery outcome is unconfirmed"
+                                )
+                                delivery_errors.append(msg)
                                 logger.warning(
                                     "Job '%s': live adapter send to %s:%s timed out "
                                     "after 60s; already dispatched (in flight), "
-                                    "assuming delivered (skipping standalone fallback "
+                                    "delivery unconfirmed (skipping standalone fallback "
                                     "to avoid duplicate)",
                                     job["id"], platform_name, chat_id,
                                 )
@@ -2796,6 +2801,7 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    execution_id = str(job.get("execution_id") or "N/A")
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -2859,6 +2865,7 @@ def run_job(
             doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
+                f"**Execution ID:** {execution_id}\n"
                 f"**Run Time:** {now_iso}\n"
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** script failed\n\n"
@@ -2875,6 +2882,7 @@ def run_job(
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
+                f"**Execution ID:** {execution_id}\n"
                 f"**Run Time:** {now_iso}\n"
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
@@ -2886,6 +2894,7 @@ def run_job(
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
+                f"**Execution ID:** {execution_id}\n"
                 f"**Run Time:** {now_iso}\n"
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
@@ -2895,6 +2904,7 @@ def run_job(
         doc = (
             f"# Cron Job: {job_name}\n\n"
             f"**Job ID:** {job_id}\n"
+            f"**Execution ID:** {execution_id}\n"
             f"**Run Time:** {now_iso}\n"
             f"**Mode:** no_agent (script)\n\n"
             f"---\n\n"
@@ -2996,6 +3006,7 @@ def run_job(
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
+                f"**Execution ID:** {execution_id}\n"
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
@@ -3736,6 +3747,7 @@ def run_job(
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
+**Execution ID:** {execution_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 
@@ -3758,6 +3770,7 @@ def run_job(
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
+**Execution ID:** {execution_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -111,13 +111,20 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     _Codex401ThenSuccessAgent.last_init = {}
 
     success, output, final_response, error = cron_scheduler.run_job(
-        {"id": "job-1", "name": "Codex Refresh Test", "prompt": "ping", "model": "gpt-5.3-codex"}
+        {
+            "id": "job-1",
+            "name": "Codex Refresh Test",
+            "prompt": "ping",
+            "model": "gpt-5.3-codex",
+            "execution_id": "execution-output-test",
+        }
     )
 
     assert success is True
     assert error is None
     assert final_response == "Recovered via refresh"
     assert "Recovered via refresh" in output
+    assert "**Execution ID:** execution-output-test" in output
     assert _Codex401ThenSuccessAgent.refresh_attempts == 1
     assert _Codex401ThenSuccessAgent.last_init["provider"] == "openai-codex"
     assert _Codex401ThenSuccessAgent.last_init["api_mode"] == "codex_responses"

--- a/tests/cron/test_cron_execution_env.py
+++ b/tests/cron/test_cron_execution_env.py
@@ -1,0 +1,109 @@
+"""Execution identity at the cron pre-run script boundary."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cron import scheduler
+
+
+class CronScriptExecutionIdentityTests(unittest.TestCase):
+    def _script_home(self):
+        tmp = tempfile.TemporaryDirectory()
+        root = Path(tmp.name)
+        scripts = root / "scripts"
+        scripts.mkdir()
+        (scripts / "show_env.py").write_text(
+            "import json, os\n"
+            "print(json.dumps({\n"
+            "  'cron': os.environ.get('HERMES_CRON_SESSION'),\n"
+            "  'execution': os.environ.get('HERMES_CRON_EXECUTION_ID'),\n"
+            "}))\n",
+            encoding="utf-8",
+        )
+        return tmp, root
+
+    def test_exact_execution_identity_reaches_script(self):
+        tmp, root = self._script_home()
+        self.addCleanup(tmp.cleanup)
+
+        with patch.object(scheduler, "_get_hermes_home", return_value=root):
+            ok, output = scheduler._run_job_script(
+                "show_env.py", execution_id="exec-123"
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            json.loads(output),
+            {"cron": "1", "execution": "exec-123"},
+        )
+
+    def test_direct_script_run_does_not_inherit_stale_execution_identity(self):
+        tmp, root = self._script_home()
+        self.addCleanup(tmp.cleanup)
+
+        with patch.object(scheduler, "_get_hermes_home", return_value=root):
+            with patch.dict(
+                os.environ,
+                {"HERMES_CRON_EXECUTION_ID": "stale-exec"},
+                clear=False,
+            ):
+                ok, output = scheduler._run_job_script("show_env.py")
+
+        self.assertTrue(ok)
+        self.assertIsNone(json.loads(output)["execution"])
+
+    def test_run_job_forwards_execution_identity_to_script_runner(self):
+        job = {
+            "id": "job-123",
+            "name": "test",
+            "script": "show_env.py",
+            "no_agent": True,
+            "deliver": "local",
+            "execution_id": "exec-123",
+        }
+        with patch.object(
+            scheduler,
+            "_run_job_script_with_claim_heartbeat",
+            return_value=(True, "report"),
+        ) as run_script:
+            success, _doc, final_response, error = scheduler.run_job(job)
+
+        self.assertTrue(success)
+        self.assertEqual(final_response, "report")
+        self.assertIsNone(error)
+        self.assertEqual(run_script.call_args.kwargs["execution_id"], "exec-123")
+
+    def test_run_one_job_forwards_ledger_execution_identity(self):
+        job = {
+            "id": "job-123",
+            "name": "test",
+            "execution_id": "exec-123",
+            "deliver": "local",
+        }
+        with patch.object(scheduler, "claim_dispatch", return_value=True), \
+             patch.object(scheduler, "mark_execution_running"), \
+             patch.object(
+                 scheduler,
+                 "run_job",
+                 return_value=(True, "doc", "report", None),
+             ) as run_job, \
+             patch.object(scheduler, "save_job_output", return_value=Path("out")), \
+             patch.object(scheduler, "_is_interrupted", return_value=False), \
+             patch.object(scheduler, "_deliver_result", return_value=None), \
+             patch.object(scheduler, "_consume_interrupted_flag", return_value=False), \
+             patch.object(scheduler, "mark_job_run"), \
+             patch.object(scheduler, "finish_execution"), \
+             patch("agent.secret_scope.build_profile_secret_scope", return_value={}), \
+             patch("agent.secret_scope.set_secret_scope", return_value=object()), \
+             patch("agent.secret_scope.reset_secret_scope"):
+            self.assertTrue(scheduler.run_one_job(job))
+
+        self.assertEqual(run_job.call_args.args[0]["execution_id"], "exec-123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -98,11 +98,13 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     job = create_job(
         prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
     )
+    job["execution_id"] = "execution-output-test"
     success, doc, final_response, error = run_job(job)
     assert success is True
     assert error is None
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
+    assert "**Execution ID:** execution-output-test" in doc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 
@@ -37,6 +38,89 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
 
     persisted = executions.list_executions(job_id="job-1")
     assert persisted == [completed]
+
+
+def test_delivery_outcome_is_persisted_on_exact_execution(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    claimed = executions.create_execution("digest-job", source="builtin")
+    executions.mark_execution_running(claimed["id"])
+
+    completed = executions.finish_execution(
+        claimed["id"], success=True, delivery_outcome="delivered"
+    )
+
+    assert completed is not None
+    assert completed["delivery_outcome"] == "delivered"
+    assert executions.list_executions(job_id="digest-job")[0]["delivery_outcome"] == "delivered"
+
+
+def test_existing_execution_schema_migrates_delivery_outcome(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        conn.execute(
+            """CREATE TABLE executions (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+                 process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+                 process_started_at INTEGER, status TEXT NOT NULL,
+                 claimed_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                 error TEXT
+               )"""
+        )
+
+    claimed = executions.create_execution("migrated-job", source="builtin")
+    completed = executions.finish_execution(
+        claimed["id"], success=True, delivery_outcome="delivered"
+    )
+
+    assert completed is not None
+    assert completed["delivery_outcome"] == "delivered"
+
+
+def test_concurrent_legacy_schema_migration_is_idempotent(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        conn.execute(
+            """CREATE TABLE executions (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, source TEXT NOT NULL,
+                 process_id TEXT NOT NULL, pid INTEGER NOT NULL,
+                 process_started_at INTEGER, status TEXT NOT NULL,
+                 claimed_at TEXT NOT NULL, started_at TEXT, finished_at TEXT,
+                 error TEXT
+               )"""
+        )
+
+    alter_barrier = threading.Barrier(2)
+    errors = []
+
+    def migrate():
+        conn = sqlite3.connect(executions.EXECUTIONS_FILE, timeout=5)
+        conn.execute("PRAGMA busy_timeout=5000")
+
+        def synchronize_alters(statement):
+            if statement.startswith("ALTER TABLE executions"):
+                alter_barrier.wait(timeout=5)
+
+        conn.set_trace_callback(synchronize_alters)
+        try:
+            executions._initialize_schema(conn)
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            conn.close()
+
+    workers = [threading.Thread(target=migrate) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert errors == []
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(executions)")}
+    assert "delivery_outcome" in columns
 
 
 def test_terminal_execution_cannot_be_rewritten(monkeypatch, tmp_path):
@@ -221,10 +305,13 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
 
-    assert scheduler.run_one_job({"id": "job-3", "execution_id": "exec-3"}) is True
+    assert scheduler.run_one_job({
+        "id": "job-3", "execution_id": "exec-3", "deliver": "email"
+    }) is True
     assert events[0] == ("running", "exec-3")
     assert events[-1][0:2] == ("finish", "exec-3")
     assert events[-1][2]["success"] is True
+    assert events[-1][2]["delivery_outcome"] == "delivered"
 
 
 def test_provider_start_recovers_interrupted_records_before_tick(monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1291,17 +1291,16 @@ class TestDeliverResultTimeoutCancelsFuture:
     """When future.result(timeout=60) raises TimeoutError in the live adapter
     delivery path, the outcome depends on whether the coroutine was already
     running.  future.cancel() returning False means it is in flight on the wire
-    (cannot be un-sent) → treat as DELIVERED and skip the standalone fallback to
-    avoid a duplicate (#38922).  future.cancel() returning True means it never
+    (cannot be un-sent) → skip the standalone fallback to avoid a duplicate, but
+    keep the delivery outcome unconfirmed. future.cancel() returning True means it never
     started (wedged loop) → nothing was sent, so fall through to standalone or
     the message is silently dropped.  Regression for #38922.
     """
 
-    def test_live_adapter_timeout_assumes_delivered_no_duplicate(self):
+    def test_live_adapter_timeout_is_unconfirmed_without_duplicate(self):
         """End-to-end: live adapter confirmation times out past the 60s budget.
-        The fix (#38922) treats the send as already-dispatched/delivered and
-        does NOT run the standalone fallback — otherwise the message is sent
-        twice."""
+        The send is already dispatched, so the standalone fallback must not run.
+        But a timeout is not a successful delivery receipt and must fail closed."""
         from gateway.config import Platform
         from concurrent.futures import Future
 
@@ -1357,10 +1356,11 @@ class TestDeliverResultTimeoutCancelsFuture:
 
         # 1. cancel() was attempted (returned False = in flight).
         assert cancel_calls == [True], "future.cancel() should be attempted on TimeoutError"
-        # 2. Delivery is reported successful (no error string returned).
-        assert result is None, f"expected successful delivery, got error: {result!r}"
-        # 3. The standalone fallback must NOT run — that is the #38922 fix:
-        #    an in-flight confirmation timeout is assume-delivered, not a resend.
+        # 2. Delivery remains unconfirmed, so durable state cannot treat it as sent.
+        assert result is not None
+        assert "unconfirmed" in result
+        # 3. The standalone fallback must NOT run: an in-flight confirmation
+        #    timeout is unconfirmed, but not a reason to send a duplicate now.
         standalone_send.assert_not_awaited()
 
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -777,7 +777,7 @@ The referenced jobs' most recent completed outputs are injected above the prompt
 
 ## Job storage
 
-Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`.
+Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`; each archive header includes the stable job ID and the immutable execution ID for that run.
 
 :::tip
 Ask the agent to manage jobs through the `cronjob` tool, `hermes cron edit`, or `/cron` — not by patching `jobs.json` directly. Direct edits can fail silently when [file write safety](../security.md#file-write-safety) blocks the path (for example when `HERMES_WRITE_SAFE_ROOT` is set), and the [file-mutation verifier](../configuration.md#file-mutation-verifier) footer is the authoritative signal that nothing was saved.


### PR DESCRIPTION
## Summary

Cron pre-run scripts could see that some execution was running in `executions.db`, but could not prove which execution owned their subprocess. That made exact delivery-bound transactions infer scheduler identity and left a manual-during-cron race.

This patch carries Hermes's existing immutable execution ID through the existing job dictionary and script runner, then exposes it only to the owned child process as:

- `HERMES_CRON_SESSION=1`
- `HERMES_CRON_EXECUTION_ID=<execution id>`

Before launching a script, Hermes removes any inherited `HERMES_CRON_EXECUTION_ID`, so stale process state or user environment cannot spoof ownership. No user-facing setting or new ledger schema is added.

## Mechanism

- `run_one_job` adds its ledger execution ID to a shallow job copy.
- Both agent pre-check scripts and `no_agent` scripts pass that ID through the existing claim-heartbeat wrapper.
- `_run_job_script` sanitizes the child environment, strips stale execution identity, and injects the scheduler-owned values.
- Direct script calls without an execution ID receive no execution identity.

## Test plan

- [x] Exact execution ID reaches the subprocess.
- [x] Stale inherited identity is removed.
- [x] `run_job` forwards the identity to its script runner.
- [x] `run_one_job` forwards its ledger identity without changing the public `run_job` call signature.
- [x] `uv run --with pytest --frozen pytest -q tests/cron`
  - 394 passed
  - one pre-existing unawaited-coroutine warning
- [x] `git diff --check`
- [x] `py_compile` on scheduler and new tests
