### PR TITLE
fix(gateway): read persisted status override without runtime activation

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import hashlib
 import inspect
+import json
 import logging
 import os
 import re
@@ -539,9 +540,16 @@ class GatewaySlashCommandsMixin:
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
-        from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model
+        from gateway.run import (
+            _AGENT_PENDING_SENTINEL,
+            _get_channel_override,
+            _load_gateway_config,
+            _resolve_gateway_model,
+        )
 
         source = event.source
+        normalize_source = getattr(self, "_normalize_source_for_session_key")
+        source = await asyncio.to_thread(normalize_source, source)
         session_entry = await self.async_session_store.get_or_create_session(source)
 
         connected_platforms = [p.value for p in self.adapters.keys()]
@@ -612,40 +620,189 @@ class GatewaySlashCommandsMixin:
                 except Exception:
                     status_agent = None
 
+        has_live_agent = (
+            status_agent is not None and status_agent is not _AGENT_PENDING_SENTINEL
+        )
         model_name = ""
         provider_name = ""
-        base_url = ""
         context_used = 0
         context_total = 0
-        if status_agent is not None and status_agent is not _AGENT_PENDING_SENTINEL:
+        if has_live_agent:
             model_name = _clean_str(getattr(status_agent, "model", ""))
             provider_name = _clean_str(getattr(status_agent, "provider", ""))
-            base_url = _clean_str(getattr(status_agent, "base_url", ""))
             ctx = getattr(status_agent, "context_compressor", None)
             if ctx is not None:
                 context_used = _int_value(getattr(ctx, "last_prompt_tokens", 0))
                 context_total = _int_value(getattr(ctx, "context_length", 0))
 
-        model_name = model_name or _clean_str(session_row.get("model"))
-        provider_name = provider_name or _clean_str(session_row.get("billing_provider"))
-        base_url = base_url or _clean_str(session_row.get("billing_base_url"))
-        context_used = context_used or _int_value(getattr(session_entry, "last_prompt_tokens", 0))
-
+        # Prefer a live/cached route, then explicit session/channel overrides,
+        # then the last actual gateway route persisted for this session.  The
+        # current config and first-accounted billing fields are fallbacks for
+        # sessions without one of those more authoritative sources.
         user_config: dict[str, Any] = {}
-        if not model_name or not provider_name or not context_total:
+        if not has_live_agent or not model_name or not provider_name or not context_total:
             try:
                 user_config = _load_gateway_config()
             except Exception:
                 user_config = {}
