### PR TITLE
docs(site): align terminal backend count across locales (#78252)

### DIFF
--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -106,7 +106,7 @@ hermes-agent/
 │   ├── credential_files.py   # File-based credential passthrough
 │   ├── env_passthrough.py    # Env var passthrough for sandboxes
 │   ├── ansi_strip.py         # ANSI escape stripping
-│   └── environments/         # Terminal backends (local, docker, ssh, modal, daytona, singularity)
+│   └── environments/         # Terminal backends (local, docker, ssh, modal, daytona, singularity, vercel_sandbox)
 │
 ├── gateway/                  # Messaging platform gateway
 │   ├── run.py                # GatewayRunner — message dispatch (large file)

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -121,7 +121,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 ## Key Features
 
 - **A closed learning loop** — Agent-curated memory with periodic nudges, autonomous skill creation, skill self-improvement during use, FTS5 cross-session recall with LLM summarization, and [Honcho](https://github.com/plastic-labs/honcho) dialectic user modeling
-- **Runs anywhere, not just your laptop** — 6 terminal backends: local, Docker, SSH, Daytona, Singularity, Modal. Daytona and Modal offer serverless persistence — your environment hibernates when idle, costing nearly nothing
+- **Runs anywhere, not just your laptop** — 7 terminal backends: local, Docker, SSH, Daytona, Singularity, Modal, and Vercel Sandbox. Daytona and Modal offer serverless persistence — your environment hibernates when idle, costing nearly nothing
 - **Lives where you do** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Matrix, Mattermost, Email, SMS, DingTalk, Feishu, WeCom, Weixin, QQ Bot, Yuanbao, BlueBubbles, Home Assistant, Microsoft Teams, Google Chat, and more — 20+ platforms from one gateway
 - **Built by model trainers** — Created by [Nous Research](https://nousresearch.com), the lab behind Hermes, Nomos, and Psyche. Works with [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai), OpenAI, or any endpoint
 - **Scheduled automations** — Built-in cron with delivery to any platform

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/index.mdx
@@ -97,7 +97,7 @@ iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ## 核心功能
 
 - **闭环学习循环** — 智能体管理的记忆，配合定期提示、自主技能创建、使用中的技能自我改进、基于 FTS5 的跨会话召回与 LLM 摘要，以及 [Honcho](https://github.com/plastic-labs/honcho) 辩证式用户建模
-- **随处运行，不限于本地** — 6 种终端后端：本地、Docker、SSH、Daytona、Singularity、Modal。Daytona 和 Modal 提供 serverless 持久化——环境闲置时休眠，几乎零成本
+- **随处运行，不限于本地** — 7 种终端后端：本地、Docker、SSH、Daytona、Singularity、Modal 和 Vercel Sandbox。Daytona 和 Modal 提供 serverless 持久化——环境闲置时休眠，几乎零成本
 - **在你所在的地方** — CLI、Telegram、Discord、Slack、WhatsApp、Signal、Matrix、Mattermost、Email、SMS、DingTalk、Feishu、WeCom、Weixin、QQ Bot、Yuanbao、BlueBubbles、Home Assistant、Microsoft Teams、Google Chat 等——通过一个网关支持 20+ 平台
 - **由模型训练者构建** — 由 [Nous Research](https://nousresearch.com) 创建，该实验室是 Hermes、Nomos 和 Psyche 背后的团队。支持 [Nous Portal](https://portal.nousresearch.com)、[OpenRouter](https://openrouter.ai)、OpenAI 或任意端点
 - **定时自动化** — 内置 cron，可向任意平台投递


### PR DESCRIPTION
## What does this PR do?

Aligns the repository-controlled documentation landing pages with the actual
seven terminal backends:

`local`, `docker`, `ssh`, `daytona`, `singularity`, `modal`, and
`vercel_sandbox`.

The English and Simplified Chinese `/docs` pages previously stated six and
omitted Vercel Sandbox, while the README, configuration reference, setup
picker, and backend implementations already expose seven.

The separate download landing page mentioned in the issue is not sourced from
this repository, so this PR deliberately limits itself to the two docs
locales maintained here.

## Related Issue

Refs #78252

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Update the English docs landing page from six to seven backends.
- Add Vercel Sandbox to the English backend list.
- Add Vercel Sandbox to the developer-guide architecture inventory.
- Apply the same correction to the Simplified Chinese locale.

## How to Test

1. Compare the lists with `website/docs/user-guide/configuration.md`.
2. Run `cd website && npm run build`.
3. Confirm both `en` and `zh-Hans` static builds complete.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this correction.
- [x] The production documentation build passes.
- [x] Both maintained locales are updated.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] The relevant source and locale documentation are updated.
- [x] `cli-config.yaml.example` update is not required.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not required.
- [x] Cross-platform impact is not applicable.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

```text
[SUCCESS] Generated static files in "build".
[SUCCESS] Generated static files in "build/zh-Hans".
```