### PR TITLE
fix(redact): stop masking from eating container delimiters

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -496,16 +496,17 @@ def _mask_token(token: str) -> str:
 
 # A quote that closes a *containing* document, plus any structural characters
 # that follow it, rather than part of the secret value. Anchored at the end of
-# the captured value; ``[}\],]*`` covers compact (un-indented) JSON, where the
-# value class also swallows the object/array/element punctuation after the
-# closing quote (``"MY_TOKEN=ab"}`` captures ``ab"}``).
-_TRAILING_DELIMITER_RE = re.compile(r"[\"'][}\],]*$")
+# the captured value; ``[}\],]*`` covers a container tail deeper than one level
+# (``"MY_TOKEN=ab"}]`` captures ``ab"}]``).
+_TRAILING_DELIMITER_RE = re.compile(r"([\"'])[}\],]*$")
 # Quote characters a capture may have wrapped whole — see
 # ``_mask_preserving_delimiter``.
 _QUOTE_CHARS = "\"'"
 
 
-def _split_trailing_delimiter(value: str, *, quote: str = "") -> tuple[str, str]:
+def _split_trailing_delimiter(
+    value: str, *, quote: str = "", text: str = "", pos: int = 0
+) -> tuple[str, str]:
     """Split a trailing container delimiter off an unquoted captured value.
 
     Several patterns here bound the secret with a "not whitespace" value class
@@ -515,41 +516,54 @@ def _split_trailing_delimiter(value: str, *, quote: str = "") -> tuple[str, str]
     to the masker, and because a value under the 18-char floor masks to a bare
     ``***`` the closing quote is deleted outright. The document no longer
     parses, so a caller that reparses the redacted text loses the whole payload.
+    The same applies to a shell string: ``sh -c 'export MY_TOKEN=xyz'`` would
+    lose its closing quote and no longer parse.
 
-    Returns ``(value, suffix)``; ``suffix`` is re-emitted verbatim after the
-    mask. Splitting is skipped when an opening ``quote`` was captured — such a
-    value already ends at its own backreference — and when nothing but the
-    delimiter was captured, which is left for the masker to handle as before.
+    Returns ``(secret, suffix)``; ``suffix`` is re-emitted after the mask.
+
+    A delimiter only closes something that was *opened*, so the split requires
+    the same quote character to appear in ``text`` before ``pos`` (the start of
+    this match). Without that requirement the run would be re-emitted verbatim
+    whenever it merely *looked* structural, which discloses secret bytes the
+    masker would otherwise have covered: ``MY_TOKEN=a'}}}}`` has no opening
+    quote, so its trailing run belongs to the secret and is masked. Skipped
+    entirely when the pattern captured its own opening ``quote`` — such a value
+    already ends at its own backreference.
 
     Known limit: a value with no whitespace before the next JSON token (truly
-    compact ``{"a":"MY_TOKEN=x","b":1}`` captures ``x","b":1}``) has no
-    delimiter-only suffix and is not split. Fully general handling would mean
-    not running a text redactor across JSON boundaries at all, which is the
-    caller's choice, not this helper's.
+    compact ``{"a":"MY_TOKEN=x","b":1}`` captures ``x","b":1}``) ends in ``}``
+    preceded by non-structural bytes, so it has no delimiter-only suffix to
+    split. Fully general handling would mean not running a text redactor across
+    JSON boundaries at all, which is the caller's choice, not this helper's.
     """
     if quote:
         return value, ""
     match = _TRAILING_DELIMITER_RE.search(value)
-    if match is None or match.start() == 0:
+    if match is None:
+        return value, ""
+    # The delimiter must close a quote opened earlier in the document.
+    if match.group(1) not in text[:pos]:
         return value, ""
     return value[: match.start()], match.group(0)
 
 
-def _mask_preserving_delimiter(value: str) -> str:
+def _mask_preserving_delimiter(value: str, *, text: str = "", pos: int = 0) -> str:
     """``_mask_token`` for a bare ``(\\S+)`` capture, keeping any delimiter.
 
     For the patterns whose value class is bare ``(\\S+)`` and which have no
-    quote group of their own to defer to (``_SECRET_HEADER_RE``). Handles the
-    two ways such a capture can pick up quotes it does not own:
+    quote group of their own to defer to (``_SECRET_HEADER_RE``,
+    ``_YAML_ASSIGN_RE``). Handles the two ways such a capture can pick up
+    quotes it does not own:
 
     * wrapped in a matching pair (``x-api-key: "abc"``) — mask the inside and
       re-emit both quotes, keeping the pair balanced;
     * a single trailing quote closing an enclosing document or shell string —
-      delegate to ``_split_trailing_delimiter``.
+      delegate to ``_split_trailing_delimiter``, which requires that quote to
+      have been opened earlier in ``text``.
     """
     if len(value) >= 2 and value[0] in _QUOTE_CHARS and value[-1] == value[0]:
         return f"{value[0]}{_mask_token(value[1:-1])}{value[0]}"
-    secret, delimiter = _split_trailing_delimiter(value)
+    secret, delimiter = _split_trailing_delimiter(value, text=text, pos=pos)
     return f"{_mask_token(secret)}{delimiter}"
 
 
