### PR TITLE
fix(hooks): preserve Windows command path separators (#78293)

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -13,8 +13,8 @@ Design notes
   :func:`hermes_cli.plugins.invoke_hook` and its aggregators.  Python
   plugins are registered first (via ``discover_and_load()``) so their
   block decisions win ties over shell-hook blocks.
-* Subprocess execution uses ``shlex.split(os.path.expanduser(command))``
-  with ``shell=False`` — no shell injection footguns.  Users that need
+* Subprocess execution tokenizes without a shell, using POSIX ``shlex`` on
+  Unix and Windows command-line quoting rules on Windows.  Users that need
   pipes/redirection wrap their logic in a script.
 * First-use consent is gated by the allowlist under
   ``~/.hermes/shell-hooks-allowlist.json``.  Non-TTY callers must pass
@@ -431,6 +431,70 @@ def _parse_single_entry(
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
 
 
+def _split_windows_command(command: str) -> List[str]:
+    """Split a command using the Windows C runtime argv quoting rules."""
+    args: List[str] = []
+    index = 0
+    length = len(command)
+
+    while index < length:
+        while index < length and command[index] in " \t":
+            index += 1
+        if index >= length:
+            break
+
+        arg: List[str] = []
+        in_quotes = False
+        while index < length:
+            char = command[index]
+            if char in " \t" and not in_quotes:
+                break
+
+            if char == "\\":
+                start = index
+                while index < length and command[index] == "\\":
+                    index += 1
+                backslashes = index - start
+                if index < length and command[index] == '"':
+                    arg.extend("\\" * (backslashes // 2))
+                    if backslashes % 2:
+                        arg.append('"')
+                        index += 1
+                    else:
+                        in_quotes = not in_quotes
+                        index += 1
+                else:
+                    arg.extend("\\" * backslashes)
+                continue
+
+            if char == '"':
+                if in_quotes and index + 1 < length and command[index + 1] == '"':
+                    arg.append('"')
+                    index += 2
+                else:
+                    in_quotes = not in_quotes
+                    index += 1
+                continue
+
+            arg.append(char)
+            index += 1
+
+        if in_quotes:
+            raise ValueError("No closing quotation")
+        args.append("".join(arg))
+
+        while index < length and command[index] in " \t":
+            index += 1
+
+    return args
+
+
+def _split_command(command: str) -> List[str]:
+    if IS_WINDOWS:
+        return _split_windows_command(command)
+    return shlex.split(command)
+
+
 def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     """Run ``spec.command`` as a subprocess with ``stdin_json`` on stdin.
 
@@ -450,7 +514,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         "error": None,
     }
     try:
-        argv = shlex.split(os.path.expanduser(spec.command))
+        argv = _split_command(os.path.expanduser(spec.command))
     except ValueError as exc:
         result["error"] = f"command {spec.command!r} cannot be parsed: {exc}"
         return result
@@ -815,7 +879,7 @@ def _command_script_path(command: str) -> str:
     common bare-path form.
     """
     try:
-        parts = shlex.split(command)
+        parts = _split_command(command)
     except ValueError:
         return command
     if not parts:
@@ -824,7 +888,7 @@ def _command_script_path(command: str) -> str:
         if part.lower().endswith(_SCRIPT_EXTENSIONS):
             return part
     for part in parts:
-        if "/" in part or part.startswith("~"):
+        if "/" in part or (IS_WINDOWS and "\\" in part) or part.startswith("~"):
             return part
     return parts[0]
 
@@ -902,7 +966,7 @@ def script_is_executable(command: str) -> bool:
     if not os.path.isfile(expanded):
         return False
     try:
-        argv = shlex.split(command)
+        argv = _split_command(command)
     except ValueError:
         return False
     is_bare_invocation = bool(argv) and argv[0] == path

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -16,11 +16,11 @@ Inspired by Block/goose's SubdirectoryHintTracker.
 import hashlib
 import logging
 import os
-import shlex
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
 from agent.prompt_builder import _scan_context_content
+from agent.shell_hooks import _split_command
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +190,7 @@ class SubdirectoryHintTracker:
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
         """Extract path-like tokens from a shell command string."""
         try:
-            tokens = shlex.split(cmd)
+            tokens = _split_command(cmd)
         except ValueError:
             tokens = cmd.split()
 
@@ -198,8 +198,8 @@ class SubdirectoryHintTracker:
             # Skip flags
             if token.startswith("-"):
                 continue
-            # Must look like a path (contains / or .)
-            if "/" not in token and "." not in token:
+            # Must look like a path (contains a separator or extension).
+            if "/" not in token and "\\" not in token and "." not in token:
                 continue
             # Skip URLs
             if token.startswith(("http://", "https://", "git@")):

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,7 +9,9 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,7 +23,7 @@ from agent import shell_hooks
 
 def _write_script(tmp_path: Path, name: str, body: str) -> Path:
     path = tmp_path / name
-    path.write_text(body)
+    path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
     return path
 
@@ -142,6 +144,58 @@ class TestMatcher:
 # ── End-to-end subprocess behaviour ───────────────────────────────────────
 
 
+class TestCommandSplitting:
+    def test_windows_backslash_path_is_preserved(self, monkeypatch):
+        monkeypatch.setattr(shell_hooks, "IS_WINDOWS", True)
+
+        command = r"C:\Users\alice\.local\bin\dcg.exe --check"
+
+        assert shell_hooks._split_command(command) == [
+            r"C:\Users\alice\.local\bin\dcg.exe",
+            "--check",
+        ]
+        assert shell_hooks._command_script_path(command) == (
+            r"C:\Users\alice\.local\bin\dcg.exe"
+        )
+        assert shell_hooks._command_script_path(
+            r"powershell C:\Users\alice\hooks\check.ps1"
+        ) == r"C:\Users\alice\hooks\check.ps1"
+
+    def test_windows_quoted_path_and_argument_follow_runtime_rules(self, monkeypatch):
+        monkeypatch.setattr(shell_hooks, "IS_WINDOWS", True)
+        argv = [
+            r"C:\Program Files\dcg.exe",
+            "--label=a b",
+            r"C:\path\with\trailing\\",
+        ]
+
+        assert shell_hooks._split_command(subprocess.list2cmdline(argv)) == argv
+
+    def test_spawn_uses_windows_argv_without_losing_backslashes(self, monkeypatch):
+        monkeypatch.setattr(shell_hooks, "IS_WINDOWS", True)
+        monkeypatch.setattr(shell_hooks, "windows_hide_flags", lambda: 0)
+        seen = {}
+
+        def fake_run(argv, **kwargs):
+            seen["argv"] = argv
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(shell_hooks.subprocess, "run", fake_run)
+        result = shell_hooks._spawn(
+            shell_hooks.ShellHookSpec(
+                event="pre_tool_call",
+                command=r"C:\Users\alice\.local\bin\dcg.exe --check",
+            ),
+            "{}",
+        )
+
+        assert result["returncode"] == 0
+        assert seen["argv"] == [
+            r"C:\Users\alice\.local\bin\dcg.exe",
+            "--check",
+        ]
+
+
 class TestCallbackSubprocess:
 
 
@@ -239,7 +293,7 @@ class TestCallbackSubprocess:
             session_id="sess-77",
             task_id="task-77",
         )
-        payload = json.loads(capture.read_text())
+        payload = json.loads(capture.read_text(encoding="utf-8"))
         assert payload["hook_event_name"] == "pre_tool_call"
         assert payload["tool_name"] == "terminal"
         assert payload["tool_input"] == {"command": "echo hi"}

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -114,6 +114,26 @@ class TestSubdirectoryHintTracker:
         assert tracker.check_tool_call("read_file", {}) is None
         assert tracker.check_tool_call("terminal", {"command": ""}) is None
 
+    def test_windows_command_preserves_backslash_path(self, project):
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        candidates = set()
+        captured = []
+
+        with (
+            patch("agent.shell_hooks.IS_WINDOWS", True),
+            patch.object(
+                tracker,
+                "_add_path_candidate",
+                side_effect=lambda raw, _candidates: captured.append(raw),
+            ),
+        ):
+            tracker._extract_paths_from_command(
+                r"cd C:\Users\alice\project",
+                candidates,
+            )
+
+        assert captured == [r"C:\Users\alice\project"]
+
 
 
 class TestPermissionErrorHandling:


### PR DESCRIPTION
## What does this PR do?

Fixes Windows shell-hook commands whose absolute paths use backslashes.
Previously the hook bridge used POSIX `shlex` for both doctor checks and
runtime execution, turning `C:\Users\alice\hook.exe` into
`C:Usersalicehook.exe`.

The three consumers now share a Windows-aware splitter that follows the C
runtime argv rules for whitespace, quotes, and backslashes:

- `_spawn()` runtime execution
- `_command_script_path()` doctor/drift resolution
- `script_is_executable()` permission checks

Unix behavior remains on the existing POSIX `shlex` path.

## Related Issue

Fixes #78293

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Preserve backslashes in bare Windows executable paths.
- Support quoted paths and quoted arguments with Windows argv semantics.
- Recognize interpreter-prefixed Windows script paths during doctor checks.
- Verify that the actual subprocess receives the intact Windows argv.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/agent/test_shell_hooks.py tests/hermes_cli/test_hooks_cli.py tests/test_windows_subprocess_no_window_flags.py -q`
2. Confirm all 37 tests pass.
3. Configure a hook command such as
   `C:\Users\alice\.local\bin\dcg.exe --check` and run
   `hermes hooks doctor`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the focused tests through `scripts/run_tests.sh`.
- [x] I've added regression coverage.
- [x] I've tested the Windows parsing behavior through platform-isolated tests.

### Documentation & Housekeeping

- [x] Documentation update is not required.
- [x] `cli-config.yaml.example` update is not required.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not required.
- [x] Cross-platform impact considered; Unix retains POSIX `shlex`.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

```text
before: C:Usersalice.localbindcg.exe
after:  C:\Users\alice\.local\bin\dcg.exe
argv:   ['C:\\Users\\alice\\.local\\bin\\dcg.exe', '--check']
```
