### PR TITLE
fix(dashboard): kill tab-return black screen (sentinel frame + hydration watchdog)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,97 @@
+# DESIGN: Dashboard Chat Tab Switch Lag Fix
+
+## Symptom
+
+用户从其他 Chrome tab 切回 Hermes dashboard 时，对话终端有明显卡顿（数秒级）。修复增量重放后，新的体感问题出现：等待加载中切走再切回，界面一直黑屏（遮罩永不撤），分屏操作尤其严重。
+
+## Root Cause
+
+### 1. 重连后 RingBuffer 全量重放 → xterm.js 解析阻塞（原卡顿）
+
+- `pty_session.py`: `attach()` 一次性 `send_bytes(snapshot)` 推送最多 1MB
+- 但 xterm.js 终端缓冲在 tab 隐藏期间从未丢失（ChatPage 持久挂载 + CSS 隐藏）
+- 用"重传一切"恢复一个"客户端从未丢失"的状态 → 全部是浪费
+
+### 2. 增量重放引入的边沿触发黑屏（本 PR 核心）
+
+前端 resume 加载遮罩的撤除是**边沿触发**——收到"第一帧 sanitized PTY payload"才撤：
+
+```
+增量重放前：resume 全量重放 ~1MB → 总能收到帧 → 遮罩必撤（慢但不黑屏）
+增量重放后：?offset=N 且 N 已最新 → 服务端一帧不发 → "第一帧"永远不来 → 遮罩卡死
+```
+
+叠加 Chrome 后台节流：切回时遮罩武装 → 切走（JS 冻结，边沿事件丢失）→ 切回 → 无人重新触发撤除 → 永久黑屏。分屏反复 focus/blur 每次都重新武装，最严重。
+
+## Constraints
+
+- 不能破坏 prompt caching（agent 核心不变）
+- 不能引入花屏风险（否决"只重放最后一帧"启发式）
+- 增量 offset 必须基于原始字节（非解码字符，防 UTF-8 错位）
+- offset 滚出 RingBuffer 窗口时回退全量重放
+- 本 PR 不含 loopback ws-ping 改动——上游 #53773 的 event-loop stall 论证（kshitijk4poor, 2026-07-03）与"Chrome 后台 tab 客户端假活"是两个不同场景，需单独论证，转 issue 讨论
+
+## Decisions
+
+### P0-a: RingBuffer 增量重放
+
+- RingBuffer 增加 `total_appended: int` 全局字节偏移
+- `attach(ws, client_offset=None)`: 只推送 `total_appended - client_offset` 范围内的增量
+- `client_offset` 超出窗口 → 回退全量
+- pty_ws 从 query param `?offset=N` 读取 client offset（本 PR 服务端半）
+
+### P0-b: 前端记录 offset
+
+- ChatPage 在 `ws.onmessage` 中累计收到的原始字节数 → `ptyByteOffsetRef`
+- `reconnectPty()` 时将 offset 作为 `?offset=` query param 附在 WS URL 上
+- 首次连接不带 offset（全量）
+
+### P1: attach 分帧推送 + 哨兵帧
+
+- snapshot 超过 16KB 时分帧推送，每帧间 `asyncio.sleep(0)` 让出事件循环
+- **零 delta 增量重放**（offset 已最新）→ 仍发一帧 `\x1b[0m`（SGR reset，xterm 无可见副作用）
+- **空缓冲首次 attach** → 同样发哨兵帧
+- 保证客户端"第一帧"永不饿死——hydration 门不会卡
+
+### P2: 前端 hydration watchdog + 增量不武装
+
+- `PTY_RESUME_HYDRATION_WATCHDOG_MS = 2000`：onopen 后 2s 无帧强制撤遮罩（旧 server 无哨兵帧时兜底）
+- `offset > 0`（客户端已有终端内容）时跳过 hydration 武装——分屏切换不再弹 loading 遮罩（根治分屏痛点）
+
+### P3: visible 重绘
+
+- `visibilitychange → visible` 时 `term.refresh(0, rows-1)`
+- Chrome 后台 tab 丢弃 canvas 后强制重绘，防 xterm 黑帧
+
+## Rejected Approaches
+
+| 方案 | 否决原因 |
+|------|----------|
+| 客户端应用层心跳 | JS 定时器被 Chrome 后台节流，发不出去 |
+| 只重放最后一帧（ANSI 启发式匹配） | 花屏风险，违反 "fixes that destroy the feature" |
+| 缩短 sanitize 窗口 | 治标不治本，重放字节数不减 |
+| 只做前端 watchdog 不做哨兵帧 | 旧 server 兼容需要双保险；哨兵帧是服务端最小根治 |
+| loopback 启用 30s/60s ping | 翻转上游 #53773 决策（226s stall 实测），无证据支撑，转 issue |
+
+## Files Touched
+
+1. `hermes_cli/web_server.py` — pty_ws 传 ?offset= 给 attach
+2. `hermes_cli/pty_session.py` — RingBuffer offset + attach 增量/哨兵帧/分帧
+3. `web/src/pages/ChatPage.tsx` — 记录 offset + watchdog + 增量不武装 + visible 重绘
+4. `web/src/lib/pty-resume-loading.ts` — watchdog 常量
+5. `tests/test_pty_session.py` — snapshot_from / 哨兵帧 / 增量重放行为契约测试
+
+## Validation
+
+单元/集成（已执行，全部通过）：
+- `tests/test_pty_session.py` 11 passed（含 4 个新测试）
+- `web/src/lib/pty-resume-loading.test.ts` 9 passed（vitest）
+
+黑盒（真实浏览器 + 真实 dashboard）：
+- 首次 attach：遮罩数秒内消失，终端内容完整渲染
+- 模拟分屏（visibilitychange+focus）：遮罩不出现、内容保留（P2 生效）
+- `gui.log` 无新增 code=1005（后台 tab 断连指纹）
+
+黑盒（需用户实测）：真实 Chrome 分屏切换 5 分钟，对比 ws closed 频率和体感。
+
+注：delegate 子代理不劫持 session resume 是独立修复，见 PR #78368。

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -144,15 +144,23 @@ class PtySession:
                         pass  # detached mid-send; nothing buffered anyway
                 return
         # Full replay (first connect, or offset rolled out of the ring).
