### PR TITLE
fix(security): match internal secret env names by shape, not exact suffix

### DIFF
--- a/tests/tools/test_internal_secret_name_shape.py
+++ b/tests/tools/test_internal_secret_name_shape.py
@@ -1,0 +1,199 @@
+"""Behavior contract for ``_is_hermes_internal_secret`` name-shape matching.
+
+These tests assert a RELATION rather than a frozen list of suffixes:
+
+    Under the ``AUXILIARY_`` and ``GATEWAY_RELAY_`` prefixes, any
+    credential-shaped name is stripped from a child process environment,
+    while non-secret routing hints and selectors stay visible.
+
+That framing is deliberate. The predicate previously enumerated exact
+suffixes (``_API_KEY`` / ``_BASE_URL`` for ``AUXILIARY_``; ``_SECRET`` /
+``_KEY`` / ``_TOKEN`` for ``GATEWAY_RELAY_``), so every adjacent real spelling
+of the same secret — ``…_APIKEY`` with no separator, ``…_SECRET`` under the
+aux prefix, ``GATEWAY_RELAY_SECRET_V2`` with a trailing qualifier — fell
+through to the child. A test that pins the suffix list would have passed
+against that bug. A test that pins the relation fails against it.
+
+Assertions run against a REAL child process (``sys.executable -c``) built
+from each of the three spawn-env builders, because that is what a
+model-authored shell command actually sees — not against the predicate.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from tools.environments.local import (
+    _make_run_env,
+    _sanitize_subprocess_env,
+    hermes_subprocess_env,
+)
+
+# Credential-shaped names under each internal prefix. Spelled several
+# different ways on purpose: separator-less (``APIKEY``), bare word
+# (``SECRET``), and qualifier-suffixed (``SECRET_V2``). All are the same
+# secret class and must be stripped identically.
+CREDENTIAL_SHAPED = [
+    "AUXILIARY_VISION_API_KEY",
+    "AUXILIARY_VISION_APIKEY",
+    "AUXILIARY_VISION_SECRET",
+    "AUXILIARY_VISION_TOKEN",
+    "AUXILIARY_VISION_PASSWORD",
+    "AUXILIARY_WEB_EXTRACT_API_KEY",
+    "AUXILIARY_MY_PLUGIN_TASK_APIKEY",
+    "GATEWAY_RELAY_SECRET",
+    "GATEWAY_RELAY_SECRET_V2",
+    "GATEWAY_RELAY_DELIVERY_KEY",
+    "GATEWAY_RELAY_ENROLL_TOKEN",
+    "GATEWAY_RELAY_IDP_CLIENT_SECRET",
+    "GATEWAY_RELAY_PASSWORD",
+]
+
+# Non-secret names under the same prefixes. Routing hints and model
+# selectors the docstring explicitly promises to keep visible — including
+# the two real in-repo names that contain a credential-shaped word but are
+# not credentials (``ROUTE_KEYS`` is a list of route ids;
+# ``IDP_TOKEN_URL`` is an endpoint URL, not a token).
+ROUTING_HINTS = [
+    "AUXILIARY_VISION_MODEL",
+    "AUXILIARY_VISION_PROVIDER",
+    "GATEWAY_RELAY_URL",
+    "GATEWAY_RELAY_PLATFORMS",
+    "GATEWAY_RELAY_PLATFORM",
+    "GATEWAY_RELAY_ENDPOINT",
+    "GATEWAY_RELAY_ROUTE_KEYS",
+    "GATEWAY_RELAY_IDP_TOKEN_URL",
+]
+
+_CANARY = "canary-value-{}"
+
+
+def _plant(monkeypatch):
+    for name in CREDENTIAL_SHAPED + ROUTING_HINTS:
+        monkeypatch.setenv(name, _CANARY.format(name))
+
+
+def _names_visible_to_child(env) -> set:
+    """Spawn a real child with ``env`` and report which canaries it can read."""
+    watched = CREDENTIAL_SHAPED + ROUTING_HINTS
+    code = (
+        "import os, json, sys;"
+        "watched = json.loads(sys.argv[1]);"
+        "print(json.dumps([n for n in watched if n in os.environ]))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code, json.dumps(watched)],
+        env=env, capture_output=True, text=True, timeout=60, check=True,
+    )
+    return set(json.loads(out.stdout))
+
+
+def _builders(monkeypatch):
+    import os
+
+    return {
+        "hermes_subprocess_env": lambda: hermes_subprocess_env(),
+        "hermes_subprocess_env(inherit_credentials=True)":
+            lambda: hermes_subprocess_env(inherit_credentials=True),
+        "_sanitize_subprocess_env": lambda: _sanitize_subprocess_env(dict(os.environ)),
+        "_make_run_env": lambda: _make_run_env(dict(os.environ)),
+    }
+
+
+@pytest.mark.parametrize("builder_name", [
+    "hermes_subprocess_env",
+    "hermes_subprocess_env(inherit_credentials=True)",
+    "_sanitize_subprocess_env",
+    "_make_run_env",
+])
+def test_credential_shaped_internal_names_never_reach_child(builder_name, monkeypatch):
+    """No credential-shaped AUXILIARY_/GATEWAY_RELAY_ name reaches a child.
+
+    The relation, not a suffix list: if a name sits under one of the two
+    internal prefixes AND carries a credential-shaped word, the child must
+    not be able to read it — on every spawn surface, including the
+    ``inherit_credentials=True`` path a model-driving CLI gets.
+    """
+    _plant(monkeypatch)
+    env = _builders(monkeypatch)[builder_name]()
+    leaked = _names_visible_to_child(env) & set(CREDENTIAL_SHAPED)
+    assert leaked == set(), (
+        f"{builder_name} leaked credential-shaped internal names to a real "
+        f"child process: {sorted(leaked)}"
+    )
+
+
+@pytest.mark.parametrize("builder_name", [
+    "hermes_subprocess_env",
+    "hermes_subprocess_env(inherit_credentials=True)",
+    "_sanitize_subprocess_env",
+    "_make_run_env",
+])
+def test_routing_hints_stay_visible_to_child(builder_name, monkeypatch):
+    """The other half of the relation: routing hints must NOT be over-blocked.
+
+    A shape test that ate ``GATEWAY_RELAY_URL`` / ``GATEWAY_RELAY_ROUTE_KEYS``
+    would break relay routing, so the contract is two-sided.
+    """
+    _plant(monkeypatch)
+    env = _builders(monkeypatch)[builder_name]()
+    visible = _names_visible_to_child(env)
+    missing = set(ROUTING_HINTS) - visible
+    assert missing == set(), (
+        f"{builder_name} over-blocked non-secret routing hints: {sorted(missing)}"
+    )
+
+
+def test_spelling_variants_of_one_secret_are_classified_alike(monkeypatch):
+    """Separator/qualifier spelling must not change the verdict.
+
+    This is the anti-regression guard for the enumeration approach: a future
+    edit that reintroduces an exact-suffix list will keep the canonical
+    spelling stripped but let a variant of the same secret through, and this
+    test fails on the disagreement rather than on a hard-coded name.
+    """
+    variants = {
+        "aux api key": [
+            "AUXILIARY_VISION_API_KEY",
+            "AUXILIARY_VISION_APIKEY",
+        ],
+        "relay secret": [
+            "GATEWAY_RELAY_SECRET",
+            "GATEWAY_RELAY_SECRET_V2",
+        ],
+    }
+    for name in [n for group in variants.values() for n in group]:
+        monkeypatch.setenv(name, _CANARY.format(name))
+
+    visible = _names_visible_to_child(hermes_subprocess_env())
+    for label, group in variants.items():
+        verdicts = {name: name in visible for name in group}
+        assert len(set(verdicts.values())) == 1, (
+            f"spelling variants of the same {label} were classified "
+            f"differently: {verdicts}"
+        )
+        assert not any(verdicts.values()), (
+            f"{label} variants reached the child: {verdicts}"
+        )
+
+
+def test_unknown_internal_credential_name_fails_closed(monkeypatch):
+    """A name nobody enumerated must still be stripped.
+
+    The predicate is a shape test, so a credential-shaped name invented after
+    this test was written is covered without editing any list.
+    """
+    invented = "GATEWAY_RELAY_FUTURE_HANDSHAKE_KEY_V9"
+    monkeypatch.setenv(invented, "canary")
+    code = (
+        "import os, sys; "
+        "print('LEAKED' if sys.argv[1] in os.environ else 'ABSENT')"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code, invented],
+        env=hermes_subprocess_env(), capture_output=True, text=True,
+        timeout=60, check=True,
+    )
+    assert out.stdout.strip() == "ABSENT"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -349,6 +349,37 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
 
 
+# Credential-shaped words used to classify *dynamically named* Hermes-internal
+# secrets. Deliberately the same shape test ``code_execution_tool.py`` already
+# applies to the execute_code child env (``_SECRET_SUBSTRINGS``), narrowed to
+# the four words that can appear under the two Hermes-internal prefixes. A
+# substring test — not a suffix test — is what catches real-world spellings
+# that carry no separator (``APIKEY``) or a trailing qualifier (``_SECRET_V2``);
+# the sandbox list calls out ``APIKEY`` for exactly that reason.
+_INTERNAL_SECRET_SUBSTRINGS = ("KEY", "SECRET", "TOKEN", "PASSWORD")
+
+# Non-secret ``GATEWAY_RELAY_*`` names that contain a credential-shaped word but
+# carry routing/config material rather than auth material.
+#
+# This set is enumerated on the SAFE side on purpose. Enumerating *secrets*
+# fails open on every name nobody thought of, which is the leak this predicate
+# keeps re-acquiring; enumerating the handful of *non-secrets* fails closed
+# instead — an unknown ``GATEWAY_RELAY_*`` name containing KEY/SECRET/TOKEN/
+# PASSWORD is treated as a secret until someone documents otherwise.
+#
+#   GATEWAY_RELAY_ROUTE_KEYS     comma-separated relay *route* identifiers
+#                                (gateway/relay/__init__.py), the routing-hint
+#                                class the docstring below promises to keep.
+#   GATEWAY_RELAY_IDP_TOKEN_URL  the OIDC token *endpoint* URL, not a token
+#                                (gateway/relay/__init__.py). The credential
+#                                that pairs with it, GATEWAY_RELAY_IDP_CLIENT_
+#                                SECRET, is still stripped.
+_GATEWAY_RELAY_NON_SECRET_NAMES: frozenset[str] = frozenset({
+    "GATEWAY_RELAY_ROUTE_KEYS",
+    "GATEWAY_RELAY_IDP_TOKEN_URL",
+})
+
+
 def _is_hermes_internal_secret(key: str) -> bool:
     """Return True for Hermes-internal secrets injected under *dynamic* names.
 
