### PR TITLE
fix(agent): drop tool_calls key when dedup empties it

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3421,7 +3421,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # Every call in this message was a duplicate — write an
+                    # empty array back and strict providers (DeepSeek v4,
+                    # OpenClaw Console) 400 it ("expected minimum length 1").
+                    # Drop the key entirely: a tool_calls-less assistant
+                    # message is semantically identical.
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2602,6 +2602,65 @@ class TestHandleMaxIterations:
         tool_ids = [m.get("tool_call_id") for m in sanitized if m.get("role") == "tool"]
         assert tool_ids == ["call_good", "call_bad"]
 
+    def test_api_sanitizer_drops_key_when_all_tool_calls_deduped(self, agent):
+        """When every tool_call in an assistant message is a duplicate of an
+        earlier call (retries / crash-resume / a compression window re-emitting
+        a tool result, #58327), the dedup pass must drop the ``tool_calls`` key
+        entirely rather than write an empty array back. Strict providers
+        (DeepSeek v4, OpenClaw Console) reject ``tool_calls: []`` with HTTP 400
+        \"Invalid 'messages[N].tool_calls': empty array\" — an assistant message
+        without the key is semantically identical and always accepted."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "first call",
+                "tool_calls": [
+                    {
+                        "id": "call_dup",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_dup", "content": "result"},
+            {
+                "role": "assistant",
+                "content": "re-emitted duplicate",
+                "tool_calls": [
+                    {
+                        "id": "call_dup",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+
+        sanitized = agent._sanitize_api_messages(messages)
+
+        # The re-emitted message keeps its content but loses the tool_calls
+        # key — never an empty array.
+        dup_msg = next(
+            m
+            for m in sanitized
+            if m.get("role") == "assistant" and m.get("content") == "re-emitted duplicate"
+        )
+        assert "tool_calls" not in dup_msg
+        # No message anywhere carries an empty tool_calls array.
+        assert not any(
+            m.get("role") == "assistant" and "tool_calls" in m and not m["tool_calls"]
+            for m in sanitized
+        )
+        # The first call and its result are untouched.
+        first = next(
+            m for m in sanitized if m.get("role") == "assistant" and m.get("content") == "first call"
+        )
+        assert first["tool_calls"][0]["id"] == "call_dup"
+        assert [m.get("tool_call_id") for m in sanitized if m.get("role") == "tool"] == [
+            "call_dup"
+        ]
+
+
 
 class TestRunConversation:
     """Tests for the main run_conversation method.


### PR DESCRIPTION
## Bug Description

The pre-send sanitizer's tool_call_id dedup pass collapses duplicate tool calls within an assistant message. When **every** call in a message is a duplicate — which happens on retries, crash/resume glitches, or when a compression window re-emits a tool result — `kept_tcs` becomes empty and the pass wrote `tool_calls: []` back into the payload.

That empty array went out **after** the empty-array drop pass had already run (the drop pass runs first in `sanitize_api_messages`), so nothing caught it before the wire. Strict OpenAI-compatible providers reject it:

```
HTTP 400: Invalid 'messages[N].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.
```

It's a non-retryable client error, so the user sees a generic "⚠️ The model provider failed after retries" warning with no actionable detail.

Observed live: a long-running session (6+ weeks, heavy compression history) hit this on `oc/deepseek-v4-flash-free` via OpenClaw's upstream.

## Root Cause

`agent/agent_runtime_helpers.py` → `sanitize_api_messages`, dedup pass:

```python
if len(kept_tcs) != len(msg.get("tool_calls") or []):
    msg = {**msg, "tool_calls": kept_tcs}   # kept_tcs can be []
```

The empty-array normalization at the top of the function only strips arrays that are empty *when the pass runs*. The dedup pass runs later and can **re-create** an empty array, defeating the earlier normalization.

## Fix

When dedup leaves zero surviving calls, drop the `tool_calls` key entirely instead of writing `[]`. An assistant message without the key is semantically identical to one with no tool calls, and every provider accepts it.

```python
if len(kept_tcs) != len(msg.get("tool_calls") or []):
    if kept_tcs:
        msg = {**msg, "tool_calls": kept_tcs}
    else:
        msg = {k: v for k, v in msg.items() if k != "tool_calls"}
```

## How to Verify

1. Review the diff in `agent/agent_runtime_helpers.py` (dedup branch).
2. Run the new regression test:
   ```
   python -m pytest tests/run_agent/test_run_agent.py -k "drops_key_when_all_tool_calls_deduped"
   ```
3. To see it fail on `main`: revert the `if kept_tcs:` guard, re-run the test — it fails with `tool_calls: []` in the payload.

## Test Plan

- [x] Added regression test for this bug (fails on unpatched code, passes with fix)
- [x] Existing sanitizer tests still pass (`-k sanitizer`: 3 passed)
- [ ] Manual verification of the fix

## Risk Assessment

Low — only changes the behavior when every tool call in a message was a duplicate, which previously produced a payload every strict provider rejected. Non-duplicate payloads are byte-identical.
