### PR TITLE
fix(acp): support per-session reasoning effort for thinking control (#78229)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -840,6 +840,25 @@ class HermesACPAgent(acp.Agent):
         return target_provider, new_model
 
     @staticmethod
+    def _parse_reasoning_effort_kwargs(kwargs: dict[str, Any]) -> dict | None:
+        """Parse an optional ``reasoning_effort`` from ACP call kwargs.
+
+        Accepts both ``reasoning_effort`` and the camelCase
+        ``reasoningEffort`` spelling.  Returns ``None`` when absent or
+        unrecognized so the caller falls back to the session default.
+        """
+        effort = kwargs.get("reasoning_effort", kwargs.get("reasoningEffort"))
+        if effort is None:
+            return None
+        try:
+            from hermes_constants import parse_reasoning_effort
+
+            return parse_reasoning_effort(effort)
+        except Exception:
+            logger.debug("Failed to parse ACP reasoning_effort=%r", effort, exc_info=True)
+            return None
+
+    @staticmethod
     def _build_usage_update(state: SessionState) -> UsageUpdate | None:
         """Build ACP native context-usage data for clients like Zed.
 
@@ -1438,7 +1457,8 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        reasoning_config = self._parse_reasoning_effort_kwargs(kwargs)
+        state = self.session_manager.create_session(cwd=cwd, reasoning_config=reasoning_config)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -2440,7 +2460,12 @@ class HermesACPAgent(acp.Agent):
     async def set_session_model(
         self, model_id: str, session_id: str, **kwargs: Any
     ) -> SetSessionModelResponse | None:
-        """Switch the model for a session (called by ACP protocol)."""
+        """Switch the model for a session (called by ACP protocol).
+
+        Accepts an optional ``reasoning_effort`` kwarg (ACP ``_meta`` or
+        direct param) to set the session's per-session thinking override,
+        matching the TUI Gateway's ``session.create`` ``reasoning_effort``.
+        """
         state = self.session_manager.get_session(session_id)
         if state:
             current_provider = getattr(state.agent, "provider", None)
@@ -2452,6 +2477,11 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            reasoning_config = self._parse_reasoning_effort_kwargs(kwargs)
+            if reasoning_config is not None:
+                state.reasoning_config = reasoning_config
+            else:
+                reasoning_config = getattr(state, "reasoning_config", None)
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,
@@ -2459,6 +2489,7 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                reasoning_config=reasoning_config,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -170,6 +170,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    reasoning_config: Any = None  # per-session reasoning override (dict or None)
 
 
 class SessionManager:
@@ -196,19 +197,22 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
+    def create_session(self, cwd: str = ".", reasoning_config: dict | None = None) -> SessionState:
         """Create a new session with a unique ID and a fresh AIAgent."""
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id, cwd=cwd, reasoning_config=reasoning_config
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,
             cwd=cwd,
             model=getattr(agent, "model", "") or "",
             cancel_event=threading.Event(),
+            reasoning_config=reasoning_config,
         )
         with self._lock:
             self._sessions[session_id] = state
@@ -253,6 +257,7 @@ class SessionManager:
             session_id=new_id,
             cwd=cwd,
             model=original.model or None,
+            reasoning_config=original.reasoning_config,
         )
         state = SessionState(
             session_id=new_id,
@@ -261,6 +266,7 @@ class SessionManager:
             model=getattr(agent, "model", original.model) or original.model,
             history=copy.deepcopy(original.history),
             cancel_event=threading.Event(),
+            reasoning_config=original.reasoning_config,
         )
         with self._lock:
             self._sessions[new_id] = state
@@ -422,6 +428,11 @@ class SessionManager:
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
+        if state.reasoning_config is not None:
+            try:
+                session_meta["reasoning_config"] = state.reasoning_config
+            except Exception:
+                logger.debug("Failed to serialize ACP session reasoning_config", exc_info=True)
         provider = getattr(state.agent, "provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
@@ -441,7 +452,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -520,6 +531,7 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        restored_reasoning_config = None
         mc = row.get("model_config")
         if mc:
             try:
@@ -529,6 +541,7 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    restored_reasoning_config = meta.get("reasoning_config") or restored_reasoning_config
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -555,6 +568,7 @@ class SessionManager:
                 requested_provider=requested_provider,
                 base_url=restored_base_url,
                 api_mode=restored_api_mode,
+                reasoning_config=restored_reasoning_config,
             )
         except Exception:
             logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
@@ -567,6 +581,7 @@ class SessionManager:
             model=model or getattr(agent, "model", "") or "",
             history=history,
             cancel_event=threading.Event(),
+            reasoning_config=restored_reasoning_config,
         )
         with self._lock:
             self._sessions[session_id] = state
@@ -596,6 +611,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        reasoning_config: dict | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -631,6 +647,8 @@ class SessionManager:
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+        if reasoning_config is not None:
+            kwargs["reasoning_config"] = reasoning_config
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -726,3 +726,81 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+# ---------------------------------------------------------------------------
+# Per-session reasoning effort via ACP (feature parity with TUI Gateway)
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningEffort:
+    @pytest.mark.asyncio
+    async def test_set_session_model_accepts_reasoning_effort(self, agent, mock_manager):
+        from acp.schema import SetSessionModelResponse
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.provider = "openrouter"
+        state.model = "current-model"
+
+        resp = await agent.set_session_model(
+            model_id="anthropic/claude-sonnet-4.5",
+            session_id=state.session_id,
+            reasoning_effort="high",
+        )
+
+        assert isinstance(resp, SetSessionModelResponse)
+        assert state.reasoning_config == {"enabled": True, "effort": "high"}
+
+    @pytest.mark.asyncio
+    async def test_set_session_model_accepts_camel_case_effort(self, agent, mock_manager):
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.provider = "openrouter"
+        state.model = "current-model"
+
+        resp = await agent.set_session_model(
+            model_id="anthropic/claude-sonnet-4.5",
+            session_id=state.session_id,
+            reasoningEffort="none",
+        )
+
+        assert resp is not None
+        assert state.reasoning_config == {"enabled": False}
+
+    @pytest.mark.asyncio
+    async def test_set_session_model_without_effort_keeps_existing_config(self, agent, mock_manager):
+        from acp.schema import SetSessionModelResponse
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.provider = "openrouter"
+        state.model = "current-model"
+        state.reasoning_config = {"enabled": True, "effort": "low"}
+
+        resp = await agent.set_session_model(
+            model_id="anthropic/claude-sonnet-4.5",
+            session_id=state.session_id,
+        )
+
+        assert isinstance(resp, SetSessionModelResponse)
+        assert state.reasoning_config == {"enabled": True, "effort": "low"}
+
+    @pytest.mark.asyncio
+    async def test_new_session_accepts_reasoning_effort(self, agent, mock_manager):
+        resp = await agent.new_session(cwd="/tmp", reasoning_effort="high")
+
+        assert resp is not None
+        state = mock_manager.get_session(resp.session_id)
+        assert state is not None
+        assert state.reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_parse_reasoning_effort_kwargs(self, agent):
+        from acp_adapter.server import HermesACPAgent
+
+        assert HermesACPAgent._parse_reasoning_effort_kwargs({}) is None
+        assert HermesACPAgent._parse_reasoning_effort_kwargs({"reasoning_effort": "high"}) == {
+            "enabled": True,
+            "effort": "high",
+        }
+        assert HermesACPAgent._parse_reasoning_effort_kwargs({"reasoningEffort": "none"}) == {
+            "enabled": False
+        }
+        assert HermesACPAgent._parse_reasoning_effort_kwargs({"reasoning_effort": "bogus"}) is None

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -327,3 +327,100 @@ class TestPersistence:
 
         assert stdout_buf.getvalue() == ""
         assert stderr_buf.getvalue() == "ACP noise\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-session reasoning effort (feature parity with TUI Gateway)
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningConfig:
+    def test_create_session_passes_reasoning_config_to_agent(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                captured["kwargs"] = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "acp_adapter.session.load_config",
+            lambda: {"model": {"default": "fake-model", "provider": "fake-provider"}, "mcp_servers": {}},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "chat_completions",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        state = SessionManager(db=None).create_session(
+            cwd="/tmp/project",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+
+        assert state.reasoning_config == {"enabled": True, "effort": "high"}
+        assert captured["kwargs"].get("reasoning_config") == {"enabled": True, "effort": "high"}
+
+    def test_create_session_without_reasoning_config_omits_kwarg(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                captured["kwargs"] = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "acp_adapter.session.load_config",
+            lambda: {"model": {"default": "fake-model", "provider": "fake-provider"}, "mcp_servers": {}},
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "chat_completions",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert "reasoning_config" not in captured["kwargs"]
+
+    def test_fork_session_preserves_reasoning_config(self, manager):
+        original = manager.create_session(
+            cwd="/tmp/base", reasoning_config={"enabled": False}
+        )
+        forked = manager.fork_session(original.session_id, cwd="/tmp/fork")
+
+        assert forked is not None
+        assert forked.reasoning_config == {"enabled": False}
+
+    def test_persist_round_trip_preserves_reasoning_config(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(agent_factory=_mock_agent, db=db)
+        state = manager.create_session(
+            cwd="/work", reasoning_config={"enabled": True, "effort": "low"}
+        )
+
+        restored = manager.get_session(state.session_id)
+
+        assert restored is state
+        # Persisted metadata contains the reasoning override.
+        row = db.get_session(state.session_id)
+        assert row is not None
+        assert '"reasoning_config"' in (row.get("model_config") or "")


### PR DESCRIPTION
Closes #78229

## Problem

When using Hermes via the ACP protocol, there is no way to enable/disable thinking or set the reasoning effort level for a model. The thinking configuration is entirely determined by the static `config.yaml` default and cannot be changed per-session or per-model-switch through ACP. The TUI Gateway already supports `reasoning_effort` in `session.create` via `parse_reasoning_effort()`, and `agent/agent_init.py` accepts `reasoning_config` — the gap is purely in the ACP adapter wiring.

## Fix

- **`acp_adapter/server.py`**: `set_session_model` now accepts an optional `reasoning_effort` kwarg (both `reasoning_effort` and `reasoningEffort` spellings, passable via ACP `_meta` or direct param) and rebuilds the agent with the parsed `reasoning_config`. `new_session` accepts the same kwarg for session creation.
- **`acp_adapter/session.py`**: `SessionState` carries `reasoning_config` so model switches without an explicit effort preserve the session override; `_make_agent` threads it into the AIAgent; it is persisted in session `model_config` and restored on session restore/fork.

ACP clients can now send e.g. `{"method": "session/set_session_model", "params": {"modelId": "...", "sessionId": "...", "reasoningEffort": "high"}}` to control thinking per session, matching TUI Gateway capability.

## Tests

- `tests/acp/test_session.py`: create passes reasoning_config to agent, absent config omits the kwarg, fork preserves it, persist round-trip keeps it.
- `tests/acp/test_server.py`: `set_session_model` accepts snake/camel effort, keeps existing config when omitted, `new_session` accepts effort, parser handles empty/invalid values.
- Full `tests/acp/` suite: 135 passed.