@@ -356,23 +387,34 @@ def _is_hermes_internal_secret(key: str) -> bool:
     provider/tool registries, but the gateway and CLI also inject secrets into
     ``os.environ`` at runtime under names no static registry knows about:
 
-    - ``AUXILIARY_<TASK>_API_KEY`` / ``AUXILIARY_<TASK>_BASE_URL`` — per-task
-      side-LLM credentials bridged from ``config.yaml[auxiliary]`` by
-      ``gateway/run.py`` and ``cli.py`` (vision, web_extract, approval,
-      compression, and any plugin-registered auxiliary task). These are
-      separate, often higher-spend API keys plus base URLs that may point at
-      private endpoints; a model-authored shell command must never see them.
-    - ``GATEWAY_RELAY_*_SECRET`` / ``GATEWAY_RELAY_*_KEY`` /
-      ``GATEWAY_RELAY_*_TOKEN`` — relay-auth material provisioned by the
-      gateway (``GATEWAY_RELAY_SECRET``, ``GATEWAY_RELAY_DELIVERY_KEY``).
+    - ``AUXILIARY_<TASK>_*`` — per-task side-LLM credentials bridged from
+      ``config.yaml[auxiliary]`` by ``gateway/run.py`` and ``cli.py`` (vision,
+      web_extract, approval, compression, and any plugin-registered auxiliary
+      task). These are separate, often higher-spend API keys plus base URLs
+      that may point at private endpoints; a model-authored shell command must
+      never see them. Non-credential ``AUXILIARY_*`` selectors
+      (``AUXILIARY_VISION_MODEL``, ``…_PROVIDER``) are NOT matched.
+    - ``GATEWAY_RELAY_*`` relay-auth material provisioned by the gateway
+      (``GATEWAY_RELAY_SECRET``, ``GATEWAY_RELAY_DELIVERY_KEY``,
+      ``GATEWAY_RELAY_ENROLL_TOKEN``, ``GATEWAY_RELAY_IDP_CLIENT_SECRET``).
       These are Tier-1 gateway secrets, like the messaging bot tokens in
       ``_ALWAYS_STRIP_KEYS``. Non-secret ``GATEWAY_RELAY_*`` routing hints
       (``GATEWAY_RELAY_URL``, ``GATEWAY_RELAY_PLATFORMS``, …) are NOT matched
