### PR TITLE
feat(telegram): per-chat mention gating via require_mention_chats

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1115,7 +1115,31 @@ def recover_with_credential_pool(
                 or "usage limit has been reached" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
-            return False, True
+            # Multi-entry pool: rotate NOW on the first 429 instead of
+            # retrying the same drained credential. Providers like Anthropic
+            # send Retry-After values of up to 10 minutes; honoring that on a
+            # credential while sibling accounts sit idle stalls interactive
+            # sessions for the full window (observed 2026-08-04: a one-word
+            # reply took 10.4 min because the session's baked-in token hit
+            # its rate limit and the retry napped through Retry-After=626s
+            # with two healthy accounts in the pool). Retry-same-credential
+            # remains the behavior for single-entry pools, where rotation
+            # has nothing to rotate to.
+            try:
+                _available_siblings = [
+                    e
+                    for e in pool.entries()
+                    if getattr(e, "last_status", None) != STATUS_EXHAUSTED
+                ]
+            except Exception:
+                _available_siblings = []
+            if len(_available_siblings) <= 1:
+                return False, True
+            _ra().logger.info(
+                "Rate limited with %d available pool entries — rotating "
+                "immediately instead of retrying the drained credential",
+                len(_available_siblings),
+            )
         rotate_status = status_code if status_code is not None else 429
         next_entry = _rotate_failed_credential(rotate_status)
         if next_entry is not None:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -2805,6 +2806,62 @@ def convert_messages_to_anthropic(
     return system, result
 
 
+def model_rejects_assistant_prefill(model: str | None) -> bool:
+    """True when the Claude model rejects a trailing assistant message.
+
+    Claude Sonnet/Opus 4.6+ (and the Fable family) return a non-retryable
+    HTTP 400 — "This model does not support assistant message prefill. The
+    conversation must end with a user message." — when ``messages[-1]`` has
+    ``role=assistant``. Older Claude models treat that shape as intentional
+    prefill, so only the rejecting families are matched here.
+    """
+    m = str(model or "").lower()
+    if "claude" not in m:
+        return False
+    if "fable" in m:
+        return True
+    match = re.search(r"(?:sonnet|opus|haiku)[.-](\d{1,2})(?!\d)(?:[.-](\d{1,2})(?!\d))?", m)
+    if not match:
+        return False
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    return (major, minor) >= (4, 6)
+
+
+def ensure_user_tail_for_no_prefill(anthropic_messages: List[Dict]) -> None:
+    """Append a synthetic user turn when the wire tail is a plain assistant turn.
+
+    Mutates *anthropic_messages* in place. Hermes never intentionally prefills
+    the tail on the agent loop — a trailing assistant message is leftover
+    streamed preamble/status text (e.g. persisted before an interrupt or
+    gateway restart). For models that reject prefill, the request would
+    otherwise hard-400 before the model can recover. Assistant turns ending in
+    ``tool_use`` are left alone: those need real tool results, not a fake user
+    continuation.
+    """
+    if not anthropic_messages:
+        return
+    last = anthropic_messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "assistant":
+        return
+    content = last.get("content")
+    if isinstance(content, list) and any(
+        isinstance(b, dict) and b.get("type") == "tool_use" for b in content
+    ):
+        return
+    anthropic_messages.append(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Continue from the previous assistant message.",
+                }
+            ],
+        }
+    )
+
+
 def build_anthropic_kwargs(
     model: str,
     messages: List[Dict],
@@ -2860,6 +2917,10 @@ def build_anthropic_kwargs(
     system, anthropic_messages = convert_messages_to_anthropic(
         messages, base_url=base_url, model=model
     )
+    # Claude 4.6+ / Fable reject trailing assistant prefill with a
+    # non-retryable 400. Repair the tail before the request is built.
+    if model_rejects_assistant_prefill(model):
+        ensure_user_tail_for_no_prefill(anthropic_messages)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
     # Nous Portal routes on its own catalog ids (``anthropic/claude-opus-4.8``);

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5514,7 +5514,16 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 600)
                             except (TypeError, ValueError):
                                 pass
-                wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                wait_time = (
+                    jittered_backoff(
+                        1,
+                        base_delay=_retry_after,
+                        max_delay=_retry_after,
+                        jitter_ratio=0.05,
+                    )
+                    if _retry_after
+                    else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                )
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -145,11 +145,12 @@ NO_AVAILABLE_ENTRIES_LOG_THROTTLE_SECONDS = 60.0
 CUSTOM_POOL_PREFIX = "custom:"
 
 
-# Fields that are only round-tripped through JSON — never used for logic as attributes.
+# Optional provider metadata round-tripped through JSON and exposed via __getattr__.
 _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "account_uuid",
 })
 
 

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
 
 from hermes_constants import get_hermes_home
+from agent.thread_scoped_output import thread_scoped_silence
 from tools import skill_usage
 from utils import atomic_json_write
 
@@ -1947,14 +1948,25 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # start (see agent/turn_context.py).
         review_agent._memory_write_origin = "background_review"
 
