### PR TITLE
fix(agent): bound request_dump_*.json growth in the sessions directory

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1858,7 +1858,7 @@ def _request_dump_keep() -> int:
         return _REQUEST_DUMP_DEFAULT_KEEP
 
 
-def prune_request_dumps(logs_dir: Path) -> int:
+def prune_request_dumps(logs_dir: Path, *, protect: Optional[Path] = None) -> int:
     """Bound ``request_dump_*.json`` growth in *logs_dir*. Returns count deleted.
 
     The glob is a fixed literal — deliberately NOT keyed to the session id, so
@@ -1869,9 +1869,21 @@ def prune_request_dumps(logs_dir: Path) -> int:
     id from escaping ``logs_dir`` in the first place, and pruning inherits that
     guarantee by only ever matching ``request_dump_*.json`` directly inside the
     resolved directory.
+
+    *protect* exempts the dump just written.  Newest-first ordering almost
+    always spares it already, but two dumps can share an mtime (coarse
+    filesystem granularity, or concurrent agents writing inside one tick), and
+    the tie is then broken on the whole filename — where the session id leads,
+    so a sibling session whose id sorts higher wins and the fresh dump is
+    deleted before its caller can print the path.  The exemption makes
+    "we never delete the dump we just wrote" hold by construction.
     """
     return prune_oldest_files(
-        logs_dir, "request_dump_*.json", _request_dump_keep(), log=logger,
+        logs_dir,
+        "request_dump_*.json",
+        _request_dump_keep(),
+        protect=protect,
+        log=logger,
     )
 
 
