### PR TITLE
fix(a2a): resolve callback host before deciding SSRF safety

### DIFF
--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -284,60 +284,103 @@ def sign_push_payload(payload: dict) -> str:
 # --------------------------------------------------------------------------
 
 import ipaddress
+import socket
 import urllib.parse
 
-# Blocked IP ranges for push callback URLs (SSRF prevention).
-# Even in localhost-only mode we block these — a remote peer shouldn't
-# be able to make us probe internal services.
-_BLOCKED_PREFIXES = (
-    "169.254.",    # link-local / AWS metadata
-    "127.",        # loopback
-    "10.",         # RFC1918 private
-    "172.16.", "172.17.", "172.18.", "172.19.", "172.20.",
-    "172.21.", "172.22.", "172.23.", "172.24.", "172.25.",
-    "172.26.", "172.27.", "172.28.", "172.29.", "172.30.", "172.31.",  # RFC1918 private
-    "192.168.",    # RFC1918 private
-    "0.0.0.0",     # unspecified
-    "::1",         # IPv6 loopback
-    "fe80:",       # IPv6 link-local
-    "fc00:", "fd00:",  # IPv6 unique-local
-)
+
+def _resolve_callback_host(hostname: str) -> Optional[list]:
+    """Resolve *hostname* to the addresses a request to it would actually reach.
+
+    Returns a list of ``ip_address`` objects, or ``None`` when the host cannot
+    be resolved. A literal IP resolves to itself.
+
+    This is the step the old prefix-matching guard skipped. Alternate integer
+    spellings of an address (``2130706433``, ``0x7f000001``, ``0177.0.0.1``)
+    are rejected by ``ipaddress.ip_address`` but accepted by the OS resolver,
+    so classifying the *string* let them through while the socket still went
+    to 127.0.0.1.
+    """
+    try:
+        return [ipaddress.ip_address(hostname)]
+    except ValueError:
+        pass
+    try:
+        addr_info = socket.getaddrinfo(
+            hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM
+        )
+    except (socket.gaierror, UnicodeError, ValueError):
+        return None
+    resolved = []
+    for *_unused, sockaddr in addr_info:
+        ip_str = str(sockaddr[0]).split("%")[0]  # drop any IPv6 scope id
+        try:
+            resolved.append(ipaddress.ip_address(ip_str))
+        except ValueError:
+            logger.warning(
+                "A2A: unparseable resolved address %r for callback host %s",
+                sockaddr[0], hostname,
+            )
+            return None  # fail closed rather than skip an address we can't classify
+    return resolved or None
 
 
 def is_safe_callback_url(url: str) -> bool:
     """Check if a push notification callback URL is safe from SSRF.
 
-    Blocks internal/private/loopback/metadata addresses.
+    Blocks internal/private/loopback/link-local/CGNAT/metadata addresses.
     Only allows http:// and https:// schemes.
+
+    The decision is made on the RESOLVED address(es), never on the spelling of
+    the hostname, and uses the same range policy as ``tools.url_safety`` so the
+    two guards cannot drift apart.
+
+    In localhost-only mode (no A2A_BEARER_TOKEN / A2A_PEER_TOKENS configured)
+    loopback callbacks stay allowed — they are the local-testing path and the
+    listener is not remotely reachable in that posture.
     """
     if not url or not isinstance(url, str):
         return False
     try:
         parsed = urllib.parse.urlparse(url)
+        hostname = (parsed.hostname or "").strip().lower().rstrip(".")
     except Exception:
         return False
     if parsed.scheme not in ("http", "https"):
         return False
-    hostname = parsed.hostname or ""
     if not hostname:
         return False
-    hostname_lower = hostname.lower()
-    if hostname_lower == "localhost":
-        # Loopback callbacks only make sense for local testing.
-        return localhost_only()
-    for prefix in _BLOCKED_PREFIXES:
-        if hostname_lower.startswith(prefix.lower()):
-            if localhost_only() and prefix in ("127.", "::1"):
-                return True
-            return False
+
+    local_mode = localhost_only()
+
+    # Cloud metadata hostnames are never a legitimate callback target.
     try:
