### PR TITLE
fix(env): preserve secret provenance on failed refresh

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3148,9 +3148,13 @@ def run_job(
         from hermes_cli.env_loader import (
             load_hermes_dotenv,
             reset_secret_source_cache,
+            restore_cached_secret_sources,
         )
         reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        try:
+            load_hermes_dotenv(hermes_home=_get_hermes_home())
+        except Exception:
+            restore_cached_secret_sources()
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -37,9 +37,12 @@ _WARNED_UTF32_PATHS: set[str] = set()
 # directly (otherwise the "credentials detected ✓" line looks identical to
 # the .env case and they don't know Bitwarden is wired up).
 _SECRET_SOURCES: dict[str, str] = {}
-# Applied values are immutable per-home snapshots.  ``os.environ`` is shared
-# across profiles and may be overwritten by a later home's source apply.
+# Stash for restore on failed refresh: a long-running gateway process
+# must keep serving existing secrets while secret-source backends are
+# temporarily unreachable.
+_SECRET_SOURCES_SNAPSHOT: dict[str, str] = {}
 _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
+_SECRET_SOURCE_VALUES_SNAPSHOT: dict[str, dict[str, str]] = {}
 
 # HERMES_HOME paths we've already pulled external secrets for during this
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
@@ -247,10 +250,38 @@ def reset_secret_source_cache() -> None:
     subsequent calls in the same process are no-ops.  Call this to force the
     next call to re-pull — useful for tests, and for long-running processes
     that want to refresh after a config change.
+
+    Snapshots the current state before clearing so callers can restore it
+    via ``restore_cached_secret_sources()`` if the refresh fails.
     """
+    global _SECRET_SOURCES_SNAPSHOT, _SECRET_SOURCE_VALUES_SNAPSHOT
+    _SECRET_SOURCES_SNAPSHOT = dict(_SECRET_SOURCES)
+    _SECRET_SOURCE_VALUES_SNAPSHOT = {
+        k: dict(v) for k, v in _SECRET_SOURCE_VALUES_BY_HOME.items()
+    }
     _APPLIED_HOMES.clear()
     _SECRET_SOURCES.clear()
     _SECRET_SOURCE_VALUES_BY_HOME.clear()
+
+
+def restore_cached_secret_sources() -> None:
+    """Restore secret source state from the snapshot taken by the last
+    ``reset_secret_source_cache()`` call.
+
+    Call this when a refresh attempt fails so that existing secrets
+    keep their provenance.  The snapshot is deliberately NOT cleared
+    so it survives multiple restore-at-most-once patterns.
+    """
+    global _SECRET_SOURCES, _SECRET_SOURCE_VALUES_BY_HOME
+    if _SECRET_SOURCES_SNAPSHOT:
+        _SECRET_SOURCES.update(
+            {k: v for k, v in _SECRET_SOURCES_SNAPSHOT.items()
+             if k not in _SECRET_SOURCES}
+        )
+    if _SECRET_SOURCE_VALUES_SNAPSHOT:
+        for home_key, snap in _SECRET_SOURCE_VALUES_SNAPSHOT.items():
+            if home_key not in _SECRET_SOURCE_VALUES_BY_HOME:
+                _SECRET_SOURCE_VALUES_BY_HOME[home_key] = dict(snap)
 
 
 def format_secret_source_suffix(env_var: str) -> str:


### PR DESCRIPTION
## Bug

`reset_secret_source_cache()` clears `_SECRET_SOURCES` before the refresh attempt. When `load_hermes_dotenv()` or the underlying `_apply_external_secret_sources()` fails mid-refresh (backend unreachable, config error, network timeout), the cache stays empty.

`_build_safe_env()` then calls `get_secret_source(key)` for every MCP child process. With an empty cache, every secret-tagged env var returns `None` — `_build_safe_env()` drops the var from the subprocess environment even though the value is still present in `os.environ` and the secret itself is unchanged.

## Fix

Snapshot `_SECRET_SOURCES` and `_SECRET_SOURCE_VALUES_BY_HOME` before clearing in `reset_secret_source_cache()`. Provide `restore_cached_secret_sources()` so callers (cron scheduler, gateway reload) can reinstate when the refresh attempt fails.