@@ -1960,13 +1972,15 @@ def dump_api_request_debug(
 
         # Bound directory growth immediately after the write, so the cap holds
         # even for a process that only ever errors once (#77472).  Pruning runs
-        # after ``dump_file`` exists and is fully written, and keeps the newest
-        # N — so the dump just written is never the one deleted.  Its own
-        # failures are swallowed inside ``prune_oldest_files``; the extra guard
-        # here means even an unexpected raise cannot cost us the return value
-        # or the user-facing path notice below.
+        # after ``dump_file`` exists and is fully written, keeps the newest N,
+        # and exempts ``dump_file`` explicitly — so the dump just written is
+        # never the one deleted even when an mtime tie would otherwise order a
+        # concurrent session's dump ahead of it.  Its own failures are
+        # swallowed inside ``prune_oldest_files``; the extra guard here means
+        # even an unexpected raise cannot cost us the return value or the
+        # user-facing path notice below.
         try:
-            prune_request_dumps(agent.logs_dir)
+            prune_request_dumps(agent.logs_dir, protect=dump_file)
         except Exception as prune_error:
             logger.debug("Request dump retention skipped: %s", prune_error)
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -39,7 +39,13 @@ from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED, credential_pool_matches_provider
 from agent.error_classifier import FailoverReason
 from agent.turn_context import drop_stale_api_content
-from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    env_var_enabled,
+    atomic_json_write,
+    prune_oldest_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1816,6 +1822,59 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
 
 
 
+# Request dumps are written one-per-API-error with a microsecond-precision
+# timestamp in the filename, so no two ever collide and nothing is reclaimed by
+# rewriting.  The only existing cleanup is session-scoped
+# (``SessionDB._remove_session_files``, which runs when a session row is
+# deleted or pruned at 90 days), so a directory of dumps from live/recent
+# sessions grows without bound (#77472: 171 dumps / 47 MB observed, individual
+# dumps up to ~1 MB because each embeds the full system prompt, tool schema and
+# message history).  Cap the directory instead, keeping the newest N — the ones
+# a user is actually trying to read after a failure.
+#
+# Default 20: enough to cover a burst of 4xx retries plus several prior
+# incidents (the worst observed single session produced 9 dumps), while
+# bounding the directory to single-digit MB in typical use.  A count cap rather
+# than a byte cap keeps every retained dump complete — truncating a dump body
+# would destroy the debuggability the feature exists for.
+_REQUEST_DUMP_DEFAULT_KEEP = 20
+
+
+def _request_dump_keep() -> int:
+    """Resolve the request-dump retention cap (``sessions.request_dump_retention``).
+
+    Behavioral setting, so it lives in ``config.yaml`` — not an env var.  Any
+    resolution failure falls back to the default rather than disabling
+    retention, so a malformed config cannot silently restore unbounded growth.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        sessions_cfg = cfg.get("sessions", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(sessions_cfg, dict):
+            return _REQUEST_DUMP_DEFAULT_KEEP
+        return int(sessions_cfg.get("request_dump_retention", _REQUEST_DUMP_DEFAULT_KEEP))
+    except Exception:
+        return _REQUEST_DUMP_DEFAULT_KEEP
+
+
+def prune_request_dumps(logs_dir: Path) -> int:
+    """Bound ``request_dump_*.json`` growth in *logs_dir*. Returns count deleted.
+
+    The glob is a fixed literal — deliberately NOT keyed to the session id, so
+    retention bounds the whole directory rather than per-session islands (a new
+    session id per run is exactly how the directory grew unbounded).  Because
+    the pattern is a constant, a hostile session id cannot widen it; the
+    write-side sanitization in ``_safe_session_filename_component`` keeps the
+    id from escaping ``logs_dir`` in the first place, and pruning inherits that
+    guarantee by only ever matching ``request_dump_*.json`` directly inside the
+    resolved directory.
+    """
+    return prune_oldest_files(
+        logs_dir, "request_dump_*.json", _request_dump_keep(), log=logger,
+    )
+
+
 def dump_api_request_debug(
     agent,
     api_kwargs: Dict[str, Any],
@@ -1898,6 +1957,18 @@ def dump_api_request_debug(
         _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
         _redacted_payload = json.loads(redact_sensitive_text(_serialized, force=True))
         atomic_json_write(dump_file, _redacted_payload, default=str)
+
+        # Bound directory growth immediately after the write, so the cap holds
+        # even for a process that only ever errors once (#77472).  Pruning runs
+        # after ``dump_file`` exists and is fully written, and keeps the newest
+        # N — so the dump just written is never the one deleted.  Its own
+        # failures are swallowed inside ``prune_oldest_files``; the extra guard
+        # here means even an unexpected raise cannot cost us the return value
+        # or the user-facing path notice below.
+        try:
+            prune_request_dumps(agent.logs_dir)
+        except Exception as prune_error:
+            logger.debug("Request dump retention skipped: %s", prune_error)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
@@ -4030,6 +4101,7 @@ __all__ = [
     "restore_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",
+    "prune_request_dumps",
     "prompt_caching_disabled_from_config",
     "blank_cache_policy_stub",
     "plan_cache_sections_for_destination",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -727,6 +727,23 @@ session_reset:
   idle_minutes: 1440   # Inactivity timeout in minutes (used by "idle"/"both")
   at_hour: 4           # Daily reset hour, 0-23 local time (used by "daily"/"both")
 
+# =============================================================================
+# Session Artifact Retention
+# =============================================================================
+# When an API call fails with a non-retryable 4xx (or exhausts its retries),
+# Hermes writes a debug dump to ~/.hermes/sessions/request_dump_<session>_<ts>.json
+# so the failing request can be inspected afterwards. Each dump embeds the full
+# request body — system prompt, tool schemas, entire message history — so they
+# can reach ~1 MB apiece, and the microsecond timestamp in the filename means
+# they never overwrite each other.
+#
+# request_dump_retention keeps the N newest dumps and deletes older ones after
+# each write. The newest are the ones worth reading after a failure, so a burst
+# of errors never evicts the dump you are currently debugging. Set to 0 (or a
+# negative value) to disable pruning if you manage cleanup externally.
+sessions:
+  request_dump_retention: 20   # Newest API-error request dumps to keep (0 = unlimited)
+
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow
 # unlimited concurrent sessions. When the limit is reached, new sessions get a

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2687,6 +2687,17 @@ DEFAULT_CONFIG = {
         # GBs of disk on heavy users.  Opt in only if you have an external
         # tool that consumes the JSON files directly.
         "write_json_snapshots": False,
+        # Retention cap for API-error request dumps
+        # (``~/.hermes/sessions/request_dump_*.json``, written by
+        # agent_runtime_helpers.dump_api_request_debug on non-retryable 4xx and
+        # exhausted retries).  Each filename carries a microsecond timestamp so
+        # dumps never overwrite each other, and each embeds the full request
+        # body (system prompt + tool schemas + message history) — up to ~1 MB
+        # apiece.  The only other cleanup is session-scoped, so without a cap
+        # the directory grew forever (#77472).  Keeps the N newest dumps, which
+        # are the ones worth reading after a failure; 0 or negative disables
+        # pruning for operators who manage cleanup externally.
+        "request_dump_retention": 20,
         # Search-index (FTS) storage optimization — the compact v23 layout
         # that drops duplicate content copies and stops trigram-indexing tool
         # output (typically reclaims ~60%+ of state.db on heavy users). It is

--- a/tests/agent/test_request_dump_retention.py
+++ b/tests/agent/test_request_dump_retention.py
@@ -172,22 +172,47 @@ class TestDirectoryStaysBounded:
 
 
 class TestConfigKnob:
-    def test_default_is_twenty_and_lives_in_config_defaults(self):
+    def test_code_default_and_config_default_do_not_drift(self):
+        """The two declarations of one default must agree.
+
+        Deliberately NOT a snapshot of the number. The cap is a tunable — a
+        maintainer may reasonably raise it — and asserting the literal would
+        turn a pure-tuning change with zero behavior difference into a CI
+        failure.  What must hold is the relationship: the value
+        ``_request_dump_keep()`` falls back to when the key is absent has to be
+        the value ``load_config()`` deep-merges in when it is present.  If
+        those drift, the effective cap depends on whether the user happens to
+        have a config.yaml, which is exactly the kind of split-brain default
+        that makes a retention bug unreproducible.
+        """
         from hermes_cli.config import DEFAULT_CONFIG
 
-        assert DEFAULT_CONFIG["sessions"]["request_dump_retention"] == 20
         assert (
             agent_runtime_helpers._REQUEST_DUMP_DEFAULT_KEEP
             == DEFAULT_CONFIG["sessions"]["request_dump_retention"]
         ), "code default and config default must not drift"
 
     def test_default_applies_with_no_config_file(self, agent):
-        """A fresh install (no config.yaml) is still bounded."""
+        """A fresh install (no config.yaml) is bounded at the shipped cap.
+
+        Behavioral, and driven off the constant rather than off ``20``: write
+        ``keep + 6`` dumps through the real path and require exactly ``keep``
+        survivors — the newest ones.  Retuning the default retunes the test
+        with it, while the assertion keeps its meaning (an unconfigured install
+        still prunes, and prunes to the cap the code declares).  This is the
+        test that would actually catch the bug; the drift check above cannot.
+        """
         assert not (Path(os.environ["HERMES_HOME"]) / "config.yaml").exists()
+        keep = agent_runtime_helpers._REQUEST_DUMP_DEFAULT_KEEP
+        assert keep > 0, "the shipped default must prune, not disable pruning"
 
-        _dump_n(agent, 26)
+        written = _dump_n(agent, keep + 6)
 
-        assert len(_dumps(agent.logs_dir)) == 20
+        survivors = {p.name for p in _dumps(agent.logs_dir)}
+        assert len(survivors) == keep, (
+            f"unconfigured install kept {len(survivors)} dumps, cap is {keep}"
+        )
+        assert survivors == {p.name for p in written[-keep:]}, "survivors are the newest"
 
     def test_custom_value_is_honored(self, agent):
         _write_config(
@@ -213,20 +238,26 @@ class TestConfigKnob:
 
     def test_malformed_value_falls_back_to_default_not_unlimited(self, agent):
         """A bad config must not silently restore unbounded growth."""
+        keep = agent_runtime_helpers._REQUEST_DUMP_DEFAULT_KEEP
         _write_config(
             Path(os.environ["HERMES_HOME"]),
             "sessions:\n  request_dump_retention: not-a-number\n",
         )
 
-        assert agent_runtime_helpers._request_dump_keep() == 20
+        assert agent_runtime_helpers._request_dump_keep() == keep
 
-        _dump_n(agent, 23)
-        assert len(_dumps(agent.logs_dir)) == 20
+        _dump_n(agent, keep + 3)
+        assert len(_dumps(agent.logs_dir)) == keep, (
+            "a malformed value must fall back to the cap, not to unlimited"
+        )
 
     def test_missing_sessions_block_falls_back_to_default(self, agent):
         _write_config(Path(os.environ["HERMES_HOME"]), "model:\n  name: gpt-4o\n")
 
-        assert agent_runtime_helpers._request_dump_keep() == 20
+        assert (
+            agent_runtime_helpers._request_dump_keep()
+            == agent_runtime_helpers._REQUEST_DUMP_DEFAULT_KEEP
+        )
 
     def test_shipped_example_config_matches_code_default(self):
         """The template is copied verbatim into ~/.hermes/config.yaml by the

--- a/tests/agent/test_request_dump_retention.py
+++ b/tests/agent/test_request_dump_retention.py
@@ -1,0 +1,360 @@
+"""Request-dump retention contract (issue #77472).
+
+``dump_api_request_debug`` writes ``request_dump_<session>_<timestamp>.json``
+into ``agent.logs_dir`` on every non-retryable 4xx and every exhausted-retry
+failure.  The microsecond timestamp makes every filename unique, so nothing is
+ever reclaimed by rewriting, and each dump embeds the full request body (system
+prompt + tool schemas + message history).  The only pre-existing cleanup is
+session-scoped (``SessionDB._remove_session_files``, on session delete/prune),
+so dumps from live and recent sessions accumulated without bound.
+
+These tests drive the REAL dump path on a real ``AIAgent`` against a temp
+``HERMES_HOME`` — the assertions are about which files exist on disk, not about
+which functions were called.
+"""
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+from agent import agent_runtime_helpers
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so config reads and dumps stay inside the test."""
+    home = tmp_path / ".hermes"
+    (home / "sessions").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def agent(hermes_home, monkeypatch):
+    """A real AIAgent whose logs_dir is the temp sessions directory."""
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+    built = run_agent.AIAgent(
+        model="gpt-4o",
+        base_url="http://127.0.0.1:9208/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    built.logs_dir = hermes_home / "sessions"
+    built._vprint = lambda *a, **k: None
+    return built
+
+
+def _write_config(home: Path, body: str) -> None:
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _kwargs(marker="hello"):
+    return {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": marker}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    }
+
+
+def _dumps(logs_dir: Path):
+    return sorted(logs_dir.glob("request_dump_*.json"))
+
+
+def _dump_n(agent, count, *, reason="non_retryable_client_error"):
+    """Drive the real dump path *count* times, returning the paths written."""
+    written = []
+    for i in range(count):
+        path = agent._dump_api_request_debug(
+            _kwargs(f"turn {i}"), reason=reason, error=ValueError("HTTP 400"),
+        )
+        assert path is not None, "dump path must still be returned to the caller"
+        written.append(path)
+    return written
+
+
+class TestDirectoryStaysBounded:
+    def test_n_plus_k_errors_leave_exactly_n_newest_dumps(self, agent):
+        """The core invariant: 30 errors under a cap of 5 leave the newest 5."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 5\n",
+        )
+
+        written = _dump_n(agent, 30)
+
+        survivors = {p.name for p in _dumps(agent.logs_dir)}
+        assert len(survivors) == 5
+        assert survivors == {p.name for p in written[-5:]}, "survivors are the newest"
+
+    def test_growth_is_bounded_at_every_step(self, agent):
+        """The cap holds continuously, not just after the last write."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 3\n",
+        )
+
+        for i in range(15):
+            agent._dump_api_request_debug(_kwargs(f"t{i}"), reason="preflight")
+            assert len(_dumps(agent.logs_dir)) <= 3, f"cap exceeded after write {i}"
+
+    def test_dump_just_written_is_never_the_one_pruned(self, agent):
+        """A burst of errors must not evict the dump the user is about to read."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 1\n",
+        )
+
+        for i in range(10):
+            path = agent._dump_api_request_debug(_kwargs(f"t{i}"), reason="preflight")
+            assert path.exists(), "the returned path must exist for the caller to read"
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            assert payload["request"]["body"]["messages"][0]["content"] == f"t{i}"
+
+    def test_retention_spans_sessions_not_just_one(self, agent):
+        """Per-session caps would not bound the directory — a new id per run is
+        exactly how it grew. The cap is directory-wide."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 4\n",
+        )
+
+        written = []
+        for session_index in range(6):
+            agent.session_id = f"20260804_12000{session_index}_abcdef"
+            written.extend(_dump_n(agent, 3))
+
+        remaining = {p.name for p in _dumps(agent.logs_dir)}
+        # 18 dumps across 6 session ids, cap 4 — the cap is directory-wide, so
+        # the survivors are the globally-newest 4 and straddle the session
+        # boundary (3 from the last session + 1 from the one before it).
+        assert len(remaining) == 4, "cap applies across sessions, not per session"
+        assert remaining == {p.name for p in written[-4:]}
+        assert len({name.split("_abcdef_")[0] for name in remaining}) == 2, (
+            "survivors straddle sessions, proving retention is not per-session"
+        )
+
+
+class TestConfigKnob:
+    def test_default_is_twenty_and_lives_in_config_defaults(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["sessions"]["request_dump_retention"] == 20
+        assert (
+            agent_runtime_helpers._REQUEST_DUMP_DEFAULT_KEEP
+            == DEFAULT_CONFIG["sessions"]["request_dump_retention"]
+        ), "code default and config default must not drift"
+
+    def test_default_applies_with_no_config_file(self, agent):
+        """A fresh install (no config.yaml) is still bounded."""
+        assert not (Path(os.environ["HERMES_HOME"]) / "config.yaml").exists()
+
+        _dump_n(agent, 26)
+
+        assert len(_dumps(agent.logs_dir)) == 20
+
+    def test_custom_value_is_honored(self, agent):
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 7\n",
+        )
+
+        _dump_n(agent, 12)
+
+        assert len(_dumps(agent.logs_dir)) == 7
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_non_positive_value_opts_out_of_pruning(self, agent, value):
+        """Operators who manage cleanup externally must be able to disable it."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            f"sessions:\n  request_dump_retention: {value}\n",
+        )
+
+        _dump_n(agent, 9)
+
+        assert len(_dumps(agent.logs_dir)) == 9, "pruning must be fully disabled"
+
+    def test_malformed_value_falls_back_to_default_not_unlimited(self, agent):
+        """A bad config must not silently restore unbounded growth."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: not-a-number\n",
+        )
+
+        assert agent_runtime_helpers._request_dump_keep() == 20
+
+        _dump_n(agent, 23)
+        assert len(_dumps(agent.logs_dir)) == 20
+
+    def test_missing_sessions_block_falls_back_to_default(self, agent):
+        _write_config(Path(os.environ["HERMES_HOME"]), "model:\n  name: gpt-4o\n")
+
+        assert agent_runtime_helpers._request_dump_keep() == 20
+
+    def test_shipped_example_config_matches_code_default(self):
+        """The template is copied verbatim into ~/.hermes/config.yaml by the
+        installers, so a mismatch would become an explicit user override."""
+        import yaml
+
+        template = Path(__file__).resolve().parents[2] / "cli-config.yaml.example"
+        parsed = yaml.safe_load(template.read_text(encoding="utf-8")) or {}
+        assert (
+            parsed["sessions"]["request_dump_retention"]
+            == agent_runtime_helpers._REQUEST_DUMP_DEFAULT_KEEP
+        )
+
+
+class TestDeletionSafety:
+    def test_only_request_dumps_are_deleted(self, agent):
+        """Session transcripts, state.db and anything else in the sessions
+        directory must be untouched."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 2\n",
+        )
+        bystanders = [
+            "state.db",
+            "session_20260804_120000_abcdef.json",
+            "20260804_120000_abcdef.jsonl",
+            "request_dump_notes.txt",
+        ]
+        for name in bystanders:
+            (agent.logs_dir / name).write_text("keep me", encoding="utf-8")
+
+        _dump_n(agent, 8)
+
+        for name in bystanders:
+            assert (agent.logs_dir / name).exists(), f"{name} must survive pruning"
+        assert len(_dumps(agent.logs_dir)) == 2
+
+    def test_traversal_shaped_session_id_stays_inside_logs_dir(self, agent, tmp_path):
+        """A hostile session id (X-Hermes-Session-Id header) must neither escape
+        logs_dir on write nor widen what pruning deletes."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 3\n",
+        )
+        outside = tmp_path / "outside_dir"
+        outside.mkdir()
+        precious = outside / "precious.json"
+        precious.write_text("do not delete", encoding="utf-8")
+
+        agent.session_id = "../../../../outside_dir/pwned"
+        written = _dump_n(agent, 6)
+
+        for path in written[-3:]:
+            assert path.parent.resolve() == agent.logs_dir.resolve(), (
+                "dump must be written directly inside logs_dir"
+            )
+        assert precious.exists(), "pruning must not reach outside logs_dir"
+        assert len(_dumps(agent.logs_dir)) == 3
+        assert not (outside / "pwned").exists()
+
+    def test_subdirectory_of_logs_dir_is_not_swept(self, agent):
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 1\n",
+        )
+        nested = agent.logs_dir / "archive"
+        nested.mkdir()
+        archived = nested / "request_dump_old_20260101_000000_000000.json"
+        archived.write_text("archived", encoding="utf-8")
+
+        _dump_n(agent, 5)
+
+        assert archived.exists(), "pruning must not recurse into subdirectories"
+
+
+class TestFailureIsNonFatal:
+    def test_prune_failure_still_returns_the_dump_path(self, agent, monkeypatch):
+        """Retention is housekeeping — it must never break debuggability."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 2\n",
+        )
+
+        def explode(*_a, **_k):
+            raise RuntimeError("filesystem on fire")
+
+        monkeypatch.setattr(agent_runtime_helpers, "prune_oldest_files", explode)
+
+        path = agent._dump_api_request_debug(_kwargs(), reason="preflight")
+
+        assert path is not None and path.exists(), (
+            "a prune failure must not cost the caller the dump"
+        )
+
+    def test_dump_content_is_unchanged_by_retention(self, agent):
+        """The feature being bounded must still produce the same payload."""
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 5\n",
+        )
+
+        path = agent._dump_api_request_debug(
+            _kwargs("inspect me"),
+            reason="max_retries_exhausted",
+            error=ValueError("HTTP 400 invalid_request_error"),
+        )
+        payload = json.loads(path.read_text(encoding="utf-8"))
+
+        assert payload["reason"] == "max_retries_exhausted"
+        assert payload["request"]["url"].endswith("/chat/completions")
+        assert payload["request"]["body"]["messages"][0]["content"] == "inspect me"
+        assert payload["request"]["body"]["tools"], "tool schemas still captured"
+        assert payload["error"]["type"] == "ValueError"
+        assert "invalid_request_error" in payload["error"]["message"]
+
+
+class TestPruneHelperDirectly:
+    def test_prune_request_dumps_reports_deleted_count(self, hermes_home):
+        _write_config(hermes_home, "sessions:\n  request_dump_retention: 2\n")
+        logs_dir = hermes_home / "sessions"
+        for i in range(6):
+            path = logs_dir / f"request_dump_sid_2026080{i}_120000_00000{i}.json"
+            path.write_text("{}", encoding="utf-8")
+            stamp = 1_700_000_000.0 + i * 10
+            os.utime(path, (stamp, stamp))
+
+        assert agent_runtime_helpers.prune_request_dumps(logs_dir) == 4
+        assert len(list(logs_dir.glob("request_dump_*.json"))) == 2
+
+    def test_prune_request_dumps_on_missing_dir_is_safe(self, hermes_home):
+        assert agent_runtime_helpers.prune_request_dumps(hermes_home / "gone") == 0

