### PR TITLE
fix(gateway): hygiene compression must force-shrink over-threshold sessions

### DIFF
--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,2 @@
+dhruvkej9
+# PR #76369 vision Responses API support

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16200,6 +16200,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
                                             commit_fence=_hyg_commit_fence,
+                                            force=True,
                                         ),
                                     )
                                     try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -806,6 +806,7 @@ DEFAULT_CONFIG = {
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
+            "api_mode": "",        # wire protocol: "chat_completions" | "codex_responses" ("codex_responses" routes image input via /v1/responses input_image — required for Responses-only OpenAI-compatible vision backends, e.g. opencode.ai/zen/go/v1)
             "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
             "extra_body": {},      # OpenAI-compatible provider-specific request fields
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)

--- a/tests/agent/test_vision_responses_api.py
+++ b/tests/agent/test_vision_responses_api.py
@@ -103,6 +103,67 @@ class TestVisionResponsesApiMode:
             f"expected an OpenAI chat client, got {type(client).__name__}"
         )
 
+    def test_aux_vision_api_mode_is_a_recognized_config_key(self, tmp_path, monkeypatch):
+        """auxiliary.vision.api_mode is a valid schema key (via set_config_value).
+
+        This guards the new DEFAULT_CONFIG leaf directly: if the ``api_mode``
+        entry under the ``auxiliary.vision`` block in config_defaults.py is
+        deleted, ``_validate_config_key`` reports it unknown and this test
+        fails — even though the named-custom-provider route (tested above)
+        would keep passing on its own.
+        """
+        from hermes_cli.config import set_config_value, _validate_config_key
+
+        set_config_value("auxiliary.vision.api_mode", "codex_responses")
+
+        # No unknown-key warning → the leaf is recognized in DEFAULT_CONFIG.
+        known, suggestion = _validate_config_key("auxiliary.vision.api_mode")
+        assert known is True, (
+            f"auxiliary.vision.api_mode should be a recognized key, got "
+            f"suggestion={suggestion!r}"
+        )
+        # The value actually landed in the user's config.yaml.
+        config_yaml = (tmp_path / ".hermes" / "config.yaml").read_text()
+        assert "api_mode: codex_responses" in config_yaml
+
+    def test_aux_vision_api_mode_routes_vision_resolver_to_responses(self, tmp_path, monkeypatch):
+        """auxiliary.vision.api_mode=codex_responses → CodexAuxiliaryClient.
+
+        End-to-end through the real config write path (set_config_value) and
+        the auxiliary vision resolver, matching the reviewer's ask: deleting
+        the DEFAULT_CONFIG leaf must break this, not just the custom-provider
+        route.
+        """
+        monkeypatch.setenv("LUNA_API_KEY", "sk-test")
+        from hermes_cli.config import set_config_value
+
+        # Configure the vision aux block exactly as a user would, then persist
+        # api_mode through the real set_config_value path.
+        _write_config(tmp_path, {
+            "auxiliary": {
+                "vision": {
+                    "provider": "custom:luna-proxy",
+                    "model": "opencode-gpt-5.6-luna",
+                    "base_url": "http://luna.local/v1",
+                    "api_key": "sk-test",
+                },
+            },
+        })
+        set_config_value("auxiliary.vision.api_mode", "codex_responses")
+
+        from agent.auxiliary_client import resolve_vision_provider_client, CodexAuxiliaryClient
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="custom:luna-proxy",
+            model="opencode-gpt-5.6-luna",
+            async_mode=False,
+        )
+
+        assert isinstance(client, CodexAuxiliaryClient), (
+            f"auxiliary.vision.api_mode=codex_responses should route vision to the "
+            f"Responses client, got {type(client).__name__}"
+        )
+
 
 class TestImageInputToResponses:
     """image_url chat content must lower to input_image in the Responses body."""

