### PR TITLE
security(dashboard): deny credential siblings and transcript DBs in managed-files reads

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1766,6 +1766,10 @@ _FS_READDIR_HIDDEN = {
 # doesn't lag behind them — an operator can point the managed root at
 # HERMES_HOME itself, at which point every one of these basenames is a live
 # secret store sitting in the browsable tree.
+#
+# This is the single declaration for this module: the sibling rule in
+# _is_sensitive_filename is DERIVED from these names rather than restated, so
+# adding an entry here automatically covers its backup/temp/sidecar siblings.
 _SENSITIVE_MANAGED_FILE_BASENAMES = frozenset({
     "auth.json",
     "auth.lock",
@@ -1780,7 +1784,46 @@ _SENSITIVE_MANAGED_FILE_BASENAMES = frozenset({
     "bws_cache.enc.json",
     # git's credential-store helper cache (agent.file_safety blocks this too).
     ".git-credentials",
+    # Environment files. Listed here rather than special-cased so the shared
+    # sibling rule below covers .env.local / .env.production / .env.bak the
+    # same way it covers every other entry.
+    ".env",
+    ".envrc",
+    # Application history stores. These are not credential *files*, but they
+    # transitively contain every secret that ever appeared in a conversation
+    # or a tool result, which makes downloading one a bigger prize than any
+    # single .env. The project already classifies them as secrets elsewhere:
+    #   * hermes_cli.backup._SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+    #   * agent.file_safety denies generic file-tool WRITES to state.db
+    #   * gateway/platforms/api_server.py chmods response_store.db to 0600 on
+    #     creation, citing "conversation history (tool payloads, prompts,
+    #     results)"
+    # Only this read guard omitted them.
+    "state.db",
+    "response_store.db",
+    "kanban.db",
 })
+
+# Separators that introduce a *sibling* of a sensitive basename — a file that
+# carries the same plaintext as the one it shadows, and so must be denied with
+# it. Two distinct rules, deliberately narrow:
+#
+#   1. A dot suffix: ``<sensitive>.<anything>``. This is the backup/temp/copy
+#      convention — auth.json.bak (editor or manual backup), auth.json.tmp
+#      (interrupted atomic write), .env.local / .env.production. The .env
+#      prefix rule this replaces already worked exactly this way; the change
+#      is that every entry gets it, not just .env.
+#
+#   2. A SQLite sidecar suffix, and ONLY these three. In WAL mode ``-wal``
+#      holds committed transactions not yet checkpointed into the main DB, and
+#      ``-shm`` / ``-journal`` are likewise real files on disk that the rest
+#      of the codebase enumerates explicitly (hermes_cli/session_recovery.py
+#      _SIDECAR_SUFFIXES, hermes_cli/profiles.py, docker/stage2-hook.sh).
+#
+# Rule 2 is a fixed list rather than "any dash suffix" on purpose: a bare dash
+# rule would also swallow ordinary files like credentials-howto.md, and
+# over-blocking the file browser is its own regression.
+_SENSITIVE_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 
 # Directory names whose entire subtree is credential material. Both canonical
 # guards deny these as directory trees, not basenames:
@@ -1800,9 +1843,16 @@ _SENSITIVE_MANAGED_DIR_NAMES = frozenset({
 def _is_sensitive_filename(name: str) -> bool:
     """Return True for a basename the managed-files API must never expose.
 
-    Covers ``.env`` / ``.env.<suffix>`` / ``.envrc`` variants plus the
-    canonical Hermes credential-store basenames (see
-    ``_SENSITIVE_MANAGED_FILE_BASENAMES`` above).
+    Matches a name in ``_SENSITIVE_MANAGED_FILE_BASENAMES`` exactly, or a
+    *sibling* of one — the same name plus a dot suffix (``auth.json.bak``,
+    ``auth.json.tmp``, ``.env.local``) or a SQLite sidecar suffix
+    (``state.db-wal``). A sibling holds the same plaintext as the file it
+    shadows, so exposing it exposes the secret.
+
+    Matching is anchored on the full basename, which keeps the guard off
+    unrelated names that merely share a prefix: ``state.dbf``,
+    ``configuration.yaml``, ``credentials-howto.md``, and ``.environment``
+    are ordinary files and stay listable.
 
     Case-insensitive so ``.ENV`` / ``.Env.local`` / ``Auth.JSON`` on
     case-insensitive filesystems (macOS/Windows mounts) can't slip past
@@ -1813,9 +1863,22 @@ def _is_sensitive_filename(name: str) -> bool:
     use :func:`_is_sensitive_path`, which the API call sites route through.
     """
     lowered = name.lower()
-    if lowered == ".env" or lowered.startswith(".env.") or lowered == ".envrc":
-        return True
-    return lowered in _SENSITIVE_MANAGED_FILE_BASENAMES
+
+    # Progressively strip trailing ``.<suffix>`` components so multi-suffix
+    # backups (``auth.json.bak``, ``auth.json.bak.1``) reduce to the name they
+    # shadow. At each step, also try removing a SQLite sidecar suffix, which
+    # covers ``state.db-wal`` and ``state.db-wal.bak`` alike.
+    candidate = lowered
+    while True:
+        if candidate in _SENSITIVE_MANAGED_FILE_BASENAMES:
+            return True
+        for suffix in _SENSITIVE_SQLITE_SIDECAR_SUFFIXES:
+            if candidate.endswith(suffix):
+                if candidate[: -len(suffix)] in _SENSITIVE_MANAGED_FILE_BASENAMES:
+                    return True
+        if "." not in candidate:
+            return False
+        candidate = candidate.rsplit(".", 1)[0]
 
 
 def _is_sensitive_path(path: Path) -> bool:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -302,3 +302,137 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+# ---------------------------------------------------------------------------
+# Sibling coverage: a credential basename and its on-disk siblings
+# ---------------------------------------------------------------------------
+
+# Suffixes that routinely appear beside a credential file on a real install:
+# editor/tool backups, interrupted atomic writes, and manual copies made
+# before an edit. Each carries the *same plaintext* as the file it shadows.
+_SIBLING_SUFFIXES = (".bak", ".tmp", ".orig", ".save", ".1", ".bak.1")
+
+
+def _assert_not_exposed(client, path, label):
+    """A path must be invisible to all three managed-files read routes."""
+    listing = client.get("/api/files", params={"path": str(path.parent)})
+    assert listing.status_code == 200, label
+    names = [e["name"] for e in listing.json()["entries"]]
+    assert path.name not in names, f"{label}: listed by /api/files"
+
+    read = client.get("/api/files/read", params={"path": str(path)})
+    assert read.status_code == 403, f"{label}: readable via /api/files/read"
+
+    download = client.get("/api/files/download", params={"path": str(path)})
+    assert download.status_code == 403, f"{label}: downloadable via /api/files/download"
+
+
+def _assert_visible(client, path, label):
+    """An ordinary file must stay fully usable in the browser."""
+    listing = client.get("/api/files", params={"path": str(path.parent)})
+    assert listing.status_code == 200, label
+    names = [e["name"] for e in listing.json()["entries"]]
+    assert path.name in names, f"{label}: over-blocked, missing from /api/files"
+
+    read = client.get("/api/files/read", params={"path": str(path)})
+    assert read.status_code == 200, f"{label}: over-blocked on /api/files/read"
+
+    download = client.get("/api/files/download", params={"path": str(path)})
+    assert download.status_code == 200, f"{label}: over-blocked on /api/files/download"
+
+
+def test_credential_basename_siblings_are_never_exposed(forced_files_client):
+    """Contract: if a basename is credential material, so are its siblings.
+
+    Asserts the RELATION rather than a frozen list literal — the cases are
+    generated from the guard's own declaration
+    (``_SENSITIVE_MANAGED_FILE_BASENAMES``), so a future entry added there is
+    covered by this test automatically.
+
+    ``.env`` already got this treatment (``.env.bak`` / ``.env.local`` are
+    denied by the prefix branch), but every other credential basename was
+    matched *exactly*. So ``auth.json`` was denied while ``auth.json.bak`` —
+    byte-identical provider keys, written by any editor or interrupted atomic
+    save — was listed, readable, and downloadable through the dashboard.
+    """
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    for basename in sorted(web_server._SENSITIVE_MANAGED_FILE_BASENAMES):
+        for suffix in _SIBLING_SUFFIXES:
+            sibling = root / f"{basename}{suffix}"
+            sibling.write_text("SECRET_KEY=abc123\n")
+            try:
+                _assert_not_exposed(client, sibling, sibling.name)
+            finally:
+                sibling.unlink()
+
+
+def test_session_transcript_stores_are_never_exposed(forced_files_client):
+    """Contract: the application history stores are credential material.
+
+    ``state.db`` is the session transcript store — every message, every tool
+    payload, and therefore every secret that ever passed through a tool result.
+    The project already classifies it as a secret elsewhere
+    (``hermes_cli.backup._SECRET_FILE_NAMES`` and the write-side deny in
+    ``agent.file_safety``), and ``response_store.db`` is chmod-0600 on creation
+    for exactly this reason (``gateway/platforms/api_server.py``), but the
+    managed-files read guard listed and served them.
+
+    The SQLite sidecars are covered too: in WAL mode ``-wal`` holds
+    transactions not yet checkpointed into the main DB, and both ``-wal`` and
+    ``-shm`` are real files on disk that the rest of the codebase enumerates
+    explicitly (``hermes_cli/profiles.py``, ``docker/stage2-hook.sh``).
+    """
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    for stem in ("state.db", "response_store.db", "kanban.db"):
+        for suffix in ("", "-wal", "-shm", "-journal", ".bak", "-wal.bak"):
+            store = root / f"{stem}{suffix}"
+            store.write_bytes(b"SQLite format 3\x00secret-transcript")
+            try:
+                _assert_not_exposed(client, store, store.name)
+            finally:
+                store.unlink()
+
+
+def test_ordinary_files_stay_visible(forced_files_client):
+    """Negative controls: widening the guard must not break the browser.
+
+    Over-blocking the managed-files browser is a regression, not a fix. These
+    names deliberately sit near the denied ones — a user's own ``.db``, a
+    longer word that merely starts with a credential basename, and a file whose
+    stem extends one without a separator — and must all stay listable,
+    readable, and downloadable.
+    """
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    for name in (
+        "notes.txt",
+        "README.md",
+        # A user's own SQLite DB that is NOT an application history store.
+        "mydata.db",
+        "mydata.db-wal",
+        # Extends a credential basename with no separator: a distinct file.
+        "state.dbf",
+        "authentication.md",
+        "environment.md",
+        "configuration.yaml",
+        # Dash suffixes are only sensitive for the SQLite sidecars, so an
+        # ordinary dash-suffixed name near a credential basename stays visible.
+        "credentials-howto.md",
+        "config.yaml-template",
+        ".environment",
+        # Suffix-only match must not be enough: these end in a sidecar suffix
+        # but their stem is not a credential basename.
+        "notes.db-wal",
+    ):
+        ordinary = root / name
+        ordinary.write_text("ordinary content\n")
+        try:
+            _assert_visible(client, ordinary, name)
+        finally:
+            ordinary.unlink()
+
+


### PR DESCRIPTION
## The bug

`hermes_cli/web_server.py::_is_sensitive_filename` mixes two matching rules:

```python
if lowered == ".env" or lowered.startswith(".env.") or lowered == ".envrc":
    return True                      # PREFIX rule  -> covers .env.<suffix>
return lowered in _SENSITIVE_MANAGED_FILE_BASENAMES   # EXACT rule, no siblings
```

`.env` gets sibling coverage. Every other credential basename gets an exact
match. And `state.db` is not in the list at all.

`_is_sensitive_path` is the **only** filter on all three managed-files read
routes:

| line | route | operation |
|---|---|---|
| `web_server.py:2361` | `GET /api/files` | list |
| `web_server.py:2388` | `GET /api/files/read` | read |
| `web_server.py:2432` | `GET /api/files/download` | download |

So each gap below is listable, readable, and downloadable.

## Reproduction

Calling the real `_is_sensitive_path` with `Path` objects on a clean checkout
of `main`:

```
basename               verdict
------------------------------------
.env                   SENSITIVE     <- prefix rule
.env.bak               SENSITIVE
.env.local             SENSITIVE
.envrc                 SENSITIVE
auth.json              SENSITIVE     <- exact list
auth.json.bak          EXPOSED  ***
auth.json.tmp          EXPOSED  ***
auth.json.orig         EXPOSED  ***
auth.json.save         EXPOSED  ***
auth.json.bak.1        EXPOSED  ***
config.yaml            SENSITIVE
config.yaml.bak        EXPOSED  ***
.git-credentials       SENSITIVE
.git-credentials.bak   EXPOSED  ***
state.db               EXPOSED  ***
state.db-wal           EXPOSED  ***
state.db-shm           EXPOSED  ***
state.db.bak           EXPOSED  ***
response_store.db      EXPOSED  ***
kanban.db              EXPOSED  ***
```

Two distinct problems:

**Siblings.** `auth.json.bak` holds byte-identical provider keys. Editor
backups and interrupted atomic writes produce these routinely — the guard
denies the original and serves the copy.

**The transcript DB.** `state.db` is the session store: every message, every
tool payload, and therefore every secret that ever passed through a tool
result. Downloading it is a complete history exfil, which makes it a larger
prize than any single `.env`.

## Why this reads as an oversight, not a scope decision

The project already classifies these as secrets everywhere else:

- `hermes_cli/backup.py:128` — `_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}`
- `agent/file_safety.py:128` — denies generic file-tool **writes** to `state.db`
- `gateway/platforms/api_server.py:814` — chmods `response_store.db` to `0600`
  on creation, citing *"conversation history (tool payloads, prompts, results)"*

Only the HTTP read guard omits them. #58222, which built the current list from
#57505, never mentions `state.db` — the list was assembled from the
credential-file guards, and the history stores were simply not in scope of
that pass.

## The fix

Fold `.env` / `.envrc` **into** `_SENSITIVE_MANAGED_FILE_BASENAMES` and derive
the sibling rule from that one set, so the module keeps a single declaration
instead of a special case plus a list. A basename matches when it is:

1. a listed name, or
2. a listed name plus a dot suffix — `auth.json.bak`, `.env.local`, or
3. a listed name plus a SQLite sidecar suffix — `state.db-wal`.

Adding a future entry to the set now covers its siblings automatically, which
is the property the old code only gave `.env`.

**On sharing one constant across modules.** The card for this work suggested
importing an existing list rather than maintaining a fourth. I looked and
deliberately didn't: `agent.file_safety`'s `credential_file_names` and
`gateway.platforms.base`'s `_ROOT_CREDENTIAL_FILES` are both *function-local*
tuples of HERMES_HOME-**relative paths** (`auth/google_oauth.json`,
`cache/bws_cache.json`), because those guards resolve against a known root.
This guard is basename-only by design — the managed root is operator-chosen
and may be anywhere — so it would have to strip the directory components back
off, and hoisting either constant to module scope to import it would widen
this PR into two unrelated modules. What I did instead is remove the
*duplication inside this module*: one set, one rule derived from it. Happy to
do the cross-module extraction as a follow-up if you'd prefer it.

**On the sidecar suffixes.** `-wal`, `-shm`, and `-journal` are an explicit
three rather than "any dash suffix". A bare dash rule would also swallow
ordinary files like `credentials-howto.md`. These three are real files on disk
that the rest of the codebase enumerates the same way
(`hermes_cli/session_recovery.py` `_SIDECAR_SUFFIXES`, `hermes_cli/profiles.py`,
`docker/stage2-hook.sh`), and in WAL mode `-wal` holds committed transactions
not yet checkpointed into the main DB.

## After the fix

Every starred row flips, and the negative controls are untouched:

```
auth.json.bak          SENSITIVE
auth.json.bak.1        SENSITIVE
config.yaml.bak        SENSITIVE
.git-credentials.bak   SENSITIVE
state.db               SENSITIVE
state.db-wal           SENSITIVE
state.db-shm           SENSITIVE
state.db-wal.bak       SENSITIVE
response_store.db      SENSITIVE
kanban.db              SENSITIVE
--- negative controls -------------
notes.txt              EXPOSED  (visible)
README.md              EXPOSED  (visible)
mydata.db              EXPOSED  (visible)
mydata.db-wal          EXPOSED  (visible)
state.dbf              EXPOSED  (visible)
configuration.yaml     EXPOSED  (visible)
credentials-howto.md   EXPOSED  (visible)
config.yaml-template   EXPOSED  (visible)
.environment           EXPOSED  (visible)
notes.db-wal           EXPOSED  (visible)
```

Over-blocking the file browser is its own regression, so
`test_ordinary_files_stay_visible` asserts each of those stays listable **and**
readable **and** downloadable — a user's own `.db`, names that merely share a
prefix, and names that merely share a sidecar suffix.

## Tests

Three tests in `tests/hermes_cli/test_web_server_files.py`. The two security
ones assert the **relation** — a credential basename and its siblings are never
exposed on any of the three routes — and generate their cases from
`_SENSITIVE_MANAGED_FILE_BASENAMES` itself rather than freezing a list literal,
so a future entry to the set is covered without editing the test.

Both fail on an unpatched checkout (test file applied alone):

```
FAILED test_credential_basename_siblings_are_never_exposed
        AssertionError: auth.json.bak: listed by /api/files
FAILED test_session_transcript_stores_are_never_exposed
        AssertionError: state.db: listed by /api/files
2 failed, 7 passed
```

And pass with the fix, alongside the rest of the `web_server` suite:

```
$ ./scripts/run_tests.sh tests/hermes_cli/test_web_server*.py
=== Summary: 18 files, 223 tests passed, 0 failed (100% complete) in 27.3s ===
```

## Scope

Read-side only. The write endpoints (`upload`/`mkdir`/`delete`) are a separate
threat class — the existing `_is_sensitive_path` docstring says so explicitly,
and #58034 is the open PR covering them. Nothing here touches them.