--- a/tests/agent/test_request_dump_retention.py
+++ b/tests/agent/test_request_dump_retention.py
@@ -358,3 +358,57 @@ class TestPruneHelperDirectly:
 
     def test_prune_request_dumps_on_missing_dir_is_safe(self, hermes_home):
         assert agent_runtime_helpers.prune_request_dumps(hermes_home / "gone") == 0
+
+
+class TestFreshDumpSurvivesAnMtimeTie:
+    """The returned path must still exist, even when mtimes collide.
+
+    ``dump_api_request_debug`` hands the path back to its caller, which prints
+    it for the user to open.  Ordering alone does not guarantee the fresh dump
+    survives: two dumps can land in one mtime tick (coarse-granularity
+    filesystem, or two agents erroring concurrently), and the tie is broken on
+    the whole filename — where the *session id* leads.  A sibling session whose
+    id sorts higher would then win the tie and the just-written dump would be
+    deleted before the user could read it.
+    """
+
+    def test_returned_path_exists_when_a_sibling_session_ties_on_mtime(self, agent):
+        _write_config(
+            Path(os.environ["HERMES_HOME"]),
+            "sessions:\n  request_dump_retention: 2\n",
+        )
+        logs_dir = agent.logs_dir
+        # Pre-seed dumps from a session id that sorts ABOVE ours, all sharing
+        # one mtime tick with the dump we are about to write.
+        tie = 1_700_000_000.0
+        for i in range(4):
+            stale = logs_dir / f"request_dump_zzzz_20260101_00000{i}_000000.json"
+            stale.write_text("{}", encoding="utf-8")
+            os.utime(stale, (tie, tie))
+
+        agent.session_id = "aaaa_20260101_000000"
+        written = agent._dump_api_request_debug(
+            _kwargs("fresh"), reason="non_retryable_client_error",
+        )
+        os.utime(written, (tie, tie))  # force the tie the guard must survive
+        agent_runtime_helpers.prune_request_dumps(logs_dir, protect=written)
+
+        assert written.exists(), "the dump whose path was returned must still exist"
+        payload = json.loads(written.read_text(encoding="utf-8"))
+        assert payload["request"]["body"]["messages"][0]["content"] == "fresh"
+        assert len(_dumps(logs_dir)) == 2, "cap still holds"
+
+    def test_protect_is_passed_through_from_the_write_path(self, agent, monkeypatch):
+        """The write path must hand its own dump to the prune as protected."""
+        seen = {}
+
+        def _spy(logs_dir, *, protect=None):
+            seen["logs_dir"] = logs_dir
+            seen["protect"] = protect
+            return 0
+
+        monkeypatch.setattr(agent_runtime_helpers, "prune_request_dumps", _spy)
+        written = agent._dump_api_request_debug(_kwargs("x"), reason="preflight")
+
+        assert seen["protect"] == written, "the fresh dump is exempted by path"
+        assert seen["logs_dir"] == agent.logs_dir

