### PR TITLE
fix(slack): show full choice text above buttons when labels are truncated

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6555,6 +6555,13 @@ class SlackAdapter(BasePlatformAdapter):
         Open-ended mode (``choices`` empty): delegates to the base
         implementation, which renders the plain question and arms the same
         text-intercept.
+
+        When any choice label exceeds Slack's 75-char button-text limit,
+        a numbered text list of the full options is included in the section
+        block above the buttons so users can always read the complete
+        choice text.  Button labels are still truncated for Slack's limit,
+        but the full text is visible above and the buttons remain as
+        quick shortcuts.
         """
         # Open-ended prompts have no buttons — the base implementation renders
         # the plain question and arms the gateway text-intercept for us.
@@ -6588,13 +6595,29 @@ class SlackAdapter(BasePlatformAdapter):
             if len(body) > budget:
                 body = body[:budget] + "..."
 
+            # When any choice label exceeds Slack's 75-char button-text limit,
+            # the truncated button text can be impossible to read.  Prepend a
+            # numbered text list of the full options to the section so users
+            # can always read the complete choice text; buttons remain as
+            # quick shortcuts below (their labels are truncated for Slack's
+            # limit, but the full text is visible above).
+            labels = [str(c).strip() or f"Option {i + 1}" for i, c in enumerate(choices)]
+            _BUTTON_LABEL_MAX = 75
+            _has_truncated = any(len(lbl) > _BUTTON_LABEL_MAX for lbl in labels)
+            if _has_truncated:
+                lines = [body, ""]
+                for i, lbl in enumerate(labels, start=1):
+                    lines.append(f"  {i}. {lbl}")
+                body = "\n".join(lines)
+                if len(body) > budget:
+                    body = body[:budget] + "..."
+
             # One button per choice + a free-text "Other" button.  Slack caps
             # an actions block at 5 elements; the clarify tool caps choices at
             # 4 (+ Other = 5) so this is normally one block, but chunk anyway
             # so a larger choice list degrades gracefully instead of 400ing.
             elements = []
-            for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
+            for idx, label in enumerate(labels):
                 elements.append({
                     "type": "button",
                     "text": {"type": "plain_text", "text": label[:75], "emoji": True},

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -135,6 +135,59 @@ class TestSlackSendClarify:
 
 
     @pytest.mark.asyncio
+    async def test_truncated_choices_show_full_text_in_section(self):
+        """When a choice label exceeds 75 chars, the full text appears in the
+        section block above the buttons (#78115)."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "99.99"})
+
+        long_choice = "Deploy to the staging environment and run the full integration test suite before promoting to production"
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="Which plan?",
+            choices=[long_choice, "Skip tests"],
+            clarify_id="cid_trunc",
+            session_key="sk_trunc",
+        )
+
+        assert result.success is True
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        blocks = kwargs["blocks"]
+        section_text = blocks[0]["text"]["text"]
+        # Full text of the long choice is in the section
+        assert long_choice in section_text
+        assert "1." in section_text
+        # Short choice also visible
+        assert "Skip tests" in section_text
+        # Buttons are still present with truncated labels
+        action_block = blocks[1]
+        assert action_block["type"] == "actions"
+        button_label = action_block["elements"][0]["text"]["text"]
+        assert len(button_label) <= 75
+        assert button_label != long_choice  # truncated
+
+    @pytest.mark.asyncio
+    async def test_short_choices_no_numbered_list(self):
+        """When all choice labels fit in 75 chars, no numbered list is added."""
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "88.88"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Pick one",
+            choices=["short", "also short"],
+            clarify_id="cid_short",
+            session_key="sk_short",
+        )
+
+        section_text = mock_client.chat_postMessage.call_args[1]["blocks"][0]["text"]["text"]
+        # No numbered options in the section for short choices
+        assert "1." not in section_text
+        assert "2." not in section_text
+
+    @pytest.mark.asyncio
     async def test_mrkdwn_escapes_question(self):
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]


### PR DESCRIPTION
## Summary

When a Slack clarify choice label exceeds Slack's 75-character button-text limit, the truncated button text can be impossible to read — there is no alt text or tooltip to recover the omitted text. This makes multi-choice clarify prompts unusable for long descriptive options (schedules, deployment plans, operational choices with qualifiers).

## Fix

When any choice label exceeds 75 chars, include a numbered text list of the full options in the section block above the buttons. Users can now read the complete choice text; buttons remain as quick shortcuts with truncated labels. When all choices fit within 75 chars, behaviour is unchanged (no numbered list, buttons only).

This is a complementary approach to #72148 (which adds an opt-out config flag). This fix makes the default experience readable without requiring configuration changes.

## Root Cause

`plugins/platforms/slack/adapter.py` line ~6600 truncates button labels with `label[:75]`. The section block above the buttons only contained the question text, not the choices — so users had no way to see the full option text.

## Changes

- `plugins/platforms/slack/adapter.py`: When any choice label > 75 chars, append a numbered text list of all options to the section block text
- `tests/gateway/test_slack_clarify_buttons.py`: Add tests for truncated-choices-full-text and short-choices-no-list

## Validation

- `tests/gateway/test_slack_clarify_buttons.py`: 7 passed (2 new + 5 existing)
- `git diff --stat`: 2 files changed, 78 insertions(+), 2 deletions(-)

Fixes #78115