### PR TITLE
Clamp search_messages limit and offset

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1419,6 +1419,19 @@ class SessionSearchMixin:
         pre-compaction transcript stays discoverable after in-place compaction
         (#38763). Pass ``include_inactive=True`` to search every row regardless.
         """
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 20
+        try:
+            offset = int(offset)
+        except (TypeError, ValueError):
+            offset = 0
+        # SQLite treats LIMIT < 0 as unbounded. Cap so FTS/LIKE scans cannot
+        # materialize every match (plus per-hit context enrichment).
+        limit = max(1, min(limit, 500))
+        offset = max(0, offset)
+
         result_fields = self._search_message_fields(fields)
 
         if not self._fts_enabled:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/gateway/test_telegram_start_polling_timeout.py
+++ b/tests/gateway/test_telegram_start_polling_timeout.py
@@ -59,6 +59,7 @@ def _bare_adapter():
     a._fatal_error_retryable = True
     a._polling_network_error_count = 0
     a._polling_conflict_count = 0
+    a._polling_conflict_recovery_generation = None
     a._polling_error_callback_ref = None
     a._background_tasks = set()
     a._send_path_degraded = False

--- a/tests/test_search_messages_pagination.py
+++ b/tests/test_search_messages_pagination.py
@@ -1,0 +1,62 @@
+"""Tests for search_messages limit/offset clamping."""
+
+from hermes_state import SessionDB
+
+
+def _seed_matches(db: SessionDB, n: int = 30) -> None:
+    db.create_session(session_id="clamp-s1", source="cli")
+    for i in range(n):
+        db.append_message(
+            "clamp-s1",
+            role="user",
+            content=f"paginationneedle unique-{i}",
+        )
+
+
+class TestSearchMessagesPaginationClamp:
+    def test_negative_limit_is_clamped_not_unbounded(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            _seed_matches(db, n=30)
+            # Without a clamp, SQLite LIMIT -1 returns every match.
+            results = db.search_messages("paginationneedle", limit=-1)
+            assert len(results) == 1
+        finally:
+            db.close()
+
+    def test_zero_limit_clamped_to_one(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            _seed_matches(db, n=10)
+            results = db.search_messages("paginationneedle", limit=0)
+            assert len(results) == 1
+        finally:
+            db.close()
+
+    def test_huge_limit_capped_at_500(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            _seed_matches(db, n=20)
+            results = db.search_messages("paginationneedle", limit=10**9)
+            assert len(results) == 20
+        finally:
+            db.close()
+
+    def test_negative_offset_clamped_to_zero(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            _seed_matches(db, n=10)
+            clamped = db.search_messages("paginationneedle", offset=-5, limit=3)
+            baseline = db.search_messages("paginationneedle", offset=0, limit=3)
+            assert clamped == baseline
+        finally:
+            db.close()
+
+    def test_valid_limit_unchanged(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            _seed_matches(db, n=10)
+            results = db.search_messages("paginationneedle", limit=5)
+            assert len(results) == 5
+        finally:
+            db.close()


### PR DESCRIPTION
Session message search accepted unbounded and negative limit/offset values at the SQLite layer, where a negative LIMIT is treated as unconstrained and can materialize a full FTS or LIKE match set plus per-hit context enrichment. This change clamps limit to a safe range of 1–500 and offset to a non-negative integer inside search_messages so every caller — tool, dashboard, and CLI  gets the same protection.