### PR TITLE
chore: contributor email mapping for junhohong

### DIFF
--- a/contributors/emails/jun@junho.co
+++ b/contributors/emails/jun@junho.co
@@ -1,0 +1,1 @@
+junhohong


### PR DESCRIPTION
Maps jun@junho.co -> junhohong for release attribution. Unblocks #77692 (check-attribution failure).