### PR TITLE
test(telegram): set _polling_conflict_recovery_generation in bare adapter helper

### DIFF
--- a/tests/gateway/test_telegram_start_polling_timeout.py
+++ b/tests/gateway/test_telegram_start_polling_timeout.py
@@ -59,6 +59,11 @@ def _bare_adapter():
     a._fatal_error_retryable = True
     a._polling_network_error_count = 0
     a._polling_conflict_count = 0
+    # `_polling_conflict_recovery_generation` is set in __init__ (adapter.py);
+    # __new__ bypasses it, and _on_polling_io_progress dereferences it, so a
+    # bare adapter must carry the same default (None) or progress recording
+    # raises AttributeError.
+    a._polling_conflict_recovery_generation = None
     a._polling_error_callback_ref = None
     a._background_tasks = set()
     a._send_path_degraded = False


### PR DESCRIPTION
## Problem

`tests/gateway/test_telegram_start_polling_timeout.py` fails on current main with:

```
AttributeError: 'TelegramAdapter' object has no attribute '_polling_conflict_recovery_generation'
plugins/platforms/telegram/adapter.py:2164
```

This CI failure (Python tests slice 2/8) is currently blocking unrelated PRs.

## Root cause

`_bare_adapter()` constructs the adapter via `TelegramAdapter.__new__()`, bypassing `__init__`. `__init__` sets `_polling_conflict_recovery_generation = None` (added in `e05eba26a`), and `_on_polling_io_progress` (adapter.py:2164) dereferences it unconditionally — so any bare-adapter test that records polling progress raises `AttributeError`. The helper sets the other polling fields it needs (`_polling_network_error_count`, `_polling_conflict_count`, ...) but was not synced when the new attribute landed.

## Fix

Set the same default (`None`) in `_bare_adapter()` alongside `_polling_conflict_count`, matching what `__init__` does.

## Validation

- `tests/gateway/test_telegram_start_polling_timeout.py`: 3 passed (was 1 failed, 1 passed, 1 failed).
- `tests/gateway/test_telegram_conflict.py`: 10 passed (regression check).
- Reproduced on clean origin/main before the fix (1 failed, 1 passed), green after.
