### PR TITLE
fix(dashboard): strip Desktop env for browser UI; --stop spares serve

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -28,6 +28,7 @@ def _m():
 def _scan_dashboard_processes(
     *,
     exclude_pids: set[int] | None = None,
+    include_serve: bool = True,
 ) -> list[tuple[int, str]]:
     """Return matching ``dashboard``/``serve`` processes with their cmdlines.
 
@@ -51,19 +52,29 @@ def _scan_dashboard_processes(
     backend process; ``_kill_stale_dashboard_processes`` reads it and
     passes it here.  (#37532)
 
+    *include_serve* defaults True so ``hermes update`` still reaps Desktop's
+    headless ``hermes serve`` backends (same mismatch class).  ``hermes
+    dashboard --stop`` sets it False so a browser-dashboard stop does not
+    tear down a live Desktop session's backend.
+
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
     patterns = [
         "hermes dashboard",
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
+    ]
+    if include_serve:
         # The headless backend (`hermes serve`) is the same long-lived server
         # under a different command name — the desktop app spawns it. Reap it
         # on update for the same frontend/backend-mismatch reason.
-        "hermes serve",
-        "hermes_cli.main serve",
-        "hermes_cli/main.py serve",
-    ]
+        patterns.extend(
+            [
+                "hermes serve",
+                "hermes_cli.main serve",
+                "hermes_cli/main.py serve",
+            ]
+        )
     self_pid = os.getpid()
     dashboard_processes: list[tuple[int, str]] = []
 
@@ -148,16 +159,17 @@ def _kill_stale_dashboard_processes(
     reason: str = "the running backend no longer matches the updated frontend",
     *,
     restart_managed: bool = False,
+    include_serve: bool = True,
 ) -> dict[str, list]:
-    """Kill running ``hermes dashboard`` / ``hermes serve`` processes.
+    """Kill running ``hermes dashboard`` / optionally ``hermes serve`` processes.
 
     Called at the end of ``hermes update`` (default ``reason``) and also
-    from ``hermes dashboard --stop`` (which overrides ``reason``).  The
-    dashboard has no service manager, so after a code update the running
-    process is guaranteed to be serving stale Python against a
-    freshly-updated JS bundle.  Leaving it alive produces silent
-    frontend/backend mismatches (new auth headers the old backend doesn't
-    recognise → every API call 401s).
+    from ``hermes dashboard --stop`` (which overrides ``reason`` and sets
+    ``include_serve=False``).  The dashboard has no service manager, so
+    after a code update the running process is guaranteed to be serving
+    stale Python against a freshly-updated JS bundle.  Leaving it alive
+    produces silent frontend/backend mismatches (new auth headers the old
+    backend doesn't recognise → every API call 401s).
 
     POSIX: SIGTERM, wait up to ~3s for graceful exit, SIGKILL any survivors.
     Windows: ``taskkill /PID <pid> /F`` since there's no clean SIGTERM
@@ -195,12 +207,16 @@ def _kill_stale_dashboard_processes(
         if parsed:
             exclude = parsed
 
-    pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude)
+    pids = _m()._find_stale_dashboard_pids(
+        exclude_pids=exclude,
+        include_serve=include_serve,
+    )
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 
     print()
-    print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
+    label = "dashboard/serve" if include_serve else "dashboard"
+    print(f"⟲ Stopping {len(pids)} {label} process(es) ({reason})")
 
     # Before killing, snapshot systemd cgroup info for each PID so we can
     # restart supervised services after the kill (the cgroup disappears

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7233,9 +7233,16 @@ from hermes_cli.dashboard_procs import (  # noqa: F401
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
+    include_serve: bool = True,
 ) -> list[int]:
-    """Return PIDs of stale ``dashboard``/``serve`` processes for update cleanup."""
-    return [pid for pid, _cmd in _scan_dashboard_processes(exclude_pids=exclude_pids)]
+    """Return PIDs of stale ``dashboard``/optionally ``serve`` processes."""
+    return [
+        pid
+        for pid, _cmd in _scan_dashboard_processes(
+            exclude_pids=exclude_pids,
+            include_serve=include_serve,
+        )
+    ]
 
 
 def _parse_dashboard_runtime(command: str) -> tuple[str, str, int] | None:
@@ -10185,17 +10192,20 @@ def cmd_dashboard(args):
         count = _report_dashboard_status()
         sys.exit(0 if count == 0 else 0)  # status is informational, always 0
 
-    # --stop: kill any running dashboards and exit, no deps needed.
+    # --stop: browser dashboard processes only — never tear down Desktop serve.
     if getattr(args, "stop", False):
-        pids = _find_stale_dashboard_pids()
+        pids = _find_stale_dashboard_pids(include_serve=False)
         if not pids:
             print("No hermes dashboard processes running.")
             sys.exit(0)
         # Reuse the same SIGTERM-grace-SIGKILL path used after `hermes update`.
-        _kill_stale_dashboard_processes(reason="requested via --stop")
+        _kill_stale_dashboard_processes(
+            reason="requested via --stop",
+            include_serve=False,
+        )
         # _kill_stale_dashboard_processes prints outcomes itself.  Exit 0 if
         # we killed at least one, 1 if they were all unkillable.
-        remaining = _find_stale_dashboard_pids()
+        remaining = _find_stale_dashboard_pids(include_serve=False)
         sys.exit(1 if remaining else 0)
 
     # `serve` is the headless backend: no UI build, no SPA mount, neutral
@@ -10212,21 +10222,27 @@ def cmd_dashboard(args):
     # ── Sanitize Desktop-inherited env that hijacks a standalone launch ─
     # Desktop Electron spawns its backend with HERMES_DESKTOP=1 plus
     # HERMES_WEB_DIST=<packaged app.asar[/unpacked]/dist> (and often
-    # HERMES_SERVE_HEADLESS=1 on the serve path). A shell that inherits
+    # HERMES_SERVE_HEADLESS=1 on the serve path). A shell/tool that inherits
     # those vars then runs `hermes dashboard` would otherwise:
     #   - serve the desktop renderer → "Desktop IPC bridge is unavailable"
     #     (issue #52945), or
     #   - disable the SPA via inherited HERMES_SERVE_HEADLESS.
-    # Only strip Electron-packaged WEB_DIST contamination — caller-managed
-    # HERMES_WEB_DIST overrides (dev / custom builds) must still work.
-    # The desktop-spawned backend itself (HERMES_DESKTOP=1) keeps its dist.
+    #
+    # Browser `hermes dashboard` (not headless) must always strip Desktop
+    # contamination — including when HERMES_DESKTOP=1 was inherited from a
+    # Desktop-agent terminal. Desktop's own backend is headless and keeps
+    # HERMES_DESKTOP + its dist. Only strip Electron-packaged WEB_DIST —
+    # caller-managed HERMES_WEB_DIST overrides must still work.
     # Intentionally headless `serve` re-sets HERMES_SERVE_HEADLESS below.
-    if os.environ.get("HERMES_DESKTOP") != "1":
-        _inherited_web_dist = os.environ.get("HERMES_WEB_DIST", "")
+    _inherited_web_dist = os.environ.get("HERMES_WEB_DIST", "")
+    if not _headless_backend:
         if _is_electron_packaged_web_dist(_inherited_web_dist):
             os.environ.pop("HERMES_WEB_DIST", None)
-    if not _headless_backend:
+        os.environ.pop("HERMES_DESKTOP", None)
         os.environ.pop("HERMES_SERVE_HEADLESS", None)
+    elif os.environ.get("HERMES_DESKTOP") != "1":
+        if _is_electron_packaged_web_dist(_inherited_web_dist):
+            os.environ.pop("HERMES_WEB_DIST", None)
 
     # ── Unified profile launch routing ────────────────────────────────
     # The dashboard is a MACHINE management surface: it can read/write any

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -73,13 +73,12 @@ class TestDashboardStatus:
 
 
 class TestDashboardStop:
-
     def test_stop_kills_and_exits_zero_when_all_killed(self, capsys):
         """After the kill, if the second scan returns empty we exit 0."""
         # First scan: finds two processes.  Second (verification) scan: empty.
         scans = iter([[12345, 12346], []])
         with patch("hermes_cli.main._find_stale_dashboard_pids",
-                   side_effect=lambda: next(scans)), \
+                   side_effect=lambda **_kw: next(scans)), \
              patch("hermes_cli.main._kill_stale_dashboard_processes") as mock_kill, \
              pytest.raises(SystemExit) as exc:
             cmd_dashboard(_ns(stop=True))
@@ -90,6 +89,8 @@ class TestDashboardStop:
         kwargs = mock_kill.call_args.kwargs
         assert "reason" in kwargs
         assert "stop" in kwargs["reason"].lower()
+        # Browser stop must not reap Desktop headless serve backends.
+        assert kwargs.get("include_serve") is False
         assert exc.value.code == 0
 
     def test_stop_exits_nonzero_if_kill_leaves_survivors(self):
@@ -97,7 +98,7 @@ class TestDashboardStop:
         detect that the stop didn't succeed (e.g. permission denied)."""
         scans = iter([[12345], [12345]])  # both scans find the same PID
         with patch("hermes_cli.main._find_stale_dashboard_pids",
-                   side_effect=lambda: next(scans)), \
+                   side_effect=lambda **_kw: next(scans)), \
              patch("hermes_cli.main._kill_stale_dashboard_processes"), \
              pytest.raises(SystemExit) as exc:
             cmd_dashboard(_ns(stop=True))
