### PR TITLE
fix(computer-use): preserve macOS screen recording grant

### DIFF
--- a/tests/computer_use/live_cua_launchservices_daemon.py
+++ b/tests/computer_use/live_cua_launchservices_daemon.py
@@ -1,0 +1,197 @@
+"""Opt-in macOS live proof for the LaunchServices-launched private daemon.
+
+Verifies the fix for the recurring macOS Screen Recording prompt: an unrestricted
+Hermes session must start its private cua-driver daemon through LaunchServices
+(as ``com.trycua.driver``) instead of as a direct child of the Hermes process, so
+ScreenCaptureKit attributes capture to CuaDriver's existing TCC grant rather than
+to Hermes' (frequently stale-cdhash) row.
+
+Never installs, updates, grants, or resets anything. Starts one private daemon,
+asserts its TCC attribution, asserts the stdio MCP proxy reaches it without
+``--embedded``, then stops it.
+
+    .venv/bin/python tests/computer_use/live_cua_launchservices_daemon.py
+
+Exit 0 = every check passed. ``--check-imports`` resolves the import path and
+exits without touching a daemon (used by the entry-point regression test).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Running a script by path puts THIS directory on sys.path[0], never the repo
+# root, so `import tools...` would otherwise resolve through whatever
+# hermes-agent distribution the interpreter happens to have installed — which is
+# a different checkout under any shared venv. Pin this worktree first so the
+# documented command tests the code next to it, with no PYTHONPATH, cwd, or
+# editable-install assumptions.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if sys.path and sys.path[0] != str(REPO_ROOT):
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.computer_use import cua_backend  # noqa: E402  (must follow the path pin)
+
+_EmbeddedCuaDaemon = cua_backend._EmbeddedCuaDaemon
+resolve_cua_driver_app = cua_backend.resolve_cua_driver_app
+
+
+def _structured(result: Any) -> dict[str, Any]:
+    value = getattr(result, "structuredContent", None)
+    if isinstance(value, dict):
+        return value
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+    return {}
+
+
+async def _probe_proxy(command: str, args: list[str], env: dict[str, str]) -> dict[str, Any]:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=command, args=args, env=env)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = [t.name for t in (await session.list_tools()).tools]
+            perms = _structured(await session.call_tool("check_permissions", {}))
+            return {"tools": tools, "permissions": perms}
+
+
+def _socket_answers(driver_cmd: str, socket_path: str) -> bool:
+    probe = subprocess.run(
+        [driver_cmd, "status", "--socket", socket_path],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=5.0,
+    )
+    return probe.returncode == 0
+
+
+def _machine_wide_capturable(driver_cmd: str) -> Any:
+    """``screen_recording_capturable`` on the standard machine daemon, or None.
+
+    Used to tell a real regression in this change apart from a machine-level
+    capture condition: if the shared daemon reports the same value, the reading
+    is about the host, not about how our private daemon was launched.
+    """
+    try:
+        probe = subprocess.run(
+            [driver_cmd, "call", "check_permissions", "{}"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+        )
+        start = (probe.stdout or "").find("{")
+        if start == -1:
+            return None
+        return json.loads(probe.stdout[start:]).get("screen_recording_capturable")
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def _check_imports() -> int:
+    """Report which checkout ``tools.computer_use.cua_backend`` came from."""
+    origin = Path(cua_backend.__file__).resolve()
+    print(f"repo_root: {REPO_ROOT}")
+    print(f"cua_backend: {origin}")
+    if not origin.is_relative_to(REPO_ROOT):
+        print("FAIL: imported cua_backend from outside this worktree")
+        return 1
+    if not hasattr(cua_backend, "resolve_cua_driver_app"):
+        print("FAIL: imported cua_backend predates resolve_cua_driver_app")
+        return 1
+    print("PASS: imports resolve to this worktree")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if "--check-imports" in argv:
+        return _check_imports()
+
+    print(f"cua_backend: {Path(cua_backend.__file__).resolve()}")
+    if sys.platform != "darwin":
+        print("skip: macOS-only proof")
+        return 0
+
+    app = resolve_cua_driver_app()
+    print(f"CuaDriver.app: {app}")
+    if not app:
+        print("FAIL: no CuaDriver.app bundle resolved; install CuaDriver first")
+        return 1
+
+    daemon = _EmbeddedCuaDaemon("", "unrestricted")
+    launch_argv, via_launch_services = daemon._launch_command()
+    print(f"launch argv: {launch_argv}")
+
+    failures: list[str] = []
+    warnings: list[str] = []
+    if not via_launch_services or launch_argv[0] != "/usr/bin/open":
+        print("FAIL: macOS launch did not go through LaunchServices")
+        return 1
+
+    daemon.start()
+    try:
+        print(f"socket: {daemon.socket_path}")
+        command, args = daemon.proxy_invocation()
+        print(f"proxy: {command} {args}")
+        if "--embedded" in args:
+            failures.append("proxy invocation still carries --embedded")
+        report = asyncio.run(_probe_proxy(command, args, daemon.child_env()))
+        perms = report["permissions"]
+        source = perms.get("source") or {}
+        print(json.dumps({"permissions": perms, "tool_count": len(report["tools"])}, indent=2))
+        # What this lane actually changed: WHICH TCC identity the daemon runs
+        # under, and that that identity holds the Screen Recording grant.
+        if source.get("attribution") != "driver-daemon":
+            failures.append(f"attribution is {source.get('attribution')!r}, want 'driver-daemon'")
+        if source.get("responsible_ppid") != 1:
+            failures.append(f"responsible_ppid is {source.get('responsible_ppid')!r}, want 1")
+        if not str(source.get("executable", "")).startswith(app):
+            failures.append(f"executable is {source.get('executable')!r}, want inside {app}")
+        if not perms.get("screen_recording"):
+            failures.append("com.trycua.driver holds no Screen Recording grant")
+        # Whether a capture SUCCEEDS right now is host state, not attribution:
+        # a pending macOS auth-warning window or stale daemons holding
+        # ScreenCaptureKit resources flip it for every daemon on the box. Compare
+        # against the shared daemon so a host condition cannot masquerade as a
+        # regression in this change.
+        if not perms.get("screen_recording_capturable"):
+            shared = _machine_wide_capturable(daemon._command)
+            warnings.append(
+                "screen_recording_capturable is false; the shared machine daemon "
+                f"reports {shared!r} for the same check, so this is host state, "
+                "not launch attribution"
+            )
+    finally:
+        daemon.stop()
+
+    if _socket_answers(daemon._command, daemon.socket_path):
+        failures.append("daemon still answering after stop()")
+
+    for line in warnings:
+        print(f"WARN: {line}")
+    for line in failures:
+        print(f"FAIL: {line}")
+    if not failures:
+        print("PASS: LaunchServices attribution, grant, proxy, and stop all verified")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/computer_use/test_live_harness_entrypoint.py
+++ b/tests/computer_use/test_live_harness_entrypoint.py
@@ -1,0 +1,97 @@
+"""The live harness must import THIS worktree, whatever interpreter runs it.
+
+Regression for a real foreman-review failure: the documented command
+
+    .venv/bin/python tests/computer_use/live_cua_launchservices_daemon.py
+
+died with ``ImportError: cannot import name 'resolve_cua_driver_app' from
+'tools.computer_use.cua_backend' (/Users/.../.hermes/hermes-agent/tools/...)``.
+
+Running a script by path puts the script's own directory on ``sys.path[0]``, never
+the repo root, so ``import tools...`` fell through to whichever hermes-agent
+distribution the interpreter had installed — a different checkout entirely under
+any shared venv. The harness now pins its own repo root ahead of everything else.
+
+These tests exercise the real entry point in a subprocess under a hostile
+environment. They never start a daemon: ``--check-imports`` returns before the
+platform gate, so they are safe and meaningful on every OS.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS = REPO_ROOT / "tests" / "computer_use" / "live_cua_launchservices_daemon.py"
+
+
+@pytest.fixture
+def decoy_checkout(tmp_path: Path) -> Path:
+    """A fake ``tools.computer_use.cua_backend`` that wins if path order is wrong.
+
+    It deliberately lacks ``resolve_cua_driver_app``, mirroring the stale checkout
+    that produced the original ImportError.
+    """
+    package = tmp_path / "decoy" / "tools" / "computer_use"
+    package.mkdir(parents=True)
+    (package.parent / "__init__.py").write_text("")
+    (package / "__init__.py").write_text("")
+    (package / "cua_backend.py").write_text("STALE_DECOY = True\n")
+    return tmp_path / "decoy"
+
+
+def _run(*args: str, cwd: Path, env_overrides: dict[str, str] | None = None):
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env.update(env_overrides or {})
+    return subprocess.run(
+        [sys.executable, str(HARNESS), *args],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_harness_imports_this_worktree_from_an_unrelated_cwd(tmp_path):
+    proc = _run("--check-imports", cwd=tmp_path)
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert f"cua_backend: {REPO_ROOT}" in proc.stdout
+    assert "PASS: imports resolve to this worktree" in proc.stdout
+
+
+def test_harness_beats_a_stale_checkout_on_pythonpath(tmp_path, decoy_checkout):
+    """A conflicting distribution on PYTHONPATH must not win."""
+    proc = _run(
+        "--check-imports",
+        cwd=tmp_path,
+        env_overrides={"PYTHONPATH": str(decoy_checkout)},
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert f"cua_backend: {REPO_ROOT}" in proc.stdout
+    assert str(decoy_checkout) not in proc.stdout
+
+
+def test_harness_does_not_depend_on_an_inherited_pythonpath(tmp_path):
+    """With PYTHONPATH explicitly emptied, resolution still lands here."""
+    proc = _run("--check-imports", cwd=tmp_path, env_overrides={"PYTHONPATH": ""})
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert f"cua_backend: {REPO_ROOT}" in proc.stdout
+
+
+def test_check_imports_never_touches_a_daemon(tmp_path):
+    """The import probe must stay side-effect free on macOS too."""
+    proc = _run("--check-imports", cwd=tmp_path)
+
+    assert "launch argv" not in proc.stdout
+    assert "socket:" not in proc.stdout
+    assert "/usr/bin/open" not in proc.stdout

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -163,7 +163,12 @@ def test_yolo_toggle_immediately_releases_mode_dependent_backend():
     ]
 
 
-def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
+def test_unrestricted_daemon_uses_private_socket_and_two_part_ack():
+    """Direct-spawn path (no CuaDriver.app bundle installed).
+
+    The macOS LaunchServices path is covered in
+    tests/tools/test_computer_use_cua_launchservices_daemon.py.
+    """
     from tools.computer_use import cua_backend
 
     process = Mock()
@@ -178,6 +183,8 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
         cua_backend,
         "_resolve_mcp_invocation",
         return_value=("/opt/cua-driver", ["mcp"]),
+    ), patch.object(
+        cua_backend, "resolve_cua_driver_app", return_value=None
     ), patch.object(cua_backend.subprocess, "Popen", return_value=process) as popen, patch.object(
         cua_backend.subprocess, "run", side_effect=[status, stopped]
     ):

