### PR TITLE
fix: avoid false lifecycle blocks for skill logs

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -74,8 +74,8 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
     # token orders because real reproductions show both.
-    r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -66,6 +66,17 @@ class TestGatewayLifecyclePattern:
         )
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
+    def test_skill_word_does_not_match_kill_branch(self):
+        text = 'grep -a "Registered /skill" ~/.hermes/logs/gateway.log'
+        assert not _contains_gateway_lifecycle_command(text)
+
+    @pytest.mark.parametrize("text", [
+        "pkill -f hermes gateway",
+        "kill hermes gateway",
+    ])
+    def test_standalone_kill_commands_still_match(self, text):
+        assert _contains_gateway_lifecycle_command(text)
+
 
     @pytest.mark.parametrize("text", [
         "restart the server application",


### PR DESCRIPTION
## Summary
- require a word boundary before kill and pkill lifecycle tokens
- add regression coverage for benign skill log searches and real kill commands

## Problem
The lifecycle guard matched the substring kill inside skill. A harmless grep of Registered /skill in a Hermes gateway log could therefore be blocked when the same path mentioned hermes and gateway.

## Solution
Require a word boundary before p?kill. Standalone kill and pkill commands remain blocked, while skill and similar words are ignored.

## Tests
- isolated regex verification passed for benign skill log text and real kill commands
- full pytest collection is blocked by missing optional httpx in the local runtime

## Scope and risk
One regex boundary and focused regression tests in the lifecycle guard.

Closes #78245