### PR TITLE
fix: strip empty tool_calls on session load so no send path can miss it

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6519,6 +6519,41 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     repaired,
                     session_id,
                 )
+        # Strip empty tool_calls arrays from assistant messages before they
+        # reach any downstream send path.  DeepSeek v4 (and other strict
+        # OpenAI-compatible providers) reject ``tool_calls: []`` with HTTP 400
+        # ("empty array — expected minimum length 1").  Empty arrays can
+        # survive the DB round-trip (stored as NULL, not present on load) but
+        # are reintroduced by repair_message_sequence's consecutive-assistant
+        # merge when ``prev`` carries a pre-existing ``[]`` from a prior
+        # repair, a hand-built host history, or an import.  The pre-send
+        # chokepoints (conversation_loop + chat_completion_helpers) already
+        # run ``sanitize_api_messages``, which is the authoritative scrub;
+        # this load-time pass is defense-in-depth so no send path can ever
+        # receive a message with an empty tool_calls array — regardless of
+        # whether the runtime calls sanitize, uses a cached agent instance
+        # that skips the prologue, or hand-builds messages.
+        # (#58755 follow-up, #77921)
+        _stripped = 0
+        for _msg in messages:
+            if (
+                isinstance(_msg, dict)
+                and _msg.get("role") == "assistant"
+                and "tool_calls" in _msg
+                and not (
+                    isinstance(_msg["tool_calls"], list)
+                    and _msg["tool_calls"]
+                )
+            ):
+                del _msg["tool_calls"]
+                _stripped += 1
+        if _stripped:
+            logger.debug(
+                "Stripped empty tool_calls from %d assistant message(s) "
+                "during session load (session=%s)",
+                _stripped,
+                session_id,
+            )
         return messages
 
     def get_resume_conversations(


### PR DESCRIPTION
Empty `tool_calls: []` arrays survive the DB round trip (stored as NULL, not present on load) and `repair_message_sequence` preserves them on merged consecutive-assistant turns. The pre-send `sanitize_api_messages` chokepoints in `conversation_loop.py` and `chat_completion_helpers.py` handle the standard paths correctly, but a cached agent instance, non-standard send path, or hand-built message list can bypass them.

This adds a load-time tool_calls scrub inside `_rows_to_conversation` — the single function every session-load path goes through — so every assistant message loaded from `state.db` is clean regardless of which code path later sends it to the API. The pre-send chokepoints remain as the authoritative scrub; this is defense-in-depth.

Fixes the DeepSeek v4 HTTP 400 `"Invalid 'messages[N].tool_calls': empty array"` on long session resume (~400+ messages) reported in #77921 (follow-up to #58755).