### PR TITLE
fix(state): verify FTS rebuild write path; spool pending-cap overflow

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3137,14 +3137,33 @@ class SessionStore:
             pending = self._dirty_transcripts.setdefault(session_id, [])
             pending.append(dict(message))
             # Cap pending messages per session to avoid unbounded memory
-            # growth when the DB is persistently broken. Drop the oldest.
+            # growth when the DB is persistently broken. Spool the oldest to
+            # the recovery-snapshot directory instead of discarding it so a
+            # multi-day gateway outage cannot rotate transcripts away with
+            # only a WARNING (#78182; complements #72680 shutdown flush).
             if len(pending) > self._MAX_PENDING_PER_SESSION:
-                pending.pop(0)
-                logger.warning(
+                dropped = pending.pop(0)
+                logger.error(
                     "Session DB transcript pending queue full for %s "
-                    "(cap=%d); dropping oldest message to make room",
-                    session_id, self._MAX_PENDING_PER_SESSION,
+                    "(cap=%d); spooling oldest message to recovery file "
+                    "instead of discarding it (#78182)",
+                    session_id,
+                    self._MAX_PENDING_PER_SESSION,
                 )
+                try:
+                    from gateway.shutdown_flush import spool_transcript_messages
+
+                    spool_transcript_messages(
+                        session_id,
+                        [dropped],
+                        reason="pending_cap_overflow",
+                    )
+                except Exception as spool_exc:
+                    logger.error(
+                        "Failed to spool overflow transcript for %s: %s",
+                        session_id,
+                        spool_exc,
+                    )
             # Snapshot the first pending message, then release the lock
             # before the DB write so other sessions are not blocked.
             msg = pending[0]

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -28,12 +28,30 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
-import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+# Monotonic counter so same-nanosecond bursts still sort stably (#78323 review).
+_spool_seq_lock = threading.Lock()
+_spool_seq = 0
+
+
+def _next_spool_file_id() -> str:
+    """Return a lexicographically sortable unique id (time_ns + counter).
+
+    Recovery walks ``sorted(glob("*.json"))``. uuid4 names re-insert out of
+    order after a burst of pending-cap spools; time_ns + a process-local
+    sequence preserves write order (#78323 / #78182 reporter review).
+    """
+    global _spool_seq
+    with _spool_seq_lock:
+        _spool_seq += 1
+        seq = _spool_seq
+    return f"{time.time_ns():020d}-{seq:06d}"
 
 
 def _get_flush_dir():
@@ -62,7 +80,7 @@ def _write_payload(flush_dir: Path, payload: Dict[str, Any]) -> None:
     """Atomically write one private, uniquely named recovery payload."""
     from utils import atomic_json_write
 
-    file_id = uuid.uuid4().hex
+    file_id = _next_spool_file_id()
     final_path = flush_dir / f"pending-{file_id}.json"
     atomic_json_write(
         final_path,
@@ -166,6 +184,29 @@ def _serialise_value(value: Any) -> Optional[dict]:
     return {"text": str(value)}
 
 
+def _message_has_recoverable_payload(message: dict) -> bool:
+    """True when a transcript row is worth spooling even with empty text.
+
+    Assistant tool-call rows often have ``content=None`` while carrying
+    ``tool_calls`` / reasoning. Skipping them at spool time avoids infinite
+    "invalid pending" warnings on every startup (#78323 review item 2).
+    """
+    if message.get("tool_calls") or message.get("tool_call_id"):
+        return True
+    if message.get("reasoning") or message.get("reasoning_content"):
+        return True
+    if message.get("api_content"):
+        return True
+    content = message.get("content")
+    if content is None:
+        content = message.get("text")
+    if isinstance(content, str) and content.strip():
+        return True
+    if content not in (None, "", []):
+        return True
+    return False
+
+
 def spool_transcript_messages(
     session_id: str,
     messages: list,
@@ -184,16 +225,21 @@ def spool_transcript_messages(
         return False
 
     flush_dir = _get_flush_dir()
-    ts = int(time.time())
+    # Sub-second ts in the payload for diagnostics; file names use time_ns
+    # for recovery ordering.
+    ts = time.time()
     spooled = 0
     for message in messages:
         if not isinstance(message, dict):
             message = {"role": "user", "content": str(message)}
+        if not _message_has_recoverable_payload(message):
+            continue
         content = message.get("content")
         if content is None:
             content = message.get("text", "")
-        if not content and not message:
-            continue
+        text = content if isinstance(content, str) else (
+            "" if content is None else str(content)
+        )
         try:
             _write_payload(
                 flush_dir,
@@ -203,8 +249,11 @@ def spool_transcript_messages(
                     "ts": ts,
                     "data": {
                         "session_id": session_id,
-                        "text": content if isinstance(content, str) else str(content),
+                        "text": text,
                         "role": message.get("role", "user"),
+                        # Full original row so recovery can restore
+                        # tool_calls / reasoning / api_content / timestamps
+                        # (#78323 review items 2–3).
                         "message": message,
                     },
                 },
@@ -272,8 +321,32 @@ def recover_pending_to_db(
                 continue
             session_key = payload.get("session_key", "")
             data = payload.get("data", {})
+            if not isinstance(data, dict):
+                data = {}
+            original = data.get("message")
+            if not isinstance(original, dict):
+                original = {}
+
             text = data.get("text", "")
-            if not text or not session_key:
+            if not text and original:
+                content = original.get("content")
+                if content is None:
+                    content = original.get("text", "")
+                text = content if isinstance(content, str) else (
+                    "" if content is None else str(content)
+                )
+
+            # Role+text is the minimum for plain user pending flushes.
+            # Transcript spools may be tool-call rows with empty text but a
+            # recoverable structured payload (#78323 review item 2).
+            has_structure = bool(
+                original.get("tool_calls")
+                or original.get("tool_call_id")
+                or original.get("reasoning")
+                or original.get("reasoning_content")
+                or original.get("api_content")
+            )
+            if (not text and not has_structure) or not session_key:
                 logger.warning(
                     "Cannot recover structurally invalid pending message from %s; "
                     "the flush file has been preserved",
@@ -287,7 +360,7 @@ def recover_pending_to_db(
             # message row.  Try the session_id field from the serialised
             # data first; fall back to scanning sessions for a matching
             # session_key in the source column.
-            session_id = data.get("session_id", "")
+            session_id = data.get("session_id", "") or original.get("session_id", "")
 
             if not session_id:
                 # Try to extract from the session_key itself — gateway
@@ -303,12 +376,37 @@ def recover_pending_to_db(
                 )
                 continue
 
-            session_db.append_message(
-                session_id=session_id,
-                role=data.get("role") or "user",
-                content=text,
-                timestamp=payload.get("ts", int(time.time())),
+            # Prefer structured fields from the full original message when
+            # present (tool_calls / reasoning / api_content / timestamps).
+            # v1 still drops display_metadata and platform-specific extras
+            # that SessionDB does not need for FTS-visible recovery.
+            role = (
+                data.get("role")
+                or original.get("role")
+                or "user"
             )
+            ts = original.get("timestamp", payload.get("ts", time.time()))
+            append_kwargs: Dict[str, Any] = {
+                "session_id": session_id,
+                "role": role,
+                "content": text if text else None,
+                "timestamp": ts,
+            }
+            for key in (
+                "tool_name",
+                "tool_calls",
+                "tool_call_id",
+                "finish_reason",
+                "reasoning",
+                "reasoning_content",
+                "reasoning_details",
+                "api_content",
+                "display_kind",
+            ):
+                if key in original and original[key] is not None:
+                    append_kwargs[key] = original[key]
+
+            session_db.append_message(**append_kwargs)
             recovered += 1
             path.unlink(missing_ok=True)
         except Exception as exc:

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -166,6 +166,68 @@ def _serialise_value(value: Any) -> Optional[dict]:
     return {"text": str(value)}
 
 
+def spool_transcript_messages(
+    session_id: str,
+    messages: list,
+    *,
+    reason: str = "pending_cap_overflow",
+) -> bool:
+    """Persist dropped/pending transcript rows for later recovery (#78182).
+
+    Uses the same ``pending_messages/`` directory as
+    :func:`flush_pending_to_file`. Each message is written as its own payload
+    so :func:`recover_pending_to_db` can re-insert after the DB is repaired.
+
+    Returns True when at least one message was spooled.
+    """
+    if not session_id or not messages:
+        return False
+
+    flush_dir = _get_flush_dir()
+    ts = int(time.time())
+    spooled = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            message = {"role": "user", "content": str(message)}
+        content = message.get("content")
+        if content is None:
+            content = message.get("text", "")
+        if not content and not message:
+            continue
+        try:
+            _write_payload(
+                flush_dir,
+                {
+                    "session_key": session_id,
+                    "reason": reason,
+                    "ts": ts,
+                    "data": {
+                        "session_id": session_id,
+                        "text": content if isinstance(content, str) else str(content),
+                        "role": message.get("role", "user"),
+                        "message": message,
+                    },
+                },
+            )
+            spooled += 1
+        except Exception as exc:
+            logger.error(
+                "Failed to spool overflow transcript for session %s: %s",
+                session_id,
+                exc,
+            )
+    if spooled:
+        logger.error(
+            "Spooled %d overflow transcript message(s) for session %s to %s "
+            "(reason=%s) — pending queue cap would have discarded them (#78182)",
+            spooled,
+            session_id,
+            flush_dir,
+            reason,
+        )
+    return spooled > 0
+
+
 def recover_pending_to_db(
     session_db=None,
 ) -> int:
@@ -243,7 +305,7 @@ def recover_pending_to_db(
 
             session_db.append_message(
                 session_id=session_id,
-                role="user",
+                role=data.get("role") or "user",
                 content=text,
                 timestamp=payload.get("ts", int(time.time())),
             )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1981,6 +1981,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # in place at most once per SessionDB instance so a genuinely
         # unrecoverable database can't put writers into a rebuild loop.
         self._fts_runtime_rebuild_attempted = False
+        # Set when the one-shot rebuild ran but the immediate retried write
+        # still failed with FTS corruption — recovery claimed success without
+        # a verified write path (#78182). Callers should escalate to ERROR and
+        # spool rather than silently rotating pending queues.
+        self._fts_write_path_broken = False
         # One-shot guard for the usermerge-floor config write on the
         # incremental FTS merge cadence (see _merge_fts_incrementally).
         self._fts_usermerge_floor_applied = False
@@ -2628,6 +2633,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # until the next process restart triggers the offline repair.
                 # Rebuild the FTS index in place (once per instance) via
                 # rebuild_fts() and retry the failed write immediately.
+                #
+                # If a rebuild already ran and the write path is still broken,
+                # do not log "rebuilt; retrying" as success — mark recovery
+                # failed and escalate (#78182).
+                if (
+                    self._fts_runtime_rebuild_attempted
+                    and self._is_fts_write_corruption_error(exc)
+                ):
+                    if not self._fts_write_path_broken:
+                        self._fts_write_path_broken = True
+                        logger.error(
+                            "state.db FTS in-place rebuild completed but the "
+                            "retried write still fails (%s). Treating as "
+                            "recovery failure — run `hermes doctor` / "
+                            "repair_state_db_schema. Canonical rows may still "
+                            "be intact; this process will not re-attempt FTS "
+                            "rebuild.",
+                            exc,
+                        )
+                    raise
                 if not self._try_runtime_fts_rebuild(exc):
                     raise
                 continue

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2643,9 +2643,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ):
                     if not self._fts_write_path_broken:
                         self._fts_write_path_broken = True
+                        # Wording: rebuild may have failed or still left a
+                        # broken write path — do not claim "completed" (#78323).
                         logger.error(
-                            "state.db FTS in-place rebuild completed but the "
-                            "retried write still fails (%s). Treating as "
+                            "state.db FTS write path still broken after the "
+                            "in-place rebuild attempt (%s). Treating as "
                             "recovery failure — run `hermes doctor` / "
                             "repair_state_db_schema. Canonical rows may still "
                             "be intact; this process will not re-attempt FTS "

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -166,5 +166,50 @@ class TestRuntimeFtsRebuild:
         _corrupt_fts(tmp_path / "state.db")
         with pytest.raises(sqlite3.DatabaseError):
             db.append_message("s1", "user", "second corruption")
+        # #78182: a rebuild that already ran, then a still-broken write path,
+        # must mark recovery failure (not claim silent success).
+        assert db._fts_write_path_broken is True
+
+
+class TestPendingCapSpoolsOverflow:
+    """Gateway pending-cap must not discard transcripts (#78182)."""
+
+    def test_overflow_message_is_spooled_not_only_dropped(self, tmp_path, monkeypatch):
+        import threading
+
+        from gateway.session import SessionStore
+        from gateway import shutdown_flush
+
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: tmp_path / "pending")
+        (tmp_path / "pending").mkdir()
+
+        class FakeDb:
+            def rebuild_fts(self):
+                return 0
+
+            def append_message(self, **kwargs):
+                raise RuntimeError("database disk image is malformed")
+
+        store = object.__new__(SessionStore)
+        store._db = FakeDb()
+        store._transcript_retry_lock = threading.Lock()
+        store._dirty_transcripts = {}
+        store._transcript_append_failures = {}
+        store._fts_rebuild_attempted = True
+
+        for i in range(store._MAX_PENDING_PER_SESSION + 3):
+            store.append_to_transcript("s1", {"role": "user", "content": f"msg{i}"})
+
+        pending = store._dirty_transcripts.get("s1", [])
+        assert len(pending) <= store._MAX_PENDING_PER_SESSION
+        # Overflow was written under pending_messages/
+        spools = list((tmp_path / "pending").glob("*.json"))
+        assert len(spools) >= 3
+        # Oldest messages should be among the spools
+        texts = []
+        for path in spools:
+            payload = __import__("json").loads(path.read_text(encoding="utf-8"))
+            texts.append(payload["data"]["text"])
+        assert "msg0" in texts
 
 

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -212,4 +212,70 @@ class TestPendingCapSpoolsOverflow:
             texts.append(payload["data"]["text"])
         assert "msg0" in texts
 
+    def test_spool_filenames_sort_in_write_order(self, tmp_path, monkeypatch):
+        """#78323: recovery must re-insert burst spools in write order."""
+        from gateway import shutdown_flush
+
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: tmp_path / "pending")
+        (tmp_path / "pending").mkdir()
+
+        msgs = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third"},
+        ]
+        assert shutdown_flush.spool_transcript_messages("sess-order", msgs) is True
+        names = sorted(p.name for p in (tmp_path / "pending").glob("*.json"))
+        # Lexicographic order of filenames must match write order.
+        texts = []
+        for name in names:
+            payload = __import__("json").loads(
+                (tmp_path / "pending" / name).read_text(encoding="utf-8")
+            )
+            texts.append(payload["data"]["text"])
+        assert texts == ["first", "second", "third"]
+
+    def test_tool_call_row_spools_and_recovers_without_text(
+        self, tmp_path, monkeypatch
+    ):
+        """#78323: assistant tool_calls with content=None must recover intact."""
+        from gateway import shutdown_flush
+
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: tmp_path / "pending")
+        (tmp_path / "pending").mkdir()
+
+        tool_row = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+            "timestamp": 1_700_000_000,
+        }
+        assert (
+            shutdown_flush.spool_transcript_messages("sess-tools", [tool_row]) is True
+        )
+
+        calls = []
+
+        class FakeDb:
+            def append_message(self, **kwargs):
+                calls.append(kwargs)
+                return 1
+
+        recovered = shutdown_flush.recover_pending_to_db(FakeDb())
+        assert recovered == 1
+        assert len(calls) == 1
+        assert calls[0]["session_id"] == "sess-tools"
+        assert calls[0]["role"] == "assistant"
+        assert calls[0]["content"] is None
+        assert calls[0]["tool_calls"] == tool_row["tool_calls"]
+        assert calls[0]["timestamp"] == 1_700_000_000
+        # File removed on success — no perpetual startup warning.
+        assert list((tmp_path / "pending").glob("*.json")) == []
+
 


### PR DESCRIPTION
## What does this PR do?

When `state.db` FTS corruption is deeper than the shadow tables, the one-shot in-place rebuild can claim success (FTS5 `'rebuild'` returned a count) while the **retried write still fails**. The one-shot flag is then burned and a long-running gateway keeps accepting turns: the 200-message pending queue **drops oldest rows with only a WARNING**, so transcripts rotate away for days.

This PR does **not** auto-replace the database (project recovery philosophy). It makes failure loud and durable:

1. After a rebuild has already been attempted, a still-corrupt write path logs **ERROR**, sets `_fts_write_path_broken`, and propagates — no false "rebuilt; retrying" success story.
2. Pending-queue overflow **spools** the oldest message to `pending_messages/` (same recovery dir as #72680 shutdown flush) instead of discarding it.

## Related Issue

Fixes #78182

Not a duplicate of:
- #72732 (detach FTS / keep canonical writes — complementary, larger design)
- #75081 (duplicate write after successful FTS retry snapshot advance)
- #72680 (shutdown flush only; this is the runtime cap half)

## Changes Made

- `hermes_state.SessionDB`: `_fts_write_path_broken` + ERROR on post-rebuild still-broken writes
- `gateway/session.py`: pending cap overflow → `spool_transcript_messages`
- `gateway/shutdown_flush.py`: `spool_transcript_messages()` helper; recover uses `data.role` when present
- Tests: one-shot path marks broken; overflow spools to recovery files

## How to Test

```bash
python -m pytest tests/state/test_fts_runtime_rebuild.py -q
python -m pytest tests/gateway/test_session.py -k pending_queue_caps -q
```

Expected: FTS rebuild suite green; pending cap still capped + spools on disk.

## Checklist

- [x] Anti-dupe searched (issue number + FTS rebuild / pending cap symbols)
- [x] Tests added/updated
- [x] No destructive auto-reset of state.db