### PR TITLE
fix(gateway): carry the profile scope into pre-turn hygiene compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16812,13 +16812,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                                     loop = asyncio.get_running_loop()
                                     _hyg_commit_fence = CompressionCommitFence()
-                                    _hyg_future = loop.run_in_executor(
-                                        None,
-                                        lambda: _hyg_agent._compress_context(
-                                            _hyg_msgs, "",
-                                            approx_tokens=_approx_tokens,
-                                            commit_fence=_hyg_commit_fence,
-                                        ),
+                                    _hyg_future = self._spawn_hygiene_compression(
+                                        loop,
+                                        _hyg_agent,
+                                        _hyg_msgs,
+                                        _approx_tokens,
+                                        _hyg_commit_fence,
                                     )
                                     try:
                                         # Progress-aware wait: the timeout is an
@@ -21115,6 +21114,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Restore session context variables to their pre-handler values."""
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
+
+    @staticmethod
+    def _spawn_hygiene_compression(loop, agent, messages, approx_tokens, commit_fence):
+        """Start pre-turn hygiene compression on the default executor.
+
+        Returns the ``Future`` the caller polls with its progress-aware wait.
+
+        The hop MUST carry the caller's ``contextvars`` context. The multiplexed
+        inbound handler runs the whole message under ``_profile_runtime_scope``,
+        which installs the profile's ``HERMES_HOME`` override and its secret
+        scope as contextvars; a bare ``loop.run_in_executor(None, fn)`` starts
+        the worker with an EMPTY context, so the compressor's aux-client
+        provider resolution reads credentials unscoped (process-global
+        ``os.environ``, i.e. possibly another profile's keys) and
+        ``get_hermes_home()`` falls back to the default profile.
+
+        This is the same reason ``/compress`` goes through
+        ``_run_in_executor_with_context``; the automatic pre-turn path needs the
+        identical treatment. Kept as its own method so the contract can be
+        exercised directly instead of only through the full message handler.
+        """
+        ctx = copy_context()
+        return loop.run_in_executor(
+            None,
+            ctx.run,
+            lambda: agent._compress_context(
+                messages, "",
+                approx_tokens=approx_tokens,
+                commit_fence=commit_fence,
+            ),
+        )
 
     async def _run_in_executor_with_context(self, func, *args):
         """Run blocking work in the thread pool while preserving session contextvars."""

--- a/tests/gateway/test_hygiene_compression_profile_scope.py
+++ b/tests/gateway/test_hygiene_compression_profile_scope.py
@@ -1,0 +1,144 @@
+"""Pre-turn hygiene compression must run inside the routed profile's scope.
+
+The multiplexed inbound handler wraps the whole message in
+``_profile_runtime_scope``, which installs the profile's ``HERMES_HOME``
+override and its secret scope as **contextvars** — its own docstring notes they
+reach the agent worker thread "via ``copy_context()``".
+
+The automatic pre-turn hygiene compression handed ``_compress_context`` to a
+bare ``loop.run_in_executor(None, fn)``. A bare executor hop starts the worker
+with an empty context, so inside it ``get_hermes_home()`` fell back to the
+default profile and ``get_secret`` read process-global ``os.environ`` — which
+under multiplexing may hold a *different* profile's credentials. That is
+exactly the failure ``gateway/slash_commands.py`` already routes ``/compress``
+through ``_run_in_executor_with_context`` to avoid; the automatic path had not
+been given the same treatment.
+
+Drives the real ``_profile_runtime_scope`` and the real spawn helper — the
+contextvar loss is a property of the hop itself, so mocking it away would test
+nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def profile_home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    home = root / "profiles" / "coder"
+    home.mkdir(parents=True)
+    (home / ".env").write_text("PROFILE_MARKER_KEY=coder-secret\n", encoding="utf-8")
+    root.mkdir(exist_ok=True)
+    (root / ".env").write_text("PROFILE_MARKER_KEY=root-secret\n", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    # The unscoped answer: what a context-less worker thread would see.
+    monkeypatch.setenv("PROFILE_MARKER_KEY", "root-secret")
+    return home
+
+
+class _RecordingAgent:
+    """Stands in for the hygiene AIAgent; records what the worker thread sees."""
+
+    def __init__(self):
+        self.seen_home = None
+        self.seen_secret = None
+        self.called_with = None
+
+    def _compress_context(self, messages, _unused, *, approx_tokens, commit_fence):
+        from hermes_constants import get_hermes_home
+
+        self.seen_home = str(get_hermes_home())
+        try:
+            from agent.secret_scope import get_secret
+
+            self.seen_secret = get_secret("PROFILE_MARKER_KEY")
+        except Exception:
+            self.seen_secret = None
+        self.called_with = (messages, approx_tokens, commit_fence)
+        return ["compressed"], True
+
+
+async def _spawn_and_wait(agent, profile_home):
+    from gateway.run import GatewayRunner, _profile_runtime_scope
+
+    loop = asyncio.get_running_loop()
+    with _profile_runtime_scope(profile_home):
+        future = GatewayRunner._spawn_hygiene_compression(
+            loop, agent, ["m1", "m2"], 1234, object()
+        )
+        return await future
+
+
+class TestHygieneCompressionRunsUnderTheRoutedProfile:
+    @pytest.mark.asyncio
+    async def test_worker_sees_the_profile_home(self, profile_home):
+        agent = _RecordingAgent()
+        await _spawn_and_wait(agent, profile_home)
+
+        assert agent.seen_home == str(profile_home)
+
+    @pytest.mark.asyncio
+    async def test_worker_sees_the_profile_secret_not_the_process_env(
+        self, profile_home
+    ):
+        agent = _RecordingAgent()
+        await _spawn_and_wait(agent, profile_home)
+
+        assert agent.seen_secret == "coder-secret"
+
+    @pytest.mark.asyncio
+    async def test_arguments_and_result_are_passed_through_unchanged(
+        self, profile_home
+    ):
+        agent = _RecordingAgent()
+        fence = object()
+
+        from gateway.run import GatewayRunner, _profile_runtime_scope
+
+        loop = asyncio.get_running_loop()
+        with _profile_runtime_scope(profile_home):
+            result = await GatewayRunner._spawn_hygiene_compression(
+                loop, agent, ["a", "b"], 99, fence
+            )
+
+        assert result == (["compressed"], True)
+        assert agent.called_with == (["a", "b"], 99, fence)
+
+    @pytest.mark.asyncio
+    async def test_returns_a_future_the_progress_wait_can_poll(self, profile_home):
+        """The caller polls .done()/.result(); keep that interface."""
+        from gateway.run import GatewayRunner, _profile_runtime_scope
+
+        agent = _RecordingAgent()
+        loop = asyncio.get_running_loop()
+        with _profile_runtime_scope(profile_home):
+            future = GatewayRunner._spawn_hygiene_compression(
+                loop, agent, ["m"], 1, object()
+            )
+            assert hasattr(future, "done") and hasattr(future, "cancel")
+            await future
+            assert future.done()
+            assert future.result() == (["compressed"], True)
+
+
+class TestSingleProfileGatewayUnchanged:
+    @pytest.mark.asyncio
+    async def test_no_scope_installed_still_resolves_the_launch_home(
+        self, profile_home, tmp_path
+    ):
+        """Non-multiplexed gateways never enter the scope — behaviour must not shift."""
+        from gateway.run import GatewayRunner
+
+        agent = _RecordingAgent()
+        loop = asyncio.get_running_loop()
+        await GatewayRunner._spawn_hygiene_compression(
+            loop, agent, ["m"], 1, object()
+        )
+
+        assert agent.seen_home == str(tmp_path / ".hermes")


### PR DESCRIPTION
## What does this PR do?

The multiplexed inbound handler runs the whole message inside
`_profile_runtime_scope`, which installs the routed profile's `HERMES_HOME`
override and its secret scope. Both are **contextvars** — the helper's own
docstring says so:

> `set_hermes_home_override` … Contextvar, so it propagates into the agent
> worker thread **via `copy_context()`**.

The automatic pre-turn hygiene compression handed `_compress_context` to a bare
executor hop:

```python
_hyg_future = loop.run_in_executor(
    None,
    lambda: _hyg_agent._compress_context(...),
)
```

`loop.run_in_executor(None, fn)` starts the worker with an **empty** context.
So inside that thread:

- `get_hermes_home()` fell back to the **default** profile — the compressor
  resolved config, model and skills from the wrong home;
- `get_secret` read process-global `os.environ`, which under multiplexing may
  hold a **different profile's** credentials (the first-writer-wins YAML→env
  bridge). The compressor's aux-client provider resolution therefore ran
  unscoped: it either failed closed (automatic compression silently stopped
  working for multiplexed profiles) or resolved against another profile's keys.

### This is a known failure mode — the other caller was already fixed

`gateway/slash_commands.py` routes the manual `/compress` through
`_run_in_executor_with_context` and says exactly why at the call site:

> `_run_in_executor_with_context` (not a bare `run_in_executor`): the profile
> secret scope installed by the wrapper is a contextvar, and the
> default-executor hop would drop it — the compressor's aux-client provider
> resolution would then read credentials unscoped and fail closed under
> multiplexing.

The automatic path never got the same treatment — and it runs unattended on
every inbound message whose session crosses the compression threshold, so it
fires far more often than the slash command.

### How it was found

Grepped the repo for its own declared invariants (`chokepoint`,
`must go through`, `single source of truth`, `not a bare …`) and then looked for
call sites that bypass them. The `/compress` comment names the rule; the hygiene
path was the remaining violation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/run.py`** — the hygiene hop now runs through `copy_context().run`,
  so the worker inherits the caller's contextvars. The executor stays the
  default one, so pool behaviour and the caller's progress-aware `Future`
  polling (`.done()` / `.result()` / `.cancel()`) are unchanged.
- **`gateway/run.py`** — extracted as `GatewayRunner._spawn_hygiene_compression`
  rather than patching the lambda in place. The call site sits ~660 lines into
  `_handle_message_with_agent`; AGENTS.md asks for exactly this extraction so
  the contract can be exercised for real instead of asserted against the
  god-file's source text.
- **`tests/gateway/test_hygiene_compression_profile_scope.py`** — 5 tests.

Single-profile gateways never enter `_profile_runtime_scope`, so their
behaviour is byte-identical.

## How to Test

1. Run a multiplexed gateway with two profiles whose `.env` files hold
   different auxiliary-provider keys.
2. Drive a session on the non-default profile past the compression threshold so
   pre-turn hygiene compression fires.
3. **Before:** the compression worker resolved `get_hermes_home()` to the
   default profile and read credentials from process-global `os.environ`.
   **After:** it resolves both from the routed profile.

## Test Results

New file `tests/gateway/test_hygiene_compression_profile_scope.py` — 5 tests.
They drive the **real** `_profile_runtime_scope` and the real spawn helper, with
a recording stand-in agent that captures what the worker thread actually sees;
the contextvar loss is a property of the hop itself, so mocking it away would
test nothing:

| Test | Asserts |
|---|---|
| `test_worker_sees_the_profile_home` | `get_hermes_home()` inside the worker is `<root>/profiles/coder` |
| `test_worker_sees_the_profile_secret_not_the_process_env` | `get_secret` returns the profile `.env` value, not the conflicting `os.environ` one |
| `test_arguments_and_result_are_passed_through_unchanged` | messages / `approx_tokens` / `commit_fence` and the return value are untouched |
| `test_returns_a_future_the_progress_wait_can_poll` | the `.done()`/`.result()`/`.cancel()` interface the caller's inactivity wait depends on is preserved |
| `TestSingleProfileGatewayUnchanged` | with no scope installed, the launch home still wins |

Red-without-fix, with only the `copy_context()` hop reverted:

```text
2 failed, 3 passed
```

With the fix:

```text
5 passed in 5.46s
```

**Regression sweep** — whole `tests/gateway/` directory, both sides on the same
`main`:

```text
baseline (change stashed):   72 failed, 4771 passed
with this fix:               73 failed, 4775 passed
```

The failing files are the same pre-existing set (feishu, runtime_footer, update,
discord, systemd, …) — none of them touch this code path. The one-test delta is
`test_telegram_start_polling_timeout.py::test_initial_connect_succeeds_on_current_generation_progress`,
which I verified fails **identically with and without this change**: it is a
pre-existing `main` regression from `e05eba26a`, where a new
`_polling_conflict_recovery_generation` attribute was added to `__init__` but
the suite's `_bare_adapter()` helper (which builds the adapter via `__new__`)
was not updated.