### PR TITLE
fix: clean up cancelled MCP elicitation approvals

### DIFF
--- a/contributors/emails/iskandartojiboyev96@gmail.com
+++ b/contributors/emails/iskandartojiboyev96@gmail.com
@@ -1,0 +1,1 @@
+iskandartojiboyev96-ai

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -5,7 +5,7 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch as mock_patch
+from unittest.mock import MagicMock, patch as mock_patch
 
 import pytest
 
@@ -1503,3 +1503,163 @@ class TestCliApprovalTimeoutClassifiedSeparately:
         assert result.get("user_consent") is False
         assert "timed out without user response" in result["message"]
         assert "Silence is not consent" in result["message"]
+
+
+class TestGatewayApprovalCancellationCleanup:
+    """A cancelled owner must not leave a stale queue entry behind."""
+
+    SESSION_KEY = "test-cancelled-approval"
+
+    def setup_method(self):
+        from tools import approval as mod
+
+        mod._gateway_queues.clear()
+
+    def teardown_method(self):
+        from tools import approval as mod
+
+        mod._gateway_queues.clear()
+
+    def test_cancel_event_removes_the_pending_entry(self):
+        from tools import approval as mod
+
+        cancel_event = threading.Event()
+        notified = threading.Event()
+        result_holder = {}
+
+        def wait_for_decision():
+            result_holder["result"] = mod._await_gateway_decision(
+                self.SESSION_KEY,
+                lambda _data: notified.set(),
+                {
+                    "command": "Submit external operation?",
+                    "description": "MCP elicitation",
+                    "pattern_key": "mcp_elicitation",
+                    "pattern_keys": ["mcp_elicitation"],
+                },
+                cancellation_event=cancel_event,
+                surface="mcp-elicitation/test",
+            )
+
+        worker = threading.Thread(target=wait_for_decision)
+        worker.start()
+        assert notified.wait(timeout=1)
+        assert mod.has_blocking_approval(self.SESSION_KEY)
+
+        cancel_event.set()
+        worker.join(timeout=2)
+
+        assert not worker.is_alive()
+        assert result_holder["result"]["resolved"] is False
+        assert not mod.has_blocking_approval(self.SESSION_KEY)
+
+    def test_pre_cancelled_wait_never_enqueues_or_notifies(self):
+        from tools import approval as mod
+
+        cancel_event = threading.Event()
+        cancel_event.set()
+        notify = MagicMock()
+
+        result = mod._await_gateway_decision(
+            self.SESSION_KEY,
+            notify,
+            {"command": "x", "description": "y"},
+            cancellation_event=cancel_event,
+        )
+
+        assert result == {"resolved": False, "choice": None}
+        notify.assert_not_called()
+        assert not mod.has_blocking_approval(self.SESSION_KEY)
+
+    def test_cancel_token_revokes_queue_while_notify_is_blocked(self):
+        from tools import approval as mod
+
+        cancellation = mod.ApprovalCancellation()
+        notified = threading.Event()
+        release_notify = threading.Event()
+        result_holder = {}
+
+        def blocking_notify(_data):
+            notified.set()
+            release_notify.wait(timeout=2)
+
+        def wait_for_decision():
+            result_holder["result"] = mod._await_gateway_decision(
+                self.SESSION_KEY,
+                blocking_notify,
+                {"command": "x", "description": "y"},
+                cancellation_event=cancellation,
+            )
+
+        worker = threading.Thread(target=wait_for_decision)
+        worker.start()
+        assert notified.wait(timeout=1)
+        assert mod.has_blocking_approval(self.SESSION_KEY)
+
+        cancellation.cancel()
+        assert not mod.has_blocking_approval(self.SESSION_KEY)
+
+        release_notify.set()
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+        assert result_holder["result"]["resolved"] is False
+
+    def test_cancellation_racing_response_wakeup_wins_fail_closed(self, monkeypatch):
+        from tools import approval as mod
+
+        cancellation = mod.ApprovalCancellation()
+
+        class RaceEvent:
+            def wait(self, timeout=None):
+                cancellation.cancel()
+                return True
+
+            def set(self):
+                pass
+
+        class RaceEntry:
+            def __init__(self, data):
+                self.data = data
+                self.event = RaceEvent()
+                self.result = "once"
+                self.reason = None
+
+        monkeypatch.setattr(mod, "_ApprovalEntry", RaceEntry)
+
+        result = mod._await_gateway_decision(
+            self.SESSION_KEY,
+            lambda _data: None,
+            {"command": "x", "description": "y"},
+            cancellation_event=cancellation,
+        )
+
+        assert result["resolved"] is False
+        assert not mod.has_blocking_approval(self.SESSION_KEY)
+
+    def test_exceptional_wait_exit_also_removes_the_entry(self, monkeypatch):
+        from tools import approval as mod
+
+        class RaisingEvent:
+            def wait(self, timeout=None):
+                raise RuntimeError("wait failed")
+
+            def set(self):
+                pass
+
+        class RaisingEntry:
+            def __init__(self, data):
+                self.data = data
+                self.event = RaisingEvent()
+                self.result = None
+                self.reason = None
+
+        monkeypatch.setattr(mod, "_ApprovalEntry", RaisingEntry)
+
+        with pytest.raises(RuntimeError, match="wait failed"):
+            mod._await_gateway_decision(
+                self.SESSION_KEY,
+                lambda _data: None,
+                {"command": "x", "description": "y"},
+            )
+
+        assert not mod.has_blocking_approval(self.SESSION_KEY)

