### PR TITLE
refactor(skills): modernize github-code-review structure + runtime test

### DIFF
--- a/contributors/emails/270496070+A-KH17@users.noreply.github.com
+++ b/contributors/emails/270496070+A-KH17@users.noreply.github.com
@@ -1,0 +1,2 @@
+A-KH17
+# docs + skill PRs

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: github-code-review
 description: "Review PRs: diffs, inline comments via gh or REST."
-version: 1.1.0
-author: Hermes Agent
+version: 1.2.0
+author: "A-KH17, Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,9 +11,18 @@ metadata:
     related_skills: [github-auth, github-pr-workflow]
 ---
 
-# GitHub Code Review
+# GitHub Code Review Skill
 
-Perform code reviews on local changes before pushing, or review open PRs on GitHub. Most of this skill uses plain `git` — the `gh`/`curl` split only matters for PR-level interactions.
+Perform code reviews on local changes before pushing, or review open PRs on GitHub and
+post comments or formal reviews. Most of this skill uses plain `git` — the `gh`/`curl`
+split only matters for PR-level interactions. It does not author PRs
+(`github-pr-workflow`) or triage issues (`github-issues`).
+
+## When to Use
+
+- "Review my changes before I push" — local `git diff main...HEAD` review, no API needed.
+- "Review PR #N" or a PR URL — fetch, inspect, test, and review a GitHub pull request.
+- "Comment on / approve / request changes on PR #N" — post inline comments or a formal review.
 
 ## Prerequisites
 
@@ -42,440 +51,142 @@ OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
 REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
 ```
 
----
+## How to Run
 
-## 1. Reviewing Local Changes (Pre-Push)
+Run every shell command via `terminal`. Read surrounding code with `read_file` and find
+related call sites with `search_files` — diffs alone can miss issues visible only in
+context. Pick the matching workflow under `## Procedure` (local pre-push or PR review)
+and follow it end to end. Full posting payloads (`gh` and REST/`curl`) live in
+[references/github-rest-api.md](references/github-rest-api.md).
 
-This is pure `git` — works everywhere, no API needed.
+## Quick Reference
 
-### Get the Diff
+| Task | Core command (via `terminal`) |
+|------|-------------------------------|
+| Local diff (pre-push) | `git diff main...HEAD` (+ `--stat`, `--name-only`) |
+| Staged changes only | `git diff --staged` |
+| PR details / diff / CI | `gh pr view N` · `gh pr diff N` · `gh pr checks N` |
+| Check out a PR | `git fetch origin pull/N/head:pr-N && git checkout pr-N` (or `gh pr checkout N`) |
+| Env/auth setup | `source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"` |
+| Inline comment | `gh api repos/$OWNER/$REPO/pulls/N/comments --method POST` (head SHA as `commit_id`) |
+| Formal review | `gh pr review N --approve\|--request-changes\|--comment --body "..."` |
+| Top-level summary | `gh pr comment N --body "..."` (format: `references/review-output-template.md`) |
+| Cleanup | `git checkout main && git branch -D pr-N` |
 
-```bash
-# Staged changes (what would be committed)
-git diff --staged
+## Procedure
 
-# All changes vs main (what a PR would contain)
-git diff main...HEAD
+### A. Local pre-push review
 
-# File names only
-git diff main...HEAD --name-only
+When the user asks to "review the code" or "check before pushing" (pure `git`, no API):
 
-# Stat summary (insertions/deletions per file)
-git diff main...HEAD --stat
-```
+1. Get the big picture first and state the scope ("N commits, M files") — a scan over an
+   empty diff means "nothing to review", not "clean":
+   ```bash
+   git diff main...HEAD --stat
+   git log main..HEAD --oneline
+   ```
+2. Review file by file — use `read_file` on changed files for full context:
+   `git diff main...HEAD -- src/auth/login.py`
+3. Check for common issues:
+   ```bash
+   # Debug statements, TODOs, console.logs left behind
+   git diff main...HEAD | grep -n "print(\|console\.log\|TODO\|FIXME\|HACK\|XXX\|debugger"
+   # Large files accidentally staged
+   git diff main...HEAD --stat | sort -t'|' -k2 -rn | head -10
+   # Secrets or credential patterns
+   git diff main...HEAD | grep -in "password\|secret\|api_key\|token.*=\|private_key"
+   # Merge conflict markers
+   git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
+   ```
+4. Apply the review checklist (below).
+5. Present findings in the structured format from
+   [references/review-output-template.md](references/review-output-template.md)
+   (Critical / Warnings / Suggestions / Looks Good). If critical issues are found, offer
+   to fix them before the user pushes.
 
-### Review Strategy
+### B. PR review (end to end)
 
-1. **Get the big picture first:**
+When the user asks to "review PR #N", "look at this PR", or gives a PR URL:
 
-```bash
-git diff main...HEAD --stat
-git log main..HEAD --oneline
-```
+1. **Set up environment** — the Setup block above, or
+   `source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"`.
+2. **Gather PR context** (metadata, changed files, CI state):
+   `gh pr view N`, `gh pr diff N --name-only`, `gh pr checks N`.
+3. **Check out the PR locally** for full access to `read_file`, `search_files`, and the
+   ability to run tests:
+   `git fetch origin pull/N/head:pr-N && git checkout pr-N` (shortcut: `gh pr checkout N`).
+4. **Read the full diff** against the base branch (`git diff main...HEAD`, or file by
+   file for large PRs); for each changed file use `read_file` to see the surrounding
+   context.
+5. **Run automated checks locally** against the checked-out PR code — the project's test
+   suite (`python -m pytest`, `npm test`, `cargo test`, …) and linter (`ruff check .`,
+   `eslint`, `clippy`, …).
+6. **Apply the review checklist** (below).
+7. **Post the review** — `gh pr review N --approve|--request-changes|--comment`, or the
+   atomic multi-comment REST payload in
+   [references/github-rest-api.md](references/github-rest-api.md). Inline comments need
+   the PR head SHA as `commit_id`; `line` is the NEW-file line number, and deleted lines
+   use `side: "LEFT"` with the OLD-file line number. Anchors must sit inside a diff
+   hunk — GitHub rejects off-diff lines with HTTP 422. Re-check against
+   `gh pr diff N -- path/to/file`, fall back to a file-level comment
+   (`subject_type: "file"`), or fold the point into the review body.
+8. **Post a top-level summary comment** so the author gets the full picture at a glance —
+   format from `references/review-output-template.md`.
+9. **Clean up:** `git checkout main && git branch -D pr-N`.
 