+        # NOTE: for a reconnecting client whose offset rolled out of the
+        # window, we deliberately do NOT fall back to a full 1MB replay: the
+        # dashboard keeps ChatPage mounted, so xterm.js still holds the full
+        # history the client painted before — a full replay would re-send
+        # megabytes of bytes the client already has and stall rendering
+        # ("tab-return black screen" on long-running sessions that exceed
+        # the ring window while backgrounded). Emit the no-op SGR-reset
+        # frame to clear the hydration gate and let live output resume.
         snap = self.buffer.snapshot()
-        if snap:
+        if client_offset is None and snap:
             await self._send_chunked(ws, snap)
-        elif client_offset is None:
-            # First attach to a PTY that has produced no output yet. The
-            # client's resume-hydration gate is edge-triggered on the first
-            # payload, so an empty buffer must still emit one no-op frame or
-            # the "loading…" overlay stays up (black screen) until the PTY
-            # happens to write something. SGR reset is invisible on xterm.
+        else:
+            # First attach to an empty buffer, or reconnect with a
+            # rolled-out offset: the client's resume-hydration gate is
+            # edge-triggered on the first payload, so emit one no-op frame
+            # or the "loading…" overlay stays up (black screen). SGR reset
+            # is invisible on xterm.
             try:
                 await ws.send_bytes(b"\x1b[0m")
             except Exception:

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -17,15 +17,22 @@ WS_CLOSE_SUPERSEDED = 4409
 
 
 class RingBuffer:
