### PR TITLE
fix(api): trigger automatic session title generation on /v1/runs completion (#78342)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6532,6 +6532,29 @@ class APIServerAdapter(BasePlatformAdapter):
                                 conversation_history=conversation_history,
                                 task_id=effective_task_id,
                             )
+                            # Auto-generate session title after the first
+                            # exchange, mirroring the regular Gateway runner
+                            # (gateway/run.py). The /v1/runs API path runs its
+                            # own agent lifecycle and previously never fired
+                            # maybe_auto_title, so sessions started through the
+                            # API kept their provisional title (#78342).
+                            if isinstance(r, dict) and r.get("final_response"):
+                                try:
+                                    from agent.title_generator import maybe_auto_title
+                                    all_msgs = r.get("messages", []) or []
+                                    _title_eff_sid = getattr(agent, "session_id", None) or session_id or run_id
+                                    maybe_auto_title(
+                                        self._ensure_session_db(),
+                                        _title_eff_sid,
+                                        user_message,
+                                        r.get("final_response", ""),
+                                        all_msgs,
+                                    )
+                                except Exception:
+                                    logger.debug(
+                                        "API /v1/runs auto-title trigger failed (harmless)",
+                                        exc_info=True,
+                                    )
                         finally:
                             # Worker finished (interrupted or complete) —
                             # clear turn ownership immediately so a later

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -331,6 +331,59 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_completed_run_triggers_auto_title(self, adapter):
+        """/v1/runs should trigger automatic session title generation after
+        the first exchange, matching the regular Gateway runner (#78342)."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent") as mock_create,
+                patch("agent.title_generator.maybe_auto_title") as mock_title,
+            ):
+                mock_agent = MagicMock()
+                mock_agent.session_id = "sess-1"
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Hello!",
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {"role": "assistant", "content": "Hello!"},
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "sess-1"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                # Wait for the background run task to finish so the
+                # maybe_auto_title trigger has a chance to fire.
+                for _ in range(50):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+                else:
+                    raise AssertionError("run never reached completed status")
+
+                mock_title.assert_called_once()
+                call_args = mock_title.call_args
+                assert call_args.args[1] == "sess-1"
+                assert call_args.args[2] == "hello"
+                assert call_args.args[3] == "Hello!"
+                assert call_args.args[4] == [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "Hello!"},
+                ]
+
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):


### PR DESCRIPTION
## Summary

`/v1/runs` runs its own agent lifecycle and never fired the automatic session-title generation that the regular Gateway runner (`gateway/run.py`) performs after the first exchange. Sessions started through the API kept their provisional title (e.g. the first user message as assigned by clients like Hermes WebUI) instead of getting a generated one.

This change mirrors the `maybe_auto_title` trigger from `gateway/run.py` in the `/v1/runs` completion path: after a run finishes with a non-empty `final_response`, it fire-and-forgets `agent.title_generator.maybe_auto_title` with the effective session id, the user message, the response, and the run's messages. Failures are logged at debug level only (same non-user-visible convention as the Gateway runner).

## Tests

- Added `test_completed_run_triggers_auto_title` to `tests/gateway/test_api_server_runs.py` — asserts `maybe_auto_title` is called once with the session id, user message, final response, and message list after a run completes.
- `tests/gateway/test_api_server_runs.py`: 17 passed
- `tests/gateway/test_api_server.py`: 99 passed
- `tests/agent/test_title_generator.py`: 15 passed

Closes #78342