-2. **Review file by file** — use `read_file` on changed files for full context, and the diff to see what changed:
+**Decision — Approve vs Request Changes vs Comment:**
 
-```bash
-git diff main...HEAD -- src/auth/login.py
-```
+- **Approve** — no critical or warning-level issues; only minor suggestions or all clear.
+- **Request Changes** — any critical or warning-level issue that should be fixed before merge.
+- **Comment** — observations and suggestions, nothing blocking (also use when unsure or
+  the PR is a draft). Comment is the ONLY valid verdict for an empty diff: never Approve
+  or Request Changes when the PR changes 0 files — note the empty diff and its likely
+  causes (already merged, branch reset to base, wrong base branch, commits never pushed)
+  in a top-level comment instead.
 
-3. **Check for common issues:**
-
-```bash
-# Debug statements, TODOs, console.logs left behind
-git diff main...HEAD | grep -n "print(\|console\.log\|TODO\|FIXME\|HACK\|XXX\|debugger"
-
-# Large files accidentally staged
-git diff main...HEAD --stat | sort -t'|' -k2 -rn | head -10
-
-# Secrets or credential patterns
-git diff main...HEAD | grep -in "password\|secret\|api_key\|token.*=\|private_key"
-
-# Merge conflict markers
-git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
-```
-
-4. **Present structured feedback** to the user.
-
-### Review Output Format
-
-When reviewing local changes, present findings in this structure:
-
-```
-## Code Review Summary
-
-### Critical
-- **src/auth.py:45** — SQL injection: user input passed directly to query.
-  Suggestion: Use parameterized queries.
-
-### Warnings
-- **src/models/user.py:23** — Password stored in plaintext. Use bcrypt or argon2.
-- **src/api/routes.py:112** — No rate limiting on login endpoint.
-
-### Suggestions
-- **src/utils/helpers.py:8** — Duplicates logic in `src/core/utils.py:34`. Consolidate.
-- **tests/test_auth.py** — Missing edge case: expired token test.
-
-### Looks Good
-- Clean separation of concerns in the middleware layer
-- Good test coverage for the happy path
-```
-
----
-
-## 2. Reviewing a Pull Request on GitHub
-
-### View PR Details
-
-**With gh:**
-
-```bash
-gh pr view 123
-gh pr diff 123
-gh pr diff 123 --name-only
-```
-
-**With git + curl:**
-
-```bash
-PR_NUMBER=123
-
-# Get PR details
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "
-import sys, json
-pr = json.load(sys.stdin)
-print(f\"Title: {pr['title']}\")
-print(f\"Author: {pr['user']['login']}\")
-print(f\"Branch: {pr['head']['ref']} -> {pr['base']['ref']}\")
-print(f\"State: {pr['state']}\")
-print(f\"Body:\n{pr['body']}\")"
-
-# List changed files
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/files \
-  | python3 -c "
-import sys, json
-for f in json.load(sys.stdin):
-    print(f\"{f['status']:10} +{f['additions']:-4} -{f['deletions']:-4}  {f['filename']}\")"
-```
-
-### Check Out PR Locally for Full Review
-
-This works with plain `git` — no `gh` needed:
-
-```bash
-# Fetch the PR branch and check it out
-git fetch origin pull/123/head:pr-123
-git checkout pr-123
-
-# Now you can use read_file, search_files, run tests, etc.
-
-# View diff against the base branch
-git diff main...pr-123
-```
-
-**With gh (shortcut):**
-
-```bash
-gh pr checkout 123
-```
-
-### Leave Comments on a PR
-
-**General PR comment — with gh:**
-
-```bash
-gh pr comment 123 --body "Overall looks good, a few suggestions below."
-```
-
-**General PR comment — with curl:**
-
-```bash
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/issues/$PR_NUMBER/comments \
-  -d '{"body": "Overall looks good, a few suggestions below."}'
-```
-
-### Leave Inline Review Comments
-
-**Single inline comment — with gh (via API):**
-
-```bash
-HEAD_SHA=$(gh pr view 123 --json headRefOid --jq '.headRefOid')
-
-gh api repos/$OWNER/$REPO/pulls/123/comments \
-  --method POST \
-  -f body="This could be simplified with a list comprehension." \
-  -f path="src/auth/login.py" \
-  -f commit_id="$HEAD_SHA" \
-  -f line=45 \
-  -f side="RIGHT"
-```
-
-**Single inline comment — with curl:**
-
-```bash
-# Get the head commit SHA
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  -d "{
-    \"body\": \"This could be simplified with a list comprehension.\",
-    \"path\": \"src/auth/login.py\",
-    \"commit_id\": \"$HEAD_SHA\",
-    \"line\": 45,
-    \"side\": \"RIGHT\"
-  }"
-```
-
-### Submit a Formal Review (Approve / Request Changes)
-
-**With gh:**
-
-```bash
-gh pr review 123 --approve --body "LGTM!"
-gh pr review 123 --request-changes --body "See inline comments."
-gh pr review 123 --comment --body "Some suggestions, nothing blocking."
-```
-
-**With curl — multi-comment review submitted atomically:**
-
-```bash
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"COMMENT\",
-    \"body\": \"Code review from Hermes Agent\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"Use parameterized queries to prevent SQL injection.\"},
-      {\"path\": \"src/models/user.py\", \"line\": 23, \"body\": \"Hash passwords with bcrypt before storing.\"},
-      {\"path\": \"tests/test_auth.py\", \"line\": 1, \"body\": \"Add test for expired token edge case.\"}
-    ]
-  }"
-```
-
-Event values: `"APPROVE"`, `"REQUEST_CHANGES"`, `"COMMENT"`
-
-The `line` field refers to the line number in the *new* version of the file. For deleted lines, use `"side": "LEFT"`.
-
----
-
-## 3. Review Checklist
+### Review checklist
 
 When performing a code review (local or PR), systematically check:
 
-### Correctness
-- Does the code do what it claims?
-- Edge cases handled (empty inputs, nulls, large data, concurrent access)?
-- Error paths handled gracefully?
+**Correctness** — does the code do what it claims; edge cases handled (empty inputs,
+nulls, large data, concurrent access); error paths handled gracefully.
 
