### PR TITLE
docs(cron): make drift-guard comments timeless

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3384,8 +3384,7 @@ def run_job(
         # global default, which can change after the job was created — a switch
         # to a paid PROVIDER (e.g. nous) OR a paid MODEL on the same provider
         # (e.g. claude-fable-5 on openrouter). Without a guard the job would
-        # silently inherit that change and spend real money on every tick — the
-        # $7.73 incident named BOTH a provider and a model.
+        # silently inherit that change and spend real money on every tick.
         #
         # create_job() snapshots whatever resolution would have picked at
         # creation for each unpinned axis (job["provider_snapshot"] /

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -3,7 +3,7 @@
 Background: an UNPINNED cron job follows the global default provider. If that
 global state is changed (e.g. a temporary switch to a paid provider like
 nous/claude-fable-5), the job would silently inherit it on its next tick and
-spend real money — the $7.73 incident.
+spend real money on the next tick.
 
 The fix has two halves:
   - create_job() snapshots the provider resolution WOULD pick at creation into
@@ -261,7 +261,7 @@ def _run_with_current_provider_and_model(
 
 class TestModelDriftGuard:
     """#44585 C1: model drift on the SAME provider must also fail closed —
-    the incident named a model (claude-fable-5), and an unpinned job reads
+    a model change alone can trip the guard, and an unpinned job reads
     config.yaml model.default fresh every tick independently of provider."""
 
     def test_model_drift_same_provider_fails_closed(self, tmp_path):


### PR DESCRIPTION
## Why

The #44585 provider/model drift guard protects unpinned cron jobs from silently inheriting a switch to a paid provider or paid model and spending real money on every tick. It fails closed: skips the run, makes no inference call, and delivers a loud error telling the user to pin explicitly.

The comments and test docstrings currently justify the guard by citing one historical incident ($7.73). That rationale is timeless — a future reader does not need a specific past spend event to understand why silent inheritance is dangerous. This PR makes the comments standalone: the guard is about preventing unintended spend, period.

No behavior change. Comments and docstrings only.

## Test plan

- Comment/docstring-only change; the affected tests (`tests/cron/test_cron_provider_pin.py`) assert guard behavior, not the wording, so no assertion updates were needed.
