### PR TITLE
perf(desktop): keep GlyphSpinner frames out of React commits (#74357 salvage)

### DIFF
--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -95,4 +95,72 @@ describe('GlyphSpinner', () => {
     act(() => vi.advanceTimersByTime(80))
     expect(status.textContent).not.toBe(frozen)
   })
+
+  it('suspends animation while the Electron window is minimized or hidden, then resumes on restore', () => {
+    let windowStateCallback: ((payload: { isMinimized?: boolean; isVisible?: boolean }) => void) | null = null
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        onWindowStateChanged: vi.fn((callback: typeof windowStateCallback) => {
+          windowStateCallback = callback
+
+          return () => {
+            if (windowStateCallback === callback) {
+              windowStateCallback = null
+            }
+          }
+        })
+      }
+    })
+
+    try {
+      render(<GlyphSpinner spinner="braille" />)
+
+      const status = screen.getByRole('status', { name: 'Loading' })
+      expect(windowStateCallback).not.toBeNull()
+      expect(vi.getTimerCount()).toBe(1)
+
+      act(() => windowStateCallback?.({ isMinimized: true, isVisible: false }))
+      expect(vi.getTimerCount()).toBe(0)
+
+      const frozen = status.textContent
+      act(() => vi.advanceTimersByTime(800))
+      expect(status.textContent).toBe(frozen)
+
+      act(() => windowStateCallback?.({ isMinimized: false, isVisible: true }))
+      expect(vi.getTimerCount()).toBe(1)
+
+      act(() => vi.advanceTimersByTime(80))
+      expect(status.textContent).not.toBe(frozen)
+    } finally {
+      delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    }
+  })
+
+  it('suspends animation while the document is hidden', () => {
+    render(<GlyphSpinner spinner="braille" />)
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+    expect(vi.getTimerCount()).toBe(1)
+
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
+    try {
+      act(() => document.dispatchEvent(new Event('visibilitychange')))
+      expect(vi.getTimerCount()).toBe(0)
+
+      const frozen = status.textContent
+      act(() => vi.advanceTimersByTime(800))
+      expect(status.textContent).toBe(frozen)
+
+      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+      act(() => document.dispatchEvent(new Event('visibilitychange')))
+      expect(vi.getTimerCount()).toBe(1)
+
+      act(() => vi.advanceTimersByTime(80))
+      expect(status.textContent).not.toBe(frozen)
+    } finally {
+      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    }
+  })
 })

--- a/apps/desktop/src/components/ui/glyph-spinner.test.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.test.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from '@testing-library/react'
+import { Profiler, type ProfilerOnRenderCallback } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
+
+import { GlyphSpinner } from './glyph-spinner'
+
+describe('GlyphSpinner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(globalThis.document, 'hasFocus').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('advances its glyph without an update-phase React commit', () => {
+    let updateCommits = 0
+
+    const onRender: ProfilerOnRenderCallback = (_id, phase) => {
+      if (phase !== 'mount') {
+        updateCommits += 1
+      }
+    }
+
+    render(
+      <Profiler id="glyph-spinner" onRender={onRender}>
+        <GlyphSpinner spinner="braille" />
+      </Profiler>
+    )
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+    expect(status.textContent).toBe('⠋')
+
+    act(() => vi.advanceTimersByTime(80))
+
+    expect(status.textContent).toBe('⠙')
+    expect(updateCommits).toBe(0)
+  })
+
+  it('does not tick while its kept-alive pane is hidden', () => {
+    const { rerender } = render(
+      <PaneVisibleContext.Provider value={false}>
+        <GlyphSpinner spinner="braille" />
+      </PaneVisibleContext.Provider>
+    )
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+
+    expect(status.textContent).toBe('⠋')
+    expect(vi.getTimerCount()).toBe(0)
+
+    rerender(
+      <PaneVisibleContext.Provider value>
+        <GlyphSpinner spinner="braille" />
+      </PaneVisibleContext.Provider>
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(80))
+    expect(status.textContent).toBe('⠙')
+
+    rerender(
+      <PaneVisibleContext.Provider value={false}>
+        <GlyphSpinner spinner="braille" />
+      </PaneVisibleContext.Provider>
+    )
+    expect(vi.getTimerCount()).toBe(0)
+
+    const frozen = status.textContent
+    act(() => vi.advanceTimersByTime(800))
+    expect(status.textContent).toBe(frozen)
+  })
+
+  it('suspends animation while the Desktop window is inactive', () => {
+    render(<GlyphSpinner spinner="braille" />)
+
+    const status = screen.getByRole('status', { name: 'Loading' })
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => window.dispatchEvent(new Event('blur')))
+    expect(vi.getTimerCount()).toBe(0)
+
+    const frozen = status.textContent
+    act(() => vi.advanceTimersByTime(800))
+    expect(status.textContent).toBe(frozen)
+
+    act(() => window.dispatchEvent(new Event('focus')))
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(80))
+    expect(status.textContent).not.toBe(frozen)
+  })
+})

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import spinners, { type BrailleSpinnerName as SpinnerName } from 'unicode-animations'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 import { cn } from '@/lib/utils'
 
 export type { SpinnerName }