@@ -118,6 +119,20 @@ class TestDashboardStop:
             cmd_dashboard(_ns(stop=True))
         assert exc.value.code == 0
 
+    def test_scan_stop_mode_excludes_serve_cmdlines(self):
+        """include_serve=False must not match Desktop hermes serve backends."""
+        from hermes_cli.dashboard_procs import _scan_dashboard_processes
+
+        ps_out = (
+            " 11111 /venv/bin/python -m hermes_cli.main dashboard --no-open\n"
+            " 22222 /venv/bin/python -m hermes_cli.main serve --host 127.0.0.1 --port 0\n"
+        )
+        fake = MagicMock(returncode=0, stdout=ps_out)
+        with patch("subprocess.run", return_value=fake):
+            dash_only = _scan_dashboard_processes(include_serve=False)
+            both = _scan_dashboard_processes(include_serve=True)
+        assert [pid for pid, _ in dash_only] == [11111]
+        assert sorted(pid for pid, _ in both) == [11111, 22222]
 
 class TestLifecycleFlagsTakePrecedence:
     """If both --stop and --status are set, --status wins (it's listed

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -9,6 +9,7 @@ the dist has no index.html, and proceed when it does.
 Design credit: PR #17845 (@Caelier).
 """
 
+import os
 import sys
 import types
 
