### PR TITLE
fix(xai): honor Firecrawl/configured web search with Grok Responses

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -28,6 +28,64 @@ def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
     return f"pck_{digest}"
 
 
+# Wire-name used when Hermes keeps client-side web_search on xAI Responses.
+# A function literally named ``web_search`` collides with Grok's native
+# server-side tool (incomplete hang or HTTP 400 duplicate names); this alias
+# avoids that while still dispatching through Hermes's configured provider
+# (Firecrawl / Tavily / …). Mapped back to ``web_search`` in normalize_response.
+_XAI_CLIENT_WEB_SEARCH_ALIAS = "hermes_web_search"
+
+
+def _xai_prefers_native_web_search() -> bool:
+    """True when xAI Responses should use Grok's native ``web_search`` built-in.
+
+    Honors explicit ``web.search_backend`` / ``web.backend`` first. Only falls
+    back to native when the resolved active provider is ``xai`` (or resolution
+    fails — preserve the incomplete-hang fix rather than risk reintroducing it).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        web = cfg.get("web") if isinstance(cfg, dict) else None
+        if isinstance(web, dict):
+            explicit = (
+                str(web.get("search_backend") or "").strip().lower()
+                or str(web.get("backend") or "").strip().lower()
+            )
+            if explicit == "xai":
+                return True
+            if explicit:
+                # User asked for Firecrawl / Tavily / etc. — keep Hermes dispatch.
+                return False
+
+        from agent.web_search_registry import get_active_search_provider
+
+        provider = get_active_search_provider()
+        if provider is not None:
+            return getattr(provider, "name", None) == "xai"
+
+        from tools.web_tools import _get_search_backend
+
+        return (_get_search_backend() or "").strip().lower() == "xai"
+    except Exception:
+        # Fail closed to native swap — same behavior as pre-fix main.
+        return True
+
+
+def _rename_client_web_search_for_xai(response_tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Rename client ``web_search`` → alias so xAI won't hijack it server-side."""
+    rewritten: List[Dict[str, Any]] = []
+    for tool in response_tools:
+        if isinstance(tool, dict) and tool.get("name") == "web_search":
+            aliased = dict(tool)
+            aliased["name"] = _XAI_CLIENT_WEB_SEARCH_ALIAS
+            rewritten.append(aliased)
+        else:
+            rewritten.append(tool)
+    return rewritten
+
+
 _EXTENDED_PROMPT_CACHE_MODELS = (
     "gpt-5.5-pro",
     "gpt-5.5",
@@ -232,63 +290,41 @@ class ResponsesApiTransport(ProviderTransport):
 
         response_tools = _responses_tools(tools)
 
-        # xAI server-side web search.
+        # xAI server-side web search vs Hermes web providers.
         #
-        # grok models on xAI's /v1/responses surface (notably
-        # grok-composer-2.5-fast on SuperGrok OAuth) have a *native*,
-        # server-executed web search.  When the model is handed a
-        # client-side function literally named ``web_search``, it routes
-        # the intent to that native engine — but because the tool is
-        # declared as a plain ``function`` rather than xAI's first-class
-        # ``{"type": "web_search"}`` built-in, the server-side search is
-        # dispatched but never reconciled: the response streams reasoning
-        # + ``web_search_call`` progress items, the searches never reach
-        # ``status="completed"`` in the assembled output, no final
-        # message is emitted, and ``_normalize_codex_response`` correctly
-        # sees reasoning-with-no-answer and reports ``incomplete``.  The
-        # turn then burns 3 continuation retries and fails with "Codex
-        # response remained incomplete after 3 continuation attempts".
-        # Verified live against grok-composer-2.5-fast (2026-06).
+        # grok models on xAI's /v1/responses surface have a *native*,
+        # server-executed web search.  A client-side function literally named
+        # ``web_search`` collides with that engine: declared as a plain
+        # ``function`` rather than ``{"type": "web_search"}``, the search
+        # dispatches but never reconciles → incomplete turn + 3 retries.
+        # Verified live against grok-composer-2.5-fast (2026-06); see #48108.
         #
-        # Fix: when the agent HAS a client-side ``web_search`` function (i.e.
-        # the user enabled the web toolset), declare xAI's native
-        # ``web_search`` built-in instead so the search actually runs to
-        # completion server-side and the model streams a real answer.  The
-        # Responses API rejects two tools sharing the name ``web_search``
-        # (HTTP 400 "Duplicate tool names"), so we drop the client-side
-        # ``web_search`` function for the xAI path and let the native tool
-        # satisfy it.  All other client-side tools (read_file, terminal,
-        # web_extract, MCP tools, …) are untouched and continue to dispatch
-        # through Hermes's agent loop.
+        # Two modes, chosen by the user's web-search backend config:
         #
-        # Scope: we ONLY swap in the native built-in when the client
-        # ``web_search`` was actually present.  We do NOT force-enable Grok
-        # server-side search on turns where the user never had web enabled —
-        # that would silently route around Hermes's web-provider config and
-        # tool-trace/citation plumbing for every xai-oauth turn.  The swap is
-        # a 1:1 replacement of an already-requested capability, not an
-        # additive grant.
-        #
-        # NOTE: for the swapped case this routes ``web_search`` to Grok's
-        # native search engine for xAI sessions instead of Hermes's
-        # configured web provider (Tavily/etc.), and those results bypass
-        # Hermes's tool-trace / citation plumbing (they arrive baked into the
-        # model's answer rather than as a tool result the loop observes).
-        # Scoped to ``is_xai_responses`` deliberately; narrow to specific
-        # models if a future grok variant should keep the client-side
-        # function.
+        # 1. **Native** (active/configured backend is ``xai``, or resolution
+        #    fails): drop the client ``web_search`` function and declare
+        #    xAI's built-in instead. 1:1 swap only when client ``web_search``
+        #    was already present — never an additive grant.
+        # 2. **Client** (Firecrawl / Tavily / Exa / … configured or resolved):
+        #    keep Hermes dispatch so ``web.backend`` / ``web.search_backend``
+        #    is honored, but rename the wire tool to
+        #    ``hermes_web_search`` so Grok cannot hijack the name. The alias
+        #    is mapped back to ``web_search`` in ``normalize_response``.
         if is_xai_responses and response_tools:
             has_client_web_search = any(
                 isinstance(t, dict) and t.get("name") == "web_search"
                 for t in response_tools
             )
             if has_client_web_search:
-                filtered = [
-                    t for t in response_tools
-                    if not (isinstance(t, dict) and t.get("name") == "web_search")
-                ]
-                filtered.append({"type": "web_search"})
-                response_tools = filtered
+                if _xai_prefers_native_web_search():
+                    filtered = [
+                        t for t in response_tools
+                        if not (isinstance(t, dict) and t.get("name") == "web_search")
+                    ]
+                    filtered.append({"type": "web_search"})
+                    response_tools = filtered
+                else:
+                    response_tools = _rename_client_web_search_for_xai(response_tools)
 
         # ``tools`` MUST be omitted entirely when there are no functions to
         # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``
@@ -487,9 +523,14 @@ class ResponsesApiTransport(ProviderTransport):
                     provider_data["call_id"] = tc.call_id
                 if hasattr(tc, "response_item_id") and tc.response_item_id:
                     provider_data["response_item_id"] = tc.response_item_id
+                name = tc.function.name if hasattr(tc, "function") else getattr(tc, "name", "")
+                # Undo the xAI client-path wire alias so Hermes dispatches
+                # the real ``web_search`` tool (Firecrawl / etc.).
+                if name == _XAI_CLIENT_WEB_SEARCH_ALIAS:
+                    name = "web_search"
                 tool_calls.append(ToolCall(
-                    id=tc.id if hasattr(tc, "id") else (tc.function.name if hasattr(tc, "function") else None),
-                    name=tc.function.name if hasattr(tc, "function") else getattr(tc, "name", ""),
+                    id=tc.id if hasattr(tc, "id") else (name or None),
+                    name=name,
                     arguments=tc.function.arguments if hasattr(tc, "function") else getattr(tc, "arguments", "{}"),
                     provider_data=provider_data or None,
                 ))

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -39,26 +39,14 @@ _XAI_CLIENT_WEB_SEARCH_ALIAS = "hermes_web_search"
 def _xai_prefers_native_web_search() -> bool:
     """True when xAI Responses should use Grok's native ``web_search`` built-in.
 
-    Honors explicit ``web.search_backend`` / ``web.backend`` first. Only falls
-    back to native when the resolved active provider is ``xai`` (or resolution
-    fails — preserve the incomplete-hang fix rather than risk reintroducing it).
+    Delegates to the web-search registry's provider resolution (which reads
+    ``web.search_backend`` / ``web.backend`` from config) and checks whether
+    the resolved provider is xAI. Falls back to the legacy ``_get_search_backend``
+    probe when the registry has no providers loaded. On any resolution failure,
+    returns True (fail-closed to native — preserves the #48108 incomplete-hang
+    fix rather than risk reintroducing it).
     """
     try:
-        from hermes_cli.config import load_config_readonly
-
-        cfg = load_config_readonly() or {}
-        web = cfg.get("web") if isinstance(cfg, dict) else None
-        if isinstance(web, dict):
-            explicit = (
-                str(web.get("search_backend") or "").strip().lower()
-                or str(web.get("backend") or "").strip().lower()
-            )
-            if explicit == "xai":
-                return True
-            if explicit:
-                # User asked for Firecrawl / Tavily / etc. — keep Hermes dispatch.
-                return False
-
         from agent.web_search_registry import get_active_search_provider
 
         provider = get_active_search_provider()
@@ -69,7 +57,7 @@ def _xai_prefers_native_web_search() -> bool:
 
         return (_get_search_backend() or "").strip().lower() == "xai"
     except Exception:
-        # Fail closed to native swap — same behavior as pre-fix main.
+        # Fail closed to native — same behavior as pre-fix main.
         return True
 
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -438,8 +438,8 @@ class TestXaiWebSearchBackendPreference:
         import agent.transports.codex as codex_mod
 
         monkeypatch.setattr(
-            "hermes_cli.config.load_config_readonly",
-            lambda: {"web": {"backend": "firecrawl"}},
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: SimpleNamespace(name="firecrawl"),
         )
         assert codex_mod._xai_prefers_native_web_search() is False
 
@@ -447,8 +447,8 @@ class TestXaiWebSearchBackendPreference:
         import agent.transports.codex as codex_mod
 
         monkeypatch.setattr(
-            "hermes_cli.config.load_config_readonly",
-            lambda: {"web": {"search_backend": "xai"}},
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: SimpleNamespace(name="xai"),
         )
         assert codex_mod._xai_prefers_native_web_search() is True
 
@@ -456,12 +456,36 @@ class TestXaiWebSearchBackendPreference:
         import agent.transports.codex as codex_mod
 
         monkeypatch.setattr(
-            "hermes_cli.config.load_config_readonly",
-            lambda: {"web": {}},
-        )
-        monkeypatch.setattr(
             "agent.web_search_registry.get_active_search_provider",
             lambda: SimpleNamespace(name="firecrawl"),
+        )
+        assert codex_mod._xai_prefers_native_web_search() is False
+
+    def test_no_provider_legacy_fallback_xai(self, monkeypatch):
+        """When no provider is registered, fall back to _get_search_backend."""
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._get_search_backend",
+            lambda: "xai",
+        )
+        assert codex_mod._xai_prefers_native_web_search() is True
+
+    def test_no_provider_legacy_fallback_non_xai(self, monkeypatch):
+        """When no provider is registered and backend isn't xai, keep client."""
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "tools.web_tools._get_search_backend",
+            lambda: "firecrawl",
         )
         assert codex_mod._xai_prefers_native_web_search() is False
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -271,13 +271,15 @@ class TestCodexBuildKwargs:
 
 
 
