### PR TITLE
fix(gateway): dedupe codex final replies

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -859,8 +859,16 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    _interim_delivery_check = getattr(agent, "_interim_text_was_delivered", None)
+    response_previewed = bool(
+        turn.final_text
+        and callable(_interim_delivery_check)
+        and _interim_delivery_check(turn.final_text)
+    )
+
     return {
         "final_response": turn.final_text,
+        "response_previewed": response_previewed,
         "messages": messages,
         "api_calls": api_calls,
         "completed": not turn.interrupted and turn.error is None,

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -399,3 +399,76 @@ class TestBridgeWiredInRuntime:
         agent.tool_progress_callback.assert_called_once()
         assert agent.tool_progress_callback.call_args.args[0] == "tool.started"
         assert agent.tool_progress_callback.call_args.args[1] == "exec_command"
+
+    def test_completed_final_message_marks_response_previewed(self, monkeypatch):
+        """A final agentMessage delivered through the bridge must prevent the
+        gateway from sending the same final text a second time."""
+        from agent import codex_runtime
+
+        captured: dict = {}
+        delivered: set[str] = set()
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, user_input, **_):
+                from agent.transports.codex_app_server_session import TurnResult
+
+                captured["on_event"](_item_completed({
+                    "type": "agentMessage",
+                    "id": "final-1",
+                    "text": "Only send this once.",
+                }))
+                return TurnResult(
+                    final_text="Only send this once.",
+                    projected_messages=[],
+                    tool_iterations=0,
+                    turn_id="t1",
+                    thread_id="th1",
+                )
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+
+        def emit_interim(message):
+            delivered.add(message["content"])
+
+        agent = SimpleNamespace(
+            session_cwd=None,
+            _codex_session=None,
+            tool_progress_callback=MagicMock(),
+            _fire_stream_delta=MagicMock(),
+            _fire_reasoning_delta=MagicMock(),
+            _emit_interim_assistant_message=emit_interim,
+            _interim_text_was_delivered=lambda text: text in delivered,
+            _iters_since_skill=0,
+            _skill_nudge_interval=0,
+            valid_tool_names=set(),
+            _sync_external_memory_for_turn=lambda **_: None,
+            _spawn_background_review=lambda **_: None,
+            session_api_calls=0,
+            session_prompt_tokens=0,
+            session_completion_tokens=0,
+            session_reasoning_tokens=0,
+            session_cached_tokens=0,
+            session_total_tokens=0,
+            context_compressor=None,
+            event_callback=None,
+            _session_db=None,
+        )
+
+        result = codex_runtime.run_codex_app_server_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t",
+        )
+
+        assert result["response_previewed"] is True


### PR DESCRIPTION
## Summary
- mark a Codex app-server final response as previewed when the exact text was already emitted through the interim assistant bridge
- let the gateway's existing confirmed-delivery check suppress only the duplicate normal final send
- preserve normal final delivery when commentary differs or the interim send was not confirmed

## Root cause
The app-server bridge emits completed agentMessage items through interim_assistant_callback, but run_codex_app_server_turn omitted response_previewed. The gateway therefore delivered the same text once as commentary and again as the normal final response.

## Verification
- 102 Codex bridge, gateway delivery, and stream-consumer tests pass; 1 unrelated test skipped
- ruff passes on the changed source and test files