### PR TITLE
fix(config): numeric-index set on a missing list silently writes a dict the runtime ignores (#78370)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1005,7 +1005,7 @@ def _set_nested(config, dotted_key: str, value):
     """
     parts = dotted_key.split(".")
     current = config
-    for part in parts[:-1]:
+    for i, part in enumerate(parts[:-1]):
         if isinstance(current, list):
             try:
                 idx = int(part)
@@ -1014,11 +1014,37 @@ def _set_nested(config, dotted_key: str, value):
                     f"Cannot navigate into list at key {dotted_key!r}: "
                     f"segment {part!r} is not a numeric index"
                 )
-            current = current[idx]
+            try:
+                current = current[idx]
+            except IndexError:
+                raise TypeError(
+                    f"Cannot set {dotted_key!r}: list index {idx} is out of "
+                    f"range (the referenced entry must already exist — "
+                    f"indexes are never created implicitly)"
+                )
         elif isinstance(current, dict):
             existing = current.get(part)
             # Preserve dicts and lists; replace missing/scalar with a fresh dict.
             if part not in current or not isinstance(existing, (dict, list)):
+                # Guard (#78370): a numeric NEXT segment means the caller is
+                # addressing a list index (this function's documented
+                # semantics) — materializing a fresh dict here would create
+                # e.g. custom_providers: {'0': {...}}, which every runtime
+                # consumer rejects by isinstance(list) check. The write would
+                # report success while the value silently never exists at
+                # runtime. Indexes are never created implicitly, so refuse
+                # loudly instead. Existing dicts with numeric keys (e.g.
+                # channel_overrides chat ids) are untouched — this fires only
+                # when the parent is being created from nothing / a scalar.
+                if parts[i + 1].isdigit():
+                    raise TypeError(
+                        f"Cannot set {dotted_key!r}: "
+                        f"{'.'.join(parts[:i + 1])!r} is not an existing "
+                        f"list, and numeric index {parts[i + 1]!r} would "
+                        f"silently create a mapping instead of a list entry. "
+                        f"Create the list in config.yaml first (indexes are "
+                        f"never created implicitly)."
+                    )
                 current[part] = {}
             current = current[part]
         else:
@@ -1027,7 +1053,21 @@ def _set_nested(config, dotted_key: str, value):
             )
     last = parts[-1]
     if isinstance(current, list):
-        current[int(last)] = value
+        try:
+            idx = int(last)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"Cannot set {dotted_key!r}: {last!r} is not a numeric list "
+                f"index"
+            )
+        try:
+            current[idx] = value
+        except IndexError:
+            raise TypeError(
+                f"Cannot set {dotted_key!r}: list index {idx} is out of range "
+                f"(the referenced entry must already exist — indexes are "
+                f"never created implicitly)"
+            )
     else:
         current[last] = value
 
@@ -4945,7 +4985,15 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
-    _set_nested(user_config, key, value)
+    try:
+        _set_nested(user_config, key, value)
+    except TypeError as exc:
+        # Structural refusal (#78370): numeric index on a missing/out-of-range
+        # list, or a non-numeric segment on a list. Surface it as a clean
+        # command error — previously these escaped as raw tracebacks with
+        # exit code 0, or silently materialized a dict the runtime ignores.
+        print(f"✗ {exc}", file=sys.stderr)
+        sys.exit(1)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
     # key the runtime resolver actually reads, instead of being silently

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,81 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Numeric-index structural guard (#78370)
+# ---------------------------------------------------------------------------
+
+class TestNumericIndexGuard:
+    """`config set` with numeric path segments must honor _set_nested's
+    documented list semantics — never silently materialize a dict shaped like
+    a list index (#78370), and never escape as a raw traceback with exit 0."""
+
+    def _write(self, home, text):
+        (home / "config.yaml").write_text(text)
+
+    def test_missing_list_parent_refuses_instead_of_writing_dict(
+        self, _isolated_hermes_home, capsys
+    ):
+        """The reported bug: no custom_providers key at all → previously wrote
+        custom_providers: {'0': {...}} with a success message, which every
+        runtime consumer rejects by isinstance(list) check
+        (hermes_cli/providers.py:773) — the credential silently never existed."""
+        self._write(_isolated_hermes_home, "model:\n  default: x\n")
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("custom_providers.0.api_key", "sk-test")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "not an existing list" in err
+        # File untouched — no dict materialized, no partial write.
+        assert "custom_providers" not in _read_config(_isolated_hermes_home)
+
+    def test_existing_list_index_write_still_works(self, _isolated_hermes_home):
+        """#17876 semantics preserved: indexed writes into an existing list."""
+        self._write(
+            _isolated_hermes_home,
+            "custom_providers:\n  - name: a\n    api_key: old\n",
+        )
+        set_config_value("custom_providers.0.api_key", "sk-new")
+        import yaml as _yaml
+        data = _yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert isinstance(data["custom_providers"], list)
+        assert data["custom_providers"][0]["api_key"] == "sk-new"
+
+    def test_existing_numeric_keyed_dict_parent_still_works(
+        self, _isolated_hermes_home
+    ):
+        """Numeric keys in EXISTING dicts (channel_overrides chat ids) are
+        legal — the guard fires only when materializing a missing parent."""
+        self._write(
+            _isolated_hermes_home,
+            "telegram:\n  channel_overrides:\n    '123456':\n      model: old\n",
+        )
+        set_config_value("telegram.channel_overrides.123456.model", "new-model")
+        import yaml as _yaml
+        data = _yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert data["telegram"]["channel_overrides"]["123456"]["model"] == "new-model"
+
+    def test_non_numeric_segment_on_list_is_clean_error(
+        self, _isolated_hermes_home, capsys
+    ):
+        """Previously: raw ValueError traceback and exit code 0."""
+        self._write(
+            _isolated_hermes_home,
+            "custom_providers:\n  - name: a\n    api_key: k\n",
+        )
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("custom_providers.abc", "x")
+        assert exc.value.code == 1
+        assert "not a numeric list index" in capsys.readouterr().err
+
+    def test_out_of_range_index_is_clean_error(self, _isolated_hermes_home, capsys):
+        self._write(
+            _isolated_hermes_home,
+            "custom_providers:\n  - name: a\n    api_key: k\n",
+        )
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("custom_providers.5.api_key", "x")
+        assert exc.value.code == 1
+        assert "out of range" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

`hermes config set custom_providers.0.api_key <key>` on a config that lacks the list **reports success but writes `custom_providers: {'0': {...}}`** — a mapping every runtime consumer rejects by `isinstance(list)` check, so the credential the user just "successfully" set silently never exists at runtime (#78370, found by dogfooding the CLI rather than the tracker). Two adjacent raw-traceback escapes in the same function are fixed as part of the class.

## Root cause

`_set_nested()` (`hermes_cli/config.py`) documents numeric segments as list indexes with *"the referenced index must already exist (we do not grow lists)"* — but only enforced it when the parent already **was** a list. Three unenforced paths:

| input | before | after |
|---|---|---|
| `custom_providers.0.api_key` (parent missing) | ✓ success message, dict `{'0': …}` written, runtime resolver returns `None` (`providers.py:773`) | `✗ Cannot set …: 'custom_providers' is not an existing list …` — exit 1, file untouched |
| `custom_providers.abc` (parent is a list) | raw `ValueError` traceback, **exit 0** | clean error, exit 1 |
| `custom_providers.5.api_key` (index out of range) | raw `IndexError` traceback, **exit 0** | clean error, exit 1 |

## Changes

- `_set_nested()`: refuse to materialize a missing/scalar parent when the next segment is numeric — fires **only** on creation, so numeric keys in *existing* dicts (`channel_overrides` chat ids) keep working; list navigation/tail errors converted from raw `ValueError`/`IndexError` escapes to the function's existing clean `TypeError` contract.
- `set_config_value()`: catch that `TypeError` and surface it as a proper stderr message + exit 1 — same UX as the freshly-merged #74995 mapping guard. (`_unset_nested` already fails safe.)
- `tests/hermes_cli/test_set_config_value.py`: `TestNumericIndexGuard` — 5 tests; 3 fail on unfixed main; existing-list index writes (#17876) and numeric-keyed-dict parents pinned as still working.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py` — 87 passed, 0 failed (84+3 red on unfixed main)
- Full `tests/hermes_cli/` + `tests/tools/test_delegate.py` sweep: 3,938 passed; the 17 failures across 7 files reproduce identically on clean main (pre-existing, none touch this path)
- Real-CLI before/after transcripts in #78370

## Scope notes

- The sibling facet — list *values* coerced to strings (`docker_volumes`) — is #64323's territory, untouched here.
- `agent.max_turns -5` writing the string `'-5'` (negative numbers miss the `isdigit()` coercion) is noted in #78370 as a separate minor; not bundled into this diff.

Fixes #78370.
