### PR TITLE
fix(website): patch high-risk transitive dependencies

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -26,7 +26,8 @@
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=20.0",
+        "npm": ">=11.17.0"
       }
     },
     "node_modules/@11ty/gray-matter": {
@@ -9998,9 +9999,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -15271,9 +15272,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15290,7 +15291,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -19015,9 +19016,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/website/package.json
+++ b/website/package.json
@@ -38,7 +38,8 @@
   "overrides": {
     "serialize-javascript": "7.0.7",
     "uuid": "14.0.1",
-    "minimatch": "10.2.6"
+    "minimatch": "10.2.6",
+    "undici": "7.29.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- update transitive fast-uri, PostCSS, and Undici to patched releases
- add an Undici 7.29 override because the docs search dependency otherwise resolves 7.28.0
- keep the change scoped to website package metadata

## Verification
- npm 11.17.0 clean install
- runtime audit: 0 vulnerabilities
- full audit: 0 vulnerabilities
- Docusaurus production build passed for both locales

## Existing issue
The website typecheck still fails with TS5101 because tsconfig uses deprecated baseUrl under TypeScript 6. The identical failure reproduces on untouched origin/main, so this PR does not introduce it. Existing broken-link warnings also remain unchanged.