### PR TITLE
fix(memory/holographic): encode search queries in the fact HRR space

### DIFF
--- a/plugins/memory/holographic/holographic.py
+++ b/plugins/memory/holographic/holographic.py
@@ -167,6 +167,19 @@ def encode_fact(content: str, entities: list[str], dim: int = 1024) -> "np.ndarr
     return bundle(*components)
 
 
+def encode_query(text: str, dim: int = 1024) -> "np.ndarray":
+    """Encode a search query in the same space as stored facts.
+
+    Facts are stored with their content bound to ROLE_CONTENT (see
+    encode_fact). A query must be bound the same way: an unbound
+    encode_text bundle is unrelated to every stored fact, so the
+    similarity would be pure noise.
+    """
+    _require_numpy()
+    role_content = encode_atom("__hrr_role_content__", dim)
+    return bind(encode_text(text, dim), role_content)
+
+
 def phases_to_bytes(phases: "np.ndarray", dim: int | None = None) -> bytes:
     """Serialize phase vectors as float32 blobs.
 

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -75,9 +75,9 @@ class FactRetriever:
         # purpose: migrated stores can have FTS candidates whose hrr_vector
         # was never backfilled (MemoryStore._init_db adds the column
         # without backfilling), and those must not pay for an encode
-        # nothing will use. encode_text is deterministic (SHA-256 counter
-        # blocks), so the hoisted vector is bit-identical to what the
-        # per-candidate calls produced.
+        # nothing will use. The query encoder is deterministic (SHA-256
+        # counter blocks), so the hoisted vector is bit-identical to what
+        # the per-candidate calls produced.
         query_vec = None
         scored = []
 
@@ -93,7 +93,7 @@ class FactRetriever:
             if self.hrr_weight > 0 and fact.get("hrr_vector"):
                 fact_vec = hrr.bytes_to_phases(fact["hrr_vector"], dim=self.hrr_dim)
                 if query_vec is None:
-                    query_vec = hrr.encode_text(query, self.hrr_dim)
+                    query_vec = hrr.encode_query(query, self.hrr_dim)
                 hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0  # shift to [0,1]
             else:
                 hrr_sim = 0.5  # neutral

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -161,10 +161,13 @@ def test_search_encodes_query_vector_once(hoisted_retriever, monkeypatch):
 
 
 def test_search_results_bit_identical_to_unhoisted(hoisted_retriever):
-    """Parity: hoisted search() must produce the exact pre-fix results.
+    """Parity: hoisted search() must produce the exact same results as the
+    equivalent unhoisted loop.
 
-    Replicates the pre-fix loop (query vector encoded per candidate) as the
-    reference and compares full scored output for exact equality.
+    Replicates the unhoisted loop (query vector encoded per candidate) as
+    the reference and compares full scored output for exact equality. The
+    reference uses the same corrected query encoding (encode_query) as
+    search(), so this test pins the hoist, not the encoding.
     """
     r = hoisted_retriever
     query = "deploy target setting"
@@ -182,7 +185,7 @@ def test_search_results_bit_identical_to_unhoisted(hoisted_retriever):
         fts_score = fact.get("fts_rank", 0.0)
         if r.hrr_weight > 0 and fact.get("hrr_vector"):
             fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
-            query_vec = hrr.encode_text(query, r.hrr_dim)  # per-candidate
+            query_vec = hrr.encode_query(query, r.hrr_dim)  # per-candidate
             hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0
         else:
             hrr_sim = 0.5
@@ -237,4 +240,91 @@ def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
     assert calls == [], (
         f"encode_text called {len(calls)}x with zero vector candidates — "
         "lazy hoist regressed to eager"
+    )
+
+
+# ---------------------------------------------------------------------------
+# HRR query-space fix: search() must compare the query in the fact space.
+#
+# Facts store content bound to ROLE_CONTENT (encode_fact). The old
+# search() compared a raw, unbound query bundle against that, which is
+# unrelated to every stored fact — the HRR score was pure noise.
+# encode_query binds the query to ROLE_CONTENT and restores the signal.
+# ---------------------------------------------------------------------------
+
+DIM = 1024
+
+
+def test_encode_query_lives_in_the_fact_space():
+    """encode_query must land in the same space as encode_fact.
+
+    The old search() compared a raw, unbound encode_text bundle, which
+    is unrelated to stored fact vectors.
+    """
+    fact_vec = hrr.encode_fact("the deployment rollback failed", [], DIM)
+    matching = hrr.encode_query("deployment rollback", DIM)
+    unrelated = hrr.encode_query("compaction threshold tuning", DIM)
+    raw = hrr.encode_text("deployment rollback", DIM)  # the old encoding: unbound
+
+    bound_sim = hrr.similarity(matching, fact_vec)
+    raw_sim = hrr.similarity(raw, fact_vec)
+    unrelated_sim = hrr.similarity(unrelated, fact_vec)
+
+    # Same-space query is clearly similar to a fact sharing its content...
+    assert bound_sim > 0.5, f"expected a real signal, got {bound_sim:.3f}"
+    # ...and clearly beats the old raw (unbound) comparison...
+    assert bound_sim > raw_sim + 0.1, (
+        f"bound query ({bound_sim:.3f}) must beat the old raw comparison "
+        f"({raw_sim:.3f})"
+    )
+    # ...and an unrelated query.
+    assert bound_sim > unrelated_sim + 0.1, (
+        f"matching query ({bound_sim:.3f}) must beat unrelated "
+        f"({unrelated_sim:.3f})"
+    )
+    # Binding scrambles the vector: the bound query is unrelated to its
+    # own unbound bundle.
+    assert hrr.similarity(matching, raw) < 0.5
+
+
+def test_search_pure_hrr_separates_matching_fact(tmp_path):
+    """With HRR as the only scoring signal, the matching fact must win.
+
+    Regression test for the fix: before it, every candidate scored ~0.5
+    (noise), so the HRR signal was dead weight and a matching fact had
+    no advantage.
+    """
+    store = MemoryStore(str(tmp_path / "query_space.db"))
+    try:
+        store.add_fact(
+            content="deployment rollback migration stale state",
+            category="project",
+        )
+        store.add_fact(
+            content="deployment config tuned for high traffic",
+            category="project",
+        )
+        store.add_fact(
+            content="rollback procedure documented in the runbook",
+            category="project",
+        )
+        retriever = FactRetriever(
+            store=store,
+            fts_weight=0.0,
+            jaccard_weight=0.0,
+            hrr_weight=1.0,
+        )
+        results = retriever.search("deployment rollback migration state", limit=3)
+    finally:
+        store.close()
+
+    assert results, "expected FTS candidates"
+    target = next(r for r in results if "migration stale" in r["content"])
+    distractors = [r for r in results if "migration stale" not in r["content"]]
+    assert distractors, "distractors must be FTS candidates too"
+    margin = target["score"] - max(d["score"] for d in distractors)
+    assert margin > 0.1, (
+        "HRR must clearly separate the matching fact from candidates that "
+        f"share only one query token (margin={margin:.3f}, "
+        f"target={target['score']:.3f})"
     )


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-space HRR comparison in holographic memory retrieval. `FactRetriever.search()` compared the query against stored fact vectors in a different vector space, so the HRR part of the score was pure noise.