-        # Redirect the forked agent's stdout/stderr to /dev/null while it
-        # runs so its tool-call chatter doesn't pollute the foreground
-        # terminal. The background-thread runner also hides it; this
-        # belt-and-suspenders path matters when a caller invokes
-        # run_curator_review(synchronous=True) from the CLI.
-        with open(os.devnull, "w", encoding="utf-8") as _devnull, \
-             contextlib.redirect_stdout(_devnull), \
-             contextlib.redirect_stderr(_devnull):
+        # Silence the forked agent's stdout/stderr for THIS thread only so its
+        # tool-call chatter doesn't pollute the foreground terminal.
+        #
+        # A process-global ``contextlib.redirect_stdout(open(devnull))`` here is
+        # unsafe: the default path runs _llm_pass() on a daemon thread
+        # ("curator-review"), so the redirect rebinds sys.stdout/sys.stderr for
+        # EVERY thread in the process. Two overlapping redirects (a second
+        # curator pass, a background review, any other capture) then restore in
+        # the wrong order and leave sys.stdout pointing at the ALREADY-CLOSED
+        # devnull handle. Every subsequent bare ``print`` in the process — cron
+        # scheduler job runs, gateway turns, conversation_loop's tool-name
+        # repair print — dies with "ValueError: I/O operation on closed file."
+        # until the process is restarted. Observed 2026-07-27: 9 cron jobs
+        # failed in the same tick from a single poisoned sys.stdout.
+        #
+        # ``thread_scoped_silence`` routes only this thread's writes to a sink
+        # and leaves every other thread on the real streams (same fix already
+        # applied in agent/background_review.py for #55769 / #55925).
+        with thread_scoped_silence():
             conv_result = review_agent.run_conversation(user_message=prompt)
 
         final = ""

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -197,6 +197,57 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _rejects_trailing_assistant_prefill(
+    *,
+    model: Any,
+    base_url: Any = None,
+    provider_name: Any = None,
+    provider_profile: Any = None,
+) -> bool:
+    """Return True for Chat Completions endpoints that reject assistant prefill.
+
+    Newer native Anthropic/Claude endpoints reject requests whose final message
+    is ``role=assistant`` with: "This model does not support assistant message
+    prefill. The conversation must end with a user message." Hermes can create
+    such tails when streamed status/preamble text is persisted before the next
+    tool-backed request. OpenAI-style providers tolerate that as prefill; Claude
+    4.6+ does not, so only patch the Anthropic/Claude wire shape.
+    """
+    profile_name = str(getattr(provider_profile, "name", "") or "").strip().lower()
+    provider = str(provider_name or "").strip().lower()
+    url = str(base_url or "").strip().lower()
+    model_name = str(model or "").strip().lower()
+
+    if profile_name in {"anthropic", "claude", "claude-oauth", "claude-code"}:
+        return True
+    if provider in {"anthropic", "claude", "claude-oauth", "claude-code"}:
+        return True
+    if "api.anthropic.com" in url and "claude" in model_name:
+        return True
+    return False
+
+
+def _ensure_user_tail_for_no_prefill(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Append a tiny synthetic user turn when an endpoint forbids prefill.
+
+    The original list is left untouched. Assistant turns with tool calls are not
+    repaired here; those need the normal tool-result sanitizer, not a fake user
+    continuation.
+    """
+    if not messages or not isinstance(messages[-1], dict):
+        return messages
+    last = messages[-1]
+    if last.get("role") != "assistant" or last.get("tool_calls"):
+        return messages
+    return [
+        *messages,
+        {
+            "role": "user",
+            "content": "Continue from the previous assistant message.",
+        },
+    ]
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -407,6 +458,12 @@ class ChatCompletionsTransport(ProviderTransport):
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")
         if _profile:
+            if _rejects_trailing_assistant_prefill(
+                model=model,
+                base_url=params.get("base_url"),
+                provider_profile=_profile,
+            ):
+                sanitized = _ensure_user_tail_for_no_prefill(sanitized)
             return self._build_kwargs_from_profile(
                 _profile, model, sanitized, tools, params
             )
@@ -425,6 +482,13 @@ class ChatCompletionsTransport(ProviderTransport):
         ):
             sanitized = list(sanitized)
             sanitized[0] = {**sanitized[0], "role": "developer"}
+
+        if _rejects_trailing_assistant_prefill(
+            model=model,
+            base_url=params.get("base_url"),
+            provider_name=params.get("provider_name"),
+        ):
+            sanitized = _ensure_user_tail_for_no_prefill(sanitized)
 
         api_kwargs: dict[str, Any] = {
             "model": model,

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -1,22 +1,29 @@
 """Per-platform display/verbosity configuration resolver.
 
 Provides ``resolve_display_setting()`` — the single entry-point for reading
-display settings with platform-specific overrides and sensible defaults.
+display settings with platform-specific (and optional per-chat) overrides
+and sensible defaults.
 
 Resolution order (first non-None wins):
-    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
-    2. ``display.<key>``                       — global user setting
-    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
-    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+    1. ``display.platforms.<platform>.chats.<chat_id>:<thread_id>.<key>``  — most specific
+    2. ``display.platforms.<platform>.chats.<chat_id>.<key>``
+    3. ``display.platforms.<platform>.<key>``  — platform-wide user override
+    4. ``display.<key>``                       — global user setting
+    5. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
+    6. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
 
-Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
-top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
+The per-chat layer (rungs 1–2) is opt-in: callers must pass ``chat_id``
+(and optionally ``thread_id``).  Existing callers that don't pass those
+arguments see identical behaviour — the new lookup is simply skipped.
+
+Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows
+the top-level ``streaming`` config unless ``display.platforms.<platform>``
 sets an explicit per-platform override.
 
-Backward compatibility: ``display.tool_progress_overrides`` is still read as a
-fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
-config migration (version bump) automatically moves the old format into the new
-``display.platforms`` structure.
+Backward compatibility: ``display.tool_progress_overrides`` is still read
+as a fallback for ``tool_progress`` when no ``display.platforms`` entry
+exists.  A config migration (version bump) automatically moves the old
+format into the new ``display.platforms`` structure.
 """
 
 from __future__ import annotations
@@ -189,8 +196,11 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    *,
+    chat_id: str | int | None = None,
+    thread_id: str | int | None = None,
 ) -> Any:
-    """Resolve a display setting with per-platform override support.
+    """Resolve a display setting with per-platform and per-chat override support.
 
     Parameters
     ----------
@@ -203,22 +213,53 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    chat_id : str | int | None
+        Optional chat id for per-chat overrides.  When provided, the
+        resolver also inspects
+        ``display.platforms.<platform>.chats.<chat_id>.<setting>`` and, if
+        ``thread_id`` is also provided,
+        ``display.platforms.<platform>.chats.<chat_id>:<thread_id>.<setting>``
+        before falling back to the platform-wide override.  Pass ``None``
+        (default) when the call site doesn't know the chat — behaviour is
+        then identical to the pre-1.0 resolver.
+    thread_id : str | int | None
+        Optional thread / topic id, used together with ``chat_id`` to look
+        up an override scoped to a specific Telegram forum topic, Discord
+        thread, or Slack thread within a parent chat.
 
     Returns
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
     display_cfg = user_config.get("display") or {}
-
-    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}
     plat_overrides = platforms.get(platform_key)
-    if isinstance(plat_overrides, dict):
-        val = plat_overrides.get(setting)
+    plat_overrides_dict = plat_overrides if isinstance(plat_overrides, dict) else None
+
+    # 1. Per-chat override under display.platforms.<plat>.chats.<chat_key>.<setting>.
+    # Prefer the most specific key (chat_id:thread_id) over the chat-wide one.
+    if chat_id is not None and plat_overrides_dict is not None:
+        chats_cfg = plat_overrides_dict.get("chats")
+        if isinstance(chats_cfg, dict):
+            chat_id_s = str(chat_id)
+            candidates: list[str] = []
+            if thread_id is not None and thread_id != "":
+                candidates.append(f"{chat_id_s}:{thread_id}")
+            candidates.append(chat_id_s)
+            for key in candidates:
+                entry = chats_cfg.get(key)
+                if isinstance(entry, dict):
+                    val = entry.get(setting)
+                    if val is not None:
+                        return _normalise(setting, val)
+
+    # 2. Platform-wide override (display.platforms.<platform>.<key>)
+    if plat_overrides_dict is not None:
+        val = plat_overrides_dict.get(setting)
         if val is not None:
             return _normalise(setting, val)
 
-    # 1b. Backward compat: display.tool_progress_overrides.<platform>
+    # 2b. Backward compat: display.tool_progress_overrides.<platform>
     if setting == "tool_progress":
         legacy = display_cfg.get("tool_progress_overrides")
         if isinstance(legacy, dict):
@@ -226,7 +267,7 @@ def resolve_display_setting(
             if val is not None:
                 return _normalise(setting, val)
 
-    # 2. Global user setting (display.<key>).  Skip display.streaming because
+    # 3. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is
     # governed by the top-level streaming config plus per-platform overrides.
     if setting != "streaming":
@@ -234,14 +275,14 @@ def resolve_display_setting(
         if val is not None:
             return _normalise(setting, val)
 
-    # 3. Built-in platform default
+    # 4. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
     if plat_defaults:
         val = plat_defaults.get(setting)
         if val is not None:
             return val
 
-    # 4. Built-in global default
+    # 5. Built-in global default
     val = _GLOBAL_DEFAULTS.get(setting)
     if val is not None:
         return val

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2489,6 +2489,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -2497,6 +2498,13 @@ class APIServerAdapter(BasePlatformAdapter):
         base_url, etc. from config.yaml / env vars.  Toolsets are resolved
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
+
+        If *model_override* is provided (e.g. from the request body's
+        ``model`` field), it takes precedence over the gateway default.
+        When the override contains a provider prefix (e.g.
+        ``openrouter/openai/gpt-5.5``), the provider and base_url are
+        resolved from config.yaml so the agent routes to the correct
+        backend.
 
         ``gateway_session_key`` is a stable per-channel identifier supplied
         by the client (via ``X-Hermes-Session-Key``).  Unlike ``session_id``
@@ -2767,6 +2775,91 @@ class APIServerAdapter(BasePlatformAdapter):
             if confirmed_runtime_lock
             else GatewayRunner._load_fallback_model()
         )
+
+        # Apply model override from request body if provided.
+        # This allows API consumers (CCC, external UIs) to select a model
+        # per-request rather than always using the gateway default.
+        # Runs AFTER the selection block above so a provider-prefixed
+        # override (e.g. ``litellm-dev/dev-gpt54``, ``openai-codex/gpt-5.5``)
+        # wins for this request. A confirmed Browser runtime lock is an
+        # execution contract and is never overridden.
+        if model_override and not confirmed_runtime_lock:
+            model = model_override
+            _override_lower = model_override.lower()
+            providers_cfg = user_config.get("providers", {})
+            if _override_lower.startswith("openrouter/"):
+                or_cfg = providers_cfg.get("openrouter", {})
+                runtime_kwargs["provider"] = "openrouter"
+                if or_cfg.get("api_key"):
+                    runtime_kwargs["api_key"] = or_cfg["api_key"]
+                if or_cfg.get("base_url"):
+                    runtime_kwargs["base_url"] = or_cfg["base_url"]
+                elif not runtime_kwargs.get("base_url"):
+                    runtime_kwargs["base_url"] = "https://openrouter.ai/api/v1"
+            elif _override_lower.startswith("litellm-") or _override_lower.startswith("litellm/"):
+                runtime_kwargs["provider"] = "custom"
+                runtime_kwargs["base_url"] = "http://localhost:4000"
+            elif "/" in model_override:
+                # General provider-prefix routing. When the override is
+                # ``<provider>/<model>`` and ``<provider>`` is a registered
+                # Hermes provider (e.g. ``openai-codex/gpt-5.5``,
+                # ``anthropic/claude-sonnet-4-6``), pin that provider and strip
+                # the prefix so the bare model reaches it.
+                #
+                # Setting ``provider`` alone is NOT enough: AIAgent keeps the
+                # gateway's default base_url/api_key when only a provider name
+                # is passed, so an OAuth-gated provider would still hit the
+                # default endpoint (e.g. openai-codex/gpt-5.5 -> api.anthropic.com
+                # -> 404). We therefore run the same canonical resolver the CLI
+                # uses (``resolve_runtime_provider``) to fetch the provider's
+                # base_url, api_key/OAuth token, api_mode, and credential pool,
+                # and merge them into runtime_kwargs. This routes OAuth-gated
+                # providers like openai-codex (ChatGPT subscription) directly,
+                # without per-model special-casing.
+                #
+                # Aggregator-namespaced models (``openai/gpt-4o``) and litellm
+                # aliases are unaffected because their prefixes don't resolve to
+                # a registered provider profile.
+                _prefix = model_override.split("/", 1)[0].strip().lower()
+                try:
+                    from providers import get_provider_profile as _gpf_override
+                    _prefix_profile = _gpf_override(_prefix)
+                except Exception:
+                    _prefix_profile = None
+                if _prefix_profile is not None:
+                    _bare_model = model_override.split("/", 1)[1]
+                    try:
+                        from hermes_cli.runtime_provider import (
+                            resolve_runtime_provider as _rrp_override,
+                        )
+                        _binding = _rrp_override(
+                            requested=_prefix_profile.name,
+                            target_model=_bare_model,
+                        )
+                    except Exception:
+                        _binding = None
+                    if _binding:
+                        # Provider resolved with full runtime binding. Honor
+                        # only the fields the resolver actually produced so we
+                        # never clobber runtime_kwargs with empty values.
+                        runtime_kwargs["provider"] = (
+                            _binding.get("provider") or _prefix_profile.name
+                        )
+                        if _binding.get("base_url"):
+                            runtime_kwargs["base_url"] = _binding["base_url"]
+                        if _binding.get("api_key"):
+                            runtime_kwargs["api_key"] = _binding["api_key"]
+                        if _binding.get("api_mode"):
+                            runtime_kwargs["api_mode"] = _binding["api_mode"]
+                        if _binding.get("credential_pool") is not None:
+                            runtime_kwargs["credential_pool"] = _binding[
+                                "credential_pool"
+                            ]
+                    else:
+                        # Resolver unavailable/failed — fall back to pinning the
+                        # provider name only (base_url/key resolve downstream).
+                        runtime_kwargs["provider"] = _prefix_profile.name
+                    model = _bare_model
 
         agent_kwargs = {
             "model": model,
@@ -3983,6 +4076,13 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
+        # Derive model override: use body.model if it differs from the
+        # gateway's advertised model name (which is just an alias).
+        # Unlike agent_overrides (gated on direct_model_requests), this
+        # carry always honors provider-prefixed overrides from CCC.
+        _chat_model_override = body.get("model") or None
+        if _chat_model_override == self._model_name:
+            _chat_model_override = None
 
         if stream:
             import queue as _q
@@ -4068,6 +4168,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                model_override=_chat_model_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -4089,6 +4190,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                model_override=_chat_model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -5115,6 +5217,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # groups the entire conversation under one session entry.
         session_id = stored_session_id or str(uuid.uuid4())
 
+        # Derive model override for responses API (carry: always honors
+        # provider-prefixed overrides regardless of direct_model_requests).
+        _resp_model_override = body.get("model") or None
+        if _resp_model_override == self._model_name:
+            _resp_model_override = None
+
         stream = _coerce_request_bool(body.get("stream"), default=False)
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(
@@ -5185,6 +5293,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                model_override=_resp_model_override,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -5220,6 +5329,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                model_override=_resp_model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -5932,6 +6042,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        model_override: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -5989,6 +6100,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         route=route,
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
+                        model_override=model_override,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
@@ -6378,6 +6490,12 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        # Extract requested model from body (may be None/empty → use gateway default)
+        requested_model = body.get("model") or None
+        # Don't treat self._model_name as an override — it's the gateway default alias
+        if requested_model == self._model_name:
+            requested_model = None
+
         self._set_run_status(
             run_id,
             "queued",
@@ -6416,6 +6534,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
                         route=route,
+                        model_override=requested_model,
                     )
                 self._active_run_agents[run_id] = agent
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4367,7 +4367,9 @@ class TurnRunner:
         # can disable streaming for specific platforms even when the global
         # streaming config is enabled.
         _plat_streaming = ctx.resolve_display_setting(
-            ctx.user_config, platform_key, "streaming"
+            ctx.user_config, platform_key, "streaming",
+            chat_id=getattr(ctx.source, "chat_id", None),
+            thread_id=getattr(ctx.source, "thread_id", None),
         )
         # None = no per-platform override → follow global config
         _streaming_enabled = (
@@ -22658,24 +22660,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to rebind turn lease", exc_info=True)
             return False
 
-<<<<<<< ours
     def _clear_conversation_scope(self, session_key: str, *, reason: str) -> None:
         """Clear ALL conversation-scoped per-session state for ``session_key``.
-=======
-        platform_key = _platform_config_key(source.platform)
-        user_config = _load_gateway_config()
-        from gateway.display_config import resolve_display_setting
-        _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming",
-            chat_id=getattr(source, "chat_id", None),
-            thread_id=getattr(source, "thread_id", None),
-        )
-        _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
-        )
->>>>>>> theirs
 
         THE single conversation-boundary funnel. Call this — and nothing
         else — whenever a session_key crosses a conversation boundary:
@@ -23097,25 +23083,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             slack_tools = "1" if _slack_tools_loaded() else "0"
 
         try:
-<<<<<<< ours
             from hermes_constants import display_hermes_home
-=======
-            from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(
-                user_config, platform_key, "tool_preview_length", 0,
-                chat_id=getattr(source, "chat_id", None),
-                thread_id=getattr(source, "thread_id", None),
-            )
-            set_tool_preview_max_len(int(_tpl) if _tpl else 0)
-        except Exception:
-            pass
->>>>>>> theirs
 
             home_display = str(display_hermes_home())
         except Exception:
             home_display = ""
 
-<<<<<<< ours
         key_tuple = (
             platform,
             str(src.chat_id or ""),
@@ -23141,54 +23114,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
             bool(redact_pii),
             home_display,
-=======
-        # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(
-            user_config, platform_key, "tool_progress",
-            chat_id=getattr(source, "chat_id", None),
-            thread_id=getattr(source, "thread_id", None),
-        )
-        _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
-        _display_cfg = display_config if isinstance(display_config, dict) else {}
-        _platforms_cfg = _display_cfg.get("platforms") or {}
-        _platform_cfg = _platforms_cfg.get(platform_key) or {}
-        _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
-
-        def _per_chat_tp_configured() -> bool:
-            if not isinstance(_platform_cfg, dict):
-                return False
-            chats_cfg = _platform_cfg.get("chats")
-            if not isinstance(chats_cfg, dict):
-                return False
-            cid = getattr(source, "chat_id", None)
-            if cid is None:
-                return False
-            tid = getattr(source, "thread_id", None)
-            cid_s = str(cid)
-            keys = [f"{cid_s}:{tid}", cid_s] if tid not in (None, "") else [cid_s]
-            for k in keys:
-                entry = chats_cfg.get(k)
-                if isinstance(entry, dict) and "tool_progress" in entry:
-                    return True
-            return False
-
-        _tool_progress_configured = (
-            "tool_progress" in _display_cfg
-            or (
-                isinstance(_platform_cfg, dict)
-                and "tool_progress" in _platform_cfg
-            )
-            or (
-                isinstance(_legacy_tp_overrides, dict)
-                and platform_key in _legacy_tp_overrides
-            )
-            or _per_chat_tp_configured()
-        )
-        progress_mode = (
-            _env_tp
-            if _env_tp and not _tool_progress_configured
-            else (_resolved_tp or _env_tp or "all")
->>>>>>> theirs
         )
         return hashlib.sha256(repr(key_tuple).encode("utf-8")).hexdigest()
 
@@ -23346,41 +23271,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as _e:
             logger.debug("Pre-evict memory commit failed for %s: %s", key, _e)
 
