### PR TITLE
fix(cron): tolerate NUL-byte paths in lifecycle guard (sibling of #76762)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: embedded NUL byte in *path* — the #76762 fix tolerated
+        # ValueError at resolve time, but os.open() raises it again for NUL
+        # paths tokenized out of a binary's decoded contents. A guarded path
+        # must never crash the guard.
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -326,8 +330,17 @@ def _contains_unsafe_gateway_action(
             return True
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
+            # A NUL-containing path can only come from junk tokenized out of a
+            # binary's decoded contents — never remote-read it (#76762).
+            if "\x00" in os.fspath(script_path):
+                continue
             script_text = read_remote_script(str(script_path))
         if not script_text:
+            continue
+        # Fallback readers return decoded bytes; mirror the local binary check
+        # so machine code (NUL bytes) is "nothing to scan", exactly like a
+        # local binary read (#76762).
+        if "\x00" in script_text:
             continue
         # Relative references inside a script resolve against that script's
         # directory, not the original command's cwd.

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,57 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_remote_binary_reference_does_not_crash_guard(self):
+        """Sibling of #76762 for fallback readers: with an SSH-style
+        read_remote_script that returns a binary's decoded bytes, a command
+        referencing a binary crashed the guard with
+        ValueError: embedded null byte.
+
+        The local read skips the ELF as "nothing to scan", but the fallback
+        re-reads it as text; re-tokenizing machine code yields NUL-byte paths
+        that reached os.open(), where only OSError was caught. Fallback text
+        containing NUL bytes must be treated like a local binary read.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        elf_bytes = (
+            b"\x7fELF\x00\x00\x01\x00/usr/bin/evil\x00"
+            b"\x00hermes gateway restart\x00"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "/usr/bin/python3 -c 'print(1)'",
+            read_remote_script=lambda path: elf_bytes.decode(
+                "utf-8", errors="replace"
+            ),
+        )
+        assert result is False
+
+    def test_remote_fallback_still_blocks_real_scripts(self):
+        """The fallback reader must still catch lifecycle commands in genuine
+        shell scripts, not just skip NUL-containing binary junk."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /nonexistent/deploy.sh",
+            read_remote_script=lambda path: (
+                "#!/bin/bash\nhermes gateway restart\n"
+                if "deploy.sh" in path
+                else None
+            ),
+        )
+        assert result is True
+
+    def test_read_referenced_script_nul_path_never_crashes(self):
+        """os.open() on a NUL-containing path raises ValueError, not OSError;
+        the guard must tolerate both (whole bug class of #76762)."""
+        from pathlib import Path
+        from cron.lifecycle_guard import _read_referenced_script
+        text, unsafe = _read_referenced_script(Path("/tmp/bad\x00path"))
+        assert text is None
+        assert unsafe is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Summary

Fixes an uncaught `ValueError: embedded null byte` crash in the gateway lifecycle guard (`cron/lifecycle_guard.py`) that hit SSH/sandboxed terminal backends whenever a command referenced a binary (e.g. `venv/bin/python -m pip ...`).

### Root cause

`_read_referenced_script` skips local binaries as "nothing to scan" via the NUL-byte check (#76762), but `terminal_tool.py`'s fallback reader `_read_script_in_env` then re-reads the same file and returns its bytes decoded as text — NUL bytes included, with no binary check. Re-tokenizing that machine code yields "paths" containing NUL bytes; `Path.resolve()` tolerated them (the #76762 fix), but `os.open()` raises `ValueError: embedded null byte`, and only `OSError` was caught. The guard crashed instead of returning a verdict, which aborted every `terminal_tool` call shaped that way — including entirely benign commands.

### Fix (whole bug class)

1. `_read_referenced_script`: catch `(OSError, ValueError)` on `os.open` — a guarded path must never crash the guard.
2. `_contains_unsafe_gateway_action`: never invoke the fallback reader for NUL-containing paths (they can only come from junk tokenized out of a binary's decoded contents).
3. `_contains_unsafe_gateway_action`: treat fallback-read text containing NUL bytes as "nothing to scan", mirroring the local binary check — this closes the actual trigger.

### Verification

- New regression tests in `tests/hermes_cli/test_gateway_restart_loop.py`:
  - `test_remote_binary_reference_does_not_crash_guard` — reproduces the crash shape (binary bytes returned via `read_remote_script`) and asserts no crash, not blocked.
  - `test_remote_fallback_still_blocks_real_scripts` — genuine lifecycle commands in fallback-read scripts are still blocked (no over-skip).
  - `test_read_referenced_script_nul_path_never_crashes` — direct unit check on the `os.open` ValueError path.
- Full `tests/hermes_cli/test_gateway_restart_loop.py`: **85 passed** (includes the existing #76762/#77131/#62891 regression tests).
- E2E: the previously crashing command shape (`venv/bin/python -c ...` via the SSH terminal backend) now passes the guard and executes normally.
