### PR TITLE
fix(codex): route gateway approvals to chat

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -644,18 +644,30 @@ def run_codex_app_server_turn(
 
         cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
         # Approval callback: defer to Hermes' standard prompt flow if a
-        # CLI thread has installed one. Gateway / cron contexts get the
-        # codex-side fail-closed default.
+        # CLI thread has installed one. Gateway contexts expose the same
+        # decision contract through their per-session approval queue.
         try:
             from tools.terminal_tool import _get_approval_callback
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+        if approval_callback is None:
+            try:
+                from tools.approval import make_gateway_approval_callback
 
-        # Gateway / cron contexts have no UI to surface codex's approval
-        # requests through, so codex app-server exec / apply_patch requests
-        # fail closed (silently decline) by default. When the user has
-        # explicitly opted out of Hermes approvals — via `approvals.mode: off`
+                approval_callback = make_gateway_approval_callback()
+            except Exception:
+                logger.debug(
+                    "codex app-server: gateway approval callback lookup failed; "
+                    "keeping fail-closed default",
+                    exc_info=True,
+                )
+                approval_callback = None
+
+        # Cron and other unattended contexts have no UI to surface codex's
+        # approval requests through, so exec / apply_patch requests fail
+        # closed by default. When the user has explicitly opted out of Hermes
+        # approvals — via `approvals.mode: off`
         # in config, the /yolo session toggle, or --yolo / HERMES_YOLO_MODE —
         # honor that and let codex's own sandbox permission profile
         # (~/.codex/config.toml) be the policy gate instead of double-gating

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -462,6 +462,57 @@ class TestRunConversationCodexPath:
         assert routing.auto_approve_exec is False
         assert routing.auto_approve_apply_patch is False
 
+    def test_gateway_manual_approval_reaches_registered_notifier(
+        self, monkeypatch
+    ):
+        """A Codex approval in a gateway turn must use the gateway's live
+        approval queue instead of being silently declined when no CLI callback
+        is installed."""
+        from tools import approval
+
+        captured = self._capture_routing_agent(monkeypatch)
+        session_key = "telegram:codex-approval-test"
+        prompts: list[dict] = []
+
+        def notify(approval_data: dict) -> None:
+            prompts.append(approval_data)
+            approval.resolve_gateway_approval(session_key, "session")
+
+        token = approval.set_current_session_key(session_key)
+        approval.register_gateway_notify(session_key, notify)
+        try:
+            with patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"approvals": {"mode": "manual"}},
+            ):
+                agent = _make_codex_agent()
+                with patch.object(
+                    agent, "_spawn_background_review", return_value=None
+                ):
+                    agent.run_conversation("fetch the dashboard branch")
+
+            callback = captured["approval_callback"]
+            choice = callback(
+                "git fetch origin codex/agent-os-dashboard",
+                "Codex requests exec in /repo",
+                allow_permanent=False,
+            )
+        finally:
+            approval.unregister_gateway_notify(session_key)
+            approval.reset_current_session_key(token)
+
+        assert choice == "session"
+        assert prompts == [
+            {
+                "command": "git fetch origin codex/agent-os-dashboard",
+                "description": "Codex requests exec in /repo",
+                "pattern_key": "codex_app_server",
+                "pattern_keys": ["codex_app_server"],
+                "allow_permanent": False,
+                "allow_session": True,
+            }
+        ]
+
     def test_frozen_yolo_env_auto_approves_codex_server_requests(
         self, monkeypatch
     ):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3529,6 +3529,68 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+def make_gateway_approval_callback(session_key: str = ""):
+    """Return a synchronous approval callback backed by a gateway session.
+
+    Codex app-server approval requests use the same callback contract as the
+    CLI, but gateway turns expose their UI through the per-session approval
+    queue instead of ``tools.terminal_tool``'s thread-local callback.  This
+    adapter bridges those two existing interfaces without weakening either
+    one's fail-closed behavior.
+
+    The notifier is looked up for every request rather than captured.  A
+    Codex session is reused across turns, while the gateway installs a fresh
+    notifier for each turn; retaining the first turn's notifier would send
+    later prompts through stale chat and event-loop state.
+    """
+    bound_session_key = session_key or get_current_session_key(default="")
+    if not bound_session_key:
+        return None
+
+    with _lock:
+        if _gateway_notify_cbs.get(bound_session_key) is None:
+            return None
+
+    def _gateway_approval_callback(
+        command: str,
+        description: str,
+        *,
+        allow_permanent: bool = True,
+    ) -> str:
+        with _lock:
+            notify_cb = _gateway_notify_cbs.get(bound_session_key)
+        if notify_cb is None:
+            return "deny"
+
+        from agent.redact import redact_sensitive_text
+
+        approval_data = {
+            "command": redact_sensitive_text(command),
+            "description": redact_sensitive_text(description),
+            "pattern_key": "codex_app_server",
+            "pattern_keys": ["codex_app_server"],
+            "allow_permanent": allow_permanent,
+            "allow_session": True,
+        }
+        decision = _await_gateway_decision(
+            bound_session_key,
+            notify_cb,
+            approval_data,
+            surface="codex_app_server",
+        )
+        if decision.get("notify_failed"):
+            return "deny"
+        if not decision.get("resolved") or decision.get("choice") is None:
+            return "timeout"
+
+        choice = decision["choice"]
+        if choice in {"once", "session", "always", "deny"}:
+            return choice
+        return "deny"
+
+    return _gateway_approval_callback
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
                              has_host_access: bool = False) -> dict:


### PR DESCRIPTION
## Summary

- bridge Codex app-server exec and file-change approval requests into Hermes's existing per-session gateway approval queue
- preserve CLI callbacks, unattended fail-closed behavior, approval bypass configuration, redaction, and once/session decision semantics
- add an integration regression test covering a manual gateway approval resolved through the registered notifier

## Root cause

The Codex app-server runtime only looked for the CLI thread-local approval callback. Gateway sessions intentionally use a separate per-session queue and notifier, so the callback was always absent in Telegram and other messaging gateways. Codex therefore silently received `decline` even when the user attempted to approve in chat.

The new adapter binds the session key but looks up the notifier for every request because Codex sessions persist across turns while gateway notifiers are recreated per turn.

## User impact

Codex-originated commands and patches now surface through the same gateway approval UI as Hermes terminal actions. Users can approve once or for the Codex session without disabling approvals globally. Cron and other unattended contexts remain fail-closed.

## Validation

- `scripts/run_tests.sh tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_session.py tests/tools/test_approval.py tests/gateway/test_telegram_approval_buttons.py` — 168 passed
- `.venv/bin/ruff check agent/codex_runtime.py tools/approval.py tests/run_agent/test_codex_app_server_integration.py`
- `git diff --check`