@@ -801,7 +815,9 @@ def redact_sensitive_text(
                 # Hand the masker only the secret and re-emit the delimiter, or
                 # a short value's bare ``***`` would swallow it and leave the
                 # document unparseable.
-                value, delimiter = _split_trailing_delimiter(value, quote=quote)
+                value, delimiter = _split_trailing_delimiter(
+                    value, quote=quote, text=m.string, pos=m.start()
+                )
                 return f"{name}={quote}{_mask_token(value)}{quote}{delimiter}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
@@ -848,7 +864,15 @@ def redact_sensitive_text(
                 # document text, not credentials (nearai/ironclaw#6129).
                 if not _key_has_secret_keyword(key):
                     return m.group(0)
-                return f"{key}{sep}{_mask_token(value)}"
+                # Same unquoted-capture hazard as the KEY=VALUE and header
+                # passes: ``[^\s&]++`` absorbs a quote that closes an enclosing
+                # shell string, so ``sh -c '\npassword: xyz'`` masked to an
+                # unterminated quote. The lookahead only rejects a *leading*
+                # quote, so a trailing one still reaches the masker.
+                return (
+                    f"{key}{sep}"
+                    f"{_mask_preserving_delimiter(value, text=m.string, pos=m.start())}"
+                )
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after
@@ -868,7 +892,8 @@ def redact_sensitive_text(
             # ``(\S+)`` value class absorbs the quote closing an enclosing
             # JSON document, and a short header value masks to a bare ``***``
             # that would delete it.
-            lambda m: m.group(1) + _mask_preserving_delimiter(m.group(2)),
+            lambda m: m.group(1)
+            + _mask_preserving_delimiter(m.group(2), text=m.string, pos=m.start()),
             text,
         )
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -496,16 +496,131 @@ def _mask_token(token: str) -> str:
 
 # A quote that closes a *containing* document, plus any structural characters
 # that follow it, rather than part of the secret value. Anchored at the end of
-# the captured value; ``[}\],]*`` covers a container tail deeper than one level
+# the captured value; ``[}\],]`` covers a container tail deeper than one level
 # (``"MY_TOKEN=ab"}]`` captures ``ab"}]``).
-_TRAILING_DELIMITER_RE = re.compile(r"([\"'])[}\],]*$")
+#
+# The structural run is uncapped: how much of it may be re-emitted is decided
+# against the containers actually open at the match (see
+# ``_justified_delimiter_len``), not against a fixed length. A real tail is as
+# long as the document is deep — ``json.dumps`` defaults on a five-level
+# payload close with ``"}]}}}`` — while a secret's own random ``}}}}`` run is
+# rejected past the open depth. The group is split so the quote and the
+# structural run can be judged separately.
+_TRAILING_DELIMITER_RE = re.compile(r"([\"'])([}\],]*)$")
 # Quote characters a capture may have wrapped whole — see
 # ``_mask_preserving_delimiter``.
 _QUOTE_CHARS = "\"'"
+# Containers a redacted document can have open at a match, and the closer that
+# balances each.
+_CONTAINER_OPENERS = {"}": "{", "]": "["}
+# ``,`` closes nothing, so the open-container stack cannot bound how many of
+# them are re-emitted — a secret ending ``',,,,`` would republish the whole run.
+# In a real container tail a separator can only appear *once*, and only as the
+# final character: whatever follows a separator is the next member, never
+# another closer (``"}],`` is a legal capture, ``",}`` and ``",,`` are not).
+# So one is accepted, last, with a container open. ``json.dumps``' default item
+# separator produces exactly that: ``…"MY_TOKEN=x", "b": 1}`` captures ``x",``.
+_ITEM_SEPARATOR = ","
+
+
+class _DocumentStateScanner:
+    """Tracks the quote and containers open at a position in one ``sub()`` pass.
+
+    ``re.sub`` invokes its callback on non-overlapping matches in increasing
+    positional order, so this state can be carried forward across calls instead
+    of rescanned per match. That keeps a whole pass linear in the subject
+    length; re-deriving it per match (e.g. scanning ``text[:pos]``) is O(N·L)
+    overall, which on a 2 MB dump with a match every ~60 bytes is seconds, not
+    milliseconds.
+
+    Two pieces of state, both needed by ``_split_trailing_delimiter``:
+
+    * the quote open at the position, if any — a delimiter only closes
+      something that was opened;
+    * the stack of containers open at the position — which bounds how much of a
+      trailing ``}]}}`` run can be the *document's* rather than the secret's.
+
+    Escape-aware: a backslash consumes the next character, so the ``\\"`` inside
+    a serialized JSON string does not flip parity. Structural characters are
+    only counted while no quote is open, so a ``{`` inside a string is content.
+    """
+
+    __slots__ = ("_text", "_pos", "_open", "_stack")
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self._pos = 0
+        self._open: str | None = None
+        self._stack: list[str] = []
+
+    def state_at(self, pos: int) -> tuple[str | None, list[str]]:
+        """Return ``(open quote or None, open-container stack)`` at ``pos``.
+
+        ``pos`` must be non-decreasing across calls, which ``re.sub`` guarantees.
+        The returned stack is the live list and is read-only to the caller.
+        """
+        text = self._text
+        i = self._pos
+        open_q = self._open
+        stack = self._stack
+        while i < pos:
+            ch = text[i]
+            if ch == "\\":
+                # Consume the escaped character with it. May step one past
+                # ``pos``; that character belongs to this match and the next
+                # call's ``pos`` is strictly greater, so no span is skipped.
+                i += 2
+                continue
+            if open_q is None:
+                if ch in _QUOTE_CHARS:
+                    open_q = ch
+                elif ch == "{" or ch == "[":
+                    stack.append(ch)
+                elif stack and stack[-1] == _CONTAINER_OPENERS.get(ch):
+                    # Only pop on a *matching* closer. A stray one in prose
+                    # ("}" in a log line) is not evidence a container closed.
+                    stack.pop()
+            elif ch == open_q:
+                open_q = None
+            i += 1
+        self._pos = i
+        self._open = open_q
+        return open_q, stack
+
+
+def _justified_delimiter_len(run: str, stack: list[str]) -> int:
+    """Length of the prefix of ``run`` that closes ``stack`` in order.
+
+    ``run`` is the structural tail a value capture absorbed after its closing
+    quote. The document's own closing run must be consistent with the
+    containers actually open at that point, so that is the test — rather than a
+    fixed cap, which cannot tell a five-level ``}]}}}`` tail (legitimate, from
+    ``json.dumps`` defaults) from a secret's ``}}}}`` (not).
+
+    Walks the stack top-down through an index rather than mutating it — the
+    caller's stack belongs to a scanner that is still carrying state forward. A
+    character that does not close the current top ends the justified prefix. A
+    separator is accepted only as the final character and only with a container
+    still open, which is the only place one can legally appear — otherwise its
+    length is bounded by nothing, since a separator closes no container.
+    """
+    remaining = len(stack)
+    for i, ch in enumerate(run):
+        if ch == _ITEM_SEPARATOR:
+            # Terminal, and only inside a container.
+            return i + 1 if remaining else i
+        if remaining == 0 or stack[remaining - 1] != _CONTAINER_OPENERS.get(ch):
+            return i
+        remaining -= 1
+    return len(run)
 
 
 def _split_trailing_delimiter(
-    value: str, *, quote: str = "", text: str = "", pos: int = 0
+    value: str,
+    *,
+    quote: str = "",
+    open_quote: str | None = None,
+    stack: list[str] | None = None,
 ) -> tuple[str, str]:
     """Split a trailing container delimiter off an unquoted captured value.
 
@@ -521,14 +636,33 @@ def _split_trailing_delimiter(
 
     Returns ``(secret, suffix)``; ``suffix`` is re-emitted after the mask.
 
-    A delimiter only closes something that was *opened*, so the split requires
-    the same quote character to appear in ``text`` before ``pos`` (the start of
-    this match). Without that requirement the run would be re-emitted verbatim
-    whenever it merely *looked* structural, which discloses secret bytes the
-    masker would otherwise have covered: ``MY_TOKEN=a'}}}}`` has no opening
-    quote, so its trailing run belongs to the secret and is masked. Skipped
-    entirely when the pattern captured its own opening ``quote`` — such a value
-    already ends at its own backreference.
+    A delimiter only closes something that was *open*, so the split requires
+    ``open_quote`` — from ``_DocumentStateScanner``, the quote actually unclosed
+    at the start of this match — to equal the captured trailing quote. Splitting
+    on shape alone re-emits the run verbatim whenever it merely *looked*
+    structural, which discloses secret bytes the masker would otherwise have
+    covered: ``MY_TOKEN=a'}}}}`` has nothing open, so its trailing run belongs
+    to the secret and is masked whole. Skipped entirely when the pattern
+    captured its own opening ``quote`` — such a value already ends at its own
+    backreference.
+
+    The structural run after that quote is bounded the same way, by ``stack``:
+    only the prefix that closes the containers actually open here is re-emitted
+    (``_justified_delimiter_len``). The rest cannot be the document's — nothing
+    is open for it to close — so it is secret and is dropped rather than
+    re-emitted or handed to the masker, where the head/tail window could
+    republish it. A five-level ``"}]}}}`` tail from ``json.dumps`` defaults
+    survives whole; ``MY_TOKEN=a'}}}}`` under a single open ``{`` keeps ``'}``
+    and loses the rest.
+
+    Residual: quote parity is a *syntactic* test, so a lone apostrophe in prose
+    ("it's", "couldn't") leaves a quote nominally open. A following
+    ``MY_TOKEN=a'}}}`` in a document with containers open therefore re-emits
+    ``'`` plus as many closers as are open — bounded by document depth, not by
+    the secret's length, which is what the earlier uncapped shape test got
+    wrong. In flat prose (nothing open) the residual is the single quote.
+    Distinguishing prose punctuation from a container delimiter is not decidable
+    by a text redactor; bounding it by document state is.
 
     Known limit: a value with no whitespace before the next JSON token (truly
     compact ``{"a":"MY_TOKEN=x","b":1}`` captures ``x","b":1}``) ends in ``}``
@@ -541,13 +675,19 @@ def _split_trailing_delimiter(
     match = _TRAILING_DELIMITER_RE.search(value)
     if match is None:
         return value, ""
-    # The delimiter must close a quote opened earlier in the document.
-    if match.group(1) not in text[:pos]:
+    # The delimiter must close the quote that is actually open here. ``None``
+    # (nothing open) can never equal the captured quote, so this one comparison
+    # covers both "nothing is open" and "a different quote is open".
+    if match.group(1) != open_quote:
         return value, ""
-    return value[: match.start()], match.group(0)
+    run = match.group(2)
+    keep = _justified_delimiter_len(run, stack or [])
+    return value[: match.start()], f"{open_quote}{run[:keep]}"
 
 
-def _mask_preserving_delimiter(value: str, *, text: str = "", pos: int = 0) -> str:
+def _mask_preserving_delimiter(
+    value: str, *, open_quote: str | None = None, stack: list[str] | None = None
+) -> str:
     """``_mask_token`` for a bare ``(\\S+)`` capture, keeping any delimiter.
 
     For the patterns whose value class is bare ``(\\S+)`` and which have no
@@ -556,14 +696,19 @@ def _mask_preserving_delimiter(value: str, *, text: str = "", pos: int = 0) -> s
     quotes it does not own:
 
     * wrapped in a matching pair (``x-api-key: "abc"``) — mask the inside and
-      re-emit both quotes, keeping the pair balanced;
+      re-emit both quotes, keeping the pair balanced. Reachable only from
+      ``_SECRET_HEADER_RE``: ``_YAML_ASSIGN_RE``'s lookahead rejects a value
+      that *starts* with a quote, deferring those to ``_JSON_FIELD_RE``;
     * a single trailing quote closing an enclosing document or shell string —
-      delegate to ``_split_trailing_delimiter``, which requires that quote to
-      have been opened earlier in ``text``.
+      delegate to ``_split_trailing_delimiter``, which requires that quote to be
+      the one actually open at this position and bounds the structural run that
+      follows it by the containers open there.
     """
     if len(value) >= 2 and value[0] in _QUOTE_CHARS and value[-1] == value[0]:
         return f"{value[0]}{_mask_token(value[1:-1])}{value[0]}"
-    secret, delimiter = _split_trailing_delimiter(value, text=text, pos=pos)
+    secret, delimiter = _split_trailing_delimiter(
+        value, open_quote=open_quote, stack=stack
+    )
     return f"{_mask_token(secret)}{delimiter}"
 
 
@@ -796,30 +941,41 @@ def redact_sensitive_text(
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)
     if not code_file:
         if "=" in text:
-            def _redact_env(m):
-                name, quote, value = m.group(1), m.group(2), m.group(3)
-                # Programmatic env lookups reference variable *names*, not
-                # secret values — masking them corrupts code snippets in
-                # prose/log contexts (issue #2852): ``KEY=os.getenv('X')``.
-                if _ENV_LOOKUP_VALUE_RE.match(value):
-                    return m.group(0)
-                # Keyword must sit at a word boundary within the key —
-                # ``author=Smith`` / ``press.secretary=…`` are prose, not
-                # credentials (ported from nearai/ironclaw#6129). All-caps
-                # keys (the _ENV_ASSIGN_RE shape) short-circuit to legacy
-                # embedded matching inside the helper.
-                if not _key_has_secret_keyword(name):
-                    return m.group(0)
-                # An unquoted value stops at whitespace, so it can absorb the
-                # quote that closes a *containing* document (serialized JSON).
-                # Hand the masker only the secret and re-emit the delimiter, or
-                # a short value's bare ``***`` would swallow it and leave the
-                # document unparseable.
-                value, delimiter = _split_trailing_delimiter(
-                    value, quote=quote, text=m.string, pos=m.start()
-                )
-                return f"{name}={quote}{_mask_token(value)}{quote}{delimiter}"
-            text = _ENV_ASSIGN_RE.sub(_redact_env, text)
+            # A scanner carries state forward only within the subject it was
+            # built for, and each ``sub()`` pass runs over a freshly rebuilt
+            # string. ``_redact_env`` is shared by three passes, so it is built
+            # per pass around its own scanner instead of closing over one.
+            def _make_redact_env(subject):
+                scanner = _DocumentStateScanner(subject)
+
+                def _redact_env(m):
+                    name, quote, value = m.group(1), m.group(2), m.group(3)
+                    # Programmatic env lookups reference variable *names*, not
+                    # secret values — masking them corrupts code snippets in
+                    # prose/log contexts (issue #2852): ``KEY=os.getenv('X')``.
+                    if _ENV_LOOKUP_VALUE_RE.match(value):
+                        return m.group(0)
+                    # Keyword must sit at a word boundary within the key —
+                    # ``author=Smith`` / ``press.secretary=…`` are prose, not
+                    # credentials (ported from nearai/ironclaw#6129). All-caps
+                    # keys (the _ENV_ASSIGN_RE shape) short-circuit to legacy
+                    # embedded matching inside the helper.
+                    if not _key_has_secret_keyword(name):
+                        return m.group(0)
+                    # An unquoted value stops at whitespace, so it can absorb the
+                    # quote that closes a *containing* document (serialized JSON).
+                    # Hand the masker only the secret and re-emit the delimiter, or
+                    # a short value's bare ``***`` would swallow it and leave the
+                    # document unparseable.
+                    open_quote, stack = scanner.state_at(m.start())
+                    value, delimiter = _split_trailing_delimiter(
+                        value, quote=quote, open_quote=open_quote, stack=stack
+                    )
+                    return f"{name}={quote}{_mask_token(value)}{quote}{delimiter}"
+
+                return _redact_env
+
+            text = _ENV_ASSIGN_RE.sub(_make_redact_env(text), text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note
             # near the bottom of this function); _DB_CONNSTR_RE still guards
@@ -833,8 +989,8 @@ def redact_sensitive_text(
             # keyword scan prevents that pathological path on secret-free
             # text.
             if "://" not in text and _CFG_SECRET_WORD_RE.search(text):
-                text = _CFG_DOTTED_RE.sub(_redact_env, text)
-                text = _CFG_ANCHORED_RE.sub(_redact_env, text)
+                text = _CFG_DOTTED_RE.sub(_make_redact_env(text), text)
+                text = _CFG_ANCHORED_RE.sub(_make_redact_env(text), text)
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         if ":" in text and '"' in text:
@@ -852,6 +1008,8 @@ def redact_sensitive_text(
         # values are handled there; the lookahead in _YAML_ASSIGN_RE skips
         # quotes). Skip URLs — web-URL query params pass through by design.
         if ":" in text and "://" not in text:
+            _yaml_scanner = _DocumentStateScanner(text)
+
             def _redact_yaml(m):
                 key, sep, value = m.group(1), m.group(2), m.group(3)
                 # Same programmatic-env-lookup exception as _redact_env above
@@ -869,10 +1027,11 @@ def redact_sensitive_text(
                 # shell string, so ``sh -c '\npassword: xyz'`` masked to an
                 # unterminated quote. The lookahead only rejects a *leading*
                 # quote, so a trailing one still reaches the masker.
-                return (
-                    f"{key}{sep}"
-                    f"{_mask_preserving_delimiter(value, text=m.string, pos=m.start())}"
+                open_quote, stack = _yaml_scanner.state_at(m.start())
+                masked = _mask_preserving_delimiter(
+                    value, open_quote=open_quote, stack=stack
                 )
+                return f"{key}{sep}{masked}"
             text = _YAML_ASSIGN_RE.sub(_redact_yaml, text)
 
     # Authorization headers — _AUTH_HEADER_RE matches any scheme after
@@ -887,15 +1046,19 @@ def redact_sensitive_text(
     # API-key style headers (x-api-key, api-key, …). Header values are
     # colon-separated, so gate on ":" — the regex itself is the precise filter.
     if ":" in text:
-        text = _SECRET_HEADER_RE.sub(
+        _hdr_scanner = _DocumentStateScanner(text)
+
+        def _redact_secret_header(m):
             # Same unquoted-capture hazard as the KEY=VALUE passes above: the
             # ``(\S+)`` value class absorbs the quote closing an enclosing
             # JSON document, and a short header value masks to a bare ``***``
             # that would delete it.
-            lambda m: m.group(1)
-            + _mask_preserving_delimiter(m.group(2), text=m.string, pos=m.start()),
-            text,
-        )
+            open_quote, stack = _hdr_scanner.state_at(m.start())
+            return m.group(1) + _mask_preserving_delimiter(
+                m.group(2), open_quote=open_quote, stack=stack
+            )
+
+        text = _SECRET_HEADER_RE.sub(_redact_secret_header, text)
 
     # Telegram bot tokens — pattern requires ":<token>" with digits prefix
     if ":" in text:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1042,15 +1042,33 @@ def redact_sensitive_text(
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         if ":" in text and '"' in text:
-            def _redact_json(m):
-                key, value = m.group(1), m.group(2)
-                # Same programmatic-env-lookup exception as _redact_env above
-                # (issue #2852): "apiKey": "os.getenv('X')" is a code snippet,
-                # not a leaked secret value.
-                if _ENV_LOOKUP_VALUE_RE.match(value):
-                    return m.group(0)
-                return f'{key}: "{_mask_token(value)}"'
-            text = _JSON_FIELD_RE.sub(_redact_json, text)
+            # Built per pass around its own subject, like _make_redact_env: the
+            # escape check below reads the byte after the value capture, which
+            # only means anything in the string this pass is running over.
+            def _make_redact_json(subject):
+                def _redact_json(m):
+                    key, value = m.group(1), m.group(2)
+                    # Same programmatic-env-lookup exception as _redact_env
+                    # above (issue #2852): "apiKey": "os.getenv('X')" is a code
+                    # snippet, not a leaked secret value.
+                    if _ENV_LOOKUP_VALUE_RE.match(value):
+                        return m.group(0)
+                    # ``[^"]+`` stops at the first ``"`` even when that quote is
+                    # ESCAPED, so a field value legitimately containing one
+                    # (``{"password": "abc\""}``) hands the trailing backslash
+                    # to the masker, which deletes it — and the closing quote
+                    # this pass re-emits then lands bare, closing the string one
+                    # byte early. Split the escape off and re-emit it with the
+                    # quote. Pre-existing (not introduced by the delimiter
+                    # split), same escape-destruction mechanism.
+                    escape = ""
+                    if _escapes_the_quote_at(subject, m.end(2)):
+                        value, escape = value[:-1], "\\"
+                    return f'{key}: "{_mask_token(value)}{escape}"'
+
+                return _redact_json
+
+            text = _JSON_FIELD_RE.sub(_make_redact_json(text), text)
 
         # Unquoted YAML / colon config: password: ***  (after JSON so quoted
         # values are handled there; the lookahead in _YAML_ASSIGN_RE skips

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1086,10 +1086,35 @@ def redact_sensitive_text(
     # "[Proxy-]Authorization:" case-insensitively, so "uthorization" is the
     # cheapest substring gate that covers every casing without a casefold().
     if "uthorization" in text or "UTHORIZATION" in text:
-        text = _AUTH_HEADER_RE.sub(
-            lambda m: m.group(1) + (m.group(2) or "") + _mask_token(m.group(3)),
-            text,
-        )
+        # The credential class excludes the quote (#43083) but NOT the backslash
+        # that escapes it, so inside a serialized JSON string the capture ends
+        # ``…secret\`` and masking destroys that escape, leaving the document's
+        # own ``"`` unescaped and closing the string early. Above the 18-char
+        # mask floor the 4-char tail happened to re-emit the backslash, which is
+        # why only short credentials corrupted — an accident of the window, not
+        # a contract. Split the escape off the credential and re-emit it.
+        def _make_redact_authz(subject):
+            scanner = _DocumentStateScanner(subject)
+
+            def _redact_authz(m):
+                cred = m.group(3)
+                escape = ""
+                end = m.end(3)
+                open_quote, _ = scanner.state_at(m.start())
+                # Only when that next byte really is the quote left open here:
+                # a trailing backslash before whitespace, or in flat text with
+                # nothing open, is the credential's own byte and stays masked.
+                if (
+                    open_quote is not None
+                    and subject[end : end + 1] == open_quote
+                    and _escapes_the_quote_at(subject, end)
+                ):
+                    cred, escape = cred[:-1], "\\"
+                return m.group(1) + (m.group(2) or "") + _mask_token(cred) + escape
+
+            return _redact_authz
+
+        text = _AUTH_HEADER_RE.sub(_make_redact_authz(text), text)
 
     # API-key style headers (x-api-key, api-key, …). Header values are
     # colon-separated, so gate on ":" — the regex itself is the precise filter.

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -523,6 +523,31 @@ _CONTAINER_OPENERS = {"}": "{", "]": "["}
 _ITEM_SEPARATOR = ","
 
 
+def _escapes_the_quote_at(text: str, quote_pos: int) -> bool:
+    """True if the quote at ``quote_pos`` in ``text`` is backslash-escaped.
+
+    The one rule behind every escape-aware branch in this module: inside a
+    serialized document the quote that closes the *enclosing* string appears as
+    ``\\"``, and a value class that admits ``\\`` captures the backslash with
+    the secret. Masking then destroys the escape and re-emits — or leaves — a
+    BARE quote, which terminates the string early. The document no longer
+    parses, which is the same failure the delimiter split exists to prevent,
+    reached through the escape byte instead of the delimiter byte.
+
+    Parity, not presence, decides it: ``json.dumps`` doubles a literal
+    backslash, so a value genuinely ending in ``\\`` is serialized ``\\\\`` and
+    leaves an EVEN run before the quote (that quote is the real delimiter). Only
+    an ODD run means the last backslash introduces an escape, making the quote
+    content rather than a closer.
+    """
+    run = 0
+    i = quote_pos - 1
+    while i >= 0 and text[i] == "\\":
+        run += 1
+        i -= 1
+    return run % 2 == 1
+
+
 class _DocumentStateScanner:
     """Tracks the quote and containers open at a position in one ``sub()`` pass.
 
@@ -655,6 +680,15 @@ def _split_trailing_delimiter(
     survives whole; ``MY_TOKEN=a'}}}}`` under a single open ``{`` keeps ``'}``
     and loses the rest.
 
+    Disclosure bound: the suffix is delimiter-only and at most ``1 + depth``
+    bytes (one quote plus the closers actually open). Splitting also SHORTENS
+    the token handed to the masker, which shifts ``_mask_token``'s tail window
+    left, so total disclosure may shift by up to ``tail`` bytes relative to
+    masking the capture whole — those bytes are the true secret's own last
+    ``tail`` bytes, i.e. head6/tail4 applied to the correct token rather than to
+    secret+delimiter. Not a new disclosure class, but the suffix bound alone
+    does not describe it.
+
     Residual: quote parity is a *syntactic* test, so a lone apostrophe in prose
     ("it's", "couldn't") leaves a quote nominally open. A following
     ``MY_TOKEN=a'}}}`` in a document with containers open therefore re-emits
@@ -681,6 +715,20 @@ def _split_trailing_delimiter(
     if match.group(1) != open_quote:
         return value, ""
     run = match.group(2)
+    # An ESCAPED quote is string *content*, not the delimiter that closes the
+    # document. Inside a serialized JSON string the enclosing quote appears as
+    # ``\"`` and a ``(\S+)`` capture absorbs both bytes, so splitting between
+    # them leaves the backslash inside the secret handed to the masker and
+    # re-emits the quote BARE — terminating the string early, at a shape that
+    # reparsed before the split existed. Parity is unaffected upstream (the
+    # scanner already skips escaped quotes, so ``open_quote`` is legitimately
+    # the enclosing one); what must not happen is consuming the escape while
+    # republishing its quote. Reached when the capture ends exactly at ``\"``,
+    # i.e. whitespace and more content follow it inside the same string.
+    if _escapes_the_quote_at(value, match.start()):
+        # Nothing after an escaped quote can close a container — it is all
+        # still inside the string — so no structural run is justified here.
+        return value[: match.start() - 1], f"\\{match.group(1)}"
     keep = _justified_delimiter_len(run, stack or [])
     return value[: match.start()], f"{open_quote}{run[:keep]}"
 

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -494,6 +494,65 @@ def _mask_token(token: str) -> str:
     return mask_secret(token, head=6, tail=4, floor=18)
 
 
+# A quote that closes a *containing* document, plus any structural characters
+# that follow it, rather than part of the secret value. Anchored at the end of
+# the captured value; ``[}\],]*`` covers compact (un-indented) JSON, where the
+# value class also swallows the object/array/element punctuation after the
+# closing quote (``"MY_TOKEN=ab"}`` captures ``ab"}``).
+_TRAILING_DELIMITER_RE = re.compile(r"[\"'][}\],]*$")
+# Quote characters a capture may have wrapped whole — see
+# ``_mask_preserving_delimiter``.
+_QUOTE_CHARS = "\"'"
+
+
+def _split_trailing_delimiter(value: str, *, quote: str = "") -> tuple[str, str]:
+    """Split a trailing container delimiter off an unquoted captured value.
+
+    Several patterns here bound the secret with a "not whitespace" value class
+    (``(\\S+)``) or an optionally-quoted equivalent. That class also admits the
+    quote which closes an *enclosing* document, and redacting a serialized JSON
+    payload is the case that matters: ``"content": "MY_TOKEN=ab"`` hands ``ab"``
+    to the masker, and because a value under the 18-char floor masks to a bare
+    ``***`` the closing quote is deleted outright. The document no longer
+    parses, so a caller that reparses the redacted text loses the whole payload.
+
+    Returns ``(value, suffix)``; ``suffix`` is re-emitted verbatim after the
+    mask. Splitting is skipped when an opening ``quote`` was captured — such a
+    value already ends at its own backreference — and when nothing but the
+    delimiter was captured, which is left for the masker to handle as before.
+
+    Known limit: a value with no whitespace before the next JSON token (truly
+    compact ``{"a":"MY_TOKEN=x","b":1}`` captures ``x","b":1}``) has no
+    delimiter-only suffix and is not split. Fully general handling would mean
+    not running a text redactor across JSON boundaries at all, which is the
+    caller's choice, not this helper's.
+    """
+    if quote:
+        return value, ""
+    match = _TRAILING_DELIMITER_RE.search(value)
+    if match is None or match.start() == 0:
+        return value, ""
+    return value[: match.start()], match.group(0)
+
+
+def _mask_preserving_delimiter(value: str) -> str:
+    """``_mask_token`` for a bare ``(\\S+)`` capture, keeping any delimiter.
+
+    For the patterns whose value class is bare ``(\\S+)`` and which have no
+    quote group of their own to defer to (``_SECRET_HEADER_RE``). Handles the
+    two ways such a capture can pick up quotes it does not own:
+
+    * wrapped in a matching pair (``x-api-key: "abc"``) — mask the inside and
+      re-emit both quotes, keeping the pair balanced;
+    * a single trailing quote closing an enclosing document or shell string —
+      delegate to ``_split_trailing_delimiter``.
+    """
+    if len(value) >= 2 and value[0] in _QUOTE_CHARS and value[-1] == value[0]:
+        return f"{value[0]}{_mask_token(value[1:-1])}{value[0]}"
+    secret, delimiter = _split_trailing_delimiter(value)
+    return f"{_mask_token(secret)}{delimiter}"
+
+
 def _redact_query_string(query: str) -> str:
     """Redact sensitive parameter values in a URL query string.
 
@@ -737,7 +796,13 @@ def redact_sensitive_text(
                 # embedded matching inside the helper.
                 if not _key_has_secret_keyword(name):
                     return m.group(0)
-                return f"{name}={quote}{_mask_token(value)}{quote}"
+                # An unquoted value stops at whitespace, so it can absorb the
+                # quote that closes a *containing* document (serialized JSON).
+                # Hand the masker only the secret and re-emit the delimiter, or
+                # a short value's bare ``***`` would swallow it and leave the
+                # document unparseable.
+                value, delimiter = _split_trailing_delimiter(value, quote=quote)
+                return f"{name}={quote}{_mask_token(value)}{quote}{delimiter}"
             text = _ENV_ASSIGN_RE.sub(_redact_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note
@@ -799,7 +864,11 @@ def redact_sensitive_text(
     # colon-separated, so gate on ":" — the regex itself is the precise filter.
     if ":" in text:
         text = _SECRET_HEADER_RE.sub(
-            lambda m: m.group(1) + _mask_token(m.group(2)),
+            # Same unquoted-capture hazard as the KEY=VALUE passes above: the
+            # ``(\S+)`` value class absorbs the quote closing an enclosing
+            # JSON document, and a short header value masks to a bare ``***``
+            # that would delete it.
+            lambda m: m.group(1) + _mask_preserving_delimiter(m.group(2)),
             text,
         )
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1511,7 +1511,7 @@ class TestEscapedQuoteSurvivesRedaction:
     unparseable document, reached through the escape byte instead of the
     delimiter byte.
 
-    The affected site:
+    Two distinct sites, one rule:
 
     * ``_ENV_ASSIGN_RE`` / ``_CFG_DOTTED_RE`` / ``_SECRET_HEADER_RE`` — the
       ``(\\S+)`` capture ends exactly at ``\\"`` when whitespace and more
@@ -1569,6 +1569,14 @@ class TestEscapedQuoteSurvivesRedaction:
         pytest.param("run {q}app.api.key={s}{q} now", id="cfg-dotted"),
     ]
 
+    AUTH_HEADER_TEMPLATES = [
+        pytest.param("curl -H {q}Authorization: Bearer {s}{q} -v", id="bearer"),
+        pytest.param("curl -H {q}Authorization: Basic {s}{q} -v", id="basic"),
+        pytest.param("curl -H {q}Authorization: {s}{q} -v", id="bare-credential"),
+        pytest.param("curl -H {q}Proxy-Authorization: Bearer {s}{q} -v", id="proxy"),
+        pytest.param("curl -H {q}Authorization: Bearer {s}{q}", id="bearer-at-end"),
+    ]
+
     @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
     @pytest.mark.parametrize("quote", ['"', "'"])
     @pytest.mark.parametrize("indent", [None, 2])
@@ -1603,6 +1611,35 @@ class TestEscapedQuoteSurvivesRedaction:
                 # its survival would pin a promise the redactor never made.
                 assert value.count('"') == inner.count('"'), ctx
         self._assert_no_incidental_overlap(template)
+
+    @pytest.mark.parametrize("template", AUTH_HEADER_TEMPLATES)
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    @pytest.mark.parametrize("indent", [None, 2])
+    def test_authorization_credential_escape_survives(
+        self, template, quote, indent
+    ):
+        """``_AUTH_HEADER_RE``'s class excludes the quote but not its escape.
+
+        The residual left by #43083: excluding ``"`` from the credential class
+        stops the capture from eating the quote, but the backslash in front of
+        it is still a "not a quote, not whitespace" character, so the capture
+        ends ``…secret\\`` inside a serialized document. Swept across the floor
+        because that is where the old behaviour changed — a 4-char tail
+        re-emitted the backslash, a bare ``***`` deleted it.
+        """
+        self._assert_no_incidental_overlap(template)
+        for n in self.LENGTHS:
+            secret = self._secret(n)
+            inner = template.format(q=quote, s=secret)
+            serialized = json.dumps(
+                {"content": inner}, ensure_ascii=False, indent=indent
+            )
+
+            redacted = redact_sensitive_text(serialized, force=True)
+
+            ctx = (n, quote, indent, serialized, redacted)
+            value = json.loads(redacted)["content"]
+            assert secret not in value, ctx
 
     @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
     @pytest.mark.parametrize("indent", [None, 2])
@@ -1649,7 +1686,10 @@ class TestEscapedQuoteSurvivesRedaction:
             index += 1
         return count
 
-    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
+    @pytest.mark.parametrize(
+        "template",
+        ESCAPED_QUOTE_TEMPLATES + AUTH_HEADER_TEMPLATES,
+    )
     @pytest.mark.parametrize("quote", ['"', "'"])
     def test_redaction_never_manufactures_delimiters(self, template, quote):
         """Redaction may delete structure bytes, never invent them.
@@ -1699,7 +1739,7 @@ class TestEscapedQuoteSurvivesRedaction:
     ]
 
     @pytest.mark.parametrize("build,path", CONSUMER_SHAPES)
-    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
+    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES + AUTH_HEADER_TEMPLATES)
     def test_redacted_json_dump_round_trips_for_reparsing_consumers(
         self, build, path, template
     ):

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -982,10 +982,11 @@ class TestSerializedJsonStaysParseable:
         unbalanced, and the same shape #43083 asserts for Authorization
         (``result.count('"') == 2``).
         """
-        for text in ['x-api-key: "quoted"', "x-api-key: 'quoted'"]:
+        for quote in ('"', "'"):
+            text = f"x-api-key: {quote}quoted{quote}"
             result = redact_sensitive_text(text, force=True)
             assert "quoted" not in result
-            assert result.count(text[11]) == 2, result
+            assert result.count(quote) == 2, result
 
     def test_shell_command_quote_survives(self):
         """The non-JSON half of the same defect: a quoted curl header.
@@ -1028,6 +1029,112 @@ class TestSerializedJsonStaysParseable:
         assert secret not in result, result
         assert result.count(quote) % 2 == 0, result
         assert result.endswith(quote), result
+
+
+class TestDelimiterSplitNeverDisclosesSecretBytes:
+    """The delimiter split must not become a channel for secret bytes.
+
+    ``_split_trailing_delimiter`` re-emits the run it split off. If that run is
+    taken purely on shape (``["'][}\\],]*$``), a secret whose own tail happens
+    to look structural gets republished verbatim: ``MY_TOKEN=a'}}}}…`` printed
+    32 of 33 characters that the bare ``***`` had covered. A redactor that
+    emits *more* plaintext than before is a regression, not a fix.
+
+    The invariant: a delimiter only closes something that was **opened**, so the
+    split requires the same quote earlier in the text. These tests pin that
+    requirement rather than the current output, so widening the run class again
+    fails here.
+    """
+
+    # (secret, the substring that must not be republished). Each ends in a run
+    # that _TRAILING_DELIMITER_RE matches on shape alone.
+    STRUCTURAL_TAIL_SECRETS = [
+        ("Tr0ub4dor&3'}", "'}"),
+        ("a" + "'" + "}" * 31, "'" + "}" * 31),
+        ("s3cret'}],", "'}],"),
+        ("pw'}]},", "'}]},"),
+        ('hunter2"]', '"]'),
+        ("pw',", "',"),
+    ]
+
+    @pytest.mark.parametrize("secret,structural_tail", STRUCTURAL_TAIL_SECRETS)
+    def test_no_opening_quote_means_tail_belongs_to_the_secret(
+        self, secret, structural_tail
+    ):
+        """With nothing opened earlier, the whole value is the secret."""
+        result = redact_sensitive_text(f"MY_TOKEN={secret}", force=True)
+
+        assert structural_tail not in result, result
+        assert secret not in result, result
+
+    @pytest.mark.parametrize("secret,structural_tail", STRUCTURAL_TAIL_SECRETS)
+    def test_disclosure_never_exceeds_the_baseline(self, secret, structural_tail):
+        """No suffix of the secret survives the mask.
+
+        Stronger than the test above and the property that actually matters:
+        for every suffix of the secret, that suffix must not appear in the
+        output. Catches a partial re-emission as well as a whole-run one.
+        """
+        result = redact_sensitive_text(f"MY_TOKEN={secret}", force=True)
+
+        for start in range(len(secret)):
+            assert secret[start:] not in result, (secret[start:], result)
+
+    def test_delimiter_is_still_split_when_a_quote_was_opened(self):
+        """The repair must survive the anti-disclosure requirement.
+
+        Same structural tail, but now a quote is genuinely open before the key,
+        so the trailing quote is a delimiter and must be re-emitted.
+        """
+        result = redact_sensitive_text("sh -c 'export MY_TOKEN=xyz'", force=True)
+
+        assert result == "sh -c 'export MY_TOKEN=***'"
+
+    def test_empty_value_keeps_its_container_delimiter(self):
+        """A key with no value at all must not eat the closing quote.
+
+        ``MY_TOKEN=`` captures only the delimiter, which an earlier guard
+        skipped — leaving the same unterminated-quote corruption the fix exists
+        to remove.
+        """
+        result = redact_sensitive_text("sh -c 'export MY_TOKEN='", force=True)
+        assert result.count("'") == 2, result
+
+        payload = json.dumps({"c": "MY_TOKEN=", "b": 1}, ensure_ascii=False, indent=2)
+        reparsed = json.loads(redact_sensitive_text(payload, force=True))
+        assert sorted(reparsed) == ["b", "c"]
+
+
+class TestYamlAssignDelimiter:
+    """``_YAML_ASSIGN_RE`` is the fourth pattern in this bug class.
+
+    Its value class ``[^\\s&]++`` absorbs a trailing quote exactly like the
+    KEY=VALUE and header patterns; the negative lookahead only rejects a
+    *leading* quote, so a quoted value defers to ``_JSON_FIELD_RE`` while a
+    trailing delimiter still reaches the masker.
+
+    Reachable through ``gateway.run._redact_approval_command``, which runs the
+    raw command string with ``code_file=False`` — so a multi-line command
+    echoed into a chat approval prompt hits this pass.
+    """
+
+    @pytest.mark.parametrize("key", ["password", "api_key", "client_secret"])
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_multiline_shell_string_stays_balanced(self, key, quote):
+        text = f"sh -c {quote}\n{key}: xyz{quote}"
+
+        result = redact_sensitive_text(text, force=True)
+
+        assert "xyz" not in result, result
+        assert result.count(quote) == 2, result
+        assert result.endswith(quote), result
+
+    def test_structural_tail_without_opening_quote_is_masked(self):
+        """Same anti-disclosure requirement as the other patterns."""
+        result = redact_sensitive_text("password: pw'}]", force=True)
+
+        assert "'}]" not in result, result
+        assert "pw" not in result, result
 
 
 class TestRedactThenReparseConsumers:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,5 +1,6 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import json
 import logging
 
 import pytest
@@ -831,3 +832,273 @@ class TestKeywordWordBoundary:
         assert "hunter2hunter2hunter2hh" not in result
 
 
+class TestSerializedJsonStaysParseable:
+    """Redacting a serialized JSON payload must not corrupt the JSON.
+
+    Same defect class as #43083 (``_AUTH_HEADER_RE``'s greedy ``\\S+`` eating a
+    closing quote), at the sibling patterns that fix did not touch: the
+    KEY=VALUE passes and ``_SECRET_HEADER_RE``. Each captures an unquoted value
+    bounded by "not whitespace", which also admits the quote that closes the
+    enclosing JSON string. Masking a value under the 18-char floor to a bare
+    ``***`` then deleted that quote, and every in-tree consumer that reparses
+    the redacted text degrades differently:
+
+    * ``agent_runtime_helpers.dump_api_request_debug`` — swallows the
+      ``JSONDecodeError``, so no request dump lands for exactly the API
+      failures the dump exists to explain.
+    * ``agent.trace_upload._tool_calls_to_blocks`` — raises
+      ``TraceRedactionError`` and refuses the whole upload.
+    * ``tools.kanban_tools`` — ``except json.JSONDecodeError: pass`` leaves the
+      *original unredacted* dict bound, so the secret is persisted verbatim.
+      That one is a redaction bypass, covered by
+      ``TestRedactThenReparseConsumers`` below.
+
+    Asserted as an invariant — redact(serialize(x)) parses — rather than as
+    fixed output, so any future pattern that eats a delimiter fails here.
+    """
+
+    # (content, the secret that must not survive). Short values (< the 18-char
+    # mask floor) mask to a bare "***" and so have no tail that could
+    # accidentally carry the delimiter — that is what made the corruption
+    # visible; long values pin the other branch.
+    #
+    # ``api_key: ab`` is deliberately absent: _YAML_ASSIGN_RE is line-anchored
+    # and a serialized-JSON line starts with its own key, so that pass does not
+    # fire inside JSON by design. Listing it would assert a behaviour the
+    # redactor never promised.
+    SECRET_BEARING_CONTENT = [
+        ("export MY_TOKEN=xyz", "xyz"),
+        ("export MY_TOKEN=abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"),
+        ("DB_PASSWORD=pw1", "pw1"),
+        ("spring.datasource.password=ab", "ab"),
+        ("spring.datasource.password=averylongpassword123", "averylongpassword123"),
+        ("value at end of string MY_TOKEN=ab", "ab"),
+        ("A_TOKEN=q1 B_PASSWORD=q2", "q2"),
+        ('MY_TOKEN="quotedshortvalue"', "quotedshortvalue"),
+        ("MY_TOKEN='sq'", "sq"),
+        # _SECRET_HEADER_RE — the sibling pattern with the same bare (\S+)
+        # value class. Short values mask to "***" and so exposed the same
+        # delimiter deletion; a curl command carrying one is an ordinary thing
+        # to find inside a request dump or a tool-call argument.
+        ("x-api-key: abc123", "abc123"),
+        ("x-auth-token: sh0rt", "sh0rt"),
+        ("api-key: pw1", "pw1"),
+        ("x-api-key: averylongheadervalue123456", "averylongheadervalue123456"),
+    ]
+
+    @pytest.mark.parametrize("content,secret", SECRET_BEARING_CONTENT)
+    def test_redacted_json_still_parses(self, content, secret):
+        payload = {"messages": [{"role": "user", "content": content}]}
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2)
+
+        redacted = redact_sensitive_text(serialized, force=True)
+
+        # The assertion under test: the payload survives the round trip.
+        reparsed = json.loads(redacted)
+        assert list(reparsed) == ["messages"]
+        assert reparsed["messages"][0]["role"] == "user"
+
+    @pytest.mark.parametrize("content,secret", SECRET_BEARING_CONTENT)
+    def test_secret_still_masked_inside_json(self, content, secret):
+        """Preserving the delimiter must not preserve the secret with it."""
+        payload = {"messages": [{"role": "user", "content": content}]}
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2)
+
+        redacted = redact_sensitive_text(serialized, force=True)
+
+        # Assert on the *parsed* value, not the raw text, so a pass can never
+        # come from the JSON having been mangled into something unparseable.
+        content_out = json.loads(redacted)["messages"][0]["content"]
+        assert f"={secret}" not in content_out
+        assert f"='{secret}'" not in content_out
+        assert f'="{secret}"' not in content_out
+
+    def test_mask_tail_is_the_value_not_the_delimiter(self):
+        """A long value's preserved tail comes from the secret, not the quote.
+
+        Before the fix the captured value included the closing quote, so
+        ``mask_secret``'s 4-char tail was ``lue"`` — the JSON happened to stay
+        parseable, but the displayed tail was wrong and one real character of
+        the value was hidden behind the delimiter.
+        """
+        serialized = json.dumps(
+            {"c": "MY_TOKEN=averylongsecretvalue"}, ensure_ascii=False, indent=2
+        )
+
+        value = json.loads(redact_sensitive_text(serialized, force=True))["c"]
+
+        assert value.endswith("alue")
+        assert not value.endswith('lue"')
+
+    def test_compact_json_closing_brace_is_preserved(self):
+        """Un-indented JSON: the value absorbs the closing brace too.
+
+        ``json.dumps`` without ``indent=`` leaves no whitespace after the value,
+        so the "not whitespace" value class captures ``xyz"}`` — the delimiter
+        run, not just one quote. ``plugins/platforms/google_chat/adapter.py``
+        redacts an un-indented dump, so this shape is a real call path.
+        """
+        serialized = json.dumps({"c": "MY_TOKEN=xyz"}, ensure_ascii=False)
+
+        redacted = redact_sensitive_text(serialized, force=True)
+
+        assert json.loads(redacted)["c"] == "MY_TOKEN=***"
+
+    def test_plain_shell_text_unquoted_value_unchanged(self):
+        """Outside a container there is no delimiter to split — mask as before."""
+        result = redact_sensitive_text("PGPASSWORD=hunter2 psql -h db", force=True)
+        assert result == "PGPASSWORD=*** psql -h db"
+
+    def test_apostrophe_in_value_is_not_treated_as_delimiter(self):
+        """Only a *trailing* quote is split, and the secret is still masked."""
+        result = redact_sensitive_text("MY_TOKEN=ab'cd", force=True)
+        assert "ab'cd" not in result
+        assert "MY_TOKEN=" in result
+
+    def test_interior_quote_value_is_fully_masked(self):
+        """A value containing a quote must not survive past the quote.
+
+        This is the property that rules out the other candidate fix — copying
+        #43083's value-class exclusion (``[^\\s\"']+``) onto these patterns.
+        That would stop the capture *at* the interior quote and re-emit the
+        rest verbatim: ``PGPASSWORD=p'ass`` -> ``PGPASSWORD=***'ass``. Bearer
+        tokens never contain quotes (#43083's stated rationale), but a
+        password may, so the exclusion is safe there and lossy here.
+        """
+        for text, leaked_tail in [
+            ("PGPASSWORD=p'ass psql", "ass"),
+            ("MY_SECRET=he\"llo", "llo"),
+            ("DB_PASSWORD=x'y'z", "y'z"),
+            ("x-api-key: ab'cd", "cd"),
+        ]:
+            result = redact_sensitive_text(text, force=True)
+            assert leaked_tail not in result, (text, result)
+
+    def test_quoted_header_value_keeps_both_quotes(self):
+        """A header value wrapped in its own quotes stays balanced.
+
+        ``x-api-key: "abc"`` must mask to ``x-api-key: "***"``. Splitting only
+        the trailing quote would emit ``***"`` — parseable, but visibly
+        unbalanced, and the same shape #43083 asserts for Authorization
+        (``result.count('"') == 2``).
+        """
+        for text in ['x-api-key: "quoted"', "x-api-key: 'quoted'"]:
+            result = redact_sensitive_text(text, force=True)
+            assert "quoted" not in result
+            assert result.count(text[11]) == 2, result
+
+    def test_shell_command_quote_survives(self):
+        """The non-JSON half of the same defect: a quoted curl header.
+
+        Direct parallel to #43083's ``test_token_flush_against_double_quote``,
+        which pins this contract for ``Authorization:``. Without it the closing
+        quote vanishes and the command no longer parses (shell EOF).
+        """
+        for quote in ('"', "'"):
+            text = f"curl -H {quote}x-api-key: abc123{quote} https://api.example.com"
+            result = redact_sensitive_text(text, force=True)
+            assert "abc123" not in result
+            assert result.count(quote) == 2, result
+            assert "https://api.example.com" in result
+
+    @pytest.mark.parametrize(
+        "template,secret",
+        [
+            ("sh -c {q}export MY_TOKEN={s}{q}", "xyz"),
+            ("docker run -e {q}DB_PASSWORD={s}{q}", "pw1"),
+            ("ssh host {q}PGPASSWORD={s} psql{q}", "pw1"),
+            ("curl -H {q}x-api-key: {s}{q}", "abc123"),
+        ],
+    )
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_quoted_shell_command_stays_balanced(self, template, secret, quote):
+        """A quote opened *before* the key must still be closed after masking.
+
+        The most common real shape of this defect, and it needs no JSON at all:
+        the shell quote wrapping the whole command is what the greedy value
+        class eats. ``sh -c 'export MY_TOKEN=xyz'`` masked to
+        ``sh -c 'export MY_TOKEN=***`` — an unterminated quote, i.e. shell EOF.
+        Asserted as balanced quote counts, the same contract #43083 pinned for
+        ``Authorization:``.
+        """
+        text = template.format(q=quote, s=secret)
+
+        result = redact_sensitive_text(text, force=True)
+
+        assert secret not in result, result
+        assert result.count(quote) % 2 == 0, result
+        assert result.endswith(quote), result
+
+
+class TestRedactThenReparseConsumers:
+    """The three in-tree callers that reparse redacted JSON, end to end.
+
+    These replicate each consumer's real handling — including its exception
+    handler — because the handler is what turns a corrupted document into the
+    user-visible failure. Behaviour contracts, not output snapshots.
+    """
+
+    # Both serializers used by the real callers. Neither is
+    # ``separators=(",", ":")``: dump_api_request_debug passes ``indent=2``,
+    # trace_upload and kanban_tools use json.dumps' default ``", "`` item
+    # separator. Both therefore leave whitespace after a string value.
+    SERIALIZERS = [
+        ("indent", {"indent": 2}),
+        ("default", {}),
+    ]
+
+    SECRETS = [
+        "export MY_TOKEN=xyz",
+        "DB_PASSWORD=pw1",
+        "spring.datasource.password=ab",
+        "x-api-key: abc123",
+        "psql; export MY_TOKEN=xyz",
+    ]
+
+    @pytest.mark.parametrize("secret_text", SECRETS)
+    @pytest.mark.parametrize("label,kwargs", SERIALIZERS)
+    def test_request_dump_payload_survives(self, secret_text, label, kwargs):
+        """dump_api_request_debug: json.loads must not raise.
+
+        The real function wraps everything in ``except Exception: return None``,
+        so a raise here means no dump file at all.
+        """
+        payload = {"request": {"body": {"messages": [{"content": secret_text}]}}}
+        serialized = json.dumps(payload, ensure_ascii=False, **kwargs)
+
+        reparsed = json.loads(redact_sensitive_text(serialized, force=True))
+
+        assert list(reparsed) == ["request"]
+
+    @pytest.mark.parametrize("secret_text", SECRETS)
+    def test_trace_upload_tool_args_survive(self, secret_text):
+        """trace_upload: a corrupted reparse raises TraceRedactionError.
+
+        ``_tool_calls_to_blocks`` re-serializes with json.dumps' defaults and
+        refuses the entire upload when the result won't parse.
+        """
+        args = {"command": secret_text, "cwd": "/tmp"}
+
+        reparsed = json.loads(redact_sensitive_text(json.dumps(args), force=True))
+
+        assert sorted(reparsed) == ["command", "cwd"]
+        assert reparsed["cwd"] == "/tmp"
+
+    @pytest.mark.parametrize("secret_text", SECRETS)
+    def test_kanban_metadata_is_not_left_unredacted(self, secret_text):
+        """kanban_tools: ``except JSONDecodeError: pass`` keeps the raw dict.
+
+        The most severe of the three — the handler leaves ``metadata`` bound to
+        the original object, so a corrupted reparse means the unredacted secret
+        is what gets persisted. Replicates tools/kanban_tools.py's five lines.
+        """
+        metadata = {"cmd": secret_text}
+        original = dict(metadata)
+
+        meta_json = redact_sensitive_text(json.dumps(metadata), force=True)
+        try:
+            metadata = json.loads(meta_json)
+        except json.JSONDecodeError:
+            pass  # the real handler
+
+        assert metadata != original, "redaction silently bypassed"

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1770,3 +1770,73 @@ class TestEscapedQuoteSurvivesRedaction:
             for step in path:
                 value = value[step]
             assert secret not in value, ctx