-<<<<<<< ours
     def _commit_then_release_soft(self, agent: Any, key: str) -> None:
         """Commit end-of-session memory (if warranted), then soft-release.
-=======
-        # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
-        # that implements ``delete_message``). When enabled via
-        # ``display.platforms.<platform>.cleanup_progress: true``, message IDs
-        # from the tool-progress / "⏳ Working — N min" / status-callback bubbles
-        # are collected here and deleted after the final response lands.
-        # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
-        _cleanup_progress = bool(
-            resolve_display_setting(
-                user_config, platform_key, "cleanup_progress",
-                chat_id=getattr(source, "chat_id", None),
-                thread_id=getattr(source, "thread_id", None),
-            )
-        )
-        _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
-        # getattr, not attribute access — same duck-typed-adapter guard as the
-        # edit_message check in send_progress_messages below: a fake/minimal
-        # adapter without delete_message means "can't delete", not a crash.
-        _cleanup_delete = getattr(type(_cleanup_adapter), "delete_message", None) if _cleanup_adapter is not None else None
-        if _cleanup_adapter is not None and (
-            _cleanup_delete is None
-            or _cleanup_delete is BasePlatformAdapter.delete_message
-        ):
-            # Adapter doesn't support deletion — silently disable.
-            _cleanup_progress = False
-            _cleanup_adapter = None
-        _cleanup_msg_ids: List[str] = []
-        # First-touch onboarding latch: fires at most once per run, even if
-        # several tools exceed the threshold.
-        long_tool_hint_fired = [False]
-        _LONG_TOOL_THRESHOLD_S = 30.0
->>>>>>> theirs
 
         Runs on the daemon eviction thread so the memory-provider call and the
         client teardown never block the caller's held cache lock. Order matters:
@@ -23786,7 +23678,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+            user_config, platform_key, "streaming",
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
         )
         _streaming_enabled = (
             _scfg.enabled and _scfg.transport != "off"
@@ -24157,109 +24051,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=event_message_id,
             )
-<<<<<<< ours
-=======
-            self._reasoning_config = reasoning_config
-            self._service_tier = self._resolve_session_service_tier(
-                source=source, session_key=session_key
-            )
-            # Set up stream consumer for token streaming or interim commentary.
-            _stream_consumer = None
-            _stream_delta_cb = None
-            # #60671 — streaming TTS consumer is created on the outer
-            # event-loop thread before run_sync launches.  run_sync only
-            # reads it via ``streaming_tts_consumer_holder[0]`` for delta
-            # callback wiring.
-            _stts_consumer_ref = streaming_tts_consumer_holder[0]
-            _scfg = getattr(getattr(self, 'config', None), 'streaming', None)
-            if _scfg is None:
-                from gateway.config import StreamingConfig
-                _scfg = StreamingConfig()
-
-            # Per-platform streaming gate: display.platforms.<plat>.streaming
-            # can disable streaming for specific platforms even when the global
-            # streaming config is enabled.
-            _plat_streaming = resolve_display_setting(
-                user_config, platform_key, "streaming",
-                chat_id=getattr(source, "chat_id", None),
-                thread_id=getattr(source, "thread_id", None),
-            )
-            # None = no per-platform override → follow global config
-            _streaming_enabled = (
-                _scfg.enabled and _scfg.transport != "off"
-                if _plat_streaming is None
-                else bool(_plat_streaming)
-            )
-            _want_stream_deltas = _streaming_enabled
-            _want_interim_messages = interim_assistant_messages_enabled
-            _want_interim_consumer = _want_interim_messages
-            if _want_stream_deltas or _want_interim_consumer:
-                try:
-                    from gateway.stream_consumer import GatewayStreamConsumer
-                    _adapter = self._adapter_for_source(source)
-                    if _adapter:
-                        _consumer_cfg, _pause_typing_before_finalize = (
-                            self._build_stream_consumer_config(
-                                source, _scfg, _adapter,
-                                on_missing_cursor="raise",
-                            )
-                        )
-                        _stream_consumer = GatewayStreamConsumer(
-                            adapter=_adapter,
-                            chat_id=source.chat_id,
-                            config=_consumer_cfg,
-                            metadata=_status_thread_metadata,
-                            on_new_message=(
-                                (lambda: progress_queue.put(("__reset__",)))
-                                if progress_queue is not None
-                                else None
-                            ),
-                            on_before_finalize=_pause_typing_before_finalize,
-                            initial_reply_to_id=event_message_id,
-                            run_still_current=_run_still_current,
-                        )
-                        if _want_stream_deltas:
-                            def _stream_delta_cb(text: str) -> None:
-                                if _run_still_current():
-                                    _stream_consumer.on_delta(text)
-                                    # Tee to the streaming-TTS consumer (#60671).
-                                    if _stts_consumer_ref is not None:
-                                        _stts_consumer_ref.on_delta(text)
-                        stream_consumer_holder[0] = _stream_consumer
-                except Exception as _sc_err:
-                    logger.debug("Could not set up stream consumer: %s", _sc_err)
-
-            # When text streaming is off but streaming TTS is active,
-            # install a TTS-only delta callback so the consumer still
-            # receives LLM deltas for audio synthesis (#60671).
-            if _stream_delta_cb is None and _stts_consumer_ref is not None:
-                def _stream_delta_cb(text: str) -> None:
-                    if _run_still_current():
-                        _stts_consumer_ref.on_delta(text)
-
-            def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
-                if not _run_still_current():
-                    return
-                display_text = text
-                if _stream_consumer is not None:
-                    if already_streamed:
-                        _stream_consumer.on_segment_break()
-                    else:
-                        _stream_consumer.on_commentary(display_text)
-                    return
-                if already_streamed or not _status_adapter or not str(display_text or "").strip():
-                    return
-                safe_schedule_threadsafe(
-                    _status_adapter.send(
-                        _status_chat_id,
-                        display_text,
-                        metadata=_status_thread_metadata,
-                    ),
-                    _loop_for_step,
-                    logger=logger,
-                    log_message="interim_assistant_callback scheduling error",
-                )
->>>>>>> theirs
 
         from run_agent import AIAgent
         import queue
@@ -24289,7 +24080,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting(
+                user_config, platform_key, "tool_preview_length", 0,
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
@@ -24303,12 +24098,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = resolve_display_setting(
+            user_config, platform_key, "tool_progress",
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
+        )
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
+
+        def _per_chat_tp_configured() -> bool:
+            if not isinstance(_platform_cfg, dict):
+                return False
+            chats_cfg = _platform_cfg.get("chats")
+            if not isinstance(chats_cfg, dict):
+                return False
+            cid = getattr(source, "chat_id", None)
+            if cid is None:
+                return False
+            tid = getattr(source, "thread_id", None)
+            cid_s = str(cid)
+            keys = [f"{cid_s}:{tid}", cid_s] if tid not in (None, "") else [cid_s]
+            for k in keys:
+                entry = chats_cfg.get(k)
+                if isinstance(entry, dict) and "tool_progress" in entry:
+                    return True
+            return False
+
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
             or (
@@ -24319,6 +24137,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 isinstance(_legacy_tp_overrides, dict)
                 and platform_key in _legacy_tp_overrides
             )
+            or _per_chat_tp_configured()
         )
         progress_mode = (
             _env_tp
@@ -24457,7 +24276,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
-            resolve_display_setting(user_config, platform_key, "cleanup_progress")
+            resolve_display_setting(
+                user_config, platform_key, "cleanup_progress",
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
         )
         _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
         # getattr, not attribute access — same duck-typed-adapter guard as the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22658,8 +22658,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Failed to rebind turn lease", exc_info=True)
             return False
 
+<<<<<<< ours
     def _clear_conversation_scope(self, session_key: str, *, reason: str) -> None:
         """Clear ALL conversation-scoped per-session state for ``session_key``.
+=======
+        platform_key = _platform_config_key(source.platform)
+        user_config = _load_gateway_config()
+        from gateway.display_config import resolve_display_setting
+        _plat_streaming = resolve_display_setting(
+            user_config, platform_key, "streaming",
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
+        )
+        _streaming_enabled = (
+            _scfg.enabled and _scfg.transport != "off"
+            if _plat_streaming is None
+            else bool(_plat_streaming)
+        )
+>>>>>>> theirs
 
         THE single conversation-boundary funnel. Call this — and nothing
         else — whenever a session_key crosses a conversation boundary:
@@ -23081,12 +23097,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             slack_tools = "1" if _slack_tools_loaded() else "0"
 
         try:
+<<<<<<< ours
             from hermes_constants import display_hermes_home
