### PR TITLE
fix(cron): hard-abort when all skills fail to load, not silent contextless LLM call (#77362)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -158,6 +158,20 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+class CronAllSkillsFailed(Exception):
+    """Raised by _build_job_prompt when EVERY declared skill fails to load.
+
+    Without this, the scheduler fell through to a contextless LLM call —
+    the agent received the user's raw prompt minus all skill methodology,
+    had no idea how to perform the task, and frequently returned
+    ``[SILENT]`` (suppressing delivery). The result was a silent multi-week
+    failure indistinguishable from "nothing happened" (#77362).
+
+    Raising instead of falling through lets the caller deliver a clear
+    error to the operator so the broken skill is visible immediately.
+    """
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -2632,6 +2646,16 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         )
 
     if skipped:
+        # When EVERY declared skill failed to load, the prompt has zero
+        # skill context. Running the LLM anyway produces a contextless
+        # call that frequently returns [SILENT], suppressing delivery —
+        # a silent multi-week failure (#77362). Abort and deliver an
+        # error instead so the operator sees the broken skill immediately.
+        if not parts and skill_names and len(skipped) == len(skill_names):
+            raise CronAllSkillsFailed(
+                f"All skill(s) failed to load for cron job "
+                f"'{job.get('name', job.get('id', '?'))}': {', '.join(skipped)}"
+            )
         notice = (
             f"[IMPORTANT: The following skill(s) were listed for this job but could not be found "
             f"and were skipped: {', '.join(skipped)}. "
@@ -3009,6 +3033,34 @@ def run_job(
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
         return False, blocked_doc, "", str(block_exc)
+    except CronAllSkillsFailed as skill_exc:
+        # Every declared skill failed to load. Do NOT fall through to a
+        # contextless LLM call — the agent would have no methodology,
+        # would likely return [SILENT], and delivery would be suppressed,
+        # producing a silent multi-week failure (#77362). Deliver a clear
+        # error so the operator sees the broken skill immediately.
+        logger.warning(
+            "Job '%s' (ID: %s): all skills failed to load — %s",
+            job_name, job_id, skill_exc,
+        )
+        skill_error_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Status:** SKILL LOAD FAILURE\n\n"
+            "Every skill declared on this cron job failed to load, so the "
+            "agent was NOT run. The job's prompt requires skill context to "
+            "be useful; running without it would produce a contextless "
+            "response or silent suppression.\n\n"
+            f"**Error:** {skill_exc}\n\n"
+            "Check that the skill(s) exist and are valid:\n"
+            "- Run `hermes skills list` to see available skills\n"
+            "- Run `skill_view('<skill-name>')` to test loading\n"
+            "- A common cause: a flat-file skill (.md) colliding with a "
+            "directory stub (skill-name/SKILL.md) from an aborted migration\n"
+            "- Remove the stale stub or consolidate to one format"
+        )
+        return False, skill_error_doc, "", str(skill_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None

--- a/tests/cron/test_cron_prompt_injection_skill.py
+++ b/tests/cron/test_cron_prompt_injection_skill.py
@@ -236,10 +236,11 @@ class TestBuildJobPromptScansSkillContent:
             "prompt": "run task",
             "skills": ["does-not-exist"],
         }
-        # Should not raise — missing skills are skipped with a notice.
-        prompt = scheduler._build_job_prompt(job)
-        assert prompt is not None
-        assert "could not be found" in prompt
+        # All skills failed to load → CronAllSkillsFailed is raised so the
+        # caller can deliver a clear error instead of running a contextless
+        # LLM call that silently suppresses delivery (#77362).
+        with pytest.raises(scheduler.CronAllSkillsFailed, match="does-not-exist"):
+            scheduler._build_job_prompt(job)
 
 
     def test_bundle_name_shadows_skill_name_for_cron_jobs(self, cron_env):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1105,12 +1105,47 @@ class TestBuildJobPromptMissingSkill:
         return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
 
-    def test_missing_skill_injects_user_notice_into_prompt(self):
-        """A system notice about the missing skill is injected into the prompt."""
+    def test_all_skills_missing_raises_hard_abort(self):
+        """When every declared skill fails to load, the prompt builder
+        raises CronAllSkillsFailed instead of returning a contextless
+        prompt (#77362). This prevents a silent multi-week failure where
+        the agent runs without skill methodology, returns [SILENT], and
+        delivery is suppressed.
+        """
+        from cron.scheduler import CronAllSkillsFailed
+
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            with pytest.raises(CronAllSkillsFailed, match="ghost-skill"):
+                _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+
+    def test_all_skills_missing_with_multiple_skills_raises_hard_abort(self):
+        """Same hard-abort when multiple skills ALL fail to load."""
+        from cron.scheduler import CronAllSkillsFailed
+
+        with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
+            with pytest.raises(CronAllSkillsFailed, match="alpha.*beta"):
+                _build_job_prompt({"skills": ["alpha", "beta"], "prompt": "go"})
+
+    def test_partial_skill_failure_still_injects_notice(self):
+        """When some skills load but others fail, the prompt is still
+        assembled with the loaded skills + a notice about the missing
+        ones. This is NOT the all-failed case, so no hard abort.
+        """
+
+        def _mixed_skill_view(name: str) -> str:
+            if name == "good-skill":
+                return json.dumps({"success": True, "content": "# Good\nDo good things."})
+            return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_mixed_skill_view), \
+             patch("tools.skill_usage.bump_use"):
+            result = _build_job_prompt(
+                {"skills": ["good-skill", "ghost-skill"], "prompt": "do something"}
+            )
+        assert "good-skill" in result
+        assert "Do good things." in result
         assert "ghost-skill" in result