--- a/tests/tools/test_computer_use_cua_launchservices_daemon.py
+++ b/tests/tools/test_computer_use_cua_launchservices_daemon.py
@@ -1,0 +1,344 @@
+"""Regression tests for the macOS LaunchServices private-daemon launch path.
+
+Symptom: every unrestricted (YOLO) Hermes session re-triggered the macOS Screen
+Recording prompt. The private daemon was spawned as a direct child of the Hermes
+process (``cua-driver serve --embedded``), so ScreenCaptureKit attributed the
+capture to Hermes' own TCC row — whose stored cdhash goes stale on every Hermes
+rebuild — instead of to CuaDriver's long-lived grant.
+
+Fix: on macOS, when a ``CuaDriver.app`` bundle is installed, launch the private
+daemon through LaunchServices (``/usr/bin/open -n -W -a CuaDriver.app --args
+serve ...``) so it is its own responsible process under ``com.trycua.driver``.
+Isolation is unchanged: private socket, unrestricted mode, approval bypass, own
+lifecycle. Non-macOS platforms and unbundled macOS installs keep the previous
+direct ``serve --embedded`` spawn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+APP = "/Applications/CuaDriver.app"
+SERVE_POLICY = [
+    "--no-permissions-gate",
+    "--permission-mode",
+    "unrestricted",
+    "--dangerously-bypass-approvals",
+]
+
+
+def _fake_process() -> Mock:
+    process = Mock()
+    process.poll.return_value = None
+    process.stderr = []
+    process.wait.return_value = 0
+    return process
+
+
+def _status(returncode: int = 0):
+    return SimpleNamespace(returncode=returncode, stdout="running", stderr="")
+
+
+class _InlineThread:
+    """Runs the target synchronously so the stderr tail is drained on start()."""
+
+    def __init__(self, target=None, args=(), **_kwargs):
+        self._target = target
+        self._args = args
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args)
+
+
+def _make_daemon(cua_backend, platform: str):
+    with patch("tools.computer_use.cua_backend.sys.platform", platform):
+        return cua_backend._EmbeddedCuaDaemon("cua-driver", "unrestricted")
+
+
+def _start(cua_backend, daemon, platform, app, *, runs=None, process=None):
+    """Run ``daemon.start()`` with every subprocess boundary stubbed out."""
+    process = process or _fake_process()
+    with patch("tools.computer_use.cua_backend.sys.platform", platform), patch.object(
+        cua_backend, "resolve_cua_driver_app", return_value=app
+    ), patch.object(
+        cua_backend, "_resolve_mcp_invocation", return_value=("/opt/cua-driver", ["mcp"])
+    ), patch(
+        "tools.computer_use.cua_backend.threading.Thread", _InlineThread
+    ), patch.object(
+        cua_backend.subprocess, "Popen", return_value=process
+    ) as popen, patch.object(
+        cua_backend.subprocess, "run", side_effect=runs or [_status()]
+    ) as run:
+        daemon.start()
+    return popen, run
+
+
+# ---------------------------------------------------------------------------
+# App-bundle resolution
+# ---------------------------------------------------------------------------
+
+
+def test_app_bundle_is_derived_from_the_installed_binarys_bundle(tmp_path):
+    """The canonical install symlinks the CLI into CuaDriver.app/Contents/MacOS."""
+    from tools.computer_use import cua_backend
+
+    bundle = tmp_path / "CuaDriver.app"
+    binary = bundle / "Contents" / "MacOS" / "cua-driver"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\n")
+    link = tmp_path / "cua-driver"
+    link.symlink_to(binary)
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "darwin"):
+        assert cua_backend.resolve_cua_driver_app(str(link)) == str(bundle)
+
+
+def test_app_bundle_falls_back_to_applications_directories(tmp_path):
+    from tools.computer_use import cua_backend
+
+    loose = tmp_path / "cua-driver"
+    loose.write_text("#!/bin/sh\n")
+    apps = tmp_path / "Applications"
+    (apps / "CuaDriver.app").mkdir(parents=True)
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "darwin"), patch.object(
+        cua_backend, "_CUA_DRIVER_APP_SEARCH_DIRS", (str(apps),)
+    ):
+        assert cua_backend.resolve_cua_driver_app(str(loose)) == str(apps / "CuaDriver.app")
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32"])
+def test_app_bundle_resolution_is_macos_only(platform):
+    from tools.computer_use import cua_backend
+
+    with patch("tools.computer_use.cua_backend.sys.platform", platform):
+        assert cua_backend.resolve_cua_driver_app("/usr/bin/cua-driver") is None
+
+
+def test_app_bundle_is_none_when_nothing_is_installed(tmp_path):
+    from tools.computer_use import cua_backend
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "darwin"), patch.object(
+        cua_backend, "_CUA_DRIVER_APP_SEARCH_DIRS", (str(tmp_path / "nowhere"),)
+    ), patch.object(cua_backend, "resolve_cua_driver_cmd", return_value=None):
+        assert cua_backend.resolve_cua_driver_app() is None
+
+
+# ---------------------------------------------------------------------------
+# start()
+# ---------------------------------------------------------------------------
+
+
+def test_macos_daemon_launches_through_launchservices_with_private_socket():
+    from tools.computer_use import cua_backend
+
+    daemon = _make_daemon(cua_backend, "darwin")
+    popen, _ = _start(cua_backend, daemon, "darwin", APP)
+    argv = popen.call_args.args[0]
+
+    assert argv[:5] == ["/usr/bin/open", "-n", "-W", "-a", APP]
+    assert argv[argv.index("--args") + 1 :] == [
+        "serve",
+        "--socket",
+        daemon.socket_path,
+        *SERVE_POLICY,
+    ]
+    # --embedded means "inherit the host app's TCC grants", i.e. Hermes'. That
+    # host attribution is the bug; LaunchServices replaces it.
+    assert "--embedded" not in argv
+
+
+def test_macos_launch_forwards_only_cua_policy_env_never_secrets(monkeypatch):
+    """LaunchServices drops the caller's env, so policy vars ride on --env.
+
+    argv is world-readable through ``ps``, so only the non-secret cua-driver
+    policy knobs may be forwarded — never the sanitized environment wholesale.
+    """
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-leak")
+    monkeypatch.setenv("HERMES_SECRET_CANARY", "canary-must-not-leak")
+
+    daemon = _make_daemon(cua_backend, "darwin")
+    with patch.object(cua_backend, "_cua_telemetry_disabled", return_value=True):
+        popen, _ = _start(cua_backend, daemon, "darwin", APP)
+    argv = popen.call_args.args[0]
+
+    forwarded = {argv[i + 1] for i, tok in enumerate(argv) if tok == "--env"}
+    assert forwarded == {
+        "CUA_DRIVER_RS_TELEMETRY_ENABLED=0",
+        "CUA_DRIVER_PERMISSION_MODE=unrestricted",
+        "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS=1",
+    }
+    joined = " ".join(argv)
+    assert "sk-must-not-leak" not in joined
+    assert "canary-must-not-leak" not in joined
+
+
+def test_macos_without_an_app_bundle_keeps_the_direct_embedded_spawn():
+    from tools.computer_use import cua_backend
+
+    daemon = _make_daemon(cua_backend, "darwin")
+    popen, _ = _start(cua_backend, daemon, "darwin", None)
+    argv = popen.call_args.args[0]
+
+    assert argv[:2] == ["/opt/cua-driver", "serve"]
+    assert "--embedded" in argv
+    assert argv[argv.index("--socket") + 1] == daemon.socket_path
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32"])
+def test_non_macos_platforms_are_unchanged(platform):
+    from tools.computer_use import cua_backend
+
+    daemon = _make_daemon(cua_backend, platform)
+    # Even with an app path in hand, non-macOS must not route through open(1);
+    # resolve_cua_driver_app itself returns None off darwin.
+    popen, _ = _start(cua_backend, daemon, platform, None)
+    argv = popen.call_args.args[0]
+    proxy_command, proxy_args = daemon.proxy_invocation()
+
+    assert argv[:2] == ["/opt/cua-driver", "serve"]
+    assert "--embedded" in argv
+    assert "/usr/bin/open" not in argv
+    assert proxy_command == "/opt/cua-driver"
+    assert proxy_args == ["mcp", "--embedded", "--socket", daemon.socket_path]
+
+
+def test_child_env_still_carries_permission_mode_and_bypass():
+    from tools.computer_use import cua_backend
+
+    daemon = _make_daemon(cua_backend, "darwin")
+    popen, _ = _start(cua_backend, daemon, "darwin", APP)
+    env = popen.call_args.kwargs["env"]
+
+    assert env["CUA_DRIVER_PERMISSION_MODE"] == "unrestricted"
+    assert env["CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"] == "1"
+
+
+def test_each_session_gets_its_own_socket():
+    from tools.computer_use import cua_backend
+
+    first = _make_daemon(cua_backend, "darwin")
+    second = _make_daemon(cua_backend, "darwin")
+
+    assert first.socket_path != second.socket_path
+
+
+def test_readiness_polls_the_private_socket_until_the_daemon_answers():
+    from tools.computer_use import cua_backend
+
+    daemon = _make_daemon(cua_backend, "darwin")
+    _, run = _start(
+        cua_backend, daemon, "darwin", APP, runs=[_status(1), _status(0)]
+    )
+
+    probes = [call.args[0] for call in run.call_args_list]
+    assert probes == [
+        ["/opt/cua-driver", "status", "--socket", daemon.socket_path],
+        ["/opt/cua-driver", "status", "--socket", daemon.socket_path],
+    ]
+
+
+def test_launcher_exiting_early_raises_with_the_stderr_tail():
+    from tools.computer_use import cua_backend
+
+    process = _fake_process()
+    process.poll.return_value = 1
+    process.stderr = ["Unable to find application named 'CuaDriver'"]
+    daemon = _make_daemon(cua_backend, "darwin")
+
+    with pytest.raises(RuntimeError, match="Unable to find application"):
+        _start(cua_backend, daemon, "darwin", APP, process=process, runs=[_status(1)])
+
+
+# ---------------------------------------------------------------------------
+# proxy_invocation()
+# ---------------------------------------------------------------------------
+
+
+def test_launchservices_proxy_targets_the_socket_without_embedded():
+    from tools.computer_use import cua_backend
+
+    daemon = _make_daemon(cua_backend, "darwin")
+    _start(cua_backend, daemon, "darwin", APP)
+    command, args = daemon.proxy_invocation()
+
+    assert command == "/opt/cua-driver"
+    assert args == ["mcp", "--socket", daemon.socket_path]
+
+
+def test_proxy_invocation_refuses_when_the_daemon_is_gone():
+    from tools.computer_use import cua_backend
+
+    process = _fake_process()
+    daemon = _make_daemon(cua_backend, "darwin")
+    _start(cua_backend, daemon, "darwin", APP, process=process)
+    process.poll.return_value = 0
+
+    with pytest.raises(RuntimeError):
+        daemon.proxy_invocation()
+
+
+# ---------------------------------------------------------------------------
+# stop()
+# ---------------------------------------------------------------------------
+
+
+def test_stop_shuts_the_daemon_down_over_its_private_socket():
+    """``stop --socket`` ends the daemon, which lets ``open -W`` exit on its own."""
+    from tools.computer_use import cua_backend
+
+    process = _fake_process()
+    daemon = _make_daemon(cua_backend, "darwin")
+    _start(cua_backend, daemon, "darwin", APP, process=process)
+
+    with patch.object(cua_backend.subprocess, "run", return_value=_status()) as run:
+        daemon.stop()
+
+    assert run.call_args.args[0] == [
+        "/opt/cua-driver",
+        "stop",
+        "--socket",
+        daemon.socket_path,
+    ]
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()
+
+
+def test_stop_is_idempotent_after_the_daemon_already_exited():
+    from tools.computer_use import cua_backend
+
+    process = _fake_process()
+    daemon = _make_daemon(cua_backend, "darwin")
+    _start(cua_backend, daemon, "darwin", APP, process=process)
+    process.poll.return_value = 0
+
+    with patch.object(cua_backend.subprocess, "run") as run:
+        daemon.stop()
+        daemon.stop()
+
+    run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Backend wiring
+# ---------------------------------------------------------------------------
+
+
+def test_backend_still_gates_the_private_daemon_on_unrestricted_mode():
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    assert CuaDriverBackend(permission_mode="standard")._embedded_daemon is None
+    assert CuaDriverBackend(permission_mode="unrestricted")._embedded_daemon is not None
+
+
+def test_daemon_rejects_any_mode_other_than_unrestricted():
+    from tools.computer_use import cua_backend
+
+    with pytest.raises(ValueError):
+        cua_backend._EmbeddedCuaDaemon("cua-driver", "standard")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -380,16 +380,71 @@ def _wsl_windows_path_to_posix(path: str) -> str:
     return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
 
 
+# macOS launches the private daemon through LaunchServices so it gets the
+# CuaDriver TCC identity instead of Hermes'. See _EmbeddedCuaDaemon.
+_MACOS_OPEN = "/usr/bin/open"
+_CUA_DRIVER_APP_NAME = "CuaDriver.app"
+_CUA_DRIVER_APP_SEARCH_DIRS = ("/Applications", "~/Applications")
+_BUNDLE_BINARY_MARKER = os.path.join("Contents", "MacOS") + os.sep
+
+
+def _app_bundle_for_binary(binary: str) -> Optional[str]:
+    """Return the ``.app`` bundle whose ``Contents/MacOS`` holds *binary*."""
+    head, marker, _ = os.path.realpath(binary).partition(_BUNDLE_BINARY_MARKER)
+    bundle = head.rstrip(os.sep) if marker else ""
+    return bundle if bundle.endswith(".app") and os.path.isdir(bundle) else None
+
+
+def resolve_cua_driver_app(driver_cmd: Optional[str] = None) -> Optional[str]:
+    """Path to the installed ``CuaDriver.app``, or ``None`` (macOS only).
+
+    The canonical installer symlinks the CLI into the bundle, so the resolved
+    binary's real path is the most reliable pointer; the Applications
+    directories are the fallback for a relocated CLI.
+    """
+    if sys.platform != "darwin":
+        return None
+    binary = driver_cmd or resolve_cua_driver_cmd()
+    bundle = _app_bundle_for_binary(binary) if binary else None
+    if bundle:
+        return bundle
+    for root in _CUA_DRIVER_APP_SEARCH_DIRS:
+        candidate = os.path.join(os.path.expanduser(root), _CUA_DRIVER_APP_NAME)
+        if os.path.isdir(candidate):
+            return candidate
+    return None
+
+
+
 class _EmbeddedCuaDaemon:
     """Private host-owned daemon used for an explicit unrestricted session.
 
     Cua Driver permission mode is immutable after daemon startup.  Reusing the
     machine-wide daemon would therefore let one Hermes session's YOLO choice