-### Security
-- No hardcoded secrets, credentials, or API keys
-- Input validation on user-facing inputs
-- No SQL injection, XSS, or path traversal
-- Auth/authz checks where needed
+**Security** — no hardcoded secrets, credentials, or API keys; input validation on
+user-facing inputs; no SQL injection, XSS, or path traversal; auth/authz checks where
+needed.
 
-### Code Quality
-- Clear naming (variables, functions, classes)
-- No unnecessary complexity or premature abstraction
-- DRY — no duplicated logic that should be extracted
-- Functions are focused (single responsibility)
+**Code Quality** — clear naming; no unnecessary complexity or premature abstraction;
+DRY; focused functions (single responsibility).
 
-### Testing
-- New code paths tested?
-- Happy path and error cases covered?
-- Tests readable and maintainable?
+**Testing** — new code paths tested; happy path and error cases covered; tests readable
+and maintainable.
 
-### Performance
-- No N+1 queries or unnecessary loops
-- Appropriate caching where beneficial
-- No blocking operations in async code paths
+**Performance** — no N+1 queries or unnecessary loops; appropriate caching; no blocking
+operations in async code paths.
 
-### Documentation
-- Public APIs documented
-- Non-obvious logic has comments explaining "why"
-- README updated if behavior changed
+**Documentation** — public APIs documented; non-obvious logic has comments explaining
+"why"; README updated if behavior changed.
 
----
+## Pitfalls
 
-## 4. Pre-Push Review Workflow
+- Never Approve code you haven't actually read, and never call a scan over an empty diff
+  "clean" — state the scope so "no findings" is meaningful.
+- Never Approve or Request Changes on an empty diff — a top-level Comment is the only
+  vehicle there.
+- Don't post anything to GitHub without confirmed auth, and never echo token values into
+  outputs or logs.
+- Inline anchors outside a diff hunk fail with HTTP 422 — verify the line against the PR
+  diff first, then fall back (nearest changed line → file-level comment → review body).
+- Run tests against the checked-out PR code, not the user's working tree — and always
+  clean up (`git checkout main`, delete `pr-N` branches) afterward.
+- Use `read_file` for context around every changed hunk; diffs alone miss issues.
 
-When the user asks you to "review the code" or "check before pushing":
+## Verification
 
