### PR TITLE
fix(kanban): key terminal-event wakes to the creator's workspace scope

### DIFF
--- a/contributors/emails/nikita.barkov@jetbrains.com
+++ b/contributors/emails/nikita.barkov@jetbrains.com
@@ -1,0 +1,2 @@
+nikitaBarkov
+# kanban wake workspace scope

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -109,6 +109,44 @@ def _release_singleton_lock(handle) -> None:
         pass
 
 
+def _wake_scope_id(adapter: Any, sub: dict) -> Optional[str]:
+    """Return the tenant scope (Slack workspace) a subscription's wake keys to.
+
+    ``build_session_key()`` includes ``SessionSource.scope_id`` on platforms
+    where one bot serves several isolated tenants, so a wake source must carry
+    the same scope as inbound messages from that chat to resolve to the same
+    session.
+
+    The subscription's persisted ``delivery_metadata`` wins over the adapter's
+    live chat → scope mapping, because it records the scope the subscription was
+    created from; the mapping only covers rows that stored no metadata. ``None``
+    means the chat has no scope, which is what an unscoped platform's key
+    contains.
+    """
+    delivery_meta = sub.get("delivery_metadata")
+    if isinstance(delivery_meta, dict):
+        for key in ("scope_id", "slack_team_id", "team_id"):
+            value = delivery_meta.get(key)
+            if value:
+                return str(value)
+    resolver = getattr(adapter, "scope_id_for_chat", None)
+    if callable(resolver):
+        try:
+            resolved = resolver(str(sub.get("chat_id") or ""))
+        except Exception as exc:
+            # An adapter-side lookup failure yields no scope, never an error.
+            logger.debug(
+                "kanban notifier: scope lookup failed for chat %s: %s",
+                sub.get("chat_id"),
+                exc,
+                exc_info=True,
+            )
+            return None
+        if resolved:
+            return str(resolved)
+    return None
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -743,6 +781,7 @@ class GatewayKanbanWatchersMixin:
                                     thread_id=sub.get("thread_id") or None,
                                     user_id=sub.get("user_id"),
                                     profile=sub_profile or None,
+                                    scope_id=_wake_scope_id(adapter, sub),
                                 )
                                 # deliver_wake preserves the synthetic
                                 # MessageEvent/handle_message path for

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2336,6 +2336,20 @@ class SlackAdapter(BasePlatformAdapter):
         """Return an in-memory routing marker without changing legacy no-team tests."""
         return (str(team_id), str(message_id)) if team_id else str(message_id)
 
+    def scope_id_for_chat(self, chat_id: str) -> Optional[str]:
+        """Return the workspace (team) id that owns ``chat_id``.
+
+        Reads the channel → workspace map maintained by
+        ``_remember_channel_team``. Returns ``None`` for unknown channels and
+        for channels claimed by more than one workspace (which that map drops),
+        so callers get no scope rather than a wrong one.
+        """
+        if not chat_id:
+            return None
+        channel_team = getattr(self, "_channel_team", None) or {}
+        team_id = channel_team.get(str(chat_id))
+        return str(team_id) if team_id else None
+
     def _get_client(self, chat_id: str, team_id: Optional[str] = None) -> Any:
         """Return the workspace-specific WebClient for a channel."""
         if team_id and team_id in self._team_clients:

--- a/tests/gateway/test_kanban_wake_scope.py
+++ b/tests/gateway/test_kanban_wake_scope.py
@@ -1,0 +1,230 @@
+"""Kanban wake events must key to the same session as inbound messages.
+
+Slack session keys include the workspace id, so the wake source the notifier
+rebuilds from a subscription row must carry it too. The contract asserted here:
+the key built from the wake source byte-matches the key built from an inbound
+source for the same conversation, a scope-less key does not, and platforms
+without tenant scoping keep their exact key shape.
+"""
+
+import asyncio
+from dataclasses import replace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.kanban_watchers import _wake_scope_id
+from gateway.run import GatewayRunner
+from gateway.session import build_session_key
+from hermes_cli import kanban_db as kb
+from plugins.platforms.slack.adapter import SlackAdapter
+
+TEAM = "T0B8U2M6NRE"
+CHANNEL = "C0BCDG3H66P"
+THREAD = "1720000000.000100"
+USER = "U0BCE4NRVKN"
+
+
+class UnscopedAdapter:
+    """Push-capable adapter for a platform without tenant scoping."""
+
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _slack_adapter(channel_team=None):
+    """Real SlackAdapter with only its I/O stubbed."""
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake-token"))
+    adapter._app = MagicMock()
+    adapter._app.client = AsyncMock()
+    adapter._running = True
+    adapter.send = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    if channel_team:
+        adapter._channel_team.update(channel_team)
+    return adapter
+
+
+def _runner(adapter, platform=Platform.SLACK):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {platform: adapter}
+    runner._kanban_sub_fail_counts = {}
+    # A gateway whose dispatcher owns the singleton lock.
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+async def _one_notifier_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _completed_subscription(**sub_kwargs):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="wake scope",
+            assignee="worker",
+            session_id="origin-session",
+        )
+        kb.add_notify_sub(conn, task_id=tid, **sub_kwargs)
+        kb.complete_task(conn, tid, summary="done")
+        return tid
+    finally:
+        conn.close()
+
+
+def _wake_source_from(adapter):
+    assert adapter.handle_message.await_count == 1, (
+        f"expected exactly one wake injection, got {adapter.handle_message.await_count}"
+    )
+    return adapter.handle_message.await_args.args[0].source
+
+
+def test_slack_wake_resumes_the_creators_workspace_scoped_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-scope.db"))
+    kb.init_db()
+    _completed_subscription(
+        platform="slack",
+        chat_id=CHANNEL,
+        chat_type="group",
+        thread_id=THREAD,
+        user_id=USER,
+        # Slack sources are stamped with slack_team_id when subscribing.
+        delivery_metadata={"slack_team_id": TEAM, "thread_id": THREAD},
+    )
+
+    adapter = _slack_adapter()
+    asyncio.run(_one_notifier_tick(monkeypatch, _runner(adapter)))
+
+    wake = _wake_source_from(adapter)
+    assert wake.scope_id == TEAM
+
+    inbound = adapter.build_source(
+        chat_id=CHANNEL,
+        chat_type="group",
+        user_id=USER,
+        thread_id=THREAD,
+        scope_id=TEAM,
+    )
+    wake_key = build_session_key(wake)
+    assert wake_key == build_session_key(inbound)
+    assert TEAM in wake_key
+    # A scope-less source keys to a different session for the same chat.
+    assert build_session_key(replace(wake, scope_id=None, guild_id=None)) != wake_key
+
+
+def test_slack_wake_falls_back_to_the_adapter_channel_workspace_map(tmp_path, monkeypatch):
+    """Subscriptions that stored no workspace resolve it from the adapter."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-scope-fallback.db"))
+    kb.init_db()
+    _completed_subscription(
+        platform="slack",
+        chat_id=CHANNEL,
+        chat_type="group",
+        thread_id=THREAD,
+        delivery_metadata={"thread_id": THREAD, "chat_type": "group"},
+    )
+
+    adapter = _slack_adapter(channel_team={CHANNEL: TEAM})
+    asyncio.run(_one_notifier_tick(monkeypatch, _runner(adapter)))
+
+    wake = _wake_source_from(adapter)
+    assert wake.scope_id == TEAM
+    assert TEAM in build_session_key(wake)
+
+
+def test_unknown_channel_keeps_the_previous_unscoped_wake(tmp_path, monkeypatch):
+    """An unresolvable workspace yields an unscoped key, not a wrong scope."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-scope-unknown.db"))
+    kb.init_db()
+    _completed_subscription(
+        platform="slack",
+        chat_id=CHANNEL,
+        chat_type="group",
+    )
+
+    adapter = _slack_adapter()
+    asyncio.run(_one_notifier_tick(monkeypatch, _runner(adapter)))
+
+    wake = _wake_source_from(adapter)
+    assert wake.scope_id is None
+    assert build_session_key(wake) == f"agent:main:slack:group:{CHANNEL}"
+
+
+def test_unscoped_platform_wake_key_is_byte_identical(tmp_path, monkeypatch):
+    """Platforms without tenant scoping must keep their exact key shape."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-scope-telegram.db"))
+    kb.init_db()
+    _completed_subscription(
+        platform="telegram",
+        chat_id="chat-dm",
+        chat_type="dm",
+    )
+
+    adapter = UnscopedAdapter()
+    asyncio.run(_one_notifier_tick(monkeypatch, _runner(adapter, Platform.TELEGRAM)))
+
+    assert len(adapter.handled) == 1
+    wake = adapter.handled[0].source
+    assert wake.scope_id is None
+    assert build_session_key(wake) == "agent:main:telegram:dm:chat-dm"
+
+
+def test_wake_scope_id_prefers_persisted_metadata_over_the_adapter_map():
+    """Persisted metadata wins; the adapter map is only a fallback."""
+    adapter = SlackAdapter.__new__(SlackAdapter)
+    adapter._channel_team = {CHANNEL: "T_STALE"}
+
+    assert _wake_scope_id(
+        adapter, {"chat_id": CHANNEL, "delivery_metadata": {"slack_team_id": TEAM}}
+    ) == TEAM
+    assert _wake_scope_id(adapter, {"chat_id": CHANNEL}) == "T_STALE"
+    assert _wake_scope_id(adapter, {"chat_id": "C_OTHER"}) is None
+
+
+def test_wake_scope_id_degrades_when_the_adapter_lookup_raises():
+    class Exploding:
+        def scope_id_for_chat(self, chat_id):
+            raise RuntimeError("adapter state gone")
+
+    assert _wake_scope_id(Exploding(), {"chat_id": CHANNEL}) is None
+
+
+def test_wake_scope_id_is_none_for_adapters_without_the_hook():
+    """Adapters that don't resolve scopes leave the wake unscoped."""
+    assert _wake_scope_id(UnscopedAdapter(), {"chat_id": CHANNEL}) is None
+
+
+def test_slack_adapter_reports_the_channel_workspace():
+    adapter = SlackAdapter.__new__(SlackAdapter)
+    adapter._channel_team = {CHANNEL: TEAM}
+
+    assert adapter.scope_id_for_chat(CHANNEL) == TEAM
+    assert adapter.scope_id_for_chat("C_UNKNOWN") is None
+    assert adapter.scope_id_for_chat("") is None
+
+
+def test_slack_adapter_reports_no_scope_for_ambiguous_channels():
+    """A channel claimed by two workspaces resolves to no scope."""
+    adapter = _slack_adapter()
+    adapter._remember_channel_team("D_SHARED", "T_ONE")
+    adapter._remember_channel_team("D_SHARED", "T_TWO")
+
+    assert adapter.scope_id_for_chat("D_SHARED") is None


