### PR TITLE
fix(security): lifecycle_guard must not crash or over-block on non-script paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: a path with an embedded NUL byte, which appears when
+        # decoded binary content is tokenized as a command line. The same case
+        # is already handled this way for Path.resolve below, with the same
+        # rationale: a guarded path must never crash the guard (#76762).
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -327,6 +331,23 @@ def _contains_unsafe_gateway_action(
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+            # The callback has NO binary detection: it reads via `cat` and
+            # decodes with errors="replace". NUL bytes are valid UTF-8 and
+            # survive, so without the check below this branch undoes the
+            # protection _read_referenced_script established above — machine
+            # code gets tokenized, the linker path in the ELF string table
+            # yields a candidate containing a NUL byte, and os.open raises.
+            #
+            # Note that `script_text is None` above means two different things:
+            # "not present locally" and "deliberately skipped as a binary".
+            # Only tools/terminal_tool.py supplies this callback, so the crash
+            # never reproduces when the function is called directly — which is
+            # why manual testing does not surface it.
+            #
+            # Same rule as the local read (#76762): a binary is "nothing to
+            # scan", not a suspicion.
+            if script_text and "\x00" in script_text[:_MAX_REFERENCED_SCRIPT_BYTES]:
+                script_text = None
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -266,7 +266,17 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     try:
         metadata = os.fstat(descriptor)
+        if stat.S_ISDIR(metadata.st_mode):
+            # A directory is not a script and cannot carry a command. Without
+            # this branch it falls into the conservative "not regular" case
+            # below and the whole command is reported unsafe. Counterpart to
+            # the binary handling further down (#76762): "not a script" is not
+            # a suspicion.
+            return None, False
         if not stat.S_ISREG(metadata.st_mode):
+            # Named Pipes, Sockets, Geraete: hier bleibt es beim vorsichtigen
+            # Urteil. Was daraus gelesen wird, kann sich zwischen Pruefung und
+            # Ausfuehrung aendern — anders als bei einer Datei auf der Platte.
             return None, True
         # Read a bounded chunk first — even for oversized files, the first
         # chunk tells us if this is a binary (NUL bytes) that should be

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -823,6 +823,46 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         assert "referenced script" in result["error"]
         assert any("cat" in c for c in calls)
 
+    def test_remote_read_of_binary_does_not_crash_the_guard(self, tmp_path):
+        """A binary read through the remote callback is 'nothing to scan'.
+
+        _read_referenced_script skips binaries locally (NUL byte in the first
+        chunk) and returns None. That None used to fall through to the remote
+        callback, which reads via `cat` and decodes with errors="replace" — NUL
+        bytes are valid UTF-8 and survive. The decoded machine code was then
+        tokenized as a command line, the linker path in the ELF string table
+        produced a candidate containing a NUL byte, and os.open raised
+        ValueError: embedded null byte. The guard crashed instead of deciding,
+        so every command invoked through an absolute binary or interpreter path
+        failed inside a gateway worker.
+
+        Without the fix this test raises ValueError; the assertion below is not
+        what fails first.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script as guard,
+        )
+
+        # Shaped like a real ELF: header, NUL padding, string table. The linker
+        # path next to NUL bytes is what tokenizes into a NUL-bearing candidate.
+        binary = tmp_path / "chrome"
+        binary.write_bytes(
+            b"\x7fELF\x02\x01\x01\x00"
+            + b"\x00" * 32
+            + b"/lib64/ld-linux-x86-64.so.2\x00libc.so.6\x00"
+        )
+        binary.chmod(0o755)
+
+        def read_remote(path):
+            """What tools/terminal_tool.py supplies: raw read, lossy decode."""
+            try:
+                with open(path, "rb") as handle:
+                    return handle.read(200_000).decode("utf-8", errors="replace")
+            except OSError:
+                return None
+
+        assert guard(f"{binary} --version", read_remote_script=read_remote) is False
+
 
 class TestCronCreateLifecycleBlockExtra:
     """Additional cron create lifecycle guard coverage."""


### PR DESCRIPTION
## What and why

`_read_referenced_script` detects binaries (NUL byte in the first chunk) and returns `None`. The caller treats that `None` as "not present locally" and falls through to `read_remote_script`:

```python
script_text, unsafe = _read_referenced_script(script_path)
if unsafe:
    return True
if script_text is None and read_remote_script is not None:
    script_text = read_remote_script(str(script_path))   # no binary detection
```

That callback reads via `cat` and decodes with `errors="replace"`. NUL bytes are valid UTF-8 and survive, so the machine code comes back as a string and is tokenized as a command line. The linker path in the ELF string table produces a candidate containing a NUL byte, which reaches `os.open`:

```
ValueError: embedded null byte
  cron/lifecycle_guard.py:260 in _read_referenced_script
```

The guard **crashes instead of deciding**. Any command invoked through an absolute binary or interpreter path is affected while `_HERMES_GATEWAY=1`, for example `/path/to/chrome --version` or `/path/to/venv/bin/python3 -c "..."`.

The root cause is that `script_text is None` means two different things — "not present locally" and "deliberately skipped as a binary". Only the second is a decision; the fallback treats both as the first.

### Why it survives testing

`tools/terminal_tool.py` is the only caller that supplies `read_remote_script`. Called directly, the guard never crashes. Every check outside a gateway worker is green, which is exactly where manual verification happens.

## How to test

Fails on `main`, passes with this PR:

```python
from cron.lifecycle_guard import (
    contains_gateway_lifecycle_command_or_referenced_script as guard,
)

def read_remote(path):
    """What tools/terminal_tool.py supplies: raw read, lossy decode."""
    with open(path, "rb") as handle:
        return handle.read(200_000).decode("utf-8", errors="replace")

cmd = "/usr/bin/python3 --version"

guard(cmd)                                   # False
guard(cmd, read_remote_script=read_remote)   # ValueError on main
```

The included regression test builds a minimal ELF-shaped file rather than depending on a system binary, so it is hermetic.

```
pytest tests/hermes_cli/test_gateway_restart_loop.py
```

- With the fix: **83 passed**
- Without the fix: `test_remote_read_of_binary_does_not_crash_the_guard` fails with `ValueError: embedded null byte`

## Protection is unchanged

Both lifecycle forms remain blocked, with and without the callback:

```
systemctl restart hermes-gateway   -> blocked
hermes gateway restart             -> blocked
```

A binary cannot carry a command, so declaring it "nothing to scan" removes no coverage. This mirrors the rule the local read path already applies (#76762).

## Platforms tested

Linux (Ubuntu, x86-64), Python 3.11, in a gateway worker with `_HERMES_GATEWAY=1` and via the test suite. Not tested on macOS or WSL2 — the change touches no platform-specific behaviour, only exception handling and a string check.

## Related

Follow-up to #76762, which introduced the binary-is-not-a-script rule for the local read path. This PR extends the same rule to the remote path.

---

## Second commit: the directory case

`_read_referenced_script` also has no `S_ISDIR` branch, so a directory falls into the conservative `not S_ISREG` case and the command is reported unsafe. Tokenizing a line like `for candidate in (Path("/opt/ms-playwright"), ...)` can yield a directory as a "referenced script". On v0.20.0 this blocked every command referencing one inside a gateway worker and silently disabled our PDF export for hours — being blocked is a normal guard outcome, so nothing surfaced as an error.

It is the exact counterpart to #76762: a directory cannot carry a command.

**Flagged honestly:** on current `main` we could not construct a command that still yields a directory as a candidate, so this commit ships without a failing test. It is defensive. Drop it if you would rather not carry a guard without a reproduction — the first commit stands on its own.