--- a/tests/tools/test_mcp_elicitation.py
+++ b/tests/tools/test_mcp_elicitation.py
@@ -154,6 +154,155 @@ class TestElicitationHandlerFailureModes:
         assert result.action == "cancel"
         assert handler.metrics["errors"] == 1
 
+    def test_cancellation_signals_worker_and_waits_for_cleanup(self):
+        """Cancelling the async callback must not strand its blocking worker.
+
+        ``asyncio.to_thread`` cannot cancel a running thread. The handler must
+        therefore signal the synchronous consent flow and wait until it has
+        released its approval state before propagating cancellation.
+        """
+        import threading
+
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        params = _form_params()
+        started = threading.Event()
+        cleaned = threading.Event()
+
+        def wait_for_cancel(*_args, cancellation_event=None, **_kwargs):
+            assert cancellation_event is not None
+            started.set()
+            assert cancellation_event.wait(timeout=2)
+            cleaned.set()
+            return "cancel"
+
+        async def exercise():
+            with patch(
+                "tools.approval.request_elicitation_consent",
+                side_effect=wait_for_cancel,
+            ):
+                task = asyncio.create_task(handler(context=None, params=params))
+                assert await asyncio.to_thread(started.wait, 1)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(exercise())
+        assert cleaned.is_set()
+
+    def test_timeout_signals_worker_and_waits_for_cleanup(self, monkeypatch):
+        """The handler's own timeout must revoke the synchronous wait too."""
+        import threading
+
+        handler = ElicitationHandler("pay", {"timeout": 5})
+        handler.timeout = 0.01
+        monkeypatch.setattr(ElicitationHandler, "_OUTER_TIMEOUT_GRACE_SECONDS", 0.01)
+        params = _form_params()
+        cleaned = threading.Event()
+
+        def wait_for_cancel(*_args, cancellation_event=None, **_kwargs):
+            assert cancellation_event is not None
+            assert cancellation_event.wait(timeout=1)
+            cleaned.set()
+            return "cancel"
+
+        with patch(
+            "tools.approval.request_elicitation_consent",
+            side_effect=wait_for_cancel,
+        ):
+            result = asyncio.run(handler(context=None, params=params))
+
+        assert result.action == "cancel"
+        assert cleaned.is_set()
+        assert handler.metrics["errors"] == 1
+
+    def test_cancelled_handler_cleans_real_gateway_entry(self):
+        """Exercise the production handler → router → queue cancellation path."""
+        import contextvars
+        import threading
+        from types import SimpleNamespace
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools import approval
+
+        session_key = "test-mcp-cancelled-gateway"
+        notified = threading.Event()
+        approval.register_gateway_notify(session_key, lambda _data: notified.set())
+        tokens = set_session_vars(
+            platform="desktop",
+            session_key=session_key,
+            cron_session="",
+        )
+        try:
+            captured = contextvars.copy_context()
+        finally:
+            clear_session_vars(tokens)
+
+        owner = SimpleNamespace(_pending_call_context=captured)
+        handler = ElicitationHandler("pay", {"timeout": 5}, owner=owner)  # type: ignore[arg-type]
+        params = _form_params()
+
+        async def exercise():
+            task = asyncio.create_task(handler(context=None, params=params))
+            assert await asyncio.to_thread(notified.wait, 1)
+            assert approval.has_blocking_approval(session_key)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        try:
+            asyncio.run(exercise())
+            assert not approval.has_blocking_approval(session_key)
+        finally:
+            approval.unregister_gateway_notify(session_key)
+
+    def test_cancelled_handler_revokes_queue_while_notify_is_blocked(self):
+        """Cleanup cannot depend on the synchronous notify callback returning."""
+        import contextvars
+        import threading
+        from types import SimpleNamespace
+
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools import approval
+
+        session_key = "test-mcp-cancelled-blocked-notify"
+        notified = threading.Event()
+        release_notify = threading.Event()
+
+        def blocking_notify(_data):
+            notified.set()
+            release_notify.wait(timeout=3)
+
+        approval.register_gateway_notify(session_key, blocking_notify)
+        tokens = set_session_vars(
+            platform="desktop",
+            session_key=session_key,
+            cron_session="",
+        )
+        try:
+            captured = contextvars.copy_context()
+        finally:
+            clear_session_vars(tokens)
+
+        owner = SimpleNamespace(_pending_call_context=captured)
+        handler = ElicitationHandler("pay", {"timeout": 5}, owner=owner)  # type: ignore[arg-type]
+        params = _form_params()
+
+        async def exercise():
+            task = asyncio.create_task(handler(context=None, params=params))
+            assert await asyncio.to_thread(notified.wait, 1)
+            assert approval.has_blocking_approval(session_key)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert not approval.has_blocking_approval(session_key)
+            release_notify.set()
+
+        try:
+            asyncio.run(exercise())
+        finally:
+            release_notify.set()
+            approval.unregister_gateway_notify(session_key)
+
 
 class TestElicitationHandlerWiring:
     def test_session_kwargs_returns_callback(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2292,6 +2292,51 @@ def _denial_breaker_addendum(session_key: str) -> str:
 # resolves every pending approval in the session.
 
 
+class ApprovalCancellation:
+    """Thread-safe cancellation signal with synchronous cleanup callbacks.
+
+    ``threading.Event`` alone only wakes code that is actively polling it. An
+    approval worker can instead be blocked in a host notify callback or another
+    synchronous extension point. Registering cleanup here lets the async owner
+    revoke queue state immediately, without waiting for that worker to resume.
+    """
+
+    def __init__(self):
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._callbacks: set = set()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+    def register(self, callback) -> None:
+        with self._lock:
+            fire_now = self._event.is_set()
+            if not fire_now:
+                self._callbacks.add(callback)
+        if fire_now:
+            callback()
+
+    def unregister(self, callback) -> None:
+        with self._lock:
+            self._callbacks.discard(callback)
+
+    def cancel(self) -> None:
+        with self._lock:
+            if self._event.is_set():
+                return
+            self._event.set()
+            callbacks = tuple(self._callbacks)
+        for callback in callbacks:
+            callback()
+
+    # Event-compatible spelling for test helpers and simple callers.
+    set = cancel
+
+
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
     __slots__ = ("event", "data", "result", "reason")
@@ -3414,8 +3459,14 @@ def _format_tirith_description(tirith_result: dict) -> str:
     return "Security scan — " + "; ".join(parts)
 
 
-def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
-                            *, surface: str = "gateway") -> dict:
+def _await_gateway_decision(
+    session_key: str,
+    notify_cb,
+    approval_data: dict,
+    *,
+    surface: str = "gateway",
+    cancellation_event: Optional[threading.Event | ApprovalCancellation] = None,
+) -> dict:
     """Enqueue *approval_data*, notify the user, and block the calling agent
     thread until the request is resolved or the gateway approval timeout
     elapses — firing pre/post approval hooks and cleaning up the queue entry.
@@ -3423,6 +3474,10 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     Shared by the terminal command guard (``check_all_command_guards``) and
     the execute_code guard (``check_execute_code_guard``) so the fiddly
     heartbeat-polling wait loop lives in one place.
+
+    When *cancellation_event* is supplied, the owning async operation can
+    revoke this blocking wait. The queue entry is removed before this function
+    returns or raises, so a later user response cannot resolve an orphan.
 
     Returns ``{"resolved": bool, "choice": str|None}`` on completion, or
     ``{"resolved": False, "choice": None, "notify_failed": True}`` if the
@@ -3433,6 +3488,9 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+
+    if cancellation_event is not None and cancellation_event.is_set():
+        return {"resolved": False, "choice": None}
 
     entry = _ApprovalEntry(approval_data)
     with _lock:
@@ -3445,6 +3503,20 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 queue.remove(entry)
             if not queue:
                 _gateway_queues.pop(session_key, None)
+
+    def _cancel_entry() -> None:
+        _drop_entry()
+        entry.event.set()
+
+    cancellation = (
+        cancellation_event
+        if isinstance(cancellation_event, ApprovalCancellation)
+        else None
+    )
+    if cancellation is not None:
+        # register() invokes immediately if cancellation won the race between
+        # the pre-enqueue check and this registration.
+        cancellation.register(_cancel_entry)
 
     # Notify plugins that an approval is being requested. Fires before the
     # gateway notify callback so observers get the event in real time.
@@ -3463,6 +3535,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         notify_cb(approval_data)
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
+        if cancellation is not None:
+            cancellation.unregister(_cancel_entry)
         _drop_entry()
         return {"resolved": False, "choice": None, "notify_failed": True}
 
@@ -3482,34 +3556,46 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     _deadline = _now + max(timeout, 0)
     _activity_state = {"last_touch": _now, "start": _now}
     resolved = False
-    while True:
-        # Respect interrupt signals (e.g. /stop, /new, or an inactivity
-        # timeout from the gateway) so a pending approval doesn't keep the
-        # session wedged on threading.Event.wait() until the 5-minute approval
-        # timeout. The wait runs on the agent's execution thread, which is the
-        # exact thread AIAgent.interrupt() flags — so is_interrupted() here
-        # sees the signal. Resolve as "deny" so the agent loop receives a
-        # normal denial and unwinds cleanly (#8697).
-        if is_interrupted():
-            logger.info(
-                "Approval wait interrupted by user signal — "
-                "returning deny for session %s",
-                session_key,
-            )
-            entry.result = "deny"
-            entry.event.set()
-            resolved = True
-            break
-        _remaining = _deadline - time.monotonic()
-        if _remaining <= 0:
-            break
-        if entry.event.wait(timeout=min(1.0, _remaining)):
-            resolved = True
-            break
-        if touch_activity_if_due is not None:
-            touch_activity_if_due(_activity_state, "waiting for user approval")
-
-    _drop_entry()
+    try:
+        while True:
+            if cancellation_event is not None and cancellation_event.is_set():
+                break
+            # Respect interrupt signals (e.g. /stop, /new, or an inactivity
+            # timeout from the gateway) so a pending approval doesn't keep the
+            # session wedged on threading.Event.wait() until the 5-minute approval
+            # timeout. The wait runs on the agent's execution thread, which is the
+            # exact thread AIAgent.interrupt() flags — so is_interrupted() here
+            # sees the signal. Resolve as "deny" so the agent loop receives a
+            # normal denial and unwinds cleanly (#8697).
+            if is_interrupted():
+                logger.info(
+                    "Approval wait interrupted by user signal — "
+                    "returning deny for session %s",
+                    session_key,
+                )
+                entry.result = "deny"
+                entry.event.set()
+                resolved = True
+                break
+            _remaining = _deadline - time.monotonic()
+            if _remaining <= 0:
+                break
+            poll_interval = 0.1 if cancellation_event is not None else 1.0
+            if entry.event.wait(timeout=min(poll_interval, _remaining)):
+                # Cancellation racing a user response must remain fail-closed.
+                if cancellation_event is not None and cancellation_event.is_set():
+                    break
+                resolved = True
+                break
+            if touch_activity_if_due is not None:
+                touch_activity_if_due(_activity_state, "waiting for user approval")
+    finally:
+        # A wait implementation, heartbeat callback, or owning task can fail
+        # independently of the approval. Never leave its queue entry available
+        # for a later response to resolve accidentally.
+        if cancellation is not None:
+            cancellation.unregister(_cancel_entry)
+        _drop_entry()
 
     choice = entry.result
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
@@ -4266,6 +4352,7 @@ def request_elicitation_consent(
     *,
     timeout_seconds: int | None = None,
     surface: str = "mcp-elicitation",
+    cancellation_event: Optional[threading.Event | ApprovalCancellation] = None,
 ) -> str:
     """Route an MCP elicitation request to whichever approval surface owns
     the active session and return a normalized result.
