### PR TITLE
docs(gateway): correct channel overrides config path (#78276)

### DIFF
--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -293,7 +293,7 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 
 ## Per-Channel Model & System Prompt Overrides
 
-Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/gateway-config.yaml`:
+Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/config.yaml`:
 
 ```yaml
 platforms:


### PR DESCRIPTION
## What does this PR do?

Corrects the per-channel model/system-prompt override guide to reference
`~/.hermes/config.yaml`.

`load_gateway_config()` reads the primary gateway configuration from
`config.yaml` and bridges `platforms.<name>.channel_overrides` into the
platform configuration. The previous `gateway-config.yaml` path is not read,
so users following the guide saw their overrides silently ignored.

## Related Issue

Fixes #78276

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Replace the incorrect `~/.hermes/gateway-config.yaml` reference with
  `~/.hermes/config.yaml` in the per-channel override section.

## How to Test

1. Inspect `gateway/config.py::load_gateway_config()` and confirm the primary
   path is `config.yaml`.
2. Run `cd website && npm run build`.
3. Confirm both `en` and `zh-Hans` static builds complete.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this correction.
- [x] The production documentation build passes.
- [x] No code behavior is changed.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] The relevant source documentation is updated.
- [x] `cli-config.yaml.example` update is not required.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not required.
- [x] Cross-platform impact is not applicable.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

```text
[SUCCESS] Generated static files in "build".
[SUCCESS] Generated static files in "build/zh-Hans".
```