+
+    # A JSON field whose VALUE legitimately contains a quote or a backslash —
+    # not a serialized document nested in a string, an ordinary one-level
+    # document. Reaches ``_JSON_FIELD_RE`` rather than the ``(\S+)`` patterns
+    # above, so it needs its own shapes. Trailing backslash runs are swept
+    # because parity is what decides whether the trailing quote is a real
+    # delimiter or an escaped one.
+    QUOTE_BEARING_VALUES = [
+        pytest.param('{s}"', id="trailing-quote"),
+        pytest.param('{s}\\', id="trailing-backslash"),
+        pytest.param('{s}\\\\', id="trailing-double-backslash"),
+        pytest.param('{s}"\\', id="quote-then-backslash"),
+    ]
+
+    @pytest.mark.parametrize("raw", QUOTE_BEARING_VALUES)
+    @pytest.mark.parametrize("field", ["password", "token", "api_key"])
+    @pytest.mark.parametrize("indent", [None, 2])
+    def test_json_field_value_containing_a_quote_stays_parseable(
+        self, raw, field, indent
+    ):
+        """``_JSON_FIELD_RE``'s ``[^"]+`` stops at an ESCAPED quote too.
+
+        The third site of the same mechanism, and the only one reachable without
+        a serialized document nested inside a string: a password that genuinely
+        contains a ``"`` is escaped by ``json.dumps``, the value class stops at
+        the backslash, and the pass re-emits its own closing quote — so the
+        backslash is masked away and the quote it was escaping lands bare.
+
+        The secret sits before the quote in every shape here, which is what makes
+        the "secret is gone" half assertable; see
+        ``test_json_field_interior_quote_parses_but_still_truncates`` for the
+        case where it does not.
+        """
+        for n in self.LENGTHS:
+            secret = self._secret(n)
+            value = raw.format(s=secret)
+            serialized = json.dumps({field: value}, ensure_ascii=False, indent=indent)
+
+            redacted = redact_sensitive_text(serialized, force=True)
+
+            ctx = (n, field, indent, serialized, redacted)
+            reparsed = json.loads(redacted)  # raises if the escape was destroyed
+            assert list(reparsed) == [field], ctx
+            assert secret not in reparsed[field], ctx
+
+    @pytest.mark.parametrize("indent", [None, 2])
+    def test_json_field_interior_quote_parses_but_still_truncates(self, indent):
+        """Scopes the fix: the escape survives, the value class still truncates.
+
+        ``[^"]+`` ends the value at the first quote, so bytes AFTER an interior
+        quote were never inside the masked span — they are re-emitted verbatim on
+        every tree. Preserving the escape does not change that; it changes the
+        document from unparseable (where ``kanban_tools`` discards the redaction
+        entirely and persists the raw dict, i.e. the whole value leaks) to
+        parseable with the post-quote bytes still exposed. Pinned so the residual
+        is a recorded limit of ``_JSON_FIELD_RE``'s value class rather than
+        something a later reader mistakes this fix for having handled.
+        """
+        head, tail = self._secret(12), "trailingpart"
+        serialized = json.dumps(
+            {"password": f'{head}"{tail}'}, ensure_ascii=False, indent=indent
+        )
+
+        redacted = redact_sensitive_text(serialized, force=True)
+
+        # The half this fix owns: the escape survived, so the document parses.
+        value = json.loads(redacted)["password"]
+        # The half it does not: only the span before the quote was masked.
+        assert head not in value, redacted
+        assert tail in value, ("known limit of [^\"]+ — see docstring", redacted)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1498,3 +1498,235 @@ class TestRedactThenReparseConsumers:
             pass  # the real handler
 
         assert metadata != original, "redaction silently bypassed"