-        assert "not found" in result.lower() or "skipped" in result.lower()
+        assert "skipped" in result.lower()
 
 
 class TestBuildJobPromptAbsoluteSkillPath:


### PR DESCRIPTION
## Summary

When a cron job declares skills and **all** of them fail to load (missing file, ambiguous resolution, invalid JSON, bundle load failure), the scheduler logged a warning but still invoked the LLM with the user's raw prompt minus all skill context. A contextless LLM has no idea how to perform the task, frequently returns `[SILENT]` (suppressing delivery), and the result is a **silent multi-week failure** indistinguishable from "nothing happened."

**Real-world impact:** A weekly market risk monitor was silently broken for 3 consecutive weeks because a flat-file skill collided with a directory stub from an aborted migration. The cron agent received the user instruction without the skill's methodology, returned `[SILENT]`, and no alert reached the user for 3 weeks.

Closes #77362.

## Root Cause

In `_build_job_prompt()` (`cron/scheduler.py`), skill loading happens in a loop. When a skill fails to load, it's appended to `skipped` and the loop continues. After the loop, if any skills were skipped, a notice is prepended to the prompt — but the function still **returns the assembled prompt** regardless of whether ALL skills failed. The LLM runs with zero skill context.

## Changes

| File | Change |
|------|--------|
| `cron/scheduler.py` | New `CronAllSkillsFailed` exception. Guard in `_build_job_prompt`: when `len(skipped) == len(skill_names)` and no skill content was loaded (`not parts`), raise instead of returning a contextless prompt. Handler in `run_one_job` catches the exception and delivers a clear error document with diagnostics and remediation steps. |
| `tests/cron/test_scheduler.py` | Updated `TestBuildJobPromptMissingSkill`: single missing skill now raises `CronAllSkillsFailed`. Added test for multiple all-failing skills. Added test for partial failure (some load, some don't) — still injects notice, no hard abort. |
| `tests/cron/test_cron_prompt_injection_skill.py` | Updated `test_missing_skill_does_not_crash` to expect `CronAllSkillsFailed`. |

## Behavior

- **All skills fail → hard abort**: Error delivered to operator with diagnostics (`hermes skills list`, `skill_view(...)`, common causes)
- **Partial failure → same as before**: Loaded skills + notice about missing ones, agent runs normally
- **No skills declared → same as before**: No change

## Test Plan

- [x] `tests/cron/test_scheduler.py` — 3 new/updated tests in `TestBuildJobPromptMissingSkill`
- [x] `tests/cron/test_cron_prompt_injection_skill.py` — 1 updated test
- [x] Full cron suite: **100 passed, 1 skipped, 0 failed**

## Adversarial 6-Check — PASS

1. **Diff integrity**: All changes trace to #77362 ✅
2. **Blast radius**: Cron scheduler only. No core agent or gateway changes ✅
3. **Edge case — bundles**: Failed bundles append to `skipped` without adding to `parts`; all-bundle-failure raises correctly ✅
4. **Edge case — empty skill list**: Returns early before the guard; no false raise ✅
5. **Backward compat**: New exception class; partial-failure path unchanged ✅
6. **Delivery**: Returns `(False, error_doc, "", error_msg)` — error is delivered, NOT silent ✅