### PR TITLE
fix(pairing): refuse to rewrite an approved store that could not be read

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -43,6 +43,16 @@ from utils import atomic_replace
 logger = logging.getLogger(__name__)
 
 
+class PairingStoreUnreadableError(RuntimeError):
+    """A pairing file exists but could not be read, so it must not be rewritten.
+
+    Raised only on read-modify-write paths (see
+    ``PairingStore._load_json_for_update``). Read-only lookups keep failing
+    closed with an empty result — an unreadable whitelist denies access, it
+    does not grant it.
+    """
+
+
 # Unambiguous alphabet -- excludes 0/O, 1/I to prevent confusion
 ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 CODE_LENGTH = 8
@@ -496,6 +506,39 @@ class PairingStore:
                 return {}
         return {}
 
+    def _load_json_for_update(self, path: Path) -> dict:
+        """``_load_json`` for read-modify-write callers — never degrades.
+
+        ``_load_json`` collapses "file does not exist yet" and "file exists but
+        I could not read or parse it" into the same empty dict. That is the
+        right fail-closed answer for a *read* (an unreadable whitelist must
+        deny, not grant), but it is destructive for a *write*: the caller adds
+        its one entry to that empty dict and ``_save_json`` atomically replaces
+        the file, so every previously approved user is gone from disk for good.
+
+        The read failure on its own is recoverable — repair the file and the
+        whitelist is back. The write is what makes it permanent. Both real
+        triggers land in the same branch: a root-owned 0600 file under a
+        hermes-owned directory (issue #10270, the ``docker exec`` symptom) is
+        unreadable yet still atomically replaceable, and a truncated restore or
+        stray editor write leaves readable bytes that are invalid JSON.
+
+        Refuse instead — the same stance ``cron.jobs.load_jobs`` already takes
+        when the job database will not parse.
+        """
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise PairingStoreUnreadableError(
+                f"Refusing to rewrite {path}: the existing pairing file could not be "
+                f"read ({exc}). Writing now would replace it with only the new entry "
+                f"and permanently drop every user already approved. Repair the file "
+                f"(or fix its ownership/permissions) and retry."
+            ) from exc
+        return data if isinstance(data, dict) else {}
+
     def _save_json(self, path: Path, data: dict) -> None:
         _secure_write(path, json.dumps(data, indent=2, ensure_ascii=False))
 
@@ -533,7 +576,7 @@ class PairingStore:
 
     def _approve_user(self, platform: str, user_id: str, user_name: str = "") -> None:
         """Add a user to the approved list. Must be called under self._lock."""
-        approved = self._load_json(self._approved_path(platform))
+        approved = self._load_json_for_update(self._approved_path(platform))
         normalized_user_id = self._normalize_user_id(platform, user_id)
         duplicate_ids = [
             approved_user_id
@@ -586,6 +629,10 @@ class PairingStore:
         self, platform: str, pending: dict, matched_key: str, matched_entry: dict
     ) -> dict:
         """Remove a pending request and approve its user. Must hold self._lock."""
+        # Prove the approved store is rewritable BEFORE consuming the pending
+        # entry. _approve_user runs last, so a refusal raised there would
+        # otherwise burn the requester's one-time code without approving them.
+        self._load_json_for_update(self._approved_path(platform))
         del pending[matched_key]
         self._save_json(self._pending_path(platform), pending)
 

