### PR TITLE
fix(mcp): treat last_mtime_ns=0 as first observation, not external refresh (#77369)

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -108,11 +108,12 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
     assert provider is not None
 
-    # First call: records mtime (zero -> real) -> returns True
+    # First call: records mtime (zero -> real) but does NOT invalidate —
+    # the zero default means "never read", not "file changed" (#77369).
     changed1 = await mgr.invalidate_if_disk_changed("srv")
-    assert changed1 is True
+    assert changed1 is False
 
-    # No file change -> False
+    # No file change -> False (baseline already recorded)
     changed2 = await mgr.invalidate_if_disk_changed("srv")
     assert changed2 is False
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -664,6 +664,27 @@ class MCPOAuthManager:
             if mtime_ns != entry.last_mtime_ns:
                 old = entry.last_mtime_ns
                 entry.last_mtime_ns = mtime_ns
+                # last_mtime_ns defaults to 0 ("never read"). A freshly
+                # created _ProviderEntry therefore always looks "changed"
+                # on its first check, even when the tokens file has not
+                # moved at all. Each false invalidation forces a full
+                # OAuth re-initialization on the next request, which on a
+                # hosted OAuth MCP server regularly exceeds
+                # connect_timeout — producing a bare TimeoutError, then
+                # the retry ladder, then parking. The server ends up
+                # unavailable most of the time while remaining perfectly
+                # healthy when tested on its own (#77369).
+                #
+                # Fix: when last_mtime_ns was 0 (never read), this is the
+                # FIRST observation, not a change. Record the mtime so the
+                # NEXT check has a real baseline, but do NOT invalidate.
+                if old == 0:
+                    logger.debug(
+                        "MCP OAuth '%s': first mtime observation (%d), "
+                        "recording baseline — no invalidation",
+                        server_name, mtime_ns,
+                    )
+                    return False
                 # Force the SDK's OAuthClientProvider to reload from storage
                 # on its next auth flow. `_initialized` is private API but
                 # stable across the MCP SDK versions we pin (>=1.26.0).


### PR DESCRIPTION
## Summary

`MCPOAuthManager.invalidate_if_disk_changed()` compares the tokens file mtime against `entry.last_mtime_ns`, whose default is `0` (documented as "Zero if never read"). A freshly created `_ProviderEntry` therefore **always** takes the "changed" branch on its first check, even when the tokens file has not moved at all.

Each false invalidation sets `provider._initialized = False`, forcing a full OAuth re-initialization on the next request. On a hosted OAuth MCP server this re-init regularly exceeds `connect_timeout`, producing a bare `TimeoutError`, then the retry ladder, then parking.

**Measured impact:** 18 spurious invalidations vs 2 genuine ones over 40 minutes. Availability over 3 days: **32%**. Meanwhile `hermes mcp test <server>` connects in under 1 second.

Closes #77369.

## Root Cause

```python
# tools/mcp_oauth_manager.py:664
if mtime_ns != entry.last_mtime_ns:  # 0 != 1785600933674347947 → always True
    entry.last_mtime_ns = mtime_ns
    entry.provider._initialized = False  # forces full re-init
    return True
```

The log line is its own proof — both operands are constant across occurrences:
```
MCP OAuth server: tokens file changed (mtime 0 -> 1785600933674347947), forcing reload
MCP OAuth server: tokens file changed (mtime 0 -> 1785600933674347947), forcing reload
```

Always `0` on the left, always the **same** mtime on the right. The file is not changing; the watcher's memory keeps starting over because entries are recreated frequently.

## Fix

When `last_mtime_ns` was `0` (never read), record the current mtime as the baseline but do **NOT** invalidate. The next check has a real baseline to compare against.

```python
if old == 0:
    logger.debug("MCP OAuth %s: first mtime observation (%d), recording baseline — no invalidation", ...)
    return False
```

## Test Plan

- Updated `test_mcp_oauth_manager.py::test_invalidate_if_disk_changed_detects_external_refresh`: first call now returns `False` (baseline recording) instead of `True` (false invalidation)
- Existing test for real mtime change (touch file → `True`) unchanged
- MCP OAuth integration tests skip in environments without the MCP SDK (pre-existing — `pydantic_core` native module issue in this venv)

## Adversarial 6-Check — PASS

1. **Diff integrity**: Single method change, traces to #77369 ✅
2. **Blast radius**: Only `invalidate_if_disk_changed`; first call behavior changes, subsequent calls unchanged ✅
3. **Edge case — file deleted/recreated**: mtime differs from non-zero baseline → correctly invalidates ✅
4. **Edge case — provider rebuilt**: `last_mtime_ns` resets to 0; first check records baseline without invalidating — correct, since fresh provider doesn't need reload ✅
5. **Backward compat**: Only behavior change is first-call returns `False` instead of `True`; callers skip one redundant reload ✅
6. **Logging**: Debug-level log for first observation — traceable but not noisy ✅