### PR TITLE
perf(cli): check local auth.json/config before slow provider registry sweep (#63457 salvage)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1013,16 +1013,9 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
-    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
-    try:
-        for provider_id, pconfig in PROVIDER_REGISTRY.items():
-            if pconfig.auth_type != "api_key":
-                continue
-            status = get_auth_status(provider_id)
-            if status.get("logged_in"):
-                return True
-    except Exception:
-        pass
+    # Cheap local checks first: auth.json and config.yaml are on-disk lookups,
+    # while the PROVIDER_REGISTRY sweep below spawns subprocesses (gh) and can
+    # take 15-20s — long enough that desktop setup.status calls time out.
 
     # Check for Nous Portal OAuth credentials
     auth_file = get_hermes_home() / "auth.json"
@@ -1049,6 +1042,17 @@ def _has_any_provider_configured() -> bool:
         cfg_api_key = (model_cfg.get("api_key") or "").strip()
         if cfg_provider or cfg_base_url or cfg_api_key:
             return True
+
+    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
+    try:
+        for provider_id, pconfig in PROVIDER_REGISTRY.items():
+            if pconfig.auth_type != "api_key":
+                continue
+            status = get_auth_status(provider_id)
+            if status.get("logged_in"):
+                return True
+    except Exception:
+        pass
 
     # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
     # Only count these if Hermes has been explicitly configured — Claude Code

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -562,7 +562,103 @@ class TestHasAnyProviderConfigured:
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is True
 
+    @staticmethod
+    def _clear_provider_env(monkeypatch):
+        """Clear every provider env var so early checks can't short-circuit."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        _all_vars = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                     "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"}
+        for pconfig in PROVIDER_REGISTRY.values():
+            if pconfig.auth_type == "api_key":
+                _all_vars.update(pconfig.api_key_env_vars)
+        for var in _all_vars:
+            monkeypatch.delenv(var, raising=False)
 
+    def _setup_home(self, monkeypatch, tmp_path):
+        from hermes_cli import config as config_module
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
+        monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._clear_provider_env(monkeypatch)
+        return hermes_home
+
+    def test_config_provider_skips_registry_sweep(self, monkeypatch, tmp_path):
+        """model.provider in config.yaml must short-circuit BEFORE the slow
+        provider-registry sweep (gh subprocess etc.) is ever invoked.
+
+        Regression test for the auth-first ordering: get_auth_status is
+        booby-trapped to fail loudly if the sweep runs. The sweep wraps its
+        loop in ``except Exception``, so we also record every call — any
+        recorded call proves the sweep ran even if the raise was swallowed.
+        """
+        import yaml
+        hermes_home = self._setup_home(monkeypatch, tmp_path)
+        (hermes_home / "config.yaml").write_text(yaml.dump({
+            "model": {"default": "anthropic/claude-opus-4.6", "provider": "openrouter"},
+        }))
+        sweep_calls = []
+
+        def _trap(provider_id):
+            sweep_calls.append(provider_id)
+            raise AssertionError("sweep must be skipped")
+
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", _trap)
+        from hermes_cli.main import _has_any_provider_configured
+        assert _has_any_provider_configured() is True
+        assert sweep_calls == [], (
+            f"provider registry sweep ran before config short-circuit: {sweep_calls}"
+        )
+
+    def test_config_base_url_api_key_skips_registry_sweep(self, monkeypatch, tmp_path):
+        """Custom endpoint (base_url/api_key in config, no provider) must also
+        short-circuit before the registry sweep."""
+        import yaml
+        hermes_home = self._setup_home(monkeypatch, tmp_path)
+        (hermes_home / "config.yaml").write_text(yaml.dump({
+            "model": {
+                "default": "local/custom-model",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "sk-local-test",
+            },
+        }))
+        sweep_calls = []
+
+        def _trap(provider_id):
+            sweep_calls.append(provider_id)
+            raise AssertionError("sweep must be skipped")
+
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", _trap)
+        from hermes_cli.main import _has_any_provider_configured
+        assert _has_any_provider_configured() is True
+        assert sweep_calls == [], (
+            f"provider registry sweep ran before config short-circuit: {sweep_calls}"
+        )
+
+    def test_auth_json_skips_registry_sweep(self, monkeypatch, tmp_path):
+        """auth.json with a logged-in active provider must short-circuit before
+        the registry sweep. get_auth_status may be called ONLY for the active
+        provider from auth.json — any other provider id means the sweep ran.
+        """
+        import json
+        hermes_home = self._setup_home(monkeypatch, tmp_path)
+        (hermes_home / "auth.json").write_text(json.dumps({
+            "active_provider": "nous",
+        }))
+        calls = []
+
+        def _guarded_status(provider_id):
+            calls.append(provider_id)
+            assert provider_id == "nous", "sweep must be skipped"
+            return {"logged_in": True}
+
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", _guarded_status)
+        from hermes_cli.main import _has_any_provider_configured
+        assert _has_any_provider_configured() is True
+        assert calls == ["nous"], (
+            f"provider registry sweep ran before auth.json short-circuit: {calls}"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
Salvage of #63457 by @frohsinnllc — commit cherry-picked to preserve authorship, plus teknium's requested regression tests as a follow-up commit.

## Context — what this changes for users

_has_any_provider_configured() ran the slow PROVIDER_REGISTRY sweep (which can spawn `gh auth token` subprocesses with 5s timeouts, 15-20s total) BEFORE checking local auth.json/config.yaml — fast on-disk lookups that answer the question for virtually every configured user. setup.status calls this helper directly (tui_gateway/server.py), so the TUI's setup path paid the sweep on every check. The reorder short-circuits on local state first; behavior for genuinely-unconfigured users is unchanged.

## Review follow-up folded (per @teknium1's review)

The review's one gap: no test proved the sweep is actually SKIPPED (existing tests pin only the final boolean). Added 3 regression tests exactly per the review spec:
- config `model.provider` set + `get_auth_status` booby-trapped with AssertionError → returns True, trap never fires
- config base_url/api_key shape (second short-circuit path)
- auth.json sibling: get_auth_status allowed only for the active provider — any other probe = the sweep ran
- Hardened against the sweep's own `except Exception` swallowing the trap: each test also asserts the recorded call list.

## Verification

105 tests green in test_api_key_providers.py (was 102). Mutation: reorder reverted via git apply -R → all 3 new tests fail (with the recorded-sweep evidence in the failure message) → restored → 105 green. Ruff clean.

Closes #63457.