-    affect another session.  A private embedded daemon gives the requesting
-    session its own socket, process, and launch-time risk acknowledgement.
+    affect another session.  A private daemon gives the requesting session its
+    own socket, process, and launch-time risk acknowledgement.
+
+    On macOS the daemon is launched through LaunchServices (``open -n -W -a
+    CuaDriver.app``) instead of spawned directly: a direct child inherits Hermes
+    as its responsible process, so ScreenCaptureKit consults *Hermes'* Screen
+    Recording row — whose stored cdhash goes stale on every Hermes rebuild,
+    re-prompting on each unrestricted session. Under LaunchServices it is its
+    own responsible process (``com.trycua.driver``) and reuses CuaDriver's
+    grant. Isolation is unchanged; platforms with no app bundle keep the direct
+    ``serve --embedded`` spawn.
     """
 
     _START_TIMEOUT_SECONDS = 15.0
+
+    # Policy flags that make this daemon the session's own unrestricted one.
+    _SERVE_POLICY_ARGS = (
+        "--no-permissions-gate", "--permission-mode", "unrestricted",
+        "--dangerously-bypass-approvals",
+    )
+    _FORWARDED_ENV_KEYS = (
+        _CUA_TELEMETRY_ENV_VAR, "CUA_DRIVER_PERMISSION_MODE",
+        "CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS",
+    )
 
     def __init__(self, driver_cmd: str, permission_mode: str) -> None:
         if permission_mode != "unrestricted":
@@ -399,6 +454,7 @@ class _EmbeddedCuaDaemon:
         self._command = driver_cmd
         self._mcp_args: List[str] = list(_CUA_DRIVER_ARGS)
         self._process: Any = None
+        self._via_launch_services = False
         self._stderr_tail: deque[str] = deque(maxlen=20)
         self._stderr_thread: Optional[threading.Thread] = None
         token = uuid.uuid4().hex[:12]
@@ -414,6 +470,45 @@ class _EmbeddedCuaDaemon:
         env["CUA_DRIVER_PERMISSION_MODE"] = "unrestricted"
         env["CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS"] = "1"
         return env
+
+    def _ensure_driver_cmd(self) -> str:
+        if not self._driver_cmd:
+            self._driver_cmd = resolve_cua_driver_cmd() or ""
+        if not self._driver_cmd:
+            raise RuntimeError(cua_driver_install_hint())
+        return self._driver_cmd
+
+    def _launch_env_args(self, env: Dict[str, str]) -> List[str]:
+        """``open --env`` pairs: LaunchServices drops the caller's environment,
+        and cua-driver's telemetry opt-out is env-only. Non-secret knobs only —
+        argv is world-readable via ``ps``."""
+        return [
+            arg
+            for key in self._FORWARDED_ENV_KEYS
+            if env.get(key) is not None
+            for arg in ("--env", f"{key}={env[key]}")
+        ]
+
+    def _launch_command(
+        self, env: Optional[Dict[str, str]] = None
+    ) -> Tuple[List[str], bool]:
+        """Return ``(argv, via_launch_services)`` for this session's daemon."""
+        driver_cmd = self._ensure_driver_cmd()
+        serve_args = ["--socket", self.socket_path, *self._SERVE_POLICY_ARGS]
+        app = resolve_cua_driver_app(driver_cmd)
+        if app is None:
+            # No app bundle (Windows, Linux, unbundled macOS): historical direct
+            # spawn. ``--embedded`` inherits the host's TCC grants, which is
+            # what you want when the host IS the responsible process.
+            command = self._command or driver_cmd
+            return [command, "serve", "--embedded", *serve_args], False
+        # -n: our own instance, never a shared one. -W: the handle we hold stays
+        # alive for exactly as long as that instance does.
+        return [
+            _MACOS_OPEN, "-n", "-W", "-a", app,
+            *self._launch_env_args(env if env is not None else self.child_env()),
+            "--args", "serve", *serve_args,
+        ], True
 
     def _drain_stderr(self, process: Any) -> None:
         stream = getattr(process, "stderr", None)
