### PR TITLE
fix(a2a): recognize a2a chat ids in send_message target parsing

### DIFF
--- a/plugins/platforms/a2a/__init__.py
+++ b/plugins/platforms/a2a/__init__.py
@@ -106,7 +106,7 @@ def register(ctx) -> None:
 
     # 2) Inbound platform adapter.
     try:
-        from .adapter import A2AAdapter
+        from .adapter import A2AAdapter, _standalone_send
         ctx.register_platform(
             name="a2a",
             label="A2A",
@@ -122,6 +122,10 @@ def register(ctx) -> None:
             allow_all_env="A2A_ALLOW_ALL_USERS",
             cron_deliver_env_var="A2A_HOME_CHANNEL",
             allow_update_command=False,
+            # Out-of-process delivery (hermes send / cron): starts a new
+            # task on the peer via message/send. Without this hook those
+            # paths fail with "No live adapter for platform 'a2a'".
+            standalone_sender_fn=_standalone_send,
             platform_hint=(
                 "You are reachable over the A2A (Agent-to-Agent) protocol. "
                 "Messages prefixed with [A2A inbound ...] come from another "

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -1309,13 +1309,25 @@ async def _standalone_send(
         }
 
     try:
-        reply, context_id, _state = await asyncio.to_thread(
+        reply, context_id, state = await asyncio.to_thread(
             _send_task, peer_name, peer, message, ""
         )
     except Exception as exc:  # urllib errors, timeouts, protocol errors
         return {"success": False, "error": f"A2A send to {peer_name} failed: {exc}"}
 
     note = f"A2A task delivered to {peer_name}"
+    if state == protocol.STATE_INPUT_REQUIRED:
+        # The peer needs the operator to answer before it can proceed —
+        # surface that explicitly instead of looking like a completed task.
+        return {
+            "success": True,
+            "message_id": context_id,
+            "needs_input": True,
+            "note": (
+                f"A2A peer {peer_name} needs input: {reply[:300]} — "
+                f"answer by sending again with context '{context_id}'."
+            ),
+        }
     if reply:
         note += f" — peer reply: {reply[:300]}"
     return {"success": True, "message_id": context_id, "note": note}

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -1270,3 +1270,52 @@ class A2AAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": f"a2a:{chat_id}", "type": "dm"}
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Out-of-process A2A delivery for ``hermes send`` / cron.
+
+    The live adapter replies into an *existing* pending peer session
+    (identified by its ``ctx-...`` id). This standalone path instead starts
+    a NEW task on the peer via ``message/send`` — the only sensible
+    semantics when the gateway is not in this process. ``chat_id`` is a peer
+    name from ``config.yaml`` → ``a2a_agents`` (optionally carrying the
+    ``a2a:`` prefix the channel directory displays). ``thread_id`` /
+    ``media_files`` are accepted for signature parity only — A2A has no
+    thread or attachment primitive.
+    """
+    from .tools import _resolve_peer, _send_task
+
+    peer_name = chat_id
+    if peer_name.startswith("a2a:"):
+        peer_name = peer_name[len("a2a:"):]
+
+    peer = _resolve_peer(peer_name)
+    if peer is None:
+        return {
+            "success": False,
+            "error": (
+                f"No A2A peer '{peer_name}' in config.yaml a2a_agents. "
+                f"Configure it there or pass a direct URL as the target."
+            ),
+        }
+
+    try:
+        reply, context_id, _state = await asyncio.to_thread(
+            _send_task, peer_name, peer, message, ""
+        )
+    except Exception as exc:  # urllib errors, timeouts, protocol errors
+        return {"success": False, "error": f"A2A send to {peer_name} failed: {exc}"}
+
+    note = f"A2A task delivered to {peer_name}"
+    if reply:
+        note += f" — peer reply: {reply[:300]}"
+    return {"success": True, "message_id": context_id, "note": note}

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import logging
 import urllib.error
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Optional, TypedDict
@@ -78,9 +79,43 @@ def _auth_header(auth: dict) -> dict:
 # HTTP
 # --------------------------------------------------------------------------
 
+# A2A peers are frequently private/Tailscale addresses (100.64.0.0/10 CGNAT,
+# 192.168.x, localhost) that must NEVER be routed through an HTTP proxy —
+# a proxy either can't reach them (502) or leaks the request off-LAN.
+# urllib's default opener honors env proxies (and only the *lowercase*
+# no_proxy list on most platforms — a classic env-var case trap), so build a
+# proxy-free opener and use it for private hosts.
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+def _is_private_host(url: str) -> bool:
+    """True for loopback / private / link-local / CGNAT (Tailscale) hosts."""
+    try:
+        import ipaddress
+
+        host = (urllib.parse.urlparse(url).hostname or "").lower()
+        if host in ("localhost", "localhost.localdomain"):
+            return True
+        ip = ipaddress.ip_address(host)
+        if ip.is_loopback or ip.is_private or ip.is_link_local:
+            return True
+        # Tailscale uses the CGNAT range 100.64.0.0/10. ip.is_private covers
+        # it on 3.11+; check explicitly so older runtimes behave the same.
+        cgnat = ipaddress.ip_network("100.64.0.0/10")
+        return ip in cgnat
+    except ValueError:
+        return False  # unresolvable hostname — let env proxies apply
+
+
+def _opener_for(url: str):
+    if _is_private_host(url):
+        return _NO_PROXY_OPENER.open
+    return urllib.request.urlopen
+
+
 def _http_get_json(url: str, headers: dict, timeout: int) -> dict:
     req = urllib.request.Request(url, headers=headers, method="GET")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
+    with _opener_for(url)(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
         return json.loads(resp.read().decode("utf-8"))
 
 
@@ -88,7 +123,7 @@ def _http_post_json(url: str, body: dict, headers: dict, timeout: int) -> dict:
     data = json.dumps(body).encode("utf-8")
     hdrs = {"Content-Type": "application/json", "A2A-Version": protocol.PROTOCOL_VERSION, **headers}
     req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
+    with _opener_for(url)(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
         return json.loads(resp.read().decode("utf-8"))
 
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1665,6 +1665,26 @@ def test_standalone_send_strips_a2a_prefix(monkeypatch):
     assert seen["name"] == "macmini"
 
 
+def test_standalone_send_surfaces_input_required_state(monkeypatch):
+    from plugins.platforms.a2a.adapter import _standalone_send
+
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._resolve_peer",
+        lambda name: {"url": "http://peer:9900", "auth": {}, "timeout": 30, "capabilities": []},
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._send_task",
+        lambda *a, **k: ("是否允许删除该文件？", "ctx-9", "TASK_STATE_INPUT_REQUIRED"),
+    )
+
+    result = asyncio.run(_standalone_send(None, "macmini", "delete the file"))
+
+    assert result["success"] is True
+    assert result["needs_input"] is True
+    assert result["message_id"] == "ctx-9"
+    assert "是否允许删除该文件" in result["note"]
+
+
 def test_standalone_send_unknown_peer_errors(monkeypatch):
     from plugins.platforms.a2a.adapter import _standalone_send
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1618,3 +1618,108 @@ print('fake reply')
         title = con.execute("SELECT title FROM sessions WHERE id='sess-1'").fetchone()[0]
         con.close()
         assert title == "a2a-dev-ctx-unsafe-value"
+
+
+# ── standalone_sender_fn (hermes send / cron out-of-process delivery) ──
+
+def test_standalone_send_delivers_new_task_to_peer(monkeypatch):
+    from plugins.platforms.a2a.adapter import _standalone_send
+
+    peer = {"url": "http://peer:9900", "auth": {"type": "bearer", "token": "t"}, "timeout": 30, "capabilities": []}
+    calls = {}
+
+    def fake_resolve(name):
+        calls["resolved"] = name
+        return peer if name == "macmini" else None
+
+    monkeypatch.setattr("plugins.platforms.a2a.tools._resolve_peer", fake_resolve)
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._send_task",
+        lambda *a, **k: ("peer reply text", "ctx-abc", "completed"),
+    )
+
+    result = asyncio.run(_standalone_send(None, "macmini", "hello"))
+
+    assert calls["resolved"] == "macmini"
+    assert result["success"] is True
+    assert result["message_id"] == "ctx-abc"
+    assert "peer reply text" in result["note"]
+
+
+def test_standalone_send_strips_a2a_prefix(monkeypatch):
+    from plugins.platforms.a2a.adapter import _standalone_send
+
+    seen = {}
+
+    def fake_resolve(name):
+        seen["name"] = name
+        return {"url": "http://peer:9900", "auth": {}, "timeout": 30, "capabilities": []}
+
+    monkeypatch.setattr("plugins.platforms.a2a.tools._resolve_peer", fake_resolve)
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._send_task",
+        lambda *a, **k: ("", "ctx-1", "completed"),
+    )
+
+    asyncio.run(_standalone_send(None, "a2a:macmini", "hi"))
+    assert seen["name"] == "macmini"
+
+
+def test_standalone_send_unknown_peer_errors(monkeypatch):
+    from plugins.platforms.a2a.adapter import _standalone_send
+
+    monkeypatch.setattr("plugins.platforms.a2a.tools._resolve_peer", lambda name: None)
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._send_task",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not send")),
+    )
+
+    result = asyncio.run(_standalone_send(None, "ghost", "hi"))
+
+    assert result["success"] is False
+    assert "ghost" in result["error"]
+
+
+def test_standalone_send_surfaces_transport_failure(monkeypatch):
+    from plugins.platforms.a2a.adapter import _standalone_send
+
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._resolve_peer",
+        lambda name: {"url": "http://peer:9900", "auth": {}, "timeout": 5, "capabilities": []},
+    )
+    monkeypatch.setattr(
+        "plugins.platforms.a2a.tools._send_task",
+        lambda *a, **k: (_ for _ in ()).throw(TimeoutError("timed out")),
+    )
+
+    result = asyncio.run(_standalone_send(None, "macmini", "hi"))
+
+    assert result["success"] is False
+    assert "timed out" in result["error"]
+
+
+# ── private-host proxy bypass (urllib env-proxy trap) ──
+
+def test_is_private_host_bypasses_proxy_for_tailscale_cgnat() -> None:
+    from plugins.platforms.a2a.tools import _is_private_host
+
+    assert _is_private_host("http://100.81.221.19:9900") is True   # Tailscale CGNAT
+    assert _is_private_host("http://100.64.0.1:9900") is True       # CGNAT range edge
+    assert _is_private_host("http://100.127.255.254:9900") is True  # CGNAT range edge
+
+
+def test_is_private_host_bypasses_proxy_for_lan_and_loopback() -> None:
+    from plugins.platforms.a2a.tools import _is_private_host
+
+    assert _is_private_host("http://192.168.31.233:9900") is True
+    assert _is_private_host("http://10.0.0.5:9900") is True
+    assert _is_private_host("http://localhost:9900") is True
+    assert _is_private_host("http://127.0.0.1:9900") is True
+
+
+def test_is_private_host_leaves_public_hosts_to_env_proxy() -> None:
+    from plugins.platforms.a2a.tools import _is_private_host
+
+    assert _is_private_host("https://a2a.example.com") is False
+    assert _is_private_host("https://peer.example.net:8443") is False
+    assert _is_private_host("http://8.8.8.8:9900") is False

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -73,15 +73,23 @@ def test_a2a_ctx_id_is_explicit() -> None:
     assert is_explicit is True
 
 
-def test_a2a_named_target_falls_through_to_directory() -> None:
+def test_a2a_peer_name_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref("a2a", "macmini")
+
+    assert chat_id == "macmini"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_a2a_prefixed_peer_name_is_explicit() -> None:
     chat_id, thread_id, is_explicit = _parse_target_ref("a2a", "a2a:macmini")
 
-    assert chat_id is None
+    assert chat_id == "a2a:macmini"
     assert thread_id is None
-    assert is_explicit is False
+    assert is_explicit is True
 
 
-def test_send_message_routes_a2a_named_target_after_directory_resolve() -> None:
+def test_send_message_routes_a2a_peer_name_without_home_fallback() -> None:
     a2a_cfg = SimpleNamespace(enabled=True, token=None, extra={"port": 9900})
     config = SimpleNamespace(
         platforms={Platform("a2a"): a2a_cfg},
@@ -90,7 +98,7 @@ def test_send_message_routes_a2a_named_target_after_directory_resolve() -> None:
 
     with patch("gateway.config.load_gateway_config", return_value=config), \
          patch("tools.interrupt.is_interrupted", return_value=False), \
-         patch("gateway.channel_directory.resolve_channel_name", return_value="ctx-25a5d320aaa34f07"), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("peer names should not resolve via directory")), \
          patch("model_tools._run_async", side_effect=_run_async_immediately), \
          patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
          patch("gateway.mirror.mirror_to_session", return_value=True):
@@ -98,7 +106,7 @@ def test_send_message_routes_a2a_named_target_after_directory_resolve() -> None:
             send_message_tool(
                 {
                     "action": "send",
-                    "target": "a2a:a2a:macmini",
+                    "target": "a2a:macmini",
                     "message": "hello peer",
                 }
             )
@@ -108,7 +116,7 @@ def test_send_message_routes_a2a_named_target_after_directory_resolve() -> None:
     send_mock.assert_awaited_once_with(
         Platform("a2a"),
         a2a_cfg,
-        "ctx-25a5d320aaa34f07",
+        "macmini",
         "hello peer",
         thread_id=None,
         media_files=[],

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -64,3 +64,54 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         force_document=False,
     )
 
+
+def test_a2a_ctx_id_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref("a2a", "ctx-25a5d320aaa34f07")
+
+    assert chat_id == "ctx-25a5d320aaa34f07"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_a2a_named_target_falls_through_to_directory() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref("a2a", "a2a:macmini")
+
+    assert chat_id is None
+    assert thread_id is None
+    assert is_explicit is False
+
+
+def test_send_message_routes_a2a_named_target_after_directory_resolve() -> None:
+    a2a_cfg = SimpleNamespace(enabled=True, token=None, extra={"port": 9900})
+    config = SimpleNamespace(
+        platforms={Platform("a2a"): a2a_cfg},
+        get_home_channel=lambda _platform: None,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", return_value="ctx-25a5d320aaa34f07"), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "a2a:a2a:macmini",
+                    "message": "hello peer",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    send_mock.assert_awaited_once_with(
+        Platform("a2a"),
+        a2a_cfg,
+        "ctx-25a5d320aaa34f07",
+        "hello peer",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )
+

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -610,12 +610,15 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if _PHOTON_DM_GUID_RE.fullmatch(target_ref.strip()):
             return target_ref.strip(), None, True
     if platform_name == "a2a":
-        # A2A chat ids are opaque context ids (ctx-...) minted per peer
-        # session; human-readable names like "a2a:macmini" resolve via the
-        # channel directory below. Without this branch every a2a target
-        # parsed to (None, None, False), so resolve_channel_name() results
-        # were re-parsed into None and send fell back to "No home channel".
-        if target_ref.strip().startswith("ctx-"):
+        # A2A targets are peer names (config.yaml a2a_agents keys, e.g.
+        # "macmini") or live-session context ids ("ctx-..."). Pass any
+        # non-empty ref through verbatim: the live adapter uses ctx ids to
+        # reply into a pending peer session, while the standalone sender
+        # (hermes send / cron) resolves peer names from a2a_agents. Without
+        # this branch every a2a target parsed to (None, None, False), so
+        # resolve_channel_name() results were re-parsed into None and send
+        # fell back to the misleading "No home channel" error.
+        if target_ref.strip():
             return target_ref.strip(), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -609,6 +609,14 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # them off the channel directory (mirrors the react handler).
         if _PHOTON_DM_GUID_RE.fullmatch(target_ref.strip()):
             return target_ref.strip(), None, True
+    if platform_name == "a2a":
+        # A2A chat ids are opaque context ids (ctx-...) minted per peer
+        # session; human-readable names like "a2a:macmini" resolve via the
+        # channel directory below. Without this branch every a2a target
+        # parsed to (None, None, False), so resolve_channel_name() results
+        # were re-parsed into None and send fell back to "No home channel".
+        if target_ref.strip().startswith("ctx-"):
+            return target_ref.strip(), None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
Fixes #78396

## Problem
`_parse_target_ref()` has no `a2a` branch, so every a2a target parses to `(None, None, False)`. `resolve_channel_name()` succeeds, but its result is re-parsed into `None`, and `_handle_send` falls back to the misleading `No home channel set` error — even though `hermes send --list` advertises the target.

## Fix (two commits)

**1. Target parsing** (`tools/send_message_tool.py`)
Add an `a2a` branch: any non-empty target (peer name from `a2a_agents`, `a2a:`-prefixed name, or live `ctx-` session id) passes through verbatim as explicit.

**2. Standalone out-of-process delivery** (`plugins/platforms/a2a/`)
- Register `standalone_sender_fn` on the a2a `PlatformEntry` so `hermes send` and cron delivery work without a live gateway adapter (previously: `No live adapter for platform 'a2a'`). The standalone sender starts a NEW task on the peer via `message/send` and returns its reply.
- A2A client HTTP bypasses the env HTTP proxy for private/Tailscale hosts (100.64.0.0/10 CGNAT, RFC1918, loopback): urllib's default opener only honors the lowercase `no_proxy` list, so a Tailscale peer could be routed through a local proxy and fail with `502 Bad Gateway`.

## Tests
- `test_a2a_ctx_id_is_explicit`, `test_a2a_peer_name_is_explicit`, `test_a2a_prefixed_peer_name_is_explicit` — parser behavior
- `test_send_message_routes_a2a_peer_name_without_home_fallback` — end-to-end routing
- `test_standalone_send_delivers_new_task_to_peer` / `_strips_a2a_prefix` / `_unknown_peer_errors` / `_surfaces_transport_failure` — standalone sender
- `test_is_private_host_*` (3) — proxy bypass

All pass. Verified end-to-end on a live setup: `hermes send --to a2a:macmini \"ping\"` now delivers to the peer and returns its reply.