+
+        model_cfg = user_config.get("model", {}) if isinstance(user_config, dict) else {}
+        if not isinstance(model_cfg, dict):
+            model_cfg = {}
+
+        persisted_runtime: dict[str, Any] = {}
+        raw_model_config = session_row.get("model_config")
+        if isinstance(raw_model_config, dict):
+            parsed_model_config = raw_model_config
+        elif isinstance(raw_model_config, str) and raw_model_config.strip():
+            try:
+                parsed_model_config = json.loads(raw_model_config)
+            except (TypeError, ValueError):
+                parsed_model_config = {}
+        else:
+            parsed_model_config = {}
+        if isinstance(parsed_model_config, dict):
+            candidate_runtime = parsed_model_config.get("gateway_runtime")
+            if isinstance(candidate_runtime, dict):
+                persisted_runtime = candidate_runtime
+        persisted_model = ""
+        persisted_provider = ""
+        if persisted_runtime:
+            persisted_model = _clean_str(
+                persisted_runtime.get("model") or session_row.get("model")
+            )
+            persisted_provider = _clean_str(persisted_runtime.get("provider"))
+
+        session_override: dict[str, Any] = {}
+        try:
+            peek_session_state = getattr(self, "_peek_session_state", None)
+            state = (
+                peek_session_state(session_key)
+                if callable(peek_session_state)
+                else None
+            )
+            conversation = getattr(state, "conversation", None)
+            override = getattr(conversation, "model_override", None)
+            if isinstance(override, dict):
+                session_override = override
+        except Exception:
+            pass
+        if not session_override:
+            override = getattr(session_entry, "model_override", None)
+            if isinstance(override, dict):
+                session_override = override
+
+        channel_override = None
+        try:
+            config = getattr(self, "config", None)
+            channel_platform = getattr(source, "platform", None)
+            if config is not None and channel_platform is not None:
+                channel_thread_id = getattr(source, "thread_id", None)
+                channel_parent_id = getattr(source, "parent_chat_id", None)
+                channel_override = _get_channel_override(
+                    config,
+                    channel_platform,
+                    str(getattr(source, "chat_id", "") or ""),
+                    thread_id=str(channel_thread_id) if channel_thread_id else None,
+                    parent_id=str(channel_parent_id) if channel_parent_id else None,
+                )
+        except Exception:
+            channel_override = None
+
+        has_channel_route_override = channel_override is not None and bool(
+            _clean_str(getattr(channel_override, "model", ""))
+            or _clean_str(getattr(channel_override, "provider", ""))
+        )
+        has_session_route_override = bool(session_override) or has_channel_route_override
+        needs_runtime_resolution = (
+            (
+                not has_live_agent
+                and has_session_route_override
+            )
+            or (has_live_agent and (not model_name or not provider_name))
+        )
+        if needs_runtime_resolution:
+            resolve_runtime = getattr(self, "_resolve_session_agent_runtime", None)
+            if callable(resolve_runtime):
+                try:
+                    resolved_route = await asyncio.to_thread(
+                        resolve_runtime,
+                        source=source,
+                        session_key=session_key,
+                        user_config=user_config,
+                    )
+                    resolved_model = (
+                        resolved_route[0]
+                        if isinstance(resolved_route, tuple) and resolved_route
+                        else ""
+                    )
+                    runtime_kwargs = (
+                        resolved_route[1]
+                        if isinstance(resolved_route, tuple) and len(resolved_route) > 1
+                        else {}
+                    )
+                    if not model_name and _clean_str(resolved_model):
+                        model_name = _clean_str(resolved_model)
+                    if isinstance(runtime_kwargs, dict):
+                        resolved_provider = _clean_str(
+                            runtime_kwargs.get("provider")
+                            or runtime_kwargs.get("requested_provider")
+                        )
+                        if not provider_name and resolved_provider:
+                            provider_name = resolved_provider
+                except Exception:
+                    pass
+
+            if has_live_agent and not has_session_route_override:
+                if not model_name:
+                    model_name = persisted_model
+                if not provider_name:
+                    provider_name = persisted_provider
+
+            if not model_name:
+                try:
+                    from hermes_cli.model_switch import resolve_effective_model
+
+                    model_name = resolve_effective_model(
+                        session_override,
+                        channel_override,
+                        _resolve_gateway_model(user_config),
+                    )
+                except Exception:
+                    model_name = _clean_str(model_cfg.get("default"))
+            if not provider_name:
+                provider_name = _clean_str(session_override.get("provider"))
+            if not provider_name and channel_override is not None:
+                provider_name = _clean_str(getattr(channel_override, "provider", ""))
+            if not provider_name:
+                provider_name = _clean_str(model_cfg.get("provider"))
+
+        # ``billing_provider`` is intentionally first-accounted attribution,
+        # while ``gateway_runtime`` is synchronized after each completed turn
+        # with the route that actually answered the session.  Prefer the latter
+        # for idle sessions unless an explicit session/channel route is active.
+        if not has_session_route_override:
+            if not model_name:
+                model_name = persisted_model
+            if not provider_name:
+                provider_name = persisted_provider
+
+        # Resolve directly from current config before consulting historical
+        # billing metadata whenever no persisted runtime field is present.
         if not model_name:
             model_name = _resolve_gateway_model(user_config)
         if not provider_name:
-            model_cfg = user_config.get("model", {}) if isinstance(user_config, dict) else {}
-            if isinstance(model_cfg, dict):
-                provider_name = _clean_str(model_cfg.get("provider"))
+            provider_name = _clean_str(model_cfg.get("provider"))
+
+        # SessionDB's model/provider fields describe the last recorded billing
+        # route.  Use them only when no live, session-scoped, or current-config
+        # value is available (e.g. an older install whose config cannot load).
+        model_name = model_name or _clean_str(session_row.get("model"))
+        provider_name = provider_name or _clean_str(session_row.get("billing_provider"))
+        context_used = context_used or _int_value(getattr(session_entry, "last_prompt_tokens", 0))
+
         if not context_total:
-            model_cfg = user_config.get("model", {}) if isinstance(user_config, dict) else {}
-            configured_context = model_cfg.get("context_length") if isinstance(model_cfg, dict) else None
+            configured_context = model_cfg.get("context_length")
             if isinstance(configured_context, int) and configured_context > 0:
                 context_total = configured_context
 

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -1,14 +1,16 @@
 from hermes_state import AsyncSessionDB
 """Tests for gateway /status behavior and token persistence."""
 
+from dataclasses import replace
 from datetime import datetime
+import json
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
@@ -45,6 +47,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.get_model_override.return_value = None
     runner.session_store.load_transcript.return_value = []
     runner.session_store.has_any_sessions.return_value = True
     runner.session_store.append_to_transcript = MagicMock()
