### PR TITLE
fix(docker): isolate Kanban workspace reuse

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -596,16 +596,26 @@ def test_labels_attribute_populated_after_init(monkeypatch):
     the sanitizer or re-importing the profile module."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
-    _mock_subprocess_run(monkeypatch)
+    calls = _mock_subprocess_run(monkeypatch)
 
     env = _make_dummy_env(task_id="abc")
 
-    assert env._labels == {
-        "hermes-agent": "1",
-        "hermes-task-id": "abc",
-        "hermes-profile": "default",
-        "hermes-egress": "off",
+    assert set(env._labels) == {
+        "hermes-agent",
+        "hermes-task-id",
+        "hermes-profile",
+        "hermes-egress",
+        "hermes-container-spec",
     }
+    assert env._labels["hermes-agent"] == "1"
+    assert env._labels["hermes-task-id"] == "abc"
+    assert env._labels["hermes-profile"] == "default"
+    assert env._labels["hermes-egress"] == "off"
+    spec_label = env._labels["hermes-container-spec"]
+    assert len(spec_label) == 24
+    assert all(character in "0123456789abcdef" for character in spec_label)
+    labels = _labels_in_run_args(_run_args_from_calls(calls))
+    assert f"hermes-container-spec={spec_label}" in labels
 
 
 # ── Cross-process container reuse (issue #20561) ──────────────────
@@ -656,6 +666,50 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
 
     monkeypatch.setattr(docker_env.subprocess, "run", _run)
     return calls
+
+
+def test_reuse_rejects_legacy_container_without_current_mount_spec(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "platform")
+    docker_env._cgroup_limits_ok = True
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "ps":
+                has_current_spec = any(
+                    str(part).startswith("label=hermes-container-spec=")
+                    for part in cmd
+                )
+                stdout = "" if has_current_spec else "legacy-cid\trunning\t<no value>\n"
+                return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-cid\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    worktree = tmp_path / "card-worktree"
+    worktree.mkdir()
+
+    env = _make_dummy_env(
+        cwd="/workspace",
+        task_id="kanban-card",
+        host_cwd=str(worktree),
+        auto_mount_cwd=True,
+    )
+
+    assert env._container_id == "fresh-cid"
+    run_calls = [
+        call for call in calls
+        if isinstance(call[0], list) and len(call[0]) >= 2 and call[0][1] == "run"
+    ]
+    assert run_calls
+    assert f"{worktree}:/workspace" in run_calls[0][0]
 
 
 def test_reuse_attaches_to_running_container_without_docker_run(monkeypatch):

--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -1,13 +1,14 @@
 """
 Regression tests for the shared-container task_id mapping.
 
-The top-level agent and all delegate_task subagents share a single
-terminal sandbox keyed by ``"default"``.  ``_resolve_container_task_id``
-is the sole gatekeeper for which tool-call task_ids go to the shared
-container vs. get their own isolated sandbox.  RL / benchmark
-environments opt in to isolation by calling
+The top-level agent and all delegate_task subagents normally share a
+terminal sandbox keyed by ``"default"``. Kanban workers instead share a
+board-and-card-scoped sandbox with only their own delegates.
+``_resolve_container_task_id`` is the sole gatekeeper for which tool-call
+task_ids go to a shared container vs. get their own isolated sandbox.
+RL / benchmark environments opt in to isolation by calling
 ``register_task_env_overrides(task_id, {...})`` before the agent loop;
-every other task_id collapses back to ``"default"``.
+other task_ids collapse back to the applicable shared key.
 
 If you change the collapse logic, update both the helper and these
 tests -- see `hermes-agent-dev` skill, "Why do subagents get their own
@@ -36,6 +37,19 @@ def test_none_task_id_maps_to_default():
 
 def test_empty_task_id_maps_to_default():
     assert terminal_tool._resolve_container_task_id("") == "default"
+
+
+def test_kanban_worker_uses_board_and_card_scoped_container(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_a082045e")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    top_level_key = terminal_tool._resolve_container_task_id(None)
+
+    assert top_level_key.startswith("kanban-")
+    assert terminal_tool._resolve_container_task_id("delegate-1") == top_level_key
+
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "other-board")
+    assert terminal_tool._resolve_container_task_id(None) != top_level_key
 
 
 def test_cwd_only_override_collapses_to_default():

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -39,6 +39,7 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_CONTAINER_SPEC_LABEL_KEY = "hermes-container-spec"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -1338,11 +1339,23 @@ class DockerEnvironment(BaseEnvironment):
         )
         logger.info("Docker run_args: %s", all_run_args)
 
+        spec_payload = json.dumps(
+            {
+                "cwd": cwd,
+                "image": image,
+                "image_uses_s6_init": image_uses_s6_init,
+                "run_args": all_run_args,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        spec_label = hashlib.sha256(spec_payload.encode("utf-8")).hexdigest()[:24]
+
         # Start the container directly via `docker run -d`.
         container_name = f"hermes-{uuid.uuid4().hex[:8]}"
         # Labels make hermes-created containers identifiable to:
         #   * the orphan reaper (`hermes-agent=1` for the global sweep filter)
-        #   * future cross-process reuse (`hermes-task-id`, `hermes-profile`)
+        #   * cross-process reuse (task, profile, and immutable create spec)
         #   * operators running `docker ps --filter label=hermes-agent=1`
         # Values are limited to the safe character set defined by
         # _sanitize_label_value(); the active Hermes profile is captured at
@@ -1354,6 +1367,7 @@ class DockerEnvironment(BaseEnvironment):
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"{_CONTAINER_SPEC_LABEL_KEY}={spec_label}",
         ]
         # Save args for container recreation on "No such container" recovery.
         self._image = image
@@ -1366,11 +1380,12 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            _CONTAINER_SPEC_LABEL_KEY: spec_label,
         }
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
         # container shared across sessions").  If a prior Hermes process
-        # already started a container for this (task_id, profile) and it
+        # already started a container for this (task_id, profile, create spec) and it
         # still exists, attach to it instead of starting a fresh one.  This
         # restores the documented contract; opt out via
         # ``terminal.docker_persist_across_processes: false``.
@@ -1382,7 +1397,7 @@ class DockerEnvironment(BaseEnvironment):
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
-                task_label, profile_name, egress_label,
+                task_label, profile_name, egress_label, spec_label,
             )
             if existing is not None:
                 container_id, state = existing
@@ -1642,7 +1657,10 @@ class DockerEnvironment(BaseEnvironment):
         task_label = self._labels.get("hermes-task-id", "")
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
-            task_label, profile_label, self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            task_label,
+            profile_label,
+            self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_CONTAINER_SPEC_LABEL_KEY, ""),
         )
         if existing is not None:
             cid, state = existing
@@ -1807,8 +1825,9 @@ class DockerEnvironment(BaseEnvironment):
         task_label: str,
         profile_label: str,
         egress_label: str,
+        spec_label: str,
     ) -> Optional[tuple[str, str]]:
-        """Look for an existing container labeled for this (task, profile).
+        """Look for a container with the same task and immutable run spec.
 
         Returns ``(container_id, state)`` on hit, ``None`` on miss / on any
         failure (including ``docker ps`` itself failing). State is one of the
@@ -1825,6 +1844,7 @@ class DockerEnvironment(BaseEnvironment):
                 "--filter", "label=hermes-agent=1",
                 "--filter", f"label=hermes-task-id={task_label}",
                 "--filter", f"label=hermes-profile={profile_label}",
+                "--filter", f"label={_CONTAINER_SPEC_LABEL_KEY}={spec_label}",
             ]
             if egress_label != "off":
                 filters.extend(["--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"])

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -33,6 +33,7 @@ Usage:
     result = terminal_tool("python server.py", background=True)
 """
 
+import hashlib
 import importlib.util
 import json
 import logging
@@ -1276,12 +1277,14 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     Map a tool-call ``task_id`` to the container/sandbox key used by
     ``_active_environments``.
 
-    The top-level agent passes ``task_id=None`` and lands on ``"default"``.
+    The top-level agent passes ``task_id=None`` and normally lands on
+    ``"default"``. A dispatcher-spawned Kanban worker instead uses a stable
+    board-and-card-scoped key so separate workspaces cannot share a sandbox.
     ``delegate_task`` children pass their own subagent ID so that
     file-state tracking, the active-subagents registry, and TUI events stay
-    distinct per child -- but we deliberately collapse that ID back to
-    ``"default"`` here so subagents share the parent's long-lived container
-    (one bash, one /workspace, one set of installed packages).
+    distinct per child -- but we deliberately collapse that ID back to the
+    parent's shared key here so subagents share its long-lived container (one
+    bash, one /workspace, one set of installed packages).
 
     Exception: RL / benchmark environments (TerminalBench2, HermesSweEnv, ...)
     call ``register_task_env_overrides(task_id, {...})`` to request a