@@ -4278,6 +4365,9 @@ def request_elicitation_consent(
     Always fails closed: missing notify_cb in a gateway session, timeouts,
     and exceptions all map to ``"decline"`` so a server treats them as
     "user did not approve" rather than retrying or hanging.
+
+    *cancellation_event* is used by the async MCP callback to stop this
+    synchronous gateway wait when its owning tool call is cancelled.
 
     Returns one of ``"accept" | "decline" | "cancel"``.
     """
@@ -4306,7 +4396,11 @@ def request_elicitation_consent(
         }
         try:
             decision = _await_gateway_decision(
-                session_key, notify_cb, approval_data, surface=surface,
+                session_key,
+                notify_cb,
+                approval_data,
+                surface=surface,
+                cancellation_event=cancellation_event,
             )
         except Exception as exc:
             logger.error(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1742,7 +1742,7 @@ class ElicitationHandler:
         # bootstrap; matching the lazy pattern used by _fire_approval_hook
         # avoids any chance of import-order coupling.
         try:
-            from tools.approval import request_elicitation_consent
+            from tools.approval import ApprovalCancellation, request_elicitation_consent
         except Exception as exc:  # pragma: no cover -- defensive
             logger.error(
                 "MCP server '%s' elicitation: approval system unavailable: %s",
@@ -1765,6 +1765,7 @@ class ElicitationHandler:
         # contextvars.Context.run so the gateway-platform detection in
         # request_elicitation_consent picks up the right session.
         captured = getattr(self.owner, "_pending_call_context", None) if self.owner else None
+        cancellation_event = ApprovalCancellation()
 
         def _invoke_consent() -> str:
             if captured is None:
@@ -1773,6 +1774,7 @@ class ElicitationHandler:
                     description,
                     timeout_seconds=int(self.timeout),
                     surface=f"mcp-elicitation/{self.server_name}",
+                    cancellation_event=cancellation_event,
                 )
             # Context.run can only execute a context once — copy to allow
             # multiple elicitations within a single tool call.
@@ -1782,14 +1784,49 @@ class ElicitationHandler:
                 description,
                 timeout_seconds=int(self.timeout),
                 surface=f"mcp-elicitation/{self.server_name}",
+                cancellation_event=cancellation_event,
             )
+
+        consent_task = asyncio.create_task(asyncio.to_thread(_invoke_consent))
+
+        async def _cancel_and_drain_worker() -> None:
+            cancellation_event.cancel()
+            try:
+                # Gateway waits observe the event within 100 ms. Keep this
+                # bounded for custom/CLI approval callbacks that cannot be
+                # interrupted while blocked in synchronous input.
+                await asyncio.wait_for(
+                    asyncio.shield(consent_task),
+                    timeout=1.0,
+                )
+            except asyncio.TimeoutError:
+                # Cancelling the asyncio wrapper cannot stop the underlying
+                # thread, but it prevents an eventual late exception/result
+                # from becoming an unobserved task warning. Gateway queue state
+                # has already been revoked through ``cancellation_event``.
+                consent_task.cancel()
+                logger.warning(
+                    "MCP server '%s' elicitation worker did not stop after cancellation",
+                    self.server_name,
+                )
+            except Exception:
+                # The original cancellation/timeout remains authoritative.
+                logger.debug(
+                    "MCP server '%s' elicitation worker failed during cleanup",
+                    self.server_name,
+                    exc_info=True,
+                )
 
         try:
             answer = await asyncio.wait_for(
-                asyncio.to_thread(_invoke_consent),
+                asyncio.shield(consent_task),
                 timeout=self.timeout + self._OUTER_TIMEOUT_GRACE_SECONDS,
             )
+        except asyncio.CancelledError:
+            await _cancel_and_drain_worker()
+            raise
         except asyncio.TimeoutError:
+            await _cancel_and_drain_worker()
             logger.warning(
                 "MCP server '%s' elicitation timed out after %ds",
                 self.server_name, int(self.timeout),


### PR DESCRIPTION
## Summary

MCP elicitation callbacks run their synchronous consent path in `asyncio.to_thread()`. Cancelling the owning async tool call—or reaching the handler's outer timeout—does not stop that thread. When the synchronous path is waiting on a gateway approval queue, the stale entry can remain live until the normal approval timeout and can receive a later response after its owner is gone.

This PR makes cancellation explicit and fail-closed:

- gives each elicitation callback an `ApprovalCancellation` token;
- lets the gateway wait register synchronous cleanup with that token, so the async owner removes queue state immediately even if the worker is blocked inside the host notify callback;
- shields the worker task from `wait_for()`'s implicit cancellation, then signals and drains it on owner cancellation or timeout;
- rechecks cancellation after response wakeup so a user-response/cancellation race cannot return approval;
- removes queue entries in a `finally` block on every wait exit, including unexpected exceptions;
- bounds cleanup for synchronous CLI/custom callbacks that cannot be interrupted, while cancelling their asyncio wrapper to avoid unobserved task results;
- preserves the existing polling cadence and behavior for approval flows that do not pass a cancellation token.

## Security impact

A cancelled or timed-out MCP request can no longer leave a gateway approval entry available for a later response. Cancellation racing an approval remains fail-closed: the owner propagates cancellation and never returns an acceptance to the MCP server.

## Scope

This is intentionally narrow and does not duplicate the open request-binding or form-schema PRs. It only addresses lifecycle cleanup for MCP elicitation approvals.

## Tests

- production path: `ElicitationHandler` → captured gateway context → consent router → real approval queue → task cancellation → queue empty;
- blocked-notify path proves queue revocation does not depend on the synchronous callback returning;
- cancellation and timeout both signal and drain the worker;
- cancellation racing a response wakeup fails closed;
- a pre-cancelled wait never enqueues or notifies;
- exceptional wait exits remove their queue entries;
- 116 focused approval, elicitation, and interrupt tests pass through the repository's hermetic `scripts/run_tests.sh` runner;
- Ruff, `git diff --check`, and contributor attribution audit pass.

One unrelated existing macOS path-safety test is excluded from the focused run: `test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`; this branch does not modify that test or its implementation.
