### PR TITLE
perf(gateway): prewarm /model picker cache on TUI startup (#72021 salvage)

### DIFF
--- a/tests/tui_gateway/test_entry_picker_prewarm.py
+++ b/tests/tui_gateway/test_entry_picker_prewarm.py
@@ -1,0 +1,101 @@
+"""Regression test: the stdio TUI entry point prewarms the /model picker cache.
+
+The classic CLI run() loop calls ``prewarm_picker_cache_async()`` during the
+idle window after the banner, so the first ``/model`` open hits a warm
+provider-models disk cache. The stdio TUI entry point (``entry.main()``) never
+did — the first ``/model`` open in a TUI session blocked on serial /v1/models
+fetches for every authenticated provider (#72021).
+
+These tests pin the entrypoint wiring itself (the helper's own worker/once
+guard is covered in ``tests/hermes_cli/test_picker_prewarm.py``):
+
+- ``main()`` invokes ``hermes_cli.model_switch.prewarm_picker_cache_async``
+  exactly once, AFTER the ``gateway.ready`` event is written (banner shown,
+  user about to type — the idle window the prewarm is meant to fill).
+- The startup path stays non-blocking: with the prewarm spied out, ``main()``
+  proceeds into the stdin read loop and returns normally on EOF.
+- A prewarm import/start failure is swallowed (fire-and-forget contract) and
+  must not prevent ``main()`` from reaching the read loop.
+
+Harness: same style as tests/test_tui_entry_mcp_owner.py — import
+``tui_gateway.entry`` and monkeypatch its module attributes, running the real
+``main()`` with stubbed I/O collaborators (no subprocess, no real gateway).
+"""
+
+from __future__ import annotations
+
+import io
+
+import hermes_cli.model_switch as ms
+from tui_gateway import entry
+
+
+def _run_main(monkeypatch, events, *, prewarm=None):
+    """Run entry.main() with stubbed collaborators, recording ordering.
+
+    ``events`` receives ``("write", <event type>)`` for every write_json call
+    and ``("prewarm",)`` when the spy fires, in call order.
+    """
+    monkeypatch.setattr(entry, "_install_sidecar_publisher", lambda: None)
+    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: None)
+    monkeypatch.setattr(entry, "resolve_skin", lambda: "default")
+    monkeypatch.setattr(entry.server, "_ensure_skin_watcher", lambda: None)
+    monkeypatch.setattr(entry, "_log_exit", lambda reason: None)
+    # Genuine EOF, no fd-0 forensics in the test process.
+    monkeypatch.setattr(entry, "handle_spurious_eof", lambda *a: False)
+
+    def _write_json(payload):
+        params = payload.get("params") or {}
+        events.append(("write", params.get("type") or payload.get("method")))
+        return True
+
+    monkeypatch.setattr(entry, "write_json", _write_json)
+
+    # entry.main() imports the helper lazily from hermes_cli.model_switch,
+    # so the spy must live on that module, not on entry.
+    if prewarm is None:
+        def prewarm():
+            events.append(("prewarm",))
+            return None  # fire-and-forget handle; never blocks
+
+    monkeypatch.setattr(ms, "prewarm_picker_cache_async", prewarm)
+
+    # Empty stdin -> immediate EOF -> main() returns after entering the loop.
+    monkeypatch.setattr(entry.sys, "stdin", io.StringIO(""))
+
+    entry.main()
+
+
+def test_main_prewarms_picker_cache_after_gateway_ready(monkeypatch):
+    """main() must call the prewarm helper once, after gateway.ready is
+    written, and still reach the stdin loop (returns on EOF = non-blocking)."""
+    events: list[tuple] = []
+
+    _run_main(monkeypatch, events)  # returning at all proves the loop was reached
+
+    prewarm_calls = [e for e in events if e[0] == "prewarm"]
+    assert len(prewarm_calls) == 1, (
+        f"main() must invoke prewarm_picker_cache_async exactly once, got {events!r}"
+    )
+
+    ready_idx = events.index(("write", "gateway.ready"))
+    prewarm_idx = events.index(("prewarm",))
+    assert ready_idx < prewarm_idx, (
+        "prewarm must fire AFTER the gateway.ready write (idle window, "
+        f"banner already shown); order was {events!r}"
+    )
+
+
+def test_main_survives_prewarm_failure(monkeypatch):
+    """Fire-and-forget contract: a prewarm that raises at start must be
+    swallowed and main() must still reach the read loop and exit cleanly."""
+    events: list[tuple] = []
+
+    def _boom():
+        events.append(("prewarm",))
+        raise RuntimeError("provider registry exploded")
+
+    _run_main(monkeypatch, events, prewarm=_boom)  # must not raise
+
+    assert ("prewarm",) in events
+    assert ("write", "gateway.ready") in events

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -455,6 +455,17 @@ def main():
     # Live-apply skins Hermes activates mid-conversation.
     server._ensure_skin_watcher()
 
+    # Warm the /model picker's provider-models cache off-thread during this
+    # idle window (gateway.ready sent, user about to type). Mirrors the classic
+    # CLI run() loop — the stdio TUI otherwise never prewarms, so the first
+    # /model open blocks on serial /v1/models fetches. Fire-and-forget,
+    # guarded once-per-process, fully exception-isolated.
+    try:
+        from hermes_cli.model_switch import prewarm_picker_cache_async
+        prewarm_picker_cache_async()
+    except Exception:
+        logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
+
     while True:
         raw = sys.stdin.readline()
         if not raw:


### PR DESCRIPTION
Salvage of #72021 by @ZachariahChu — commit cherry-picked to preserve authorship, plus teknium's requested entrypoint regression test as a follow-up commit.

## Context — what this changes for users

The classic CLI prewarms the /model picker's provider-models disk cache during idle startup (cli.py), so the first /model open renders instantly. The stdio TUI entry never got that call — first /model open in a TUI session blocked ~1-2s on serial /v1/models fetches. This is the 11-line gap-fill: same pre-existing helper (fire-and-forget daemon thread, once-per-process guard, exception-isolated), called right after gateway.ready.

## Review follow-up folded (per @teknium1's review)

The review's one gap: no test that tui_gateway.entry.main() actually invokes the helper after readiness. Added tests/tui_gateway/test_entry_picker_prewarm.py (2 tests) following the established in-process harness from test_tui_entry_mcp_owner.py (no new harness style):
- spy on prewarm_picker_cache_async, capture stdout writes → assert gateway.ready is written and the spy fired; main() returns on EOF stdin (non-blocking startup proven by the test completing)
- a spy that raises RuntimeError → main() still enters/exits the loop cleanly (the try/except isolation holds)

## Verification

4 tests green (2 new entrypoint + 2 existing helper). Mutation: prewarm hunk deleted → both new tests fail (existing helper tests alone do NOT catch it — exactly the gap teknium named) → restored → 4 green. Ruff clean.

Closes #72021.