### PR DESCRIPTION
## What does this PR do?

On `main`, a kanban terminal-event wake for a **Slack** subscription does not resume the creator's session — it wakes an *alias* of it. Symptom on a live gateway: the woken turn is stuck "waiting" for minutes (400+s observed) before it starts, and a self-test task produced **two** runs for one event.

**Root cause — two correct changes that don't know about each other.**

1. #70190 (`a60b00e12`) made Slack session keys workspace-scoped: `build_session_key()` folds `SessionSource.scope_id` in ahead of the chat id, so a real inbound channel message keys to `agent:main:slack:group:<team>:<channel>:<thread>`.
2. The kanban notifier rebuilds its wake source from the subscription row (`gateway/kanban_watchers.py`), and `kanban_notify_subs` has no scope column, so the synthetic `SessionSource(...)` passed to `deliver_wake()` carries **no** `scope_id` — it keys to `agent:main:slack:group:<channel>:<thread>`. `grep -c scope_id gateway/kanban_watchers.py` on `main` is `0`.

The two keys are not independent sessions. The legacy-key adoption shipped in the same change (`_legacy_slack_session_key()` / `_recovered_row_matches_source_scope()` in `gateway/session.py`) deliberately resolves the unscoped key onto the **same `session_id`** for migration. So the wake:

- passes the busy guards, because both are keyed by **routing key** — `_active_sessions` in `gateway/platforms/base.py` and `_running_agents` in `gateway/run.py` are looking at the scoped key while the wake arrives under the alias. That is the duplicate run.
- then collides in the **per-session turn lease** (#64934 / #67401), which keys by `session_id` and correctly serializes `[load history → run → flush]`. That is the multi-minute wait, and it is the lease doing exactly what it says in its docstring: "busy-guards are keyed by routing key … an alias key passes them".

This is the same failure mode as #56580 / #68874, fixed in #72191 — one field over. There, the wake rebuilt the source with a hardcoded `chat_type="group"` and DM tasks woke a group-scoped session. `scope_id` is the remaining unstamped key component on the same code path.

**Fix — read the workspace that is already persisted; no schema change.**

`_thread_metadata_for_source()` in `gateway/run.py` stamps `slack_team_id` on every Slack source, the `/kanban` notify-subscribe path persists that dict as `delivery_metadata`, and the notifier **already** unpacks it (it only ever forwarded it to `send`). So the workspace is available at the exact point the wake source is built — unlike #72191, this needs no nullable column and no backfill.

Subscriptions written by `tools/kanban_tools.py::_maybe_auto_subscribe` persist only `thread_id`/`chat_type`, so metadata alone would leave those rows aliased. For them, ask the live adapter for the channel's workspace via `scope_id_for_chat()`, read with `getattr` so adapters opt in and nothing is added to the base class:

- an adapter that doesn't implement it (every non-Slack platform) resolves to `None`, which is exactly what its key already contains — so those keys stay **byte-identical**;
- Slack answers from the `_channel_team` map maintained by `_remember_channel_team()` (populated on every inbound event and every opened DM). That map **drops** channels claimed by two workspaces by design, so an ambiguous or unknown channel yields `None` and the wake degrades to today's behavior instead of guessing a wrong workspace.

Resolution order, single helper (`_wake_scope_id`): persisted `delivery_metadata` (`scope_id` / `slack_team_id` / `team_id`) → `adapter.scope_id_for_chat()` → `None`. Persisted metadata wins because it is the creator's own workspace; an adapter-side lookup that raises is swallowed to `None` (logged at debug) so a wake can never fail on scope resolution.

**Premise verified, not assumed.** `grep -c scope_id gateway/kanban_watchers.py` == 0 on `main`; the alias/scoped key pair is asserted directly against `build_session_key()` in the new tests; and reverting just the `scope_id=` argument turns the two key assertions red (see "How to Test"), which is what proves the fix acts on the line the bug manifests at.

## Related Issue

No open issue for this bug — searched before filing and found none.

It is a regression of the interaction between #70190 (workspace-scoped Slack keys) and #67401 (the per-session turn lease); the closest precedent is #72191, which fixed the `chat_type` field on this same code path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/kanban_watchers.py`: new module-level `_wake_scope_id(adapter, sub)` (documented resolution order + why an alias key is worse than a plain mismatch); the wake `SessionSource(...)` before `deliver_wake()` now passes `scope_id=_wake_scope_id(adapter, sub)`.
- `plugins/platforms/slack/adapter.py`: new `scope_id_for_chat()`, answering from the existing `_channel_team` map (unknown or ambiguous channel → `None`). Read via `getattr` at the call site, so adapters opt in and the base class gains nothing.
- `tests/gateway/test_kanban_wake_scope.py` (new, 9 tests): drives the real notifier tick against the real `SlackAdapter` (only `send`/`handle_message` stubbed) and asserts the wake key **byte-matches** the key built by the adapter's own `build_source()`, that the scope-less shape does not, the metadata path, the adapter-map fallback, unknown-channel degradation, an unscoped platform's key being unchanged, metadata-over-map precedence, an adapter lookup that raises, and an adapter that doesn't resolve scopes at all.
- `contributors/emails/nikita.barkov@jetbrains.com`: the attribution check hard-fails on an unmapped author email.

## How to Test

1. **Reproduce on `main`** (two Slack windows are not needed — the keys are deterministic): in a Slack channel create a task and subscribe it (`/kanban notify-subscribe <task-id>`), let the task reach a terminal state, and compare the two keys in `~/.hermes/logs/gateway.log`. The inbound turn logs `agent:main:slack:group:<team>:<channel>:…`, the wake logs `agent:main:slack:group:<channel>:…`, and the turn lease logs one WARNING carrying the shared `session_id` plus both routing keys and the wait it enforced.
2. **Automated, this branch:** `scripts/run_tests.sh tests/gateway/test_kanban_wake_scope.py -q` → **9 passed, 0 failed**.
3. **Sabotage check** (the fix acts where the bug manifests): replace `scope_id=_wake_scope_id(adapter, sub)` with `scope_id=None` → `test_slack_wake_resumes_the_creators_workspace_scoped_session` and `test_slack_wake_falls_back_to_the_adapter_channel_workspace_map` fail, the other 7 stay green. Restored → all 9 green.

4. **Regression sweep:** `scripts/run_tests.sh tests/gateway/test_kanban_wake_scope.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_apiserver_wake.py tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py tests/gateway/test_kanban_notifier_zero_sub_gate.py tests/gateway/test_kanban_watchers_mixin.py tests/gateway/test_slack.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_slack_group_dm_scope_warning.py tests/gateway/test_slack_wake_external_bot_messages.py tests/gateway/test_session.py tests/gateway/test_handoff_thread_session_key.py -q` → **256 passed, 0 failed**.
5. **Full gateway suite:** `scripts/run_tests.sh tests/gateway/ -q` → only 7 pre-existing failures (`test_api_server`, `test_readiness`, `test_shutdown_forensics`, `test_systemd_notify`, `test_telegram_start_polling_timeout`, `test_wecom_callback` ×2). Verified as environment background, not this change: stashing the diff and re-running those 6 files on pristine `main` reproduces the identical 7 (116 passed / 7 failed both ways) on macOS 15 arm64.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits) — 1 commit
- [x] I've run the affected suites via `scripts/run_tests.sh` and all tests pass (see "How to Test"; the full `tests/gateway/` run leaves only the 7 failures that also fail on pristine `main`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A for user docs; the new helper and adapter method carry docstrings stating what they resolve
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python session-key resolution)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no model-facing tool changed)

## Screenshots / Logs

Routing keys for one Slack channel conversation, before and after:

```
inbound turn   agent:main:slack:group:T0B8U2M6NRE:C0BCDG3H66P:1720000000.000100
wake (before)  agent:main:slack:group:C0BCDG3H66P:1720000000.000100   ← alias, same session_id
wake (after)   agent:main:slack:group:T0B8U2M6NRE:C0BCDG3H66P:1720000000.000100
```

No schema, config, public API, or cursor-format change. Rollback is a plain revert of the single commit.