--- a/tests/test_utils_prune_oldest_files.py
+++ b/tests/test_utils_prune_oldest_files.py
@@ -120,6 +120,91 @@ class TestOrderingIsByMtimeNotName:
         assert survivors_a == survivors_b
 
 
+class TestProtectedFileSurvives:
+    """``protect`` exempts the file the caller just wrote.
+
+    Newest-first ordering usually spares it, but when mtimes tie the whole
+    filename breaks the tie — and for ``request_dump_<session>_<ts>.json`` the
+    session id leads, so a sibling session's id can sort higher and evict the
+    fresh dump. These assert the invariant the caller depends on ("the file I
+    just wrote is still there when this returns"), not a sort order.
+    """
+
+    def test_protected_file_survives_an_mtime_tie_it_would_lose(self, tmp_path):
+        # Same mtime for all four; the protected name sorts LAST lexically, so
+        # without the exemption the tiebreaker deletes it.
+        losers = [f"request_dump_zzz_{i:02d}.json" for i in range(3)]
+        just_written = "request_dump_aaa_99.json"
+        for path in _seed(tmp_path, [*losers, just_written], step=0.0):
+            os.utime(path, (1_700_000_000.0, 1_700_000_000.0))
+        target = tmp_path / just_written
+
+        prune_oldest_files(tmp_path, "request_dump_*.json", 1, protect=target)
+
+        assert target.exists(), "the file the caller just wrote must survive"
+        assert [p.name for p in tmp_path.glob("request_dump_*.json")] == [just_written]
+
+    def test_protected_file_still_counts_against_the_cap(self, tmp_path):
+        """The exemption must not let the directory exceed *keep*."""
+        names = [f"dump_{i}.json" for i in range(10)]
+        _seed(tmp_path, names)
+        target = tmp_path / names[0]  # oldest, so it would normally be deleted
+
+        prune_oldest_files(tmp_path, "dump_*.json", 3, protect=target)
+
+        survivors = sorted(p.name for p in tmp_path.glob("dump_*.json"))
+        assert len(survivors) == 3, "cap still holds exactly"
+        assert names[0] in survivors, "protected file is one of the survivors"
+
+    def test_protected_name_in_another_directory_is_not_credited(self, tmp_path):
+        """A same-named file elsewhere must not exempt a local file by name."""
+        other = tmp_path / "other"
+        other.mkdir()
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(5)])
+
+        deleted = prune_oldest_files(
+            tmp_path, "dump_*.json", 2, protect=other / "dump_0.json",
+        )
+
+        assert deleted == 3
+        assert len(list(tmp_path.glob("dump_*.json"))) == 2
+
+    def test_protect_of_a_missing_file_keeps_the_full_cap(self, tmp_path):
+        """Nothing to exempt → no slot is reserved, so *keep* files remain."""
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(6)])
+
+        prune_oldest_files(
+            tmp_path, "dump_*.json", 3, protect=tmp_path / "dump_never_written.json",
+        )
+
+        assert len(list(tmp_path.glob("dump_*.json"))) == 3
+
+    def test_protect_none_is_the_previous_behavior(self, tmp_path):
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(6)])
+
+        assert prune_oldest_files(tmp_path, "dump_*.json", 2, protect=None) == 4
+        assert len(list(tmp_path.glob("dump_*.json"))) == 2
+
+    def test_under_cap_with_protect_deletes_nothing(self, tmp_path):
+        paths = _seed(tmp_path, [f"dump_{i}.json" for i in range(3)])
+
+        assert prune_oldest_files(tmp_path, "dump_*.json", 5, protect=paths[-1]) == 0
+        assert len(list(tmp_path.glob("dump_*.json"))) == 3
+
+    def test_keep_one_with_protect_leaves_only_the_protected_file(self, tmp_path):
+        paths = _seed(tmp_path, [f"dump_{i}.json" for i in range(4)])
+        target = paths[1]
+
+        prune_oldest_files(tmp_path, "dump_*.json", 1, protect=target)
+
+        assert [p.name for p in tmp_path.glob("dump_*.json")] == [target.name]
+
+    def test_garbage_protect_value_does_not_break_pruning(self, tmp_path):
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(5)])
+
+        assert prune_oldest_files(tmp_path, "dump_*.json", 2, protect=object()) == 3
+
+
 class TestScopeSafety:
     def test_only_matching_pattern_is_touched(self, tmp_path):
         _seed(tmp_path, [f"dump_{i}.json" for i in range(5)])

