### PR TITLE
fix(desktop): free session-tab strip reorder + always-visible row kebab

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -2,7 +2,7 @@ import type { PointerEvent as ReactPointerEvent } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { group } from '@/components/pane-shell/tree/model'
-import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { $layoutTree, reorderTreePane } from '@/components/pane-shell/tree/store'
 import { openSessionTile } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
@@ -17,9 +17,20 @@ import { startSessionDrag } from './session-drag'
 
 vi.mock('@/store/session-states', () => ({ openSessionTile: vi.fn() }))
 vi.mock('./composer/focus', () => ({ requestComposerInsertRefs: vi.fn() }))
+vi.mock('@/components/pane-shell/tree/store', async () => {
+  const actual = await vi.importActual<typeof import('@/components/pane-shell/tree/store')>(
+    '@/components/pane-shell/tree/store'
+  )
+
+  return {
+    ...actual,
+    reorderTreePane: vi.fn(actual.reorderTreePane)
+  }
+})
 
 const ZONE = { left: 0, top: 0, right: 1000, bottom: 800 }
 const COMPOSER = { left: 100, top: 700, right: 900, bottom: 780 }
+const STRIP = { left: 0, top: 0, right: 1000, bottom: 40 }
 
 const stubRect = (el: Element, box: { left: number; top: number; right: number; bottom: number }) => {
   el.getBoundingClientRect = () =>
@@ -109,5 +120,93 @@ describe('session drop targeting across stacked tabs', () => {
 
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
+  })
+})
+
+describe('session tab strip reorder', () => {
+  it('reorders an existing tab via reorderTreePane instead of openSessionTile', () => {
+    document.body.innerHTML = `
+      <div data-tree-group="g1">
+        <div data-zone-tabstrip="g1" id="strip">
+          <div data-tree-tab="workspace" id="tab-ws"></div>
+          <div data-tree-tab="session-tile:a" id="tab-a"></div>
+          <div data-tree-tab="session-tile:b" id="tab-b"></div>
+        </div>
+        <div data-session-anchor="workspace" data-composer-target="main">
+          <div data-slot="composer-root"></div>
+        </div>
+      </div>
+    `
+
+    stubRect(document.querySelector('[data-tree-group]')!, ZONE)
+    stubRect(document.getElementById('strip')!, STRIP)
+    // Three equal tabs across the strip: mids at 100 / 300 / 500
+    stubRect(document.getElementById('tab-ws')!, { left: 0, top: 0, right: 200, bottom: 40 })
+    stubRect(document.getElementById('tab-a')!, { left: 200, top: 0, right: 400, bottom: 40 })
+    stubRect(document.getElementById('tab-b')!, { left: 400, top: 0, right: 600, bottom: 40 })
+    stubRect(document.querySelector('[data-session-anchor]')!, ZONE)
+    stubRect(document.querySelector('[data-slot="composer-root"]')!, COMPOSER)
+
+    $layoutTree.set(group(['workspace', 'session-tile:a', 'session-tile:b'], { id: 'g1' }))
+
+    const tabA = document.getElementById('tab-a')!
+    // Drag tab A to the left of workspace (x=50 → before workspace)
+    startSessionDrag(
+      { id: 'a', profile: 'default', title: 'A' },
+      {
+        button: 0,
+        clientX: 300,
+        clientY: 20,
+        currentTarget: tabA,
+        pointerId: 1
+      } as unknown as ReactPointerEvent<HTMLElement>
+    )
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 50, clientY: 20 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 50, clientY: 20 }))
+
+    expect(openSessionTile).not.toHaveBeenCalled()
+    expect(reorderTreePane).toHaveBeenCalledWith('g1', 'session-tile:a', 0)
+  })
+
+  it('reorders the workspace/main tab (selected session) instead of no-op openSessionTile', () => {
+    document.body.innerHTML = `
+      <div data-tree-group="g1">
+        <div data-zone-tabstrip="g1" id="strip">
+          <div data-tree-tab="workspace" id="tab-ws"></div>
+          <div data-tree-tab="session-tile:b" id="tab-b"></div>
+        </div>
+        <div data-session-anchor="workspace" data-composer-target="main">
+          <div data-slot="composer-root"></div>
+        </div>
+      </div>
+    `
+
+    stubRect(document.querySelector('[data-tree-group]')!, ZONE)
+    stubRect(document.getElementById('strip')!, STRIP)
+    stubRect(document.getElementById('tab-ws')!, { left: 0, top: 0, right: 200, bottom: 40 })
+    stubRect(document.getElementById('tab-b')!, { left: 200, top: 0, right: 400, bottom: 40 })
+    stubRect(document.querySelector('[data-session-anchor]')!, ZONE)
+    stubRect(document.querySelector('[data-slot="composer-root"]')!, COMPOSER)
+
+    $layoutTree.set(group(['workspace', 'session-tile:b'], { id: 'g1' }))
+
+    const tabWs = document.getElementById('tab-ws')!
+    // Drag workspace past B (x=350 → append)
+    startSessionDrag(
+      { id: 'main-session', profile: 'default', title: 'Main' },
+      {
+        button: 0,
+        clientX: 100,
+        clientY: 20,
+        currentTarget: tabWs,
+        pointerId: 1
+      } as unknown as ReactPointerEvent<HTMLElement>
+    )
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 350, clientY: 20 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 350, clientY: 20 }))
+
+    // openSessionTile would early-return for the selected main session — reorder must win.
+    expect(openSessionTile).not.toHaveBeenCalled()
+    expect(reorderTreePane).toHaveBeenCalledWith('g1', 'workspace', 1)
   })
 })

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { group } from '@/components/pane-shell/tree/model'
 import { $layoutTree, reorderTreePane } from '@/components/pane-shell/tree/store'
