### PR TITLE
fix(dashboard): don't hijack session resume into delegate subagent sessions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11222,6 +11222,13 @@ def _session_latest_descendant(session_id: str, db):
             except Exception:
                 return None
 
+    def is_delegate_model_config(model_config):
+        try:
+            parsed = json.loads(model_config or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return False
+        return isinstance(parsed, dict) and parsed.get("_delegate_from") is not None
+
     sid = db.resolve_session_id(session_id)
     if not sid or not db.get_session(sid):
         return None, []
@@ -11243,19 +11250,17 @@ def _session_latest_descendant(session_id: str, db):
                 SELECT s.id, s.parent_session_id, s.started_at, s.model_config
                 FROM sessions s
                 JOIN descendants d ON s.parent_session_id = d.id
+                WHERE CASE
+                    WHEN json_valid(s.model_config)
+                    THEN json_extract(s.model_config, '$._delegate_from') IS NULL
+                    ELSE 1
+                END
             )
             SELECT id, parent_session_id, started_at, model_config FROM descendants
             """,
             (sid,),
         ).fetchall()
         for row in raw_rows:
-            # Skip delegate subagent sessions: they are not continuation
-            # targets (see docstring). The tag lives in model_config as
-            # "_delegate_from": "<parent session id>", written by
-            # delegate_tool when spawning the child.
-            model_config = row_get(row, "model_config", 3) or ""
-            if "_delegate_from" in model_config:
-                continue
             rows.append({
                 "id": row_get(row, "id", 0),
                 "parent_session_id": row_get(row, "parent_session_id", 1),
@@ -11265,7 +11270,7 @@ def _session_latest_descendant(session_id: str, db):
         rows = db.list_sessions_rich(limit=10000, offset=0, compact_rows=True)
         rows = [
             r for r in rows
-            if "_delegate_from" not in (r.get("model_config") or "")
+            if not is_delegate_model_config(r.get("model_config"))
         ]
 
     children = {}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11055,6 +11055,14 @@ def _session_latest_descendant(session_id: str, db):
 
     /model may create child sessions. Dashboard refresh should continue the
     newest child instead of reopening the old parent.
+
+    Delegate subagent sessions (created via the delegate_task tool, tagged in
+    ``model_config._delegate_from``) are NOT continuation targets: they are
+    short-lived parallel workers spawned *by* the parent, not forks the user
+    chose to continue. Including them hijacks the resume — clicking the parent
+    session in the dashboard silently opens the newest subagent session
+    instead. The recursion skips them, so a parent with only delegate children
+    resolves back to itself.
     """
     def row_get(row, key, index):
         if isinstance(row, dict):
@@ -11082,18 +11090,25 @@ def _session_latest_descendant(session_id: str, db):
     if conn is not None:
         raw_rows = conn.execute(
             """
-            WITH RECURSIVE descendants(id, parent_session_id, started_at) AS (
-                SELECT id, parent_session_id, started_at FROM sessions WHERE id = ?
+            WITH RECURSIVE descendants(id, parent_session_id, started_at, model_config) AS (
+                SELECT id, parent_session_id, started_at, model_config FROM sessions WHERE id = ?
                 UNION
-                SELECT s.id, s.parent_session_id, s.started_at
+                SELECT s.id, s.parent_session_id, s.started_at, s.model_config
                 FROM sessions s
                 JOIN descendants d ON s.parent_session_id = d.id
             )
-            SELECT id, parent_session_id, started_at FROM descendants
+            SELECT id, parent_session_id, started_at, model_config FROM descendants
             """,
             (sid,),
         ).fetchall()
         for row in raw_rows:
+            # Skip delegate subagent sessions: they are not continuation
+            # targets (see docstring). The tag lives in model_config as
+            # "_delegate_from": "<parent session id>", written by
+            # delegate_tool when spawning the child.
+            model_config = row_get(row, "model_config", 3) or ""
+            if "_delegate_from" in model_config:
+                continue
             rows.append({
                 "id": row_get(row, "id", 0),
                 "parent_session_id": row_get(row, "parent_session_id", 1),
@@ -11101,6 +11116,10 @@ def _session_latest_descendant(session_id: str, db):
             })
     else:
         rows = db.list_sessions_rich(limit=10000, offset=0, compact_rows=True)