@@ -433,23 +528,10 @@ class _EmbeddedCuaDaemon:
             return
         from tools.environments.local import _sanitize_subprocess_env
 
-        if not self._driver_cmd:
-            self._driver_cmd = resolve_cua_driver_cmd() or ""
-        if not self._driver_cmd:
-            raise RuntimeError(cua_driver_install_hint())
-        self._command, self._mcp_args = _resolve_mcp_invocation(self._driver_cmd)
+        driver_cmd = self._ensure_driver_cmd()
+        self._command, self._mcp_args = _resolve_mcp_invocation(driver_cmd)
         env = _sanitize_subprocess_env(self.child_env())
-        command = [
-            self._command,
-            "serve",
-            "--embedded",
-            "--socket",
-            self.socket_path,
-            "--no-permissions-gate",
-            "--permission-mode",
-            "unrestricted",
-            "--dangerously-bypass-approvals",
-        ]
+        command, self._via_launch_services = self._launch_command(env)
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.DEVNULL,
@@ -495,9 +577,13 @@ class _EmbeddedCuaDaemon:
     def proxy_invocation(self) -> Tuple[str, List[str]]:
         if self._process is None or self._process.poll() is not None:
             raise RuntimeError("embedded cua-driver daemon is not running")
+        # ``--embedded`` makes the proxy claim the HOST's TCC identity for
+        # check_permissions and suppresses daemon relaunch.  A LaunchServices
+        # daemon owns its own identity, so the proxy must not overlay Hermes'.
+        host_args = [] if self._via_launch_services else ["--embedded"]
         return self._command, [
             *self._mcp_args,
-            "--embedded",
+            *host_args,
             "--socket",
             self.socket_path,
         ]

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -420,10 +420,16 @@ HERMES_CUA_DRIVER_CMD=/path/to/cua/libs/cua-driver/rust/target/debug/cua-driver
 
 - **Hermes spawns a `cua-driver mcp` stdio proxy.** In a normal session the
   proxy connects to (and may start) the standard machine daemon. In explicit
