### PR TITLE
docs(contributing): search each state explicitly in the duplicate-check commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,15 @@ A quick search before you build saves your time and keeps the PR queue clean —
 
 - **Search both open *and* merged PRs and issues** for your topic or error symptom — the duplicate-check in the PR template fires at review time, after you've already done the work:
   ```bash
-  gh search issues --repo NousResearch/hermes-agent "<your terms>"
-  gh search prs --repo NousResearch/hermes-agent --state all "<your terms>"
+  gh search issues --repo NousResearch/hermes-agent --state open   "<your terms>"
+  gh search issues --repo NousResearch/hermes-agent --state closed "<your terms>"
+  gh search prs    --repo NousResearch/hermes-agent --state open   "<your terms>"
+  gh search prs    --repo NousResearch/hermes-agent --state closed "<your terms>"
   ```
+  Run each state explicitly. A search with no `--state` is ranked, not state-filtered: on a
+  broad query the open results fill the result limit and merged and closed ones never appear.
+  `--state closed` on PRs covers merged *and* closed-unmerged, so a rejected earlier attempt
+  shows up too.
   Or use the web UI: [issues](https://github.com/NousResearch/hermes-agent/issues?q=) · [PRs (all states)](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr).
 - **The issue tracker can lag the code.** Many requested features are already implemented in-tree, so also search the source (`search_files`, or your editor's grep) for the capability before proposing it.
 - **If an open PR already addresses it**, consider reviewing or improving that one instead of opening a competing duplicate.


### PR DESCRIPTION
## What does this PR do?

Neither command in **Before You Start: Search First** returns what the section says it returns.

`gh search prs` rejects `--state all`. The flag takes `{open|closed}`. That line exits `1`, prints the error to stderr, and puts nothing on stdout.

`gh search issues` on the line above exits `0` and still misses results. With no `--state` the search ranks by relevance, and open results come first. On a broad query they fill the result limit, so closed issues never appear.

Running each state as its own pass returns all of them. On PRs, `--state closed` covers merged and closed-unmerged, so an earlier attempt that was rejected shows up too.

## Related Issue

None. I searched open and closed PRs and issues first and didn't find one.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `CONTRIBUTING.md` - both commands in the "Before You Start: Search First" block replaced with per-state passes, plus a short note on why a bare search misses results. One code block.

## How to Test

Use a broad query. A narrow one returns fewer results than the limit, so both versions look the same. `kanban` is broad enough here. The `--jq` line tallies results by state.

**1. The `gh search prs` line as currently documented:**

```bash
gh search prs --repo NousResearch/hermes-agent --state all "kanban"
```

Exit code `1`. stderr, then the usage block. Nothing on stdout:

```
invalid argument "all" for "--state" flag: valid values are {open|closed}
```

**2. The `gh search issues` line as currently documented:**

```bash
gh search issues --repo NousResearch/hermes-agent "kanban" --limit 60 \
  --json state --jq '[.[].state]|group_by(.)|map({(.[0]):length})|add'
```

Exit code `0`. Every result is open:

```
{"open":60}
```

**3. Both lines, as this PR writes them:**

```bash
gh search issues --repo NousResearch/hermes-agent --state open   "kanban" --limit 60 \
  --json state --jq '[.[].state]|group_by(.)|map({(.[0]):length})|add'
gh search issues --repo NousResearch/hermes-agent --state closed "kanban" --limit 60 \
  --json state --jq '[.[].state]|group_by(.)|map({(.[0]):length})|add'
gh search prs    --repo NousResearch/hermes-agent --state open   "kanban" --limit 60 \
  --json state --jq '[.[].state]|group_by(.)|map({(.[0]):length})|add'
gh search prs    --repo NousResearch/hermes-agent --state closed "kanban" --limit 60 \
  --json state --jq '[.[].state]|group_by(.)|map({(.[0]):length})|add'
```

```
{"open":60}
{"closed":60}
{"open":60}
{"closed":49,"merged":11}
```

60 closed issues and 11 merged PRs the documented commands never showed.

Drop the `--json`/`--jq` part to read the results normally. Full output is six tab-separated columns: repo, number, state, title, labels, timestamp.

gh 2.96.0, Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, `gh` 2.96.0

> Two boxes are unchecked on purpose. This is a docs change with no code path behind it, so there's nothing to test and nothing to write tests against. If you want the suite run anyway, say so and I'll post the output.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Above, under How to Test - the state tallies before and after, on the same broad query.