@@ -1303,6 +1306,14 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
         overrides = _task_env_overrides[task_id]
         if set(overrides.keys()) & _ISOLATION_KEYS:
             return task_id
+
+    kanban_task = os.getenv("HERMES_KANBAN_TASK", "").strip()
+    if kanban_task:
+        kanban_board = os.getenv("HERMES_KANBAN_BOARD", "").strip() or "default"
+        scope = hashlib.sha256(
+            f"{kanban_board}\0{kanban_task}".encode("utf-8")
+        ).hexdigest()[:24]
+        return f"kanban-{scope}"
     return "default"
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -259,13 +259,14 @@ terminal:
 
 #### Container lifecycle
 
-Every Hermes-managed container is tagged with three labels so subsequent processes (and the orphan reaper) can identify it:
+Every Hermes-managed container is tagged with labels so subsequent processes (and the orphan reaper) can identify it:
 
 - `hermes-agent=1` — marks it as Hermes-managed
 - `hermes-task-id=<sanitized task_id>` — keys the per-task reuse probe
 - `hermes-profile=<sanitized profile name>` — scopes reuse and reaping to the active Hermes profile
+- `hermes-container-spec=<fingerprint>` — identifies the immutable image, working directory, mounts, and other `docker run` arguments
 
-On startup, Hermes runs `docker ps --filter label=hermes-task-id=<id> --filter label=hermes-profile=<profile>` and **attaches to the existing container** when it finds one. If the container is `exited` (e.g. after a Docker daemon restart), it's `docker start`'d and reused — filesystem state and any installed packages survive, but in-container background processes do not.
+On startup, Hermes probes for matching task, profile, and container-spec labels and **attaches to the existing container** when it finds one. A changed image, workspace bind, network mode, forwarded environment, or other immutable create argument starts a fresh container instead of reusing one with stale access. Dispatcher-spawned Kanban workers use a board-and-card-scoped task key, so a worker and its delegates share one sandbox without sharing another card's workspace. If a matching container is `exited` (e.g. after a Docker daemon restart), it's `docker start`'d and reused — filesystem state and any installed packages survive, but in-container background processes do not.
 
 When a Hermes process exits — `/quit`, closing a TUI session, gateway shutdown, even SIGKILL — the cleanup path is a **no-op for the container in default mode**. The container keeps running. The next Hermes process attaches to it in milliseconds via the label probe. This is the behavior the "one long-lived container shared across sessions" contract requires: it's the only way background processes (npm watchers, dev servers, long-running pytest) survive across sessions.
 


### PR DESCRIPTION
## Summary

- scope dispatcher-spawned Docker sandboxes to the Kanban board and card
- fingerprint immutable Docker create inputs and reuse only exact matching containers
- reject legacy containers without a current workspace spec label
- document the updated container lifecycle contract

## Root cause

Kanban workers and delegates collapsed to the global `default` container key, while cross-process Docker reuse matched only task/profile/egress labels. A container created without the card worktree bind could therefore be reused after `docker_mount_cwd_to_workspace` was enabled.

## Validation

- `git diff --check`
- `ruff check` on changed Python files
- 85 related tests through `scripts/run_tests.sh`
- live Docker QA: legacy container rejected, exact spec reused, changed mount created a fresh container, and both `/workspace` bind sources verified
- `ty` and basedpyright error sets compared to `origin/main`: no new errors