### PR TITLE
fix(slack): recover empty turns and mention requesters

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3608,6 +3608,14 @@ class BasePlatformAdapter(ABC):
         """
         return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
 
+    def prepare_final_response(self, content: str, source: SessionSource) -> str:
+        """Apply platform-specific formatting to a final user-visible reply.
+
+        The hook runs before the delivery obligation is recorded, so durable
+        retries preserve the exact content originally prepared for delivery.
+        """
+        return content
+
     async def play_tts(
         self,
         chat_id: str,
@@ -5222,6 +5230,12 @@ class BasePlatformAdapter(ABC):
                             self.name, len(_response_pre_extract), event.source.chat_id,
                         )
                         text_content = _recovered
+
+                if text_content:
+                    text_content = self.prepare_final_response(
+                        text_content,
+                        event.source,
+                    )
 
                 # Final user-visible content (text, TTS, media, files) gets
                 # the existing notify=True marker. Clone once so typing/status

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1553,6 +1553,16 @@ def _home_target_env_var(platform_name: str) -> str:
     return f"{platform_name.upper()}_HOME_CHANNEL"
 
 
+def _home_channel_prompt_enabled(platform_name: str) -> bool:
+    """Return whether first-turn home-channel onboarding should be shown."""
+    raw = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL_PROMPT")
+    if raw is None:
+        raw = os.getenv("HERMES_HOME_CHANNEL_PROMPT")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"false", "0", "no", "off"}
+
+
 def _home_thread_env_var(platform_name: str) -> str:
     """Return the optional thread/topic env var for a platform home target."""
     return f"{_home_target_env_var(platform_name)}_THREAD_ID"
@@ -2481,8 +2491,9 @@ def _build_media_placeholder(event) -> str:
 def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
     """Context note prepended to a user turn when they attach a document.
 