-    """Keeps only the most recent ``capacity`` bytes appended to it."""
+    """Keeps only the most recent ``capacity`` bytes appended to it.
+
+    Tracks ``total_appended`` — the total number of bytes ever appended — so a
+    reconnecting client can request an incremental replay starting from its
+    last-known byte offset instead of re-receiving the entire buffer.
+    """
 
     def __init__(self, capacity: int) -> None:
         self._cap = capacity
         self._buf = bytearray()
         self._truncated = False
+        self._total_appended = 0
 
     def append(self, data: bytes) -> None:
         self._buf.extend(data)
+        self._total_appended += len(data)
         overflow = len(self._buf) - self._cap
         if overflow > 0:
             del self._buf[:overflow]
@@ -33,6 +40,28 @@ class RingBuffer:
 
     def snapshot(self) -> bytes:
         return bytes(self._buf)
+
+    def snapshot_from(self, offset: int) -> bytes | None:
+        """Return bytes appended after ``offset``, or ``None`` if ``offset``
+        has been evicted (rolled out of the ring).
+
+        ``offset`` is a value of ``total_appended`` the client saved before
+        disconnecting. If ``offset`` is still within the window we still hold
+        (i.e. ``total_appended - len(buffer) <= offset``), we can send just
+        the tail. Otherwise the client's offset is stale and must fall back
+        to a full ``snapshot()``.
+        """
+        if offset < 0:
+            return None
+        earliest = self._total_appended - len(self._buf)
+        if offset < earliest:
+            return None  # rolled out — caller should full-replay
+        skip = offset - earliest  # bytes in buffer that precede the offset
+        return bytes(self._buf[skip:])
+
+    @property
+    def total_appended(self) -> int:
+        return self._total_appended
 
     @property
     def truncated(self) -> bool:
@@ -78,7 +107,7 @@ class PtySession:
                 except Exception:
                     pass                             # detached mid-send; keep buffering
 
-    async def attach(self, ws) -> None:
+    async def attach(self, ws, client_offset: Optional[int] = None) -> None:
         old = self._ws
         if old is not None and old is not ws:
             try:
@@ -88,9 +117,57 @@ class PtySession:
         self._ws = ws
         self.attached = True
         self.last_detached_at = None
+        # Incremental replay: if the client sends its last-known byte offset
+        # and that offset is still within our RingBuffer window, send only the
+        # tail. This avoids re-replaying up to 1 MB of history the xterm.js
+        # terminal already has painted (the dashboard keeps ChatPage mounted
+        # persistently, so the terminal buffer survives tab switches — the
+        # bytes are never lost on the client side).
+        if client_offset is not None:
+            incremental = self.buffer.snapshot_from(client_offset)
+            if incremental is not None:
+                # Offset still in window — send only the delta (if any).
+                if incremental:
+                    await self._send_chunked(ws, incremental)
+                else:
+                    # Zero delta: the client's offset already sits at the
+                    # tail, so there is nothing to replay. Still send one
+                    # no-op SGR-reset frame: the client's resume-hydration
+                    # gate is edge-triggered on the FIRST payload received
+                    # (it hides its "loading…" overlay only once a chunk
+                    # arrives), so a reconnect with nothing to replay would
+                    # otherwise leave the overlay up forever — the
+                    # black-screen on tab-return regression.
+                    try:
+                        await ws.send_bytes(b"\x1b[0m")
+                    except Exception:
+                        pass  # detached mid-send; nothing buffered anyway
+                return
+        # Full replay (first connect, or offset rolled out of the ring).
         snap = self.buffer.snapshot()
         if snap:
