### PR TITLE
fix(dashboard): add system_prompts to read-only schema probe (#78217)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11171,7 +11171,8 @@ _SESSION_DB_READ_PROBE_SQL = (
     "SELECT (SELECT archived FROM sessions LIMIT 1), "
     "(SELECT pinned FROM sessions LIMIT 1), "
     "(SELECT active FROM messages LIMIT 1), "
-    "(SELECT compacted FROM messages LIMIT 1)"
+    "(SELECT compacted FROM messages LIMIT 1), "
+    "(SELECT hash FROM system_prompts LIMIT 1)"
 )
 
 


### PR DESCRIPTION
## Summary

Fixes #78217

The read-only session-detail probe (`_SESSION_DB_READ_PROBE_SQL`) only checks columns on the `sessions` and `messages` tables. After SCHEMA_VERSION 25 added the `system_prompts` table, the probe silently passed on old-schema DBs, causing `LEFT JOIN system_prompts` to fail with `OperationalError: no such table: system_prompts` (HTTP 500).

## Root cause

Probe coverage < query dependencies. The probe was written when migrations only ADDED COLUMNS to existing tables; v25 added a whole new table and the probe was never updated.

## Fix

Add `(SELECT hash FROM system_prompts LIMIT 1)` to the probe SQL. This ensures the self-heal branch fires during the schema-migration window, reopening read-write to trigger migration before returning the read-only connection.

## Changes

- `hermes_cli/web_server.py`: Added `system_prompts` subquery to `_SESSION_DB_READ_PROBE_SQL`

## Test plan

- [ ] Dashboard session-detail endpoint no longer returns 500 in the schema-migration window after v25 upgrade
- [ ] Existing read-only probe behavior unchanged for up-to-date DBs