### PR TITLE
feat(ntfy): support multiple conversation topics

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -18,7 +18,10 @@ Configuration in config.yaml::
         enabled: true
         extra:
           server: "https://ntfy.sh"       # or self-hosted URL
-          topic: "hermes-in"              # subscribe topic (incoming)
+          topic: "hermes-in"              # one subscribe topic (incoming)
+          topics:                          # or several independent chats
+            - "hermes-1"
+            - "hermes-2"
           publish_topic: "hermes-out"     # optional — defaults to topic
           token: "..."                    # optional Bearer / Basic auth token
           markdown: true                  # optional — enable markdown (default: false)
@@ -146,31 +149,40 @@ def _truncate_body(message: str, *, context: str) -> bytes:
     return message[:MAX_MESSAGE_LENGTH].encode("utf-8")
 
 
-def check_requirements() -> bool:
-    """Check whether the ntfy adapter is installable and minimally configured.
+def _configured_topics(extra: Dict[str, Any]) -> List[str]:
+    """Return ordered, de-duplicated topics from config or the legacy env."""
+    configured = extra.get("topics")
+    if isinstance(configured, (list, tuple)):
+        return list(dict.fromkeys(
+            topic.strip()
+            for topic in configured
+            if isinstance(topic, str) and topic.strip()
+        ))
+    topic = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+    topic = topic.strip()
+    return [topic] if topic else []
 
-    Reads ``NTFY_TOPIC`` directly to avoid the cost of a full
-    ``load_gateway_config()`` (which also writes to ``os.environ``) on
-    every pre-flight check.
+
+def check_requirements() -> bool:
+    """Check whether the ntfy adapter's runtime dependency is available.
+
+    Topic configuration is validated separately from the supplied
+    ``PlatformConfig`` so config-only ``topics`` setups work without a legacy
+    ``NTFY_TOPIC`` environment variable.
     """
-    if not HTTPX_AVAILABLE:
-        return False
-    topic = os.getenv("NTFY_TOPIC", "").strip()
-    return bool(topic)
+    return HTTPX_AVAILABLE
 
 
 def validate_config(config) -> bool:
-    """Validate that the configured ntfy platform has a topic set."""
+    """Validate that the configured ntfy platform has at least one topic."""
     extra = getattr(config, "extra", {}) or {}
-    topic = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
-    return bool(topic)
+    return bool(_configured_topics(extra))
 
 
 def is_connected(config) -> bool:
     """Check whether ntfy is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    topic = os.getenv("NTFY_TOPIC") or extra.get("topic", "")
-    return bool(topic)
+    return bool(_configured_topics(extra))
 
 
 class NtfyAdapter(BasePlatformAdapter):
@@ -191,11 +203,13 @@ class NtfyAdapter(BasePlatformAdapter):
             extra.get("server")
             or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
         ).rstrip("/")
-        self._topic: str = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+        self._topics = _configured_topics(extra)
+        # Keep the original single-topic attribute for compatibility with
+        # callers and plugins that inspect it.
+        self._topic: str = self._topics[0] if self._topics else ""
         self._publish_topic: str = (
             extra.get("publish_topic")
             or os.getenv("NTFY_PUBLISH_TOPIC", "")
-            or self._topic
         )
         self._token: str = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
 
@@ -212,15 +226,20 @@ class NtfyAdapter(BasePlatformAdapter):
         if not HTTPX_AVAILABLE:
             logger.warning("[%s] httpx not installed. Run: pip install httpx", self.name)
             return False
-        if not self._topic:
-            logger.warning("[%s] NTFY_TOPIC not configured", self.name)
+        if not self._topics:
+            logger.warning("[%s] No ntfy topics configured", self.name)
             return False
 
         try:
             self._http_client = httpx.AsyncClient(timeout=None)
             self._stream_task = asyncio.create_task(self._run_stream())
             self._mark_connected()
-            logger.info("[%s] Connected — subscribing to %s/%s", self.name, self._server, self._topic)
+            logger.info(
+                "[%s] Connected — subscribing to %s/%s",
+                self.name,
+                self._server,
+                ",".join(self._topics),
+            )
             return True
         except Exception as e:
             logger.error("[%s] Failed to connect: %s", self.name, e)
@@ -230,7 +249,7 @@ class NtfyAdapter(BasePlatformAdapter):
         """Subscribe to the ntfy topic with automatic reconnection."""
         backoff_idx = 0
         stream_start: float = 0.0
-        url = f"{self._server}/{self._topic}/json"
+        url = f"{self._server}/{','.join(self._topics)}/json"
         headers = self._auth_headers()
 
         while self._running:
@@ -351,9 +370,9 @@ class NtfyAdapter(BasePlatformAdapter):
         # ntfy has no native authenticated user identity. The title field is
         # publisher-controlled and must NOT be used for authorization — any
         # publisher who knows the topic can set title to an allowed username.
