### PR TITLE
fix(deps): update lark-oapi version constraint for feishu extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,7 +304,7 @@ termux-all = [
   "hermes-agent[pty]",
 ]
 dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
-feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]
+feishu = ["lark-oapi>=1.7.1,<2.0", "qrcode==7.4.2"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so dev environments (`uv sync --extra google`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,7 +289,7 @@ termux-all = [
   "hermes-agent[pty]",
 ]
 dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
-feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]
+feishu = ["lark-oapi>=1.7.1", "qrcode==7.4.2"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so dev environments (`uv sync --extra google`)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "qrcode==7.4.2",
     ),
     "platform.feishu": (
-        "lark-oapi==1.6.8",
+        "lark-oapi>=1.7.1,<2.0",
         "qrcode==7.4.2",
     ),
     # WeCom callback-mode adapter — parses untrusted XML POST bodies. Pulls

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "qrcode==7.4.2",
     ),
     "platform.feishu": (
-        "lark-oapi==1.6.8",
+        "lark-oapi>=1.7.1",
         "qrcode==7.4.2",
     ),
     # WeCom callback-mode adapter — parses untrusted XML POST bodies. Pulls

--- a/uv.lock
+++ b/uv.lock
@@ -1876,7 +1876,7 @@ requires-dist = [
     { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.7.0" },
     { name = "httpx2", marker = "extra == 'mcp'", specifier = "==2.7.0" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
+    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.7.1,<2.0" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.1" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1865,7 +1865,7 @@ requires-dist = [
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
+    { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.7.1" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.28.1" },


### PR DESCRIPTION
## 问题

Feishu gateway 启动时进入崩溃循环：当 venv 里已安装的 `lark-oapi` **不满足**声明的 `lark-oapi==1.6.8` 时，每次启动都会走 `gateway/platform_registry.py:365` 的依赖检查分支：

```
INFO gateway.platform_registry: Platform 'Feishu / Lark' dependencies missing — attempting install...
```

该安装在**事件循环上同步执行**；当 PyPI 访问缓慢或不通时，事件循环停止响应 liveness 探针，watchdog 以 exit 75 结束进程，systemd 重启，于是循环往复 —— 飞书全程无法连接。

2026-09-10 在 `main @ 2bbb279c18f` 上实测：**每 ~127 秒一次，重启计数 26+**。把声明改成 `lark-oapi>=1.7.1,<2.0`（venv 里已装的 1.7.2 直接满足）后，`18:55:57 [Feishu] Connected in websocket mode`，循环立即停止。

判定路径（`tools/lazy_deps.py`）：`_specifier_from_spec()` 取出声明的 spec → `_is_satisfied()` 判定已装版本是否满足 → 不满足则 `ensure()` 走同步安装。

## 修改

- `pyproject.toml`：`feishu = ["lark-oapi>=1.7.1,<2.0", "qrcode==7.4.2"]`
- `tools/lazy_deps.py`：`LAZY_DEPS["platform.feishu"]` → `"lark-oapi>=1.7.1,<2.0"`
- `uv.lock`：`specifier = ">=1.7.1,<2.0"`

带上限（而不是裸 `>=1.7.1`）符合仓库 `AGENTS.md` 的依赖钉版规范，同时把 PyPI 上的 `2.0.0.dev*` 预发布挡在门外。

## 附注：一处早期描述的更正

本 PR 早期版本称「`lark-oapi==1.6.8` 已从 PyPI 下架，`pip install hermes-agent[feishu]` 会失败」。**该说法不成立** —— `https://pypi.org/pypi/lark-oapi/json` 显示 1.6.0–1.6.9、1.7.0–1.7.3、2.0.0.dev0–dev4 均在列，1.6.8 并未下架。真正的问题是「**声明与已安装版本不一致，触发阻塞式启动安装**」，已按此更正。

另：即使版本声明修好，`ensure()` 在事件循环上同步安装这条路径仍是潜在故障点（慢网络下可拖死整个 gateway）。相关独立修复建议见 #107318。

## 相关

- **#107318** —— 本问题的追踪 issue，含完整 `journalctl` / `gateway.log` 证据
- **#88398** —— 早期复现记录（当前被标 `invalid`，与事实不符）
- **#103980** —— 建议提到 1.7.3
