### PR TITLE
fix(credential-pool): re-select in acquire_lease after a deferred single-use-token refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2084,6 +2084,14 @@ class CredentialPool:
         chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
+            # Mirror select(): if nothing was leasable but we just refreshed
+            # deferred single-use-token entries, retry now that they are back
+            # in rotation. Without this, a pool whose only entries all needed
+            # a refresh returns None even though the refresh succeeded — the
+            # caller sees "no credentials available" and fails a request that
+            # should have gone through.
+            if chosen_id is None:
+                chosen_id, _ = self._acquire_lease_under_lock(credential_id)
         return chosen_id
 
     def _acquire_lease_under_lock(

--- a/tests/agent/test_credential_pool_lease_refresh_reselect.py
+++ b/tests/agent/test_credential_pool_lease_refresh_reselect.py
@@ -1,0 +1,115 @@
+"""acquire_lease must re-select after a deferred single-use-token refresh.
+
+Post-merge gate-sweep finding on the #71775 salvage (deferred refresh moved
+OUTSIDE the pool lock). ``select()`` re-selects once the refreshed entries
+are back in rotation (credential_pool.py, select() -> "if pending_refresh:
+re-select"); ``acquire_lease()`` did not, so a pool whose only entries all
+needed a refresh returned None even though the refresh had just succeeded —
+the caller saw "no credentials available" and failed a request that should
+have gone through.
+
+These tests stub ``_available_entries`` / ``_refresh_pending_entries`` at the
+same seam the production deferred-refresh contract uses: _available_entries
+returns ``(available, pending_refresh)`` and entries pending a refresh are
+NOT in ``available`` until the refresh has run.
+"""
+
+import threading
+
+from agent.credential_pool import CredentialPool, PooledCredential
+
+
+def _entry(entry_id: str) -> PooledCredential:
+    return PooledCredential(
+        id=entry_id,
+        provider="anthropic",
+        auth_type="oauth",
+        access_token="tok",
+        label=entry_id,
+        source="oauth",
+        priority=0,
+    )
+
+
+def _bare_pool(entries):
+    """Minimal pool shell — avoids disk/keyring I/O in __init__."""
+    pool = CredentialPool.__new__(CredentialPool)
+    pool._lock = threading.RLock()
+    pool._entries = list(entries)
+    pool._active_leases = {}
+    pool._current_id = None
+    pool._max_concurrent = 2
+    pool._unmatched_rotation_streak = 0
+    pool.provider = "anthropic"
+    return pool
+
+
+def _wire_deferred_refresh(pool, *, refresh_succeeds: bool = True):
+    """Model the deferred-refresh contract with an explicit state flag."""
+    state = {"needs_refresh": True, "refresh_calls": 0}
+
+    def fake_refresh(pending):
+        state["refresh_calls"] += 1
+        if refresh_succeeds:
+            state["needs_refresh"] = False
+
+    def fake_available(clear_expired=False, refresh=False):
+        if state["needs_refresh"]:
+            # Pending a refresh -> not yet available.
+            pending = [(e.id, "tok") for e in pool._entries] if refresh else []
+            return [], pending
+        return list(pool._entries), []
+
+    pool._refresh_pending_entries = fake_refresh
+    pool._available_entries = fake_available
+    return state
+
+
+def test_acquire_lease_reselects_after_deferred_refresh():
+    """The only entry needs a refresh; once refreshed it is available, so a
+    lease MUST be granted rather than reporting no credentials."""
+    pool = _bare_pool([_entry("e1")])
+    state = _wire_deferred_refresh(pool)
+
+    lease = pool.acquire_lease()
+
+    assert state["refresh_calls"] == 1, "the deferred refresh should run once"
+    assert state["needs_refresh"] is False, "entry is available post-refresh"
+    assert lease == "e1", (
+        "acquire_lease returned None despite a successfully refreshed, "
+        "available entry — the caller would fail an answerable request"
+    )
+    assert pool._active_leases.get("e1") == 1, "the lease must be recorded"
+
+
+def test_acquire_lease_without_pending_refresh_does_not_double_select():
+    """No pending refresh -> exactly one selection pass (no wasted work)."""
+    pool = _bare_pool([_entry("e1")])
+    state = _wire_deferred_refresh(pool)
+    state["needs_refresh"] = False  # already healthy
+
+    passes = {"n": 0}
+    original = pool._acquire_lease_under_lock
+
+    def counting(credential_id):
+        passes["n"] += 1
+        return original(credential_id)
+
+    pool._acquire_lease_under_lock = counting
+
+    lease = pool.acquire_lease()
+
+    assert lease == "e1"
+    assert passes["n"] == 1, "healthy pool must not trigger the retry path"
+    assert state["refresh_calls"] == 0
+
+
+def test_acquire_lease_still_none_when_refresh_does_not_help():
+    """If the refresh leaves nothing available, None is still the answer —
+    the retry must not loop or invent a credential."""
+    pool = _bare_pool([_entry("e1")])
+    state = _wire_deferred_refresh(pool, refresh_succeeds=False)
+
+    assert pool.acquire_lease() is None
+    assert state["refresh_calls"] == 1, "retry must not refresh repeatedly"
+    assert pool._active_leases == {}


### PR DESCRIPTION
Follow-up to the #71775 salvage (#77714), found by a post-merge gate sweep of that campaign's merged PRs.

## Context — what this fixes, for whom

Anyone using a credential pool whose entries are **single-use OAuth tokens** (openai-codex, xai-oauth). If every entry in the pool needs a token refresh at the moment a lease is requested — the normal state after an idle period, and the universal state for a single-entry pool — `acquire_lease()` performs the refresh and then **still returns `None`**. The caller sees "no credentials available" and fails a request that was fully answerable: the refresh had just succeeded and the credential was sitting there healthy.

`select()` does not have this bug. When #71775 moved deferred refreshes outside the pool lock, it gave `select()` a re-select pass:

```python
# select(), credential_pool.py
if pending_refresh:
    entry, _ = self._select_under_lock()   # retry now that refresh is done
```

`acquire_lease()` got the same refactor but not the retry:

```python
chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
if pending_refresh:
    self._refresh_pending_entries(pending_refresh)
return chosen_id          # <- still the pre-refresh answer (None)
```

Because `_acquire_lease_under_lock` returns early (`if not available: return None, pending_refresh`) precisely when a refresh is pending, the `None` is guaranteed in exactly the case the refresh was meant to resolve.

## The fix

Mirror `select()`: retry the lease once, and only when the first pass came back empty AND a refresh actually ran. No retry for a healthy pool (no wasted selection pass), and no loop when the refresh doesn't help.

## Verification

- New `tests/agent/test_credential_pool_lease_refresh_reselect.py`: 3 tests — the bug case, a no-double-select guard for the healthy path, and a still-returns-None guard for a failed refresh.
- **Mutation check:** with `agent/credential_pool.py` reverted to main, the bug test FAILS and the two guard tests pass; restored, all 3 pass. The regression test genuinely pins the fix.
- Full surface: `test_credential_pool.py` + `test_credential_pool_deferred_refresh.py` + `test_reset_aware_primary_restore.py` + the new file → **79 passed**.
- ruff clean.

## Provenance

This is a gap-closing pass over the salvage campaign's merged PRs (#77714 / #77631 / #77740 all touched `credential_pool.py`). Three related checks came back clean and are worth recording: every `_available_entries()` caller correctly unpacks the tuple (no second dead gate like #77740 fixed), the `next_available_at` lock probe correctly tests ownership from a helper thread rather than same-thread — which would be vacuous under an RLock — and the RLock downgrade introduced no re-entrancy path that mutates state a caller then reads stale.
