### PR TITLE
fix(cli): make profile.yaml and skin writes atomic to stop silent field loss (supersedes #51808)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -867,8 +867,17 @@ def write_profile_meta(
         existing["description"] = description.strip()
     if description_auto is not None:
         existing["description_auto"] = bool(description_auto)
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(existing, f, sort_keys=False, default_flow_style=False)
+    # Route through the shared atomic helper (temp file + fsync + replace).
+    # A bare ``open(path, "w")`` truncates before the dump, so a crash or
+    # SIGINT mid-write leaves profile.yaml empty or half-written. The read
+    # half above swallows the resulting parse error and falls back to
+    # ``{}``, so the NEXT call would silently and permanently drop every
+    # field the caller did not pass — breaking this function's documented
+    # merge contract. atomic_yaml_write also emits emoji descriptions as
+    # real UTF-8 rather than ``\UXXXXXXXX`` escapes (GitHub #51356).
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(path, existing, sort_keys=False, default_flow_style=False)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/skin_cmd.py
+++ b/hermes_cli/skin_cmd.py
@@ -72,8 +72,18 @@ def _skin_set(key: str, value: str, skin: str | None) -> int:
     data["colors"][key] = value
     data.setdefault("name", target)
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    # Route through the shared atomic helper (temp file + fsync + replace;
+    # it creates the parent dir and keeps allow_unicode=True for the kaomoji
+    # cursors and box-drawing tool prefixes). ``write_text`` truncates and
+    # writes with no fsync and no atomic swap, so a crash or power loss can
+    # leave <skin>.yaml zero-length — and the read above falls back to ``{}``
+    # on a parse error, so the next ``hermes skin set`` rewrites from empty
+    # and permanently drops the rest of the palette. The gateway's skin
+    # watcher repaints live surfaces from this file within ~1s, so a
+    # half-written file is observable, not only a crash-window concern.
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(path, data, sort_keys=False)
 
     if target != name:
         _use(target)

--- a/hermes_cli/skin_cmd.py
+++ b/hermes_cli/skin_cmd.py
@@ -76,11 +76,13 @@ def _skin_set(key: str, value: str, skin: str | None) -> int:
     # it creates the parent dir and keeps allow_unicode=True for the kaomoji
     # cursors and box-drawing tool prefixes). ``write_text`` truncates and
     # writes with no fsync and no atomic swap, so a crash or power loss can
-    # leave <skin>.yaml zero-length — and the read above falls back to ``{}``
-    # on a parse error, so the next ``hermes skin set`` rewrites from empty
-    # and permanently drops the rest of the palette. The gateway's skin
-    # watcher repaints live surfaces from this file within ~1s, so a
-    # half-written file is observable, not only a crash-window concern.
+    # leave <skin>.yaml zero-length — and ``safe_load("")`` returns ``None``,
+    # which the ``or {}`` above turns into an empty palette, so the next
+    # ``hermes skin set`` rewrites from empty and permanently drops every
+    # other color. (A file left with *invalid* YAML raises instead and
+    # aborts the command — loud, and not a loss.) The gateway's skin watcher
+    # repaints live surfaces from this file within ~1s, so a half-written
+    # file is observable, not only a crash-window concern.
     from utils import atomic_yaml_write
 
     atomic_yaml_write(path, data, sort_keys=False)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -711,6 +711,110 @@ class TestInternalHelpers:
 
 
 # ===================================================================
+# TestWriteProfileMetaDurability
+# ===================================================================
+
+class TestWriteProfileMetaDurability:
+    """``profile.yaml`` must survive an interrupted ``write_profile_meta``.
+
+    ``write_profile_meta`` is a read-modify-write whose docstring promises
+    "unspecified fields preserve existing values".  Its read half swallows
+    any parse error and falls back to ``{}``, so a truncated profile.yaml is
+    not transient corruption — the *next* call reads ``{}`` and silently and
+    permanently drops every field the caller did not explicitly pass.
+    """
+
+    @staticmethod
+    def _seed(tmp_path):
+        profile_dir = tmp_path / "coder"
+        profile_dir.mkdir()
+        profiles.write_profile_meta(
+            profile_dir, description="Curated by hand", description_auto=False
+        )
+        return profile_dir
+
+    @staticmethod
+    def _interrupted_write(profile_dir):
+        """Run a ``write_profile_meta`` whose serialization fails mid-call.
+
+        The pre-fix code called ``yaml.safe_dump``; ``utils.atomic_yaml_write``
+        calls ``yaml.dump``.  Breaking both keeps this serializer-agnostic, so
+        it measures durability rather than the choice of entry point.  A
+        scoped ``MonkeyPatch.context`` is used instead of the fixture so the
+        patch is reverted immediately, without touching the session-wide env
+        isolation that shares the function-scoped ``monkeypatch`` instance.
+        """
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated interruption mid-write")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(yaml, "safe_dump", _boom)
+            mp.setattr(yaml, "dump", _boom)
+            with pytest.raises(RuntimeError):
+                profiles.write_profile_meta(profile_dir, description_auto=True)
+
+    def test_failed_write_leaves_existing_file_intact(self, tmp_path):
+        profile_dir = self._seed(tmp_path)
+        path = profile_dir / "profile.yaml"
+        before = path.read_text(encoding="utf-8")
+        assert "Curated by hand" in before
+
+        self._interrupted_write(profile_dir)
+
+        # A truncating open() destroys the file before the dump ever runs.
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_failed_write_does_not_silently_drop_unspecified_fields(self, tmp_path):
+        profile_dir = self._seed(tmp_path)
+
+        self._interrupted_write(profile_dir)
+
+        # The user retries; this call does not pass a description, so the
+        # documented merge contract requires the existing one to survive.
+        profiles.write_profile_meta(profile_dir, description_auto=True)
+        meta = profiles.read_profile_meta(profile_dir)
+        assert meta["description"] == "Curated by hand"
+        assert meta["description_auto"] is True
+
+    def test_emoji_description_is_written_as_real_utf8(self, tmp_path):
+        """Astral-plane chars must not become ``\\UXXXXXXXX`` escapes (#51356).
+
+        Supersedes #51808, which fixed this symptom alone by adding
+        ``allow_unicode=True``; ``atomic_yaml_write`` sets it internally.
+        """
+        profile_dir = tmp_path / "wizard"
+        profile_dir.mkdir()
+        profiles.write_profile_meta(profile_dir, description="Code wizard 🧙 ✨")
+
+        raw = (profile_dir / "profile.yaml").read_text(encoding="utf-8")
+        assert "\\U" not in raw
+        assert "🧙" in raw
+        assert profiles.read_profile_meta(profile_dir)["description"] == "Code wizard 🧙 ✨"
+
+    def test_symlinked_profile_yaml_survives_the_write(self, tmp_path):
+        """Guard on the conversion, not a behavior change.
+
+        Dotfile managers (chezmoi/stow) symlink profile.yaml into a tracked
+        repo.  ``open(path, "w")`` wrote through the link; a naive
+        ``os.replace`` would detach it.  ``atomic_replace`` resolves the link
+        first (GitHub #16743), so the link must still be intact afterwards.
+        """
+        profile_dir = tmp_path / "linked"
+        profile_dir.mkdir()
+        real_dir = tmp_path / "dotfiles"
+        real_dir.mkdir()
+        real = real_dir / "profile.yaml"
+        real.write_text("description: from dotfiles\n", encoding="utf-8")
+        (profile_dir / "profile.yaml").symlink_to(real)
+
+        profiles.write_profile_meta(profile_dir, description="updated")
+
+        assert (profile_dir / "profile.yaml").is_symlink()
+        assert "updated" in real.read_text(encoding="utf-8")
+        assert [p.name for p in profile_dir.iterdir() if p.name.endswith(".tmp")] == []
+
+
+# ===================================================================
 # Edge cases and additional coverage
 # ===================================================================
 

--- a/tests/hermes_cli/test_skin_cmd.py
+++ b/tests/hermes_cli/test_skin_cmd.py
@@ -66,10 +66,11 @@ def test_set_persists_the_skin_durably():
     ``write_text`` truncates and writes without ever calling ``fsync``, so a
     power loss or container kill right after the command "succeeds" can leave
     ``<skin>.yaml`` zero-length.  That is not transient: ``_skin_set`` is a
-    read-modify-write whose read half falls back to ``{}``, so the next tweak
-    rewrites the file from that empty state and the rest of the palette is
-    gone for good — and the gateway's skin watcher repaints every live
-    surface from this file within ~1s either way.
+    read-modify-write and ``safe_load("")`` returns ``None``, which its
+    ``or {}`` turns into an empty palette — so the next tweak rewrites the
+    file from that empty state and the rest of the palette is gone for good.
+    The gateway's skin watcher repaints every live surface from this file
+    within ~1s either way.
     """
     path = _skins() / "oasis.yaml"
     path.write_text(

--- a/tests/hermes_cli/test_skin_cmd.py
+++ b/tests/hermes_cli/test_skin_cmd.py
@@ -4,6 +4,9 @@ The whole point is that changing one token never disturbs the rest of the look
 (background especially), which hand-authoring kept getting wrong.
 """
 
+import os
+
+import pytest
 import yaml
 
 from hermes_cli import skin_cmd
@@ -55,3 +58,66 @@ def test_set_forks_a_builtin_without_inventing_a_background():
 def test_set_rejects_non_hex():
     _activate("default")
     assert skin_cmd._skin_set("ui_tool", "teal", None) == 1
+
+
+def test_set_persists_the_skin_durably():
+    """The palette must reach disk before ``skin set`` returns.
+
+    ``write_text`` truncates and writes without ever calling ``fsync``, so a
+    power loss or container kill right after the command "succeeds" can leave
+    ``<skin>.yaml`` zero-length.  That is not transient: ``_skin_set`` is a
+    read-modify-write whose read half falls back to ``{}``, so the next tweak
+    rewrites the file from that empty state and the rest of the palette is
+    gone for good — and the gateway's skin watcher repaints every live
+    surface from this file within ~1s either way.
+    """
+    path = _skins() / "oasis.yaml"
+    path.write_text(
+        'name: oasis\ncolors:\n  background: "#08201f"\n  banner_title: "#f2dfb3"\n',
+        encoding="utf-8",
+    )
+    _activate("oasis")
+
+    synced = []
+    real_fsync = os.fsync
+
+    def _tracking_fsync(fd):
+        synced.append(fd)
+        return real_fsync(fd)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(os, "fsync", _tracking_fsync)
+        assert skin_cmd._skin_set("ui_tool", "#00FFFF", None) == 0
+
+    assert synced, "skin file written without fsync — a crash can leave it empty"
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data["colors"]["ui_tool"] == "#00FFFF"
+    assert data["colors"]["background"] == "#08201f"  # untouched — the whole point
+    assert data["colors"]["banner_title"] == "#f2dfb3"
+    assert [p.name for p in _skins().iterdir() if p.name.endswith(".tmp")] == []
+
+
+def test_set_preserves_a_symlinked_skin_file():
+    """Guard on the conversion, not a behavior change.
+
+    ``write_text`` wrote through a symlink; a naive ``os.replace`` would
+    detach it.  ``atomic_replace`` resolves the link first (GitHub #16743),
+    so a skin file symlinked out to a dotfiles repo must stay a symlink.
+    """
+    real_dir = _skins().parent / "dotfiles"
+    real_dir.mkdir(parents=True, exist_ok=True)
+    real = real_dir / "oasis.yaml"
+    real.write_text(
+        'name: oasis\ncolors:\n  background: "#08201f"\n', encoding="utf-8"
+    )
+    link = _skins() / "oasis.yaml"
+    link.symlink_to(real)
+    _activate("oasis")
+
+    assert skin_cmd._skin_set("ui_tool", "#00FFFF", None) == 0
+
+    assert link.is_symlink()
+    data = yaml.safe_load(real.read_text(encoding="utf-8"))
+    assert data["colors"]["ui_tool"] == "#00FFFF"
+    assert data["colors"]["background"] == "#08201f"


### PR DESCRIPTION
## What does this PR do?

Two Channel-A CLI helpers rewrite a **user-visible YAML file with a bare truncating write**, bypassing `utils.atomic_yaml_write` — the shared helper whose own docstring states the invariant:

> "Used by the memory store, skill manager, and agent importer so that **every destructive file rewrite in the codebase shares one implementation**."

Both are **read-modify-write** helpers whose read half degrades an unreadable file to `{}`. That is what turns a torn write from transient corruption into **silent, permanent data loss**: the next call reads `{}` and drops every field the caller did not explicitly pass. The two get there differently, and the distinction matters — `write_profile_meta` wraps its read in `try/except Exception: existing = {}`, so it absorbs *any* corruption; `_skin_set` has no `try/except`, so invalid YAML raises and aborts loudly, and only a **zero-length** file degrades silently (`safe_load("") is None`, then `or {}`). Zero-length is precisely what an unsynced, non-atomic write leaves behind, so the loss chain holds for both.

**`hermes_cli/profiles.py` — `write_profile_meta` (sharpest).** Its docstring promises *"Only the explicitly passed fields are overwritten; unspecified fields preserve existing values."* `open(path, "w")` truncates **before** `yaml.safe_dump` runs, so a crash or Ctrl-C mid-write leaves `profile.yaml` empty. The user retries; that call passes only `description_auto`, the read falls back to `{}` — and the profile's `description` is gone from `hermes profile list` for good, with no error surfaced. This is a direct violation of the function's documented merge contract.

**`hermes_cli/skin_cmd.py` — `_skin_set`.** The module docstring says `set` "changes ONE color of the ACTIVE skin **in place**, so tweaking (say) the tool marker never disturbs the rest of the look — background included." `path.write_text(...)` neither `fsync`s nor swaps atomically, so a crash or power loss can leave `<skin>.yaml` zero-length; the next `hermes skin set` then loads that as `None`, falls back to `{}`, and the rest of the palette is permanently gone. The gateway's skin watcher repaints every live surface from this file within ~1s, so a half-written file is directly observable, not just a crash-window concern.

Routing both through `atomic_yaml_write` gives temp file + `fsync` + `atomic_replace`, which additionally **preserves a symlinked target** (GitHub #16743 — dotfile managers symlink these paths into a tracked repo), restores owner and mode, and emits emoji descriptions and kaomoji cursors as real UTF-8 instead of `\UXXXXXXXX` escapes (GitHub #51356).

### Supersedes #51808

@srojk34's #51808 (open since 2026-06-24, no reviews) targets **the exact line this PR replaces**, adding `allow_unicode=True` to that `yaml.safe_dump` call. `atomic_yaml_write` passes `allow_unicode=True` internally, so this change **strictly subsumes it** — it fixes the unicode escaping *and* the torn write. `test_emoji_description_is_written_as_real_utf8` covers #51808's case and is verified to fail on current `main`. The assertion lives in the existing `tests/hermes_cli/test_profiles.py` rather than in a new file, so nothing collides with #51808's own test module if the maintainers prefer to land that one instead.

### Sibling-site sweep — every `yaml` write site in Channel A

Enumerated with `git ls-tree -r --name-only origin/main | grep -E '^(hermes_cli/|gateway/|tui_gateway/|cli\.py|utils\.py|hermes_state.*\.py)'` piped through `grep -n 'yaml.safe_dump\|yaml.dump\|write_text(yaml'`. Six hits, all accounted for:

| Site | Verdict |
|---|---|
| `hermes_cli/profiles.py:871` | **fixed here** — truncating `open(w)` + `safe_dump` on `profile.yaml` |
| `hermes_cli/skin_cmd.py:76` | **fixed here** — `write_text(safe_dump(...))` on `~/.hermes/skins/<name>.yaml` |
| `hermes_cli/xai_retirement.py:249` | **deliberately excluded — see below** |
| `hermes_cli/config.py:1185` | excluded — `return yaml.safe_dump(value)`, a formatter returning a string; no file touched |
| `hermes_cli/profile_distribution.py:257` | excluded — same, `return yaml.safe_dump(data, ...)`; no file touched |
| `utils.py:345` | excluded — this **is** `atomic_yaml_write`'s implementation |

**Why `xai_retirement.py:249` is not converted here.** That site dumps a **`ruamel.yaml` round-trip document** (`YAML(typ="rt")`), which exists precisely to preserve the user's comments and quoting in `config.yaml`. `atomic_yaml_write` is PyYAML-based and raises `RepresenterError: cannot represent an object` on a `CommentedMap` — I verified this directly, so the "obvious" one-line conversion there would **break the migration**, not harden it. Making that path atomic needs a round-trip-aware helper (the pattern already inlined in `utils.atomic_roundtrip_yaml_update`), which is a separate change with its own blast radius. It is also the least exposed of the three: it is a one-shot migration, already guarded by `require_readable_config_before_write`, and takes a `shutil.copy2` backup to `.bak-pre-migrate-xai-<ts>` on the default path, so loss there is recoverable. Happy to follow up on it separately if you'd like it in the same series.

### Precedent on these exact files

`main` already carries a merged symlink-preservation and atomic-write series across `hermes_cli/profiles.py` — `b6b9bcd2a` (profile export), `8d9684c9d` (default-export paths, #58394), `b7192b1cb` (clone-all + skills clone) — plus #3800, #4320/#4298, #18217, #10618 and #16980 elsewhere. Those covered the clone/export paths; the `profile.yaml` **metadata** write was never converted. This ships the missed site of a series you already merged.

## Related Issue

No filed issue — found by sweeping the remaining destructive YAML write sites against `utils.atomic_yaml_write`'s stated single-implementation invariant.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py` — `write_profile_meta` now calls `atomic_yaml_write(path, existing, sort_keys=False, default_flow_style=False)` instead of `open(path, "w")` + `yaml.safe_dump`. Same kwargs, same defaults.
- `hermes_cli/skin_cmd.py` — `_skin_set` now calls `atomic_yaml_write(path, data, sort_keys=False)` instead of `path.write_text(yaml.safe_dump(..., allow_unicode=True))`. The explicit `path.parent.mkdir(...)` is dropped because the helper does it; `allow_unicode=True` is set inside the helper, so the kaomoji cursors and box-drawing `tool_prefix` values still round-trip as UTF-8.
- `tests/hermes_cli/test_profiles.py` — new `TestWriteProfileMetaDurability` (4 tests), inserted mid-file between `TestInternalHelpers` and `TestEdgeCases` rather than appended at EOF, to avoid colliding with the several open PRs that append there.
- `tests/hermes_cli/test_skin_cmd.py` — 2 new tests.

One behavioral note: the helper serializes with `IndentDumper`, so nested sequences gain 2-space indentation. That is the repo's canonical layout (#31999, aligning PyYAML with the `ruamel` writers); neither file's schema currently contains a list (`profile.yaml` is `description`/`description_auto`; skins are flat `str -> str` maps plus `tool_prefix`), so no existing file's bytes change.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_profiles.py tests/hermes_cli/test_skin_cmd.py -v
```

**Fail-before / pass-after was verified in both directions** by stashing only the two production hunks and re-running the new tests against unmodified `main`:

| Test | On `main` | With this PR |
|---|---|---|
| `test_failed_write_leaves_existing_file_intact` | **FAILED** — `profile.yaml` is already truncated when the dump raises | PASSED |
| `test_failed_write_does_not_silently_drop_unspecified_fields` | **FAILED** — `assert '' == 'Curated by hand'` | PASSED |
| `test_emoji_description_is_written_as_real_utf8` | **FAILED** — file contains `description: "Code wizard \U0001F9D9 ✨"` | PASSED |
| `test_set_persists_the_skin_durably` | **FAILED** — no `fsync` before `skin set` returns | PASSED |
| `test_symlinked_profile_yaml_survives_the_write` | passed (guard) | PASSED |
| `test_set_preserves_a_symlinked_skin_file` | passed (guard) | PASSED |

The last two are stated as **conversion guards, not fixes**: `open(w)` / `write_text` already write *through* a symlink, so symlink survival is an invariant this change must not regress — a naive `os.replace` conversion would detach the link, which is exactly what `atomic_replace` prevents (#16743). They are included because that regression is the main hazard of this kind of change, and they pass before and after by design.

The two durability tests break `yaml.safe_dump` **and** `yaml.dump` so the failure is serializer-agnostic — the old code used the former, the helper uses the latter — which keeps them measuring durability rather than the choice of entry point. They use a scoped `pytest.MonkeyPatch.context()` rather than the `monkeypatch` fixture so the patch is reverted mid-test without disturbing the session-wide env isolation that shares the function-scoped instance.

Manual check:

1. `hermes profile create demo && hermes profile describe demo --description "Curated by hand"`
2. `printf '' > ~/.hermes/profiles/demo/profile.yaml`  (simulates the post-crash state)
3. Re-run a metadata write that does not pass a description — on `main` the description is gone from `hermes profile list`; the point of this PR is that step 2 can no longer be reached by an interrupted write.

Adjacent suites run green: `tests/hermes_cli/test_profile_describer.py`, `tests/hermes_cli/test_skin_engine.py`, `tests/hermes_cli/test_skin_palettes.py`, `tests/cli/test_cli_skin_integration.py`, `tests/test_cli_skin_integration.py` — **102 passed** together with the two touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent suites listed above (102 passed), not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-facing behavior or docstring contract changed; the contract is now actually honored)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — reasoned but not executed on Windows: `atomic_replace` is the repo's existing cross-platform primitive and already has `EXDEV`/`EBUSY` fallbacks; the two symlink guard tests will skip or fail on a Windows runner without developer mode, so please flag if CI shows that and I'll gate them on `os.symlink` availability
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

Checked against the open queue two ways, because the two nets are blind in opposite directions:

- **By changed path** (`gh pr list --json files`, 800 most recent open PRs, spanning #76714–#78295): zero rivals on `hermes_cli/skin_cmd.py` or `tests/hermes_cli/test_skin_cmd.py`. Five PRs touch `hermes_cli/profiles.py` or its test file (#77992, #77901, #77058, #76853, #76791) — all hunk-disjoint from `write_profile_meta`'s write.
- **By symbol, corpus-wide** (`gh search prs`, all open): `write_profile_meta` returns exactly one PR — **#51808**, superseded as described above. `skin_cmd` / `_skin_set` return zero. #27708 edits the `description_auto` coercion two lines above this hunk; different bug, no overlap with the write itself.