-        # Treat ntfy as a single trusted channel; user_id is fixed to the
-        # topic name. NTFY_ALLOWED_USERS is only a real trust boundary when
-        # the topic itself is protected by a read token.
+        # Treat each ntfy topic as one logical user/channel; user_id is the
+        # event's topic name. NTFY_ALLOWED_USERS is only a real trust boundary
+        # when every subscribed topic is protected by authenticated ntfy ACLs.
         user_id = topic
         user_name = topic
 
@@ -411,7 +430,23 @@ class NtfyAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Publish a message to the configured publish topic."""
         metadata = metadata or {}
-        publish_topic = metadata.get("publish_topic") or self._publish_topic or chat_id
+        if len(self._topics) > 1:
+            # Every subscribed topic is a distinct Hermes chat. Replies must
+            # return to the originating topic instead of collapsing all
+            # conversations onto a legacy fixed publish topic.
+            publish_topic = (
+                metadata.get("publish_topic")
+                or chat_id
+                or self._publish_topic
+                or self._topic
+            )
+        else:
+            publish_topic = (
+                metadata.get("publish_topic")
+                or self._publish_topic
+                or chat_id
+                or self._topic
+            )
 
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
@@ -544,8 +579,7 @@ async def _standalone_send(
         chat_id
         or extra.get("publish_topic")
         or os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
-        or extra.get("topic")
-        or os.getenv("NTFY_TOPIC", "").strip()
+        or next(iter(_configured_topics(extra)), "")
     )
     if not publish_topic:
         return {"error": "ntfy standalone send: NTFY_TOPIC not configured"}

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -68,11 +68,25 @@ class TestNtfyRequirements:
         monkeypatch.setattr(_ntfy, "HTTPX_AVAILABLE", False)
         assert check_requirements() is False
 
+    def test_config_only_setup_requires_httpx_not_topic_env(self, monkeypatch):
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        monkeypatch.setattr(_ntfy, "HTTPX_AVAILABLE", True)
+        assert check_requirements() is True
+
 
     def test_is_connected_from_extra(self, monkeypatch):
         monkeypatch.delenv("NTFY_TOPIC", raising=False)
         assert is_connected(PlatformConfig(enabled=True, extra={"topic": "t"})) is True
         assert is_connected(PlatformConfig(enabled=True, extra={})) is False
+
+    def test_topics_list_is_valid_connected_config(self, monkeypatch):
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        config = PlatformConfig(
+            enabled=True,
+            extra={"topics": [f"hermes-{number}" for number in range(1, 6)]},
+        )
+        assert validate_config(config) is True
+        assert is_connected(config) is True
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +102,14 @@ class TestNtfyAdapterInit:
         config = PlatformConfig(enabled=True, extra={})
         adapter = NtfyAdapter(config)
         assert adapter._topic == "env-topic"
+
+    def test_topics_list_read_from_config(self, monkeypatch):
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        topics = [f"hermes-{number}" for number in range(1, 6)]
+        adapter = NtfyAdapter(
+            PlatformConfig(enabled=True, extra={"topics": topics})
+        )
+        assert adapter._topics == topics
 
 
     def test_publish_topic_uses_extra_value(self):
@@ -173,6 +195,24 @@ class TestConnect:
         except (asyncio.CancelledError, Exception):
             pass
 
+    def test_stream_subscribes_to_all_configured_topics(self):
+        topics = [f"hermes-{number}" for number in range(1, 6)]
+        adapter = NtfyAdapter(
+            PlatformConfig(enabled=True, extra={"topics": topics})
+        )
+        adapter._running = True
+
+        async def consume_once(url, headers):
+            adapter._running = False
+
+        with patch.object(
+            adapter, "_consume_stream", side_effect=consume_once
+        ) as consume:
+            _run(adapter._run_stream())
+
+        subscribed_url = consume.call_args.args[0]
+        assert subscribed_url.endswith(f"/{','.join(topics)}/json")
+
 
     def test_disconnect_cancels_stream_task(self):
         adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
@@ -238,6 +278,25 @@ class TestSend:
         assert result.success is True
         posted_url = mock_client.post.call_args[0][0]
         assert posted_url.endswith("/hermes-in")
+
+    def test_send_replies_to_originating_topic_in_multi_topic_mode(self):
+        topics = [f"hermes-{number}" for number in range(1, 6)]
+        adapter = NtfyAdapter(
+            PlatformConfig(enabled=True, extra={"topics": topics})
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-4", "Hello topic four"))
+
+        assert result.success is True
+        posted_url = mock_client.post.call_args.args[0]
+        assert posted_url.endswith("/hermes-4")
 
     def test_send_uses_metadata_publish_topic(self):
         adapter = self._make_adapter(topic="hermes-in")
@@ -314,6 +373,28 @@ class TestOnMessage:
         _run(adapter._on_message(event))
         assert len(calls) == 1
         assert calls[0].text == "Hello from ntfy"
+
+    def test_each_topic_has_a_distinct_chat_identity(self):
+        topics = [f"hermes-{number}" for number in range(1, 6)]
+        adapter = NtfyAdapter(
+            PlatformConfig(enabled=True, extra={"topics": topics})
+        )
+        calls = []
+
+        async def handler(event):
+            calls.append(event)
+
+        adapter.set_message_handler(handler)
+        for number, topic in enumerate(topics, start=1):
+            _run(adapter._on_message({
+                "id": f"evt-{number}",
+                "event": "message",
+                "topic": topic,
+                "message": f"message {number}",
+                "time": None,
+            }))
+
+        assert [event.source.chat_id for event in calls] == topics
 
     def test_empty_message_skipped(self):
         adapter = self._make_adapter()
@@ -406,6 +487,27 @@ class TestStandaloneSend:
         result = _run(_standalone_send(pconfig, "", "hello"))
         assert "error" in result
         assert "NTFY_TOPIC" in result["error"]
+
+    def test_uses_first_configured_topic_when_chat_id_is_empty(self, monkeypatch):
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        monkeypatch.delenv("NTFY_PUBLISH_TOPIC", raising=False)
+        pconfig = MagicMock()
+        pconfig.extra = {"topics": ["hermes-1", "hermes-2"]}
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "id-1"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(_ntfy, "httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            result = _run(_standalone_send(pconfig, "", "hi"))
+
+        assert result["success"] is True
+        assert mock_client.post.call_args.args[0].endswith("/hermes-1")
 
 
     def test_emits_echo_tag_header(self, monkeypatch):

--- a/website/docs/user-guide/messaging/ntfy.md
+++ b/website/docs/user-guide/messaging/ntfy.md
@@ -46,6 +46,39 @@ NTFY_HOME_CHANNEL=hermes-myname-2026
 | `NTFY_HOME_CHANNEL` | Optional | Default topic for cron / notification delivery |
 | `NTFY_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
 
+## Multiple independent conversations
+
+One ntfy topic maps to one Hermes chat and session. To run several independent
+conversations with the same Hermes profile, configure multiple topics in
+`config.yaml`:
+
+```yaml
+platforms:
+  ntfy:
+    enabled: true
+    extra:
+      topics:
+        - hermes-1
+        - hermes-2
+        - hermes-3
+        - hermes-4
+        - hermes-5
+```
+
+Hermes opens one ntfy subscription covering all configured topics. Each
+incoming event's topic becomes its chat ID, so conversation history, active
+runs, and session locks stay separate. Replies return to the topic that
+originated the message. The profile's configuration, skills, and persistent
+memory remain shared. Add every configured topic to `NTFY_ALLOWED_USERS` and
+grant the authenticated ntfy account read/write access to each topic; otherwise
+the stream may connect but Hermes will reject messages during authorization.
+
+`topic` and `NTFY_TOPIC` remain supported for a single conversation. Use either
+`topic` or `topics`, not both. A fixed `publish_topic` still controls legacy
+single-topic split-input/output setups; multi-topic replies always return to
+their originating topic unless a send operation explicitly overrides the
+destination.
+
 ## Identity model — read this before deploying
 
 ntfy has no native authenticated user identity. The `title` field on a published message is **publisher-controlled** and can be anything the sender wants. The Hermes adapter does NOT use `title` for authorization — it would let any publisher who knows the topic spoof an allowed user.
@@ -143,7 +176,7 @@ If you only want Hermes to *push* notifications to ntfy (cron summaries, alerts)
 
 - **Message size**: ntfy caps message bodies at 4096 chars. Hermes truncates with a warning when this is exceeded.
 - **No typing indicators**: the protocol doesn't expose one; `send_typing` is a no-op.
-- **No threads or attachments**: ntfy is plain push notifications. Long replies stay in the message body, no thread fanout.
+- **No native threads or attachments**: ntfy is plain push notifications. Configure multiple topics when you need independent Hermes conversations.
 - **No native user identity**: see the identity-model section above.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- accept an ordered `platforms.ntfy.extra.topics` list while preserving the existing single `topic` / `NTFY_TOPIC` configuration
- subscribe once to ntfy's comma-separated multi-topic JSON stream
- preserve each event's topic as its Hermes chat identity and return replies to the originating topic
- keep legacy single-topic `publish_topic` routing intact
- support config-only multi-topic adapters and standalone delivery fallback
- document five concurrent topic-backed conversations

## Why

ntfy has no native thread identifier, so a single subscribed topic maps to one Hermes chat. Multiple subscribed topics provide independent concurrent Hermes sessions while sharing the same profile, skills, configuration, and persistent memory.

## Tests

```text
55 passed: tests/gateway/test_ntfy_plugin.py + tests/gateway/test_platform_registry.py
ruff check: passed
```

The tests cover five configured topics, aggregate subscription URL construction, distinct source chat IDs, reply-to-origin routing, config-only startup, standalone fallback, and existing single-topic behavior.
