### PR TITLE
Clamp search_files pagination upper bound

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -281,6 +281,12 @@ class TestShellFileOpsHelpers:
         assert normalize_read_pagination(offset="bad", limit="bad") == (1, 2000)
         assert normalize_read_pagination(offset=2, limit=999999) == (2, 2000)
 
+    def test_normalize_search_pagination_clamps_invalid_values(self):
+        assert normalize_search_pagination(offset=-10, limit=-5) == (0, 1)
+        assert normalize_search_pagination(offset="bad", limit="bad") == (0, 50)
+        assert normalize_search_pagination(offset=2, limit=999999) == (2, 500)
+        assert normalize_search_pagination(offset=0, limit=50) == (0, 50)
+
 
     def test_escape_shell_arg_simple(self, file_ops):
         assert file_ops._escape_shell_arg("hello") == "'hello'"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -729,6 +729,7 @@ DEFAULT_READ_OFFSET = 1
 DEFAULT_READ_LIMIT = 2000
 DEFAULT_SEARCH_OFFSET = 0
 DEFAULT_SEARCH_LIMIT = 50
+MAX_SEARCH_RESULTS = 500
 
 
 def _coerce_int(value: Any, default: int) -> int:
@@ -760,9 +761,15 @@ def normalize_read_pagination(offset: Any = DEFAULT_READ_OFFSET,
 
 def normalize_search_pagination(offset: Any = DEFAULT_SEARCH_OFFSET,
                                 limit: Any = DEFAULT_SEARCH_LIMIT) -> tuple[int, int]:
-    """Return safe search pagination bounds for shell head/tail pipelines."""
+    """Return safe search pagination bounds for shell head/tail pipelines.
+
+    Unlike read pagination (which uses tool_output.max_lines), search is
+    capped at ``MAX_SEARCH_RESULTS`` so a huge limit cannot inflate
+    ``fetch_limit = limit + offset`` into unbounded ``head -n`` / rg work.
+    """
     normalized_offset = max(0, _coerce_int(offset, DEFAULT_SEARCH_OFFSET))
-    normalized_limit = max(1, _coerce_int(limit, DEFAULT_SEARCH_LIMIT))
+    normalized_limit = _coerce_int(limit, DEFAULT_SEARCH_LIMIT)
+    normalized_limit = max(1, min(normalized_limit, MAX_SEARCH_RESULTS))
     return normalized_offset, normalized_limit
 
 


### PR DESCRIPTION
search_files pagination already floored invalid offset and limit values but had no upper bound, so a huge limit could inflate head -n and ripgrep fetch sizes into oversized tool results. This change caps the search limit at 500 while preserving the existing default of 50, matching the hardening pattern already used by read_file pagination and nearby list clamps.