### PR TITLE
fix(gateway): bound SQLite file descriptor usage

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6029,7 +6029,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._session_db = None
         try:
             from hermes_state import AsyncSessionDB, SessionDB
-            self._session_db = AsyncSessionDB(SessionDB())
+            # SessionStore already opens the process-wide gateway SessionDB.
+            # Reuse it so the WAL per-thread reader pool (and its file
+            # descriptors) is not duplicated across two long-lived instances.
+            _sync_session_db = getattr(self.session_store, "_db", None)
+            if _sync_session_db is None:
+                _sync_session_db = SessionDB()
+                self.session_store._db = _sync_session_db
+            self._session_db = AsyncSessionDB(_sync_session_db)
         except Exception as e:
             # WARNING (not DEBUG) so the failure appears in errors.log — matches
             # cli.py's handling of the same init path.  Users hitting NFS-mounted
@@ -12935,9 +12942,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # unwrap to the sync handle. ``session_store`` holds it at ``_db``.
             _self_db = getattr(self, "_session_db", None)
             _self_db = getattr(_self_db, "_db", _self_db)
+            _closed_db_ids = set()
             for _db in (_self_db, getattr(getattr(self, "session_store", None), "_db", None)):
                 if _db is None or not hasattr(_db, "close"):
                     continue
+                if id(_db) in _closed_db_ids:
+                    continue
+                _closed_db_ids.add(id(_db))
                 try:
                     _db.close()
                 except Exception as _e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1914,6 +1914,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _FTS_MERGE_EVERY_N_WRITES = 1000
     _FTS_MERGE_MAX_PAGES_PER_INDEX = 500
     _FTS_MERGE_COMMANDS_PER_PASS = 4
+    # WAL reads use one read-only connection per worker thread. Long-lived
+    # gateways have both a dedicated agent executor and asyncio's default
+    # executor, and short-lived helper threads may also touch the shared DB.
+    # Keeping every thread's connection alive until process shutdown can
+    # otherwise consume the common launchd soft limit of 256 descriptors.
+    # Once this budget is full, additional threads use the existing locked
+    # writer-connection fallback rather than opening another descriptor pair.
+    _MAX_READ_CONNECTIONS = 16
     # Session imports intentionally use a lower cap than exports: import holds
     # one BEGIN IMMEDIATE transaction, so bounded batches avoid starving live
     # gateway/CLI writers. The dashboard accepts one exported JSON/JSONL file
@@ -2222,11 +2230,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return conn
         if getattr(self._read_local, "failed", False):
             return None
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                self._read_local.failed = True
+                return None
+            if len(self._read_conns) >= self._MAX_READ_CONNECTIONS:
+                self._read_local.failed = True
+                return None
         try:
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )
@@ -2242,6 +2258,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if self._read_conns_closed:
                     # close() already drained — don't register; close
                     # immediately so no tracked fd leaks.
+                    conn.close()
+                    self._read_local.failed = True
+                    return None
+                if len(self._read_conns) >= self._MAX_READ_CONNECTIONS:
+                    # Another thread filled the final slot while this
+                    # connection was opening. Close deterministically and use
+                    # the locked writer fallback for this thread.
                     conn.close()
                     self._read_local.failed = True
                     return None

--- a/tests/gateway/test_runner_session_db_fd_budget.py
+++ b/tests/gateway/test_runner_session_db_fd_budget.py
@@ -1,0 +1,23 @@
+"""Regression coverage for the gateway's long-lived SQLite FD budget."""
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+
+
+def test_gateway_runner_reuses_session_store_database(monkeypatch, tmp_path):
+    """One runner must own one SessionDB, not one per gateway subsystem."""
+    import hermes_state
+
+    created = []
+
+    class FakeSessionDB:
+        def __init__(self, *args, **kwargs):
+            created.append(self)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeSessionDB)
+
+    runner = GatewayRunner(GatewayConfig(sessions_dir=tmp_path / "sessions"))
+
+    assert len(created) == 1
+    assert runner._session_db is not None
+    assert runner._session_db._db is runner.session_store._db

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -44,6 +44,57 @@ def test_read_conn_reused_within_thread(db):
 
 
 @pytest.mark.requires_wal
+def test_read_conn_pool_is_bounded_for_short_lived_threads(db, monkeypatch):
+    """Dead reader threads must not consume descriptors without a hard bound."""
+    monkeypatch.setattr(db, "_MAX_READ_CONNECTIONS", 2)
+    barrier = threading.Barrier(4)
+    conns = {}
+    fallback_reads = {}
+
+    def grab(key):
+        barrier.wait()
+        conn = db._get_read_conn()
+        conns[key] = conn
+        if conn is None:
+            fallback_reads[key] = db.get_session("s1")
+
+    threads = [threading.Thread(target=grab, args=(key,)) for key in range(3)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=5.0)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert sum(conn is not None for conn in conns.values()) == 2
+    assert len(db._read_conns) == 2
+    assert len(fallback_reads) == 1
+    assert next(iter(fallback_reads.values()))["id"] == "s1"
+
+
+@pytest.mark.requires_wal
+def test_close_releases_read_connections_created_by_worker_threads(tmp_path):
+    """The owner thread must be able to close every worker-owned reader."""
+    from hermes_cli.sqlite_safe_read import has_live_connection
+
+    db_path = tmp_path / "cross-thread-close.db"
+    worker_db = SessionDB(db_path=db_path)
+    worker_db.create_session(session_id="s1", source="cli", model="m")
+
+    thread = threading.Thread(target=lambda: worker_db.get_session("s1"))
+    thread.start()
+    thread.join(timeout=5.0)
+
+    assert not thread.is_alive()
+    assert len(worker_db._read_conns) == 1
+    assert has_live_connection(db_path)
+
+    worker_db.close()
+
+    assert not has_live_connection(db_path)
+
+
+@pytest.mark.requires_wal
 def test_reads_do_not_take_writer_lock(db):
     """Reads must complete while another thread holds self._lock."""
     acquired = db._lock.acquire()


### PR DESCRIPTION
## Summary
- reuse the gateway `SessionStore`'s existing `SessionDB` instead of creating a second long-lived instance
- cap per-thread WAL reader connections at 16 and fall back to the locked writer connection after the cap
- make worker-created read connections cross-thread closable so `SessionDB.close()` actually releases their descriptors
- de-duplicate `SessionDB` shutdown when the runner and store share one instance

## Reproduction
A long-lived macOS gateway with launchd's soft `RLIMIT_NOFILE=256` reached 252 numeric descriptors. 145 were `state.db` / WAL descriptors. `GatewayRunner` created two `SessionDB` instances, and each retained one WAL reader connection per worker thread. In addition, readers were opened with SQLite's default `check_same_thread=True`, so the owner-thread close loop raised `ProgrammingError` and silently left worker-created descriptors open.

## Verification
- `scripts/run_tests.sh tests/test_hermes_state.py tests/test_session_db_read_path_split.py tests/gateway/test_session.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_runner_session_db_fd_budget.py -q`
- 257 tests passed on current `main`
- 100 short-lived reader-thread stress: 16 tracked readers at peak; process FD count returned from 39 to 4 after `SessionDB.close()`
- local launchd gateway after hotfix restart: 39 numeric FDs / 6 `state.db` FDs, stable for 60 seconds; Slack auth remained healthy