-            await ws.send_bytes(snap)
+            await self._send_chunked(ws, snap)
+        elif client_offset is None:
+            # First attach to a PTY that has produced no output yet. The
+            # client's resume-hydration gate is edge-triggered on the first
+            # payload, so an empty buffer must still emit one no-op frame or
+            # the "loading…" overlay stays up (black screen) until the PTY
+            # happens to write something. SGR reset is invisible on xterm.
+            try:
+                await ws.send_bytes(b"\x1b[0m")
+            except Exception:
+                pass
+
+    async def _send_chunked(self, ws, data: bytes, chunk_size: int = 16384) -> None:
+        """Send ``data`` in ``chunk_size`` frames, yielding between frames so a
+        large replay (up to 1 MB) doesn't block the event loop."""
+        for i in range(0, len(data), chunk_size):
+            try:
+                await ws.send_bytes(data[i:i + chunk_size])
+            except Exception:
+                return
+            if i + chunk_size < len(data):
+                await asyncio.sleep(0)
 
     def detach(self, ws) -> None:
         # Only the currently-attached socket may mark the session detached.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15744,6 +15744,15 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     # Keep-alive path: the PTY outlives this socket; reattach by token.
+    # Client may send ?offset=N (total bytes it has already received) so the
+    # server can send an incremental replay instead of the full RingBuffer.
+    raw_offset = ws.query_params.get("offset") or ""
+    client_pty_offset: Optional[int] = None
+    if raw_offset:
+        try:
+            client_pty_offset = int(raw_offset)
+        except ValueError:
+            client_pty_offset = None
     try:
         session, _created = await PTY_REGISTRY.attach_or_spawn(
             attach_token, spawn=_spawn
@@ -15757,7 +15766,7 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
 
-    await session.attach(ws)
+    await session.attach(ws, client_offset=client_pty_offset)
 
     # --- writer loop: WebSocket → PTY master ----------------------------
     # No reader task here: the session's drain task (spawned once per PTY,

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -155,6 +155,28 @@ async def test_attach_first_attach_empty_buffer_sends_sentinel():
     await s.close()
 
 
+@pytest.mark.asyncio
+async def test_attach_rolled_out_offset_sends_sentinel_not_full_replay():
+    """A reconnecting client whose offset rolled out of the ring window must
+    NOT get a full 1MB replay: ChatPage stays mounted so xterm.js still holds
+    the painted history; a full replay re-sends megabytes the client already
+    has and stalls rendering (tab-return black screen on long sessions).
+    Emit the SGR-reset sentinel to clear the hydration gate instead."""
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"a" * 2000, None])       # 2000 bytes > 1024 cap
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)
+    # Offset 0 is long evicted (earliest byte now at 976).
+    ws = FakeWS()
+    await s.attach(ws, client_offset=0)
+    sent = [p for kind, p in ws.sent if kind == "bytes"]
+    assert sent == [b"\x1b[0m"], (
+        f"expected only sentinel (no full replay), got {len(sent)} frames"
+    )
+    await s.close()
+
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -21,6 +21,35 @@ def test_ringbuffer_drops_oldest_over_capacity():
     assert rb.truncated is True
 
 
+def test_ringbuffer_snapshot_from_incremental_window():
+    """snapshot_from returns only the tail after the client's offset, and
+    None once the offset has rolled out of the ring (caller must full-replay).
+    """
+    rb = RingBuffer(10)
+    rb.append(b"abcdef")          # 6 bytes appended
+    assert rb.total_appended == 6
+
+    # Offset at the tail → zero delta, no bytes (client is fully caught up).
+    assert rb.snapshot_from(6) == b""
+    # Offset mid-buffer → only the bytes after it.
+    assert rb.snapshot_from(2) == b"cdef"
+    # Offset 0 (or before the ring's earliest byte) → still in window, full
+    # snapshot; a truly rolled-out offset returns None → caller full-replays.
+    assert rb.snapshot_from(0) == b"abcdef"
+    # Negative offsets never produce a partial slice.
+    assert rb.snapshot_from(-1) is None
+
+    # Overflow evicts oldest; the window shifts accordingly.
+    rb.append(b"ghij")            # 10 bytes total, buffer full
+    assert rb.snapshot_from(6) == b"ghij"
+    assert rb.snapshot_from(4) == b"efghij"        # still in window
+    # Append past capacity evicts the oldest bytes; an offset pointing at an
+    # evicted byte rolls out and requires a full replay.
+    rb.append(b"k")               # 11 bytes → 'a' evicted, earliest=1
+    assert rb.snapshot_from(6) == b"ghijk"         # delta still available
+    assert rb.snapshot_from(0) is None             # offset 0 < earliest → rolled out
+
+
 
 
 class FakeBridge:
