### PR TITLE
fix(gateway): resume interactive tasks after restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -949,13 +949,11 @@ def build_resume_recovery_note(
     startup auto-resume turn synthesized by
     ``_schedule_resume_pending_sessions`` with no human message attached.
 
-    ``interactive`` selects the empty-message guidance: on interactive
-    platforms a human is present, so "report the restore and ask what next"
-    is right.  On non-interactive event platforms (webhook, API server —
-    adapters with ``interactive_resume = False``) nobody can answer; the
-    resumed turn must instead complete the interrupted work, or the task is
-    silently abandoned behind a "restored" acknowledgement that goes
-    nowhere (#57056).
+    Empty startup auto-resume turns always continue the saved unfinished
+    work.  This applies to interactive chats as well as non-interactive event
+    platforms: asking the user what to do next abandons a task that is already
+    present in the transcript and clears the durable recovery marker after the
+    acknowledgement turn completes.
     """
     reason_phrase = (
         "a gateway restart"
@@ -973,20 +971,11 @@ def build_resume_recovery_note(
             "Do NOT re-execute old tool calls — skip any "
             "unfinished work from the conversation history."
         )
-    elif interactive:
-        resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
-        )
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
-        )
     else:
         resume_guidance = (
-            "No user is present on this non-interactive platform, "
-            "so do NOT emit a 'session restored' acknowledgement "
-            "or ask questions. Review the conversation history and "
+            "Do NOT emit only a 'session restored' acknowledgement "
+            "or ask the user to restate the task. Review the conversation "
+            "history and "
             "CONTINUE the interrupted task to completion."
         )
         tail_guidance = (
@@ -5201,12 +5190,10 @@ class TurnRunner:
             _persist_user_message_override = ctx.message
             # The empty-message case is the auto-resume startup turn
             # synthesized by _schedule_resume_pending_sessions — there is
-            # no NEW user message to address.  Guidance is adapter-aware:
-            # interactive platforms report the restore and ask what next;
-            # non-interactive event platforms (webhook, API server)
-            # continue the interrupted work instead, because nobody is
-            # present to answer and an acknowledgement would silently
-            # abandon the task (#57056).
+            # no NEW user message to address. All adapters continue the saved
+            # unfinished work; a restore-only acknowledgement would complete
+            # this synthetic turn and clear the durable resume marker without
+            # doing the work recorded in the transcript.
             _resume_adapter = self._runner._adapter_for_source(ctx.source)
             _interactive_resume = bool(
                 getattr(_resume_adapter, "interactive_resume", True)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -313,6 +313,18 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_empty_message_interactive_note_continues_task(self):
+        """Interactive chat restarts must resume the saved unfinished task.
+
+        A startup auto-resume is an internal event, not a request for the
+        user to restate work that is already present in the transcript.
+        """
+        note = build_resume_recovery_note("shutdown_timeout", "", interactive=True)
+        assert "CONTINUE the interrupted task" in note
+        assert "ask what they would like to do next" not in note
+        assert "skip any unfinished work" not in note
+        assert "already appear in the history" in note
+
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires
@@ -1038,5 +1050,4 @@ async def test_startup_restore_gate_releases_when_resume_turn_outlives_timeout(
 
     never_finishes.set()
     await slow_task
-
 


### PR DESCRIPTION
## Summary
- continue saved unfinished work during startup auto-resume on interactive messaging platforms
- avoid consuming the durable resume marker with a restore-only acknowledgement
- retain protection against replaying tool calls whose results are already recorded

## Root cause
The interactive recovery note told the model to ask what to do next and skip unfinished history. That acknowledgement completed successfully, so the gateway cleared resume_pending even though the original task remained unfinished in the transcript.

## Verification
- 53 restart, drain, and busy-session tests pass
- ruff passes on the changed source and test files