-  Hermes YOLO, Hermes instead owns a private `cua-driver serve --embedded`
-  child and points the proxy at its private socket or named pipe. The Windows
-  autostart/UIAccess pattern still matters for interactive Session 1+ input
-  from SSH — see the Limitations section.
+  Hermes YOLO, Hermes owns a private daemon on its own socket or named pipe and
+  points the proxy at it. On macOS that private daemon is started through
+  LaunchServices (`open -n -W -a CuaDriver.app --args serve ...`) so it is its
+  own responsible process under `com.trycua.driver` and reuses CuaDriver's
+  Screen Recording grant; a direct child would be attributed to Hermes and
+  re-prompt on every session. Where no `CuaDriver.app` bundle exists (Windows,
+  Linux, an unbundled macOS install) Hermes spawns `cua-driver serve
+  --embedded` directly instead. The Windows autostart/UIAccess pattern still
+  matters for interactive Session 1+ input from SSH — see the Limitations
+  section.
 - **Locked binary on Windows.** A running `cua-driver-serve` daemon can
   hold `cua-driver.exe` and block an overwrite on rebuild.
   `install-local.ps1` renames the locked binary out of the way


### PR DESCRIPTION
## Summary

- Start unrestricted macOS CuaDriver daemons through LaunchServices.
- Use the granted `com.trycua.driver` Screen Recording identity.
- Preserve each private socket and all permission arguments.
- Keep the original direct launch path when no application bundle exists.
- Add focused regression tests and a real macOS verification harness.

## Cause

Hermes started `cua-driver serve --embedded` as its direct child.

macOS then treated Hermes as the responsible screen capture process. Hermes uses an ad-hoc signature, which changes after rebuilds. Its stored privacy requirement became stale.

System Settings still showed Hermes enabled. Screen capture still failed because the current Hermes build no longer matched the stored requirement.

## Verification

- `scripts/run_tests.sh tests/tools/test_computer_use_cua_0_9.py tests/tools/test_computer_use_cua_0_10_permissions.py tests/tools/test_computer_use_cua_launchservices_daemon.py tests/computer_use/test_live_harness_entrypoint.py`
  - 70 tests passed.
- Ruff passed on all changed Python files.
- The live macOS harness reported:
  - `screen_recording: true`
  - `screen_recording_capturable: true`
  - `attribution: driver-daemon`
  - CuaDriver parent process ID `1`
  - 38 Model Context Protocol tools available
- The private daemon stopped and removed its socket after verification.