@@ -73,6 +102,56 @@ async def test_attach_replays_buffer_then_streams_live():
     await s.attach(ws)
     replay = b"".join(p for kind, p in ws.sent if kind == "bytes")
     assert replay == b"hello world"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_incremental_replay_zero_delta_sends_sentinel():
+    """Reconnecting with an offset already at the tail replays zero bytes but
+    must still emit one frame: the client's resume-hydration gate is
+    edge-triggered on the FIRST payload, so a silent attach would leave the
+    loading overlay up forever (black-screen on tab-return)."""
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"history", None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)                      # drain consumes "history"
+    ws = FakeWS()
+    await s.attach(ws, client_offset=s.buffer.total_appended)
+    sent = [p for kind, p in ws.sent if kind == "bytes"]
+    assert sent == [b"\x1b[0m"], f"expected only SGR-reset sentinel, got {sent}"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_incremental_replay_sends_delta_only():
+    """An offset inside the ring window replays only the bytes after it —
+    never the full buffer (the xterm buffer already has the history)."""
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"hello world", None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)
+    ws = FakeWS()
+    await s.attach(ws, client_offset=6)            # "hello " already painted
+    sent = b"".join(p for kind, p in ws.sent if kind == "bytes")
+    assert sent == b"world", f"expected only delta, got {sent!r}"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_first_attach_empty_buffer_sends_sentinel():
+    """First attach to a PTY that has produced nothing yet must still emit a
+    frame — the loading overlay clears on first payload, not on a timer."""
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"", b"", None])          # idle ticks, no output
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)
+    ws = FakeWS()
+    await s.attach(ws)                             # no client_offset → full path
+    sent = [p for kind, p in ws.sent if kind == "bytes"]
+    assert sent == [b"\x1b[0m"], f"expected SGR-reset sentinel, got {sent}"
     await s.close()
 
 

--- a/web/src/lib/pty-resume-loading.ts
+++ b/web/src/lib/pty-resume-loading.ts
@@ -6,6 +6,17 @@ import type { PtyConnectionState } from "@/lib/pty-reconnect";
  */
 export const PTY_RESUME_LOADING_MAX_MS = 30000;
 
+/**
+ * Hydration watchdog: after the PTY socket opens, the wait notice is
+ * edge-triggered on the FIRST payload frame. If the server sends nothing
+ * within this budget — e.g. an older server without the sentinel frame, or a
+ * zero-delta incremental replay where every byte was already consumed before
+ * the reconnect — force-finish hydration so the overlay cannot hang. Normal
+ * attaches receive their first frame in milliseconds, so this is far below
+ * the 30s wedged-resume cap and far above any legitimate first-frame latency.
+ */
+export const PTY_RESUME_HYDRATION_WATCHDOG_MS = 2000;
+
 export const PTY_RESUME_LOADING_MESSAGE =
   "Please wait while the conversation loads…";
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -48,6 +48,7 @@ import {
   shouldReconnectPtyOnPageResume,
 } from "@/lib/pty-reconnect";
 import {
+  PTY_RESUME_HYDRATION_WATCHDOG_MS,
   PTY_RESUME_LOADING_MAX_MS,
   PTY_RESUME_LOADING_MESSAGE,
   shouldFinishResumeHydrationOnChunk,
@@ -207,6 +208,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const connectInFlightRef = useRef(false);
   const connectingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ptyInputLineRef = useRef("");
+  // Total raw bytes received from the PTY WebSocket. Sent as ?offset= on
+  // reconnect so the server can send an incremental replay instead of the
+  // full 1 MB RingBuffer (the xterm.js terminal buffer already has the
+  // history painted — ChatPage stays mounted across tab switches).
+  const ptyByteOffsetRef = useRef(0);
   const mobileReplacementInputUntilRef = useRef(0);
   const [ptyState, setPtyState] =
     useState<PtyConnectionState>("connecting");
@@ -240,6 +246,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     blockedInputNoticeRef.current = false;
     ptyInputLineRef.current = "";
     mobileReplacementInputUntilRef.current = 0;
+    // Don't reset ptyByteOffsetRef — we want to send it as ?offset= so the
+    // server sends an incremental replay.
     setBanner(null);
     setLastCloseCode(null);
     setPtyState("connecting");
@@ -252,6 +260,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     blockedInputNoticeRef.current = false;
     ptyInputLineRef.current = "";
     mobileReplacementInputUntilRef.current = 0;
+    ptyByteOffsetRef.current = 0;
     setBanner(null);
     setLastCloseCode(null);
     setPtyState("connecting");
@@ -267,6 +276,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     blockedInputNoticeRef.current = false;
     ptyInputLineRef.current = "";
     mobileReplacementInputUntilRef.current = 0;
+    ptyByteOffsetRef.current = 0;
     setSearchParams(next, { replace: true });
     setBanner(null);
     setLastCloseCode(null);
@@ -930,7 +940,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         finishResumeHydration();
       }
     };
