### PR TITLE
fix(a2a): let long-running peer calls survive the timeout stack

### DIFF
--- a/contributors/emails/philipstayetski2416@gmail.com
+++ b/contributors/emails/philipstayetski2416@gmail.com
@@ -1,0 +1,1 @@
+pstayets

--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -25,7 +25,7 @@ a2a_agents:
   researcher:
     url: "http://localhost:9999"
     auth: { type: bearer, token: "sk-..." }
-    timeout: 120
+    timeout: 900   # optional, seconds (default 330); raise for slow peers
     capabilities: [web_search, research]
 ```
 
@@ -34,7 +34,7 @@ a2a_agents:
 The agent gets five tools:
 
 - `a2a_discover(url)` — what can this agent do?
-- `a2a_call(agent, message, context_id?)` — send it a task, get the reply.
+- `a2a_call(agent, message, context_id?, timeout?)` — send it a task, get the reply.
 - `a2a_list()` — configured peers, saved conversations, metrics.
 - `a2a_history(context_id)` — recall a saved A2A conversation.
 - `a2a_orchestrate(capability, message, mode?)` — fan-out a task to every

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -14,7 +14,7 @@ Peers are resolved from config.yaml under ``a2a_agents``::
       researcher:
         url: "http://localhost:9999"
         auth: { type: bearer, token: "sk-..." }
-        timeout: 120
+        timeout: 900   # optional, seconds (default 330)
         capabilities: [web_search, research]
 
 Transport is stdlib urllib (no a2a-sdk dependency). The wire format is the A2A
@@ -34,7 +34,11 @@ from . import protocol, security
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_TIMEOUT = 120
+# Must exceed the serving side's reply window (A2A_REPLY_TIMEOUT, default 300s
+# in adapter.py): the server holds the sync message/send RPC open while the
+# agent works, so a shorter client timeout makes every long task die as a
+# client-side socket timeout instead of a proper in-protocol task state.
+_DEFAULT_TIMEOUT = 330
 _ORCHESTRATE_MAX_WORKERS = 6  # max parallel peers for fan-out
 
 
@@ -51,12 +55,23 @@ def _load_config() -> dict:
 
 
 def _resolve_peer(agent: str) -> Optional[dict]:
-    """Resolve a peer name to {url, auth, timeout, capabilities}, or treat ``agent`` as a URL."""
-    if agent.startswith("http://") or agent.startswith("https://"):
-        return {"url": agent, "auth": {}, "timeout": _DEFAULT_TIMEOUT, "capabilities": []}
+    """Resolve a peer name to {url, auth, timeout, capabilities}, or treat ``agent`` as a URL.
+
+    A raw URL that matches a configured peer's ``url`` resolves to that peer's
+    entry, so its auth/timeout apply no matter how the model addressed it.
+    """
     cfg = _load_config()
     peers = cfg.get("a2a_agents") or {}
-    entry = peers.get(agent)
+    if agent.startswith("http://") or agent.startswith("https://"):
+        entry = next(
+            (e for e in peers.values()
+             if (e.get("url") or "").rstrip("/") == agent.rstrip("/")),
+            None,
+        )
+        if not entry:
+            return {"url": agent, "auth": {}, "timeout": _DEFAULT_TIMEOUT, "capabilities": []}
+    else:
+        entry = peers.get(agent)
     if not entry:
         return None
     return {
@@ -261,6 +276,7 @@ def a2a_call(args: dict, **_: Any) -> str:
 
     ``agent`` is a configured peer name (from ``a2a_agents``) or a direct URL.
     ``context_id`` continues a prior exchange (multi-turn) when provided.
+    ``timeout`` overrides the peer's configured timeout for this call (seconds).
     """
     # Accept common aliases models reach for (observed live: 'agent_name').
     agent = str(args.get("agent") or args.get("agent_name") or args.get("name") or "").strip()
@@ -275,6 +291,13 @@ def a2a_call(args: dict, **_: Any) -> str:
             f"Error: unknown agent '{agent}'. Configure it under 'a2a_agents' in "
             f"config.yaml or pass a full http(s):// URL."
         )
+
+    raw_timeout = args.get("timeout") or args.get("timeout_seconds")
+    if raw_timeout is not None:
+        try:
+            peer["timeout"] = max(1, int(raw_timeout))
+        except (TypeError, ValueError):
+            return f"Error: 'timeout' must be a number of seconds, got {raw_timeout!r}."
 
     try:
         reply, reply_ctx, state = _send_task(agent, peer, message, context_id)
@@ -517,6 +540,7 @@ _SCHEMAS: dict[str, _ToolSchema] = {
                     "agent": {"type": "string", "description": "Configured peer name (from a2a_agents) or a full http(s):// URL."},
                     "message": {"type": "string", "description": "The task / message to send the peer, in natural language."},
                     "context_id": {"type": "string", "description": "Optional: context id from a prior reply, to continue the conversation."},
+                    "timeout": {"type": "integer", "description": "Optional: seconds to wait for the peer's reply, overriding the peer's configured timeout. Use for long-running tasks."},
                 },
                 "required": ["agent", "message"],
             },

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -546,6 +546,76 @@ class TestClientTools:
         out = tools.a2a_list({})
         assert "No peers configured" in out
 
+    def test_call_timeout_override(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999", "timeout": 5}}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+
+        captured = {}
+
+        def fake_post(url, body, headers, timeout):
+            captured["timeout"] = timeout
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "done"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "r", "message": "slow task", "timeout": 900})
+        assert "done" in out
+        assert captured["timeout"] == 900
+
+    def test_call_timeout_rejects_garbage(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
+        out = tools.a2a_call({"agent": "r", "message": "hi", "timeout": "soon"})
+        assert "Error" in out and "timeout" in out
+
+    def test_raw_url_inherits_configured_peer(self, monkeypatch):
+        """Calling a configured peer by its URL applies that peer's auth + timeout."""
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {"r": {
+            "url": "http://localhost:9999",
+            "timeout": 777,
+            "auth": {"type": "bearer", "token": "tok-abc"},
+        }}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+
+        captured = {}
+
+        def fake_post(url, body, headers, timeout):
+            captured["timeout"] = timeout
+            captured["headers"] = headers
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "done"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "http://localhost:9999/", "message": "hi"})
+        assert "done" in out
+        assert captured["timeout"] == 777
+        assert captured["headers"].get("Authorization") == "Bearer tok-abc"
+
+    def test_raw_url_unknown_still_works(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+
+        def fake_post(url, body, headers, timeout):
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "done"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "http://localhost:8888", "message": "hi"})
+        assert "done" in out
+
+    def test_default_timeout_exceeds_server_reply_window(self):
+        # adapter.py holds the sync message/send RPC open for A2A_REPLY_TIMEOUT
+        # (default 300s); the client default must outlive it so long tasks fail
+        # in-protocol (task state) rather than as client socket timeouts.
+        assert tools._DEFAULT_TIMEOUT > 300
+
 
 class TestRegistryDispatchConvention:
     """Tools must accept the args-as-dict positional that registry.dispatch

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -38,7 +38,7 @@ With the `a2a` toolset enabled, the agent gets:
 | Tool | What it does |
 |---|---|
 | `a2a_discover(url)` | Fetch and summarize a peer's Agent Card |
-| `a2a_call(agent, message, context_id?)` | Send a task, get the reply; multi-turn via `context_id` |
+| `a2a_call(agent, message, context_id?, timeout?)` | Send a task, get the reply; multi-turn via `context_id`; `timeout` (seconds) for long tasks |
 | `a2a_list()` | Configured peers, saved conversations, metrics |
 | `a2a_history(context_id)` | Recall a persisted A2A conversation |
 | `a2a_orchestrate(capability, message, mode?)` | Fan a task out to every peer advertising a capability (`all` / `first` / `best`) |
@@ -50,7 +50,7 @@ a2a_agents:
   researcher:
     url: "http://research-box.local:9900"
     auth: { type: bearer, token: "..." }
-    timeout: 120
+    timeout: 900   # optional, seconds (default 330); raise for slow peers
     capabilities: [web_search, research]
 ```
 