-    def test_xai_injects_native_web_search_when_client_web_search_present(self, transport):
-        """xAI path swaps a client-side ``web_search`` function for xAI's
-        native server-side ``web_search`` built-in so grok server-side search
-        runs to completion (otherwise the turn stalls as
-        reasoning-with-no-answer -> false 'incomplete' -> 3 retries -> fail).
+    def test_xai_injects_native_web_search_when_client_web_search_present(self, transport, monkeypatch):
+        """When the active/configured search backend is xAI, swap client
+        ``web_search`` for Grok's native built-in so server-side search
+        completes (otherwise the turn stalls as incomplete → 3 retries).
         Non-conflicting client tools are preserved.
         """
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_xai_prefers_native_web_search", lambda: True)
         messages = [{"role": "user", "content": "Find current prices."}]
         kw = transport.build_kwargs(
             model="grok-composer-2.5-fast", messages=messages,
@@ -298,6 +300,71 @@ class TestCodexBuildKwargs:
         # Non-conflicting client-side tools are preserved.
         names = [t.get("name") for t in kw.get("tools", []) if t.get("type") == "function"]
         assert "read_file" in names
+        assert "web_search" not in names
+        assert "hermes_web_search" not in names
+
+    def test_xai_renames_client_web_search_when_firecrawl_configured(self, transport, monkeypatch):
+        """Configured Firecrawl (or any non-xai backend) must keep Hermes
+        dispatch — rename the wire tool so Grok cannot hijack ``web_search``.
+        """
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_xai_prefers_native_web_search", lambda: False)
+        messages = [{"role": "user", "content": "Find current prices."}]
+        kw = transport.build_kwargs(
+            model="grok-4.5", messages=messages,
+            tools=[
+                {"type": "function", "function": {
+                    "name": "read_file", "description": "Read a file.",
+                    "parameters": {"type": "object",
+                                   "properties": {"path": {"type": "string"}}}}},
+                {"type": "function", "function": {
+                    "name": "web_search", "description": "Search the web.",
+                    "parameters": {"type": "object",
+                                   "properties": {"query": {"type": "string"}}}}},
+            ],
+            is_xai_responses=True,
+        )
+        tools = kw.get("tools", [])
+        assert not any(t.get("type") == "web_search" for t in tools), tools
+        names = [t.get("name") for t in tools if t.get("type") == "function"]
+        assert "read_file" in names
+        assert "hermes_web_search" in names
+        assert "web_search" not in names
+
+    def test_xai_normalize_maps_client_web_search_alias_back(self, transport, monkeypatch):
+        """Alias used on the wire must become ``web_search`` for Hermes dispatch."""
+        import agent.transports.codex as codex_mod
+
+        msg = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id="call_1",
+                    response_item_id="fc_1",
+                    function=SimpleNamespace(
+                        name=codex_mod._XAI_CLIENT_WEB_SEARCH_ALIAS,
+                        arguments='{"query":"hermes"}',
+                    ),
+                )
+            ],
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            reasoning_details=None,
+        )
+        response = SimpleNamespace(output=[], status="completed")
+
+        monkeypatch.setattr(
+            "agent.codex_responses_adapter._normalize_codex_response",
+            lambda resp, issuer_kind=None: (msg, "tool_calls"),
+        )
+        normalized = transport.normalize_response(response)
+
+        assert normalized.tool_calls is not None
+        assert len(normalized.tool_calls) == 1
+        assert normalized.tool_calls[0].name == "web_search"
 
     def test_xai_does_not_inject_native_web_search_without_client_web_search(self, transport):
         """The native ``web_search`` built-in is a 1:1 swap for an