--- a/tests/gateway/test_pairing_unreadable_approved_store.py
+++ b/tests/gateway/test_pairing_unreadable_approved_store.py
@@ -1,0 +1,141 @@
+"""Approving a user must never rewrite an approved store it could not read.
+
+``PairingStore._load_json`` returns ``{}`` both when a pairing file does not
+exist yet and when it exists but could not be read or parsed. For a lookup that
+is the correct fail-closed answer. For ``_approve_user`` it was destructive: the
+one new entry was added to that empty dict and ``_save_json`` atomically
+replaced the file, so every previously approved user was gone from disk.
+
+The read failure alone is recoverable; the write made it permanent. Two real
+triggers land in the same branch — a root-owned 0600 file under a hermes-owned
+directory (issue #10270, the ``docker exec`` symptom) is unreadable yet still
+atomically replaceable, and a truncated restore leaves readable bytes that are
+invalid JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import gateway.pairing as pairing_mod
+
+# Resolved lazily, never bound at import time: a sibling suite
+# (test_pairing_allowlist_bypass.py) calls importlib.reload on this module, and
+# a class captured here would go stale and stop matching the raised instance.
+def _unreadable_error():
+    return pairing_mod.PairingStoreUnreadableError
+
+
+EXISTING = {
+    "111": {"user_name": "alice", "approved_at": 1.0},
+    "222": {"user_name": "bob", "approved_at": 2.0},
+    "333": {"user_name": "carol", "approved_at": 3.0},
+}
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    s = pairing_mod.PairingStore()
+    # Pin the store directory per test: PairingStore resolves it through
+    # get_hermes_dir(), which is shared enough that the per-user pairing
+    # rate limit would leak between tests.
+    s._dir = tmp_path / "pairing"
+    s._dir.mkdir(parents=True, exist_ok=True)
+    return s
+
+
+def _seed_approved(store) -> Path:
+    path = store._approved_path("telegram")
+    path.write_text(json.dumps(EXISTING, indent=2), encoding="utf-8")
+    return path
+
+
+class TestApproveRefusesUnreadableApprovedStore:
+    def test_approve_code_refuses_and_leaves_the_file_byte_identical(self, store):
+        path = _seed_approved(store)
+        code = store.generate_code("telegram", "999", "dave")
+        assert code
+
+        path.write_text('{"111": {"user_name": "alice",', encoding="utf-8")
+        before = path.read_bytes()
+
+        with pytest.raises(_unreadable_error()):
+            store.approve_code("telegram", code)
+
+        assert path.read_bytes() == before
+
+    def test_refusal_does_not_burn_the_one_time_code(self, store):
+        """The pending entry must survive so a repaired store can still pair."""
+        path = _seed_approved(store)
+        code = store.generate_code("telegram", "999", "dave")
+        path.write_text("not json at all", encoding="utf-8")
+
+        with pytest.raises(_unreadable_error()):
+            store.approve_code("telegram", code)
+
+        # Repair the store — the same code must still work.
+        path.write_text(json.dumps(EXISTING, indent=2), encoding="utf-8")
+        assert store.approve_code("telegram", code) == {
+            "user_id": "999",
+            "user_name": "dave",
+        }
+        saved = json.loads(path.read_text(encoding="utf-8"))
+        assert set(saved) == {"111", "222", "333", "999"}
+
+    def test_approve_request_is_guarded_too(self, store):
+        path = _seed_approved(store)
+        store.generate_code("telegram", "999", "dave")
+        pending = store._load_json(store._pending_path("telegram"))
+        request_id = next(iter(pending))
+
+        path.write_text("{oops", encoding="utf-8")
+        before = path.read_bytes()
+
+        with pytest.raises(_unreadable_error()):
+            store.approve_request("telegram", request_id)
+
+        assert path.read_bytes() == before
+
+
+class TestUnaffectedPaths:
+    def test_first_ever_approval_still_creates_the_file(self, store):
+        path = store._approved_path("telegram")
+        assert not path.exists()
+
+        code = store.generate_code("telegram", "999", "dave")
+        assert store.approve_code("telegram", code) is not None
+        assert set(json.loads(path.read_text(encoding="utf-8"))) == {"999"}
+
+    def test_normal_approval_preserves_existing_users(self, store):
+        path = _seed_approved(store)
+        code = store.generate_code("telegram", "999", "dave")
+
+        assert store.approve_code("telegram", code) is not None
+
+        saved = json.loads(path.read_text(encoding="utf-8"))
+        assert set(saved) == {"111", "222", "333", "999"}
+
+    def test_lookups_still_fail_closed_without_raising(self, store):
+        """An unreadable whitelist must deny, not raise, on the read path."""
+        path = _seed_approved(store)
+        path.write_text("{broken", encoding="utf-8")
+
+        assert store.is_approved("telegram", "222") is False
+        assert store.list_approved("telegram") == []
+
+    def test_revoke_on_unreadable_store_reports_not_found_and_writes_nothing(
+        self, store
+    ):
+        path = _seed_approved(store)
+        path.write_text("{broken", encoding="utf-8")
+        before = path.read_bytes()
+
+        assert store.revoke("telegram", "222") is False
+        assert path.read_bytes() == before


### PR DESCRIPTION
## What does this PR do?

`PairingStore._load_json` returns `{}` in two very different situations: the
pairing file **does not exist yet**, and the file **exists but could not be read
or parsed**. For a lookup that is the correct fail-closed answer — an unreadable
whitelist must deny, not grant.

`_approve_user` used that same reader immediately before a full-file rewrite:

```python
approved = self._load_json(self._approved_path(platform))   # {} on read failure
approved[normalized_user_id] = {...}
self._save_json(self._approved_path(platform), approved)    # atomic replace
```

So approving **one** user replaced the file with **only** that user, erasing
every previously approved account.

The read failure on its own is recoverable — repair the file and the whitelist
is back. The write is what makes it permanent: a transient inability to read
turns into irreversible loss of the gateway's authorization list.

### Both triggers land in that same branch

- **Unreadable.** A root-owned `0600` pairing file inside a hermes-owned
  directory — the `docker exec <container> hermes pairing approve` symptom
  already documented in #10270 and warned about in `_load_json` — cannot be
  read, but *can* still be atomically replaced, because replacing needs write
  permission on the **directory**, not on the file.
- **Unparsable.** A truncated restore, a `docker cp` of a partial file, or a
  stray editor write leaves perfectly readable bytes that are invalid JSON.

### Reproduction (before this PR)

```text
approved.json BEFORE : ['111', '222', '333']       # alice, bob, carol
is_approved(222)     : True

# file becomes unparsable
_load_json() returns : {}
is_approved(222)     : False          <- denied, but still recoverable

# one new user pairs and is approved
approve_code -> {'user_id': '999', 'user_name': 'dave'}

approved.json AFTER  : {"999": {"user_name": "dave", ...}}

==== VERDICT ====
  alice  (111) still approved: False
  bob    (222) still approved: False
  carol  (333) still approved: False
```

The original bytes are gone. There is no copy and no backup — every paired user
must re-pair.

## Related Issue

Same failure mode `_load_json`'s `PermissionError` branch was hardened for in
#10270; that fix made the read loud, but left the write path able to act on the
empty result it returns.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/pairing.py`** — new `PairingStore._load_json_for_update()`: same
  read, but raises `PairingStoreUnreadableError` when the file exists and will
  not parse. This is the stance `cron.jobs.load_jobs` already takes for a
  corrupt job database.
- **`gateway/pairing.py`** — `_approve_user()` reads through the new helper.
- **`gateway/pairing.py`** — the same check runs at the top of
  `_finish_approval()`, *before* the pending entry is consumed, so a refused
  approval does not burn the requester's one-time code. Repair the file and the
  same code still works.
- **`tests/gateway/test_pairing_unreadable_approved_store.py`** — 7 tests.

### Deliberately narrow

Only the approved store is guarded, because it is the only one whose loss is
permanent and user-visible:

| Path | Why it is untouched |
|---|---|
| `is_approved`, `list_approved` | read-only — must keep failing closed with `{}`, not raise |
| `revoke` | already a no-op on an empty load (no match → no write) |
| `clear_pending` | writes `{}` on purpose |
| `_rate_limits.json` | ephemeral counters; losing them is harmless |
| pending stores | codes are TTL-bound and self-heal; raising here would block all pairing over a throwaway file |

## How to Test

1. Approve two or three users on a platform.
2. Corrupt `~/.hermes/platforms/pairing/<platform>-approved.json` (truncate it),
   or make it unreadable to the gateway user.
3. Approve a new user.
4. **Before:** the call succeeds and the file now contains only the new user —
   everyone else is permanently gone.
   **After:** it raises with
   `Refusing to rewrite …: the existing pairing file could not be read (…).
   Writing now would replace it with only the new entry and permanently drop
   every user already approved.` and the file is **byte-identical** to before.

## Test Results

New file `tests/gateway/test_pairing_unreadable_approved_store.py` — 7 tests
driving the real `PairingStore` against a temp store directory:

| Group | Covers |
|---|---|
| `TestApproveRefusesUnreadableApprovedStore` | `approve_code` refuses + file byte-identical; the refusal does not burn the one-time code (repair → same code still pairs, and all four users end up saved); `approve_request` guarded too |
| `TestUnaffectedPaths` | first-ever approval still creates the file; a normal approval still preserves existing users; lookups still fail closed **without** raising; `revoke` on an unreadable store reports not-found and writes nothing |

Red-without-fix, with only the two `_load_json_for_update` call sites reverted:

```text
3 failed, 4 passed
```

With the fix:

```text
7 passed in 3.05s
```

**Regression sweep**

```text
full pairing suite (test_pairing, allowlist_bypass, multiplex_pairing_stores,
internal_event_bypass_pairing + new file):     53 passed, 1 skipped
```

Whole `tests/gateway/` directory, run the same way on both sides:

```text
clean main:      72 failed, 4769 passed
with this fix:   71 failed, 4777 passed
```

The failures are identical pre-existing ones in unrelated files (feishu,
runtime_footer, update, discord, systemd) — none of them touch pairing.

One note for reviewers on the test file: it resolves `PairingStore` and
`PairingStoreUnreadableError` off the module at call time rather than binding
them at import. `tests/gateway/test_pairing_allowlist_bypass.py` calls
`importlib.reload(gateway.pairing)`, which swaps the class objects, so an
import-time binding silently stops matching the raised instance depending on
test order.