### PR TITLE
fix(credential-pool): rotate immediately on first 429 when healthy pool siblings exist

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1115,7 +1115,31 @@ def recover_with_credential_pool(
                 or "usage limit has been reached" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
-            return False, True
+            # Multi-entry pool: rotate NOW on the first 429 instead of
+            # retrying the same drained credential. Providers like Anthropic
+            # send Retry-After values of up to 10 minutes; honoring that on a
+            # credential while sibling accounts sit idle stalls interactive
+            # sessions for the full window (observed 2026-08-04: a one-word
+            # reply took 10.4 min because the session's baked-in token hit
+            # its rate limit and the retry napped through Retry-After=626s
+            # with two healthy accounts in the pool). Retry-same-credential
+            # remains the behavior for single-entry pools, where rotation
+            # has nothing to rotate to.
+            try:
+                _available_siblings = [
+                    e
+                    for e in pool.entries()
+                    if getattr(e, "last_status", None) != STATUS_EXHAUSTED
+                ]
+            except Exception:
+                _available_siblings = []
+            if len(_available_siblings) <= 1:
+                return False, True
+            _ra().logger.info(
+                "Rate limited with %d available pool entries — rotating "
+                "immediately instead of retrying the drained credential",
+                len(_available_siblings),
+            )
         rotate_status = status_code if status_code is not None else 429
         next_entry = _rotate_failed_credential(rotate_status)
         if next_entry is not None:

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -164,10 +164,14 @@ class TestPoolRotationCycle:
         for i in range(pool_entries):
             e = MagicMock(name=f"entry_{i}")
             e.id = f"cred-{i}"
+            # Healthy by default — the first-429 fast-rotate path counts
+            # non-exhausted siblings via pool.entries().
+            e.last_status = None
             entries.append(e)
 
         pool = MagicMock()
         pool.has_credentials.return_value = True
+        pool.entries.return_value = entries
         # Must be set explicitly — MagicMock.provider returns a truthy
         # child mock, which would trigger the provider-mismatch guard.
         pool.provider = ""
@@ -192,9 +196,39 @@ class TestPoolRotationCycle:
 
         return agent, pool, entries
 
-    def test_first_429_sets_retry_flag_no_rotation(self):
-        """First 429 should just set has_retried_429=True, no rotation."""
-        agent, pool, _ = self._make_agent_with_pool(3)
+    def test_first_429_multi_entry_rotates_immediately(self):
+        """First 429 on a MULTI-entry pool rotates now — no retry-same-credential.
+
+        Waiting out a provider Retry-After (up to 10 min) on a drained
+        credential while healthy siblings sit idle stalls interactive
+        sessions (2026-08-04 incident: one-word reply took 10.4 min).
+        """
+        agent, pool, entries = self._make_agent_with_pool(3)
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429, has_retried_429=False
+        )
+        assert recovered is True
+        assert has_retried is False
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None, api_key_hint="test-api-key")
+        agent._swap_credential.assert_called_once_with(entries[1])
+
+    def test_first_429_single_entry_sets_retry_flag_no_rotation(self):
+        """First 429 on a SINGLE-entry pool keeps retry-first behavior —
+        there is nothing to rotate to, so honoring Retry-After is correct."""
+        agent, pool, _ = self._make_agent_with_pool(1)
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429, has_retried_429=False
+        )
+        assert recovered is False
+        assert has_retried is True
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+    def test_first_429_all_siblings_exhausted_sets_retry_flag(self):
+        """First 429 when every OTHER entry is already exhausted behaves like
+        a single-entry pool: retry-first, no futile rotation."""
+        agent, pool, entries = self._make_agent_with_pool(3)
+        for e in entries[1:]:
+            e.last_status = "exhausted"
         recovered, has_retried = agent._recover_with_credential_pool(
             status_code=429, has_retried_429=False
         )


### PR DESCRIPTION
## Symptom

With a multi-entry credential pool, a rate-limited request stalls the whole session for the provider's full `Retry-After` window even though healthy sibling credentials sit idle in the pool.

Observed live (Anthropic, 3-account pool, 2026-08-04): a one-line Telegram reply took **10.4 minutes** — the session's baked-in token got a 429 with `Retry-After≈626s`, and the retry loop honored it on that same drained credential while two healthy accounts went unused:

```
06:58:16 inbound message
06:58:18 WARNING API call failed (attempt 1/3) error_type=RateLimitError ... HTTP 429
06:58:18 WARNING Retrying API call in 626.45s (attempt 1/3)
07:08:54 Turn ended (response finally delivered)
```

## Root cause

`recover_with_credential_pool()` deliberately retries the same credential on the **first** 429 and only rotates on the second consecutive one. That policy is right for a single-credential pool (rotation has nothing to offer, honoring Retry-After is correct) — but with N>1 healthy entries it converts a ~2-second credential swap into a multi-minute nap. Since `pool.select()` bakes the token in at session creation, a long-lived interactive session can land on whichever account is hot and pay this penalty on the first message.

## Fix

On the first 429, count non-exhausted pool entries:

- **>1 available** → rotate immediately (`mark_exhausted_and_rotate` + `_swap_credential`), same as the existing second-429 path.
- **≤1 available** (single-entry pool, or all siblings already exhausted) → unchanged retry-first behavior.

The existing pre-exhausted fast path, billing (402) immediate rotation, auth refresh path, and upstream-rate-limit guard are untouched.

## Tests

`tests/agent/test_credential_pool_routing.py`:
- `test_first_429_multi_entry_rotates_immediately` — new behavior
- `test_first_429_single_entry_sets_retry_flag_no_rotation` — old behavior preserved where it's correct
- `test_first_429_all_siblings_exhausted_sets_retry_flag` — degenerate multi-entry case degrades to retry-first

All rotation-cycle tests pass; the fix is running live on my gateway.