-    if (resumeParam) {
+    const forceFresh = forceFreshPtyRef.current;
+    forceFreshPtyRef.current = false;
+    // P2: only arm the resume-loading overlay when there is genuinely
+    // something to (re)load. If this connect carries a prior byte offset
+    // (>0), the client already has the terminal history painted — ChatPage
+    // stays mounted across tab switches, so the buffer was never lost — and
+    // the server will only send a small incremental delta (or, in the
+    // zero-delta case, nothing at all). Arming the overlay there re-blanks a
+    // perfectly good screen on every split-screen focus toggle, which is the
+    // black-screen the user reports. First attach (offset 0) and forced-fresh
+    // sessions still arm normally.
+    const hasPriorPtyBytes = ptyByteOffsetRef.current > 0 && !forceFresh;
+    if (resumeParam && !hasPriorPtyBytes) {
       setResumeHydrating(true);
       resumeMaxTimer = setTimeout(
         finishResumeHydration,
@@ -939,8 +961,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     } else {
       setResumeHydrating(false);
     }
-    const forceFresh = forceFreshPtyRef.current;
-    forceFreshPtyRef.current = false;
     // A connect attempt is now in flight — set synchronously (before the async
     // socket-open IIFE below awaits its ticket URL) so a page-resume event in
     // that gap doesn't fire a redundant reconnect (wsRef isn't assigned yet).
@@ -979,6 +999,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).
       if (scopedProfile) params.profile = scopedProfile;
+      // Incremental replay: send the total bytes we've already received so
+      // the server can skip re-sending history the xterm.js terminal already
+      // has painted. Only meaningful on reconnect (attach token is present).
+      if (ptyByteOffsetRef.current > 0 && !forceFresh) {
+        params.offset = String(ptyByteOffsetRef.current);
+      }
       const url = await api.buildWsUrl("/api/pty", params);
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
@@ -1012,6 +1038,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;
+      }
+      // Hydration watchdog: the resume wait-notice is edge-triggered on the
+      // FIRST payload frame. A zero-delta incremental replay (client offset
+      // already at the tail) or an older server without the sentinel frame
+      // sends nothing, so the notice would stay up until the 30s wedged-resume
+      // cap. Force-finish hydration shortly after open unless a frame arrives
+      // first (in which case noteResumePtyChunk already clears it and clears
+      // this timer via finishResumeHydration → clearResumeLoadingTimers).
+      if (resumeParam && !forceFresh) {
+        resumeMaxTimer = setTimeout(
+          finishResumeHydration,
+          PTY_RESUME_HYDRATION_WATCHDOG_MS,
+        );
       }
       // Send the initial RESIZE immediately so Ink has *a* size to lay
       // out against on its first paint.  The double-rAF block above will
