### PR TITLE
feat(plugins/memory-tencentdb): upgrade to v2.0.0 + fix(auxiliary): Aliyun MaaS /compatible-mode/v1

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1239,6 +1239,16 @@ def _to_openai_base_url(base_url: str) -> str:
             rewritten = url[: -len("/anthropic")] + "/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
             return rewritten
+        # Aliyun MaaS / token-plan / DashScope uses /apps/anthropic (or bare
+        # /anthropic) for Anthropic wire but /compatible-mode/v1 for OpenAI
+        # wire — the generic /v1 rewrite is a 404 on this platform.
+        if "aliyuncs.com" in url or "token-plan" in url:
+            base = url[: -len("/anthropic")]
+            if base.endswith("/apps"):
+                base = base[: -len("/apps")]
+            rewritten = base + "/compatible-mode/v1"
+            logger.debug("Auxiliary client: rewrote Aliyun MaaS base URL %s → %s", url, rewritten)
+            return rewritten
         rewritten = url[: -len("/anthropic")] + "/v1"
         logger.debug("Auxiliary client: rewrote base URL %s → %s", url, rewritten)
         return rewritten

--- a/package-lock.json
+++ b/package-lock.json
@@ -1835,6 +1835,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1851,6 +1852,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1867,6 +1869,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1883,6 +1886,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1899,6 +1903,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1915,6 +1920,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1931,6 +1937,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1947,6 +1954,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1963,6 +1971,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1979,6 +1988,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1995,6 +2005,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2011,6 +2022,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2027,6 +2039,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2043,6 +2056,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2059,6 +2073,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2075,6 +2090,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2091,6 +2107,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2107,6 +2124,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2123,6 +2141,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2139,6 +2158,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2155,6 +2175,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,6 +2192,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2187,6 +2209,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2203,6 +2226,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2219,6 +2243,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2235,6 +2260,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17643,6 +17669,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2260,6 +2260,22 @@ function Install-Venv {
         return
     }
 
+    # Quick health check: if the venv is already healthy, skip recreation.
+    # Recreation kills the desktop's own backend process, causing a crash loop.
+    $venvPython = Join-Path $InstallDir "venv\Scripts\python.exe"
+    if (Test-Path $venvPython) {
+        $healthy = $false
+        try {
+            & $venvPython -c "import fastapi,uvicorn,pydantic,openai,yaml,cryptography,annotated_doc" 2>$null 1>$null
+            if ($LASTEXITCODE -eq 0) { $healthy = $true }
+        } catch { }
+        if ($healthy) {
+            Write-Info "Virtual environment is healthy, skipping recreation"
+            return
+        }
+        Write-Info "Virtual environment exists but is unhealthy, recreating..."
+    }
+
     # Re-resolve the interpreter before creating the venv.  Under Hermes-Setup.exe
     # each stage runs in its own powershell.exe, so the fallback the `python`
     # stage picked (e.g. 3.12 when 3.11 is absent) did NOT propagate into this


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Upgrade memory-tencentdb plugin to v2.0.0
Bump from v1.0.1 to v2.0.0-beta.1, pulling in the full MemoryCore v2 release from [TencentDB-Agent-Memory](https://github.com/Tencent/TencentDB-Agent-Memory) (tag v2.0.0).

**Key additions:**
- Python adapter: v3 isolation, circuit breaker, watchdog, read_scene tool
- Node.js Core: Skill/Wiki/CodeGraph pipelines, metadata service, API trace, store isolation
- New CLI tools: bin/seed-v2, bin/export-tencent-vdb, bin/migrate-sqlite-to-tcvdb
- Dockerfile, install scripts, skill docs

### 2. Fix auxiliary client URL rewrite for Aliyun MaaS
The generic /v1 rewrite produced a 404 for token-plan / Aliyun MaaS providers whose OpenAI wire lives at /compatible-mode/v1. Detect the aliyuncs.com / token-plan pattern and route correctly.

**Supersedes:** https://github.com/NousResearch/hermes-agent/pull/73820 (closed)