### PR TITLE
fix(desktop): reap orphan gateways at startup

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -209,6 +209,19 @@ async def _lifespan(app: "FastAPI"):
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
+        # Before forking a fresh gateway, reap any orphan left by a previous
+        # serve session. Graceful shutdown reaps the managed child, but an
+        # abnormal exit (crash, SIGKILL, power loss, forced update) reparents
+        # the old gateway to launchd (PPID=1). It keeps holding the QQ
+        # WebSocket, and a newly forked gateway then races the same credential,
+        # splitting messages across parallel session trees (#77276).
+        try:
+            from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
+
+            _reap_unsupervised_gateway_orphans()
+        except Exception:
+            _log.exception("Desktop startup: orphan gateway reap failed")
+
         cron_stop = threading.Event()
         cron_thread = threading.Thread(
             target=_start_desktop_cron_ticker,

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -967,3 +967,45 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
 
     assert "_HERMES_GATEWAY" not in captured["env"]
     assert captured["env"]["HERMES_NONINTERACTIVE"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Desktop lifespan reaps orphan gateways at serve startup (#77276)
+# ---------------------------------------------------------------------------
+
+def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
+    monkeypatch, _isolate_hermes_home
+):
+    """Starting a Desktop serve backend should reap orphan gateways left by a
+    previous serve session before forking a fresh one (#77276).
+
+    Graceful shutdown reaps the managed child, but an abnormal exit reparents
+    the old gateway to launchd (PPID=1) where it keeps holding the QQ
+    WebSocket. The lifespan calls _reap_unsupervised_gateway_orphans() once at
+    startup under HERMES_DESKTOP=1 so the stale orphan is cleared first.
+    """
+    import hermes_cli.web_server as ws
+
+    called = []
+
+    def _fake_reap():
+        called.append(True)
+        return True
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    # Keep the lifespan cheap: don't re-import the gateway module or spin up the
+    # real cron scheduler thread.
+    monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
+    monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args: None)
+    # web_server imports the reaper lazily from hermes_cli.gateway, so patch it
+    # on that module.
+    import hermes_cli.gateway as g
+
+    monkeypatch.setattr(g, "_reap_unsupervised_gateway_orphans", _fake_reap)
+
+    client, _header = _client()
+    with client:
+        pass
+
+    assert called == [True]
+


### PR DESCRIPTION
Fixes #77276.

**🎯Problem**

The Desktop backend forks a gateway child on every serve, but only graceful shutdown reaps it. On abnormal exit (crash / SIGKILL / power loss / forced update), the old gateway is reparented to launchd (PPID=1) and keeps holding the QQ WebSocket. The next serve forks a new gateway, and both race the same QQ credential — messages split across parallel session trees.

**🎯Fix**
_reap_unsupervised_gateway_orphans() (in hermes_cli/gateway.py) already handles exactly this case, but was only wired into the CLI stop path. This PR calls it once at Desktop lifespan startup, before the new gateway is forked — so stale orphans are cleared first.

**Desktop-only (guarded by HERMES_DESKTOP=1)**
Wrapped in try/except — a reap failure never blocks startup
Lazy import, matching the file's existing style
Reaper itself unchanged (SIGTERM → 5s → SIGKILL, current-profile match, no-op under systemd)
Net ~5 lines — a wiring fix reusing existing code, no new mechanism.

Relationship to #77297
Orthogonal: #77297 covers graceful shutdown, this covers all abnormal-exit paths. Merges independently.

**Testing**
Added test_desktop_lifespan_reaps_orphan_gateways_on_startup asserting the reaper runs once at startup under HERMES_DESKTOP=1. Existing reaper tests unchanged and green; full dashboard suite (39 tests) passes.