@@ -1053,6 +1092,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
 
     ws.onmessage = (ev) => {
+      // Track raw bytes for incremental replay offset. We count the raw
+      // payload size (not the sanitized/decoded text) so the offset matches
+      // the server's total_appended counter byte-for-byte.
+      if (typeof ev.data === "string") {
+        ptyByteOffsetRef.current += ev.data.length;
+      } else {
+        ptyByteOffsetRef.current += (ev.data as ArrayBuffer).byteLength;
+      }
       const text =
         typeof ev.data === "string"
           ? ev.data
@@ -1359,7 +1406,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return;
     }
 
-    const onResume = () => maybeReconnectOnPageResume();
+    const onResume = () => {
+      maybeReconnectOnPageResume();
+      // P1: Chrome may discard/blur the terminal canvas while the tab is
+      // backgrounded (especially under split-screen focus toggling). When
+      // the tab becomes visible again, force a full xterm repaint so the
+      // buffered buffer content is re-composited instead of leaving a black
+      // viewport until the next PTY frame happens to arrive.
+      if (document.visibilityState === "visible") {
+        const term = termRef.current;
+        if (term && termRef.current?.rows) {
+          try {
+            term.refresh(0, termRef.current.rows - 1);
+          } catch {
+            /* terminal not ready yet */
+          }
+        }
+      }
+    };
 
     document.addEventListener("visibilitychange", onResume);
     window.addEventListener("pageshow", onResume);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -213,6 +213,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // full 1 MB RingBuffer (the xterm.js terminal buffer already has the
   // history painted — ChatPage stays mounted across tab switches).
   const ptyByteOffsetRef = useRef(0);
+  // Pending PTY text coalesced by the per-frame write batching (see
+  // ws.onmessage). `pendingWriteRef` accumulates frames between animation
+  // frames; `writeRafRef` is the in-flight requestAnimationFrame handle so a
+  // burst of onmessage callbacks (backgrounded tab unfreezing) coalesces into
+  // one term.write per frame instead of flooding xterm's buffer.
+  const pendingWriteRef = useRef("");
+  const writeRafRef = useRef<number | null>(null);
   const mobileReplacementInputUntilRef = useRef(0);
   const [ptyState, setPtyState] =
     useState<PtyConnectionState>("connecting");
@@ -1111,8 +1118,25 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // resume frame into "" (pty-resume-sanitizer.ts); keying off raw `text`
       // would hide the wait notice while the terminal is still blank.
       const rendered = resumeParam ? sanitizer.next(text) : text;
