### PR TITLE
fix(desktop): rename misleading 'Actual Size' zoom menu item

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5428,7 +5428,11 @@ function buildApplicationMenu() {
       { role: 'toggleDevTools' },
       { type: 'separator' },
       {
-        label: 'Actual Size',
+        // Not Chromium's "Actual Size" (100%) — resets to our shipped 90%
+        // default (see DEFAULT_ZOOM_LEVEL in zoom.ts). The old "Actual Size"
+        // label misled users into thinking ⌘0 restored 100%, when it silently
+        // overwrote their chosen UI Scale (e.g. 110%) with 90%.
+        label: 'Reset Zoom to Default (90%)',
         accelerator: 'CommandOrControl+0',
         click: () => {
           setAndPersistZoomLevel(mainWindow, DEFAULT_ZOOM_LEVEL)
@@ -5600,7 +5604,8 @@ function installZoomShortcuts(window) {
   // is 0.1 vs Chromium's 0.2). The menu items handle this on macOS (where the
   // menu is always present), but on Linux/Windows the menu is null and
   // Chromium's default handler would use the full 0.2 step, so we intercept
-  // here for consistency. Ctrl/Cmd+0 resets to DEFAULT_ZOOM_LEVEL, not Chromium 0.
+  // here for consistency. Ctrl/Cmd+0 resets to DEFAULT_ZOOM_LEVEL (our shipped
+  // 90% preset), NOT Chromium's 0/100% "actual size" — see the View menu item.
   window.webContents.on('before-input-event', (event, input) => {
     const mod = IS_MAC ? input.meta : input.control
 

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -18,7 +18,7 @@ const MAX_ZOOM_LEVEL = 9
 /** Half Chromium's default step; matching the shortcuts and View menu. */
 export const ZOOM_STEP = 0.1
 
-/** Appearance 90% preset. Fresh installs + Actual Size / Ctrl+0. */
+/** Appearance 90% preset. Fresh installs + View menu "Reset Zoom to Default" / Ctrl+0. */
 export const DEFAULT_ZOOM_LEVEL = Math.log(0.9) / Math.log(ZOOM_FACTOR_BASE)
 
 export function clampZoomLevel(value) {


### PR DESCRIPTION
## Summary
The View menu's ⌘0 item is labeled **"Actual Size"** but it doesn't reset zoom to Chromium's true 100% baseline — it resets to our shipped 90% default (`DEFAULT_ZOOM_LEVEL` in `zoom.ts`, set in #73161).

Users who set a custom UI Scale in Appearance settings (e.g. 110%) and then hit ⌘0, or click View > Actual Size, get their preference silently overwritten with 90%, with no indication why the UI keeps 'resetting' back to 90%. Reported by a user who set 110% and kept seeing the app snap back to 90%.

## Change
- Renamed the View menu item from `Actual Size` to `Reset Zoom to Default (90%)` so the label matches the actual behavior.
- Updated the surrounding code comments in `main.ts` and `zoom.ts` to spell out that ⌘0 targets `DEFAULT_ZOOM_LEVEL` (90%), not Chromium's 0/100% actual-size baseline.
- No behavior change — purely a label/comment fix so users aren't misled about what ⌘0 does.

## Test Plan
- `vitest run electron/zoom.test.ts` — 17/17 passing (pure zoom-logic tests unaffected by the label change).
- `tsc --noEmit` in `apps/desktop` — clean.