@@ -139,6 +142,496 @@ async def test_status_command_includes_live_agent_model_and_context():
     assert "**Model:** `openai/gpt-test` (openai)" in result
     assert "**Context:** 12,345 / 100,000 (12%)" in result
     assert "**Lifetime tokens billed:** 1,250" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_falls_back_to_config_for_incomplete_live_agent(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "stale-model",
+        "billing_provider": "stale-provider",
+    }
+    runner._running_agents[session_entry.session_key] = SimpleNamespace(
+        model="",
+        provider="",
+        base_url="",
+        context_compressor=SimpleNamespace(last_prompt_tokens=0, context_length=0),
+    )
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model",
+        lambda config: config["model"]["default"],
+    )
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=(
+            "configured-model",
+            {"provider": "configured-provider"},
+        )
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `configured-model` (configured-provider)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_preserves_live_model_when_provider_is_missing():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "stale-model",
+        "billing_provider": "stale-provider",
+    }
+    runner._running_agents[session_entry.session_key] = SimpleNamespace(
+        model="live-model",
+        provider="",
+        context_compressor=SimpleNamespace(last_prompt_tokens=12, context_length=100),
+    )
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("resolver-model", {"provider": "resolved-provider"})
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `live-model` (resolved-provider)" in result
+    runner._resolve_session_agent_runtime.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_cached_agent_over_current_config(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+    }
+    runner._agent_cache[session_entry.session_key] = (
+        SimpleNamespace(
+            model="cached-model",
+            provider="cached-provider",
+            base_url="https://cached.example/v1",
+            context_compressor=SimpleNamespace(
+                last_prompt_tokens=12,
+                context_length=100,
+            ),
+        ),
+        "signature",
+        0,
+        session_entry.session_id,
+    )
+    runner.config.platforms[Platform.TELEGRAM].channel_overrides["c1"] = ChannelOverride(
+        model="channel-model",
+        provider="channel-provider",
+    )
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("wrong-model", {"provider": "wrong-provider"})
+    )
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `cached-model` (cached-provider)" in result
+    assert "**Context:** 12 / 100 (12%)" in result
+    runner._resolve_session_agent_runtime.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_runtime_session_override_over_config(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        model_override={
+            "model": "persisted-model",
+            "provider": "persisted-provider",
+        },
+    )
+    runner = _make_runner(session_entry)
+    runner._session_state(session_entry.session_key).conversation.model_override = {
+        "model": "once-model",
+        "provider": "once-provider",
+    }
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "persisted-model",
+        "billing_provider": "persisted-provider",
+    }
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("once-model", {"provider": "once-provider"})
+    )
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `once-model` (once-provider)" in result
+    runner._resolve_session_agent_runtime.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_channel_override_over_global_config(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner.config.platforms[Platform.TELEGRAM].channel_overrides["c1"] = ChannelOverride(
+        model="channel-model",
+        provider="channel-provider",
+    )
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("channel-model", {"provider": "channel-provider"})
+    )
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `channel-model` (channel-provider)" in result
+    runner._resolve_session_agent_runtime.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_status_command_resolves_config_for_pending_agent(monkeypatch):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._running_agents[session_entry.session_key] = _AGENT_PENDING_SENTINEL
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "stale-model",
+        "billing_provider": "stale-provider",
+    }
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model",
+        lambda config: config["model"]["default"],
+    )
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `configured-model` (configured-provider)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_uses_normalized_session_key_for_override():
+    raw_source = _make_source()
+    normalized_source = replace(raw_source, thread_id="topic-1")
+    normalized_key = build_session_key(normalized_source)
+    session_entry = SessionEntry(
+        session_key=normalized_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._normalize_source_for_session_key = MagicMock(return_value=normalized_source)
+    runner._session_state(normalized_key).conversation.model_override = {
+        "model": "topic-model",
+        "provider": "topic-provider",
+    }
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("topic-model", {"provider": "topic-provider"})
+    )
+
+    event = MessageEvent(text="/status", source=raw_source, message_id="m1")
+    result = await runner._handle_status_command(event)
+
+    assert "**Model:** `topic-model` (topic-provider)" in result
+    runner._normalize_source_for_session_key.assert_called_once_with(raw_source)
+    runner.session_store.get_or_create_session.assert_called_once_with(normalized_source)
+    runner._resolve_session_agent_runtime.assert_called_once()
+    assert runner._resolve_session_agent_runtime.call_args.kwargs["session_key"] == normalized_key
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_current_config_over_stale_billing_route(monkeypatch):
+    """A persisted billing route must not mask the gateway's current config."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "stepfun-ai/step-3.7-flash",
+        "billing_provider": "openrouter",
+        "billing_base_url": "https://openrouter.ai/api/v1",
+    }
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "stepfun-ai/step-3.7-flash",
+                "provider": "custom",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model",
+        lambda config: config["model"]["default"],
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `stepfun-ai/step-3.7-flash` (custom)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_persisted_runtime_over_billing_and_config(monkeypatch):
+    """The last actual gateway route must beat accounting and changed defaults."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "persisted-model",
+        "billing_provider": "openrouter",
+        "model_config": json.dumps(
+            {
+                "gateway_runtime": {
+                    "provider": "custom",
+                    "base_url": "https://integrate.api.nvidia.com/v1",
+                }
+            }
+        ),
+    }
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `persisted-model` (custom)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_ignores_malformed_persisted_runtime(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "stale-model",
+        "billing_provider": "stale-provider",
+        "model_config": "{not-json",
+    }
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "configured-model",
+                "provider": "configured-provider",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model",
+        lambda config: config["model"]["default"],
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `configured-model` (configured-provider)" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_preserves_explicit_session_model_override(monkeypatch):
+    """A session-scoped /model choice must remain authoritative over global config."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+        model_override={
+            "model": "session-model",
+            "provider": "session-provider",
+            "base_url": "https://session.example/v1",
+        },
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "reasoning_tokens": 0,
+        "model": "old-model",
+        "billing_provider": "old-provider",
+    }
+
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "global-model",
+                "provider": "global-provider",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.run._resolve_gateway_model",
+        lambda config: config["model"]["default"],
+    )
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("session-model", {"provider": "session-provider"})
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Model:** `session-model` (session-provider)" in result
+    runner._resolve_session_agent_runtime.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Narrowed after #110223 landed and now adapted to the merged context-window work in #112283. Thanks for incorporating and crediting the earlier route-selection reports. This PR does not replace the route resolver or change config/channel precedence.

The remaining fix separates **reading a persisted model override** from **activating its session runtime**, while preserving authenticated context-window metadata lookup.

## Fix

After a committed `/model` switch and gateway restart, `/status` calls `_rehydrate_session_model_override()`, which resolves provider runtime and creates `SessionState.conversation.model_override` merely to display status.

- Peek at an existing in-memory override, or read its non-secret durable record through `AsyncSessionStore.get_model_override()` without rehydrating session state.
- Preserve the merged precedence: **live/cached agent → session override → most recent usage route → session row → config**.
- In the existing off-loop, profile-scoped context resolver, independently obtain missing metadata-probe credentials. Forward them only if the provider's current endpoint matches the saved route using the existing URL-identity normalizer.
- Leave the durable override unchanged. Metadata failure still permits model/provider display; the live compressor and existing context rendering remain authoritative.

This is deliberately **not** a blanket prohibition on provider or credential lookup: authenticated metadata requests remain supported. The existing free-tier authentication check and session-store lifecycle behavior are unchanged.

## Verification

Base: `01382698fc32ec7740b6a204d9b7a6abeac74d33`.

- Strengthened the existing real `/model` commit/restart regression: fresh store and runner, correct model/provider display, and no per-session runtime state creation.
- Added a loopback authenticated `/models` integration test using real config/provider/storage code and temporary homes **A → B → A under multiplex**. It verifies profile-specific context windows, durable-record immutability, and no credential forwarding when the configured provider endpoint differs from the saved endpoint.
- RED/GREEN verified: untouched upstream activates runtime state; read-only override lookup alone loses metadata authentication; an unguarded credential fallback forwards credentials to a mismatched endpoint. The final patch passes all three contracts.
- Identical affected-area manifest on pristine upstream: **206 passed, 4 skipped**. Candidate: **208 passed, 4 skipped**, no failures.
- Ruff, compatibility-pointer check, added-line security scan, and `git diff --check` passed.
- Independent agent review of the exact final diff found no blockers and reran the status file: **17 passed**. This is not maintainer approval.

```bash
scripts/run_tests.sh tests/gateway/test_status_command.py tests/gateway/test_usage_command.py tests/hermes_state/test_recent_model_route.py tests/gateway/test_session_model_override_persistence.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_id_cache_coherence.py tests/e2e/test_platform_commands.py tests/gateway/test_login_command.py tests/gateway/test_session_model_override_routing.py tests/gateway/test_model_command_context_offload.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_local_context_resolution.py --file-retries 0 -q --tb=short
```

The full repository suite was not rerun. New-head CI must be evaluated separately from previous revisions. No dependency or lockfile changes.

## Scope and related work

Refs #77521 and #100323 without claiming to close their remaining config-precedence questions. #113663 addresses the separate configured-default precedence gap; persisted `gateway_runtime` fallback remains separate (#75549). Existing route selection and `/context` behavior are retained.

AI-assisted implementation and review; I own the reproduction, verification, and follow-up.