-      and remain visible.
+      and remain visible — see ``_GATEWAY_RELAY_NON_SECRET_NAMES`` for the two
+      routing hints that would otherwise collide with the shape test.
 
-    ``code_execution_tool.py`` already catches these via substring matching on
-    ``KEY`` / ``SECRET`` / ``TOKEN``; the terminal backend's narrower name-based
-    blocklist did not, which is the leak this predicate closes.
+    **Shape test, not a suffix list.** Both prefixes classify on the
+    credential-shaped words in ``_INTERNAL_SECRET_SUBSTRINGS``. An exact-suffix
+    list only strips the spellings its author enumerated, so adjacent real
+    spellings of the same secret fall straight through to the child:
+    ``AUXILIARY_<TASK>_APIKEY`` (no separator before KEY),
+    ``AUXILIARY_<TASK>_SECRET`` / ``_TOKEN`` (the aux branch matched
+    ``_API_KEY`` / ``_BASE_URL`` only), and ``GATEWAY_RELAY_SECRET_V2`` (a
+    trailing qualifier defeats ``endswith``). ``code_execution_tool.py`` already
+    catches these via substring matching on ``KEY`` / ``SECRET`` / ``TOKEN``;
+    the terminal backend's narrower name-based blocklist did not, which is the
+    leak this predicate closes — so matching on shape here makes the two child
+    surfaces agree instead of introducing a new policy.
 
     This is the single source of truth for "Hermes-internal dynamic secret"
     across every spawn path — the terminal ``_make_run_env`` /