### PR DESCRIPTION
## Summary
Raises the A2A client default timeout from 120s to 330s so long-running peer tasks survive the server's 300s reply window instead of dying as client socket timeouts. Adds a per-call `timeout` override to `a2a_call`, and makes raw-URL calls match configured peers by URL so they inherit auth+timeout.

Closes #78007 (points 1+2). Point 3 (server deadline discards finished work) intentionally left as a semantics follow-up per the original issue.

## Changes
- `plugins/platforms/a2a/tools.py`: `_DEFAULT_TIMEOUT` 120→330 (with comment explaining the 300s server reply window), `_resolve_peer` now matches raw URLs against configured peer URLs (trailing-slash normalized), `a2a_call` accepts optional `timeout` param with validation, tool schema updated
- `plugins/platforms/a2a/README.md`, `website/docs/user-guide/messaging/a2a.md`: docs updated with `timeout` param and new default
- `tests/plugins/test_a2a_plugin.py`: 5 new regression tests (timeout override, garbage rejection, raw-URL inherits peer, unknown URL still works, default > 300 invariant)

## Validation
| | Before | After |
|---|---|---|
| Default client timeout | 120s (dies before 300s server window) | 330s (outlives server window) |
| Raw-URL call auth/timeout | Hardcoded default, no auth | Inherits configured peer's auth+timeout |
| Per-call timeout override | Not possible | `timeout` param in schema + handler |
| Tests | 168 | 173 pass |

Salvage of #78008 by @pstayets. Authorship preserved via cherry-pick.