+
+
+class TestEscapedQuoteSurvivesRedaction:
+    """Masking must not destroy the backslash that escapes a quote.
+
+    The delimiter-preserving half of this module answers "don't consume the
+    quote that closes the document." This class answers its twin: inside a
+    serialized JSON string that quote appears as ``\\"``, and a value class that
+    admits ``\\`` captures the ESCAPE with the secret. Destroy the escape and
+    the quote left behind is bare, so the string ends one byte early — the same
+    unparseable document, reached through the escape byte instead of the
+    delimiter byte.
+
+    The affected site:
+
+    * ``_ENV_ASSIGN_RE`` / ``_CFG_DOTTED_RE`` / ``_SECRET_HEADER_RE`` — the
+      ``(\\S+)`` capture ends exactly at ``\\"`` when whitespace and more
+      content follow it inside the same string, and the delimiter split then
+      cut between the backslash and the quote, masking the escape away while
+      re-emitting its quote bare.
+    * ``_AUTH_HEADER_RE`` — its class excludes the quote (#43083) but not the
+      backslash, so the capture ends ``…secret\\``. Above the 18-char mask floor
+      the 4-char tail happened to re-emit that backslash; below it the bare
+      ``***`` deleted it. Only short credentials corrupted, which made this look
+      like a floor bug rather than an escape bug.
+
+    Parametrized across the mask floor because the floor is what decides bare
+    ``***`` versus a head/tail window, and that choice is exactly what decided
+    whether the escape survived by accident.
+    """
+
+    # Secret lengths sweep 1..40 inside each test rather than as pytest params:
+    # the contract is uniform in n, and 40 ids per template would triple this
+    # file's case count for no extra signal. The failing n is reported in the
+    # assertion message.
+    LENGTHS = range(1, 41)
+
+    # Drawn only from characters absent from every template below, so a short
+    # secret can never coincide with the surrounding text ("k" appearing in
+    # "x-api-key", "z" in "Authorization"). That keeps the assertion the strong,
+    # unqualified ``secret not in value`` at every n — including n=1 — instead of
+    # a minimum-length carve-out, which would stop testing the lower half of the
+    # mask floor, i.e. exactly the band where the escape was destroyed.
+    # ``_assert_no_incidental_overlap`` enforces the disjointness, so a template
+    # added later that breaks it fails loudly rather than silently weakening the
+    # sweep.
+    SECRET_ALPHABET = "fgjmq0234567890"
+
+    def _secret(self, n):
+        alphabet = self.SECRET_ALPHABET
+        return (alphabet * (n // len(alphabet) + 1))[:n]
+
+    def _assert_no_incidental_overlap(self, template):
+        """No character of a generated secret may occur in the literal text.
+
+        Cheaper and stricter than checking substrings: if the template shares no
+        character with the alphabet, no substring of any secret can appear in it.
+        """
+        literal = template.replace("{q}", "").replace("{s}", "")
+        shared = set(literal) & set(self.SECRET_ALPHABET)
+        assert not shared, (template, sorted(shared))
+
+    # Content follows the escaped quote, so the value capture terminates *at*
+    # ``\"`` — the shape that makes the escape reachable. One template per
+    # affected pattern.
+    ESCAPED_QUOTE_TEMPLATES = [
+        pytest.param("sh -c {q}export MY_TOKEN={s}{q} && echo done", id="env-assign"),
+        pytest.param("curl -H {q}x-api-key: {s}{q} --verbose", id="secret-header"),
+        pytest.param("run {q}app.api.key={s}{q} now", id="cfg-dotted"),
+    ]
+
+    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    @pytest.mark.parametrize("indent", [None, 2])
+    def test_escaped_quote_in_json_string_keeps_document_parseable(
+        self, template, quote, indent
+    ):
+        """The document parses, the secret is gone, and the quote is still there.
+
+        All three, because any one alone is satisfiable the wrong way: a
+        document can parse because the secret survived unmasked, and a secret
+        can be masked into an unparseable document. The third assertion is the
+        one this fix adds — the inner quote must still be in the *decoded*
+        value, which is only true if its escape survived masking.
+        """
+        for n in self.LENGTHS:
+            secret = self._secret(n)
+            inner = template.format(q=quote, s=secret)
+            serialized = json.dumps(
+                {"content": inner}, ensure_ascii=False, indent=indent
+            )
+
+            redacted = redact_sensitive_text(serialized, force=True)
+
+            ctx = (n, quote, indent, serialized, redacted)
+            value = json.loads(redacted)["content"]  # raises if corrupted
+            assert secret not in value, ctx
+            if quote == '"':
+                # json.dumps only escapes ``"``. A single-quoted inner string
+                # carries no escape, and the quote left open at the match is the
+                # JSON string's own, so the redactor cannot tell that ``'`` from
+                # content — it is masked with the value on every tree. Asserting
+                # its survival would pin a promise the redactor never made.
+                assert value.count('"') == inner.count('"'), ctx
+        self._assert_no_incidental_overlap(template)
+
+    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
+    @pytest.mark.parametrize("indent", [None, 2])
+    def test_escaped_quote_when_secret_is_not_the_last_field(self, template, indent):
+        """A following field is a different path through the split.
+
+        When the secret's string is the document's last value, the capture runs
+        past the escaped quote to the document's real closing ``"}``, and the
+        ``$``-anchored trailing-delimiter search lands on that genuine
+        delimiter. With a field after it, the capture stops at the escaped quote
+        instead and the search lands on ``\\"`` — the corrupting case. Both
+        shapes must hold, so both are asserted.
+        """
+        self._assert_no_incidental_overlap(template)
+        for n in self.LENGTHS:
+            secret = self._secret(n)
+            inner = template.format(q='"', s=secret)
+            serialized = json.dumps(
+                {"a": inner, "b": 1}, ensure_ascii=False, indent=indent
+            )
+
+            redacted = redact_sensitive_text(serialized, force=True)
+
+            ctx = (n, indent, serialized, redacted)
+            reparsed = json.loads(redacted)
+            assert reparsed["b"] == 1, ctx
+            assert secret not in reparsed["a"], ctx
+            assert reparsed["a"].count('"') == inner.count('"'), ctx
+
+    # Characters whose count carries JSON/shell structure. A redactor may drop
+    # them (they were the secret's own) but may never emit more than it received.
+    STRUCTURAL_CHARS = "\"'{}[],"
+
+    @staticmethod
+    def _bare_quotes(text):
+        """Count unescaped ``"`` — the ones JSON syntax actually owns."""
+        count = index = 0
+        while index < len(text):
+            if text[index] == "\\":
+                index += 2  # the escaped character is content, not syntax
+                continue
+            if text[index] == '"':
+                count += 1
+            index += 1
+        return count
+
+    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_redaction_never_manufactures_delimiters(self, template, quote):
+        """Redaction may delete structure bytes, never invent them.
+
+        The mechanism-level guard, stated over the text so it binds any future
+        pattern rather than the three fixed here. Turning a source ``\\"`` into a
+        bare ``"`` is precisely "manufacturing a delimiter": the byte count is
+        unchanged but a content quote became a syntax quote, which is what ended
+        the JSON string early. Counting *unescaped* quotes is what detects that;
+        counting quotes alone does not.
+
+        The trailing run is bounded by the input's own run rather than by
+        ``1 + depth``: a document whose last string *content* ends in quotes or
+        braces has a longer trailing run than its nesting depth, and that is the
+        input's business, not the redactor's. ``1 + depth`` bounds the suffix the
+        split re-emits (asserted in TestDelimiterSplitNeverDisclosesSecretBytes),
+        not the document's tail.
+        """
+        for n in self.LENGTHS:
+            inner = template.format(q=quote, s=self._secret(n))
+            for indent in (None, 2):
+                serialized = json.dumps(
+                    {"content": inner}, ensure_ascii=False, indent=indent
+                )
+
+                redacted = redact_sensitive_text(serialized, force=True)
+
+                ctx = (n, quote, indent, serialized, redacted)
+                for char in self.STRUCTURAL_CHARS:
+                    assert redacted.count(char) <= serialized.count(char), (char, ctx)
+                assert self._bare_quotes(redacted) <= self._bare_quotes(serialized), ctx
+                trailing = re.search(r"[\"'}\],]*$", redacted).group(0)
+                original_trailing = re.search(r"[\"'}\],]*$", serialized).group(0)
+                assert len(trailing) <= len(original_trailing), ctx
+
+    # The shapes the reparsing consumers actually hand us, now carrying an
+    # escaped quote. ``nested`` matters because the delimiter run the split may
+    # re-emit is bounded by open-container depth, and depth > 1 is where a
+    # too-generous bound would show up.
+    CONSUMER_SHAPES = [
+        pytest.param(lambda inner: {"content": inner}, ("content",), id="flat"),
+        pytest.param(
+            lambda inner: {"a": {"b": [{"content": inner}]}},
+            ("a", "b", 0, "content"),
+            id="nested-3-deep",
+        ),
+    ]
+
+    @pytest.mark.parametrize("build,path", CONSUMER_SHAPES)
+    @pytest.mark.parametrize("template", ESCAPED_QUOTE_TEMPLATES)
+    def test_redacted_json_dump_round_trips_for_reparsing_consumers(
+        self, build, path, template
+    ):
+        """kanban_tools' handler, driven by the escaped-quote shape.
+
+        ``except json.JSONDecodeError: pass`` leaves ``metadata`` bound to the
+        ORIGINAL unredacted dict, so a document this module corrupts is not a
+        cosmetic failure — it is a redaction bypass that persists the secret
+        verbatim. Asserted the way the consumer experiences it: the object it
+        ends up storing must not be the raw one.
+        """
+        self._assert_no_incidental_overlap(template)
+        for n in self.LENGTHS:
+            secret = self._secret(n)
+            inner = template.format(q='"', s=secret)
+            metadata = build(inner)
+            original = json.loads(json.dumps(metadata))  # deep copy
+
+            meta_json = redact_sensitive_text(json.dumps(metadata), force=True)
+            try:
+                metadata = json.loads(meta_json)
+            except json.JSONDecodeError:
+                pass  # the real handler in tools/kanban_tools.py
+
+            ctx = (n, template, meta_json)
+            assert metadata != original, ("redaction silently bypassed", ctx)
+            value = metadata
+            for step in path:
+                value = value[step]
+            assert secret not in value, ctx

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -2,10 +2,16 @@
 
 import json
 import logging
+import re
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    _mask_token,
+    redact_cdp_url,
+    redact_sensitive_text,
+    RedactingFormatter,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1040,10 +1046,16 @@ class TestDelimiterSplitNeverDisclosesSecretBytes:
     32 of 33 characters that the bare ``***`` had covered. A redactor that
     emits *more* plaintext than before is a regression, not a fix.
 
-    The invariant: a delimiter only closes something that was **opened**, so the
-    split requires the same quote earlier in the text. These tests pin that
-    requirement rather than the current output, so widening the run class again
-    fails here.
+    Two invariants, both about what is actually **open** at the match:
+
+    * the trailing quote must be the quote left unclosed there — *present*
+      earlier in the text is not enough;
+    * the structural run after it may only go as far as it closes the
+      containers open there, so a secret's own ``}}}}`` is cut at the open
+      depth.
+
+    These tests pin those requirements rather than the current output, so
+    widening the run class again fails here.
     """
 
     # (secret, the substring that must not be republished). Each ends in a run
@@ -1066,6 +1078,170 @@ class TestDelimiterSplitNeverDisclosesSecretBytes:
 
         assert structural_tail not in result, result
         assert secret not in result, result
+
+    # Prefixes that put a quote earlier in the subject *without* leaving one
+    # open. A membership test ("does this quote appear earlier?") passes all of
+    # these and re-emits the run verbatim; a parity test ("is one open here?")
+    # rejects them. Every case above is prefix-free, so without these a mutant
+    # that always splits would survive the suite.
+    #
+    # Split by quote parity, because the two halves have different achievable
+    # contracts:
+    #
+    # * BALANCED — the prefix's quotes close each other, so parity at the key is
+    #   the same as with no prefix at all. Full behaviour, repair included.
+    # * ODD — the prefix leaves a quote nominally open (a prose apostrophe, or
+    #   one belonging to an earlier secret). Parity is *inverted* for the rest
+    #   of the subject: this is the residual, and it is a property of reading
+    #   quotes without a grammar, not of this fix. Anti-disclosure still holds;
+    #   repair is not attempted (see the two tests below).
+    BALANCED_QUOTE_PREFIXES = [
+        pytest.param("echo 'hi' && ", id="closed-shell-string"),
+        pytest.param('he said "hi" then ', id="closed-double-quote"),
+        pytest.param('{"a": 1, "b": 2} ', id="closed-json-object"),
+    ]
+    ODD_QUOTE_PREFIXES = [
+        pytest.param("it's fine, ", id="prose-apostrophe"),
+        pytest.param("couldn't parse; ", id="prose-contraction"),
+        pytest.param("A_TOKEN=ab'cd ", id="quote-inside-earlier-secret"),
+    ]
+    CLOSED_QUOTE_PREFIXES = BALANCED_QUOTE_PREFIXES + ODD_QUOTE_PREFIXES
+
+    @pytest.mark.parametrize("prefix", CLOSED_QUOTE_PREFIXES)
+    @pytest.mark.parametrize("secret,structural_tail", STRUCTURAL_TAIL_SECRETS)
+    def test_closed_quote_earlier_does_not_enable_the_split(
+        self, secret, structural_tail, prefix
+    ):
+        """An earlier quote that is already closed must not enable the split.
+
+        The distinction is *open* versus merely *present*. A lone apostrophe in
+        prose, an already-closed shell string, or a quote belonging to a
+        different secret all put the character earlier in the subject while
+        leaving nothing open at this position — so the trailing run still
+        belongs to the secret and must be masked with it.
+
+        Holds for both parities. Where the prefix leaves a quote nominally open
+        (``ODD_QUOTE_PREFIXES``) the split does fire, but the open-container
+        stack is empty in flat prose, so the run is cut to nothing and only the
+        quote itself is re-emitted — never the structural tail this asserts on.
+        """
+        result = redact_sensitive_text(f"{prefix}MY_TOKEN={secret}", force=True)
+
+        assert structural_tail not in result, result
+
+    @pytest.mark.parametrize("prefix", BALANCED_QUOTE_PREFIXES)
+    def test_closed_quote_prefix_still_repairs_a_later_open_container(self, prefix):
+        """Parity must not over-reject: a genuinely open quote still splits.
+
+        The counterpart to the test above. After a closed quote earlier in the
+        subject, a *newly* opened one must still be recognised, or the repair
+        this fix exists for would regress on any text containing prose.
+        """
+        result = redact_sensitive_text(f"{prefix}sh -c 'export MY_TOKEN=xyz'", force=True)
+
+        assert "xyz" not in result, result
+        assert result.endswith("'"), result
+
+    @pytest.mark.parametrize("prefix", ODD_QUOTE_PREFIXES)
+    def test_odd_quote_prefix_masks_but_does_not_repair(self, prefix):
+        """The documented residual, asserted as what it is.
+
+        An unbalanced quote earlier in the subject — a prose apostrophe, or one
+        inside an earlier secret — inverts parity for everything after it, so
+        the quote that really does close this shell string reads as *closing*
+        rather than opening and the repair is skipped. Reading quotes without a
+        grammar cannot tell the two apart.
+
+        What must still hold, and is what this pins: the secret is masked, and
+        the outcome is no worse than ``upstream/main``, which eats the closing
+        quote on every one of these inputs (verified in a clean worktree). So
+        this asserts masking, not corruption — a future improvement that repairs
+        the quote here should not have to edit this test.
+        """
+        result = redact_sensitive_text(f"{prefix}sh -c 'export MY_TOKEN=xyz'", force=True)
+
+        assert "xyz" not in result, result
+        assert "MY_TOKEN=***" in result, result
+
+    def test_escaped_quote_does_not_flip_parity(self):
+        """A ``\\"`` inside serialized JSON is content, not a delimiter.
+
+        ``json.dumps`` escapes an embedded quote, so a naive parity count would
+        see it as opening a string and mis-track every delimiter after it.
+        """
+        payload = {"note": 'he said "hi"', "c": "MY_TOKEN=ab"}
+        serialized = json.dumps(payload, ensure_ascii=False, indent=2)
+
+        reparsed = json.loads(redact_sensitive_text(serialized, force=True))
+
+        assert sorted(reparsed) == ["c", "note"]
+        assert "MY_TOKEN=ab" not in reparsed["c"]
+
+    @pytest.mark.parametrize("note", ['say "hi', 'a"b"c"d', 'trailing"', '"leading'])
+    @pytest.mark.parametrize("label,kwargs", [("compact", {}), ("indent", {"indent": 2})])
+    def test_odd_escaped_quote_count_does_not_flip_parity(self, note, label, kwargs):
+        """An *odd* number of escaped quotes is what actually has teeth.
+
+        With an even count, parity is unchanged whether or not the scanner
+        honours the backslash, so an even-count fixture cannot catch a scanner
+        that ignores escapes. Each ``note`` here serializes to an odd number of
+        ``\\"``, so ignoring the backslash inverts parity at the key and the
+        closing quote is eaten again — the exact corruption this PR removes.
+        """
+        payload = {"note": note, "c": "MY_TOKEN=ab"}
+        serialized = json.dumps(payload, ensure_ascii=False, **kwargs)
+        assert serialized.count('\\"') % 2 == 1, serialized
+
+        reparsed = json.loads(redact_sensitive_text(serialized, force=True))
+
+        assert reparsed["note"] == note
+        assert reparsed["c"] == "MY_TOKEN=***"
+
+    @pytest.mark.parametrize("prefix", BALANCED_QUOTE_PREFIXES)
+    @pytest.mark.parametrize("secret,structural_tail", STRUCTURAL_TAIL_SECRETS)
+    def test_balanced_prefix_discloses_exactly_what_the_baseline_does(
+        self, secret, structural_tail, prefix
+    ):
+        """With parity balanced, the redacted value is byte-identical to base.
+
+        Nothing is open at the key, so no split may fire and the emitted value
+        is exactly ``_mask_token(secret)`` — the unpatched behaviour. This is
+        the strict form of "never emit more plaintext than upstream": not a
+        bound, an equality.
+        """
+        result = redact_sensitive_text(f"{prefix}MY_TOKEN={secret}", force=True)
+
+        _, _, emitted = result.rpartition("MY_TOKEN=")
+        assert emitted == _mask_token(secret), (emitted, result)
+
+    @pytest.mark.parametrize("prefix", ODD_QUOTE_PREFIXES)
+    @pytest.mark.parametrize("secret,structural_tail", STRUCTURAL_TAIL_SECRETS)
+    def test_odd_prefix_discloses_at_most_one_quote_beyond_the_baseline(
+        self, secret, structural_tail, prefix
+    ):
+        """The residual, measured instead of excused.
+
+        An unbalanced quote earlier in the subject leaves one nominally open, so
+        a secret ending in that quote does split. These subjects are flat — no
+        ``{`` or ``[`` is open — so the justified structural run is empty and the
+        re-emitted suffix is at most the single quote character. Every longer
+        suffix of the secret, including the structural tail, is gone.
+
+        Asserted as ``base`` or ``base + the one quote``, so the residual cannot
+        grow silently: widening the run class, or dropping the stack check, emits
+        more than this and fails here.
+        """
+        result = redact_sensitive_text(f"{prefix}MY_TOKEN={secret}", force=True)
+
+        _, _, emitted = result.rpartition("MY_TOKEN=")
+        baseline = _mask_token(secret)
+        allowed = {baseline}
+        # The split only fires when the secret's own trailing quote is the one
+        # the prefix left open.
+        match = re.search(r"([\"'])[}\],]*$", secret)
+        if match and match.group(1) == "'":
+            allowed.add(_mask_token(secret[: match.start()]) + "'")
+        assert emitted in allowed, (emitted, sorted(allowed), result)
 
     @pytest.mark.parametrize("secret,structural_tail", STRUCTURAL_TAIL_SECRETS)
     def test_disclosure_never_exceeds_the_baseline(self, secret, structural_tail):
@@ -1103,6 +1279,119 @@ class TestDelimiterSplitNeverDisclosesSecretBytes:
         payload = json.dumps({"c": "MY_TOKEN=", "b": 1}, ensure_ascii=False, indent=2)
         reparsed = json.loads(redact_sensitive_text(payload, force=True))
         assert sorted(reparsed) == ["b", "c"]
+
+
+class TestDelimiterRunBoundedByOpenContainers:
+    """The structural run is bounded by document state, not by a fixed cap.
+
+    An earlier iteration of this fix capped the run at three characters to bound
+    disclosure. That cap is not a property of anything: ``json.dumps`` defaults
+    on a five-level payload close with ``"}]}}}`` — five structural characters —
+    so the cap rejected the real container tail and left exactly the corruption
+    the fix exists to remove, while still admitting three characters of a
+    secret's own ``}}}}``.
+
+    What bounds the run instead is the stack of containers actually open at the
+    match: a closing run may only go as far as it closes them, in order. That
+    admits a legitimate tail of any depth and cuts a secret's run at the open
+    depth.
+    """
+
+    def test_nesting_deeper_than_the_old_cap_round_trips(self):
+        """Five closers — the shape the {0,3} cap rejected."""
+        payload = {"request": {"body": {"messages": [{"content": "export MY_TOKEN=xyz"}]}}}
+        serialized = json.dumps(payload, ensure_ascii=False)
+        assert serialized.endswith('"}]}}}'), serialized
+
+        redacted = redact_sensitive_text(serialized, force=True)
+
+        reparsed = json.loads(redacted)
+        content = reparsed["request"]["body"]["messages"][0]["content"]
+        assert content == "export MY_TOKEN=***"
+
+    @pytest.mark.parametrize("depth", [1, 2, 4, 6, 9])
+    def test_any_nesting_depth_round_trips(self, depth):
+        """No cap: the tail is as long as the document is deep."""
+        payload = {"c": "MY_TOKEN=xyz"}
+        for _ in range(depth):
+            payload = {"n": [payload]}
+        serialized = json.dumps(payload, ensure_ascii=False)
+
+        redacted = redact_sensitive_text(serialized, force=True)
+
+        node = json.loads(redacted)
+        for _ in range(depth):
+            node = node["n"][0]
+        assert node["c"] == "MY_TOKEN=***"
+
+    def test_run_longer_than_the_open_depth_is_truncated(self):
+        """A secret's own run is cut where the open containers run out.
+
+        One ``{`` is open, so one ``}`` is justified; the other three belong to
+        the secret and are dropped rather than republished.
+        """
+        result = redact_sensitive_text("{ it's MY_TOKEN=a'}}}}", force=True)
+
+        assert result == "{ it's MY_TOKEN=***'}", result
+        assert "}}" not in result, result
+
+    def test_separator_needs_an_open_container(self):
+        """``,`` closes nothing, so it is only legal while something is open."""
+        inside = redact_sensitive_text('{"c": "MY_TOKEN=xyz", "b": 1}', force=True)
+        assert json.loads(inside)["b"] == 1
+        assert json.loads(inside)["c"] == "MY_TOKEN=***"
+
+        # Flat prose: nothing is open, so the trailing comma is secret.
+        flat = redact_sensitive_text("it's MY_TOKEN=pw',", force=True)
+        assert "'," not in flat, flat
+
+    @pytest.mark.parametrize(
+        "run", [",", ",,", ",,,,", ",}", ",]", "},", "}],"]
+    )
+    def test_separator_is_accepted_only_as_the_final_character(self, run):
+        """A separator ends the justified run — nothing may follow it.
+
+        The stack bounds *closers*, but a separator closes nothing, so it cannot
+        be bounded by depth: accepting a run of them would republish a secret's
+        whole ``',,,,`` tail. In a real container tail a separator can appear
+        only once and only last, because whatever follows one is the next member
+        — never another closer. So ``}],`` is a legal capture and ``,}`` is not.
+
+        Asserted through the public function, on a subject with one container
+        open, so the bound is a behaviour and not an implementation detail.
+        """
+        result = redact_sensitive_text(f"{{ it's MY_TOKEN=pw'{run}", force=True)
+
+        _, _, emitted = result.partition("MY_TOKEN=")
+        # everything after the mask must be a legal tail: closers that the one
+        # open "{" justifies, with at most one separator, and it last
+        suffix = emitted[len("***") :]
+        assert suffix.startswith("'"), (suffix, result)
+        structural = suffix[1:]
+        assert structural.count(",") <= 1, (suffix, result)
+        assert "," not in structural[:-1], (suffix, result)
+        assert len(structural.replace(",", "")) <= 1, (suffix, result)
+
+    def test_mismatched_closer_is_not_justified(self):
+        """``]`` does not close ``{`` — a stray closer is not a container tail."""
+        result = redact_sensitive_text('{"c": "MY_TOKEN=xyz"]}', force=True)
+
+        assert "xyz" not in result, result
+        assert result == '{"c": "MY_TOKEN=***"', result
+
+    def test_structural_characters_inside_a_string_are_content(self):
+        """A ``{`` inside a JSON string does not open a container.
+
+        Otherwise a value that merely mentions a brace would inflate the stack
+        and justify a longer run than the document actually has open.
+        """
+        payload = {"note": "use {braces} and [brackets]", "c": "MY_TOKEN=xyz"}
+        serialized = json.dumps(payload, ensure_ascii=False)
+
+        reparsed = json.loads(redact_sensitive_text(serialized, force=True))
+
+        assert reparsed["note"] == "use {braces} and [brackets]"
+        assert reparsed["c"] == "MY_TOKEN=***"
 
 
 class TestYamlAssignDelimiter:


### PR DESCRIPTION
## What does this PR do?

`redact_sensitive_text()` corrupts the document it is redacting. Five patterns bound the secret with a "not whitespace" value class (`(\S+)`, or `[^\s&]+?` / `[^\s&]++` for the config and YAML forms), which also admits the quote that closes an **enclosing** document. Because `_mask_token` masks anything under its 18-char floor to a bare `***`, that quote is **deleted** rather than merely displaced.

This is the same defect class as **#43083** — *"`_AUTH_HEADER_RE`'s greedy `\S+` credential class ate a closing quote … turning value corruption into syntax corruption"* — at the sibling patterns that fix did not touch: `_ENV_ASSIGN_RE`, `_CFG_DOTTED_RE` / `_CFG_ANCHORED_RE` (via `_CFG_VALUE`), `_SECRET_HEADER_RE`, and `_YAML_ASSIGN_RE`.

**It needs no JSON to bite.** On current `main`:

```
sh -c 'export MY_TOKEN=xyz'        ->  sh -c 'export MY_TOKEN=***      # unterminated quote
sh -c 'export MY_TOKEN='           ->  sh -c 'export MY_TOKEN=***      # empty value, same
docker run -e 'DB_PASSWORD=pw1'    ->  docker run -e 'DB_PASSWORD=***  # shell EOF
curl -H 'x-api-key: abc123'        ->  curl -H 'x-api-key: ***         # shell EOF
```

### Why it matters: three consumers reparse redacted text, and each degrades differently

| consumer | handler | user-visible result |
|---|---|---|
| `agent_runtime_helpers.dump_api_request_debug` | `except Exception: return None` | **no request dump lands at all**, for exactly the API failures the dump exists to explain |
| `agent.trace_upload._tool_calls_to_blocks` | raises `TraceRedactionError` | the **whole upload is refused** |
| `tools.kanban_tools` | `except json.JSONDecodeError: pass` | leaves the **original unredacted dict** bound — the secret is persisted verbatim |

The third is a **redaction bypass**, not data loss.

## Related Issue

Refs #77472 — the "redacted only by regex (`force=True` makes it a controlled residual)" item in cluster R-DUMP. The file-mode items from that issue are covered separately by #77520 / #77655 / #77717, and its unbounded-growth item by #78395; the *"exact-value redaction on every persistence path"* ask remains deliberately **not** implemented, per #43083 (masking a credential in a replayed path poisons the replay — guarded by `tests/agent/test_tool_call_arg_no_redaction.py`).

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

> **This body describes the mechanism as of `59bb144ff`.** Earlier pushes on this branch used different mechanisms and this body described one of them. Review found defects in each; see *"Review found three defects across my earlier pushes"* and *"An adversarial re-audit found a P0 in this PR"* below. I have corrected the claims rather than quietly replacing them.

- **`agent/redact.py`**
  - `_DocumentStateScanner` — tracks, for one `sub()` pass, **which quote is open** and **which containers are open** at a position. `re.sub` calls its callback on non-overlapping matches in increasing positional order, so the state is carried forward incrementally and a whole pass stays **O(L)**. Escape-aware (the `\"` inside serialized JSON does not flip parity); `{` / `[` are only counted while no quote is open, so a brace inside a string is content, not structure.
  - `_justified_delimiter_len(run, stack)` — how much of a trailing `}]}}` run is **consistent with closing the containers actually open there**, in order.
  - `_split_trailing_delimiter(value, *, quote="", open_quote=None, stack=None)` — splits a trailing delimiter off an *unquoted* capture and returns `(secret, suffix)`; the suffix is re-emitted after the mask. Two requirements, both about what is **open**: the captured trailing quote must *be* the open one, and the structural run after it is truncated to its justified prefix. The rest is secret and is **dropped** — not re-emitted, and not handed back to the masker where the head/tail window could republish it.
  - `_mask_preserving_delimiter(value, *, open_quote=None, stack=None)` — for bare-value captures with no quote group of their own. Adds the balanced-pair case so `x-api-key: "abc"` → `x-api-key: "***"` instead of an unbalanced `***"`. That branch is reachable only from `_SECRET_HEADER_RE`; `_YAML_ASSIGN_RE`'s `(?!['\"])` lookahead rejects a value that *starts* with a quote. Verified by instrumentation — 0 firings from `_redact_yaml` over 2,872 inputs.
  - Wired into `_redact_env` (shared by `_ENV_ASSIGN_RE`, `_CFG_DOTTED_RE`, `_CFG_ANCHORED_RE`) and the `_SECRET_HEADER_RE` and `_YAML_ASSIGN_RE` passes. One scanner per `sub()` pass, since each pass runs over a freshly rebuilt subject.
  - `_escapes_the_quote_at(text, quote_pos)` — is the quote at that position backslash-**escaped**? Keyed on **parity, not presence**: `json.dumps` doubles a literal backslash, so a value genuinely ending in `\` serializes to `\\` and leaves an EVEN run before the real delimiter. Only an ODD run means the last backslash introduces an escape. This is the one rule behind every escape-aware branch in the module, and it is wired into three sites (see the P0 section below).
- **`tests/agent/test_redact.py`** — 73 → **356** tests.

### The mechanism, and why it is bounded by document state rather than by a cap

The structural bytes a capture absorbs are **document bytes** — they must be re-emitted or the document loses them. But a *secret's* random `}}}}` run is distinguishable from a *document's* closing run, because the document's run has to be consistent with what is actually open at that position:

| capture | open containers | emitted | masked |
|---|---|---|---|
| `xyz"}]}}}` | `{ { { [ {` | `"}]}}}` — fully justified | `xyz` |
| `a'}}}}` | `{` | `'}` — one closer justified | `a` + the rest **dropped** |
| `pw',` | `{` | `',` — separator, inside a container | `pw` |
| `pw'}]},` | *(nothing open)* | no split at all | the whole value |

A separator is accepted only as the **final** character and only with a container open. The stack bounds *closers*, but `,` closes nothing, so a run of them is bounded by nothing — my own differential fuzzer caught `',,,,` being republished whole before this landed.

### Why not copy #43083's mechanism

The obvious move is to reuse that fix's shape: exclude quotes from the value class (`(\S+)` → `([^\s\"']+)`). I implemented it and measured it head-to-head, then rejected it. It truncates at an **interior** quote and re-emits the tail verbatim:

```
                                    #43083 mechanism          this PR
PGPASSWORD=p'ass psql        ->  PGPASSWORD=***'ass       PGPASSWORD=*** psql
MY_SECRET=he"llo             ->  MY_SECRET=***"llo        MY_SECRET=***
DB_PASSWORD=x'y'z            ->  DB_PASSWORD=***'y'z      DB_PASSWORD=***
```

It also cannot cross the escaped `\"` inside serialized JSON, which leaks the whole value *and* still corrupts the document:

```
in   {"c": "MY_TOKEN=\"quotedshortvalue\""}
out  {"c": "MY_TOKEN=***"quotedshortvalue\""}     # leaked + unparseable
```

#43083's stated rationale — *"real credentials never contain `"` or `'`"* — holds for the opaque bearer tokens it was written for. It does not hold for **passwords**, which is what `PGPASSWORD` / `_CFG_*` match. Making a redactor leak more is the wrong direction, so the fix goes in the masking callbacks instead.

### Review found three defects across my earlier pushes

I had this branch adversarially reviewed before asking for yours, twice. Both earlier commits were wrong, and one of my own claims in this body was wrong. Stating it plainly rather than editing history:

**`ca158df8b` — the split was itself a disclosure channel.** `_TRAILING_DELIMITER_RE` matched on *shape alone* (`["'][}\],]*$`) and the run was re-emitted verbatim, so a secret whose own tail looked structural got republished: `MY_TOKEN=a'}}}…` (33 chars) printed **32 of them**, all of which the bare `***` had covered on `main`. My first body described this as a one-character delta. That was simply wrong.

**`2df71234e` — "present" is not "open", and the check was quadratic.** That commit required the quote to *appear* earlier in the subject (`quote in text[:pos]`). Two further defects:

1. A prose apostrophe (`it's`, `couldn't`) satisfies a membership test, so the leak came straight back — **2,335 of 6,000** fuzz cases.
2. `text[:pos]` copies a prefix **per match**, i.e. O(N·L) per pass — **8.7 GB copied** on a 1 MB input.

**`aad60d98c` (this push) — the cap was not a property of anything.** An intermediate iteration replaced presence with real quote **parity** (correct, kept) but bounded the structural run with a `{0,3}` cap. `json.dumps`' *default* separators on a five-level payload close with `"}]}}}` — **five** structural characters — so the cap rejected the genuine container tail and left exactly the corruption this PR exists to remove (5 consumer tests failed), while still admitting three characters of a secret's own `}}}}`. Replaced with the open-container-stack test above.

Measured across the three, same metric, same 2,772-input corpus — inputs where the candidate discloses more than the open-container stack justifies:

| | `ca158df8b` | `2df71234e` | `aad60d98c` |
|---|---|---|---|
| inputs over the justified bound | 321 | 128 | **0** |
| valid-JSON inputs that reparse (of 462) | — | — | **462** (base: 123) |

### Known limitations, stated plainly

**1. Quote parity is syntactic, so an unbalanced quote earlier in the subject inverts it.** A prose apostrophe, or a quote inside an *earlier* secret, leaves a quote nominally open for everything after it. Two consequences, both **no worse than `main`**:

- A genuine shell quote after prose is **not repaired**: `it's fine, sh -c 'export MY_TOKEN=xyz'` still loses its closing quote. `main` eats it too — verified in a clean worktree — so this is an un-repaired case, not a regression.
- A secret ending in that quote re-emits it. Bounded by **1 + the open container depth**, drawn from `"'}],`; in flat prose that is a single character. Above the 18-char mask floor `mask_secret`'s head/tail window dominates and base and fix disclose the same 4-char window; the residual only appears below the floor, where base emitted a bare `***`.

This is asserted, not excused: `test_odd_prefix_discloses_at_most_one_quote_beyond_the_baseline` pins the output to *base* or *base + the one quote*, so the residual cannot grow silently.

**2. A truly compact serializer** (`separators=(",", ":")`) leaves no whitespace after the value, so the capture ends in `}` preceded by non-structural bytes — no delimiter-only suffix to split. That input is still corrupted, and the helper's docstring says so. It is unreachable from the three reparsing callers: `dump_api_request_debug` passes `indent=2`; `trace_upload` and `kanban_tools` use `json.dumps`' default `", "`. Of the 52 `separators=(",", ":")` sites in the tree, none feed the redactor (wire framing, cache keys, canonical hashing). `plugins/platforms/google_chat/adapter.py:1410` redacts an un-indented dump but only logs it, never reparses. Handling it generally means walking the parsed structure instead of running a *text* redactor across JSON boundaries — a caller-side change at three sites, so not here.

**3. One shape stays unbalanced, identically to base:** `sh -c "MY_TOKEN="quotedshort""` — the input is genuinely ambiguous about which quote closes what. Byte-identical to `main`.

### Intentional behavior deltas

Container-free output is byte-identical to `main` on **17 of 22** probe inputs; the 5 deltas are the repairs:

- A quoted header value keeps both quotes: `x-api-key: "quoted"` → `x-api-key: "***"` (was `x-api-key: ***`). Matches the contract #43083 already pins for `Authorization:` (`assert result.count('"') == 2`).
- A long value's preserved tail now comes from the **value** rather than from the delimiter: `MY_TOKEN=averylongsecretvalue` inside JSON shows `…alue` where base showed `…lue"`. Same 4-char budget, correct bytes.

### An adversarial re-audit found a P0 in this PR, and two more sites of the same defect

I had this branch attacked rather than reviewed. It found a regression **I introduced**, plus two pre-existing siblings of the same mechanism. All three are fixed in `5e0656bdf`, `971dca686`, `59bb144ff`.

**The P0 (mine).** `_split_trailing_delimiter` compared the captured trailing quote to the quote open at the match, but never asked whether that quote was **escaped**. Inside a serialized JSON string the enclosing quote appears as `\"`, and the `(\S+)` value classes absorb both bytes — so the split cut *between* the backslash and the quote. The backslash went into the secret handed to `_mask_token` (deleted outright below the 18-char floor, where the mask is a bare `***`) and the quote was re-emitted **bare**, terminating the string early:

```
in    {"content": "sh -c \"export MY_TOKEN=9\" && echo done"}
main  {"content": "sh -c \"export MY_TOKEN=*** && echo done"}   parses
prev  {"content": "sh -c \"export MY_TOKEN=***" && echo done"}  BROKEN
now   {"content": "sh -c \"export MY_TOKEN=***\" && echo done"} parses
```

**Why every sweep in this body missed it.** The defect needs whitespace **and more content after** the escaped quote, so the capture terminates exactly at `\"`. When the escaped quote is the last thing in the string the capture runs past it and the `$`-anchored search lands on the document's real quote instead — which is the shape all my earlier corpora generated. `json.dumps` of a plain value never produces the failing shape either, so 11,664 valid-JSON probes also reported clean. My corpus was structurally blind to the family, and the fuzz numbers above should be read with that in mind.

**Why it was a merge blocker, not a cosmetic regression.** `tools/kanban_tools.py` keeps the **original unredacted dict** on `JSONDecodeError`, so every corrupted document is a redaction bypass that persists the secret verbatim. Measured on 4,800 cases (3 families × lengths 1-40 × quote `"` and `'` × `indent` None/2 × last / not-last / nested):

| metric | base `1be70d635` | pre-guard `aad60d98c` | guarded `59bb144ff` |
|---|---|---|---|
| reparse OK | 3882/4800 | 4032/4800 | **4800/4800** |
| kanban raw secret persisted | 918 | 768 | **0** |
| reparse regressions vs base | — | **288** | **0** |

Independently re-measured on a smaller focused grid (320 P0+authz probes, 120 `_JSON_FIELD_RE` probes), importing `agent.redact` from each worktree with an asserted `__file__`: reparse failures 32 → 128 → **0**, kanban raw-persisted 32 → 128 → **0**, JSON-field failures 48 → 48 → **0**.

**Sibling 1 — `_AUTH_HEADER_RE`, pre-existing on `main`.** Its credential class `[^\s\"']+` excludes the quote (the #43083 exclusion, doing its job) but **not the backslash that escapes it**. The capture therefore ends `…secret\`, masking destroys the escape, and the document's own `"` is left unescaped. It only corrupted credentials **under** the mask floor, which made it look like a floor bug — above the floor `_mask_token`'s 4-char tail happened to include the backslash, so the escape survived by accident of the window:

```
len=16  captured='…abcdefgh\'   mask='***'           reparse FAIL
len=17  captured='…abcdefghi\'  mask='k9v3zq...ghi\' reparse OK
```

Fixed with the same parity rule rather than by widening the value class — excluding `\` would stop the capture at any backslash and re-emit the rest verbatim, the lossy outcome `test_interior_quote_value_is_fully_masked` already rules out for the sibling patterns. authz reparse 1920/2400 → 1920/2400 → **2400/2400**.

**Sibling 2 — `_JSON_FIELD_RE`, pre-existing on `main`.** `[^"]+` stops at the first `"` even when it is escaped, so this is the one site reachable **without** a serialized document nested inside a string — an ordinary one-level `{"password": "abc\""}` corrupts:

```
main  {"password": "***""}     broken
now   {"password": "***\""}    parses
```

Scope, pinned by a test: the fix makes the document **parseable**, it does not extend the masked span — `[^"]+` still ends the value at the first quote, so bytes after an interior quote are re-emitted verbatim as on `main`. The improvement is still strict, because an unparseable document makes `kanban_tools` discard the redaction and persist the whole original value. Field cases 12/30 → **30/30**, no new leaks. Deliberately *not* switched to `(?:[^"\\]|\\.)+`: that regex does not match at all when the closing quote is missing (truncated or malformed JSON, which a redactor does see), turning a masked value into an unmasked one — a disclosure regression on exactly the inputs least able to afford it.

**Disclosure delta, stated rather than buried.** Both escape fixes hand the masker the *correct* token instead of `token + \`, which shifts `_mask_token`'s tail window left by one byte. Measured: 378 of 1600 cases disclose exactly **one more byte** than the pre-guard revision, all at credential length ≥ 18, all inside the true secret's own last-4 window, **0** outside it, and **0** cases gain disclosure while still failing to reparse. Below the floor both mask to `***`, so lengths 1-17 disclose strictly **less** than `main`. This is head6/tail4 applied to the right token, not a new channel — the same effect the delimiter split has, one byte instead of four. The `_split_trailing_delimiter` docstring now states this bound; the earlier suffix-only bound (`delimiter-only, ≤ 1 + depth`) was true but did not describe it.

**Knowingly left, all unchanged from `main`:**
- An inner **shell** quote nested inside a JSON string (`sh -c 'export MY_TOKEN=x'`) still loses its `'`. `json.dumps` does not escape `'`, so the quote open at the match is the JSON string's own and a text redactor cannot tell that `'` from content. The document parses; only the inner shell quote is lost.
- `_JSON_FIELD_RE` truncation (above) — parseable, not fully masked. Pinned by `test_json_field_interior_quote_parses_but_still_truncates` so it is a recorded limit rather than a surprise.
- Two pre-existing defects outside this PR's premise, both filed as separate work: `x-api-key: <val>'` at depth 0 loses its quote to `_YAML_ASSIGN_RE` → `_SECRET_HEADER_RE` double-masking within one call, and `api_key: <secret>` inside a JSON string is redacted by **no** tree (`_SECRET_HEADER_NAMES` lists `api-key`/`apikey` but not `api_key`).

**Cost.** The authz pass now builds a scanner: ~4 ms on a synthetic 112 KB payload with 2,000 `Authorization` matches (10.3 → 14.3 ms). Gate-skipped text is unaffected (23.4 → 24.9 ms on a 297 KB secret-free log).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_redact.py` — **356 passed** (was **73** at the merge base; an earlier revision of this body said 79, which was wrong — I re-measured at `3aeff239b`, `f5be9236e`, `4075c8fd5` and `1be70d635` and got 73 every time).
2. **Teeth check.** Copy the new test file onto clean `upstream/main` and run it: **83 of 259 fail** at the pre-guard revision; against the three trees, the escaped-quote class alone gives base `37 failed / 33 passed`, pre-guard `46 failed / 24 passed`, guarded `70 passed`.
3. **Differential fuzz, base vs fix**, 2,772 inputs (11 container shapes × 7 prose prefixes × 6 key patterns × 6 secret shapes, both quote kinds, both serializers, secrets above and below the mask floor):
   - **0** inputs where the fix discloses more than the open-container stack justifies (`ca158df8b`: 321, `2df71234e`: 128).
   - Instrumenting the helper over the same corpus: 2,054 re-emitted suffixes, **0** containing a non-delimiter byte, **0** longer than `1 + open depth`.
   - Payload bytes disclosed through the mask window: **0** inputs where the fix shows a longer run than base; 128 where it shows fewer.
   - Of the 462 corpus inputs that are valid JSON *before* redaction, base reparses 123, the fix reparses **462**.
4. **Mutation testing** — 10 mutations, **10 caught**: neuter parity; treat nothing-open as a match; neuter the stack check; drop the structural run; re-add the old `match.start() == 0` guard; neuter escape-awareness; ignore quote state when tracking containers; make the separator non-terminal; re-add the `{0,3}` cap; re-emit the rejected run. Three of those **survived the first run** — the escaped-quote fixture used an *even* number of `\"` (parity-neutral either way) and there was no test for separator position. Both gaps are now covered, which is why this push adds `test_odd_escaped_quote_count_does_not_flip_parity` and `test_separator_is_accepted_only_as_the_final_character`.
5. Consumer regression pass: `scripts/run_tests.sh tests/agent/test_redact.py tests/agent/test_trace_upload.py tests/tools/test_kanban_redaction.py tests/agent/test_tool_call_arg_no_redaction.py tests/monitoring/test_export_redaction.py` — **275 passed**. (`test_tool_call_arg_no_redaction.py` is the #43083 guard: this PR does not re-introduce history redaction.)
6. Blast radius over every redaction-touching test file — `scripts/run_tests.sh $(rg -ln "redact" tests/ | rg -v " 2\.py")` — 84 files, **3012 passed, 2 failed**; both reproduce identically on clean `upstream/main` (`test_approval.py::…nonrecursive_verification_artifact_cleanup…`, `test_api_server.py::…health_detailed_returns_ok`).
7. **Sibling audit** — 24 patterns × 4 container shapes (both serializers + both shell quotings): base corrupts **22** cases, the fix **1** (limitation 3 above, byte-identical to base). That audit was run before the escape work below. **It is now out of date in one direction:** `_AUTH_HEADER_RE` and `_JSON_FIELD_RE` are no longer unaffected — both carried the same escape-destruction defect on `main` and both are now fixed (see below). The remaining patterns are still byte-for-byte unaffected, each for a stated reason: `_TELEGRAM_RE` and `_PRIVATE_KEY_RE` emit fixed replacement text; `_JWT_RE`, `_SIGNAL_PHONE_RE` and `_PREFIX_RE` have value classes that exclude both `"` and `\`; `_DB_CONNSTR_RE` and `_URL_BARE_TOKEN_RE` do admit both, but their captures are bounded by a mandatory following `@`, so an escape and its quote are always consumed **together** — that deletes content but never leaves a bare quote, so no syntax corruption.
8. **Perf.** The scanner is incremental, so a pass is O(L). Measured on the shape that actually reaches the split path (every value ends in a quote, so every match pays the cost), min of 3:

   | matches | base | `2df71234e` | this push |
   |---|---|---|---|
   | 2,000 | 19.3 ms | 16.8 ms | 21.4 ms |
   | 4,000 | 39.2 ms | 40.8 ms | 43.4 ms |
   | 8,000 | 78.5 ms | 93.8 ms | 88.7 ms |
   | 16,000 | 157.4 ms | 218.4 ms | 175.2 ms |
   | µs/match, 2k → 16k | 9.64 → 9.84 | **8.42 → 13.65** | 10.69 → 10.95 |
   | scaling per doubling | ×2.00 | ×2.33 | **×1.98** |

   A realistic 637 KB `indent=2` request dump (2,400 messages, three secret shapes per message): base 85 ms → fix 129 ms, reparses under both. The ~1.1 µs/match constant is the scanner step; the slope is flat.

9. Full CI-parity suite — `scripts/run_tests.sh` — 3,093 files, **28,599 passed, 52 failed**. **None are redaction-related** (no failing test name or file matches `redact`). I re-ran every failing file against clean `upstream/main` to attribute them: 32 reproduce identically there, and the remaining 20 are all files that do not exist on `upstream/main` — stale untracked `"… 2.py"` duplicates in my local tree. Of the three *tracked* files that differ, two are whole-tree AST scans (`test_update_zip_two_phase.py`, `test_managed_runtime_resolution.py`) that fail on a stray untracked `hermes_cli/update_cmd 2.py` in my working copy, not on anything this PR touches, and the third (`test_telegram_start_polling_timeout.py`) fails on the parent commit `2df71234e` as well. Nothing in the failure set is attributable to this change.

**Platforms tested:** macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15 (venv) — pure-stdlib `re` and string handling, no platform-conditional code, no filesystem or path behavior, so Linux / WSL2 / Windows behavior is unchanged. No config keys added, no new env vars, no docs impact.

> **CI has never run on this PR.** Fork PRs from contributors without a merged PR are gated (`check-suites` = `action_required`), so every number above is a local run on this commit, not a CI result.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suite and all tests pass (pre-existing failures unchanged — see How to Test 6)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (internal helpers; behavior documented in docstrings, including the residual and the known limitations)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact considered — see Platforms tested

