### PR TITLE
fix(agent): wire reasoning_effort for alibaba-coding-plan provider

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1252,6 +1252,10 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         or base_url_host_matches(agent.base_url, "moonshot.ai")
         or base_url_host_matches(agent.base_url, "moonshot.cn")
     )
+    _is_alibaba_coding = (
+        agent.provider == "alibaba-coding-plan"
+        or base_url_host_matches(agent._base_url_lower, "coding-intl.dashscope.aliyuncs.com")
+    )
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
@@ -1368,6 +1372,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         is_github_models=_is_gh,
         is_nvidia_nim=_is_nvidia,
         is_kimi=_is_kimi,
+        is_alibaba_coding=_is_alibaba_coding,
         is_tokenhub=_is_tokenhub,
         is_lmstudio=_is_lmstudio,
         is_custom_provider=agent.provider == "custom",

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -380,6 +380,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_kimi = params.get("is_kimi", False)
         is_tokenhub = params.get("is_tokenhub", False)
+        is_alibaba_coding = params.get("is_alibaba_coding", False)
         reasoning_config = _reasoning_config_for_model(model, params.get("reasoning_config"))
 
         if ephemeral is not None and max_tokens_fn:
@@ -418,6 +419,21 @@ class ChatCompletionsTransport(ProviderTransport):
                     if _e in {"low", "medium", "high"}:
                         _tokenhub_effort = _e
                 api_kwargs["reasoning_effort"] = _tokenhub_effort
+
+        # Alibaba Coding Plan: top-level reasoning_effort (unless thinking disabled)
+        if is_alibaba_coding:
+            _ali_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _ali_thinking_off:
+                _ali_effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in {"low", "medium", "high", "xhigh"}:
+                        _ali_effort = _e
+                api_kwargs["reasoning_effort"] = _ali_effort
 
         # LM Studio: top-level reasoning_effort. Only emit when the model
         # declares reasoning support via /api/v1/models capabilities (gated


### PR DESCRIPTION
## Bug

The alibaba-coding-plan provider was never wired into the reasoning_effort dispatch. `agent.reasoning_effort` in config.yaml and `/reasoning` in chat were silently dropped — the outgoing request always omitted the field and the endpoint defaulted to xhigh.

## Fix

Add `is_alibaba_coding` detection in `chat_completion_helpers.py` and forward `reasoning_effort` (xhigh/medium/low) in `chat_completions.py` transport layer, matching the same pattern kimi and tokenhub already use.