@@ -43,29 +44,66 @@ interface GlyphSpinnerProps {
  */
 export function GlyphSpinner({ ariaLabel = 'Loading', className, spinner = 'braille' }: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
-  const [frame, setFrame] = useState(0)
+  const glyphRef = useRef<HTMLSpanElement>(null)
   // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
-  // ticking a setInterval + setState burn CPU for pixels nobody can see.
+  // ticking a setInterval burns CPU for pixels nobody can see.
   const visible = usePaneVisible()
 
   useEffect(() => {
-    if (!visible) {
+    const glyph = glyphRef.current
+
+    if (!visible || !glyph) {
       return
     }
 
-    setFrame(0)
-    const id = window.setInterval(() => setFrame(f => (f + 1) % spin.frames.length), spin.interval)
+    let frame = 0
+    let timer: number | undefined
+    let pauseController: ReturnType<typeof createRendererLoopPauseController> | undefined
+    glyph.textContent = spin.frames[frame]
 
-    return () => window.clearInterval(id)
+    const stopAnimation = () => {
+      if (timer === undefined) {
+        return
+      }
+
+      window.clearInterval(timer)
+      timer = undefined
+    }
+
+    const syncAnimation = () => {
+      if (pauseController?.isPaused()) {
+        stopAnimation()
+
+        return
+      }
+
+      if (timer !== undefined) {
+        return
+      }
+
+      timer = window.setInterval(() => {
+        frame = (frame + 1) % spin.frames.length
+        glyph.textContent = spin.frames[frame]
+      }, spin.interval)
+    }
+
+    pauseController = createRendererLoopPauseController(syncAnimation)
+    syncAnimation()
+
+    return () => {
+      pauseController.dispose()
+      stopAnimation()
+    }
   }, [spin, visible])
 
   return (
     <span
       aria-label={ariaLabel}
       className={cn('inline-flex items-center justify-center font-mono leading-none tabular-nums', className)}
+      ref={glyphRef}
       role="status"
     >
-      {spin.frames[frame]}
+      {spin.frames[0]}
     </span>
   )
 }


### PR DESCRIPTION
Salvage of #74357 by @myk0la-b — commit cherry-picked to preserve authorship, plus teknium's requested window-state regression test as a follow-up commit.

## Context — what this changes for users

GlyphSpinner advanced frames via useState + setInterval — every animation frame was a React commit, multiplied across every mounted spinner during streaming. The fix moves frame advances outside React (useRef + direct textContent writes) and adopts the existing createRendererLoopPauseController so spinners pause when the pane/window is inactive. Sibling #73033 (static-glyph alternative) was closed by its author in favor of this PR, resolving the dossier's maintainer-taste question.

## Review follow-up folded (per @teknium1's review)

The review's one gap: the inactive-window test covered only blur/focus, but the adopted controller also pauses via document.visibilityState and Electron's native minimized/hidden window-state events. Added 2 regression tests using the exact onWindowStateChanged mock pattern from persistent.test.tsx:
- {isMinimized: true, isVisible: false} → interval cleared (vi.getTimerCount()===0), textContent frozen through 800ms; restore → timer back, glyph advances
- document.visibilityState hidden/visible via visibilitychange → same clear/resume contract

## Verification

5/5 vitest green (was 3, +2 new; real run with workspace-hoisted node_modules). Mutation: onWindowStateChanged registration disabled in renderer-loop-pause.ts → the new window-state test fails specifically → restored → 5/5. Prior Phase 2 (React Profiler zero-commit proof, 3/3) still holds — the cherry-pick is byte-identical.

Closes #74357.