@@ -383,14 +425,16 @@ def _is_hermes_internal_secret(key: str) -> bool:
     a model-driving CLI legitimately needs matches these patterns.
     """
     upper = key.upper()
-    if upper.startswith("AUXILIARY_") and (
-        upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
-    ):
-        return True
-    if upper.startswith("GATEWAY_RELAY_") and (
-        upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
-    ):
-        return True
+    if upper.startswith("AUXILIARY_"):
+        # ``_BASE_URL`` carries no credential-shaped word but is still internal
+        # (it may address a private endpoint), so it stays explicitly matched.
+        if upper.endswith("_BASE_URL"):
+            return True
+        return any(word in upper for word in _INTERNAL_SECRET_SUBSTRINGS)
+    if upper.startswith("GATEWAY_RELAY_"):
+        if upper in _GATEWAY_RELAY_NON_SECRET_NAMES:
+            return False
+        return any(word in upper for word in _INTERNAL_SECRET_SUBSTRINGS)
     return False
 
 


### PR DESCRIPTION
This builds on **#77027** (@andrexibiza) and **#77193** (@andrexibiza), which are
open against the same function and which I'd like to see land first — this is a
narrow follow-up to the part neither covers, not a competing rewrite. Happy to
rebase behind whichever merges, or to fold this into one of them if that's
easier for review.

## The gap

`_is_hermes_internal_secret` matches a fixed set of exact suffixes: `_API_KEY` /
`_BASE_URL` for `AUXILIARY_*`, and `_SECRET` / `_KEY` / `_TOKEN` for
`GATEWAY_RELAY_*`. Adjacent real spellings fall straight through and reach the
child environment.

Measured end to end by spawning a real `/usr/bin/env` through
`hermes_subprocess_env()` with canary values — this is what a model-authored
shell command actually sees:

| tree | secrets leaked to child |
|---|---|
| `main` | 5 |
| + #77027 | 4 |
| + #77193 | 5 |
| this PR | **0** |

Still leaking after both open PRs:

```
AUXILIARY_VISION_APIKEY     # no separator before KEY
AUXILIARY_VISION_SECRET     # aux only matched _API_KEY / _BASE_URL
AUXILIARY_VISION_TOKEN
GATEWAY_RELAY_SECRET_V2     # suffix match ends at _SECRET
```

(#77027 does close `GATEWAY_RELAY_PASSWORD`, which is why its row is 4 and not 5.)

## The fix

Match by **shape** rather than by an enumerated suffix list: under the
`AUXILIARY_` and `GATEWAY_RELAY_` prefixes, a name containing `KEY` / `SECRET` /
`TOKEN` / `PASSWORD` is internal.

This is not a new policy — it's the rule `code_execution_tool.py` already
applies, and the existing docstring says as much:

> ``code_execution_tool.py`` already catches these via substring matching on
> ``KEY`` / ``SECRET`` / ``TOKEN``; the terminal backend's narrower name-based
> blocklist did not, which is the leak this predicate closes.

The terminal backend now uses the same rule as the code-execution backend.

## Not over-blocking

The docstring explicitly protects non-secret routing hints, so those are the
important negative controls:

| variable | before | after |
|---|---|---|
| `GATEWAY_RELAY_URL` | visible | visible |
| `GATEWAY_RELAY_PLATFORMS` | visible | visible |
| `PATH`, `HOME` | visible | visible |
| `AUXILIARY_VISION_API_KEY` | stripped | stripped |
| `GATEWAY_RELAY_SECRET` | stripped | stripped |

4/4 routing hints survive; the two already-caught controls are unchanged.

## Tests

`tests/tools/test_internal_secret_name_shape.py` asserts the *relation* — under
these prefixes a credential-shaped name is stripped while routing hints survive
— rather than freezing a suffix list, so it keeps working as new spellings
appear.

Verified RED before GREEN: applying only the test file to unpatched `main` fails
6 of 10. With the fix, 10/10.

```
tests/tools/test_internal_secret_name_shape.py     10 passed
tests/tools/test_build_subprocess_env.py           }  29 passed
tests/tools/test_env_passthrough.py                }
```

All three spawn builders are affected identically (`_make_run_env`,
`_sanitize_subprocess_env`, `hermes_subprocess_env`), so this covers the
terminal, Docker and plain-subprocess paths.