--- a/tests/test_utils_prune_oldest_files.py
+++ b/tests/test_utils_prune_oldest_files.py
@@ -1,0 +1,248 @@
+"""Behavior contract for ``utils.prune_oldest_files``.
+
+Shared retention primitive for append-only artifact directories (issue #77472).
+Every test drives the real filesystem — no mocks — because the whole point of
+the helper is which files actually survive on disk.
+"""
+
+import os
+import time
+
+import pytest
+
+from utils import prune_oldest_files
+
+
+def _seed(directory, names, *, start_mtime=1_700_000_000.0, step=10.0):
+    """Create *names* in order, oldest first, with explicit spaced mtimes.
+
+    Explicit mtimes rather than real sleeps: filesystem timestamp granularity
+    varies (HFS+ 1s, ext3 1s, NTFS 100ns), so writing files back-to-back can
+    produce identical mtimes and make ordering assertions flaky.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    created = []
+    for index, name in enumerate(names):
+        path = directory / name
+        path.write_text(f"payload {name}", encoding="utf-8")
+        stamp = start_mtime + index * step
+        os.utime(path, (stamp, stamp))
+        created.append(path)
+    return created
+
+
+class TestKeepsNewest:
+    def test_keeps_exactly_keep_newest_and_deletes_rest(self, tmp_path):
+        names = [f"dump_{i:02d}.json" for i in range(10)]
+        _seed(tmp_path, names)
+
+        deleted = prune_oldest_files(tmp_path, "dump_*.json", 3)
+
+        assert deleted == 7
+        survivors = sorted(p.name for p in tmp_path.glob("dump_*.json"))
+        assert survivors == names[-3:], "the three newest must be the survivors"
+
+    def test_no_op_when_under_cap(self, tmp_path):
+        names = [f"dump_{i}.json" for i in range(3)]
+        _seed(tmp_path, names)
+
+        assert prune_oldest_files(tmp_path, "dump_*.json", 5) == 0
+        assert sorted(p.name for p in tmp_path.glob("dump_*.json")) == sorted(names)
+
+    def test_no_op_when_exactly_at_cap(self, tmp_path):
+        names = [f"dump_{i}.json" for i in range(4)]
+        _seed(tmp_path, names)
+
+        assert prune_oldest_files(tmp_path, "dump_*.json", 4) == 0
+        assert len(list(tmp_path.glob("dump_*.json"))) == 4
+
+    def test_repeated_writes_stay_bounded(self, tmp_path):
+        """The invariant that matters: N+k writes leave exactly N on disk."""
+        keep = 5
+        newest = []
+        for i in range(40):
+            path = tmp_path / f"dump_{i:03d}.json"
+            path.write_text("x", encoding="utf-8")
+            stamp = 1_700_000_000.0 + i * 10
+            os.utime(path, (stamp, stamp))
+            newest.append(path.name)
+            prune_oldest_files(tmp_path, "dump_*.json", keep)
+            assert len(list(tmp_path.glob("dump_*.json"))) <= keep
+
+        assert sorted(p.name for p in tmp_path.glob("dump_*.json")) == sorted(newest[-keep:])
+
+
+class TestOrderingIsByMtimeNotName:
+    def test_variable_prefix_does_not_corrupt_ordering(self, tmp_path):
+        """Reverse-lexical sorting is wrong when a variable field precedes the timestamp.
+
+        Request-dump filenames are ``request_dump_<session>_<timestamp>.json``.
+        Sorting those by name orders by session id first, so the newest dump of
+        an alphabetically-early session would be deleted while an older dump of
+        a later session survived. mtime ordering is the contract.
+        """
+        # 'zzz' session is OLDEST, 'aaa' session is NEWEST — name order is the
+        # exact inverse of age.
+        _seed(
+            tmp_path,
+            [
+                "request_dump_zzz_20260101_000000_000000.json",
+                "request_dump_mmm_20260101_000000_000000.json",
+                "request_dump_aaa_20260101_000000_000000.json",
+            ],
+        )
+
+        deleted = prune_oldest_files(tmp_path, "request_dump_*.json", 1)
+
+        assert deleted == 2
+        survivors = [p.name for p in tmp_path.glob("request_dump_*.json")]
+        assert survivors == ["request_dump_aaa_20260101_000000_000000.json"]
+
+    def test_tie_on_mtime_is_deterministic(self, tmp_path):
+        """Identical mtimes (coarse filesystems) must not produce arbitrary results."""
+        paths = _seed(tmp_path, [f"dump_{i}.json" for i in range(6)], step=0.0)
+        for path in paths:
+            os.utime(path, (1_700_000_000.0, 1_700_000_000.0))
+
+        first = prune_oldest_files(tmp_path, "dump_*.json", 2)
+        survivors_a = sorted(p.name for p in tmp_path.glob("dump_*.json"))
+
+        # Same seed, same expectation — the name tiebreaker makes it repeatable.
+        for path in tmp_path.glob("dump_*.json"):
+            path.unlink()
+        paths = _seed(tmp_path, [f"dump_{i}.json" for i in range(6)], step=0.0)
+        for path in paths:
+            os.utime(path, (1_700_000_000.0, 1_700_000_000.0))
+        second = prune_oldest_files(tmp_path, "dump_*.json", 2)
+        survivors_b = sorted(p.name for p in tmp_path.glob("dump_*.json"))
+
+        assert first == second == 4
+        assert survivors_a == survivors_b
+
+
+class TestScopeSafety:
+    def test_only_matching_pattern_is_touched(self, tmp_path):
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(5)])
+        keepers = ["state.db", "session_abc.json", "notes.txt", "dump_5.json.bak"]
+        for name in keepers:
+            (tmp_path / name).write_text("keep me", encoding="utf-8")
+
+        prune_oldest_files(tmp_path, "dump_*.json", 1)
+
+        for name in keepers:
+            assert (tmp_path / name).exists(), f"{name} must not be pruned"
+
+    def test_does_not_recurse_into_subdirectories(self, tmp_path):
+        nested = tmp_path / "nested"
+        _seed(nested, [f"dump_{i}.json" for i in range(5)])
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(5)])
+
+        prune_oldest_files(tmp_path, "dump_*.json", 1)
+
+        assert len(list(nested.glob("dump_*.json"))) == 5, "subdirectory untouched"
+        assert len(list(tmp_path.glob("dump_*.json"))) == 1
+
+    def test_directories_matching_pattern_are_skipped(self, tmp_path):
+        (tmp_path / "dump_dir.json").mkdir(parents=True)
+        _seed(tmp_path, [f"dump_{i}.json" for i in range(4)])
+
+        prune_oldest_files(tmp_path, "dump_*.json", 1)
+
+        assert (tmp_path / "dump_dir.json").is_dir(), "directory must survive"
+
+    @pytest.mark.skipif(
+        not hasattr(os, "symlink"), reason="platform has no symlink support"
+    )
+    def test_symlinks_are_never_followed_or_deleted(self, tmp_path):
+        """A symlink in the pruned directory must not let deletion escape it."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        precious = outside / "precious.json"
+        precious.write_text("do not delete", encoding="utf-8")
+
+        pruned = tmp_path / "pruned"
+        _seed(pruned, [f"dump_{i}.json" for i in range(4)])
+        link = pruned / "dump_link.json"
+        try:
+            link.symlink_to(precious)
+        except (OSError, NotImplementedError):  # pragma: no cover - Windows w/o privilege
+            pytest.skip("symlink creation not permitted on this platform")
+
+        prune_oldest_files(pruned, "dump_*.json", 1)
+
+        assert precious.exists(), "symlink target outside the directory must survive"
+        assert precious.read_text(encoding="utf-8") == "do not delete"
+        assert link.is_symlink(), "the symlink itself must be left alone"
+
+
+class TestDisableAndFailureModes:
+    @pytest.mark.parametrize("keep", [0, -1, -100])
+    def test_non_positive_keep_disables_pruning(self, tmp_path, keep):
+        names = [f"dump_{i}.json" for i in range(6)]
+        _seed(tmp_path, names)
+
+        assert prune_oldest_files(tmp_path, "dump_*.json", keep) == 0
+        assert len(list(tmp_path.glob("dump_*.json"))) == 6
+
+    def test_missing_directory_is_not_an_error(self, tmp_path):
+        assert prune_oldest_files(tmp_path / "nope", "dump_*.json", 3) == 0
+
+    def test_empty_directory_is_not_an_error(self, tmp_path):
+        assert prune_oldest_files(tmp_path, "dump_*.json", 3) == 0
+
+    def test_unlink_failure_does_not_abort_the_sweep(self, tmp_path, monkeypatch):
+        """One undeletable file (Windows open handle) must not strand the rest."""
+        names = [f"dump_{i:02d}.json" for i in range(6)]
+        _seed(tmp_path, names)
+
+        real_unlink = os.unlink
+        blocked = tmp_path / names[0]
+
+        def flaky_unlink(target, *args, **kwargs):
+            if str(target) == str(blocked):
+                raise PermissionError("file is open in another process")
+            return real_unlink(target, *args, **kwargs)
+
+        monkeypatch.setattr(os, "unlink", flaky_unlink)
+
+        deleted = prune_oldest_files(tmp_path, "dump_*.json", 2)
+
+        # 6 files, keep 2 -> 4 targeted, 1 refuses -> 3 deleted, no exception.
+        assert deleted == 3
+        assert blocked.exists(), "undeletable file remains, deferred to next prune"
+        assert sorted(p.name for p in tmp_path.glob("dump_*.json")) == sorted(
+            [names[0], names[-2], names[-1]]
+        )
+
+    def test_file_vanishing_mid_scan_is_tolerated(self, tmp_path):
+        """Concurrent prune from another process removes a candidate underneath us."""
+        names = [f"dump_{i}.json" for i in range(5)]
+        paths = _seed(tmp_path, names)
+        paths[0].unlink()  # gone before the sweep even starts
+
+        deleted = prune_oldest_files(tmp_path, "dump_*.json", 1)
+
+        assert deleted == 3
+        assert len(list(tmp_path.glob("dump_*.json"))) == 1
+
+    def test_returns_int_and_never_raises_on_bad_input(self, tmp_path):
+        # A file where a directory is expected: glob raises NotADirectoryError on
+        # some platforms and yields nothing on others; either way, no traceback.
+        target = tmp_path / "a_file"
+        target.write_text("x", encoding="utf-8")
+        assert prune_oldest_files(target, "dump_*.json", 2) == 0
+
+
+def test_real_clock_ordering_matches_write_order(tmp_path):
+    """Sanity check against the real clock, not just synthetic mtimes."""
+    written = []
+    for i in range(4):
+        path = tmp_path / f"dump_{i}.json"
+        path.write_text("x", encoding="utf-8")
+        written.append(path)
+        time.sleep(0.02)
+
+    prune_oldest_files(tmp_path, "dump_*.json", 2)
+    survivors = {p.name for p in tmp_path.glob("dump_*.json")}
+
+    assert survivors == {written[-2].name, written[-1].name}

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ import shutil
 import stat
 import tempfile
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -248,6 +248,7 @@ def prune_oldest_files(
     pattern: str,
     keep: int,
     *,
+    protect: Optional[Union[str, Path]] = None,
     log: logging.Logger | None = None,
 ) -> int:
     """Keep the *keep* newest files matching *pattern*; delete the rest.
@@ -269,6 +270,17 @@ def prune_oldest_files(
     timestamp is the whole filename; it silently orders by the wrong field
     when a variable component (e.g. a session id) precedes the timestamp.
 
+    *protect* names one file that must survive this sweep regardless of
+    ordering — normally the file the caller just wrote.  It is excluded from
+    the candidate set and takes one of the *keep* slots, so the cap still holds
+    exactly.  Ordering alone is not enough to guarantee this: when two files
+    share an mtime (coarse-granularity filesystems, or several writes inside
+    one timestamp tick) the filename tiebreaker decides, and it compares the
+    *whole* name — so a sibling whose variable leading component (e.g. a
+    different session id) sorts higher wins the tie and the just-written file
+    is deleted out from under its caller.  An explicit exemption is a property
+    of the write, not of a sort key, so it cannot be lost that way.
+
     Safety properties, because this deletes user files:
 
     * Only direct children of *directory* are considered — ``glob`` is not
@@ -286,10 +298,25 @@ def prune_oldest_files(
     if keep <= 0:
         return 0
     logger_ = log or logging.getLogger(__name__)
+    # Compare by name within this directory: the caller's *protect* and the
+    # glob results are siblings by construction, and name comparison costs no
+    # extra stat() calls on the hot path.
+    protected_name: Optional[str] = None
+    if protect is not None:
+        try:
+            protect_path = Path(protect)
+            if protect_path.parent == Path(directory):
+                protected_name = protect_path.name
+        except (OSError, ValueError, TypeError) as exc:
+            logger_.debug("Could not interpret protected path %r: %s", protect, exc)
     try:
         candidates = []
+        protected_found = False
         for entry in Path(directory).glob(pattern):
             try:
+                if protected_name is not None and entry.name == protected_name:
+                    protected_found = True
+                    continue
                 # is_symlink() first: is_file() follows links, so checking it
                 # alone would happily accept a symlink pointing outside the
                 # directory and then unlink our end of it.
@@ -304,12 +331,15 @@ def prune_oldest_files(
         logger_.debug("Could not scan %s for retention: %s", directory, exc)
         return 0
 
-    if len(candidates) <= keep:
+    # The protected file occupies one of the *keep* slots when it is actually
+    # present, so the directory still ends up with at most *keep* files.
+    effective_keep = keep - 1 if protected_found else keep
+    if len(candidates) <= effective_keep:
         return 0
 
     candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
     deleted = 0
-    for _mtime, name, stale in candidates[keep:]:
+    for _mtime, name, stale in candidates[effective_keep:]:
         try:
             stale.unlink()
             deleted += 1

--- a/utils.py
+++ b/utils.py
@@ -243,6 +243,83 @@ def atomic_json_write(
         raise
 
 
+def prune_oldest_files(
+    directory: Union[str, Path],
+    pattern: str,
+    keep: int,
+    *,
+    log: logging.Logger | None = None,
+) -> int:
+    """Keep the *keep* newest files matching *pattern*; delete the rest.
+
+    Shared retention primitive for append-only debug/output artifacts that are
+    written under a fixed directory with a unique (timestamped) filename per
+    write, and therefore never overwrite each other.  Without a cap, such a
+    writer grows the directory forever.  Callers invoke this right after the
+    write so the directory is bounded at all times.
+
+    Newest-wins is deliberate: these artifacts exist to post-mortem a failure
+    that *just* happened, so the most recent ones carry all the value and the
+    tail is what should go.
+
+    Ordering is by mtime (newest first), with the filename as a deterministic
+    tiebreaker for filesystems with coarse timestamp granularity.  A reverse
+    *lexical* sort — as used by the older, artifact-specific prune helpers in
+    ``cron.jobs`` and ``hermes_cli.backup`` — is only correct when the
+    timestamp is the whole filename; it silently orders by the wrong field
+    when a variable component (e.g. a session id) precedes the timestamp.
+
+    Safety properties, because this deletes user files:
+
+    * Only direct children of *directory* are considered — ``glob`` is not
+      recursive here and *pattern* is caller-supplied, never user input.
+    * Symlinks are skipped, so a link planted in the directory can never be
+      followed to delete a file outside it.
+    * Non-files (directories, sockets) are skipped.
+    * ``keep <= 0`` disables pruning entirely (opt-out for operators who
+      manage cleanup externally).
+    * Every failure mode is swallowed and logged at debug level: retention is
+      housekeeping and must never break the write path it protects.
+
+    Returns the number of files deleted (0 on any failure).
+    """
+    if keep <= 0:
+        return 0
+    logger_ = log or logging.getLogger(__name__)
+    try:
+        candidates = []
+        for entry in Path(directory).glob(pattern):
+            try:
+                # is_symlink() first: is_file() follows links, so checking it
+                # alone would happily accept a symlink pointing outside the
+                # directory and then unlink our end of it.
+                if entry.is_symlink() or not entry.is_file():
+                    continue
+                candidates.append((entry.stat().st_mtime, entry.name, entry))
+            except OSError:
+                # Vanished or unreadable mid-scan (concurrent prune, network
+                # FS hiccup) — skip it rather than abandoning the sweep.
+                continue
+    except (OSError, ValueError) as exc:
+        logger_.debug("Could not scan %s for retention: %s", directory, exc)
+        return 0
+
+    if len(candidates) <= keep:
+        return 0
+
+    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    deleted = 0
+    for _mtime, name, stale in candidates[keep:]:
+        try:
+            stale.unlink()
+            deleted += 1
+        except OSError as exc:
+            # Windows refuses to unlink a file another process holds open;
+            # skipping it just defers that one file to the next prune.
+            logger_.debug("Failed to prune %s: %s", name, exc)
+    return deleted
+
+
 def warn_if_credential_file_broadly_readable(
     path: Union[str, Path],
     *,


### PR DESCRIPTION
## What does this PR do?

`dump_api_request_debug()` writes `request_dump_<session>_<timestamp>.json` into `~/.hermes/sessions/` on **every** non-retryable 4xx and **every** exhausted-retry failure (`agent/conversation_loop.py` — two unconditional call sites, plus the `HERMES_DUMP_REQUESTS`-gated preflight one). The filename carries a microsecond-precision timestamp, so no two dumps ever collide and nothing is reclaimed by rewriting. Each dump embeds the full request body — system prompt, tool schemas, entire message history — so individual files reach ~1 MB.

**Why nothing already bounds this.** There *is* pre-existing cleanup, but it is keyed to session *lifetime*, not to the directory:

- `SessionDB._remove_session_files()` globs `request_dump_<id>_*.json` — only when that session row is deleted.
- `maybe_auto_prune_and_vacuum()` sweeps dumps for sessions inactive past `sessions.retention_days` (90) — and `sessions.auto_prune` defaults to **false**.

So dumps belonging to live and recent sessions were never bounded by anything. Measured on a real install: **171 dumps / 47 MB**, which was the entire contents of `~/.hermes/sessions/`, oldest 45 days old and therefore nowhere near the 90-day sweep.

**The fix.** Cap the directory rather than the session: keep the newest N dumps and prune the rest immediately after each write. Newest-wins is the whole point — the recent dumps are the ones a user is trying to read after a failure, and the dump just written is never the one deleted. A count cap rather than a byte cap keeps every retained dump *complete*; truncating a body would destroy the debuggability the feature exists for.

**Extend, don't duplicate.** Two artifact-specific copies of this keep-newest-N loop already existed — `cron.jobs._prune_job_output` (added for the same bug class in #52383) and `hermes_cli.backup._prune_quick_snapshots`. Rather than adding a third, this extracts the shared primitive as `utils.prune_oldest_files()`, right next to `atomic_json_write` which this dump path already imports. Both existing copies sort **reverse-lexically**, which is only correct when the timestamp is the entire filename; request-dump names put a variable session id *before* the timestamp, so a lexical sort would order by session id and delete the wrong files. The shared helper orders by mtime with the filename as a deterministic tiebreaker. I deliberately did **not** migrate `cron.jobs` / `hermes_cli.backup` onto it in this PR — that is a behavior-affecting refactor of working code and belongs in its own change.

**Config, not env var.** The knob is `sessions.request_dump_retention` in `config.yaml` (default 20, `0`/negative disables). Noting explicitly because #72499 proposed `HERMES_DISABLE_REQUEST_DUMPS` for this same area and was closed under the `env-var-for-config` policy — no new `HERMES_*` variable is introduced here, and there is no internal env bridge because none is needed. A malformed value falls back to the default rather than disabling retention, so a bad config cannot silently restore unbounded growth.

## Related Issue

Refs #77472

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `utils.py` — new `prune_oldest_files(directory, pattern, keep, *, log=None)`: shared keep-newest-N retention primitive for append-only artifact directories.
- `agent/agent_runtime_helpers.py` — new `_REQUEST_DUMP_DEFAULT_KEEP` / `_request_dump_keep()` / `prune_request_dumps()`; `dump_api_request_debug()` prunes after a successful write. Covers all three call sites because they funnel through this one writer.
- `hermes_cli/config_defaults.py` — `sessions.request_dump_retention: 20`.
- `cli-config.yaml.example` — documents the key (matches the code default, so an installer copying the template verbatim does not become a divergent explicit override).
- `tests/test_utils_prune_oldest_files.py` — 19 tests for the shared helper.
- `tests/agent/test_request_dump_retention.py` — 19 tests driving the real dump path on a real `AIAgent` against a temp `HERMES_HOME`.

## Deletion-safety reasoning

This code deletes user files, so the scope is pinned deliberately:

- **Fixed glob, never interpolated.** The pattern is the literal `request_dump_*.json`. It is *not* keyed to the session id, so a hostile `X-Hermes-Session-Id` cannot widen it. (Write-side, `_safe_session_filename_component` already collapses the id to a single traversal-free segment, which is why the dump lands inside `logs_dir` at all; pruning inherits that guarantee instead of re-deriving it.)
- **Directory-scoped, non-recursive.** `Path.glob()` with a non-recursive pattern only yields direct children of the resolved `logs_dir`. Subdirectories are untouched — covered by a test that archives a dump in `sessions/archive/` and asserts it survives.
- **Symlinks are never followed.** `is_symlink()` is checked *before* `is_file()` (which follows links), so a symlink planted in the directory can neither be deleted nor used to reach a file outside it. Tested with a link pointing at a file in a sibling directory.
- **Only files.** Directories and non-files matching the pattern are skipped.
- **Bystanders untouched.** `state.db`, `session_*.json`, `*.jsonl` and `request_dump_notes.txt` are all asserted to survive.
- **Never breaks the agent.** Every failure is swallowed and logged at debug level, inside the helper *and* again at the call site, so a prune error cannot cost the caller the dump path it just wrote. A single undeletable file (Windows open handle) is skipped and deferred rather than stranding the rest of the sweep.
- **Opt-out preserved.** `0`/negative disables pruning entirely for operators managing cleanup externally.

## How to Test

1. Reproduce the unbounded growth on `main` — drive the real dump path N times and count what is left:
   ```bash
   python - <<'PY'
   import os, tempfile
   from pathlib import Path
   from unittest.mock import patch
   home = Path(tempfile.mkdtemp()); (home / "sessions").mkdir()
   os.environ["HERMES_HOME"] = str(home)
   import run_agent
   with patch.object(run_agent, "get_tool_definitions", lambda **k: []), \
        patch.object(run_agent, "check_toolset_requirements", lambda: {}):
       a = run_agent.AIAgent(model="gpt-4o", base_url="http://127.0.0.1:9/v1",
                             api_key="k", quiet_mode=True, max_iterations=1,
                             skip_context_files=True, skip_memory=True)
   a.logs_dir = home / "sessions"; a._vprint = lambda *x, **k: None
   body = {"model": "gpt-4o",
           "messages": [{"role": "system", "content": "You are Hermes. " * 2000}]
                       + [{"role": "user", "content": f"turn {i} " * 500} for i in range(20)]}
   for i in range(100):
       a._dump_api_request_debug(body, reason="non_retryable_client_error",
                                 error=ValueError("HTTP 400"))
   files = list(a.logs_dir.glob("request_dump_*.json"))
   print(len(files), sum(f.stat().st_size for f in files))
   PY
   ```
   On `main`: `100 12847800`. On this branch: `20 2569560`.
2. `./scripts/run_tests.sh tests/agent/test_request_dump_retention.py tests/test_utils_prune_oldest_files.py`
3. Set `sessions.request_dump_retention: 0` in `~/.hermes/config.yaml` and re-run step 1 — all 100 dumps are kept (opt-out works).

### Measured before → after

| | API errors | dumps on disk | bytes |
|---|---|---|---|
| `main` | 100 | 100 | 12,847,800 (12.3 MB) |
| this branch | 100 | 20 | 2,569,560 (2.5 MB) |

Real install for scale, before the fix: 171 dumps / 47 MB / largest single dump 1,026,957 bytes.

Teeth check — the new tests were run against unmodified `upstream/main` in a separate worktree: **14 failed + 1 collection error (`ImportError: cannot import name 'prune_oldest_files'`), 19 tests total failing**, 5 passing (those 5 assert dump-content invariants that hold either way, and are there so a regression in the *feature* is caught, not just in the cap).

### Test results

- New tests: 38 passed, 0 failed.
- Blast radius (`rg -ln "request_dump|dump_api_request_debug|logs_dir" tests/`, 11 files incl. `tests/test_hermes_state.py`, `tests/run_agent/test_run_agent.py`, `tests/run_agent/test_run_agent_codex_responses.py`, `tests/plugins/test_disk_cleanup_plugin.py`, `tests/tools/test_delegate_subagent_timeout_diagnostic.py`): **620 passed, 0 failed**.
- Config/retention neighbors (`tests/cron/test_jobs.py`, `tests/test_session_vacuum_config.py`, `tests/gateway/test_config.py`, `tests/hermes_cli/test_config*.py`): **247 passed, 0 failed**.
- Whole `tests/agent/` directory: **3798 passed, 0 failed** across 348 files. `tests/agent/test_anthropic_output_field_leak.py` errors at fixture setup, but it does so **identically on clean `upstream/main`** (verified in a separate worktree) — pre-existing, unrelated to this change.

## Scope notes

Sibling debug-artifact writers under a logs directory were checked for the same defect. `tools/delegate_tool.py` writes `subagent-timeout-<id>-<ts>.log` into `~/.hermes/logs/` with the same never-overwritten shape, so it is unbounded in principle — but it only fires when a subagent exceeds its (300s+) timeout, each file is a few KB rather than ~1 MB, and it lands in a different directory under a different config domain. On the install that showed 171 request dumps there were **zero** of these. It is deliberately left out to keep this one logical change, and `prune_oldest_files()` is generic enough that wiring it up there is a small follow-up. The three request-dump call sites all funnel through `dump_api_request_debug()`, so capping the writer covers that whole bug class rather than one call path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#72499 closed as env-var-for-config; #51049 / #52905 are redaction, not retention; #69498 is DB session-row retention, not the on-disk dump artifact)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the new tests and the blast radius; all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both new helpers; no `docs/` page references request dumps
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — `Path.glob`, `st_mtime` and `unlink()` are portable. The filename tiebreaker keeps ordering deterministic on coarse-granularity filesystems (HFS+/ext3 1s). On Windows, unlinking a file another process holds open raises `PermissionError`, which is caught per-file so that one file is deferred to the next prune instead of aborting the sweep (explicitly tested). Verified on macOS; the logic is platform-neutral, and WSL2/Linux take the same POSIX path.
- [x] N/A — no tool schema or description change