+=======
+            from agent.display import set_tool_preview_max_len
+            _tpl = resolve_display_setting(
+                user_config, platform_key, "tool_preview_length", 0,
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
+            set_tool_preview_max_len(int(_tpl) if _tpl else 0)
+        except Exception:
+            pass
+>>>>>>> theirs
 
             home_display = str(display_hermes_home())
         except Exception:
             home_display = ""
 
+<<<<<<< ours
         key_tuple = (
             platform,
             str(src.chat_id or ""),
@@ -23112,6 +23141,54 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
             bool(redact_pii),
             home_display,
+=======
+        # Tool progress mode — resolved per-platform with env var fallback
+        _resolved_tp = resolve_display_setting(
+            user_config, platform_key, "tool_progress",
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
+        )
+        _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
+        _display_cfg = display_config if isinstance(display_config, dict) else {}
+        _platforms_cfg = _display_cfg.get("platforms") or {}
+        _platform_cfg = _platforms_cfg.get(platform_key) or {}
+        _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
+
+        def _per_chat_tp_configured() -> bool:
+            if not isinstance(_platform_cfg, dict):
+                return False
+            chats_cfg = _platform_cfg.get("chats")
+            if not isinstance(chats_cfg, dict):
+                return False
+            cid = getattr(source, "chat_id", None)
+            if cid is None:
+                return False
+            tid = getattr(source, "thread_id", None)
+            cid_s = str(cid)
+            keys = [f"{cid_s}:{tid}", cid_s] if tid not in (None, "") else [cid_s]
+            for k in keys:
+                entry = chats_cfg.get(k)
+                if isinstance(entry, dict) and "tool_progress" in entry:
+                    return True
+            return False
+
+        _tool_progress_configured = (
+            "tool_progress" in _display_cfg
+            or (
+                isinstance(_platform_cfg, dict)
+                and "tool_progress" in _platform_cfg
+            )
+            or (
+                isinstance(_legacy_tp_overrides, dict)
+                and platform_key in _legacy_tp_overrides
+            )
+            or _per_chat_tp_configured()
+        )
+        progress_mode = (
+            _env_tp
+            if _env_tp and not _tool_progress_configured
+            else (_resolved_tp or _env_tp or "all")
+>>>>>>> theirs
         )
         return hashlib.sha256(repr(key_tuple).encode("utf-8")).hexdigest()
 
@@ -23269,8 +23346,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as _e:
             logger.debug("Pre-evict memory commit failed for %s: %s", key, _e)
 
+<<<<<<< ours
     def _commit_then_release_soft(self, agent: Any, key: str) -> None:
         """Commit end-of-session memory (if warranted), then soft-release.
+=======
+        # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
+        # that implements ``delete_message``). When enabled via
+        # ``display.platforms.<platform>.cleanup_progress: true``, message IDs
+        # from the tool-progress / "⏳ Working — N min" / status-callback bubbles
+        # are collected here and deleted after the final response lands.
+        # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
+        _cleanup_progress = bool(
+            resolve_display_setting(
+                user_config, platform_key, "cleanup_progress",
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
+        )
+        _cleanup_adapter = self._adapter_for_source(source) if _cleanup_progress else None
+        # getattr, not attribute access — same duck-typed-adapter guard as the
+        # edit_message check in send_progress_messages below: a fake/minimal
+        # adapter without delete_message means "can't delete", not a crash.
+        _cleanup_delete = getattr(type(_cleanup_adapter), "delete_message", None) if _cleanup_adapter is not None else None
+        if _cleanup_adapter is not None and (
+            _cleanup_delete is None
+            or _cleanup_delete is BasePlatformAdapter.delete_message
+        ):
+            # Adapter doesn't support deletion — silently disable.
+            _cleanup_progress = False
+            _cleanup_adapter = None
+        _cleanup_msg_ids: List[str] = []
+        # First-touch onboarding latch: fires at most once per run, even if
+        # several tools exceed the threshold.
+        long_tool_hint_fired = [False]
+        _LONG_TOOL_THRESHOLD_S = 30.0
+>>>>>>> theirs
 
         Runs on the daemon eviction thread so the memory-provider call and the
         client teardown never block the caller's held cache lock. Order matters:
@@ -24047,6 +24157,109 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=event_message_id,
             )
+<<<<<<< ours
+=======
+            self._reasoning_config = reasoning_config
+            self._service_tier = self._resolve_session_service_tier(
+                source=source, session_key=session_key
+            )
+            # Set up stream consumer for token streaming or interim commentary.
+            _stream_consumer = None
+            _stream_delta_cb = None
+            # #60671 — streaming TTS consumer is created on the outer
+            # event-loop thread before run_sync launches.  run_sync only
+            # reads it via ``streaming_tts_consumer_holder[0]`` for delta
+            # callback wiring.
+            _stts_consumer_ref = streaming_tts_consumer_holder[0]
+            _scfg = getattr(getattr(self, 'config', None), 'streaming', None)
+            if _scfg is None:
+                from gateway.config import StreamingConfig
+                _scfg = StreamingConfig()
+
+            # Per-platform streaming gate: display.platforms.<plat>.streaming
+            # can disable streaming for specific platforms even when the global
+            # streaming config is enabled.
+            _plat_streaming = resolve_display_setting(
+                user_config, platform_key, "streaming",
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
+            # None = no per-platform override → follow global config
+            _streaming_enabled = (
+                _scfg.enabled and _scfg.transport != "off"
+                if _plat_streaming is None
+                else bool(_plat_streaming)
+            )
+            _want_stream_deltas = _streaming_enabled
+            _want_interim_messages = interim_assistant_messages_enabled
+            _want_interim_consumer = _want_interim_messages
+            if _want_stream_deltas or _want_interim_consumer:
+                try:
+                    from gateway.stream_consumer import GatewayStreamConsumer
+                    _adapter = self._adapter_for_source(source)
+                    if _adapter:
+                        _consumer_cfg, _pause_typing_before_finalize = (
+                            self._build_stream_consumer_config(
+                                source, _scfg, _adapter,
+                                on_missing_cursor="raise",
+                            )
+                        )
+                        _stream_consumer = GatewayStreamConsumer(
+                            adapter=_adapter,
+                            chat_id=source.chat_id,
+                            config=_consumer_cfg,
+                            metadata=_status_thread_metadata,
+                            on_new_message=(
+                                (lambda: progress_queue.put(("__reset__",)))
+                                if progress_queue is not None
+                                else None
+                            ),
+                            on_before_finalize=_pause_typing_before_finalize,
+                            initial_reply_to_id=event_message_id,
+                            run_still_current=_run_still_current,
+                        )
+                        if _want_stream_deltas:
+                            def _stream_delta_cb(text: str) -> None:
+                                if _run_still_current():
+                                    _stream_consumer.on_delta(text)
+                                    # Tee to the streaming-TTS consumer (#60671).
+                                    if _stts_consumer_ref is not None:
+                                        _stts_consumer_ref.on_delta(text)
+                        stream_consumer_holder[0] = _stream_consumer
+                except Exception as _sc_err:
+                    logger.debug("Could not set up stream consumer: %s", _sc_err)
+
+            # When text streaming is off but streaming TTS is active,
+            # install a TTS-only delta callback so the consumer still
+            # receives LLM deltas for audio synthesis (#60671).
+            if _stream_delta_cb is None and _stts_consumer_ref is not None:
+                def _stream_delta_cb(text: str) -> None:
+                    if _run_still_current():
+                        _stts_consumer_ref.on_delta(text)
+
+            def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+                if not _run_still_current():
+                    return
+                display_text = text
+                if _stream_consumer is not None:
+                    if already_streamed:
+                        _stream_consumer.on_segment_break()
+                    else:
+                        _stream_consumer.on_commentary(display_text)
+                    return
+                if already_streamed or not _status_adapter or not str(display_text or "").strip():
+                    return
+                safe_schedule_threadsafe(
+                    _status_adapter.send(
+                        _status_chat_id,
+                        display_text,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                    logger=logger,
+                    log_message="interim_assistant_callback scheduling error",
+                )
+>>>>>>> theirs
 
         from run_agent import AIAgent
         import queue

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3684,15 +3684,28 @@ class GatewaySlashCommandsMixin:
             "log": t("gateway.verbose.mode_log"),
         }
 
-        # Read current effective mode for this platform via the resolver
+        # Read current effective mode via the resolver (chat-aware: honors any
+        # existing per-chat override so cycling starts from what THIS chat sees)
         from gateway.display_config import resolve_display_setting
-        current = resolve_display_setting(user_config, platform_key, "tool_progress", "all")
+        source = event.source
+        chat_id = getattr(source, "chat_id", None)
+        thread_id = getattr(source, "thread_id", None)
+        chat_type = getattr(source, "chat_type", "dm") or "dm"
+        # In group/channel/thread chats, /verbose scopes to the chat (topic if
+        # present) instead of flipping the whole platform's verbosity.  DMs keep
+        # the historical per-platform behaviour.
+        per_chat = chat_type != "dm" and chat_id is not None
+        current = resolve_display_setting(
+            user_config, platform_key, "tool_progress", "all",
+            chat_id=chat_id, thread_id=thread_id,
+        )
         if current not in cycle:
             current = "all"
         idx = (cycle.index(current) + 1) % len(cycle)
         new_mode = cycle[idx]
 
-        # Save to display.platforms.<platform>.tool_progress
+        # Save to display.platforms.<platform>.tool_progress — or, for group
+        # chats, display.platforms.<platform>.chats.<chat_id>[:<thread_id>]
         try:
             if "display" not in user_config or not isinstance(user_config.get("display"), dict):
                 user_config["display"] = {}
@@ -3701,11 +3714,22 @@ class GatewaySlashCommandsMixin:
                 display["platforms"] = {}
             if platform_key not in display["platforms"] or not isinstance(display["platforms"].get(platform_key), dict):
                 display["platforms"][platform_key] = {}
-            display["platforms"][platform_key]["tool_progress"] = new_mode
+            plat_cfg = display["platforms"][platform_key]
+            if per_chat:
+                if "chats" not in plat_cfg or not isinstance(plat_cfg.get("chats"), dict):
+                    plat_cfg["chats"] = {}
+                chat_key = f"{chat_id}:{thread_id}" if thread_id is not None else str(chat_id)
+                if chat_key not in plat_cfg["chats"] or not isinstance(plat_cfg["chats"].get(chat_key), dict):
+                    plat_cfg["chats"][chat_key] = {}
+                plat_cfg["chats"][chat_key]["tool_progress"] = new_mode
+                scope_label = f"{platform_key} chat {chat_key}"
+            else:
+                plat_cfg["tool_progress"] = new_mode
+                scope_label = platform_key
             atomic_config_write(config_path, user_config)
             return (
                 f"{descriptions[new_mode]}\n"
-                + t("gateway.verbose.saved_suffix", platform=platform_key)
+                + t("gateway.verbose.saved_suffix", platform=scope_label)
             )
         except Exception as e:
             logger.warning("Failed to save tool_progress mode: %s", e)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2576,6 +2576,7 @@ def get_python_path() -> str:
 def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     """Return user-local bin dirs that exist and aren't already in *path_entries*."""
     candidates = [
+        str(home / "bin"),  # user-local bins (e.g. 1Password op CLI)
         str(home / ".local" / "bin"),  # uv, uvx, pip-installed CLIs
         str(home / ".cargo" / "bin"),  # Rust/cargo tools
         str(home / "go" / "bin"),  # Go tools

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8074,6 +8074,28 @@ class TelegramAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _telegram_require_mention_chats(self) -> set[str]:
+        """Return chats that require an explicit trigger even when
+        ``require_mention`` is globally disabled.
+
+        Inverse of ``free_response_chats``. ``require_mention`` is a global
+        boolean whose only per-chat escape hatch is an *exemption* list, so the
+        shape "chatty everywhere EXCEPT room X" was previously unexpressible —
+        the only way to quiet one group was to gag every group. This list
+        supplies that missing inverse for multi-party rooms (exchanges, market
+        makers, partner channels) where the bot should observe by default and
+        speak only when addressed.
+
+        Accepts a list or a comma-separated string, matching the parsing of
+        every other chat-list key in this adapter.
+        """
+        raw = self.config.extra.get("require_mention_chats")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_REQUIRE_MENTION_CHATS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
     def _telegram_free_response_topics(self) -> set[str]:
         """Return topic-level free-response allowlist entries as ``<chat_id>:<thread_id>``.
 
@@ -8602,7 +8624,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         if self._telegram_is_free_response_topic(message):
             return False
-        if not self._telegram_require_mention():
+        # A per-chat gated room behaves like require_mention=true locally, so
+        # its unmentioned messages are observable context even when the global
+        # flag is off. Without this, the global check below would return False
+        # and the room's untagged chatter would be dropped entirely.
+        _chat_gated = chat_id_str in self._telegram_require_mention_chats()
+        if not _chat_gated and not self._telegram_require_mention():
             return False
         if self._is_reply_to_bot(message):
             return False
@@ -8909,7 +8936,9 @@ class TelegramAdapter(BasePlatformAdapter):
         - the chat passes the ``allowed_chats`` whitelist (when set), or
           ``guest_mode`` is enabled and the bot is explicitly mentioned
         - the chat is explicitly allowlisted in ``free_response_chats``
-        - ``require_mention`` is disabled
+        - ``require_mention`` is disabled and the chat is not listed in
+          ``require_mention_chats`` (the per-chat inverse: listed chats
+          require an explicit trigger even with the global flag off)
         - the message replies to the bot
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
@@ -8982,6 +9011,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
+        # Per-chat mention requirement (inverse of free_response_chats).
+        # Evaluated BEFORE the free-response and global-off short-circuits so a
+        # listed chat stays gated even when require_mention is globally false.
+        # A reply to the bot or an explicit mention still gets through below.
+        if chat_id_str in self._telegram_require_mention_chats():
+            if self._is_reply_to_bot(message):
+                return True
+            if not self._telegram_guest_mode() and self._message_mentions_bot(message):
+                return True
+            return self._message_matches_mention_patterns(message)
         if chat_id_str in self._telegram_free_response_chats():
             return True
         if self._telegram_is_free_response_topic(message):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6649,6 +6649,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
+        # --- TickTick floating-task nudge callbacks (tt:action:task_id) ---
+        if data.startswith("tt:"):
+            await self._handle_ticktick_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return
@@ -6798,6 +6810,125 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 # Per-email one-shot: strip keyboard so the action can't fire twice.
                 await query.edit_message_text(text=appended, reply_markup=None)
+        except Exception:
+            pass
+
+    # TickTick button action → (human verb, keep_keyboard) for logging/labels.
+    _TT_ACTION_VERBS = {
+        "d": "schedule tomorrow 9am",
+        "t": "pull into today 5pm",
+        "k": "keep floating",
+        "x": "dismiss",
+    }
+
+    async def _handle_ticktick_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Dispatch a TickTick floating-task nudge callback (tt:action:task_id).
+
+        Buttons are emitted by ~/.hermes/scripts/ticktick_{morning_brief,
+        evening_review}.py. Actions: d=tomorrow 9am, t=today 5pm, k=keep
+        floating, x=dismiss(complete). The heavy lifting lives in the helper
+        script ticktick_button.py so this stays a thin dispatcher.
+        """
+        parts = data.split(":", 2)
+        if len(parts) != 3:
+            await query.answer(text="Invalid task data.")
+            return
+        action, task_id = parts[1], parts[2]
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to act on this task.")
+            return
+
+        if action not in self._TT_ACTION_VERBS:
+            await query.answer(text=f"Unknown action: {action}")
+            return
+
+        # Immediate UI responsiveness: ack the tap right away so Telegram stops
+        # spinning ("shimmering"), then swap the card to a working state.
+        await query.answer()
+        original_html = (query.message.text_html or "") if query.message else ""
+        try:
+            await query.edit_message_text(
+                text=f"{original_html}\n⏳ working…",
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+        except Exception:
+            pass
+
+        script_path = _Path.home() / ".hermes" / "scripts" / "ticktick_button.py"
+        if not script_path.exists():
+            logger.error("[%s] ticktick_button.py missing: %s", self.name, script_path)
+            try:
+                await query.edit_message_text(
+                    text=f"{original_html}\n❌ helper missing — action not applied",
+                    parse_mode=ParseMode.HTML,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+            return
+
+        emoji_map = {"d": "📅", "t": "📅", "k": "💤", "x": "✅"}
+        label = ""
+        success = False
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, str(script_path), action, task_id,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=30,
+            )
+            if proc.returncode == 0:
+                label = stdout_bytes.decode("utf-8", errors="replace").strip() or "done"
+                success = True
+                logger.info(
+                    "[%s] ticktick callback ok: action=%s task=%s label=%s",
+                    self.name, action, task_id, label,
+                )
+            else:
+                stderr_text = stderr_bytes.decode("utf-8", errors="replace").strip()
+                last_line = stderr_text.splitlines()[-1] if stderr_text else f"exit {proc.returncode}"
+                label = f"failed: {last_line[:100]}"
+                logger.error(
+                    "[%s] ticktick callback failed: action=%s task=%s rc=%s stderr=%s",
+                    self.name, action, task_id, proc.returncode, stderr_text,
+                )
+        except asyncio.TimeoutError:
+            label = "timed out"
+            logger.error("[%s] ticktick callback timed out: action=%s task=%s", self.name, action, task_id)
+        except Exception as exc:  # noqa: BLE001
+            label = f"error: {exc}"
+            logger.error(
+                "[%s] ticktick callback exception: action=%s task=%s err=%s",
+                self.name, action, task_id, exc, exc_info=True,
+            )
+
+        prefix = emoji_map.get(action, "✅") if success else "❌"
+        try:
+            await query.edit_message_text(
+                text=f"{original_html}\n{prefix} {label}",
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
         except Exception:
             pass
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6331,6 +6331,23 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
 
+        # --- Inert resolved-row button (ccc:noop) ---
+        if data == "ccc:noop":
+            await query.answer()
+            return
+
+        # --- CCC callbacks (decision / follow-up / meeting action items) ---
+        if data.startswith(("ccc:decision:", "ccc:followup:", "ai:")):
+            await self._handle_ccc_script_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
+            return
+
         # --- Exec approval callbacks (ea:choice:id) ---
         if data.startswith("ea:"):
             parts = data.split(":", 2)
@@ -6824,6 +6841,126 @@ class TelegramAdapter(BasePlatformAdapter):
         if size <= max_bytes:
             return True, None
         return False, self._telegram_media_too_large_note(label, size, max_bytes)
+
+    # CCC callback action → (success label, keep_keyboard) mapping.
+    _CCC_ACTION_LABELS = {
+        "approve": ("✅ Approved", False),
+        "reject": ("❌ Rejected", False),
+        "defer": ("⏭ Deferred", False),
+        "view": ("🔗 Opening…", True),
+        "done": ("✅ Done", False),
+        "dismiss": ("🗑 Dismissed", False),
+        "snooze1h": ("⏰ Snoozed 1h", False),
+        "snooze4h": ("⏰ Snoozed 4h", False),
+        "snooze1d": ("⏰ Snoozed 1d", False),
+        "snooze1w": ("⏰ Snoozed 1w", False),
+        "snooze3d": ("⏰ Snoozed 3d", False),
+    }
+
+    async def _handle_ccc_script_callback(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Dispatch a CCC inline-button callback by shelling out to the
+        ccc-decision-callback.sh handler.
+
+        Handles three prefixes:
+          - ccc:decision:<approve|reject|defer|view>:<id>
+          - ccc:followup:<dismiss|done|snooze*>:<id>
+          - ai:<done|snooze3d|dismiss>:<meetingId>:<index>
+        """
+        # Parse the action verb for labelling. The action sits in a different
+        # field depending on prefix:
+        #   ccc:decision:<action>:<id>   → parts[2]
+        #   ccc:followup:<action>:<id>   → parts[2]
+        #   ai:<action>:<meetingId>:<idx> → parts[1]
+        parts = data.split(":")
+        if data.startswith("ai:"):
+            action = parts[1] if len(parts) >= 2 else ""
+        else:
+            action = parts[2] if len(parts) >= 3 else ""
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ Not authorized.")
+            return
+
+        script_path = _Path.home() / "workspace" / "scripts" / "ccc-decision-callback.sh"
+        if not script_path.exists():
+            await query.answer(text="❌ Callback handler missing")
+            logger.error("[%s] CCC callback script missing: %s", self.name, script_path)
+            return
+
+        success_label, keep_keyboard = self._CCC_ACTION_LABELS.get(
+            action, (f"✓ {action}", False)
+        )
+        success = False
+        label = success_label
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                str(script_path),
+                data,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=30,
+            )
+            if proc.returncode == 0:
+                success = True
+                logger.info("[%s] CCC callback ok: %s", self.name, data)
+            else:
+                stderr_text = stderr_bytes.decode("utf-8", errors="replace").strip()
+                # Surface the API's error message (e.g. "already approved") to the user.
+                detail = stderr_text.splitlines()[-1] if stderr_text else f"exit {proc.returncode}"
+                if "already" in detail.lower():
+                    label = "⚠️ Already resolved"
+                    success = True  # treat as resolved — strip buttons
+                else:
+                    label = f"❌ {action} failed: {detail[:80]}"
+                logger.error(
+                    "[%s] CCC callback failed: %s rc=%s stderr=%s",
+                    self.name, data, proc.returncode, stderr_text,
+                )
+        except asyncio.TimeoutError:
+            label = f"❌ {action} timed out"
+            logger.error("[%s] CCC callback timed out: %s", self.name, data)
+        except Exception as exc:
+            label = f"❌ {action} error: {exc}"
+            logger.error(
+                "[%s] CCC callback exception: %s err=%s",
+                self.name, data, exc, exc_info=True,
+            )
+
+        await query.answer(text=label)
+        if not success or keep_keyboard:
+            return
+
+        # Terminal action succeeded — append outcome and strip the keyboard so
+        # it can't fire twice. Preserve HTML (producers send parse_mode=HTML).
+        user_display = getattr(query.from_user, "first_name", "User")
+        original_html = (query.message.text_html or "") if query.message else ""
+        appended = f"{original_html}\n\n— <i>{_html.escape(label)} by {_html.escape(str(user_display))}</i>"
+        try:
+            await query.edit_message_text(
+                text=appended,
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+        except Exception:
+            pass
 
     async def send_voice(
         self,

--- a/tests/agent/test_anthropic_prefill_repair.py
+++ b/tests/agent/test_anthropic_prefill_repair.py
@@ -1,0 +1,137 @@
+"""Tests for trailing-assistant prefill repair on Claude 4.6+/Fable.
+
+Claude Sonnet/Opus 4.6+ and the Fable family reject requests whose final
+message is role=assistant with a non-retryable HTTP 400:
+"This model does not support assistant message prefill. The conversation
+must end with a user message."
+
+Hermes can produce that tail when streamed preamble/status text is persisted
+as an assistant turn before the next request (interrupt, gateway restart,
+cron resume). The adapter must append a synthetic user continuation for the
+rejecting model families and leave genuine prefill behaviour alone elsewhere.
+"""
+
+import pytest
+
+from agent.anthropic_adapter import (
+    build_anthropic_kwargs,
+    ensure_user_tail_for_no_prefill,
+    model_rejects_assistant_prefill,
+)
+
+
+class TestModelRejectsAssistantPrefill:
+
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4-6",
+        "claude-sonnet-4.6",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-haiku-4-6",
+        "claude-fable-5",
+        "anthropic/claude-sonnet-4-6",
+    ])
+    def test_rejecting_models(self, model):
+        assert model_rejects_assistant_prefill(model) is True
+
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4-5",
+        "claude-opus-4-1",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-sonnet-20241022",  # legacy naming, no (sonnet)-N suffix ≥4.6
+        "gpt-4o",
+        "gemini-3-pro",
+        "",
+        None,
+    ])
+    def test_prefill_capable_models(self, model):
+        assert model_rejects_assistant_prefill(model) is False
+
+
+class TestEnsureUserTail:
+
+    def test_appends_user_turn_after_text_assistant_tail(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "go"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Checking logs."}]},
+        ]
+        ensure_user_tail_for_no_prefill(msgs)
+        assert msgs[-1]["role"] == "user"
+        assert msgs[-2]["role"] == "assistant"
+        assert "Continue" in msgs[-1]["content"][0]["text"]
+
+    def test_noop_when_tail_is_user(self):
+        msgs = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        ensure_user_tail_for_no_prefill(msgs)
+        assert len(msgs) == 1
+
+    def test_noop_when_tail_assistant_has_tool_use(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "run"}]},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "Running."},
+                {"type": "tool_use", "id": "toolu_1", "name": "terminal", "input": {}},
+            ]},
+        ]
+        ensure_user_tail_for_no_prefill(msgs)
+        assert len(msgs) == 2  # tool_use tails need real tool results, not fakes
+
+    def test_noop_on_empty(self):
+        msgs = []
+        ensure_user_tail_for_no_prefill(msgs)
+        assert msgs == []
+
+
+class TestBuildKwargsIntegration:
+
+    def _msgs(self):
+        return [
+            {"role": "system", "content": "be useful"},
+            {"role": "user", "content": "diagnose the cron"},
+            {"role": "assistant", "content": "Smoking gun hunt, checking configs."},
+        ]
+
+    def test_sonnet_46_gets_user_tail(self):
+        kw = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=self._msgs(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles[-2:] == ["assistant", "user"]
+
+    def test_fable_gets_user_tail(self):
+        kw = build_anthropic_kwargs(
+            model="claude-fable-5",
+            messages=self._msgs(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        assert kw["messages"][-1]["role"] == "user"
+
+    def test_older_claude_keeps_prefill(self):
+        kw = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=self._msgs(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        assert kw["messages"][-1]["role"] == "assistant"
+
+    def test_user_tail_already_present_unchanged(self):
+        msgs = self._msgs() + [{"role": "user", "content": "and?"}]
+        kw = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        # No double user tail beyond what _merge_consecutive_roles produces
+        assert kw["messages"][-1]["role"] == "user"
+        assert kw["messages"][-2]["role"] == "assistant"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,27 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_anthropic_account_uuid_survives_pool_round_trip():
+    from agent.credential_pool import PooledCredential
+
+    account_uuid = "91c44813-4ecc-4c5b-9dd7-878b3ff2bab8"
+    credential = PooledCredential.from_dict(
+        "anthropic",
+        {
+            "id": "casper",
+            "label": "anthropic-casper",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:hermes_pkce",
+            "access_token": "sk-ant-oat-test",
+            "account_uuid": account_uuid,
+        },
+    )
+
+    assert credential.account_uuid == account_uuid
+    assert credential.to_dict()["account_uuid"] == account_uuid
+
+
 
 
 

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -164,10 +164,14 @@ class TestPoolRotationCycle:
         for i in range(pool_entries):
             e = MagicMock(name=f"entry_{i}")
             e.id = f"cred-{i}"
+            # Healthy by default — the first-429 fast-rotate path counts
+            # non-exhausted siblings via pool.entries().
+            e.last_status = None
             entries.append(e)
 
         pool = MagicMock()
         pool.has_credentials.return_value = True
+        pool.entries.return_value = entries
         # Must be set explicitly — MagicMock.provider returns a truthy
         # child mock, which would trigger the provider-mismatch guard.
         pool.provider = ""
@@ -192,9 +196,39 @@ class TestPoolRotationCycle:
 
         return agent, pool, entries
 
-    def test_first_429_sets_retry_flag_no_rotation(self):
-        """First 429 should just set has_retried_429=True, no rotation."""
-        agent, pool, _ = self._make_agent_with_pool(3)
+    def test_first_429_multi_entry_rotates_immediately(self):
+        """First 429 on a MULTI-entry pool rotates now — no retry-same-credential.
+
+        Waiting out a provider Retry-After (up to 10 min) on a drained
+        credential while healthy siblings sit idle stalls interactive
+        sessions (2026-08-04 incident: one-word reply took 10.4 min).
+        """
+        agent, pool, entries = self._make_agent_with_pool(3)
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429, has_retried_429=False
+        )
+        assert recovered is True
+        assert has_retried is False
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None, api_key_hint="test-api-key")
+        agent._swap_credential.assert_called_once_with(entries[1])
+
+    def test_first_429_single_entry_sets_retry_flag_no_rotation(self):
+        """First 429 on a SINGLE-entry pool keeps retry-first behavior —
+        there is nothing to rotate to, so honoring Retry-After is correct."""
+        agent, pool, _ = self._make_agent_with_pool(1)
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429, has_retried_429=False
+        )
+        assert recovered is False
+        assert has_retried is True
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+    def test_first_429_all_siblings_exhausted_sets_retry_flag(self):
+        """First 429 when every OTHER entry is already exhausted behaves like
+        a single-entry pool: retry-first, no futile rotation."""
+        agent, pool, entries = self._make_agent_with_pool(3)
+        for e in entries[1:]:
+            e.last_status = "exhausted"
         recovered, has_retried = agent._recover_with_credential_pool(
             status_code=429, has_retried_429=False
         )

--- a/tests/agent/test_curator_stdout_isolation.py
+++ b/tests/agent/test_curator_stdout_isolation.py
@@ -1,0 +1,125 @@
+"""Regression: the curator's LLM fork must not poison process-global stdout.
+
+``run_curator_review()`` runs its LLM pass on a daemon thread by default.  The
+old implementation wrapped ``review_agent.run_conversation()`` in a
+process-global ``contextlib.redirect_stdout(open(os.devnull))``.  Because
+``redirect_stdout`` rebinds ``sys.stdout`` for the WHOLE process, two overlapping
+curator/background-review passes restore in the wrong order and leave
+``sys.stdout`` pointing at an already-closed devnull handle.  Every subsequent
+bare ``print`` anywhere in the process then raises::
+
+    ValueError: I/O operation on closed file.
+
+Observed 2026-07-27 on a live gateway: nine cron jobs failed inside a single
+scheduler tick, all with that error, because one curator pass had poisoned
+``sys.stdout`` for the entire process.
+
+The contract asserted here is behavioural, not implementation-shaped: after any
+number of concurrent curator review passes, a print from an unrelated thread
+must still reach the real stream.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+
+def _drain(fn):
+    """Bind a StringIO as the real stdout, run fn, return what reached it."""
+    real_out = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = real_out
+    try:
+        fn()
+    finally:
+        sys.stdout = orig
+    return real_out.getvalue()
+
+
+def test_global_redirect_on_overlapping_threads_poisons_stdout():
+    """Characterize the bug we are protecting against.
+
+    This documents WHY the curator may not use ``contextlib.redirect_stdout``
+    from a worker thread. If CPython ever makes redirect_stdout thread-local
+    this test will fail loudly and the guard below can be revisited.
+    """
+
+    def body():
+        def worker(hold: float):
+            with open(os.devnull, "w", encoding="utf-8") as devnull, \
+                    contextlib.redirect_stdout(devnull):
+                time.sleep(hold)
+
+        # Overlapping enter/exit: A exits first and restores sys.stdout to the
+        # devnull handle B installed; B then exits and closes that handle.
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        time.sleep(0.02)
+        b.start()
+        a.join()
+        b.join()
+
+        with pytest.raises(ValueError, match="closed file"):
+            sys.stdout.write("this must fail")
+
+    _drain(body)
+
+
+def test_thread_scoped_silence_leaves_stdout_usable():
+    """The replacement primitive survives the same overlapping pattern."""
+    from agent.thread_scoped_output import thread_scoped_silence
+
+    def body():
+        def worker(hold: float):
+            with thread_scoped_silence():
+                print("silenced chatter")
+                time.sleep(hold)
+
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        time.sleep(0.02)
+        b.start()
+        a.join()
+        b.join()
+
+        # No poisoning: the main thread can still print.
+        print("survivor")
+
+    captured = _drain(body)
+    assert "survivor" in captured
+    assert "silenced chatter" not in captured
+
+
+def test_curator_llm_pass_does_not_use_global_redirect():
+    """Source-level guard on the exact call site that caused the outage.
+
+    A behavioural test would need a real forked AIAgent + credentials; instead
+    we assert the invariant that matters: the curator's review call is wrapped
+    in ``thread_scoped_silence()``, not a process-global redirect.
+    """
+    import inspect
+
+    import agent.curator as curator
+
+    src = inspect.getsource(curator)
+
+    # Find the block that runs the forked agent's conversation.
+    assert "run_conversation(user_message=prompt)" in src
+    idx = src.index("run_conversation(user_message=prompt)")
+    window = src[max(0, idx - 600):idx]
+    assert "thread_scoped_silence()" in window, (
+        "curator LLM pass must silence output per-thread; a process-global "
+        "redirect_stdout here poisons sys.stdout for every other thread"
+    )
+    assert "redirect_stdout" not in window, (
+        "process-global redirect_stdout found at the curator LLM call site"
+    )

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -162,6 +162,77 @@ class TestChatCompletionsBuildKwargs:
 
 
 
+    def test_anthropic_chat_completions_appends_user_tail_after_assistant(self, transport):
+        """Claude Chat Completions rejects trailing assistant prefill.
+
+        Hermes can persist streamed preamble/status text as the current tail;
+        append a tiny synthetic user turn for Anthropic/Claude endpoints instead
+        of sending a request that hard-400s before the model can recover.
+        """
+        msgs = [
+            {"role": "user", "content": "diagnose this"},
+            {"role": "assistant", "content": "Smoking gun: ..."},
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_name="anthropic",
+        )
+        assert kw["messages"][-2]["role"] == "assistant"
+        assert kw["messages"][-1]["role"] == "user"
+        assert kw["messages"][-1]["content"] == "Continue from the previous assistant message."
+        assert not any(k.startswith("_") for k in kw["messages"][-1])
+        assert msgs[-1]["role"] == "assistant"  # original untouched
+
+    def test_anthropic_profile_path_appends_user_tail_after_assistant(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("anthropic")
+        msgs = [
+            {"role": "user", "content": "run cron"},
+            {"role": "assistant", "content": "Checking logs."},
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_profile=profile,
+        )
+        assert [m["role"] for m in kw["messages"][-2:]] == ["assistant", "user"]
+
+    def test_openai_style_provider_keeps_trailing_assistant_prefill(self, transport):
+        msgs = [
+            {"role": "user", "content": "diagnose this"},
+            {"role": "assistant", "content": "Partial prefill"},
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            base_url="https://api.openai.com/v1",
+            provider_name="openai",
+        )
+        assert kw["messages"] is msgs
+        assert kw["messages"][-1]["role"] == "assistant"
+
+    def test_anthropic_tail_repair_does_not_fake_tool_results(self, transport):
+        msgs = [
+            {"role": "user", "content": "run tool"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_name="anthropic",
+        )
+        assert kw["messages"][-1]["role"] == "assistant"
+        assert kw["messages"][-1]["tool_calls"]
+
     def test_tools_included(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]

--- a/tests/gateway/test_api_server_model_override.py
+++ b/tests/gateway/test_api_server_model_override.py
@@ -1,0 +1,163 @@
+"""Tests for per-request model override in the API server adapter.
+
+When API consumers (e.g. CCC task dispatcher, external UIs) include a
+``model`` field in their request body, the API server must honour it
+instead of always falling back to the gateway default.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch, MagicMock
+from typing import Optional
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    """Build a minimal APIServerAdapter with stubbed internals."""
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._model_name = "claude-opus-4-6"
+    adapter._session_db = None
+    # Upstream #35314 recovery cache (normally set in __init__).
+    adapter._last_resolved_model = {}
+    return adapter
+
+
+def _stub_runtime(monkeypatch):
+    """Patch the heavy imports that _create_agent() pulls in."""
+    fake_config = {
+        "providers": {
+            "openrouter": {
+                "api_key": "sk-or-test-key",
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        },
+    }
+    monkeypatch.setattr(
+        "gateway.platforms.api_server.APIServerAdapter._ensure_session_db",
+        lambda self: None,
+    )
+    # Patch the lazy imports inside _create_agent
+    mock_agent_cls = MagicMock()
+    mock_agent_cls.return_value = MagicMock()
+
+    def _fake_resolve_runtime():
+        return {
+            "api_key": "sk-ant-default",
+            "base_url": "https://api.anthropic.com",
+            "provider": "anthropic",
+            "api_mode": None,
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    def _fake_resolve_model():
+        return "claude-opus-4-6"
+
+    def _fake_load_config():
+        return fake_config
+
+    mock_runner = MagicMock()
+    mock_runner._load_reasoning_config.return_value = {}
+    mock_runner._load_fallback_model.return_value = None
+
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs", _fake_resolve_runtime,
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model", _fake_resolve_model,
+    )
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config", _fake_load_config,
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(lambda: {}),
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_fallback_model",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda cfg, platform: ["terminal"],
+    )
+    monkeypatch.setattr("run_agent.AIAgent", mock_agent_cls)
+
+    return mock_agent_cls
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCreateAgentModelOverride:
+    """_create_agent respects the model_override parameter."""
+
+    def test_no_override_uses_gateway_default(self, monkeypatch):
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        adapter._create_agent()
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs.get("model") or call_kwargs[1].get("model") == "claude-opus-4-6"
+
+    def test_openrouter_override_resolves_credentials(self, monkeypatch):
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        adapter._create_agent(model_override="openrouter/openai/gpt-5.5")
+
+        call_kwargs = mock_cls.call_args
+        # Model should be the override, not the default
+        assert call_kwargs.kwargs.get("model") == "openrouter/openai/gpt-5.5"
+        # Provider should be resolved to openrouter
+        assert call_kwargs.kwargs.get("provider") == "openrouter"
+        # API key should come from config
+        assert call_kwargs.kwargs.get("api_key") == "sk-or-test-key"
+        assert call_kwargs.kwargs.get("base_url") == "https://openrouter.ai/api/v1"
+
+    def test_litellm_override_routes_to_proxy(self, monkeypatch):
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        adapter._create_agent(model_override="litellm-main/gemini-2.5-flash")
+
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs.get("model") == "litellm-main/gemini-2.5-flash"
+        assert call_kwargs.kwargs.get("provider") == "custom"
+        assert call_kwargs.kwargs.get("base_url") == "http://localhost:4000"
+
+    def test_plain_model_name_swaps_model_keeps_provider(self, monkeypatch):
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        adapter._create_agent(model_override="claude-sonnet-4-6")
+
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs.get("model") == "claude-sonnet-4-6"
+        # Provider stays as default (anthropic) since no prefix
+        assert call_kwargs.kwargs.get("provider") == "anthropic"
+
+    def test_gateway_default_model_is_not_treated_as_override(self, monkeypatch):
+        """When body.model matches self._model_name, no override should apply."""
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        # Pass the gateway default model name — should behave identically to no override
+        adapter._create_agent(model_override=None)
+        no_override_kwargs = mock_cls.call_args
+
+        adapter._create_agent(model_override="claude-opus-4-6")
+        with_default_kwargs = mock_cls.call_args
+
+        # Both should use the same model — override with default model should
+        # still work (the filtering happens at the call site, not inside _create_agent)
+        assert with_default_kwargs.kwargs.get("model") == "claude-opus-4-6"

--- a/tests/gateway/test_api_server_model_override_routing.py
+++ b/tests/gateway/test_api_server_model_override_routing.py
@@ -1,0 +1,169 @@
+"""Regression tests for api_server per-request model_override provider routing.
+
+The gateway's ``_create_agent`` resolves a per-request ``model_override``
+(sent by CCC and other API consumers) into a provider + bare model. Three
+prefix forms are recognised:
+
+  * ``openrouter/<vendor>/<model>`` → provider=openrouter, strip ``openrouter/``
+  * ``litellm-*`` / ``litellm/*``    → provider=custom (local LiteLLM proxy)
+  * ``<provider>/<model>``           → any *registered* Hermes provider prefix
+    (e.g. ``openai-codex/gpt-5.5``, ``anthropic/claude-sonnet-4-6``) is pinned
+    and the prefix stripped, so OAuth-gated providers route directly.
+
+The general branch must NOT hijack aggregator-namespaced models whose prefix
+is not a registered provider (``openai/gpt-4o``), nor bare model strings.
+
+CRITICAL CONTRACT (regression for the api.anthropic.com 404 bug): pinning the
+provider *name* alone is insufficient — AIAgent keeps the gateway default
+base_url/api_key when only ``provider`` is passed, so an OAuth-gated provider
+silently hits the wrong endpoint. The general branch must therefore run the
+canonical ``resolve_runtime_provider`` resolver and merge base_url + api_key +
+api_mode + credential_pool into the runtime kwargs.
+
+These tests exercise the branch logic in isolation (mirroring the code in
+``gateway/platforms/api_server.py``) so the routing contract is locked.
+"""
+
+from providers import get_provider_profile
+
+
+def _route(model_override: str, *, resolve_binding: bool = False):
+    """Mirror the model_override branch logic in GatewayRunner._create_agent.
+
+    When *resolve_binding* is True, the general provider-prefix branch also runs
+    the canonical resolver and merges the full runtime binding — mirroring the
+    production code path that fixes OAuth endpoint routing.
+    """
+    model = model_override
+    _override_lower = model_override.lower()
+    runtime: dict = {}
+    if _override_lower.startswith("openrouter/"):
+        runtime["provider"] = "openrouter"
+        model = model[len("openrouter/"):]
+    elif _override_lower.startswith("litellm-") or _override_lower.startswith("litellm/"):
+        runtime["provider"] = "custom"
+        runtime["base_url"] = "http://localhost:4000"
+    elif "/" in model_override:
+        _prefix = model_override.split("/", 1)[0].strip().lower()
+        try:
+            _profile = get_provider_profile(_prefix)
+        except Exception:
+            _profile = None
+        if _profile is not None:
+            _bare = model_override.split("/", 1)[1]
+            _binding = None
+            if resolve_binding:
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    _binding = resolve_runtime_provider(
+                        requested=_profile.name, target_model=_bare,
+                    )
+                except Exception:
+                    _binding = None
+            if _binding:
+                runtime["provider"] = _binding.get("provider") or _profile.name
+                if _binding.get("base_url"):
+                    runtime["base_url"] = _binding["base_url"]
+                if _binding.get("api_key"):
+                    runtime["api_key"] = _binding["api_key"]
+                if _binding.get("api_mode"):
+                    runtime["api_mode"] = _binding["api_mode"]
+                if _binding.get("credential_pool") is not None:
+                    runtime["credential_pool"] = _binding["credential_pool"]
+            else:
+                runtime["provider"] = _profile.name
+            model = _bare
+    return runtime.get("provider"), model, runtime
+
+
+def test_openai_codex_prefix_routes_to_codex_oauth():
+    """gpt-5.5 dispatched as openai-codex/gpt-5.5 must pin the OAuth provider."""
+    provider, model, _ = _route("openai-codex/gpt-5.5")
+    assert provider == "openai-codex"
+    assert model == "gpt-5.5"
+
+
+def test_codex_alias_prefix_resolves():
+    """The 'codex' alias resolves to the openai-codex provider."""
+    provider, model, _ = _route("codex/gpt-5.5")
+    assert provider == "openai-codex"
+    assert model == "gpt-5.5"
+
+
+def test_anthropic_prefix_routes_to_anthropic():
+    provider, model, _ = _route("anthropic/claude-sonnet-4-6")
+    assert provider == "anthropic"
+    assert model == "claude-sonnet-4-6"
+
+
+def test_openrouter_prefix_unchanged():
+    """OpenRouter branch still strips only its own tag, keeping vendor/model."""
+    provider, model, _ = _route("openrouter/openai/gpt-5.5")
+    assert provider == "openrouter"
+    assert model == "openai/gpt-5.5"
+
+
+def test_litellm_prefix_routes_to_custom():
+    provider, model, _ = _route("litellm-ccc/gpt-5.5")
+    assert provider == "custom"
+    # litellm models keep their full alias — the proxy resolves them.
+    assert model == "litellm-ccc/gpt-5.5"
+
+
+def test_aggregator_namespaced_model_not_hijacked():
+    """'openai/gpt-4o' must NOT be captured — 'openai' is not a registered provider."""
+    provider, model, _ = _route("openai/gpt-4o")
+    assert provider is None
+    assert model == "openai/gpt-4o"
+
+
+def test_bare_model_falls_through_to_gateway_default():
+    provider, model, _ = _route("gpt-5.5")
+    assert provider is None
+    assert model == "gpt-5.5"
+
+
+def test_codex_binding_resolves_oauth_endpoint_not_default():
+    """Regression for the api.anthropic.com 404 bug.
+
+    Pinning provider='openai-codex' alone left base_url at the gateway default
+    (api.anthropic.com), 404ing on gpt-5.5. The branch must resolve the full
+    runtime binding so base_url points at the ChatGPT Codex backend and the
+    api_mode is the Codex Responses surface.
+
+    Skips gracefully when no Codex OAuth credential is provisioned on the host
+    (the resolver raises AuthError) — the binding-merge wiring is still proven
+    by the assertions that run when credentials exist.
+    """
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        resolve_runtime_provider(requested="openai-codex", target_model="gpt-5.5")
+    except Exception:
+        import pytest
+        pytest.skip("no openai-codex OAuth credential provisioned on this host")
+
+    provider, model, runtime = _route("openai-codex/gpt-5.5", resolve_binding=True)
+    assert provider == "openai-codex"
+    assert model == "gpt-5.5"
+    # The whole point: endpoint is ChatGPT's Codex backend, NOT api.anthropic.com.
+    assert "chatgpt.com" in runtime.get("base_url", "")
+    assert "api.anthropic.com" not in runtime.get("base_url", "")
+    # Codex uses the Responses API surface, not anthropic_messages.
+    assert runtime.get("api_mode") == "codex_responses"
+    # A live OAuth token must have been merged in.
+    assert runtime.get("api_key")
+
+
+def test_anthropic_binding_resolves_messages_api():
+    """anthropic/<model> resolves to the anthropic_messages surface when bound."""
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        resolve_runtime_provider(requested="anthropic", target_model="claude-sonnet-4-6")
+    except Exception:
+        import pytest
+        pytest.skip("no anthropic credential provisioned on this host")
+
+    provider, model, runtime = _route("anthropic/claude-sonnet-4-6", resolve_binding=True)
+    assert provider == "anthropic"
+    assert model == "claude-sonnet-4-6"
+    assert runtime.get("api_mode") == "anthropic_messages"

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -52,6 +52,195 @@ class TestResolveDisplaySetting:
 
 
 # ---------------------------------------------------------------------------
+# Per-chat overrides (display.platforms.<plat>.chats.<chat_id>[:<thread_id>])
+# ---------------------------------------------------------------------------
+
+class TestPerChatOverrides:
+    """``chat_id`` (+ optional ``thread_id``) selects narrower overrides."""
+
+    def test_per_chat_override_wins_over_platform(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "chats": {
+                            "-100123": {"tool_progress": "off"},
+                        },
+                    }
+                }
+            }
+        }
+        # No chat_id → platform-wide value.
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
+        # Matching chat_id → per-chat value.
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "off"
+        )
+        # Different chat_id → platform-wide value.
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100999"
+            )
+            == "all"
+        )
+
+    def test_thread_specific_override_wins_over_chat_wide(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "chats": {
+                            "-100123": {"tool_progress": "off"},
+                            "-100123:65": {"tool_progress": "verbose"},
+                        },
+                    }
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id=65,
+            )
+            == "verbose"
+        )
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id=99,
+            )
+            == "off"
+        )
+
+    def test_per_chat_falls_through_to_global_when_no_setting(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {
+                    "telegram": {
+                        "chats": {
+                            "-100123": {"show_reasoning": True},
+                        },
+                    }
+                },
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "all"
+        )
+        assert (
+            resolve_display_setting(
+                config, "telegram", "show_reasoning", chat_id="-100123"
+            )
+            is True
+        )
+
+    def test_int_and_str_chat_ids_both_match(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "chats": {"-100123": {"tool_progress": "off"}},
+                    }
+                }
+            }
+        }
+        for cid in ("-100123", -100123):
+            assert (
+                resolve_display_setting(
+                    config, "telegram", "tool_progress", chat_id=cid
+                )
+                == "off"
+            )
+
+    def test_thread_id_zero_matches_explicit_key(self):
+        """thread_id=0 looks up the ``<chat>:0`` key before the chat-wide one."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "new",
+                        "chats": {
+                            "-100123:0": {"tool_progress": "verbose"},
+                            "-100123": {"tool_progress": "off"},
+                        },
+                    }
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id=0,
+            )
+            == "verbose"
+        )
+        # thread_id="" is treated as "no thread".
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id="",
+            )
+            == "off"
+        )
+
+    def test_per_chat_normalises_yaml_values(self):
+        from gateway.display_config import resolve_display_setting
+
+        # YAML's bare ``off`` parses as False.
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "chats": {"-100123": {"tool_progress": False}},
+                    }
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "off"
+        )
+
+    def test_no_chats_section_falls_through_silently(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {"tool_progress": "off"},
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "off"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_telegram_require_mention_chats.py
+++ b/tests/gateway/test_telegram_require_mention_chats.py
@@ -1,0 +1,223 @@
+"""Tests for Telegram per-chat mention gating (``require_mention_chats``).
+
+``require_mention`` is a global boolean whose only per-chat escape hatch is
+the ``free_response_chats`` *exemption* list, so "respond freely everywhere
+EXCEPT chat X" was unexpressible: quieting one group meant gating every
+group.  ``require_mention_chats`` is the inverse allowlist — chats listed
+there require an explicit trigger (mention / reply / pattern) even when
+``require_mention`` is globally disabled.
+
+These tests exercise the real adapter methods against a stub config, as
+behavior contracts:
+
+* a listed chat requires a trigger even with the global flag off
+* an unlisted chat keeps free-response behavior with the global flag off
+* mentions / replies still get through in a listed chat
+* unmentioned messages in a listed chat are observable context
+  (``_should_observe_group_message``) rather than dropped
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    mod.error.Forbidden = type("Forbidden", (Exception,), {})
+    mod.error.RetryAfter = type(
+        "RetryAfter", (Exception,), {"retry_after": 1}
+    )
+    mod.error.TelegramError = type("TelegramError", (Exception,), {})
+    sys.modules.setdefault("telegram", mod)
+    sys.modules.setdefault("telegram.ext", mod.ext)
+    sys.modules.setdefault("telegram.constants", mod.constants)
+    sys.modules.setdefault("telegram.error", mod.error)
+    sys.modules.setdefault("telegram.request", MagicMock())
+    sys.modules.setdefault("telegram.helpers", MagicMock())
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+GATED_CHAT = "-100111"
+FREE_CHAT = "-100222"
+
+
+def _adapter(extra: dict) -> TelegramAdapter:
+    """Bare adapter instance with only what the gating methods touch."""
+    adapter = TelegramAdapter.__new__(TelegramAdapter)
+    adapter.config = SimpleNamespace(extra=extra)
+    return adapter
+
+
+def _extra(**overrides) -> dict:
+    base = {
+        "require_mention": False,
+        "require_mention_chats": GATED_CHAT,
+        "free_response_chats": "",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestRequireMentionChatsParsing:
+    def test_comma_separated_string(self):
+        adapter = _adapter(_extra(require_mention_chats="-1, -2 ,, -3"))
+        assert adapter._telegram_require_mention_chats() == {"-1", "-2", "-3"}
+
+    def test_list_form(self):
+        adapter = _adapter(_extra(require_mention_chats=[-100111, " -100222 "]))
+        assert adapter._telegram_require_mention_chats() == {
+            "-100111",
+            "-100222",
+        }
+
+    def test_unset_is_empty(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION_CHATS", raising=False)
+        adapter = _adapter({"require_mention": False})
+        assert adapter._telegram_require_mention_chats() == set()
+
+    def test_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_REQUIRE_MENTION_CHATS", "-42")
+        adapter = _adapter({"require_mention": False})
+        assert adapter._telegram_require_mention_chats() == {"-42"}
+
+
+class _GateHarness:
+    """Drive the per-chat branch of the group-response gate.
+
+    Replicates the gate-tail contract: a chat listed in
+    ``require_mention_chats`` must only respond on reply / mention /
+    pattern, regardless of the global ``require_mention`` value.
+    """
+
+    def __init__(self, adapter, *, reply=False, mention=False, pattern=False):
+        self.adapter = adapter
+        adapter._is_reply_to_bot = lambda m: reply
+        adapter._message_mentions_bot = lambda m: mention
+        adapter._message_matches_mention_patterns = lambda m: pattern
+        adapter._telegram_guest_mode = lambda: False
+        adapter._telegram_is_free_response_topic = lambda m: False
+
+    def responds(self, chat_id: str) -> bool:
+        adapter = self.adapter
+        message = object()
+        if chat_id in adapter._telegram_require_mention_chats():
+            if adapter._is_reply_to_bot(message):
+                return True
+            if not adapter._telegram_guest_mode() and adapter._message_mentions_bot(
+                message
+            ):
+                return True
+            return adapter._message_matches_mention_patterns(message)
+        if chat_id in adapter._telegram_free_response_chats():
+            return True
+        if not adapter._telegram_require_mention():
+            return True
+        if adapter._is_reply_to_bot(message):
+            return True
+        if adapter._message_mentions_bot(message):
+            return True
+        return adapter._message_matches_mention_patterns(message)
+
+
+class TestPerChatGating:
+    def test_listed_chat_silent_on_plain_message(self):
+        gate = _GateHarness(_adapter(_extra()))
+        assert gate.responds(GATED_CHAT) is False
+
+    def test_listed_chat_responds_to_mention(self):
+        gate = _GateHarness(_adapter(_extra()), mention=True)
+        assert gate.responds(GATED_CHAT) is True
+
+    def test_listed_chat_responds_to_reply(self):
+        gate = _GateHarness(_adapter(_extra()), reply=True)
+        assert gate.responds(GATED_CHAT) is True
+
+    def test_listed_chat_responds_to_pattern(self):
+        gate = _GateHarness(_adapter(_extra()), pattern=True)
+        assert gate.responds(GATED_CHAT) is True
+
+    def test_unlisted_chat_keeps_free_response(self):
+        gate = _GateHarness(_adapter(_extra()))
+        assert gate.responds(FREE_CHAT) is True
+
+    def test_listed_chat_gated_even_when_global_flag_off(self):
+        # The defining contract: global require_mention=False must NOT
+        # override the per-chat requirement.
+        gate = _GateHarness(_adapter(_extra(require_mention=False)))
+        assert gate.responds(GATED_CHAT) is False
+
+    def test_per_chat_beats_free_response_listing(self):
+        # A chat listed in BOTH lists is gated: require_mention_chats is
+        # checked first, so a config conflict resolves to the quieter option.
+        gate = _GateHarness(
+            _adapter(_extra(free_response_chats=GATED_CHAT))
+        )
+        assert gate.responds(GATED_CHAT) is False
+
+
+class TestObserveGatedChat:
+    """Unmentioned messages in a gated chat are context, not dropped."""
+
+    def _observe(self, adapter, chat_id: str) -> bool:
+        """Replicate the observe-path contract for a group message."""
+        message = object()
+        if chat_id in adapter._telegram_free_response_chats():
+            return False
+        if adapter._telegram_is_free_response_topic(message):
+            return False
+        chat_gated = chat_id in adapter._telegram_require_mention_chats()
+        if not chat_gated and not adapter._telegram_require_mention():
+            return False
+        if adapter._is_reply_to_bot(message):
+            return False
+        if adapter._message_mentions_bot(message):
+            return False
+        if adapter._message_matches_mention_patterns(message):
+            return False
+        return True
+
+    def test_gated_chat_observes_unmentioned_when_global_off(self):
+        adapter = _adapter(_extra())
+        _GateHarness(adapter)  # install neutral trigger stubs
+        assert self._observe(adapter, GATED_CHAT) is True
+
+    def test_unlisted_chat_not_observed_when_global_off(self):
+        # Unlisted + global off = message is dispatched normally, so the
+        # observe path must decline it.
+        adapter = _adapter(_extra())
+        _GateHarness(adapter)
+        assert self._observe(adapter, FREE_CHAT) is False
+
+    def test_gated_chat_mentions_are_dispatched_not_observed(self):
+        adapter = _adapter(_extra())
+        _GateHarness(adapter, mention=True)
+        assert self._observe(adapter, GATED_CHAT) is False

--- a/tests/gateway/test_telegram_ticktick_callbacks.py
+++ b/tests/gateway/test_telegram_ticktick_callbacks.py
@@ -1,0 +1,172 @@
+"""Tests for the TickTick floating-task nudge inline-button callback (tt:*).
+
+The bug these guard against: when Telegram moved into plugins/platforms/telegram,
+the tt: dispatch was dropped, so tapping Tomorrow/Today/Keep/Dismiss on a floating
+task fell through to the bare update_prompt: return with no query.answer() — the
+button shimmered forever and no side effect ran.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    # Authorize everyone for these tests unless a case overrides it.
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    return adapter
+
+
+def _make_query(data):
+    query = MagicMock()
+    query.data = data
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    query.from_user = MagicMock()
+    query.from_user.id = 8756311637
+    query.from_user.first_name = "Michael"
+    query.message = MagicMock()
+    query.message.text_html = "  • BMW Service"
+    query.message.chat_id = 8756311637
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.message.message_thread_id = None
+    return query
+
+
+class _FakeProc:
+    def __init__(self, rc, out=b"", err=b""):
+        self.returncode = rc
+        self._out = out
+        self._err = err
+
+    async def communicate(self):
+        return self._out, self._err
+
+
+@pytest.mark.asyncio
+async def test_dismiss_answers_and_completes():
+    """tt:x → ack immediately (kills shimmer), run helper, edit card with result."""
+    adapter = _make_adapter()
+    query = _make_query("tt:x:69e5deb889a9d1c36b0de909")
+
+    fake = _FakeProc(0, out=b"dismissed (marked complete)\n")
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)) as spawn, \
+         patch("pathlib.Path.exists", return_value=True):
+        await adapter._handle_ticktick_callback(
+            query, query.data,
+            query_chat_id=8756311637, query_chat_type="private",
+            query_thread_id=None, query_user_name="Michael",
+        )
+
+    # Shimmer killer: query.answer must be called.
+    assert query.answer.await_count >= 1
+    # Helper invoked with action + task_id as the trailing argv.
+    argv = spawn.call_args[0]
+    assert argv[-2:] == ("x", "69e5deb889a9d1c36b0de909")
+    # Final card carries the success label and no keyboard.
+    final = query.edit_message_text.await_args_list[-1]
+    assert "dismissed (marked complete)" in final.kwargs["text"]
+    assert final.kwargs["reply_markup"] is None
+    assert "✅" in final.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_is_rejected():
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = MagicMock(return_value=False)
+    query = _make_query("tt:x:abc123")
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock()) as spawn:
+        await adapter._handle_ticktick_callback(
+            query, query.data,
+            query_chat_id=1, query_chat_type="private",
+            query_thread_id=None, query_user_name="Stranger",
+        )
+
+    query.answer.assert_awaited()  # answered with the ⛔ toast
+    spawn.assert_not_called()      # no side effect for unauthorized taps
+
+
+@pytest.mark.asyncio
+async def test_helper_failure_shows_error_card():
+    adapter = _make_adapter()
+    query = _make_query("tt:d:abc123")
+
+    fake = _FakeProc(1, err=b"RuntimeError: TickTick POST -> 404\n")
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=fake)), \
+         patch("pathlib.Path.exists", return_value=True):
+        await adapter._handle_ticktick_callback(
+            query, query.data,
+            query_chat_id=1, query_chat_type="private",
+            query_thread_id=None, query_user_name="Michael",
+        )
+
+    final = query.edit_message_text.await_args_list[-1]
+    assert "❌" in final.kwargs["text"]
+    assert "404" in final.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_rejected():
+    adapter = _make_adapter()
+    query = _make_query("tt:zz:abc123")
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock()) as spawn:
+        await adapter._handle_ticktick_callback(
+            query, query.data,
+            query_chat_id=1, query_chat_type="private",
+            query_thread_id=None, query_user_name="Michael",
+        )
+
+    query.answer.assert_awaited()
+    spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_tt_prefix():
+    """The main callback dispatcher must route tt:* to the handler (not fall through)."""
+    adapter = _make_adapter()
+    query = _make_query("tt:k:abc123")
+    update = MagicMock()
+    update.callback_query = query
+
+    adapter._handle_ticktick_callback = AsyncMock()
+    await adapter._handle_callback_query(update, MagicMock())
+    adapter._handle_ticktick_callback.assert_awaited_once()

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -20,8 +20,6 @@ def test_service_path_includes_node_modules_when_present(tmp_path):
     assert str(nm_bin) in dirs
 
 
-<<<<<<< ours
-=======
 def test_service_path_includes_hermes_home_node_modules(tmp_path):
     """Service PATH should include ~/.hermes/node_modules/.bin when it exists."""
     hermes_nm = tmp_path / ".hermes" / "node_modules" / ".bin"
@@ -52,4 +50,3 @@ def test_user_local_paths_skips_home_bin_when_absent(tmp_path):
     from hermes_cli.gateway import _build_user_local_paths
     result = _build_user_local_paths(tmp_path, [])
     assert str(tmp_path / "bin") not in result
->>>>>>> theirs

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -20,3 +20,36 @@ def test_service_path_includes_node_modules_when_present(tmp_path):
     assert str(nm_bin) in dirs
 
 
+<<<<<<< ours
+=======
+def test_service_path_includes_hermes_home_node_modules(tmp_path):
+    """Service PATH should include ~/.hermes/node_modules/.bin when it exists."""
+    hermes_nm = tmp_path / ".hermes" / "node_modules" / ".bin"
+    hermes_nm.mkdir(parents=True)
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+    assert str(hermes_nm) in dirs
+
+
+def test_user_local_paths_includes_home_bin_when_present(tmp_path):
+    """~/bin should be on the service PATH when it exists.
+
+    ~/bin is on the default Debian/Ubuntu login PATH and is where CLIs like
+    the 1Password `op` binary commonly live. Omitting it from the generated
+    systemd unit means `op://` secret references (e.g. TELEGRAM_BOT_TOKEN)
+    fail to resolve under the service even though they work in a login shell.
+    """
+    home_bin = tmp_path / "bin"
+    home_bin.mkdir()
+    from hermes_cli.gateway import _build_user_local_paths
+    result = _build_user_local_paths(tmp_path, [])
+    assert str(home_bin) in result
+
+
+def test_user_local_paths_skips_home_bin_when_absent(tmp_path):
+    """~/bin should not be added when it doesn't exist."""
+    from hermes_cli.gateway import _build_user_local_paths
+    result = _build_user_local_paths(tmp_path, [])
+    assert str(tmp_path / "bin") not in result
+>>>>>>> theirs

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1740,10 +1740,19 @@ class TestRetryAfterCap:
         agent.run_conversation("hello")
         return next((m for m in captured if "Waiting" in m), "")
 
-    def test_retry_after_under_cap_is_honored(self, agent):
-        # 300s > old 120s cap but < new 600s cap → used verbatim.
-        status = self._drive_once(agent, 300)
-        assert "Waiting 300.0s" in status
+    def test_retry_after_under_cap_is_jittered_above_floor(self, agent):
+        # Respect the provider's 300s floor, but decorrelate concurrent callers
+        # so a gateway fleet does not wake and retry at the exact same instant.
+        with patch("agent.conversation_loop.jittered_backoff", return_value=307.5) as jitter:
+            status = self._drive_once(agent, 300)
+
+        assert "Waiting 307.5s" in status
+        jitter.assert_called_once_with(
+            1,
+            base_delay=300.0,
+            max_delay=300.0,
+            jitter_ratio=0.05,
+        )
 
 
 

--- a/tests/tools/test_code_execution_stdout_isolation.py
+++ b/tests/tools/test_code_execution_stdout_isolation.py
@@ -1,0 +1,147 @@
+"""Regression: concurrent execute_code tool dispatch must not poison sys.stdout.
+
+``code_execution_tool``'s sandbox RPC handler runs on a per-connection socket
+thread, so several ``execute_code`` calls can be in flight simultaneously (e.g.
+a parallel ``delegate_task`` batch, where every subagent uses execute_code).
+
+The old implementation silenced internal tool handlers with a raw
+process-global assignment::
+
+    _real_stdout, _real_stderr = sys.stdout, sys.stderr
+    devnull = open(os.devnull, "w")
+    try:
+        sys.stdout = devnull
+        sys.stderr = devnull
+        result = handle_function_call(...)
+    finally:
+        sys.stdout, sys.stderr = _real_stdout, _real_stderr
+        devnull.close()
+
+``sys.stdout`` is process-global. With two threads interleaving, thread B
+captures thread A's devnull as its ``_real_stdout``, A closes that handle, and
+B then "restores" the CLOSED handle. Every subsequent bare ``print`` anywhere
+in the process raises::
+
+    ValueError: I/O operation on closed file.
+
+Observed 2026-07-28 on a live gateway: 328 occurrences beginning the instant a
+3-way parallel delegation launched; all three subagents died. The tracebacks
+landed on an innocent ``print`` in agent/conversation_loop.py, nowhere near the
+actual culprit.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+
+def _drain(fn):
+    """Bind a StringIO as the real stdout, run fn, return what reached it."""
+    real_out = io.StringIO()
+    orig = sys.stdout
+    sys.stdout = real_out
+    try:
+        fn()
+    finally:
+        sys.stdout = orig
+    return real_out.getvalue()
+
+
+def test_concurrent_raw_assignment_poisons_stdout():
+    """Characterize the exact race the old code had.
+
+    Two threads each save/replace/restore sys.stdout by direct assignment. The
+    interleaving leaves sys.stdout bound to a closed handle.
+    """
+
+    def body():
+        barrier = threading.Barrier(2)
+
+        def worker(hold: float):
+            real_out, real_err = sys.stdout, sys.stderr
+            devnull = open(os.devnull, "w", encoding="utf-8")
+            try:
+                sys.stdout = devnull
+                sys.stderr = devnull
+                barrier.wait(timeout=5)
+                time.sleep(hold)
+            finally:
+                sys.stdout, sys.stderr = real_out, real_err
+                devnull.close()
+
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        b.start()
+        a.join()
+        b.join()
+
+        with pytest.raises(ValueError, match="closed file"):
+            sys.stdout.write("this must fail")
+
+    _drain(body)
+
+
+def test_thread_scoped_silence_survives_concurrency():
+    """The replacement primitive is safe under the same interleaving."""
+    from agent.thread_scoped_output import thread_scoped_silence
+
+    def body():
+        barrier = threading.Barrier(2)
+
+        def worker(hold: float):
+            with thread_scoped_silence():
+                print("internal tool chatter")
+                barrier.wait(timeout=5)
+                time.sleep(hold)
+
+        a = threading.Thread(target=worker, args=(0.05,))
+        b = threading.Thread(target=worker, args=(0.30,))
+        a.start()
+        b.start()
+        a.join()
+        b.join()
+
+        print("survivor")
+
+    captured = _drain(body)
+    assert "survivor" in captured
+    assert "internal tool chatter" not in captured
+
+
+def test_code_execution_tool_dispatch_sites_are_thread_scoped():
+    """Guard both sandbox dispatch sites against a regression.
+
+    Fails on the pre-fix source, which used ``sys.stdout = devnull``.
+    """
+    import inspect
+    import re
+
+    import tools.code_execution_tool as cet
+
+    src = inspect.getsource(cet)
+    # Strip comment lines so the prose explaining the old bug doesn't trip the
+    # assertions below.
+    code_only = "\n".join(
+        line for line in src.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+    assert not re.search(r"^\s*sys\.stdout\s*=\s*devnull", code_only, re.M), (
+        "process-global stdout assignment found in code_execution_tool; "
+        "use thread_scoped_silence() — this handler runs on concurrent "
+        "socket threads and a global rebind poisons sys.stdout process-wide"
+    )
+    assert not re.search(r"^\s*sys\.stderr\s*=\s*devnull", code_only, re.M)
+
+    # Both dispatch sites (local sandbox + remote sandbox) must be wrapped.
+    assert code_only.count("with thread_scoped_silence():") >= 2, (
+        "expected both handle_function_call dispatch sites to be wrapped in "
+        "thread_scoped_silence()"
+    )

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -49,6 +49,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.thread_context import propagate_context_to_thread
+from agent.thread_scoped_output import thread_scoped_silence
 
 # Availability gate.  On Windows we fall back to loopback TCP for the
 # sandbox RPC transport (AF_UNIX is unreliable on Windows Python) — see
@@ -740,18 +741,21 @@ def _rpc_server_loop(
                 # Dispatch through the standard tool handler.
                 # Suppress stdout/stderr from internal tool handlers so
                 # their status prints don't leak into the CLI spinner.
+                #
+                # MUST be thread-scoped: this handler runs on a per-connection
+                # socket thread, so several execute_code calls (e.g. parallel
+                # subagents) are in flight at once. Assigning sys.stdout
+                # directly rebinds it PROCESS-WIDE; with two threads
+                # interleaving, thread B captures A's devnull as "_real_stdout",
+                # A closes it, and B restores a CLOSED handle — after which
+                # every bare print in the process raises
+                # "ValueError: I/O operation on closed file." (observed
+                # 2026-07-28: 328 occurrences, killing 3 subagents).
                 try:
-                    _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    devnull = open(os.devnull, "w", encoding="utf-8")
-                    try:
-                        sys.stdout = devnull
-                        sys.stderr = devnull
+                    with thread_scoped_silence():
                         result = handle_function_call(
                             tool_name, tool_args, task_id=task_id
                         )
-                    finally:
-                        sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                        devnull.close()
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
                     result = tool_error(str(exc))
@@ -1021,19 +1025,16 @@ def _rpc_poll_loop(
                         for param in _TERMINAL_BLOCKED_PARAMS:
                             tool_args.pop(param, None)
 
-                    # Dispatch through the standard tool handler
+                    # Dispatch through the standard tool handler.
+                    # Thread-scoped silencing — see the identical note on the
+                    # local-sandbox path above. A process-global
+                    # ``sys.stdout = devnull`` here races other in-flight
+                    # execute_code calls and leaves sys.stdout closed.
                     try:
-                        _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                        devnull = open(os.devnull, "w", encoding="utf-8")
-                        try:
-                            sys.stdout = devnull
-                            sys.stderr = devnull
+                        with thread_scoped_silence():
                             tool_result = handle_function_call(
                                 tool_name, tool_args, task_id=task_id
                             )
-                        finally:
-                            sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                            devnull.close()
                     except Exception as exc:
                         logger.error("Tool call failed in remote sandbox: %s",
                                      exc, exc_info=True)


### PR DESCRIPTION
## Problem

`require_mention` is a global boolean whose only per-chat escape hatch is the `free_response_chats` **exemption** list. That makes one common shape unexpressible: **"respond freely everywhere except chat X."**

Real-world case: the bot sits in several working groups where it should respond normally, plus one multi-party room (an exchange/market-maker channel with external participants) where it should observe silently and speak only when addressed. Today the only options are:

- `require_mention: true` + exempt every other group → gags the bot everywhere by default, and every new group needs a config edit before the bot will talk in it
- `require_mention: false` → the bot answers everything in the one room where it shouldn't

## Solution

`require_mention_chats` — the inverse allowlist, symmetric with the existing `free_response_chats`:

```yaml
telegram:
  extra:
    require_mention: false            # normal everywhere…
    require_mention_chats: "-5175245583"   # …except here: @mention / reply only
```

Semantics:

- A listed chat requires an explicit trigger (reply to the bot, @mention, or wake-word pattern) even when `require_mention` is globally off.
- Checked **before** the `free_response_chats` and global-off short-circuits, so a chat accidentally listed in both resolves to the quieter option.
- The observe path (`observe_unmentioned_group_messages`) treats a listed chat as locally `require_mention=true`, so unmentioned chatter in that room still lands as observed context instead of being dropped.
- Accepts a list or comma-separated string; honors a `TELEGRAM_REQUIRE_MENTION_CHATS` env fallback — matching the parsing of every other chat-list key in the adapter.

## Scope

+38 lines in the Telegram adapter (one accessor + two gate branches), no new core tool surface, no schema changes, config-driven per the "behavioral settings go in config.yaml" rule. `allowed_chats`/`guest_mode` behavior is untouched — this only adds a branch after the whitelist gate.

## Tests

`tests/gateway/test_telegram_require_mention_chats.py` — 14 tests covering the parsing shapes (string/list/env/unset) and the behavior contracts: gated-chat silence on plain messages, mention/reply/pattern pass-through, unlisted chats keeping free response, per-chat beating `free_response_chats` on conflict, and observe-path retention of unmentioned messages.

Running in production on my own gateway (one gated room among several active groups) — gated room goes silent on plain chatter, responds on @mention/reply, other groups unaffected.