### PR TITLE
fix(cli): report updates with unknown commit counts (#78253)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5007,7 +5007,7 @@ def _print_version_info(*, check_updates: bool = True) -> None:
 
     # Show update status (synchronous — acceptable since user asked for version info)
     try:
-        from hermes_cli.banner import check_for_updates
+        from hermes_cli.banner import UPDATE_AVAILABLE_NO_COUNT, check_for_updates
         from hermes_cli.config import recommended_update_command
 
         behind = check_for_updates()
@@ -5015,6 +5015,11 @@ def _print_version_info(*, check_updates: bool = True) -> None:
             commits_word = "commit" if behind == 1 else "commits"
             print(
                 f"Update available: {behind} {commits_word} behind — "
+                f"run '{recommended_update_command()}'"
+            )
+        elif behind == UPDATE_AVAILABLE_NO_COUNT:
+            print(
+                "Update available (commit count unknown) — "
                 f"run '{recommended_update_command()}'"
             )
         elif behind == 0:

--- a/tests/cli/test_version_command.py
+++ b/tests/cli/test_version_command.py
@@ -3,7 +3,9 @@
 from unittest.mock import patch
 
 from cli import HermesCLI
+from hermes_cli.banner import UPDATE_AVAILABLE_NO_COUNT
 from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+from hermes_cli.main import _print_version_info
 
 
 def test_version_command_is_registered():
@@ -26,3 +28,22 @@ def test_process_command_version_prints_version_info():
         assert cli_obj.process_command("/version") is True
 
     mock_print.assert_called_once_with(check_updates=True)
+
+
+def test_version_info_reports_update_when_commit_count_is_unknown(capsys):
+    with (
+        patch(
+            "hermes_cli.banner.check_for_updates",
+            return_value=UPDATE_AVAILABLE_NO_COUNT,
+        ),
+        patch(
+            "hermes_cli.config.recommended_update_command",
+            return_value="hermes update",
+        ),
+    ):
+        _print_version_info(check_updates=True)
+
+    output = capsys.readouterr().out
+    assert "Update available (commit count unknown)" in output
+    assert "run 'hermes update'" in output
+    assert "Up to date" not in output


### PR DESCRIPTION
## What does this PR do?

Handles the `UPDATE_AVAILABLE_NO_COUNT` result in `hermes version` so every
update source that knows an update exists without a meaningful commit count,
including shallow checkouts and embedded-revision/Nix builds, reports a generic
update instead of silently ending after the SDK version.

The startup banner already handles this sentinel through its generic update
warning. This focused change closes only the version-command gap and does not
alter update detection or caching.

## Related Issue

Fixes #78253

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Import and handle `UPDATE_AVAILABLE_NO_COUNT` in `hermes_cli/main.py`.
- Print a generic update command when the exact behind count is unavailable.
- Add a behavior-level regression test for the unknown-count path.

## How to Test

1. Run `scripts/run_tests.sh tests/cli/test_version_command.py -q`.
2. Confirm all 4 tests pass.
3. Mock `check_for_updates()` to return `UPDATE_AVAILABLE_NO_COUNT` and confirm
   `_print_version_info()` includes `Update available (commit count unknown)`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the focused test file through `scripts/run_tests.sh`.
- [x] I've added a regression test.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update is not required.
- [x] `cli-config.yaml.example` update is not required.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not required.
- [x] Cross-platform impact considered: the output branch is platform-neutral.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

```text
Hermes Agent v0.20.0 (2026.8.3) · upstream 9076adac
Install method: git
Python: 3.11.15
OpenAI SDK: 2.24.0
Update available (commit count unknown) — run 'hermes update'
```