### PR TITLE
fix(kanban): isolate background-review lifecycle

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1586,6 +1586,10 @@ def init_agent(
     # background skill/memory review fork so its harness turn can't leak into
     # the user's real session and hijack the next live turn. Default False.
     agent._persist_disabled = False
+    # Auxiliary forks may share a Kanban worker's process environment without
+    # owning its task claim or run. Such forks set this flag so turn
+    # finalization cannot attribute their failures to the parent card.
+    agent._kanban_lifecycle_disabled = False
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -826,6 +826,11 @@ def _run_review_in_thread(
             # _get_session_db_for_recall); the review writes only to the skill
             # and memory stores via its tools, which is all it needs.
             review_agent._persist_disabled = True
+            # The fork inherits process environment, including a worker's
+            # HERMES_KANBAN_TASK, but it does not own that task lifecycle.
+            # Prevent its independent budget exhaustion from consuming the
+            # parent card's failure allowance.
+            setattr(review_agent, "_kanban_lifecycle_disabled", True)
             review_agent._session_db = None
             review_agent._session_json_enabled = False
             # Suppress all status/warning emits from the fork so the

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -151,7 +151,9 @@ def finalize_turn(
         # We route through ``_record_task_failure(outcome="timed_out")``
         # rather than ``kanban_block`` so this counts toward the dispatcher's
         # consecutive-failure circuit breaker (#29747 gap 2).
-        _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
+        _kanban_task = None
+        if not getattr(agent, "_kanban_lifecycle_disabled", False):
+            _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
         if _kanban_task:
             try:
                 from hermes_cli import kanban_db as _kb

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -46,6 +46,7 @@ class _LimitAgent:
         self.persisted_messages = None
         self._handle_max_iterations_called = False
         self._completion_explainer = completion_explainer
+        self._kanban_lifecycle_disabled = False
 
     def _handle_max_iterations(self, messages, api_call_count):
         self._handle_max_iterations_called = True
@@ -194,6 +195,28 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
         end_run=True,
         event_payload_extra={"budget_used": 60, "budget_max": 60},
     )
+
+
+def test_auxiliary_fork_does_not_record_kanban_timeout(monkeypatch):
+    """Auxiliary agents share process env but do not own the Kanban run."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    record = MagicMock(name="record_task_failure")
+    conn = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    agent = _LimitAgent()
+    agent._kanban_lifecycle_disabled = True
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+        pending_verification_response="auxiliary review report",
+    )
+
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    record.assert_not_called()
 
 
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -120,6 +120,39 @@ def test_background_review_fork_opts_out_of_session_finalization(monkeypatch):
     assert seen.get("at_run_time") is False
 
 
+def test_background_review_fork_opts_out_of_kanban_lifecycle(monkeypatch):
+    """The fork inherits the worker's env but must never mutate its card."""
+    seen = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            seen["at_run_time"] = getattr(
+                self, "_kanban_lifecycle_disabled", False
+            )
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert seen.get("at_run_time") is True
+
+
 
 
 


### PR DESCRIPTION
## Summary

- prevent background skill/memory review forks from recording Kanban task failures inherited from their parent process environment
- preserve normal budget-exhaustion failure recording for dispatcher-owned workers
- add regression coverage at both fork setup and turn-finalization boundaries

## Problem

A background review fork runs in-process and inherits `HERMES_KANBAN_TASK` from a dispatcher-spawned worker. The fork has its own hardcoded 16-iteration budget. If it exhausts that budget, `turn_finalizer.py` sees the inherited task id and records a second task failure against the parent card.

In production this appears as a real worker timeout followed seconds later by a synthetic auxiliary failure, for example:

```text
60/60 timed_out
16/16 gave_up
```

The review fork does not own the task claim or run and must not advance the parent card's failure circuit.

## Fix

Add an agent-local Kanban lifecycle ownership flag. Background review forks set the opt-out before `run_conversation()`. The turn finalizer consults it before resolving `HERMES_KANBAN_TASK` and recording a budget-exhaustion failure.

This uses agent-local state rather than mutating `os.environ`, which would be unsafe because the review runs in a thread inside the parent worker process.

## Test plan

- `scripts/run_tests.sh tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/agent/test_turn_finalizer_interrupt_alternation.py tests/agent/test_turn_finalizer_final_response_persistence.py tests/agent/test_turn_finalizer_cleanup_guard.py tests/test_background_review_session_isolation.py tests/test_background_review_list_shapes.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_background_review_summary.py tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review_cache_parity.py -q`
- full `scripts/run_tests.sh -q`

Related: #71175. This fixes the auxiliary `16/16` false-failure component; it is complementary to #71189's goal-mode claim-retention work.
