### PR TITLE
fix(agent): strip max_tokens together with temperature on unsupported parameter retry

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8729,6 +8729,9 @@ def call_llm(
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
+            if max_tokens is not None:
+                retry_kwargs.pop("max_tokens", None)
+                retry_kwargs.pop("max_completion_tokens", None)
             logger.info(
                 "Auxiliary %s: provider rejected temperature; retrying once without it",
                 task or "call",
@@ -9377,6 +9380,9 @@ async def async_call_llm(
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
+            if max_tokens is not None:
+                retry_kwargs.pop("max_tokens", None)
+                retry_kwargs.pop("max_completion_tokens", None)
             logger.info(
                 "Auxiliary %s (async): provider rejected temperature; retrying once without it",
                 task or "call",


### PR DESCRIPTION
## Bug

GPT-5 and o-series models reject both `temperature` and `max_tokens`. The temperature retry path only stripped temperature — the retry immediately failed again on max_tokens, and the user saw `"temperature" is not supported` instead of the real error. The fallback max_tokens detection exists but depends on the error string matching, which varies across endpoints.

## Fix

When `max_tokens` is present and the provider rejects temperature, strip both parameters in the retry path. The existing fallback max_tokens detection below remains as a belt-and-suspenders guard.