### PR TITLE
fix(gateway): preserve exception type when error string is empty (#78183)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -518,7 +518,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             msg_id = data.get("guid") or data.get("messageGuid") or "ok"
             return SendResult(success=True, message_id=str(msg_id), raw_response=res)
         except Exception as exc:
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
     # ------------------------------------------------------------------
     # Text sending
@@ -581,7 +581,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     success=True, message_id=str(msg_id), raw_response=res
                 )
             except Exception as exc:
-                return SendResult(success=False, error=str(exc))
+                return SendResult(success=False, error=str(exc) or type(exc).__name__)
         return last
 
     # ------------------------------------------------------------------

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2545,7 +2545,7 @@ class QQAdapter(BasePlatformAdapter):
                     )
                     await asyncio.sleep(delay)
 
-        error_msg = str(last_exc) if last_exc else "Unknown error"
+        error_msg = (str(last_exc) or type(last_exc).__name__) if last_exc else "Unknown error"
         logger.error("[%s] Send failed: %s", self._log_tag, error_msg)
         retryable = not any(
             k in error_msg.lower() for k in ("invalid", "forbidden", "not found")
@@ -2661,7 +2661,7 @@ class QQAdapter(BasePlatformAdapter):
             logger.error(
                 "[%s] send_with_keyboard failed: %s", self._log_tag, exc
             )
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
     async def send_approval_request(
             self,
@@ -3013,7 +3013,7 @@ class QQAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("[%s] Media send failed: %s", self._log_tag, exc)
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
     async def _upload_local_file(
             self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -552,7 +552,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 resp = await self._http_client.post(url, headers=headers, json=payload)
             except Exception as exc:
                 logger.exception("[whatsapp_cloud] send failed")
-                return SendResult(success=False, error=str(exc))
+                return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
             if resp.status_code != 200:
                 # Meta returns structured errors in the body — surface them
@@ -710,7 +710,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             resp = await self._http_client.post(url, headers=headers, json=payload)
         except Exception as exc:
             logger.exception("[whatsapp_cloud] interactive send failed")
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
         if resp.status_code != 200:
             try:
@@ -1086,7 +1086,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             resp = await self._http_client.post(url, headers=headers, json=payload)
         except Exception as exc:
             logger.exception("[whatsapp_cloud] media send failed")
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
         if resp.status_code != 200:
             try:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3876,7 +3876,7 @@ class MediaSendHandler(ABC):
                 "[%s] %s.handle() failed: %s",
                 adapter.name, handler_name, exc, exc_info=True,
             )
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=str(exc) or type(exc).__name__)
 
 
 class ImageUrlHandler(MediaSendHandler):

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -2,9 +2,11 @@
 import asyncio
 import json
 
+import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -436,5 +438,91 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert len(deleted_ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# Regression for #78183: httpx timeout exceptions stringify to "" which
+# defeats _is_timeout_error, causing the plain-text fallback to re-send an
+# already-delivered message (duplicate delivery).
+# ---------------------------------------------------------------------------
+
+class TestBlueBubblesTimeoutErrorNormalization:
+    """When an httpx timeout has an empty string representation, the adapter
+    must fall back to the exception type name so the base-layer timeout guard
+    can still recognise it."""
+
+    @pytest.mark.asyncio
+    async def test_send_read_timeout_produces_matchable_error(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        async def fake_api_post(path, payload):
+            raise httpx.ReadTimeout("")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("chat-1", "hello world")
+
+        assert not result.success
+        assert result.error, "error must not be empty"
+        assert BasePlatformAdapter._is_timeout_error(result.error), (
+            f"_is_timeout_error must recognise {result.error!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_write_timeout_produces_matchable_error(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        async def fake_api_post(path, payload):
+            raise httpx.WriteTimeout("")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("chat-1", "hello world")
+
+        assert not result.success
+        assert result.error
+        assert BasePlatformAdapter._is_timeout_error(result.error)
+
+    @pytest.mark.asyncio
+    async def test_create_chat_for_handle_timeout_produces_matchable_error(
+        self, monkeypatch,
+    ):
+        """Sibling call path — _create_chat_for_handle has the same
+        error=str(exc) pattern and must also preserve the exception type."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            raise httpx.ReadTimeout("")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter._create_chat_for_handle("test@example.com", "hi")
+
+        assert not result.success
+        assert result.error
+        assert BasePlatformAdapter._is_timeout_error(result.error)
+
+    @pytest.mark.asyncio
+    async def test_non_empty_error_string_is_unchanged(self, monkeypatch):
+        """A normal exception with a message must keep its original text."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        async def fake_api_post(path, payload):
+            raise RuntimeError("Server error '500 Internal Server Error'")
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send("chat-1", "hello world")
+
+        assert not result.success
+        assert "500 Internal Server Error" in (result.error or "")
 
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -440,6 +440,55 @@ class TestWaitForReconnection:
 
 
 # ---------------------------------------------------------------------------
+# Regression for #78183: httpx timeout empty-string defeats _is_timeout_error
+# ---------------------------------------------------------------------------
+
+class TestQQTimeoutErrorNormalization:
+    """When an httpx timeout has an empty string representation, qqbot's send
+    paths must preserve the exception type name so the base-layer timeout guard
+    (_is_timeout_error) can still recognise it and suppress the duplicate-
+    delivery plain-text fallback."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    @pytest.mark.asyncio
+    async def test_send_chunk_preserves_read_timeout_type(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter = self._make_adapter()
+
+        async def _boom(*args, **kwargs):
+            raise httpx.ReadTimeout("")
+
+        adapter._send_c2c_text = _boom
+
+        result = await adapter._send_chunk("test_openid", "hello world")
+
+        assert not result.success
+        assert result.error, "error must not be empty"
+        assert BasePlatformAdapter._is_timeout_error(result.error), (
+            f"_is_timeout_error must recognise {result.error!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_chunk_non_empty_error_unchanged(self):
+        """A normal exception with a message must keep its original text."""
+        adapter = self._make_adapter()
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("Server error '500 Internal Server Error'")
+
+        adapter._send_c2c_text = _boom
+
+        result = await adapter._send_chunk("test_openid", "hello world")
+
+        assert not result.success
+        assert "500 Internal Server Error" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
 # ChunkedUploader
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`httpx` timeout exceptions (`ReadTimeout`, `WriteTimeout`) stringify to the empty string `""`. When an adapter stores `error=str(exc)`, `_is_timeout_error("")` returns `False` on its very first guard line (`if not error: return False`). The base-layer plain-text fallback then re-sends the full message body — even though the message was already delivered to the device. The user receives the reply **twice**, the second copy prefixed `(Response formatting failed, plain text:)`.

This is the same user-visible symptom as #14061 (WeCom, non-empty-string variant) but via a **different defeat mechanism** — the empty string short-circuits before any substring matching runs.

## Fix

Replace `error=str(exc)` with `error=str(exc) or type(exc).__name__` at every httpx-based adapter boundary. This yields `"ReadTimeout"` / `"WriteTimeout"`, which the **existing** `_is_timeout_error` matcher already recognises (`"readtimeout" in lowered or "writetimeout" in lowered`). No change to `base.py` is required.

`ConnectTimeout` intentionally stays **unmatched**: if the connection never opened, the message was not delivered, so retry/fallback is the correct behaviour. Only `Read`/`Write` timeouts imply possible delivery.

## Scope — closes the whole bug class

Every httpx-based adapter that stores `error=str(exc)` from an httpx call has this latent bug. This PR fixes all of them:

| Adapter | Sites | Paths |
|---|---|---|
| BlueBubbles | 2 | `send()`, `_create_chat_for_handle()` |
| WhatsApp Cloud | 3 | text send, interactive send, media send |
| QQ Bot | 3 | `_send_chunk()`, `send_with_keyboard()`, `_send_media()` |
| Yuanbao | 1 | `MediaSendHandler.handle()` |

Weixin is excluded: it uses `aiohttp` (not httpx), and its exceptions have non-empty string representations.

## Tests

Regression tests exercise real production code paths (not boolean recomputation):

**`tests/gateway/test_bluebubbles.py`** — `TestBlueBubblesTimeoutErrorNormalization` (4 tests):
- `send()` with `httpx.ReadTimeout("")` → error is matchable by `_is_timeout_error`
- `send()` with `httpx.WriteTimeout("")` → matchable
- `_create_chat_for_handle()` sibling path → matchable
- non-empty error string (`RuntimeError`) → unchanged

**`tests/gateway/test_qqbot.py`** — `TestQQTimeoutErrorNormalization` (2 tests):
- `_send_chunk()` with `httpx.ReadTimeout("")` → error is matchable
- non-empty error string → unchanged

### RED proof (pre-fix)
3/4 BlueBubbles tests + 1/2 QQ tests fail on `upstream/main` with `AssertionError: error must not be empty` — confirming the empty-string bug.

### GREEN (with fix)
```
test_bluebubbles.py + test_qqbot.py + test_send_retry.py + test_whatsapp_cloud.py: 140 passed
yuanbao suites: 92 passed
Total: 232 passed, 0 failed
```

## Verification

- `git rev-list --left-right --count upstream/main...HEAD` → `0 1` (one focused commit)
- `git diff --check` → clean
- No competing open PRs found for #78183 or related keywords

Closes #78183.

---

*Auto-published by Moonsong via Path B automated pipeline.*