-1. `git diff main...HEAD --stat` — see scope of changes
-2. `git diff main...HEAD` — read the full diff
-3. For each changed file, use `read_file` if you need more context
-4. Apply the checklist above
-5. Present findings in the structured format (Critical / Warnings / Suggestions / Looks Good)
-6. If critical issues found, offer to fix them before the user pushes
-
----
-
-## 5. PR Review Workflow (End-to-End)
-
-When the user asks you to "review PR #N", "look at this PR", or gives you a PR URL, follow this recipe:
-
-### Step 1: Set up environment
-
-```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
-# Or run the inline setup block from the top of this skill
-```
-
-### Step 2: Gather PR context
-
-Get the PR metadata, description, and list of changed files to understand scope before diving into code.
-
-**With gh:**
-```bash
-gh pr view 123
-gh pr diff 123 --name-only
-gh pr checks 123
-```
-
-**With curl:**
-```bash
-PR_NUMBER=123
-
-# PR details (title, author, description, branch)
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER
-
-# Changed files with line counts
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/files
-```
-
-### Step 3: Check out the PR locally
-
-This gives you full access to `read_file`, `search_files`, and the ability to run tests.
-
-```bash
-git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
-git checkout pr-$PR_NUMBER
-```
-
-### Step 4: Read the diff and understand changes
-
-```bash
-# Full diff against the base branch
-git diff main...HEAD
-
-# Or file-by-file for large PRs
-git diff main...HEAD --name-only
-# Then for each file:
-git diff main...HEAD -- path/to/file.py
-```
-
-For each changed file, use `read_file` to see full context around the changes — diffs alone can miss issues visible only with surrounding code.
-
-### Step 5: Run automated checks locally (if applicable)
-
-```bash
-# Run tests if there's a test suite
-python -m pytest 2>&1 | tail -20
-# or: npm test, cargo test, go test ./..., etc.
-
-# Run linter if configured
-ruff check . 2>&1 | head -30
-# or: eslint, clippy, etc.
-```
-
-### Step 6: Apply the review checklist (Section 3)
-
-Go through each category: Correctness, Security, Code Quality, Testing, Performance, Documentation.
-
-### Step 7: Post the review to GitHub
-
-Collect your findings and submit them as a formal review with inline comments.
-
-**With gh:**
-```bash
-# If no issues — approve
-gh pr review $PR_NUMBER --approve --body "Reviewed by Hermes Agent. Code looks clean — good test coverage, no security concerns."
-
-# If issues found — request changes with inline comments
-gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inline comments."
-```
-
-**With curl — atomic review with multiple inline comments:**
-```bash
-HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-# Build the review JSON — event is APPROVE, REQUEST_CHANGES, or COMMENT
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"REQUEST_CHANGES\",
-    \"body\": \"## Hermes Agent Review\n\nFound 2 issues, 1 suggestion. See inline comments.\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"🔴 **Critical:** User input passed directly to SQL query — use parameterized queries.\"},
-      {\"path\": \"src/models.py\", \"line\": 23, \"body\": \"⚠️ **Warning:** Password stored without hashing.\"},
-      {\"path\": \"src/utils.py\", \"line\": 8, \"body\": \"💡 **Suggestion:** This duplicates logic in core/utils.py:34.\"}
-    ]
-  }"
-```
-
-### Step 8: Also post a summary comment
-
-In addition to inline comments, leave a top-level summary so the PR author gets the full picture at a glance. Use the review output format from `references/review-output-template.md`.
-
-**With gh:**
-```bash
-gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
-## Code Review Summary
-
-**Verdict: Changes Requested** (2 issues, 1 suggestion)
-
-### 🔴 Critical
-- **src/auth.py:45** — SQL injection vulnerability
-
-### ⚠️ Warnings
-- **src/models.py:23** — Plaintext password storage
-
-### 💡 Suggestions
-- **src/utils.py:8** — Duplicated logic, consider consolidating
-
-### ✅ Looks Good
-- Clean API design
-- Good error handling in the middleware layer
-
----
-*Reviewed by Hermes Agent*
-EOF
-)"
-```
-
-### Step 9: Clean up
-
-```bash
-git checkout main
-git branch -D pr-$PR_NUMBER
-```
-
-### Decision: Approve vs Request Changes vs Comment
-
-- **Approve** — no critical or warning-level issues, only minor suggestions or all clear
-- **Request Changes** — any critical or warning-level issue that should be fixed before merge
-- **Comment** — observations and suggestions, but nothing blocking (use when you're unsure or the PR is a draft)
+Before delivering, confirm:
+- [ ] Scope stated (N commits, M files) and full diff read with surrounding context.
+- [ ] Tests/linter run against the checked-out PR code — or explicitly reported as not run.
+- [ ] Review checklist applied across all six categories.
+- [ ] Every posted item confirmed by the API response (comment or review URL).
+- [ ] Verdict matches the findings — empty diff → Comment only.
+- [ ] Cleanup done: original branch restored, `pr-N` branch deleted.

--- a/skills/github/github-code-review/references/github-rest-api.md
+++ b/skills/github/github-code-review/references/github-rest-api.md
@@ -1,0 +1,123 @@
+# GitHub Posting Payloads — github-code-review
+
+Full `gh` and REST/`curl` forms for every PR interaction in the skill. The `curl`
+variants assume the Setup block from SKILL.md has run, so `$GITHUB_TOKEN`, `$OWNER`,
+`$REPO` are set and `PR_NUMBER=N`.
+
+## Posting with gh
+
+```bash
+# Single inline comment — head SHA required as commit_id
+HEAD_SHA=$(gh pr view N --json headRefOid --jq '.headRefOid')
+
+gh api repos/$OWNER/$REPO/pulls/N/comments \
+  --method POST \
+  -f body="This could be simplified with a list comprehension." \
+  -f path="src/auth/login.py" \
+  -f commit_id="$HEAD_SHA" \
+  -f line=45 \
+  -f side="RIGHT"
+
+# Formal review
+gh pr review N --approve --body "LGTM!"
+gh pr review N --request-changes --body "See inline comments."
+gh pr review N --comment --body "Some suggestions, nothing blocking."
+
+# Top-level comment
+gh pr comment N --body "Overall looks good, a few suggestions below."
+```
+
+## PR metadata and changed files (curl)
+
+```bash
+# PR details (title, author, description, branch, state)
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
+  | python3 -c "
+import sys, json
+pr = json.load(sys.stdin)
+print(f\"Title: {pr['title']}\")
+print(f\"Author: {pr['user']['login']}\")
+print(f\"Branch: {pr['head']['ref']} -> {pr['base']['ref']}\")
+print(f\"State: {pr['state']}\")
+print(f\"Body:\n{pr['body']}\")"
+
+# Changed files with line counts
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/files \
+  | python3 -c "
+import sys, json
+for f in json.load(sys.stdin):
+    print(f\"{f['status']:10} +{f['additions']:-4} -{f['deletions']:-4}  {f['filename']}\")"
+```
+
+## Single inline comment (curl)
+
+```bash
+# Get the head commit SHA (required as commit_id)
+HEAD_SHA=$(curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
+  -d "{
+    \"body\": \"This could be simplified with a list comprehension.\",
+    \"path\": \"src/auth/login.py\",
+    \"commit_id\": \"$HEAD_SHA\",
+    \"line\": 45,
+    \"side\": \"RIGHT\"
+  }"
+```
+
+The `line` field is the line number in the *new* version of the file. For deleted lines,
+use `"side": "LEFT"` with the line number in the *old* version. Multi-line ranges use
+`start_line`/`start_side` + `line`/`side`.
+
+## Formal review — atomic multi-comment payload (curl)
+
+```bash
+HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+
+# Build the review JSON — event is APPROVE, REQUEST_CHANGES, or COMMENT
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews \
+  -d "{
+    \"commit_id\": \"$HEAD_SHA\",
+    \"event\": \"REQUEST_CHANGES\",
+    \"body\": \"Found 2 issues, 1 suggestion. See inline comments.\",
+    \"comments\": [
+      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"🔴 **Critical:** User input passed directly to SQL query — use parameterized queries.\"},
+      {\"path\": \"src/models.py\", \"line\": 23, \"body\": \"⚠️ **Warning:** Password stored without hashing.\"},
+      {\"path\": \"src/utils.py\", \"line\": 8, \"body\": \"💡 **Suggestion:** This duplicates logic in core/utils.py:34.\"}
+    ]
+  }"
+```
+
+## Top-level comment
+
+```bash
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/issues/$PR_NUMBER/comments \
+  -d '{"body": "Overall looks good, a few suggestions below."}'
+```
+
+(Top-level PR comments use the **issues** comments endpoint.)
+
+## Failure triage
+
+- **401/403** — token missing or lacking write scope (`repo` on a classic token, or
+  Pull requests: write on a fine-grained token).
+- **404** — wrong owner/repo, or a private repo without auth.
+- **422** — inline anchor outside a diff hunk. Re-check the line/side against
+  `gh pr diff N -- path/to/file` (old-file line number for `side: "LEFT"`), or fall back
+  to a file-level comment (`"subject_type": "file"`, no line/side), or fold the point
+  into the review body.

--- a/tests/skills/test_github_code_review_skill.py
+++ b/tests/skills/test_github_code_review_skill.py
@@ -1,0 +1,73 @@
+"""Runtime loading tests for the bundled github-code-review skill.
+
+These exercise the production skill-loading/validation code paths in
+``tools.skill_manager_tool`` against the shipped skill bundle — the same gates
+a skill passes when Hermes creates, edits, and loads it — plus bundle
+consistency (every ``references/`` file the SKILL.md points at must ship).
+No source-shape assertions, no network; stdlib + pytest only.
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+from tools.skill_manager_tool import (
+    _find_skill,
+    _security_scan_skill,
+    _validate_category,
+    _validate_content_size,
+    _validate_frontmatter,
+    _validate_name,
+)
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2] / "skills" / "github" / "github-code-review"
+)
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_skill_loads_through_production_validation():
+    """The skill must pass the same gates the skill manager applies on write/load."""
+    content = _skill_text()
+    assert _validate_name("github-code-review") is None
+    assert _validate_category("github") is None
+    assert _validate_frontmatter(content) is None
+    assert _validate_content_size(content) is None
+
+
+def test_description_fits_new_skill_prompt_budget():
+    """Create-path gate: description must fit the system-prompt char budget."""
+    assert _validate_frontmatter(_skill_text(), new_skill=True) is None
+
+
+def test_skill_dir_passes_security_scan():
+    assert _security_scan_skill(SKILL_DIR) is None
+
+
+def test_referenced_bundle_files_exist():
+    """Every references/ file the SKILL.md points at must ship in the bundle."""
+    refs = set(re.findall(r"references/[A-Za-z0-9._-]+\.md", _skill_text()))
+    assert refs, "expected the skill to reference at least one bundle file"
+    for ref in sorted(refs):
+        assert (SKILL_DIR / ref).is_file(), f"missing referenced file: {ref}"
+
+
+def test_skill_discoverable_and_loadable_after_install():
+    """Copied into a fresh HERMES_HOME, the skill is found by name through the
+    production discovery path and its content loads clean."""
+    import tools.skill_manager_tool as smt
+
+    # conftest points HERMES_HOME at a per-test tempdir; install the bundle there.
+    dest = get_hermes_home() / "skills" / "github" / "github-code-review"
+    shutil.copytree(SKILL_DIR, dest)
+
+    found = smt._find_skill("github-code-review")
+    assert found is not None, "skill not discoverable after install"
+    content = (found["path"] / "SKILL.md").read_text(encoding="utf-8")
+    assert smt._validate_frontmatter(content) is None
+    assert smt._validate_content_size(content) is None

--- a/website/docs/user-guide/skills/bundled/github/github-github-code-review.md
+++ b/website/docs/user-guide/skills/bundled/github/github-github-code-review.md
@@ -16,8 +16,8 @@ Review PRs: diffs, inline comments via gh or REST.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/github/github-code-review` |
-| Version | `1.1.0` |
-| Author | Hermes Agent |
+| Version | `1.2.0` |
+| Author | A-KH17, Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `GitHub`, `Code-Review`, `Pull-Requests`, `Git`, `Quality` |
@@ -29,9 +29,18 @@ Review PRs: diffs, inline comments via gh or REST.
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# GitHub Code Review
+# GitHub Code Review Skill
 
-Perform code reviews on local changes before pushing, or review open PRs on GitHub. Most of this skill uses plain `git` — the `gh`/`curl` split only matters for PR-level interactions.
+Perform code reviews on local changes before pushing, or review open PRs on GitHub and
+post comments or formal reviews. Most of this skill uses plain `git` — the `gh`/`curl`
+split only matters for PR-level interactions. It does not author PRs
+(`github-pr-workflow`) or triage issues (`github-issues`).
+
+## When to Use
+
+- "Review my changes before I push" — local `git diff main...HEAD` review, no API needed.
+- "Review PR #N" or a PR URL — fetch, inspect, test, and review a GitHub pull request.
+- "Comment on / approve / request changes on PR #N" — post inline comments or a formal review.
 
 ## Prerequisites
 
@@ -60,440 +69,142 @@ OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
 REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
 ```
 
----
+## How to Run
 
-## 1. Reviewing Local Changes (Pre-Push)
+Run every shell command via `terminal`. Read surrounding code with `read_file` and find
+related call sites with `search_files` — diffs alone can miss issues visible only in
+context. Pick the matching workflow under `## Procedure` (local pre-push or PR review)
+and follow it end to end. Full posting payloads (`gh` and REST/`curl`) live in
+[references/github-rest-api.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/github-rest-api.md).
 
-This is pure `git` — works everywhere, no API needed.
+## Quick Reference
 
-### Get the Diff
+| Task | Core command (via `terminal`) |
+|------|-------------------------------|
+| Local diff (pre-push) | `git diff main...HEAD` (+ `--stat`, `--name-only`) |
+| Staged changes only | `git diff --staged` |
+| PR details / diff / CI | `gh pr view N` · `gh pr diff N` · `gh pr checks N` |
+| Check out a PR | `git fetch origin pull/N/head:pr-N && git checkout pr-N` (or `gh pr checkout N`) |
+| Env/auth setup | `source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"` |
+| Inline comment | `gh api repos/$OWNER/$REPO/pulls/N/comments --method POST` (head SHA as `commit_id`) |
+| Formal review | `gh pr review N --approve\|--request-changes\|--comment --body "..."` |
+| Top-level summary | `gh pr comment N --body "..."` (format: `references/review-output-template.md`) |
+| Cleanup | `git checkout main && git branch -D pr-N` |
 
-```bash
-# Staged changes (what would be committed)
-git diff --staged
+## Procedure
 
-# All changes vs main (what a PR would contain)
-git diff main...HEAD
+### A. Local pre-push review
 
-# File names only
-git diff main...HEAD --name-only
+When the user asks to "review the code" or "check before pushing" (pure `git`, no API):
 
-# Stat summary (insertions/deletions per file)
-git diff main...HEAD --stat
-```
+1. Get the big picture first and state the scope ("N commits, M files") — a scan over an
+   empty diff means "nothing to review", not "clean":
+   ```bash
+   git diff main...HEAD --stat
+   git log main..HEAD --oneline
+   ```
+2. Review file by file — use `read_file` on changed files for full context:
+   `git diff main...HEAD -- src/auth/login.py`
+3. Check for common issues:
+   ```bash
+   # Debug statements, TODOs, console.logs left behind
+   git diff main...HEAD | grep -n "print(\|console\.log\|TODO\|FIXME\|HACK\|XXX\|debugger"
+   # Large files accidentally staged
+   git diff main...HEAD --stat | sort -t'|' -k2 -rn | head -10
+   # Secrets or credential patterns
+   git diff main...HEAD | grep -in "password\|secret\|api_key\|token.*=\|private_key"
+   # Merge conflict markers
+   git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
+   ```
+4. Apply the review checklist (below).
+5. Present findings in the structured format from
+   [references/review-output-template.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/review-output-template.md)
+   (Critical / Warnings / Suggestions / Looks Good). If critical issues are found, offer
+   to fix them before the user pushes.
 
-### Review Strategy
+### B. PR review (end to end)
 
-1. **Get the big picture first:**
+When the user asks to "review PR #N", "look at this PR", or gives a PR URL:
 
-```bash
-git diff main...HEAD --stat
-git log main..HEAD --oneline
-```
+1. **Set up environment** — the Setup block above, or
+   `source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"`.
+2. **Gather PR context** (metadata, changed files, CI state):
+   `gh pr view N`, `gh pr diff N --name-only`, `gh pr checks N`.
+3. **Check out the PR locally** for full access to `read_file`, `search_files`, and the
+   ability to run tests:
+   `git fetch origin pull/N/head:pr-N && git checkout pr-N` (shortcut: `gh pr checkout N`).
+4. **Read the full diff** against the base branch (`git diff main...HEAD`, or file by
+   file for large PRs); for each changed file use `read_file` to see the surrounding
+   context.
+5. **Run automated checks locally** against the checked-out PR code — the project's test
+   suite (`python -m pytest`, `npm test`, `cargo test`, …) and linter (`ruff check .`,
+   `eslint`, `clippy`, …).
+6. **Apply the review checklist** (below).
+7. **Post the review** — `gh pr review N --approve|--request-changes|--comment`, or the
+   atomic multi-comment REST payload in
+   [references/github-rest-api.md](https://github.com/NousResearch/hermes-agent/blob/main/skills/github/github-code-review/references/github-rest-api.md). Inline comments need
+   the PR head SHA as `commit_id`; `line` is the NEW-file line number, and deleted lines
+   use `side: "LEFT"` with the OLD-file line number. Anchors must sit inside a diff
+   hunk — GitHub rejects off-diff lines with HTTP 422. Re-check against
+   `gh pr diff N -- path/to/file`, fall back to a file-level comment
+   (`subject_type: "file"`), or fold the point into the review body.
+8. **Post a top-level summary comment** so the author gets the full picture at a glance —
+   format from `references/review-output-template.md`.
+9. **Clean up:** `git checkout main && git branch -D pr-N`.
 
-2. **Review file by file** — use `read_file` on changed files for full context, and the diff to see what changed:
+**Decision — Approve vs Request Changes vs Comment:**
 
-```bash
-git diff main...HEAD -- src/auth/login.py
-```
+- **Approve** — no critical or warning-level issues; only minor suggestions or all clear.
+- **Request Changes** — any critical or warning-level issue that should be fixed before merge.
+- **Comment** — observations and suggestions, nothing blocking (also use when unsure or
+  the PR is a draft). Comment is the ONLY valid verdict for an empty diff: never Approve
+  or Request Changes when the PR changes 0 files — note the empty diff and its likely
+  causes (already merged, branch reset to base, wrong base branch, commits never pushed)
+  in a top-level comment instead.
 
-3. **Check for common issues:**
-
-```bash
-# Debug statements, TODOs, console.logs left behind
-git diff main...HEAD | grep -n "print(\|console\.log\|TODO\|FIXME\|HACK\|XXX\|debugger"
-
-# Large files accidentally staged
-git diff main...HEAD --stat | sort -t'|' -k2 -rn | head -10
-
-# Secrets or credential patterns
-git diff main...HEAD | grep -in "password\|secret\|api_key\|token.*=\|private_key"
-
-# Merge conflict markers
-git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
-```
-
-4. **Present structured feedback** to the user.
-
-### Review Output Format
-
-When reviewing local changes, present findings in this structure:
-
-```
-## Code Review Summary
-
-### Critical
-- **src/auth.py:45** — SQL injection: user input passed directly to query.
-  Suggestion: Use parameterized queries.
-
-### Warnings
-- **src/models/user.py:23** — Password stored in plaintext. Use bcrypt or argon2.
-- **src/api/routes.py:112** — No rate limiting on login endpoint.
-
-### Suggestions
-- **src/utils/helpers.py:8** — Duplicates logic in `src/core/utils.py:34`. Consolidate.
-- **tests/test_auth.py** — Missing edge case: expired token test.
-
-### Looks Good
-- Clean separation of concerns in the middleware layer
-- Good test coverage for the happy path
-```
-
----
-
-## 2. Reviewing a Pull Request on GitHub
-
-### View PR Details
-
-**With gh:**
-
-```bash
-gh pr view 123
-gh pr diff 123
-gh pr diff 123 --name-only
-```
-
-**With git + curl:**
-
-```bash
-PR_NUMBER=123
-
-# Get PR details
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "
-import sys, json
-pr = json.load(sys.stdin)
-print(f\"Title: {pr['title']}\")
-print(f\"Author: {pr['user']['login']}\")
-print(f\"Branch: {pr['head']['ref']} -> {pr['base']['ref']}\")
-print(f\"State: {pr['state']}\")
-print(f\"Body:\n{pr['body']}\")"
-
-# List changed files
-curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/files \
-  | python3 -c "
-import sys, json
-for f in json.load(sys.stdin):
-    print(f\"{f['status']:10} +{f['additions']:-4} -{f['deletions']:-4}  {f['filename']}\")"
-```
-
-### Check Out PR Locally for Full Review
-
-This works with plain `git` — no `gh` needed:
-
-```bash
-# Fetch the PR branch and check it out
-git fetch origin pull/123/head:pr-123
-git checkout pr-123
-
-# Now you can use read_file, search_files, run tests, etc.
-
-# View diff against the base branch
-git diff main...pr-123
-```
-
-**With gh (shortcut):**
-
-```bash
-gh pr checkout 123
-```
-
-### Leave Comments on a PR
-
-**General PR comment — with gh:**
-
-```bash
-gh pr comment 123 --body "Overall looks good, a few suggestions below."
-```
-
-**General PR comment — with curl:**
-
-```bash
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/issues/$PR_NUMBER/comments \
-  -d '{"body": "Overall looks good, a few suggestions below."}'
-```
-
-### Leave Inline Review Comments
-
-**Single inline comment — with gh (via API):**
-
-```bash
-HEAD_SHA=$(gh pr view 123 --json headRefOid --jq '.headRefOid')
-
-gh api repos/$OWNER/$REPO/pulls/123/comments \
-  --method POST \
-  -f body="This could be simplified with a list comprehension." \
-  -f path="src/auth/login.py" \
-  -f commit_id="$HEAD_SHA" \
-  -f line=45 \
-  -f side="RIGHT"
-```
-
-**Single inline comment — with curl:**
-
-```bash
-# Get the head commit SHA
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments \
-  -d "{
-    \"body\": \"This could be simplified with a list comprehension.\",
-    \"path\": \"src/auth/login.py\",
-    \"commit_id\": \"$HEAD_SHA\",
-    \"line\": 45,
-    \"side\": \"RIGHT\"
-  }"
-```
-
-### Submit a Formal Review (Approve / Request Changes)
-
-**With gh:**
-
-```bash
-gh pr review 123 --approve --body "LGTM!"
-gh pr review 123 --request-changes --body "See inline comments."
-gh pr review 123 --comment --body "Some suggestions, nothing blocking."
-```
-
-**With curl — multi-comment review submitted atomically:**
-
-```bash
-HEAD_SHA=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"COMMENT\",
-    \"body\": \"Code review from Hermes Agent\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"Use parameterized queries to prevent SQL injection.\"},
-      {\"path\": \"src/models/user.py\", \"line\": 23, \"body\": \"Hash passwords with bcrypt before storing.\"},
-      {\"path\": \"tests/test_auth.py\", \"line\": 1, \"body\": \"Add test for expired token edge case.\"}
-    ]
-  }"
-```
-
-Event values: `"APPROVE"`, `"REQUEST_CHANGES"`, `"COMMENT"`
-
-The `line` field refers to the line number in the *new* version of the file. For deleted lines, use `"side": "LEFT"`.
-
----
-
-## 3. Review Checklist
+### Review checklist
 
 When performing a code review (local or PR), systematically check:
 
-### Correctness
-- Does the code do what it claims?
-- Edge cases handled (empty inputs, nulls, large data, concurrent access)?
-- Error paths handled gracefully?
+**Correctness** — does the code do what it claims; edge cases handled (empty inputs,
+nulls, large data, concurrent access); error paths handled gracefully.
 
-### Security
-- No hardcoded secrets, credentials, or API keys
-- Input validation on user-facing inputs
-- No SQL injection, XSS, or path traversal
-- Auth/authz checks where needed
+**Security** — no hardcoded secrets, credentials, or API keys; input validation on
+user-facing inputs; no SQL injection, XSS, or path traversal; auth/authz checks where
+needed.
 
-### Code Quality
-- Clear naming (variables, functions, classes)
-- No unnecessary complexity or premature abstraction
-- DRY — no duplicated logic that should be extracted
-- Functions are focused (single responsibility)
+**Code Quality** — clear naming; no unnecessary complexity or premature abstraction;
+DRY; focused functions (single responsibility).
 
-### Testing
-- New code paths tested?
-- Happy path and error cases covered?
-- Tests readable and maintainable?
+**Testing** — new code paths tested; happy path and error cases covered; tests readable
+and maintainable.
 
-### Performance
-- No N+1 queries or unnecessary loops
-- Appropriate caching where beneficial
-- No blocking operations in async code paths
+**Performance** — no N+1 queries or unnecessary loops; appropriate caching; no blocking
+operations in async code paths.
 
-### Documentation
-- Public APIs documented
-- Non-obvious logic has comments explaining "why"
-- README updated if behavior changed
+**Documentation** — public APIs documented; non-obvious logic has comments explaining
+"why"; README updated if behavior changed.
 
----
+## Pitfalls
 
-## 4. Pre-Push Review Workflow
+- Never Approve code you haven't actually read, and never call a scan over an empty diff
+  "clean" — state the scope so "no findings" is meaningful.
+- Never Approve or Request Changes on an empty diff — a top-level Comment is the only
+  vehicle there.
+- Don't post anything to GitHub without confirmed auth, and never echo token values into
+  outputs or logs.
+- Inline anchors outside a diff hunk fail with HTTP 422 — verify the line against the PR
+  diff first, then fall back (nearest changed line → file-level comment → review body).
+- Run tests against the checked-out PR code, not the user's working tree — and always
+  clean up (`git checkout main`, delete `pr-N` branches) afterward.
+- Use `read_file` for context around every changed hunk; diffs alone miss issues.
 
-When the user asks you to "review the code" or "check before pushing":
+## Verification
 
-1. `git diff main...HEAD --stat` — see scope of changes
-2. `git diff main...HEAD` — read the full diff
-3. For each changed file, use `read_file` if you need more context
-4. Apply the checklist above
-5. Present findings in the structured format (Critical / Warnings / Suggestions / Looks Good)
-6. If critical issues found, offer to fix them before the user pushes
-
----
-
-## 5. PR Review Workflow (End-to-End)
-
-When the user asks you to "review PR #N", "look at this PR", or gives you a PR URL, follow this recipe:
-
-### Step 1: Set up environment
-
-```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
-# Or run the inline setup block from the top of this skill
-```
-
-### Step 2: Gather PR context
-
-Get the PR metadata, description, and list of changed files to understand scope before diving into code.
-
-**With gh:**
-```bash
-gh pr view 123
-gh pr diff 123 --name-only
-gh pr checks 123
-```
-
-**With curl:**
-```bash
-PR_NUMBER=123
-
-# PR details (title, author, description, branch)
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER
-
-# Changed files with line counts
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/files
-```
-
-### Step 3: Check out the PR locally
-
-This gives you full access to `read_file`, `search_files`, and the ability to run tests.
-
-```bash
-git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
-git checkout pr-$PR_NUMBER
-```
-
-### Step 4: Read the diff and understand changes
-
-```bash
-# Full diff against the base branch
-git diff main...HEAD
-
-# Or file-by-file for large PRs
-git diff main...HEAD --name-only
-# Then for each file:
-git diff main...HEAD -- path/to/file.py
-```
-
-For each changed file, use `read_file` to see full context around the changes — diffs alone can miss issues visible only with surrounding code.
-
-### Step 5: Run automated checks locally (if applicable)
-
-```bash
-# Run tests if there's a test suite
-python -m pytest 2>&1 | tail -20
-# or: npm test, cargo test, go test ./..., etc.
-
-# Run linter if configured
-ruff check . 2>&1 | head -30
-# or: eslint, clippy, etc.
-```
-
-### Step 6: Apply the review checklist (Section 3)
-
-Go through each category: Correctness, Security, Code Quality, Testing, Performance, Documentation.
-
-### Step 7: Post the review to GitHub
-
-Collect your findings and submit them as a formal review with inline comments.
-
-**With gh:**
-```bash
-# If no issues — approve
-gh pr review $PR_NUMBER --approve --body "Reviewed by Hermes Agent. Code looks clean — good test coverage, no security concerns."
-
-# If issues found — request changes with inline comments
-gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inline comments."
-```
-
-**With curl — atomic review with multiple inline comments:**
-```bash
-HEAD_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-
-# Build the review JSON — event is APPROVE, REQUEST_CHANGES, or COMMENT
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$GH_OWNER/$GH_REPO/pulls/$PR_NUMBER/reviews \
-  -d "{
-    \"commit_id\": \"$HEAD_SHA\",
-    \"event\": \"REQUEST_CHANGES\",
-    \"body\": \"## Hermes Agent Review\n\nFound 2 issues, 1 suggestion. See inline comments.\",
-    \"comments\": [
-      {\"path\": \"src/auth.py\", \"line\": 45, \"body\": \"🔴 **Critical:** User input passed directly to SQL query — use parameterized queries.\"},
-      {\"path\": \"src/models.py\", \"line\": 23, \"body\": \"⚠️ **Warning:** Password stored without hashing.\"},
-      {\"path\": \"src/utils.py\", \"line\": 8, \"body\": \"💡 **Suggestion:** This duplicates logic in core/utils.py:34.\"}
-    ]
-  }"
-```
-
-### Step 8: Also post a summary comment
-
-In addition to inline comments, leave a top-level summary so the PR author gets the full picture at a glance. Use the review output format from `references/review-output-template.md`.
-
-**With gh:**
-```bash
-gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
-## Code Review Summary
-
-**Verdict: Changes Requested** (2 issues, 1 suggestion)
-
-### 🔴 Critical
-- **src/auth.py:45** — SQL injection vulnerability
-
-### ⚠️ Warnings
-- **src/models.py:23** — Plaintext password storage
-
-### 💡 Suggestions
-- **src/utils.py:8** — Duplicated logic, consider consolidating
-
-### ✅ Looks Good
-- Clean API design
-- Good error handling in the middleware layer
-
----
-*Reviewed by Hermes Agent*
-EOF
-)"
-```
-
-### Step 9: Clean up
-
-```bash
-git checkout main
-git branch -D pr-$PR_NUMBER
-```
-
-### Decision: Approve vs Request Changes vs Comment
-
-- **Approve** — no critical or warning-level issues, only minor suggestions or all clear
-- **Request Changes** — any critical or warning-level issue that should be fixed before merge
-- **Comment** — observations and suggestions, but nothing blocking (use when you're unsure or the PR is a draft)
+Before delivering, confirm:
+- [ ] Scope stated (N commits, M files) and full diff read with surrounding context.
+- [ ] Tests/linter run against the checked-out PR code — or explicitly reported as not run.
+- [ ] Review checklist applied across all six categories.
+- [ ] Every posted item confirmed by the API response (comment or review URL).
+- [ ] Verdict matches the findings — empty diff → Comment only.
+- [ ] Cleanup done: original branch restored, `pr-N` branch deleted.


### PR DESCRIPTION
## What does this PR do?

Restructures the bundled `github-code-review` skill to the modern skill-authoring standard — required section order, ~190-line body, progressive-disclosure `references/` split, and a runtime behavior-contract test — **without changing its operational content**. Supersedes the restructure portion of #69641 per its closing audit.

## What is preserved (per the audit)

- Setup/auth block verbatim — `.env` probed **before** the `git-credential-token.py` helper (#3466 order), `tr -d '\n\r'` sanitization intact, `.env` resolved via `${HERMES_HOME}`.
- `gh pr checks`, `gh pr checkout`, `gh-env.sh`, and the `references/review-output-template.md` reference (including the "Reviewed by Hermes Agent" footer) all retained.
- All posting payloads kept — full `gh` forms plus the REST/`curl` variants — moved to `references/github-rest-api.md` with side/line semantics, the atomic multi-comment review payload, and 401/404/422 triage.

## What changed

- Section order per AGENTS.md: `# GitHub Code Review Skill` → When to Use → Prerequisites → How to Run → Quick Reference → Procedure → Pitfalls → Verification. Body 481 → ~190 lines.
- `## How to Run` / `## Quick Reference` added with native-tool framing (`terminal`, `read_file`, `search_files`).
- Three small operational additions: empty-diff verdict rule (never Approve/Request-Changes on 0 changed files — Comment only), 422 anchor-fallback order, scope-first scan discipline.
- Small fix: the previous §5 curl examples used `$GH_OWNER`/`$GH_REPO`, but the setup block defines `$OWNER`/`$REPO` — the reference file standardizes on the variables the setup block actually sets.
- NEW `tests/skills/test_github_code_review_skill.py`: runtime coverage through the production `tools.skill_manager_tool` gates (frontmatter incl. the 60-char create-path budget, content size, name/category, security scan), bundle-consistency checks, and an install → discovery → load test via `_find_skill`. No source-shape assertions.
- Website docs page regenerated; version 1.1.0 → 1.2.0.

## Related Issue

N/A — supersedes the restructure portion of #69641 per its closing audit.

## Type of Change

- [x] 🎯 Skill update (bundled)

## Changes Made

- `skills/github/github-code-review/SKILL.md` — restructured (481 → ~190 lines)
- `skills/github/github-code-review/references/github-rest-api.md` — NEW: full `gh` + `curl` posting payloads, side/line semantics, failure triage
- `tests/skills/test_github_code_review_skill.py` — NEW: runtime behavior-contract tests
- `website/docs/user-guide/skills/bundled/github/github-github-code-review.md` — regenerated with `website/scripts/generate-skill-docs.py`
- `contributors/emails/` — email→login mapping for the commit author

Note: the zh-Hans skill page (`website/i18n/zh-Hans/.../github-github-code-review.md`) is a translation of the previous English page and will need an i18n refresh once this lands; left untouched per the translation workflow — happy to include it if preferred.

## How to Test

1. `scripts/run_tests.sh tests/skills/ -q` → 242 passed, 0 failed (including the #22722 credential-regex regression test).
2. Behavioral: ask Hermes to "review PR #N and post inline comments" in a repo with an open PR — end-to-end flow unchanged (context → checkout → diff → tests → review → summary → cleanup).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate found
- [x] My PR contains **only** changes related to this restructure
- [x] `scripts/run_tests.sh tests/skills/ -q` — 242 passed, 0 failed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — bundled-skill docs page regenerated from SKILL.md
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — skill content is platform-agnostic; `platforms: [linux, macos, windows]` unchanged