@@ -138,6 +139,70 @@ def test_skip_build_missing_dist_attempts_one_recovery_build(
 # ---------------------------------------------------------------------------
 # Desktop-inherited env isolation (issue #52945 / supersedes #52948, #67402)
 # ---------------------------------------------------------------------------
+
+
+class TestDesktopInheritedEnvIsolation:
+    """Browser `hermes dashboard` must not serve the Desktop renderer."""
+
+    def test_browser_dashboard_strips_inherited_desktop_flag_and_asar_dist(
+        self, main_mod, monkeypatch, tmp_path
+    ):
+        asar_dist = tmp_path / "app.asar" / "dist"
+        asar_dist.mkdir(parents=True)
+        (asar_dist / "index.html").write_text("<html></html>", encoding="utf-8")
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setenv("HERMES_WEB_DIST", str(asar_dist))
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+
+        captured = {}
+
+        def fake_start_server(**kwargs):
+            captured["env_desktop"] = os.environ.get("HERMES_DESKTOP")
+            captured["env_web_dist"] = os.environ.get("HERMES_WEB_DIST")
+            captured["env_headless"] = os.environ.get("HERMES_SERVE_HEADLESS")
+            raise SystemExit(0)
+
+        _wire_common(main_mod, monkeypatch)
+        monkeypatch.setattr(main_mod, "_build_web_ui", lambda *a, **k: True)
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.web_server",
+            types.SimpleNamespace(start_server=fake_start_server),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args(no_open=True, headless_backend=False, skip_build=True))
+        assert exc.value.code == 0
+        assert captured.get("env_desktop") is None
+        assert captured.get("env_web_dist") is None
+        assert captured.get("env_headless") is None
+
+    def test_headless_desktop_serve_keeps_desktop_flag(self, main_mod, monkeypatch, tmp_path):
+        asar_dist = tmp_path / "app.asar" / "dist"
+        asar_dist.mkdir(parents=True)
+        (asar_dist / "index.html").write_text("<html></html>", encoding="utf-8")
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setenv("HERMES_WEB_DIST", str(asar_dist))
+
+        captured = {}
+
+        def fake_start_server(**kwargs):
+            captured["env_desktop"] = os.environ.get("HERMES_DESKTOP")
+            captured["env_web_dist"] = os.environ.get("HERMES_WEB_DIST")
+            raise SystemExit(0)
+
+        _wire_common(main_mod, monkeypatch)
+        monkeypatch.setattr(main_mod, "_build_web_ui", lambda *a, **k: True)
+        monkeypatch.setitem(
+            sys.modules,
+            "hermes_cli.web_server",
+            types.SimpleNamespace(start_server=fake_start_server),
+        )
+
+        with pytest.raises(SystemExit):
+            main_mod.cmd_dashboard(_args(no_open=True, headless_backend=True, skip_build=True))
+        assert captured.get("env_desktop") == "1"
+        assert captured.get("env_web_dist") == str(asar_dist)
 
 
 


### PR DESCRIPTION
## Summary
- Browser `hermes dashboard` no longer inherits Desktop `HERMES_DESKTOP` / packaged `app.asar` `HERMES_WEB_DIST` / `HERMES_SERVE_HEADLESS`, which caused the Electron renderer to load without IPC and show \"Desktop IPC bridge is unavailable\" (#52945) when launched from a Desktop agent shell.
- `hermes dashboard --stop` kills **dashboard** processes only; it no longer tears down Desktop headless `hermes serve` backends. Update path still reaps serve for frontend/backend mismatch cleanup.

## Test plan
- [x] `pytest tests/hermes_cli/test_dashboard_lifecycle_flags.py tests/hermes_cli/test_dashboard_web_dist_validation.py` (13 passed)
- [ ] Manual: from Desktop chat/tooling, run `hermes dashboard` → browser admin UI, not Desktop recovery IPC screen
- [ ] Manual: with Desktop + serve running, `hermes dashboard --stop` leaves serve up