### PR TITLE
fix(cli): reserve rows below the clarify panel so choices stay visible

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16733,12 +16733,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             #          + blank_before_bottom + bottom border = 5 rows
             #   tight: top border + bottom border = 2 rows (drop all blanks)
             #
-            # reserved_below matches the approval-panel budget (~6 rows for
-            # spinner/tool-progress + status + input + separators + prompt).
+            # reserved_below must cover EVERYTHING below the clarify panel in
+            # the real TUI HSplit: status bar + tool-progress/spinner + agent
+            # status line + multi-line composer input + prompt gutter +
+            # separators. The approval-panel budget of 6 under-estimates this:
+            # `available` is inflated, the question claims rows that do not
+            # exist, the panel exceeds the viewport, and HSplit clips its tail —
+            # which is exactly where the choices live (residual of #34808).
+            # 12 is a conservative floor for typical TUI layouts; the
+            # choices-overflow guard below still wins when even that is short.
             term_rows = shutil.get_terminal_size((100, 24)).lines
             chrome_full = 5
             chrome_tight = 2
-            reserved_below = 6
+            reserved_below = 12
 
             available = max(0, term_rows - reserved_below)
             # The compact decision must reserve room for at least one question


### PR DESCRIPTION
## Summary

Fixes the residual of #34808: in the TUI, the clarify panel can still clip its choices off-screen even after the `choices_overflow` guard from #34808, because `reserved_below = 6` under-estimates the rows the layout consumes **below** the clarify panel.

## Problem

The clarify panel is rendered inside an HSplit. When the panel's total height exceeds the viewport, the HSplit clips the panel's **tail** — which is exactly where the choices live. The user sees the question but the selectable options are silently missing.

Root cause chain:

1. `reserved_below = 6` budgets only the approval-panel chrome (spinner/tool-progress, status, input, separators, prompt).
2. In the real TUI layout the space below the clarify panel is larger: status bar + tool-progress/spinner + agent status line + multi-line composer input + prompt gutter + separators ≈ 12 rows.
3. With `available = term_rows - 6` inflated, the question claims rows that do not exist.
4. #34808 fixed the "choices alone exceed the viewport" case (`choices_overflow` drops the question entirely), but the "question grows into rows that were never there" case still overflows the panel and clips the choices tail.

## Fix

- Raise `reserved_below` from 6 to 12 — a conservative floor for typical TUI layouts.
- The `choices_overflow` guard from #34808 remains authoritative when even 12 rows is short.
- The existing question-truncation logic keeps the panel inside the budget on small terminals (e.g. 24-row terminals still render ~4-6 choices plus the question).

## Manual verification

1. Open `hermes chat --tui` in a ~24-row terminal.
2. Trigger the clarify tool with 4-6 choices (e.g. any multi-option prompt).
3. Before this fix (v0.20.0): choices clipped off-screen, only the question visible.
4. After this fix: all choices render; the question is truncated/dropped instead when space is tight.

## Tests

- `tests/cli/test_cli_approval_ui.py` — 15 passed (approval/clarify panel regression suite from #41098 / #34808).
- `tests/cli/` full run — 761 passed, 1 pre-existing order-dependent flake (`test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode` fails only in full-suite order; passes in isolation on both `main` and this branch).