-        ip = ipaddress.ip_address(hostname)
-        if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved:
-            if localhost_only() and ip.is_loopback:
-                return True
-            return False
-    except ValueError:
-        pass  # not an IP, it's a hostname — fine
+        from tools.url_safety import is_always_blocked_url, is_blocked_ip
+    except Exception:  # pragma: no cover - core module always present
+        logger.error("A2A: url_safety unavailable — refusing callback URL")
+        return False
+    if is_always_blocked_url(url):
+        return False
+
+    addresses = _resolve_callback_host(hostname)
+    if addresses is None:
+        # Unresolvable host: fail closed. A callback we cannot resolve cannot
+        # be delivered anyway, and resolving later (rebinding) must not be a
+        # way to skip the check.
+        logger.warning("A2A: callback URL blocked — cannot resolve host: %s", hostname)
+        return False
+
+    for ip in addresses:
+        if not is_blocked_ip(ip):
+            continue
+        # Blocked range. The one carve-out is the documented local-testing
+        # posture, and only for loopback — never for RFC1918/link-local/CGNAT.
+        if local_mode and ip.is_loopback:
+            continue
+        logger.warning(
+            "A2A: callback URL blocked — %s resolves to internal address %s",
+            hostname, ip,
+        )
+        return False
     return True
 
 

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -21,6 +21,7 @@ import socket
 import time
 import urllib.error
 import urllib.request
+from unittest.mock import patch
 
 import pytest
 
