### PR TITLE
fix(relay): deliver media from Git Bash paths and legacy connectors on Windows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1472,6 +1472,17 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in "`\"'":
         candidate = candidate[1:-1].strip()
     candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    # On Windows, normalize Git Bash style paths (/c/Users/... -> C:\Users\...)
+    # so the is_absolute() check below passes. The Hermes terminal on Windows
+    # runs via the bundled Git Bash (MinGit), which reports paths in Unix
+    # format — without the drive letter Path.is_absolute() returns False and
+    # every file the agent names would be rejected as "unsafe". Guard on the
+    # drive existing so POSIX-style paths (/r/a.png) are left untouched.
+    if os.name == "nt" and candidate.startswith("/"):
+        _m = re.match(r"^/([a-zA-Z])/(.*)", candidate)
+        if _m and os.path.isdir(f"{_m.group(1).upper()}:\\"):
+            _sep = "\\"
+            candidate = f"{_m.group(1).upper()}:{_sep}{_m.group(2).replace('/', _sep)}"
     if not candidate:
         return None
 
@@ -1800,7 +1811,21 @@ def _normalize_media_tag_path(raw: str) -> str:
     path = str(raw or "").strip()
     if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
         path = path[1:-1].strip()
-    return path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+    # On Windows, normalize Git Bash style paths (/c/Users/... -> C:\Users\...).
+    # The Hermes terminal on Windows runs via the bundled Git Bash (MinGit),
+    # which reports paths in Unix format. When the agent emits a MEDIA: tag
+    # with one of these paths, Path.is_absolute() returns False (no drive
+    # letter) and validate_media_delivery_path rejects it. Convert early so
+    # the rest of the pipeline sees a proper absolute Windows path. Guard on
+    # the drive actually existing so POSIX-style paths (/r/a.png) that merely
+    # start with a letter are left untouched.
+    if os.name == "nt" and path.startswith("/"):
+        _m = re.match(r"^/([a-zA-Z])/(.*)", path)
+        if _m and os.path.isdir(f"{_m.group(1).upper()}:\\"):
+            _sep = "\\"
+            path = f"{_m.group(1).upper()}:{_sep}{_m.group(2).replace('/', _sep)}"
+    return path
 
 
 def _path_lacks_deliverable_extension(path: str) -> bool:
@@ -4622,7 +4647,17 @@ class BasePlatformAdapter(ABC):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
-            expanded = os.path.expanduser(raw)
+            # On Windows, normalize Git Bash style paths (/c/Users/... -> C:\Users/...)
+            # so os.path.isfile can find the file. The raw text is returned as-is
+            # for display/stripping; only the existence check uses the normalized form.
+            # Guard on the drive existing so POSIX-style paths (/r/a.png) are left
+            # as-is for the existence check instead of being mangled to R:\a.png.
+            _check = raw
+            if os.name == "nt" and _check.startswith("/"):
+                _m = re.match(r"^/([a-zA-Z])/(.*)", _check)
+                if _m and os.path.isdir(f"{_m.group(1).upper()}:\\"):
+                    _check = f"{_m.group(1).upper()}:/{_m.group(2)}"
+            expanded = os.path.expanduser(_check)
             if os.path.isfile(expanded):
                 found.append((raw, expanded))
             else:

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1359,7 +1359,20 @@ class RelayAdapter(BasePlatformAdapter):
         pre-media behaviour — media delivery is progressive enhancement,
         never a regression when the connector predates the op.
         """
-        if self._transport is None or not self.descriptor.supports_op("send_media"):
+        if self._transport is None:
+            return None
+        # Respect an explicit capability declaration: when the connector
+        # advertised its op set and send_media is not in it, don't attempt the
+        # lane (the caller falls back to text). Legacy connectors (empty
+        # supported_ops) predate the discovery field — send_media was added
+        # after it, so such a connector can never advertise the op even when it
+        # implements it. Fail open for those: attempt the op and let a
+        # transport decline degrade to the caller's text fallback, the same
+        # failure mode as gating but without dropping connectors that do
+        # handle send_media.
+        if self.descriptor.supported_ops and not self.descriptor.supports_op(
+            "send_media"
+        ):
             return None
         source_url = source
         if source_is_path:


### PR DESCRIPTION
## Problem

On native Windows, Hermes cannot deliver files (e.g. `.pdf`) to messaging platforms. The bundled Git Bash (MinGit) terminal reports paths in Unix format (`/c/Users/...`), and two code paths drop or reject the media:

1. **Git Bash paths fail the delivery gate.** `validate_media_delivery_path()` checks `Path.is_absolute()`, which returns `False` for `/c/Users/...` (no drive letter). Every file the agent names is rejected as "unsafe" and silently falls back to a text notice. The same rejection hits `_normalize_media_tag_path()` (MEDIA: tags) and `extract_local_files()` (bare paths in the reply).

2. **Relay connectors never advertise `send_media`.** `send_media` was added *after* the `supported_ops` discovery field (Phase 1 #71300 came before Phase 2 #71363). A legacy connector (empty `supported_ops`) falls back to `LEGACY_OPS = ("send", "edit", "typing", "follow_up")`, which omits `send_media` - so the op-gated media lane is never attempted, even when the connector implements it.

## Fix

1. **Normalize Git Bash paths** in the three path consumers - `validate_media_delivery_path`, `_normalize_media_tag_path`, `extract_local_files`. On `os.name == "nt"`, convert `/c/Users/...` ? `C:\Users\...`. The conversion is guarded on the drive letter actually existing (`os.path.isdir("C:\\")`), so genuine POSIX-style paths like `/r/a.png` are left untouched.

2. **Fail open for `send_media` on legacy connectors.** Respect an explicit op declaration that excludes `send_media` (the caller falls back to text, unchanged), but for legacy connectors (empty `supported_ops` - which predate the discovery field and can therefore never advertise the op even when they implement it), attempt the lane and let a transport decline degrade to the same text fallback.

## Verification

- Reproduced on current `main`: Git Bash path rejected by `validate_media_delivery_path`; relay `send_media` gated out for empty `supported_ops`.
- After fix: `/c/Users/...` validates, extracts via MEDIA: tag and bare-path detection, and resolves to the real file; native `C:\...` paths behave unchanged.
- Test suites: `tests/gateway/relay/test_relay_media.py` (12/12), `test_media_tag_formatting_variants.py`, `test_media_tag_cleanup.py`, `test_media_extraction.py` all green. The 6 remaining failures in the media suite are pre-existing Windows-vs-POSIX path-format assertions that also fail on clean `main` without this change.