@@ -341,8 +408,6 @@ class TestCodexBuildKwargs:
             for t in tools
         )
 
-
-
     # --- Grok reasoning-effort capability allowlist ---
     # api.x.ai 400s with "Model X does not support parameter reasoningEffort"
     # on grok-4 / grok-4-fast / grok-3 / grok-code-fast / grok-4.20-0309-*.
@@ -350,10 +415,6 @@ class TestCodexBuildKwargs:
     # must omit the `reasoning` key for them.  As of May 2026 we DO request
     # ``reasoning.encrypted_content`` back from xAI on every model —
     # see test_xai_reasoning_effort_passed for the rationale.
-
-
-
-
 
     def test_xai_grok_4_20_0309_variants_omit_reasoning_effort(self, transport):
         """grok-4.20-0309-(non-)reasoning reject the effort dial.
@@ -370,7 +431,39 @@ class TestCodexBuildKwargs:
             assert "reasoning" not in kw, f"{model} must not receive reasoning"
 
 
+class TestXaiWebSearchBackendPreference:
+    """``_xai_prefers_native_web_search`` must honor web backend config."""
 
+    def test_explicit_firecrawl_prefers_client(self, monkeypatch):
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"backend": "firecrawl"}},
+        )
+        assert codex_mod._xai_prefers_native_web_search() is False
+
+    def test_explicit_search_backend_xai_prefers_native(self, monkeypatch):
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {"search_backend": "xai"}},
+        )
+        assert codex_mod._xai_prefers_native_web_search() is True
+
+    def test_resolved_non_xai_provider_prefers_client(self, monkeypatch):
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly",
+            lambda: {"web": {}},
+        )
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: SimpleNamespace(name="firecrawl"),
+        )
+        assert codex_mod._xai_prefers_native_web_search() is False
 
 
 class TestCodexValidateResponse:

--- a/tests/gateway/test_telegram_start_polling_timeout.py
+++ b/tests/gateway/test_telegram_start_polling_timeout.py
@@ -59,6 +59,7 @@ def _bare_adapter():
     a._fatal_error_retryable = True
     a._polling_network_error_count = 0
     a._polling_conflict_count = 0
+    a._polling_conflict_recovery_generation = None
     a._polling_error_callback_ref = None
     a._background_tasks = set()
     a._send_path_degraded = False


### PR DESCRIPTION
## Summary
xAI Responses web search now honors the user's configured web backend — Grok's native server-side search is only used when the active provider is `xai`; Firecrawl/Tavily/etc. keep client-side dispatch under a renamed wire tool so Grok can't hijack the name.

## Context
PR #48108 fixed an incomplete-turn hang on xAI Responses by always swapping client `web_search` for Grok's native server-side search. That silently ignored the user's configured web backend — every xAI session routed through Grok's search engine regardless of `web.backend` / `web.search_backend` config. This PR (salvaged from #78375 by @xxxigm) makes the swap conditional on the resolved backend being xai.

## Changes
- `agent/transports/codex.py`: New `_xai_prefers_native_web_search()` delegates to `get_active_search_provider()` + `_get_search_backend()` to decide native vs client dispatch. New `_rename_client_web_search_for_xai()` renames the wire tool to `hermes_web_search` when keeping client dispatch. `normalize_response` maps the alias back to `web_search` for Hermes dispatch.
- `tests/agent/transports/test_codex_transport.py`: 5 new tests covering native swap (xai provider), client rename (firecrawl provider), alias mapping in normalize, and legacy fallback path.
- `tests/gateway/test_telegram_start_polling_timeout.py`: Defensive init of `_polling_conflict_recovery_generation` in bare-adapter test fixture (attribute added to adapter in a recent main commit but fixture didn't init it).

## Follow-up commit (salvage simplification)
Simplified `_xai_prefers_native_web_search()` to drop the manual `web.search_backend` / `web.backend` config-reading block that duplicated `_read_config_key` in `web_search_registry.py`. Now delegates directly to the registry's `get_active_search_provider()` and only falls back to `_get_search_backend()` when the registry has no providers. Eliminates 3-4 redundant config reads per turn on xAI sessions.

## Validation
| | Before (#48108 on main) | After (this PR) |
|---|---|---|
| xAI + web.backend=firecrawl | Grok native search (ignores config) | Firecrawl client dispatch |
| xAI + web.backend=xai | Grok native search | Grok native search (unchanged) |
| xAI + no backend configured | Grok native search | Client dispatch (firecrawl default) |

- `tests/agent/transports/test_codex_transport.py`: 66 passed
- `tests/gateway/test_telegram_start_polling_timeout.py`: 3 passed
- `tests/agent/test_codex_responses_adapter.py`: 16 passed
- E2E with real imports: alias flow verified (web_search → hermes_web_search → web_search)
- Ruff: clean

Closes #78375

Credit: @xxxigm original fix + tests; @kshitijk4poor simplification follow-up.
