### PR TITLE
fix(security): enforce 0600 on snapshot copies of secret files (#77470)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -124,8 +124,41 @@ _IMPORT_SKIP_NAMES = {
     "processes.json",
 }
 
+# Files that must never be readable by group/other, wherever they are written.
 # zipfile.open() drops Unix mode bits on extract; restore tightens these to 0600.
+# Quick snapshots need the same treatment for the opposite reason: shutil.copy2
+# PRESERVES the source mode and sqlite3's backup() creates the destination with
+# 0666 & ~umask, so without an explicit chmod the copy's protection is inherited
+# (or invented by umask) rather than enforced.
 _SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+
+# Owner-only mode for snapshot copies of _SECRET_FILE_NAMES and the directories
+# that hold them. Directories additionally need the execute bit to be traversable
+# by their owner.
+_SECRET_FILE_MODE = 0o600
+_SECRET_DIR_MODE = 0o700
+
+
+def _harden_secret_copy(path: Path) -> None:
+    """chmod *path* to 0600 when it is a copy of a known secret-bearing file.
+
+    Best-effort: mode bits are not enforced on Windows and the copy may live on
+    a filesystem that rejects chmod, neither of which should fail a snapshot.
+    """
+    if path.name not in _SECRET_FILE_NAMES:
+        return
+    try:
+        os.chmod(path, _SECRET_FILE_MODE)
+    except (OSError, NotImplementedError):
+        logger.debug("Could not tighten permissions on %s", path, exc_info=True)
+
+
+def _harden_secret_dir(path: Path) -> None:
+    """chmod *path* to 0700. Best-effort, same rationale as _harden_secret_copy."""
+    try:
+        os.chmod(path, _SECRET_DIR_MODE)
+    except (OSError, NotImplementedError):
+        logger.debug("Could not tighten permissions on %s", path, exc_info=True)
 
 # Reserved archive subtree for provider state that lives OUTSIDE HERMES_HOME
 # (e.g. ~/.honcho, ~/.hindsight). The active memory provider declares these via
