### PR TITLE
fix(cli): map Ctrl+Backspace from enhanced terminals (#78285)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -79,6 +79,7 @@ except (ImportError, AttributeError):
 try:
     from hermes_cli.pt_input_extras import (
         install_cmd_backspace_alias,
+        install_ctrl_backspace_alias,
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
         install_shift_enter_alias,
@@ -86,8 +87,11 @@ try:
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_cmd_backspace_alias()
+    install_ctrl_backspace_alias()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_ignored_terminal_sequences
+    del install_shift_enter_alias, install_ctrl_enter_alias
+    del install_cmd_backspace_alias, install_ctrl_backspace_alias
+    del install_ignored_terminal_sequences
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -126,6 +126,37 @@ def install_cmd_backspace_alias() -> int:
     return changed
 
 
+def install_ctrl_backspace_alias() -> int:
+    """Map Ctrl+Backspace to prompt_toolkit's word-delete binding.
+
+    Terminals using Kitty CSI-u or xterm modifyOtherKeys report Ctrl as
+    modifier 5 (or 6 with Shift). prompt_toolkit does not map these enhanced
+    Backspace sequences, so the raw bytes otherwise fall through instead of
+    invoking ``unix-word-rubout``.
+
+    Ctrl+Backspace -> ``Keys.ControlW``:
+      - ``\\x1b[127;5u`` / ``\\x1b[127;6u`` - Kitty CSI-u
+      - ``\\x1b[27;5;127~``                  - xterm modifyOtherKeys
+
+    Ctrl+ForwardDelete is deliberately excluded because prompt_toolkit already
+    maps ``\\x1b[3;5~`` to ``Keys.ControlDelete``.
+
+    Returns the number of sequences whose mapping was changed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    changed = 0
+    for seq in ("\x1b[127;5u", "\x1b[127;6u", "\x1b[27;5;127~"):
+        if ANSI_SEQUENCES.get(seq) != Keys.ControlW:
+            ANSI_SEQUENCES[seq] = Keys.ControlW
+            changed += 1
+    return changed
+
+
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they
     are consumed by the VT100 parser before they reach key bindings or

--- a/tests/cli/test_cli_cmd_backspace.py
+++ b/tests/cli/test_cli_cmd_backspace.py
@@ -1,6 +1,5 @@
-"""Verify Cmd+Backspace / Cmd+ForwardDelete byte sequences from CSI-u
-terminals reach prompt_toolkit's readline kill bindings instead of leaking
-into the buffer as literal text.
+"""Verify enhanced Cmd/Ctrl+Backspace byte sequences reach prompt_toolkit's
+readline kill bindings instead of leaking into the buffer as literal text.
 """
 
 from __future__ import annotations
@@ -11,15 +10,18 @@ from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit.input.vt100_parser import Vt100Parser
 from prompt_toolkit.keys import Keys
 
-from hermes_cli.pt_input_extras import install_cmd_backspace_alias
+from hermes_cli.pt_input_extras import (
+    install_cmd_backspace_alias,
+    install_ctrl_backspace_alias,
+)
 
 
 # Cmd rides as the super modifier bit (8), so modifier = 9 (super) or
 # 10 (super+shift).
 CMD_BACKSPACE_SEQUENCES = (
-    "\x1b[127;9u",       # Kitty CSI-u
-    "\x1b[127;10u",      # Kitty CSI-u, +shift
-    "\x1b[27;9;127~",    # xterm modifyOtherKeys
+    "\x1b[127;9u",  # Kitty CSI-u
+    "\x1b[127;10u",  # Kitty CSI-u, +shift
+    "\x1b[27;9;127~",  # xterm modifyOtherKeys
 )
 
 # Forward-delete is a CSI tilde key, not a CSI-u codepoint.
@@ -28,10 +30,17 @@ CMD_FWD_DELETE_SEQUENCES = (
     "\x1b[3;10~",
 )
 
+CTRL_BACKSPACE_SEQUENCES = (
+    "\x1b[127;5u",  # Kitty CSI-u
+    "\x1b[127;6u",  # Kitty CSI-u, +shift
+    "\x1b[27;5;127~",  # xterm modifyOtherKeys
+)
+
 
 @pytest.fixture(autouse=True)
 def _ensure_alias_installed():
     install_cmd_backspace_alias()
+    install_ctrl_backspace_alias()
 
 
 def _parse(byte_seq: str):
@@ -55,7 +64,16 @@ def test_cmd_forward_delete_parses_as_ctrl_k(seq):
     assert _parse(seq) == _parse("\x0b")
 
 
-@pytest.mark.parametrize("seq", CMD_BACKSPACE_SEQUENCES + CMD_FWD_DELETE_SEQUENCES)
+@pytest.mark.parametrize("seq", CTRL_BACKSPACE_SEQUENCES)
+def test_ctrl_backspace_parses_as_ctrl_w(seq):
+    """Ctrl+Backspace must reach unix-word-rubout, exactly as Ctrl+W does."""
+    assert _parse(seq) == _parse("\x17")
+
+
+@pytest.mark.parametrize(
+    "seq",
+    CMD_BACKSPACE_SEQUENCES + CMD_FWD_DELETE_SEQUENCES + CTRL_BACKSPACE_SEQUENCES,
+)
 def test_sequences_emit_exactly_one_keypress(seq):
     """The whole sequence is consumed. A partial match would emit Escape
     plus the remainder as literal text — the bug this alias exists to fix."""
@@ -65,6 +83,8 @@ def test_sequences_emit_exactly_one_keypress(seq):
 def test_install_is_idempotent():
     install_cmd_backspace_alias()
     assert install_cmd_backspace_alias() == 0
+    install_ctrl_backspace_alias()
+    assert install_ctrl_backspace_alias() == 0
 
 
 def test_unmodified_keys_keep_their_own_bindings():


### PR DESCRIPTION
## What does this PR do?

Maps Ctrl+Backspace sequences emitted by Kitty CSI-u and xterm
modifyOtherKeys terminals to prompt_toolkit's existing `ControlW`
word-delete binding.

The classic CLI already installs aliases for enhanced Shift+Enter,
Ctrl+Enter, and Cmd+Backspace sequences. Ctrl+Backspace was missing, so the
enhanced escape sequence was dropped instead of invoking
`unix-word-rubout`.

## Related Issue

Fixes #78285

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add `install_ctrl_backspace_alias()` for Kitty CSI-u and xterm
  modifyOtherKeys sequences.
- Register the alias during classic CLI startup.
- Exercise the real prompt_toolkit `Vt100Parser`, idempotent installation,
  and preservation of the native Ctrl+Delete binding.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/cli/test_cli_cmd_backspace.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_ctrl_enter_newline.py -q`
2. Confirm all 28 tests pass.
3. In a CSI-u-capable terminal, press Ctrl+Backspace and confirm it deletes
   the previous word.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the focused CLI input tests through `scripts/run_tests.sh`.
- [x] I've added regression coverage.
- [x] I've tested the parser behavior on macOS.

### Documentation & Housekeeping

- [x] Documentation update is not required.
- [x] `cli-config.yaml.example` update is not required.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not required.
- [x] Cross-platform impact considered; the aliases target terminal protocols
  used on Linux, Windows/WSL, and macOS.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

```text
'\x1b[127;5u' -> Keys.ControlW
'\x1b[127;6u' -> Keys.ControlW
'\x1b[27;5;127~' -> Keys.ControlW
'\x1b[3;5~' -> Keys.ControlDelete
```
