### PR TITLE
fix(desktop): give gateway-specific recovery for updater blockers

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -17,6 +17,7 @@ import { describe, it } from 'vitest'
 import {
   formatBlockerMessage,
   formatProbeFailedMessage,
+  isHermesGatewayCommandLine,
   parseVenvBlockerScanOutput,
   resolveVenvPython,
   scanVenvBlockers
@@ -65,6 +66,45 @@ describe('formatBlockerMessage', () => {
     assert.ok(msg.includes('remote backend'))
     assert.ok(msg.includes('retry'))
     assert.ok(!msg.includes('force-venv'))
+  })
+
+  it('gives gateway-specific recovery guidance for a reported gateway blocker', () => {
+    const msg = formatBlockerMessage({
+      blocked: true,
+      processes: [
+        {
+          pid: 20132,
+          name: 'python.exe',
+          cmdline:
+            'C:\\Users\\athif\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe -m hermes_cli.main gateway run'
+        }
+      ]
+    })
+
+    assert.ok(msg.includes('Hermes messaging gateway'))
+    assert.ok(msg.includes('hermes gateway stop'))
+    assert.ok(msg.includes('disconnect remote clients'))
+  })
+})
+
+describe('isHermesGatewayCommandLine', () => {
+  it('recognizes the Windows gateway command shown by the updater', () => {
+    assert.equal(
+      isHermesGatewayCommandLine(
+        'C:\\Users\\athif\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe -m hermes_cli.main gateway run'
+      ),
+      true
+    )
+  })
+
+  it('handles a profile named gateway without mistaking the profile value for the command', () => {
+    assert.equal(isHermesGatewayCommandLine('python.exe -m hermes_cli.main --profile gateway gateway run'), true)
+  })
+
+  it('does not classify other Hermes subcommands or non-Hermes processes as gateways', () => {
+    assert.equal(isHermesGatewayCommandLine('python.exe -m hermes_cli.main gateway stop'), false)
+    assert.equal(isHermesGatewayCommandLine('python.exe -m hermes_cli.main serve --host 127.0.0.1'), false)
+    assert.equal(isHermesGatewayCommandLine('python.exe -m http.server 8077'), false)
   })
 })
 

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -34,6 +34,38 @@ export type ScanOutcome =
   | { kind: 'blocked'; result: VenvBlockerScanResult }
   | { kind: 'probe-failure'; error: string }
 
+/**
+ * Conservative compatibility check for the recovery copy below.
+ *
+ * Current runtimes classify pausable gateways in the Python scan and let the
+ * CLI updater pause them. Older/stale installations can still surface a
+ * `gateway run` process as a blocker, though. Recognizing that exact Hermes
+ * invocation here lets the error explain the manual recovery without changing
+ * the blocker decision or duplicating the updater's canonical matcher.
+ */
+export function isHermesGatewayCommandLine(cmdline: string): boolean {
+  const tokens = cmdline.match(/"[^"]*"|'[^']*'|\S+/g)?.map(token => token.replace(/^["']|["']$/g, '')) ?? []
+  const moduleIndex = tokens.findIndex(token => token.toLowerCase() === 'hermes_cli.main')
+
+  if (moduleIndex === -1) {
+    return false
+  }
+
+  for (let index = moduleIndex + 1; index < tokens.length; index += 1) {
+    if (tokens[index]?.toLowerCase() !== 'gateway') {
+      continue
+    }
+
+    const next = tokens[index + 1]?.toLowerCase()
+
+    if (next === undefined || next === 'run' || next.startsWith('--')) {
+      return true
+    }
+  }
+
+  return false
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -196,7 +228,21 @@ export function formatBlockerMessage(result: VenvBlockerScanResult): string {
     'Close the terminal, app, or service owning that process.  If it is a ' +
       'remote backend, stopping it will disconnect remote clients.'
   )
-  lines.push('Then retry the update.')
+
+  const gatewayBlockers = result.processes.filter(proc => isHermesGatewayCommandLine(proc.cmdline))
+
+  if (gatewayBlockers.length > 0) {
+    lines.push('')
+    lines.push(
+      gatewayBlockers.length === result.processes.length
+        ? 'A Hermes messaging gateway is holding the installation.'
+        : 'One of the listed processes is a Hermes messaging gateway.'
+    )
+    lines.push('Run `hermes gateway stop`, then retry the update.')
+    lines.push('Stopping the gateway may disconnect remote clients.')
+  } else {
+    lines.push('Then retry the update.')
+  }
 
   return lines.join('\n')
 }


### PR DESCRIPTION
## Summary

On Windows, an older or stale Desktop updater can still report a real Hermes gateway as a venv blocker. The resulting dialog only says to close a terminal/app/service, even though the process is a Hermes gateway and the correct recovery is `hermes gateway stop` followed by retrying the update.

This patch adds a conservative compatibility check for the exact `python -m hermes_cli.main gateway run` shape and appends gateway-specific recovery guidance. It does not change the blocker decision, stop processes automatically, or replace the Python updater's canonical gateway classification. Generic blockers keep the existing message.

## Reproduction evidence

The attached screenshots show the full flow:

1. Update available dialog
2. Hermes restarting while the updater takes over
3. Update aborting with PID 20132 and `python.exe -m hermes_cli.main gateway run`

## Related

- Related to #75334 and merged gateway handling in #75881.
- This is separate from #77422/#77864, which concerns non-Hermes Python processes such as `python -m http.server`.

## Validation

- `npm run test:desktop:platforms -- electron/venv-blocker-scan.test.ts` — 24 passed
- `npm run typecheck` — passed
- targeted ESLint — passed
- Prettier check — passed
- repository lint — passed with 88 pre-existing warnings in unrelated files

Screenshots will be attached to this description.