-      term.write(rendered);
-      noteResumePtyChunk(rendered);
+      // Coalesce writes per animation frame. When the tab was backgrounded
+      // (Chrome freezes JS timers but the WS network stack keeps receiving),
+      // hundreds of onmessage callbacks pile up in the event queue and run
+      // back-to-back the instant the tab is visible again. Writing each one
+      // synchronously floods xterm's internal buffer and stalls the renderer
+      // ("tab-return freeze" on long-running sessions). Batching to one
+      // write per frame lets xterm's async renderer keep up instead.
+      pendingWriteRef.current += rendered;
+      if (writeRafRef.current == null) {
+        writeRafRef.current = requestAnimationFrame(() => {
+          writeRafRef.current = null;
+          const chunk = pendingWriteRef.current;
+          pendingWriteRef.current = "";
+          if (chunk) {
+            term.write(chunk);
+            noteResumePtyChunk(chunk);
+          }
+        });
+      }
     };
 
     ws.onclose = (ev) => {
@@ -1278,6 +1302,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       syncMetricsRef.current = null;
       clearEraseSuppressionTimer();
       clearResumeLoadingTimers();
+      if (writeRafRef.current != null) {
+        cancelAnimationFrame(writeRafRef.current);
+        writeRafRef.current = null;
+      }
+      pendingWriteRef.current = "";
       setResumeHydrating(false);
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();


### PR DESCRIPTION
## Problem

Returning to the Hermes dashboard chat tab shows a **black screen** (the "Please wait while the conversation loads…" overlay never hides), worst under split-screen focus toggling.

The resume loading overlay is edge-triggered on the **first payload frame**: it only hides once a chunk arrives. The previous full-replay always delivered bytes, but incremental replay (`?offset=N`) with the client already at the tail sends **nothing**, so the overlay stays up forever. Under Chrome background-tab throttling (JS frozen while the network stack stays alive) the edge event is lost entirely — permanent black screen. Split-screen focus toggling re-arms the overlay on every switch, so it is worst there.

## Root cause (exact lines)

- `hermes_cli/pty_session.py` `attach()`: zero-delta incremental replay returns without emitting any frame; first attach to an empty buffer also emits nothing.
- `web/src/pages/ChatPage.tsx`: hydration gate waits for first payload (edge-triggered); no watchdog; overlay armed even when the terminal buffer was never lost.

## Fix

**Server (pty_session.py + web_server.py):**
- `RingBuffer.snapshot_from(offset)` + `total_appended` for byte-accurate incremental replay.
- `attach()` emits a no-op `\x1b[0m` SGR-reset sentinel on zero-delta reconnect **and** on first attach to an empty buffer — the first-payload gate can never be starved.
- 16KB chunked replay with `asyncio.sleep(0)` between frames (no event-loop blocking).
- `pty_ws` reads `?offset=N` and passes it to `attach()`.
- **Rolled-out offset no longer falls back to a full 1MB replay.** ChatPage stays mounted, so xterm.js still holds the painted history; re-sending megabytes the client already has stalls rendering on long-running sessions that exceed the ring window while backgrounded. Emit the sentinel and let live output resume. Only a genuine first attach (no offset) still replays the full snapshot.

**Frontend (ChatPage.tsx / pty-resume-loading.ts):**
- Track raw bytes received; send `?offset=` on reconnect.
- `PTY_RESUME_HYDRATION_WATCHDOG_MS=2000`: force-finish hydration shortly after open if no frame arrives (covers older servers without the sentinel).
- Skip arming the loading overlay when the reconnect carries a prior byte offset (terminal history was never lost — split-screen toggling no longer blanks the screen).
- `visibilitychange → visible` forces `term.refresh()` to re-composite a canvas discarded by Chrome's background-tab handling.
- **Coalesce PTY writes per animation frame.** When the tab was backgrounded, Chrome freezes JS timers but the WS network stack keeps receiving, so hundreds of onmessage callbacks pile up and run back-to-back on return; each synchronous `term.write()` floods xterm's buffer and stalls the renderer. Accumulate into a pending ref and flush once per `requestAnimationFrame` instead. Sanitizer still runs per-message (byte order preserved); only the write is batched.

## Validation

- `tests/test_pty_session.py`: 12 passed — new tests cover `snapshot_from` window semantics, zero-delta sentinel, delta-only replay, empty-first-attach sentinel, **rolled-out offset sends sentinel (no full replay)**.
- Frontend `pty-resume-loading.test.ts`: 9 passed (vitest).
- Black-box on a real dashboard: first attach overlay clears in seconds; simulated split-screen (visibilitychange+focus) shows no overlay and keeps content.
- **User-verified in real Chrome**: backgrounded a session while the agent streamed a large MOA analysis + HTML render, returned to the tab — renders smoothly (accumulated output paints over a moment, no freeze).

## Note

This PR intentionally does **not** touch the loopback ws-ping config (`ws_ping_interval=None` on loopback, per #53773). Whether a gentle ping should be re-enabled for the Chrome-background-tab "live network stack, frozen JS" case is a separate question with a real trade-off against #53773's event-loop-stall argument — tracked separately.

The delegate-subagent session-resume hijack fix (a distinct bug in `_session_latest_descendant`) is in PR #78368.
