### PR TITLE
fix(gateway): hygiene compression must force-shrink over-threshold sessions

### DIFF
--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,2 @@
+dhruvkej9
+# PR #78401 gateway hygiene force-compress

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19741,6 +19741,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
                                             commit_fence=_hyg_commit_fence,
+                                            force=True,
                                         ),
                                     )
                                     try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16818,6 +16818,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
                                             commit_fence=_hyg_commit_fence,
+                                            force=True,
                                         ),
                                     )
                                     try:

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1083,3 +1083,113 @@ async def test_hygiene_compression_cooldown_survives_gateway_restart(
         assert runner2._run_agent.await_count == 1
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_calls_compress_with_force(monkeypatch, tmp_path):
+    """Regression for the recurring no-op hygiene compression: the gateway
+    hygiene sweep must call ``_compress_context(force=True)`` so it can shrink
+    an over-threshold session even when the automatic anti-thrash guard
+    (``_automatic_compression_blocked``) is tripped by earlier summary failures.
+
+    Without ``force=True``, compress_context returns the transcript unchanged
+    (``_last_compaction_in_place`` stays False), the session rides into the
+    hard context limit, and the gateway logs the misleading #21301 warning
+    ("no session_db") while reducing nothing."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    captured = {}
+
+    class ForceCaptureAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.compression_in_place = True
+            self._last_compaction_in_place = True  # in-place success path
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            captured["force"] = _kwargs.get("force")
+            return ([{"role": "assistant", "content": "summary only"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ForceCaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert captured.get("force") is True, (
+        "REGRESSION (#21301): the gateway hygiene sweep must call "
+        "_compress_context(force=True) so it can shrink an over-threshold "
+        "session even when the automatic anti-thrash guard is tripped; got "
+        f"force={captured.get('force')!r}"
+    )
+

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1196,3 +1196,113 @@ async def test_hygiene_compression_cooldown_survives_gateway_restart(
         assert escalated["remaining_seconds"] == pytest.approx(900, abs=5)
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_calls_compress_with_force(monkeypatch, tmp_path):
+    """Regression for the recurring no-op hygiene compression: the gateway
+    hygiene sweep must call ``_compress_context(force=True)`` so it can shrink
+    an over-threshold session even when the automatic anti-thrash guard
+    (``_automatic_compression_blocked``) is tripped by earlier summary failures.
+
+    Without ``force=True``, compress_context returns the transcript unchanged
+    (``_last_compaction_in_place`` stays False), the session rides into the
+    hard context limit, and the gateway logs the misleading #21301 warning
+    ("no session_db") while reducing nothing."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    captured = {}
+
+    class ForceCaptureAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.model = kwargs.get("model")
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self.compression_in_place = True
+            self._last_compaction_in_place = True  # in-place success path
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            captured["force"] = _kwargs.get("force")
+            return ([{"role": "assistant", "content": "summary only"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ForceCaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:17585",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="17585",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert captured.get("force") is True, (
+        "REGRESSION (#21301): the gateway hygiene sweep must call "
+        "_compress_context(force=True) so it can shrink an over-threshold "
+        "session even when the automatic anti-thrash guard is tripped; got "
+        f"force={captured.get('force')!r}"
+    )
+


### PR DESCRIPTION
## Problem
The gateway hygiene compression was a no-op: every few minutes it logged
`did not rotate or compact in place (no session_db on the hygiene agent)`
and the session stayed stuck at ~265K tokens (557→557 msgs, same tokens).
The model could stop responding because context exceeded the limit.

## Root cause
The warning text is misleading — the hygiene agent *is* built with a
session_db. The real cause: the hygiene sweep called `_compress_context`
**without `force=True`**. When the automatic anti-thrash guard was tripped
(an earlier summary-failure cooldown / `_ineffective_compression_count >= 2`
from the auxiliary compression model returning empty content),
`compress_context` returned the transcript unchanged. `_last_compaction_in_place`
stayed False, so the gateway's guard correctly preserved the transcript but
reduced nothing.

Manual `/compress` already passes `force=True` for exactly this reason.
The gateway hygiene sweep is the gateway's own decision to shrink an
over-threshold session and should do the same.

## Fix
- `gateway/run.py`: pass `force=True` to the hygiene agent's
  `_compress_context` call.
- `tests/gateway/test_session_hygiene.py`: regression test asserting the
  hygiene agent receives `force=True`.

## Verification
`venv/bin/python -m pytest tests/gateway/test_session_hygiene.py -q` →
**15 passed** (14 existing + 1 new regression).

Fixes #21301