**Why it was broken.** Facts are persisted via `encode_fact()`, which binds content tokens to `ROLE_CONTENT` before bundling. `search()` encoded the query with a raw, unbound `encode_text()` bundle. Binding makes the raw bundle unrelated to every stored fact: `similarity(query, fact)` returned ~0 for all candidates. The HRR weight (0.3 by default) was dead weight, and every fact looked the same to it.

**The fix.**
- `plugins/memory/holographic/holographic.py`: new `encode_query(text, dim)`. It is `encode_text` bound to `ROLE_CONTENT`, matching `encode_fact()`'s content branch exactly (same role atom, same dim, same empty-text fallback).
- `plugins/memory/holographic/retrieval.py`: `search()` now calls `encode_query()`. The lazy once-per-call encoding stays: both encoders are deterministic (SHA-256), so the hoisted vector is identical to what per-candidate encoding would produce.

**Scope.** `search()` was the only cross-space comparison. `probe()`, `related()`, and `reason()` already bind their keys correctly.

### Evidence (deterministic, dim 1024)

```
bound_sim  = similarity(encode_query("deployment rollback"), fact)  = 0.631  <- real signal
raw_sim    = similarity(encode_text ("deployment rollback"), fact)  = -0.010 <- old code: noise
unrelated  = similarity(encode_query("compaction threshold"), fact) = -0.007
```

The bound query aligns with a fact that shares its words. The old raw query scored the same as an unrelated query.

## Related Issue

No linked issue. The bug was found while operating the holographic memory provider; I can open one and reference it if the maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/memory/holographic/holographic.py`: add `encode_query()`, content bound to `ROLE_CONTENT`
- `plugins/memory/holographic/retrieval.py`: in `search()`, encode the query with `encode_query()` instead of raw `encode_text()`
- `tests/plugins/memory/test_holographic_retrieval.py`: unit test for `encode_query()`; integration regression test that runs search with pure-HRR scoring and requires the matching fact to clearly beat candidates sharing only one query token; the hoist-parity test's reference loop now uses the corrected encoding (it pins the hoist, not the encoding)

## How to Test

1. Run `pytest tests/plugins/memory/test_holographic_retrieval.py tests/plugins/memory/test_holographic_store.py tests/plugins/test_holographic_vector_storage.py -q`. All pass.
2. Both new tests fail on `main` without this change:
   - `test_encode_query_lives_in_the_fact_space`: `encode_query` does not exist yet
   - `test_search_pure_hrr_separates_matching_fact`: margin is ~0, every candidate scores ~0.5
3. Manual: search a store that has facts. HRR now measurably prefers facts sharing words with the query.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Searched open and merged PRs/issues for holographic, HRR, ROLE_CONTENT, and RRF. Closest related: the merged encode-hoisting PR (#76881), which this builds on, and #21468 (HRR probe algebra, different area)
- [x] My PR contains only changes related to this fix (single commit, no unrelated changes)
- [x] I've run `pytest tests/ -q` and all tests pass. Holographic and memory-plugin suites pass (53/53, including the 2 new tests). Full-suite note below: pre-existing, unrelated failures only
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Linux (Debian, x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A. The `encode_query()` docstring explains the space-matching requirement; otherwise N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): pure numpy/HRR arithmetic, no I/O or platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A (internal retrieval scoring)

### Test results (full `pytest tests/ -q` on this branch)

1901 tests passed. The run then hit pre-existing, environment-dependent failures that also reproduce on `main` (CI runs hermetic `env -i` for exactly this reason; each failing test passes in isolation on this branch and on `main`):

- `test_hub_index_cache_blocked`: order/state-dependent in a non-hermetic run, unrelated subsystem (file safety)
- `tests/plugins/memory/test_hindsight_provider.py`: requires an external OpenViking server, unavailable in this environment

## Screenshots / Logs

Regression test on `main` (before) vs this branch (after), pure-HRR scoring:

```
# before: every candidate tied at noise
target=0.2500  best_distractor=0.2500  margin=0.0000  -> FAIL

# after
target=0.4736  best_distractor=0.3010  margin=0.1726  -> PASS
```