+import type * as TreeStoreModule from '@/components/pane-shell/tree/store'
 import { openSessionTile } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
@@ -17,10 +18,8 @@ import { startSessionDrag } from './session-drag'
 
 vi.mock('@/store/session-states', () => ({ openSessionTile: vi.fn() }))
 vi.mock('./composer/focus', () => ({ requestComposerInsertRefs: vi.fn() }))
-vi.mock('@/components/pane-shell/tree/store', async () => {
-  const actual = await vi.importActual<typeof import('@/components/pane-shell/tree/store')>(
-    '@/components/pane-shell/tree/store'
-  )
+vi.mock('@/components/pane-shell/tree/store', async importActual => {
+  const actual = await importActual<typeof TreeStoreModule>()
 
   return {
     ...actual,

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -28,7 +28,7 @@
 import type { PointerEvent as ReactPointerEvent } from 'react'
 
 import { queryAllVisible } from '@/components/pane-shell/pane-visibility'
-import { findGroup } from '@/components/pane-shell/tree/model'
+import { findGroup, findGroupOfPane } from '@/components/pane-shell/tree/model'
 import {
   type DoubleTapContext,
   rectContains,
@@ -44,6 +44,7 @@ import {
   $treeDragging,
   type DropHint,
   isSessionStripPane,
+  reorderTreePane,
   revealTreePane,
   SESSION_TILE_DRAG
 } from '@/components/pane-shell/tree/store'
@@ -89,12 +90,21 @@ function chatZonePane(groupId: string): null | string {
 }
 
 /**
- * Begin dragging a session — a sidebar row OR a tile's own tab (same drop
+ * Begin dragging a session — a sidebar row OR a tile/workspace tab (same drop
  * language either way: stack, split, or composer link). Sub-threshold releases
  * stay ordinary clicks, so `opts.onTap` (activate the tile) and `opts.double`
- * (hide the tab bar) ride the tab's gestures; Esc aborts instantly. A stack/
- * split commits through `openSessionTile`, which OPENS a new tile from a sidebar
- * row and MOVES the existing one when its tab is the drag source.
+ * (hide the tab bar) ride the tab's gestures; Esc aborts instantly.
+ *
+ * Drop commits:
+ *   - **In-strip reorder** when the drag source is already a tab in that strip
+ *     (workspace or `session-tile:*`) → `reorderTreePane` (browser-tab order).
+ *     Session-tab chrome hijacks pointerdown via this resolver, so without this
+ *     path the generic pane reorder never runs and history tabs only "dock" to
+ *     limited targets (or the main tab no-ops via openSessionTile's selected
+ *     early-return).
+ *   - **Stack / split** from a sidebar row (or a tab torn onto another zone)
+ *     → `openSessionTile`.
+ *   - **Composer center** → `@session` link chip.
  */
 export function startSessionDrag(
   payload: SessionDragPayload,
@@ -111,13 +121,20 @@ export function startSessionDrag(
   // move before commit, so these always match the released-at position).
   let split: { anchor: string; before?: null | string; pos: TileDock } | null = null
   let link: null | string = null
+  let reorder: { groupId: string; paneId: string; before: null | string } | null = null
 
   // The drag SOURCE (sidebar row or tile tab). Captured synchronously — React
   // clears `currentTarget` after the pointerdown handler returns, but this runs
   // inside it. Dimmed while lifted so the source reads as "picked up" — the
   // same in-place feedback pane-tab drags use, replacing the old cursor chip.
-  const source = e.currentTarget
+  const source = e.currentTarget as HTMLElement | null
   const restoreOpacity = source?.style.opacity ?? ''
+  // Tab chrome sets data-tree-tab on the PaneTab (or an ancestor). Sidebar rows
+  // have none — they only stack/open, never strip-reorder.
+  const sourcePaneId =
+    source?.closest?.('[data-tree-tab]')?.getAttribute('data-tree-tab') ||
+    source?.getAttribute?.('data-tree-tab') ||
+    null
 
   startDragSession(e, {
     double: opts?.double,
@@ -149,6 +166,7 @@ export function startSessionDrag(
       if (!zone || !host) {
         split = null
         link = null
+        reorder = null
 
         return null
       }
@@ -157,14 +175,28 @@ export function startSessionDrag(
       const strip = strips.find(s => s.groupId === zone.id && rectContains(s.rect, x, y))
 
       if (strip) {
-        // Exclude the tile's OWN tab from the slots so re-dropping it in its
-        // home strip reorders cleanly (a no-op for a sidebar-row drag).
-        const stack = slotBefore(strip.slots, x, `session-tile:${payload.id}`)
-        split = { anchor: host, before: stack.before, pos: 'center' }
-        link = null
+        // Prefer the real tab pane id (workspace OR session-tile:…) so the
+        // main tab is excluded from slot geometry the same way tiles are.
+        const excludeId = sourcePaneId ?? `session-tile:${payload.id}`
+        const stack = slotBefore(strip.slots, x, excludeId)
+        const tree = $layoutTree.get()
+        const home = sourcePaneId && tree ? findGroupOfPane(tree, sourcePaneId) : null
+
+        // Already a tab in this strip → browser-style reorder (not openSessionTile).
+        if (sourcePaneId && home?.id === strip.groupId) {
+          reorder = { groupId: strip.groupId, paneId: sourcePaneId, before: stack.before }
+          split = null
+          link = null
+        } else {
+          reorder = null
+          split = { anchor: host, before: stack.before, pos: 'center' }
+          link = null
+        }
 
         return { kind: 'group', groupId: zone.id, groupIds: [zone.id], pos: 'center', stack }
       }
+
+      reorder = null
 
       // The composer (and everything in it) is always the link/attach drop;
       // elsewhere the shared radial targeting decides center vs edge.
@@ -183,6 +215,19 @@ export function startSessionDrag(
     },
 
     onCommit() {
+      if (reorder) {
+        const tree = $layoutTree.get()
+        const panes = tree ? (findGroup(tree, reorder.groupId)?.panes ?? []) : []
+        const others = panes.filter(id => id !== reorder.paneId)
+        const toIndex = reorder.before ? others.indexOf(reorder.before) : others.length
+
+        if (toIndex >= 0) {
+          reorderTreePane(reorder.groupId, reorder.paneId, toIndex)
+        }
+
+        return
+      }
+
       if (split) {
         openSessionTile(payload.id, split.pos, split.anchor, split.before)
         // A tile for this session may already exist (openSessionTile is

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -215,14 +215,17 @@ export function startSessionDrag(
     },
 
     onCommit() {
-      if (reorder) {
+      // Capture for TS control-flow narrowing: callbacks (filter) would
+      // otherwise see `reorder` as still possibly null (TS18047).
+      const activeReorder = reorder
+      if (activeReorder) {
         const tree = $layoutTree.get()
-        const panes = tree ? (findGroup(tree, reorder.groupId)?.panes ?? []) : []
-        const others = panes.filter(id => id !== reorder.paneId)
-        const toIndex = reorder.before ? others.indexOf(reorder.before) : others.length
+        const panes = tree ? (findGroup(tree, activeReorder.groupId)?.panes ?? []) : []
+        const others = panes.filter(id => id !== activeReorder.paneId)
+        const toIndex = activeReorder.before ? others.indexOf(activeReorder.before) : others.length
 
         if (toIndex >= 0) {
-          reorderTreePane(reorder.groupId, reorder.paneId, toIndex)
+          reorderTreePane(activeReorder.groupId, activeReorder.paneId, toIndex)
         }
 
         return

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -121,7 +121,10 @@ function SidebarSessionRowImpl({
             >
               <Button
                 aria-label={r.sessionActions}
-                className="size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
+                // Always paint the kebab (not hover-only transparent): unpinned
+                // recents rows were easy to miss — users reported "no ⋯ options"
+                // when the control never registered as present until hover.
+                className="size-5 rounded-[4px] bg-transparent text-(--ui-text-quaternary) transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
                 size="icon"
                 variant="ghost"
               >


### PR DESCRIPTION
## Summary
- Session tabs reorder via `reorderTreePane` inside the strip (no dead drag).
- Sidebar non-pinned row ⋯ (kebab) stays visible by default for discoverability.

## Test plan
- [ ] Vitest: `session-drag.test.ts`
- [ ] Manual: drag tabs within strip; order persists
- [ ] Manual: non-pinned sidebar row shows ⋯ without hover-only trap

## Origin
Local patch ledger `session-tab-strip-reorder` (commit 9ef9cc955).