@@ -685,3 +686,164 @@ class TestSSRFProtection:
     def test_empty_url_blocked(self):
         assert security.is_safe_callback_url("") is False
         assert security.is_safe_callback_url(None) is False
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SSRF: the guard must decide on the RESOLVED address, not the spelling
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+def _resolves_to(*ips):
+    """Patch ``socket.getaddrinfo`` so any hostname resolves to *ips*.
+
+    Keeps these tests hermetic: the contract is "whatever this host resolves
+    to decides the verdict", so the resolver is the thing to control.
+    """
+    return patch(
+        "socket.getaddrinfo",
+        return_value=[
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips
+        ],
+    )
+
+
+# Spellings the OS resolver accepts but ``ipaddress.ip_address`` rejects, so a
+# guard that classifies the hostname string never sees them as addresses.
+_LOOPBACK_SPELLINGS = [
+    "127.0.0.1",      # canonical (control)
+    "2130706433",     # decimal
+    "0x7f000001",     # hex
+    "0177.0.0.1",     # octal
+    "localhost",      # hostname
+    "localhost.",     # FQDN trailing dot
+]
+
+
+class TestCallbackSSRFResolvesBeforeDeciding:
+    """Contract: a callback is refused when it *resolves* to an internal
+    address, whatever the hostname is spelled like. Asserting the relation
+    rather than a list of blocked prefixes is the point — a new spelling that
+    resolves to loopback must fail these tests without anyone editing a table.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _remote_mode(self, monkeypatch):
+        # Token configured => localhost_only() is False. This is the exposed
+        # posture, the only one where callback SSRF matters.
+        monkeypatch.setenv("A2A_BEARER_TOKEN", "tok")
+        monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+
+    @pytest.mark.parametrize("host", _LOOPBACK_SPELLINGS)
+    def test_every_spelling_that_resolves_to_loopback_is_refused(self, host):
+        with _resolves_to("127.0.0.1"):
+            assert security.is_safe_callback_url(f"http://{host}:8080/hook") is False
+
+    @pytest.mark.parametrize("ip, label", [
+        ("127.0.0.1", "loopback"),
+        ("10.0.0.1", "RFC1918"),
+        ("192.168.1.1", "RFC1918"),
+        ("172.16.0.1", "RFC1918"),
+        ("169.254.169.254", "link-local / cloud metadata"),
+        ("100.64.0.1", "CGNAT RFC6598 — not covered by ipaddress.is_private"),
+        ("0.0.0.0", "unspecified"),
+        ("::1", "IPv6 loopback"),
+        ("fd00::1", "IPv6 unique-local"),
+        ("fe80::1", "IPv6 link-local"),
+    ])
+    def test_public_hostname_resolving_to_internal_is_refused(self, ip, label):
+        """A perfectly ordinary hostname is refused when DNS points it inward."""
+        with _resolves_to(ip):
+            assert security.is_safe_callback_url("https://callbacks.example.com/hook") is False, label
+
+    def test_multi_answer_is_refused_when_any_address_is_internal(self):
+        """One internal answer poisons the set — we cannot choose which the
+        HTTP client will dial."""
+        with _resolves_to("93.184.216.34", "127.0.0.1"):
+            assert security.is_safe_callback_url("https://callbacks.example.com/hook") is False
+
+    def test_unresolvable_host_is_refused(self):
+        """Fail closed: a host we cannot resolve must not be assumed public."""
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("nope")):
+            assert security.is_safe_callback_url("https://nx.invalid/hook") is False
+
+    def test_ordinary_public_callback_still_allowed(self):
+        """False-positive guard: the normal case must keep working."""
+        with _resolves_to("93.184.216.34"):
+            assert security.is_safe_callback_url("https://callbacks.example.com/hook") is True
+            assert security.is_safe_callback_url("http://hooks.example.org/a2a") is True
+
+    def test_public_literal_ip_still_allowed(self):
+        assert security.is_safe_callback_url("https://93.184.216.34/hook") is True
+
+
+class TestCallbackSSRFLocalModeUnchanged:
+    """The no-token posture is a documented local-testing affordance, not a
+    bug. Loopback stays allowed there; genuinely internal ranges do not.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _local_mode(self, monkeypatch):
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+
+    @pytest.mark.parametrize("host", _LOOPBACK_SPELLINGS)
+    def test_loopback_allowed_in_local_mode_for_every_spelling(self, host):
+        with _resolves_to("127.0.0.1"):
+            assert security.is_safe_callback_url(f"http://{host}:8080/hook") is True
+
+    @pytest.mark.parametrize("ip", ["10.0.0.1", "192.168.1.1", "169.254.169.254", "100.64.0.1"])
+    def test_non_loopback_internal_still_blocked_in_local_mode(self, ip):
+        """Local mode relaxes loopback only — not the whole private space."""
+        assert security.is_safe_callback_url(f"http://{ip}/hook") is False
+
+
+class TestCallbackSSRFWireLevel:
+    """The predicate is not the security boundary — the POST is. This drives
+    the adapter's real ``_send_push_notification`` against a real listener.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _remote_mode(self, monkeypatch):
+        monkeypatch.setenv("A2A_BEARER_TOKEN", "tok")
+        monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+
+    @pytest.mark.parametrize("host_tmpl", _LOOPBACK_SPELLINGS)
+    def test_no_post_reaches_an_internal_listener(self, host_tmpl):
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        import threading
+
+        from plugins.platforms.a2a.adapter import A2AAdapter
+
+        received: list[str] = []
+
+        class _Victim(BaseHTTPRequestHandler):
+            def do_POST(self):
+                received.append(self.path)
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *_args):  # silence
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), _Victim)
+        port = srv.server_address[1]
+        thread = threading.Thread(target=srv.serve_forever, daemon=True)
+        thread.start()
+        try:
+            adapter = A2AAdapter.__new__(A2AAdapter)  # no gateway needed
+            adapter.tasks = protocol.TaskStore()
+            adapter.tasks.create("t1", "ctx", "peer")
+            adapter.tasks.set_push_config("t1", f"http://{host_tmpl}:{port}/hook")
+
+            adapter._send_push_notification("t1", "ctx", "reply", "completed")
+        finally:
+            srv.shutdown()
+            thread.join(timeout=5)
+            srv.server_close()
+
+        assert received == [], (
+            f"SSRF: a push notification POST reached the internal listener via "
+            f"{host_tmpl!r} — the callback guard did not stop it"
+        )

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -308,6 +308,16 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return False
 
 
+def is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Public wrapper over the shared private/internal address policy.
+
+    Exposed so other guards (e.g. the A2A push-callback check) classify
+    addresses with the *same* range list instead of maintaining their own
+    copy, which is how ranges like 100.64.0.0/10 get missed.
+    """
+    return _is_blocked_ip(ip)
+
+
 def is_always_blocked_url(url: str) -> bool:
     """Return True when the URL targets an always-blocked endpoint.
 


### PR DESCRIPTION
## The defect

`plugins/platforms/a2a/security.py::is_safe_callback_url` decides SSRF safety by string-prefix matching the callback **hostname**:

```python
for prefix in _BLOCKED_PREFIXES:          # ('127.', '10.', '192.168.', '::1', ...)
    if hostname_lower.startswith(prefix): ...
try:
    ip = ipaddress.ip_address(hostname)   # only reached for canonical text
except ValueError:
    pass                                  # "not an IP, it's a hostname — fine"
```

`ipaddress.ip_address()` rejects the alternate integer spellings that the OS resolver happily accepts, so those spellings fall through **both** checks and are allowed.

Measured on `main` with `A2A_BEARER_TOKEN` set — i.e. `localhost_only()` is `False`, the exposed posture where callback SSRF actually matters:

| callback URL | verdict | resolves to |
|---|---|---|
| `http://127.0.0.1/cb` | BLOCKED (control — guard works) | 127.0.0.1 |
| `http://2130706433/cb` | **ALLOWED** | 127.0.0.1 |
| `http://0x7f000001/cb` | **ALLOWED** | 127.0.0.1 |
| `http://0177.0.0.1/cb` | **ALLOWED** | 127.0.0.1 |
| `http://localhost./cb` | **ALLOWED** | 127.0.0.1 |
| `http://100.64.0.1/cb` | **ALLOWED** | 100.64.0.1 |
| `http://169.254.169.254/cb` | BLOCKED (control) | 169.254.169.254 |
| `https://example.com/cb` | ALLOWED (negative control) | public |

`100.64.0.0/10` (RFC 6598 CGNAT) slipped for a second reason worth calling out: `ipaddress.is_private` returns `False` for it, so neither the prefix table nor the `ipaddress` fallback covered it. `tools/url_safety.py` already has an explicit `_CGNAT_NETWORK` constant for exactly this.

## This is reachable, and a POST really lands

`adapter.py:1193` is the only gate before `adapter.py:1210`:

```python
req = urllib.request.Request(callback_url, data=data, headers=headers, method="POST")
with urllib.request.urlopen(req, timeout=10) as resp:   # noqa: S310
```

A peer that registers a task push config chooses the URL, so it is attacker-controlled by design.

To confirm this isn't just a predicate-level lint, I stood up a real HTTP listener on `127.0.0.1:<port>`, registered each spelling through the adapter's own `TaskStore`, and let `_send_push_notification` run:

```
CALLBACK URL                        GUARD     POST LANDED?
------------------------------------------------------------------
http://127.0.0.1:41519/hook         blocked   False   no request sent
http://2130706433:41519/hook        ALLOWED   True    *** POST LANDED
http://0x7f000001:41519/hook        ALLOWED   True    *** POST LANDED
http://0177.0.0.1:41519/hook        ALLOWED   True    *** POST LANDED
http://localhost.:41519/hook        ALLOWED   True    *** POST LANDED

victim received 4 POST(s):
   Host: 2130706433:41519    path=/hook  body=309B
   Host: 0x7f000001:41519    path=/hook  body=309B
   Host: 0177.0.0.1:41519    path=/hook  body=309B
   Host: localhost.:41519    path=/hook  body=309B
```

The signed payload (`X-A2A-Signature`) is delivered to whatever internal service is listening.

## Why I read this as an oversight rather than a decision

The same repo already solves this correctly one directory over. `tools/url_safety.py::is_safe_url` resolves the host and classifies the **resolved** addresses, and it blocks every probe in the table above — including the CGNAT range. Several platform adapters already import from it (`discord`, `slack`, `telegram`, `teams`, `feishu`, `matrix`, `mattermost`, `wecom`). So the argument here is **consistency with the project's existing guard**, not a new policy.

## The fix

Stop classifying the spelling; classify what the host actually resolves to, and reuse the existing range policy instead of growing a fourth copy of it.

- Normalise the hostname (lowercase, strip the trailing dot) before anything else.
- Resolve it — a literal IP resolves to itself — and check **every** answer.
- Delegate the range decision to `tools/url_safety.py` (new thin public `is_blocked_ip` wrapper over the existing private `_is_blocked_ip`, plus the existing `is_always_blocked_url` floor for metadata hostnames). The plugin imports it directly, the same way the other platform adapters do, so there was no reason to reimplement.
- Fail closed on an unresolvable host, and refuse the whole set if *any* answer is internal (we can't pick which address the HTTP client will dial).

### `localhost_only()` behaviour is deliberately preserved

With no token configured, loopback callbacks are a documented local-testing affordance ("Loopback callbacks only make sense for local testing") and the listener isn't remotely reachable in that posture. That is **unchanged** — it just now applies consistently to every spelling of loopback rather than only the canonical one. The relaxation stays scoped to loopback: RFC1918 / link-local / CGNAT remain blocked in *both* postures.

Before/after, both postures:

| URL | token set: before → after | no token: before → after |
|---|---|---|
| `http://127.0.0.1/cb` | BLOCKED → BLOCKED | ALLOWED → ALLOWED |
| `http://2130706433/cb` | **ALLOWED → BLOCKED** | ALLOWED → ALLOWED |
| `http://0x7f000001/cb` | **ALLOWED → BLOCKED** | ALLOWED → ALLOWED |
| `http://0177.0.0.1/cb` | **ALLOWED → BLOCKED** | ALLOWED → ALLOWED |
| `http://localhost./cb` | **ALLOWED → BLOCKED** | ALLOWED → ALLOWED |
| `http://100.64.0.1/cb` | **ALLOWED → BLOCKED** | **ALLOWED → BLOCKED** |
| `http://10.0.0.1/cb` | BLOCKED → BLOCKED | BLOCKED → BLOCKED |
| `http://169.254.169.254/cb` | BLOCKED → BLOCKED | BLOCKED → BLOCKED |
| `https://example.com/cb` | ALLOWED → ALLOWED | ALLOWED → ALLOWED |

No false positives: ordinary public callbacks (hostname and literal public IP) stay allowed, and the whole local-testing flow is untouched.

## Tests

The new tests assert the **relation** — anything that resolves to a loopback/private/link-local/CGNAT address is refused — rather than freezing a list of blocked prefixes, so a spelling nobody thought of fails the suite without anyone editing a table. They patch `socket.getaddrinfo` to stay hermetic, and include a wire-level case that fails if a POST reaches a real local listener.

**RED on unpatched `main`, applying only the test file** (no source changes):

```
$ git diff --stat
 tests/plugins/test_a2a_phase23.py | 162 +++++++++++++++++++++++++++++++++++
 1 file changed, 162 insertions(+)

$ ./scripts/run_tests.sh tests/plugins/test_a2a_phase23.py
================= 21 failed, 60 passed, 7 deselected in 3.00s ==================
```

including:

```
FAILED ...::TestCallbackSSRFWireLevel::test_no_post_reaches_an_internal_listener[2130706433]
E   AssertionError: SSRF: a push notification POST reached the internal listener
    via 'localhost.' — the callback guard did not stop it
E   assert ['/hook'] == []
FAILED ...::test_public_hostname_resolving_to_internal_is_refused[100.64.0.1-CGNAT RFC6598 ...]
```

**GREEN with the fix:**

```
$ ./scripts/run_tests.sh tests/plugins/test_a2a_phase23.py
=== Summary: 1 files, 81 tests passed, 0 failed (100% complete) in 3.6s ===
```

No regressions in the neighbouring suites (`test_a2a_plugin.py`, and `test_url_safety.py` since `tools/url_safety.py` is touched):

```
=== Summary: 3 files, 248 tests passed, 0 failed (100% complete) in 3.5s ===
```

## Notes / follow-up

- Scoped deliberately to this one guard. `tools/transcription_tools.py::_is_local_or_private_url` has the same class of gap (it also prefix-matches), but it's a different file and threat model — happy to file that separately rather than widen this PR.
- Like every pre-flight DNS check, this remains subject to DNS rebinding (TOCTOU), which `tools/url_safety.py` documents as a known limitation and addresses for direct httpx paths via `create_ssrf_safe_client()`. This callback uses `urllib`, so it can't reuse that transport as-is; closing the rebinding window here would mean moving the push sender onto the guarded client, which felt out of scope for a bug fix. Flagging it so the residual risk is explicit rather than implied.