-    Text documents (``text/*``) have their content inlined upstream by the
-    platform adapter, so the note just confirms that and records the path.
+    Small text documents may have their content inlined upstream. Large files
+    and undecodable text remain path-backed, so never claim unconditional
+    inclusion; tell the agent to open the cached file when needed.
 
     Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
     must tell the agent to *extract* the text itself before answering — earlier
@@ -2493,8 +2504,9 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
     if mtype.startswith("text/"):
         return (
             f"[The user sent a text document: '{display_name}'. "
-            f"Its content has been included below. "
-            f"The file is also saved at: {agent_path}]"
+            f"Its content may be included below. The file is saved at: {agent_path}. "
+            f"If its content is not included below, read the saved file yourself "
+            f"with read_file before answering.]"
         )
     return (
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
@@ -3089,7 +3101,10 @@ def _normalize_empty_agent_response(
         return response
     if api_calls > 0:
         if _is_gateway_hidden_reasoning_incomplete_turn(agent_result):
-            return ""
+            return (
+                "⚠️ 답변을 생성하지 못했습니다. 대화 상태를 초기화했으니 "
+                "같은 질문을 다시 보내 주세요."
+            )
         if agent_result.get("partial"):
             err = agent_result.get("error", "processing incomplete")
             return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
@@ -13827,7 +13842,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             home_env = "set"
                 except Exception:
                     pass
-            if not home_env:
+            if not home_env and _home_channel_prompt_enabled(platform_name):
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".
@@ -14285,11 +14300,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             elif hidden_reasoning_incomplete:
                 logger.warning(
-                    "Suppressing hidden-reasoning-only incomplete gateway turn "
-                    "for session %s: %s",
+                    "Resetting hidden-reasoning-only incomplete gateway turn "
+                    "for session %s after notifying the user: %s",
                     session_entry.session_id,
                     agent_result.get("error", "processing incomplete"),
                 )
+
+            hidden_incomplete_reset = False
+            if hidden_reasoning_incomplete and session_entry and session_key:
+                new_entry = await self.async_session_store.reset_session(session_key)
+                self._evict_cached_agent(session_key)
+                self._clear_conversation_scope(
+                    session_key, reason="hidden_incomplete_reset"
+                )
+                if new_entry is not None:
+                    session_entry = new_entry
+                hidden_incomplete_reset = True
 
             # When compression is exhausted, the session is permanently too
             # large to process.  Auto-reset it so the next message starts
@@ -14350,8 +14376,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If this is a fresh session (no history), write the full tool
             # definitions as the first entry so the transcript is self-describing
             # -- the same list of dicts sent as tools=[...] in the API request.
-            if is_context_overflow_failure:
-                pass  # Skip all transcript writes — don't grow a broken session
+            if is_context_overflow_failure or hidden_incomplete_reset:
+                pass  # Skip transcript writes for broken/reset sessions.
             elif not history:
                 tool_defs = agent_result.get("tools", [])
                 await self.async_session_store.append_to_transcript(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -808,6 +808,25 @@ _SLACK_EXT_TO_AUDIO_MIME = {
 }
 
 
+def _decode_slack_text_attachment(
+    raw_bytes: bytes, ext: str, mimetype: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Decode a Slack text attachment, including Korean Excel CSV encodings."""
+    is_csv_like = ext in {".csv", ".tsv"} or mimetype in {
+        "text/csv",
+        "text/tab-separated-values",
+    }
+    encodings = ["utf-8-sig", "utf-8"]
+    if is_csv_like:
+        encodings.extend(["cp949", "euc-kr"])
+    for encoding in encodings:
+        try:
+            return raw_bytes.decode(encoding), encoding
+        except UnicodeDecodeError:
+            continue
+    return None, None
+
+
 def _resolve_slack_audio_ext(file_obj: Dict[str, Any], mimetype: str) -> str:
     """Pick the cache extension that matches an inbound Slack audio file's bytes.
 
@@ -2435,6 +2454,28 @@ class SlackAdapter(BasePlatformAdapter):
         parent_channel_id = str(channel_id).split(":", 1)[0]
         ignored = self._slack_ignored_channels()
         return "*" in ignored or parent_channel_id in ignored
+
+    def prepare_final_response(self, content: str, source: Any) -> str:
+        """Mention the triggering Slack user in configured channel replies."""
+        if not self._slack_mention_requester():
+            return content
+        if getattr(source, "chat_type", None) == "dm":
+            return content
+
+        user_id = str(getattr(source, "user_id", "") or "").strip()
+        if not re.fullmatch(r"[UW][A-Z0-9]+", user_id):
+            return content
+
+        mention = f"<@{user_id}>"
+        to_header = re.compile(
+            r"^(\s*(?:\*\*)?To:(?:\*\*)?\s*)[^\r\n]*",
+            re.IGNORECASE | re.MULTILINE,
+        )
+        if to_header.search(content):
+            return to_header.sub(rf"\g<1>{mention}  ", content, count=1)
+        if mention in content:
+            return content
+        return f"{mention}\n\n{content}"
 
     async def send(
         self,
@@ -5736,6 +5777,38 @@ class SlackAdapter(BasePlatformAdapter):
                 # hidden behind the leading mention on the first probe.
                 command_probe_text = command_text
                 is_command_text = True
+
+            # A bare @mention carries no actionable user intent once Slack's
+            # bot token is stripped.  Do not create an agent session for it:
+            # besides wasting a model turn, an empty first turn can poison the
+            # live thread cache and make the next real question inherit an
+            # incomplete assistant response.  Attachments or meaningful Block
+            # Kit text are still valid intent, so only intercept a truly empty
+            # mention-only event.
+            meaningful_block_text = (
+                _extract_text_from_slack_blocks(blocks).replace(f"<@{bot_uid}>", "").strip()
+                if blocks
+                else ""
+            )
+            if (
+                not mention_stripped
+                and not meaningful_block_text
+                and not event.get("files")
+                and not slack_attachments
+            ):
+                await self.send(
+                    channel_id,
+                    "궁금한 내용을 봇 멘션과 함께 입력해 주세요.",
+                    reply_to=event_thread_ts or ts,
+                    metadata={"team_id": team_id} if team_id else None,
+                )
+                logger.info(
+                    "[Slack] Replied to mention-only message without starting an agent session: "
+                    "channel=%s user=%s",
+                    channel_id,
+                    user_id,
+                )
+                return
             # Register this thread so all future messages auto-trigger the bot.
             # Skipped in strict/thread-gated mode: strict_mention=true and
             # thread_require_mention=true bots must be re-mentioned for
@@ -6102,12 +6175,31 @@ class SlackAdapter(BasePlatformAdapter):
                         )
                         continue
 
-                    # Download and cache
+                    # Download and cache. Korean CSV files exported by Windows
+                    # Excel commonly arrive as CP949/EUC-KR; normalize those to
+                    # UTF-8 so read_file can consume both small and path-backed
+                    # large uploads without mojibake.
                     raw_bytes = await self._download_slack_file_bytes(
                         url, team_id=team_id
                     )
+                    _is_text = ext in _TEXT_INJECT_EXTENSIONS or (
+                        mimetype or ""
+                    ).startswith("text/")
+                    text_content: Optional[str] = None
+                    detected_encoding: Optional[str] = None
+                    cache_bytes = raw_bytes
+                    if _is_text:
+                        text_content, detected_encoding = _decode_slack_text_attachment(
+                            raw_bytes, ext, mimetype or ""
+                        )
+                        if text_content is not None and (
+                            ext in {".csv", ".tsv"}
+                            or mimetype
+                            in {"text/csv", "text/tab-separated-values"}
+                        ):
+                            cache_bytes = text_content.encode("utf-8")
                     cached_path = cache_document_from_bytes(
-                        raw_bytes, original_filename or f"document{ext or '.bin'}"
+                        cache_bytes, original_filename or f"document{ext or '.bin'}"
                     )
                     if in_allowlist:
                         doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
@@ -6124,19 +6216,20 @@ class SlackAdapter(BasePlatformAdapter):
                     # decodable ASCII headers. Binary files are surfaced as a
                     # cached path only (run.py emits a path-pointing note).
                     MAX_TEXT_INJECT_BYTES = 100 * 1024
-                    _is_text = ext in _TEXT_INJECT_EXTENSIONS or (mimetype or "").startswith("text/")
-                    if _is_text and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
-                        try:
-                            text_content = raw_bytes.decode("utf-8")
-                            display_name = original_filename or f"document{ext or '.txt'}"
-                            display_name = re.sub(r"[^\w.\- ]", "_", display_name)
-                            injection = f"[Content of {display_name}]:\n{text_content}"
-                            if text:
-                                text = f"{injection}\n\n{text}"
-                            else:
-                                text = injection
-                        except UnicodeDecodeError:
-                            pass  # Binary content, skip injection
+                    if text_content is not None and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                        display_name = original_filename or f"document{ext or '.txt'}"
+                        display_name = re.sub(r"[^\w.\- ]", "_", display_name)
+                        injection = f"[Content of {display_name}]:\n{text_content}"
+                        if text:
+                            text = f"{injection}\n\n{text}"
+                        else:
+                            text = injection
+                    if detected_encoding:
+                        logger.debug(
+                            "[Slack] Decoded text attachment %s as %s",
+                            original_filename or f"document{ext or '.txt'}",
+                            detected_encoding,
+                        )
 
                 except Exception as e:  # pragma: no cover - defensive logging
                     detail = self._describe_slack_download_failure(e, file_obj=f)
@@ -8366,6 +8459,15 @@ class SlackAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("disable_dms")
         if raw is None:
             raw = os.getenv("SLACK_DISABLE_DMS", "false")
+        if isinstance(raw, str):
+            return raw.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(raw)
+
+    def _slack_mention_requester(self) -> bool:
+        """Return whether final channel replies should mention their requester."""
+        raw = self.config.extra.get("mention_requester")
+        if raw is None:
+            raw = os.getenv("SLACK_MENTION_REQUESTER", "false")
         if isinstance(raw, str):
             return raw.strip().lower() in {"true", "1", "yes", "on"}
         return bool(raw)

--- a/tests/gateway/test_document_context_note.py
+++ b/tests/gateway/test_document_context_note.py
@@ -5,7 +5,7 @@ A user who attaches a PDF / DOCX in chat used to see the agent treat it as
 they'd like you to do with it" — steering it away from extracting the text it
 is perfectly capable of reading. These tests pin the contract:
 
-- text documents: note confirms the (adapter-)inlined content + records path.
+- text documents: note handles either adapter-inlined content or a cached path.
 - binary documents (PDF/DOCX/…): note tells the agent to extract the text
   itself and never tells it to punt back to the user.
 """
@@ -20,12 +20,14 @@ _build_document_context_note = gateway_run._build_document_context_note
 
 class TestTextDocumentNote:
     @pytest.mark.parametrize("mtype", ["text/plain", "text/markdown", "text/csv"])
-    def test_text_note_mentions_included_content_and_path(self, mtype):
+    def test_text_note_handles_inlined_or_path_backed_content(self, mtype):
         note = _build_document_context_note("notes.txt", "/cache/doc_notes.txt", mtype)
         assert "text document" in note
         assert "notes.txt" in note
         assert "/cache/doc_notes.txt" in note
-        assert "included below" in note
+        assert "may be included below" in note
+        assert "read_file" in note
+        assert "has been included" not in note
 
 
 class TestBinaryDocumentNote:

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -97,6 +97,9 @@ def _make_runner(adapter: CaptureSlackAdapter) -> gateway_run.GatewayRunner:
     # (#47237). A bare MagicMock returns a truthy mock, which would wrongly
     # mark the user turn as a duplicate and skip persisting it.
     runner.session_store.has_platform_message_id = MagicMock(return_value=False)
+    runner.session_store.reset_session = MagicMock(
+        return_value=runner.session_store.get_or_create_session.return_value
+    )
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
@@ -104,6 +107,8 @@ def _make_runner(adapter: CaptureSlackAdapter) -> gateway_run.GatewayRunner:
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
     runner._run_agent = AsyncMock(return_value=_make_incomplete_result())
+    runner._evict_cached_agent = MagicMock()
+    runner._clear_conversation_scope = MagicMock()
     return runner
 
 
@@ -121,7 +126,7 @@ def _make_event() -> MessageEvent:
     )
 
 
-def test_incomplete_codex_warning_is_not_surfaced_as_chat_text():
+def test_incomplete_codex_turn_returns_retry_notice():
     agent_result = _make_incomplete_result()
 
     # Mirror the gateway pipeline: the hidden-turn detector blanks the
@@ -136,7 +141,8 @@ def test_incomplete_codex_warning_is_not_surfaced_as_chat_text():
         history_len=4,
     )
 
-    assert response == ""
+    assert "답변을 생성하지 못했습니다" in response
+    assert "다시 보내" in response
 
 
 def test_real_answer_alongside_incomplete_error_is_never_suppressed():
@@ -157,7 +163,7 @@ def test_interrupted_or_failed_turns_are_not_classified_hidden():
 
 
 @pytest.mark.asyncio
-async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, tmp_path):
+async def test_incomplete_codex_turn_notifies_and_resets_session(monkeypatch, tmp_path):
     adapter = CaptureSlackAdapter()
     runner = _make_runner(adapter)
 
@@ -175,15 +181,19 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
     event = _make_event()
     await adapter._process_message_background(event, build_session_key(event.source))
 
-    assert adapter.sent == []
+    assert len(adapter.sent) == 1
+    assert "답변을 생성하지 못했습니다" in adapter.sent[0]["content"]
+    assert getattr(runner.session_store.reset_session, "call_count") == 1
+    runner._evict_cached_agent.assert_called_once()
+    runner._clear_conversation_scope.assert_called_once()
     assert runner.session_store.update_session.called
 
     transcript_roles = [
         call.args[1]["role"]
         for call in runner.session_store.append_to_transcript.call_args_list
     ]
-    assert transcript_roles == ["session_meta", "user"]
-    assert runner.session_store.append_to_transcript.call_args_list[1].args[1]["content"] == "hello"
+    assert transcript_roles == ["user"]
+    assert "assistant" not in transcript_roles
     assert adapter.processing_hooks == [
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -13,17 +13,18 @@ import contextlib
 import importlib
 from importlib.machinery import PathFinder
 import os
+from pathlib import Path
 import socket
 import sys
 import time
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
 
 import agent.secret_scope as secret_scope
 from gateway.config import Platform, PlatformConfig
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _home_channel_prompt_enabled
 from gateway.platforms.base import (
     MessageEvent,
     MessageType,
@@ -250,6 +251,86 @@ def _redirect_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
     )
+
+
+@pytest.mark.asyncio
+async def test_mention_only_message_gets_usage_hint_without_starting_agent(adapter):
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="hint-1"))
+
+    await adapter._handle_slack_message(
+        {
+            "text": "<@U_BOT>",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T123",
+            "ts": "1785806964.795449",
+            "thread_ts": "1785801603.247069",
+            "client_msg_id": "client-1",
+        }
+    )
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+    send_call = adapter.send.await_args
+    assert send_call is not None
+    assert "멘션과 함께 입력" in send_call.args[1]
+    assert send_call.kwargs["reply_to"] == "1785801603.247069"
+
+
+def test_final_response_mentions_requester_with_native_slack_token():
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"mention_requester": True},
+    )
+    adapter = SlackAdapter(config)
+    source = SimpleNamespace(user_id="U0B3QMXHFBJ", chat_type="group")
+
+    content = "**To:** 요청자  \n**CC:** —\n\n광고 ROAS 답변"
+    rendered = adapter.prepare_final_response(content, source)
+
+    assert rendered.startswith("**To:** <@U0B3QMXHFBJ>")
+    assert "To:** 요청자" not in rendered
+
+
+def test_final_response_prefixes_requester_when_to_header_is_absent():
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"mention_requester": True},
+    )
+    adapter = SlackAdapter(config)
+    source = SimpleNamespace(user_id="U0B3QMXHFBJ", chat_type="group")
+
+    rendered = adapter.prepare_final_response("광고 ROAS 답변", source)
+
+    assert rendered == "<@U0B3QMXHFBJ>\n\n광고 ROAS 답변"
+
+
+def test_final_response_does_not_mention_requester_in_dm():
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"mention_requester": True},
+    )
+    adapter = SlackAdapter(config)
+    source = SimpleNamespace(user_id="U0B3QMXHFBJ", chat_type="dm")
+
+    assert adapter.prepare_final_response("광고 ROAS 답변", source) == "광고 ROAS 답변"
+
+
+def test_slack_home_channel_prompt_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("SLACK_HOME_CHANNEL_PROMPT", "false")
+
+    assert _home_channel_prompt_enabled("slack") is False
+
+
+def test_home_channel_prompt_defaults_to_enabled(monkeypatch):
+    monkeypatch.delenv("SLACK_HOME_CHANNEL_PROMPT", raising=False)
+    monkeypatch.delenv("HERMES_HOME_CHANNEL_PROMPT", raising=False)
+
+    assert _home_channel_prompt_enabled("slack") is True
 
 
 class TestBotEventDiagnostics:
@@ -1755,6 +1836,16 @@ class TestStandaloneSendUserDmResolution:
 
 
 class TestSendDocument:
+    def test_plain_csv_media_line_is_extracted(self, adapter, tmp_path):
+        csv_path = tmp_path / "sales.csv"
+        csv_path.write_text("name,value\nA,1\n", encoding="utf-8")
+
+        media, cleaned = adapter.extract_media(f"완료했습니다.\nMEDIA:{csv_path}")
+
+        assert media == [(str(csv_path), False)]
+        assert "MEDIA:" not in cleaned
+        assert "완료했습니다." in cleaned
+
     @pytest.mark.asyncio
     async def test_send_document_success(self, adapter, tmp_path):
         test_file = tmp_path / "report.pdf"
@@ -1811,6 +1902,25 @@ class TestSendDocument:
         assert result.success
         call_kwargs = adapter._app.client.files_upload_v2.call_args[1]
         assert call_kwargs["filename"] == "quarterly-report.csv"
+
+    @pytest.mark.asyncio
+    async def test_send_document_uploads_large_cp949_csv_opaquely(
+        self, adapter, tmp_path
+    ):
+        content = ("상품명,수량\n" + "스크럽대디,10\n" * 10_000).encode("cp949")
+        assert len(content) > 100 * 1024
+        csv_path = tmp_path / "대용량_판매량.csv"
+        csv_path.write_bytes(content)
+        adapter._app.client.files_upload_v2 = AsyncMock(return_value={"ok": True})
+
+        result = await adapter.send_document("C123", str(csv_path))
+
+        assert result.success
+        kwargs = adapter._app.client.files_upload_v2.call_args[1]
+        assert kwargs["channel"] == "C123"
+        assert kwargs["file"] == str(csv_path)
+        assert kwargs["filename"] == "대용량_판매량.csv"
+        assert csv_path.read_bytes() == content
 
     @pytest.mark.asyncio
     async def test_send_document_missing_file(self, adapter):
@@ -2536,6 +2646,67 @@ class TestIncomingDocumentHandling:
         assert "Hello from a text file" in msg_event.text
         assert "[Content of notes.txt]" in msg_event.text
         assert "summarize this" in msg_event.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("encoding", ["euc-kr", "cp949"])
+    async def test_cp949_csv_is_normalized_and_injected(self, adapter, encoding):
+        """Korean Excel CSV uploads should be readable as normalized UTF-8."""
+        content = "상품명,수량\n스크럽대디,10\n".encode(encoding)
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = content
+            event = self._make_event(
+                text="이 파일을 요약해줘",
+                files=[
+                    {
+                        "mimetype": "text/csv",
+                        "name": "판매량.csv",
+                        "url_private_download": "https://files.slack.com/sales.csv",
+                        "size": len(content),
+                    }
+                ],
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "상품명,수량" in msg_event.text
+        assert "스크럽대디,10" in msg_event.text
+        assert Path(msg_event.media_urls[0]).read_text(encoding="utf-8") == (
+            "상품명,수량\n스크럽대디,10\n"
+        )
+
+    @pytest.mark.asyncio
+    async def test_large_cp949_csv_is_cached_as_utf8_without_injection(self, adapter):
+        """Large Korean CSVs stay path-backed but remain readable by read_file."""
+        text = "상품명,수량\n" + "스크럽대디,10\n" * 10_000
+        content = text.encode("cp949")
+        assert len(content) > 100 * 1024
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = content
+            event = self._make_event(
+                text="이 파일을 분석해줘",
+                files=[
+                    {
+                        "mimetype": "text/csv",
+                        "name": "대용량_판매량.csv",
+                        "url_private_download": "https://files.slack.com/large.csv",
+                        "size": len(content),
+                    }
+                ],
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Content of" not in msg_event.text
+        cached = Path(msg_event.media_urls[0])
+        assert cached.read_bytes() == text.encode("utf-8")
+        normalized = cached.read_text(encoding="utf-8")
+        assert normalized.startswith("상품명,수량\n스크럽대디,10")
 
     @pytest.mark.asyncio
     async def test_md_document_injects_content(self, adapter):


### PR DESCRIPTION
## Summary
- short-circuit mention-only Slack messages before creating an agent session
- recover hidden-reasoning-only incomplete turns with a clean session reset
- add an opt-out for first-session home-channel onboarding notices while preserving the default behavior
- normalize UTF-8/UTF-8-SIG/CP949/EUC-KR CSV uploads so cached files are readable
- make text-document context notes accurate for both inlined and path-backed files
- preserve inline-code MEDIA masking; generated files must use a standalone plain MEDIA directive
- mention the triggering Slack user with a native mention in configured channel replies while leaving DMs unmentioned

## Verification
- pytest -q tests/gateway/test_slack.py tests/gateway/test_incomplete_gateway_turns.py tests/gateway/test_document_context_note.py
- 450 passed, 28 pre-existing AsyncMock RuntimeWarnings
- ruff check passed
- git diff --check passed