+        rows = [
+            r for r in rows
+            if "_delegate_from" not in (r.get("model_config") or "")
+        ]
 
     children = {}
     for row in rows:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11202,6 +11202,14 @@ def _session_latest_descendant(session_id: str, db):
 
     /model may create child sessions. Dashboard refresh should continue the
     newest child instead of reopening the old parent.
+
+    Delegate subagent sessions (created via the delegate_task tool, tagged in
+    ``model_config._delegate_from``) are NOT continuation targets: they are
+    short-lived parallel workers spawned *by* the parent, not forks the user
+    chose to continue. Including them hijacks the resume — clicking the parent
+    session in the dashboard silently opens the newest subagent session
+    instead. The recursion skips them, so a parent with only delegate children
+    resolves back to itself.
     """
     def row_get(row, key, index):
         if isinstance(row, dict):
@@ -11229,18 +11237,25 @@ def _session_latest_descendant(session_id: str, db):
     if conn is not None:
         raw_rows = conn.execute(
             """
-            WITH RECURSIVE descendants(id, parent_session_id, started_at) AS (
-                SELECT id, parent_session_id, started_at FROM sessions WHERE id = ?
+            WITH RECURSIVE descendants(id, parent_session_id, started_at, model_config) AS (
+                SELECT id, parent_session_id, started_at, model_config FROM sessions WHERE id = ?
                 UNION
-                SELECT s.id, s.parent_session_id, s.started_at
+                SELECT s.id, s.parent_session_id, s.started_at, s.model_config
                 FROM sessions s
                 JOIN descendants d ON s.parent_session_id = d.id
             )
-            SELECT id, parent_session_id, started_at FROM descendants
+            SELECT id, parent_session_id, started_at, model_config FROM descendants
             """,
             (sid,),
         ).fetchall()
         for row in raw_rows:
+            # Skip delegate subagent sessions: they are not continuation
+            # targets (see docstring). The tag lives in model_config as
+            # "_delegate_from": "<parent session id>", written by
+            # delegate_tool when spawning the child.
+            model_config = row_get(row, "model_config", 3) or ""
+            if "_delegate_from" in model_config:
+                continue
             rows.append({
                 "id": row_get(row, "id", 0),
                 "parent_session_id": row_get(row, "parent_session_id", 1),
@@ -11248,6 +11263,10 @@ def _session_latest_descendant(session_id: str, db):
             })
     else:
         rows = db.list_sessions_rich(limit=10000, offset=0, compact_rows=True)
+        rows = [
+            r for r in rows
+            if "_delegate_from" not in (r.get("model_config") or "")
+        ]
 
     children = {}
     for row in rows:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -953,6 +953,66 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["session_id"] == "cyc-b"
 
+    def test_latest_descendant_skips_delegate_subagent_children(self):
+        """A delegate_task subagent session (tagged ``_delegate_from`` in
+        model_config) is a short-lived parallel worker, NOT a continuation
+        target. Clicking the parent session in the dashboard must resolve back
+        to the parent itself, not hijack into the newest subagent session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="par-a", source="cli")
+            # /model-style child: a genuine fork the user chose to continue.
+            db.create_session(
+                session_id="child-model", source="cli", parent_session_id="par-a"
+            )
+            # delegate subagent child: tagged with _delegate_from → must be skipped.
+            db.create_session(
+                session_id="child-del", source="cli", parent_session_id="par-a"
+            )
+            db._conn.execute(
+                "UPDATE sessions SET model_config='{\"_delegate_from\": \"par-a\"}' "
+                "WHERE id='child-del'"
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        # The /model child is newer than the parent, so a parent with only a
+        # delegate child resolves back to itself; with a /model child present
+        # the newest NON-delegate child wins.
+        resp = self.client.get("/api/sessions/par-a/latest-descendant")
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "child-model"
+
+    def test_latest_descendant_parent_with_only_delegate_children_resolves_to_self(self):
+        """A parent whose only children are delegate subagents must resolve
+        back to itself — otherwise clicking it in the dashboard silently opens
+        an unrelated subagent session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="par-only-del", source="cli")
+            db.create_session(
+                session_id="del-1", source="cli", parent_session_id="par-only-del"
+            )
+            db.create_session(
+                session_id="del-2", source="cli", parent_session_id="par-only-del"
+            )
+            db._conn.execute(
+                "UPDATE sessions SET model_config='{\"_delegate_from\": \"par-only-del\"}' "
+                "WHERE id IN ('del-1','del-2')"
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/par-only-del/latest-descendant")
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "par-only-del"
+
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1118,6 +1118,143 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["session_id"] == "par-only-del"
 
+    def test_latest_descendant_only_treats_top_level_delegate_marker_as_delegate(self):
+        """Marker-like text and nested keys are ordinary model config data.
+
+        A real top-level marker prunes that session and its descendants from
+        the continuation chain.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            configs = {
+                "literal-marker": {"notes": 'mentions "_delegate_from" here'},
+                "nested-marker": {"delegation": {"_delegate_from": "json-root"}},
+                "delegate-marker": {"_delegate_from": "json-root"},
+            }
+            db.create_session(session_id="json-root", source="cli")
+            db.create_session(
+                session_id="literal-marker",
+                source="cli",
+                parent_session_id="json-root",
+                model_config=configs["literal-marker"],
+            )
+            db.create_session(
+                session_id="nested-marker",
+                source="cli",
+                parent_session_id="literal-marker",
+                model_config=configs["nested-marker"],
+            )
+            db.create_session(
+                session_id="malformed-config",
+                source="cli",
+                parent_session_id="nested-marker",
+            )
+            db._conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                ("{not-json", "malformed-config"),
+            )
+            db._conn.commit()
+            db.create_session(
+                session_id="delegate-marker",
+                source="cli",
+                parent_session_id="malformed-config",
+                model_config=configs["delegate-marker"],
+            )
+            db.create_session(
+                session_id="delegate-descendant",
+                source="cli",
+                parent_session_id="delegate-marker",
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/json-root/latest-descendant")
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "malformed-config"
+        assert resp.json()["path"] == [
+            "json-root",
+            "literal-marker",
+            "nested-marker",
+            "malformed-config",
+        ]
+
+    def test_latest_descendant_connectionless_fallback_parses_delegate_marker(self):
+        from hermes_cli.web_server import _session_latest_descendant
+
+        class ConnectionlessDB:
+            conn = None
+
+            def resolve_session_id(self, session_id):
+                return session_id
+
+            def get_session(self, session_id):
+                return {"id": session_id}
+
+            def list_sessions_rich(self, **_kwargs):
+                return [
+                    {
+                        "id": "fallback-root",
+                        "parent_session_id": None,
+                        "started_at": 1,
+                        "model_config": None,
+                    },
+                    {
+                        "id": "literal-marker",
+                        "parent_session_id": "fallback-root",
+                        "started_at": 2,
+                        "model_config": json.dumps(
+                            {"notes": 'mentions "_delegate_from" here'}
+                        ),
+                    },
+                    {
+                        "id": "nested-marker",
+                        "parent_session_id": "literal-marker",
+                        "started_at": 3,
+                        "model_config": json.dumps(
+                            {"delegation": {"_delegate_from": "fallback-root"}}
+                        ),
+                    },
+                    {
+                        "id": "null-marker",
+                        "parent_session_id": "nested-marker",
+                        "started_at": 4,
+                        "model_config": json.dumps({"_delegate_from": None}),
+                    },
+                    {
+                        "id": "malformed-config",
+                        "parent_session_id": "null-marker",
+                        "started_at": 5,
+                        "model_config": "{not-json",
+                    },
+                    {
+                        "id": "delegate-marker",
+                        "parent_session_id": "malformed-config",
+                        "started_at": 6,
+                        "model_config": json.dumps(
+                            {"_delegate_from": "fallback-root"}
+                        ),
+                    },
+                    {
+                        "id": "delegate-descendant",
+                        "parent_session_id": "delegate-marker",
+                        "started_at": 7,
+                        "model_config": None,
+                    },
+                ]
+
+        latest, path = _session_latest_descendant("fallback-root", ConnectionlessDB())
+
+        assert latest == "malformed-config"
+        assert path == [
+            "fallback-root",
+            "literal-marker",
+            "nested-marker",
+            "null-marker",
+            "malformed-config",
+        ]
+
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1058,6 +1058,66 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["session_id"] == "cyc-b"
 
+    def test_latest_descendant_skips_delegate_subagent_children(self):
+        """A delegate_task subagent session (tagged ``_delegate_from`` in
+        model_config) is a short-lived parallel worker, NOT a continuation
+        target. Clicking the parent session in the dashboard must resolve back
+        to the parent itself, not hijack into the newest subagent session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="par-a", source="cli")
+            # /model-style child: a genuine fork the user chose to continue.
+            db.create_session(
+                session_id="child-model", source="cli", parent_session_id="par-a"
+            )
+            # delegate subagent child: tagged with _delegate_from → must be skipped.
+            db.create_session(
+                session_id="child-del", source="cli", parent_session_id="par-a"
+            )
+            db._conn.execute(
+                "UPDATE sessions SET model_config='{\"_delegate_from\": \"par-a\"}' "
+                "WHERE id='child-del'"
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        # The /model child is newer than the parent, so a parent with only a
+        # delegate child resolves back to itself; with a /model child present
+        # the newest NON-delegate child wins.
+        resp = self.client.get("/api/sessions/par-a/latest-descendant")
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "child-model"
+
+    def test_latest_descendant_parent_with_only_delegate_children_resolves_to_self(self):
+        """A parent whose only children are delegate subagents must resolve
+        back to itself — otherwise clicking it in the dashboard silently opens
+        an unrelated subagent session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="par-only-del", source="cli")
+            db.create_session(
+                session_id="del-1", source="cli", parent_session_id="par-only-del"
+            )
+            db.create_session(
+                session_id="del-2", source="cli", parent_session_id="par-only-del"
+            )
+            db._conn.execute(
+                "UPDATE sessions SET model_config='{\"_delegate_from\": \"par-only-del\"}' "
+                "WHERE id IN ('del-1','del-2')"
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/par-only-del/latest-descendant")
+        assert resp.status_code == 200
+        assert resp.json()["session_id"] == "par-only-del"
+
 
 
 


### PR DESCRIPTION
## Problem

Clicking a parent session in the dashboard silently opens the newest **delegate subagent** session instead of the session the user clicked.

`_session_latest_descendant()` treats *every* child as a continuation target. `delegate_task` subagent sessions (tagged `model_config._delegate_from`, written by delegate_tool when spawning the child) are short-lived parallel workers spawned **by** the parent — not forks the user chose to continue.

## Repro

1. Start a session, delegate a few tasks to subagents (they spawn child sessions tagged `_delegate_from`).
2. In the dashboard, click the parent session in the session list.
3. The chat opens showing the newest subagent's transcript — not the parent's.

## Fix

`_session_latest_descendant()` (web_server.py) now carries `model_config` through the recursive CTE and skips rows tagged `_delegate_from`. A parent with only delegate children resolves back to itself. `/model` children (untagged) are still followed — the upstream follow-latest-child design (b12a5a72b) is preserved.

## Validation

- `tests/hermes_cli/test_web_server.py -k descendant`: 3 passed (delegate child skipped → model child wins; parent with only delegate children resolves to itself; existing parent-cycle regression still green).
- Black-box on a real dashboard: clicking the parent session renders that session's own title (was hijacked before).