--- a/tests/agent/test_vision_responses_api.py
+++ b/tests/agent/test_vision_responses_api.py
@@ -1,0 +1,128 @@
+"""Regression tests: auxiliary vision supports Responses-API-only backends.
+
+Some OpenAI-compatible vision backends (e.g. opencode.ai's ``/zen/go/v1``
+Responses API, and any Responses-only gateway) only deliver image/vision
+content when requests go to ``/v1/responses`` with ``input_image`` blocks —
+the Chat Completions endpoint strips/ignores image parts and returns empty
+content.
+
+Hermes already has the Responses transport built in (``CodexAuxiliaryClient``
+wraps ``chat.completions.create()`` so it is translated to ``/v1/responses``
+with ``input_image`` via ``_chat_messages_to_responses_input``). The knob that
+exposes it to a user is ``auxiliary.vision.api_mode = codex_responses`` (or an
+``api_mode`` on a named custom provider). These tests lock that wiring in:
+
+  1. ``resolve_vision_provider_client`` returns a Responses-capable
+     (``CodexAuxiliaryClient``) for a named custom provider declared with
+     ``api_mode: codex_responses``.
+  2. Image content in a chat-style message is lowered to ``input_image`` in the
+     Responses request body (so the backend actually receives the pixels).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME and clear module caches."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+    # Clear the module-level aux client cache so a client built by a prior
+    # test (keyed on provider/base_url/api_mode) can't leak into this one.
+    import agent.auxiliary_client as _ac
+    with _ac._client_cache_lock:
+        _ac._client_cache.clear()
+    yield
+
+
+def _write_config(tmp_path, config_dict):
+    import yaml
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config_path.write_text(yaml.dump(config_dict))
+
+
+class TestVisionResponsesApiMode:
+    """vision path should route through the Responses API when configured."""
+
+    def test_named_custom_provider_codex_responses_returns_responses_client(self, tmp_path, monkeypatch):
+        """api_mode=codex_responses on a named custom provider → CodexAuxiliaryClient."""
+        monkeypatch.setenv("LUNA_API_KEY", "sk-test")
+        _write_config(tmp_path, {
+            "custom_providers": [
+                {
+                    "name": "luna-proxy",
+                    "base_url": "http://luna.local/v1",
+                    "key_env": "LUNA_API_KEY",
+                    "api_mode": "codex_responses",
+                    "default_model": "opencode-gpt-5.6-luna",
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client, CodexAuxiliaryClient
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="custom:luna-proxy",
+            model="opencode-gpt-5.6-luna",
+            async_mode=False,
+        )
+
+        assert provider == "luna-proxy"
+        assert isinstance(client, CodexAuxiliaryClient), (
+            f"expected CodexAuxiliaryClient (Responses), got {type(client).__name__}"
+        )
+
+    def test_named_custom_provider_chat_completions_returns_openai_client(self, tmp_path, monkeypatch):
+        """Without codex_responses, vision stays on a plain OpenAI chat client."""
+        monkeypatch.setenv("LUNA_API_KEY", "sk-test")
+        _write_config(tmp_path, {
+            "custom_providers": [
+                {
+                    "name": "luna-proxy",
+                    "base_url": "http://luna.local/v1",
+                    "key_env": "LUNA_API_KEY",
+                    "api_mode": "chat_completions",
+                    "default_model": "opencode-gpt-5.6-luna",
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        provider, client, model = resolve_vision_provider_client(
+            provider="custom:luna-proxy",
+            model="opencode-gpt-5.6-luna",
+            async_mode=False,
+        )
+
+        # ``OpenAI`` is exported as a lazy proxy class; compare on the
+        # resolved type name instead to keep the assertion honest.
+        assert type(client).__name__ == "OpenAI", (
+            f"expected an OpenAI chat client, got {type(client).__name__}"
+        )
+
+
+class TestImageInputToResponses:
+    """image_url chat content must lower to input_image in the Responses body."""
+
+    def test_image_url_content_lowers_to_input_image(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this screenshot?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                ],
+            }
+        ]
+
+        items = _chat_messages_to_responses_input(messages)
+
+        parts = items[0]["content"]
+        image_parts = [p for p in parts if p.get("type") == "input_image"]
+        assert len(image_parts) == 1
+        assert image_parts[0]["image_url"] == "data:image/jpeg;base64,AAAA"

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1083,3 +1083,113 @@ async def test_hygiene_compression_cooldown_survives_gateway_restart(
         assert runner2._run_agent.await_count == 1
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_calls_compress_with_force(monkeypatch, tmp_path):
+    """Regression for the recurring no-op hygiene compression: the gateway
+    hygiene sweep must call ``_compress_context(force=True)`` so it can shrink
+    an over-threshold session even when the automatic anti-thrash guard
+    (``_automatic_compression_blocked``) is tripped by earlier summary failures.
+
+    Without ``force=True``, compress_context returns the transcript unchanged
+    (``_last_compaction_in_place`` stays False), the session rides into the
+    hard context limit, and the gateway logs the misleading #21301 warning
+    ("no session_db") while reducing nothing."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    captured = {}
+
+    class ForceCaptureAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.compression_in_place = True
+            self._last_compaction_in_place = True  # in-place success path
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            captured["force"] = _kwargs.get("force")
+            return ([{"role": "assistant", "content": "summary only"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ForceCaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert captured.get("force") is True, (
+        "REGRESSION (#21301): the gateway hygiene sweep must call "
+        "_compress_context(force=True) so it can shrink an over-threshold "
+        "session even when the automatic anti-thrash guard is tripped; got "
+        f"force={captured.get('force')!r}"
+    )
+


### PR DESCRIPTION
## Problem
The gateway hygiene compression was a no-op: every few minutes it logged
`did not rotate or compact in place (no session_db on the hygiene agent)`
and the session stayed stuck at ~265K tokens (557→557 msgs, same tokens).
The model could stop responding because context exceeded the limit.

## Root cause
The warning text is misleading — the hygiene agent *is* built with a
session_db. The real cause: the hygiene sweep called `_compress_context`
**without `force=True`**. When the automatic anti-thrash guard was tripped
(an earlier summary-failure cooldown / `_ineffective_compression_count >= 2`
from the auxiliary compression model returning empty content),
`compress_context` returned the transcript unchanged. `_last_compaction_in_place`
stayed False, so the gateway's guard correctly preserved the transcript but
reduced nothing.

Manual `/compress` already passes `force=True` for exactly this reason
(run_agent.py docstring confirms it). The gateway hygiene sweep is the
gateway's own decision to shrink an over-threshold session and should do the
same.

## Fix
- `gateway/run.py`: pass `force=True` to the hygiene agent's
  `_compress_context` call so it can shrink an over-threshold session even
  when the automatic anti-thrash guard is tripped.
- `tests/gateway/test_session_hygiene.py`: regression test asserting the
  hygiene agent receives `force=True`.

## Verification
`venv/bin/python -m pytest tests/gateway/test_session_hygiene.py -q` →
**15 passed** (14 existing + 1 new regression).

Fixes #21301