@@ -1204,6 +1237,12 @@ def _create_quick_snapshot_locked(
     staging_dir = root / f".{snap_id}.{os.getpid()}.partial"
     shutil.rmtree(staging_dir, ignore_errors=True)
     staging_dir.mkdir(parents=True, exist_ok=False)
+    # Snapshots hold copies of .env / auth.json / state.db. Tighten the staging
+    # directory before anything is written into it, and the shared root, so a
+    # snapshot is never exposed by a traversable parent. os.replace() below
+    # preserves the staging directory's mode for the final snapshot dir.
+    _harden_secret_dir(staging_dir)
+    _harden_secret_dir(root)
     logger.info("quick snapshot phase=copy status=started id=%s", snap_id)
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
@@ -1257,6 +1296,7 @@ def _create_quick_snapshot_locked(
                             continue
                     else:
                         shutil.copy2(sub, dst)
+                    _harden_secret_copy(dst)
                     manifest[sub_rel] = dst.stat().st_size
                 except (OSError, PermissionError) as exc:
                     logger.warning("Could not snapshot %s: %s", sub_rel, exc)
@@ -1289,6 +1329,7 @@ def _create_quick_snapshot_locked(
                     continue
             else:
                 shutil.copy2(src, dst)
+            _harden_secret_copy(dst)
             manifest[rel] = dst.stat().st_size
         except (OSError, PermissionError) as exc:
             logger.warning("Could not snapshot %s: %s", rel, exc)
@@ -1461,10 +1502,21 @@ def restore_quick_snapshot(
                 # Atomic-ish replace for databases
                 tmp = dst.parent / f".{dst.name}.snap_restore"
                 shutil.copy2(src, tmp)
+                # Harden the staged file before publishing it, so the live path
+                # is never briefly readable by group/other. The temp name is not
+                # a secret name, so chmod against the FINAL name.
+                if dst.name in _SECRET_FILE_NAMES:
+                    try:
+                        os.chmod(tmp, _SECRET_FILE_MODE)
+                    except (OSError, NotImplementedError):
+                        logger.debug(
+                            "Could not tighten permissions on %s", tmp, exc_info=True
+                        )
                 dst.unlink(missing_ok=True)
                 shutil.move(str(tmp), str(dst))
             else:
                 shutil.copy2(src, dst)
+                _harden_secret_copy(dst)
             restored += 1
         except (OSError, PermissionError) as exc:
             logger.error("Failed to restore %s: %s", rel, exc)

--- a/tests/hermes_cli/test_backup_snapshot_permissions.py
+++ b/tests/hermes_cli/test_backup_snapshot_permissions.py
@@ -1,0 +1,156 @@
+"""Contract tests for quick-snapshot secret file permissions (#77470).
+
+These assert a RELATION — "a secret-named file inside a snapshot is never
+readable by group or other, whatever the source mode was" — rather than
+freezing an exact mode literal for every file. Non-secret entries are
+asserted to keep their source mode so the hardening cannot silently become
+a blanket chmod.
+"""
+
+import os
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX file permission bits only"
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Run with umask 0 so a passing test proves an explicit chmod.
+
+    With a masking umask the snapshot can look hardened purely by accident of
+    process state; clearing it removes that false negative.
+    """
+    old = os.umask(0)
+    try:
+        yield
+    finally:
+        os.umask(old)
+
+
+def _make_home(tmp_path: Path, secret_mode: int) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text("OPENROUTER_API_KEY=test-key-123\n")
+    (home / "auth.json").write_text('{"providers": {"nous": "token"}}\n')
+    (home / "config.yaml").write_text("model:\n  provider: openrouter\n")
+
+    conn = sqlite3.connect(str(home / "state.db"))
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, data TEXT)")
+    conn.execute("INSERT INTO sessions VALUES ('s1', 'hello world')")
+    conn.commit()
+    conn.close()
+
+    for name in (".env", "auth.json", "state.db"):
+        os.chmod(home / name, secret_mode)
+    os.chmod(home / "config.yaml", 0o644)
+    return home
+
+
+class TestQuickSnapshotSecretPermissions:
+    """#77470: snapshot copies must ENFORCE 0600, not inherit the source mode."""
+
+    @pytest.mark.parametrize("source_mode", [0o600, 0o644, 0o664, 0o666])
+    @pytest.mark.parametrize("secret_name", [".env", "auth.json", "state.db"])
+    def test_secret_copy_never_group_or_world_accessible(
+        self, tmp_path, permissive_umask, source_mode, secret_name
+    ):
+        from hermes_cli.backup import create_quick_snapshot
+
+        home = _make_home(tmp_path, source_mode)
+        snap_id = create_quick_snapshot(label="perm", hermes_home=home)
+        assert snap_id is not None
+
+        copy = home / "state-snapshots" / snap_id / secret_name
+        assert copy.exists(), f"{secret_name} missing from snapshot"
+
+        mode = _mode(copy)
+        assert not (mode & 0o077), (
+            f"{secret_name} snapshotted from a {source_mode:04o} source landed at "
+            f"{mode:04o} — readable by group/other"
+        )
+
+    @pytest.mark.parametrize("source_mode", [0o600, 0o644])
+    def test_non_secret_files_keep_their_source_mode(
+        self, tmp_path, permissive_umask, source_mode
+    ):
+        """The hardening must be scoped to secrets, not a blanket chmod."""
+        from hermes_cli.backup import create_quick_snapshot
+
+        home = _make_home(tmp_path, source_mode)
+        snap_id = create_quick_snapshot(label="perm", hermes_home=home)
+        snap_dir = home / "state-snapshots" / snap_id
+
+        assert _mode(snap_dir / "config.yaml") == _mode(home / "config.yaml")
+
+    def test_snapshot_directories_not_group_or_world_accessible(
+        self, tmp_path, permissive_umask
+    ):
+        """A hardened file under a traversable dir is still a listing leak."""
+        from hermes_cli.backup import create_quick_snapshot
+
+        home = _make_home(tmp_path, 0o600)
+        snap_id = create_quick_snapshot(label="perm", hermes_home=home)
+
+        root = home / "state-snapshots"
+        for directory in (root, root / snap_id):
+            mode = _mode(directory)
+            assert not (mode & 0o077), (
+                f"{directory.name}/ is {mode:04o} — traversable by group/other"
+            )
+
+    def test_hardening_does_not_break_restore(self, tmp_path, permissive_umask):
+        """False-positive guard: the snapshot must still be usable."""
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        home = _make_home(tmp_path, 0o644)
+        snap_id = create_quick_snapshot(label="perm", hermes_home=home)
+
+        (home / ".env").write_text("CLOBBERED\n")
+        (home / "state.db").unlink()
+
+        assert restore_quick_snapshot(snap_id, hermes_home=home) is True
+        assert (home / ".env").read_text() == "OPENROUTER_API_KEY=test-key-123\n"
+
+        conn = sqlite3.connect(str(home / "state.db"))
+        rows = conn.execute("SELECT * FROM sessions").fetchall()
+        conn.close()
+        assert rows == [("s1", "hello world")]
+
+    @pytest.mark.parametrize("secret_name", [".env", "auth.json", "state.db"])
+    def test_restore_does_not_loosen_live_secrets(
+        self, tmp_path, permissive_umask, secret_name
+    ):
+        """Restoring a legacy loose snapshot must not downgrade live secrets.
+
+        The zip-import path already chmods 0600 after extract; the quick-snapshot
+        restore path is the same contract.
+        """
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        home = _make_home(tmp_path, 0o644)
+        snap_id = create_quick_snapshot(label="perm", hermes_home=home)
+
+        # Simulate a snapshot written by an older, unhardened build.
+        snap_dir = home / "state-snapshots" / snap_id
+        for name in (".env", "auth.json", "state.db"):
+            os.chmod(snap_dir / name, 0o644)
+
+        for name in (".env", "auth.json", "state.db"):
+            os.chmod(home / name, 0o600)
+
+        assert restore_quick_snapshot(snap_id, hermes_home=home) is True
+
+        mode = _mode(home / secret_name)
+        assert not (mode & 0o077), (
+            f"restore left live {secret_name} at {mode:04o} — readable by group/other"
+        )


### PR DESCRIPTION
## Problem

Quick state snapshots **inherit** file modes instead of **enforcing** them, while
the zip-restore path in the same file already enforces `0600`.

`hermes_cli/backup.py` defines

```python
_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
```

and chmods those to `0600` after a zip extract (`backup.py`, restore path),
because `zipfile.open()` drops Unix mode bits. The codebase therefore already
treats these three files as "must end up owner-only". The **snapshot writer
never got the same treatment.**

To be precise about what is and is not wrong here: with a `0600` source, the
`.env` and `auth.json` snapshot copies are also `0600`. "World-readable
secrets" is not an accurate description of the default case. The defect is
that the protection is *inherited from the source*, or *invented by the
caller's umask*, rather than enforced by the code.

### Two distinct mechanisms

Measured on `be54f28b1` against a temp `HERMES_HOME` with synthetic canary
secrets.

**1. `shutil.copy2` preserves the source mode.** A user whose `.env` is `0644`
— common after editing over a network share, restoring from a tarball, or
writing it from a script with a permissive umask — gets a second
group/world-readable copy per snapshot, multiplied by retention (default
`keep=20`).

**2. `state.db` is worse: the source mode is discarded entirely.**
`_safe_copy_db` creates the destination via `sqlite3.connect()`, which makes a
fresh file at `0666 & ~umask`. So a `0600` source produced a `0644` snapshot
copy under the common `umask 022` — a **downgrade**, not merely inheritance.

Snapshot mode as a function of source mode and ambient umask, before the fix:

| umask | source secret mode | `.env` | `auth.json` | `state.db` | `config.yaml` |
|---|---|---|---|---|---|
| 022 | 0600 | 0600 | 0600 | **0644** | 0644 |
| 022 | 0644 | **0644** | **0644** | **0644** | 0644 |
| 077 | 0600 | 0600 | 0600 | 0600 | 0644 |
| 077 | 0644 | **0644** | **0644** | 0600 | 0644 |
| 002 | 0600 | 0600 | 0600 | **0644** | 0644 |
| 002 | 0644 | **0644** | **0644** | **0644** | 0644 |

Note rows 1 and 3: the *same* `0600` source yields `0644` or `0600` purely
depending on the caller's umask. Protection was decided by ambient process
state rather than by the code.

Containing directories were `0755` (`state-snapshots/` and each timestamped
child), so a loose copy inside them is genuinely reachable whenever
`HERMES_HOME` itself is not owner-only — managed mode sets `0750`, and
`HERMES_HOME_MODE` exists specifically to widen it so a web server can
traverse.

## Fix

Reuses the existing `_SECRET_FILE_NAMES` constant rather than introducing a
second list.

- `_harden_secret_copy()` chmods `0600` after each snapshot write, applied at
  **both** write sites (top-level entries and directory-walked entries).
- `restore_quick_snapshot()` applies the same `0600` contract the zip-import
  path already applies, so restoring a snapshot written by an older build
  cannot downgrade a live `0600` secret back to `0644`. The `.db` branch
  chmods the staged temp file *before* publishing it, so the live path is
  never briefly loose.
- Snapshot directories are tightened to `0700`.

**The directory change is a deliberate change of semantics and I want to flag
it rather than slip it in.** `state-snapshots/` and each timestamped child
were `0755`. The argument for `0700`: the directory's entire purpose is to
hold copies of the three secret files, hardening the files alone still leaks
snapshot *names* and timestamps via listing, and `HERMES_HOME` is already
`0700` by default so this matches the surrounding convention rather than
introducing a new one. The argument against: a deployment that sets
`HERMES_HOME_MODE` to allow a service user to traverse into `HERMES_HOME`
would no longer be able to traverse into `state-snapshots/`. I judged that
acceptable because such a service should not be reading snapshot secrets
anyway, but I'll happily drop it to a files-only change if you prefer the
narrower diff. Staging is hardened *before* any file is written into it and
`os.replace()` preserves that mode, so there is no window where a populated
snapshot directory is traversable.

`chmod` is best-effort — `OSError`/`NotImplementedError` are caught and logged
at debug. Mode bits are not enforced on Windows, and a snapshot can land on a
filesystem that rejects `chmod`; neither should fail a backup.

Non-secret entries keep their existing modes. This is scoped hardening, not a
blanket chmod.

**No encryption.** The issue suggests encrypting snapshots; that is a much
larger design change (key management, restore UX, recovery when the key is
lost) and does not belong in a drive-by fix.

## After

| umask | source secret mode | `.env` | `auth.json` | `state.db` | `config.yaml` |
|---|---|---|---|---|---|
| 022 | 0600 | 0600 | 0600 | 0600 | 0644 |
| 022 | 0644 | 0600 | 0600 | 0600 | 0644 |
| 077 | 0600 | 0600 | 0600 | 0600 | 0644 |
| 077 | 0644 | 0600 | 0600 | 0600 | 0644 |
| 002 | 0600 | 0600 | 0600 | 0600 | 0644 |
| 002 | 0644 | 0600 | 0600 | 0600 | 0644 |

Directories: `state-snapshots/` `0755` → `0700`, timestamped child `0755` →
`0700`. `config.yaml` and `manifest.json` unchanged at `0644`.

## Tests

`tests/hermes_cli/test_backup_snapshot_permissions.py` asserts the **relation**
— a secret-named file in a snapshot is never group/other readable, whatever the
source mode — rather than freezing a mode literal per file. Source modes
`0600/0644/0664/0666` are parametrised across all three secret names.

The tests run under `umask 0`, so a pass proves an explicit `chmod` rather than
an accident of ambient umask. That matters here specifically because mechanism
2 was a umask artifact.

Also covered: non-secret files keep their source mode (guards against the fix
degenerating into a blanket chmod), directories are not group/other accessible,
the snapshot is still restorable with correct content (`.env` bytes and a
`SELECT` against the restored `state.db`), and restore does not loosen live
secrets.

**RED on unpatched upstream**, applying the test file alone to `be54f28b1`:

```
14 failed, 5 passed
```

Failures include `test_secret_copy_never_group_or_world_accessible[state.db-384]`
— that is source mode `0o600` (384 decimal) landing group-readable, i.e.
mechanism 2.

**GREEN after the fix:**

```
$ ./scripts/run_tests.sh tests/hermes_cli/test_backup_snapshot_permissions.py
=== Summary: 1 files, 19 tests passed, 0 failed (100% complete) ===

$ ./scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py
=== Summary: 2 files, 46 tests passed, 0 failed (100% complete) ===

$ ./scripts/run_tests.sh tests/hermes_cli/ -k "backup or snapshot or update or profile or state"
=== Summary: 545 files, 539 tests passed, 0 failed (100% complete) ===
```

`ruff check` clean on both changed files.

One unrelated pre-existing failure,
`test_doctor.py::test_doctor_reports_vercel_backend_diagnostics`, reproduces
identically on pristine `be54f28b1` with my changes stashed, so it is not from
this PR.

## Follow-up, deliberately not in this PR

The issue also mentions the emergency `.bak` copies. I verified that
`_backup_db_file` in `hermes_state.py` copies a malformed `state.db` (plus
`-wal`/`-shm` sidecars) with `shutil.copy2` and has the same inherited-mode
property. Different file, different blast radius, and it writes beside the live
DB rather than into a snapshot tree — worth its own PR rather than widening
this one.

Closes #77470 partially — the snapshot half. Filing the `hermes_state.py` half
separately if you agree with the split.
