### PR TITLE
fix(gateway): surface httpx timeout errors when str(exc) is empty

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4987,7 +4987,7 @@ class BasePlatformAdapter(ABC):
         if not error:
             return False
         lowered = error.lower()
-        return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
+        return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered or "connecttimeout" in lowered or lowered.startswith("httpx.read") or lowered.startswith("httpx.write") or lowered.startswith("httpx.connect")
 
     def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -518,7 +518,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             msg_id = data.get("guid") or data.get("messageGuid") or "ok"
             return SendResult(success=True, message_id=str(msg_id), raw_response=res)
         except Exception as exc:
-            return SendResult(success=False, error=str(exc))
+            err = str(exc)
+            if not err:
+                # httpx timeout exceptions stringify to "".
+                err = f"httpx.{type(exc).__name__}"
+            return SendResult(success=False, error=err)
 
     # ------------------------------------------------------------------
     # Text sending


### PR DESCRIPTION
## Bug

`httpx.TimeoutException` stringifies to `''`. `_is_timeout_error` short-circuits on the empty check and never detects the timeout, so BlueBubbles falls through to plain-text fallback and re-sends a duplicate message.

## Fix

- BlueBubbles adapter: fall back to `type(exc).__name__` when `str(exc) == ''`  
- `_is_timeout_error`: also match `httpx.ReadTimeout`/`WriteTimeout`/`ConnectTimeout` class names