### PR TITLE
fix(catalog): bump blender MCP pin to 1.6.5 (mcp>=2.0 crash)

### DIFF
--- a/optional-mcps/blender/manifest.yaml
+++ b/optional-mcps/blender/manifest.yaml
@@ -22,11 +22,15 @@ transport:
   command: "uvx"
   # Pinned per catalog dependency policy: exact version, and the release must
   # be at least 2 weeks old at pin time (supply-chain cooldown — same rule as
-  # pyproject.toml dependencies). 1.6.4 released 2026-06-11. The catalog never
-  # auto-updates; bumping the pin is a PR to this manifest.
+  # pyproject.toml dependencies). 1.6.5 released 2026-07-29 — emergency bump
+  # before cooldown expiry: 1.6.4 declares `mcp[cli]>=1.3.0` unbounded, so uv
+  # resolves mcp 2.0.0 (removed `mcp.server.fastmcp`) and the server crashes
+  # with ModuleNotFoundError at import. 1.6.5 pins `mcp[cli]<2,>=1.3.0` and is
+  # verified working. The catalog never auto-updates; bumping the pin is a PR
+  # to this manifest.
   args:
-    - "blender-mcp==1.6.4"
-  version: "1.6.4"
+    - "blender-mcp==1.6.5"
+  version: "1.6.5"
   env:
     # Upstream ships anonymous telemetry, on by default. Hermes policy is
     # no outbound telemetry without explicit opt-in, so the catalog entry


### PR DESCRIPTION
## Summary

Bumps the blender MCP catalog pin from `blender-mcp==1.6.4` to `blender-mcp==1.6.5` in `optional-mcps/blender/manifest.yaml`.

**Why:** 1.6.4 is broken at install time. It declares `mcp[cli]>=1.3.0` with **no upper bound**, so `uvx` resolves mcp 2.0.0 — which removed `mcp.server.fastmcp` — and the server crashes with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` on startup (exit 1, `Connection closed` in `hermes mcp test`). Only reproducible under Hermes' filtered subprocess env; a full shell env can mask it via an older importable mcp on `PYTHONPATH`.

**Fix verified:** 1.6.5 pins `mcp[cli]<2,>=1.3.0` and connects cleanly (22 tools). Already validated end-to-end in the working session: `hermes mcp test blender` → Connected (2848ms), full drive of a live Blender 5.2 session via `get_scene_info` / `execute_blender_code`.

## Dependency evidence (PyPI metadata)

| version | `Requires-Dist` | released |
|---|---|---|
| 1.6.4 | `mcp[cli]>=1.3.0` (unbounded) | 2026-06-11 |
| 1.6.5 | `mcp[cli]<2,>=1.3.0` | 2026-07-29 |

## Supply-chain cooldown note

The catalog comment policy requires a release to be ≥2 weeks old at pin time. 1.6.5 is **6 days old** — this is an **emergency bump** ahead of cooldown expiry because the currently pinned 1.6.4 is broken at install time (no working version satisfies the policy). The manifest comment documents this deviation explicitly; a future PR can re-confirm the pin after the cooldown window passes.

## Test plan

- [x] `hermes mcp test blender` → Connected, 22 tools (against 1.6.5)
- [x] End-to-end: created/verified objects in live Blender 5.2 session via MCP
- [x] Manifest YAML parses (`name: blender`, `args: ['blender-mcp==1.6.5']`, `version: 1.6.5`)

Closes the install-time breakage reproduced in task t_7958b52b (Hermes kanban).