### PR TITLE
fix(vision): order Z.ai image content before text

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7837,17 +7837,23 @@ def _order_zai_vision_content_parts(
             normalized.append(message)
             continue
 
-        image_parts = [
-            part
-            for part in content
-            if isinstance(part, dict) and part.get("type") == "image_url"
+        first_image_index = next(
+            (
+                index
+                for index, part in enumerate(content)
+                if isinstance(part, dict) and part.get("type") == "image_url"
+            ),
+            None,
+        )
+        if first_image_index in (None, 0):
+            normalized.append(message)
+            continue
+
+        reordered = [
+            content[first_image_index],
+            *content[:first_image_index],
+            *content[first_image_index + 1:],
         ]
-        other_parts = [
-            part
-            for part in content
-            if not (isinstance(part, dict) and part.get("type") == "image_url")
-        ]
-        reordered = image_parts + other_parts
         if reordered != content:
             normalized.append({**message, "content": reordered})
             changed = True

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7804,6 +7804,59 @@ def _contains_profile_reasoning_fields(value: Any) -> bool:
     return False
 
 
+def _order_zai_vision_content_parts(
+    messages: list,
+    *,
+    provider: str,
+    base_url: Optional[str],
+    task: Optional[str],
+) -> list:
+    """Put Z.ai image parts before text without mutating message history.
+
+    Z.ai's OpenAI-compatible vision endpoint rejects a user content list that
+    starts with ``text`` and is followed by ``image_url`` (provider error
+    1210). Other OpenAI-compatible providers accept the generic text-first
+    shape, so keep this normalization limited to Z.ai vision requests.
+    """
+    if task != "vision":
+        return messages
+
+    provider_norm = _normalize_aux_provider(provider)
+    is_zai_endpoint = any(
+        base_url_host_matches(base_url or "", hostname)
+        for hostname in ("api.z.ai", "open.bigmodel.cn")
+    )
+    if provider_norm != "zai" and not is_zai_endpoint:
+        return messages
+
+    normalized: list = []
+    changed = False
+    for message in messages:
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            normalized.append(message)
+            continue
+
+        image_parts = [
+            part
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "image_url"
+        ]
+        other_parts = [
+            part
+            for part in content
+            if not (isinstance(part, dict) and part.get("type") == "image_url")
+        ]
+        reordered = image_parts + other_parts
+        if reordered != content:
+            normalized.append({**message, "content": reordered})
+            changed = True
+        else:
+            normalized.append(message)
+
+    return normalized if changed else messages
+
+
 def _build_call_kwargs(
     provider: str,
     model: str,
@@ -7818,6 +7871,12 @@ def _build_call_kwargs(
     task: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
+    messages = _order_zai_vision_content_parts(
+        messages,
+        provider=provider,
+        base_url=base_url,
+        task=task,
+    )
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,

--- a/tests/agent/test_zai_vision_part_order.py
+++ b/tests/agent/test_zai_vision_part_order.py
@@ -59,3 +59,32 @@ def test_non_zai_vision_preserves_caller_part_order():
         "text",
         "image_url",
     ]
+
+
+def test_zai_vision_moves_only_first_image_and_preserves_remaining_part_order():
+    """Starting with an image must not detach later text from later images."""
+    content = [
+        {"type": "text", "text": "Describe image A."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,A"}},
+        {"type": "text", "text": "Compare image B with image A."},
+        {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,B"}},
+    ]
+    messages = [{"role": "user", "content": content}]
+
+    kwargs = _build_call_kwargs(
+        "custom",
+        "glm-4.6v-flash",
+        messages,
+        base_url="https://api.z.ai/api/paas/v4",
+        task="vision",
+    )
+
+    assert kwargs["messages"][0]["content"] == [
+        content[1],
+        content[0],
+        content[2],
+        content[3],
+        content[4],
+    ]
+    assert messages[0]["content"] == content

--- a/tests/agent/test_zai_vision_part_order.py
+++ b/tests/agent/test_zai_vision_part_order.py
@@ -1,0 +1,61 @@
+"""Regression coverage for Z.ai vision content-part ordering."""
+
+import pytest
+
+from agent.auxiliary_client import _build_call_kwargs
+
+
+def _text_then_image_messages() -> list[dict]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Read every visible value."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,AAAA"},
+                },
+            ],
+        }
+    ]
+
+
+@pytest.mark.parametrize("provider", ["zai", "custom"])
+def test_zai_vision_sends_image_before_text_without_mutating_history(provider):
+    """Z.ai rejects the generic text-first vision payload with error 1210."""
+    messages = _text_then_image_messages()
+
+    kwargs = _build_call_kwargs(
+        provider,
+        "glm-4.6v-flash",
+        messages,
+        base_url="https://api.z.ai/api/paas/v4",
+        task="vision",
+    )
+
+    assert [part["type"] for part in kwargs["messages"][0]["content"]] == [
+        "image_url",
+        "text",
+    ]
+    assert [part["type"] for part in messages[0]["content"]] == [
+        "text",
+        "image_url",
+    ]
+
+
+def test_non_zai_vision_preserves_caller_part_order():
+    messages = _text_then_image_messages()
+
+    kwargs = _build_call_kwargs(
+        "openrouter",
+        "google/gemini-2.5-flash",
+        messages,
+        base_url="https://openrouter.ai/api/v1",
+        task="vision",
+    )
+
+    assert kwargs["messages"] is messages
+    assert [part["type"] for part in kwargs["messages"][0]["content"]] == [
+        "text",
+        "image_url",
+    ]


### PR DESCRIPTION
## What does this PR do?

Fixes Z.ai vision requests that fail with provider error 1210 when Hermes sends a multimodal user message as `[text, image_url]`.

The shared auxiliary request builder now normalizes only Z.ai vision traffic so the first `image_url` part is sent first. If a message contains additional text, image, or unknown content parts, their relative order is preserved. It recognizes both the built-in `zai` provider and custom-provider routes targeting `api.z.ai` or `open.bigmodel.cn`. The transformation creates new message/content containers when needed, so persisted conversation history is not mutated. Other providers retain the caller's original part order.

## Related Issue

N/A — reproduced against the live Z.ai OpenAI-compatible vision endpoint.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added provider/endpoint-specific Z.ai vision part ordering in `agent/auxiliary_client.py`.
- Preserved the relative order of all content parts except for moving the first required image to the front.
- Added regression coverage for built-in `zai`, custom Z.ai endpoint routing, non-mutation, non-Z.ai preservation, and interleaved multi-image content in `tests/agent/test_zai_vision_part_order.py`.

## How to Test

1. Run `uv run pytest -q tests/agent/test_zai_vision_part_order.py tests/tools/test_vision_tools.py tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_client.py` (207 passed locally).
2. Configure `auxiliary.vision` for `glm-4.6v-flash` at `https://api.z.ai/api/paas/v4` and call `vision_analyze` with a local JPEG plus a text question.
3. Confirm the call succeeds without error 1210 and the original in-memory message remains text-first.

Additional verification:

- The new multi-image regression test was observed failing against the previous implementation before the minimal ordering change was applied.
- `uv run ruff check .` passed.
- `uv run python scripts/check-windows-footguns.py --all` passed across 912 files.
- Contributor attribution audit passed.
- Live macOS smoke through the built-in `vision_analyze_tool` succeeded; traced wire content was `[image_url, text]` while caller history remained `[text, image_url]`.
- `scripts/run_tests.sh -q` was attempted but cannot complete in this local minimal-extra environment: unrelated ACP/Anthropic tests fail collection or client-shape assertions because optional `acp` and `anthropic` packages are absent; an unrelated LSP live-system guard also failed. The focused affected suites above are green.

## Checklist

### Code

- [ ] I've read the full Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (see environment note above)
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Relevant documentation updated — N/A; behavior and rationale are documented in code and regression tests
- [x] `cli-config.yaml.example` updated — N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` updated — N/A; no workflow or architecture change
- [x] Cross-platform impact considered; Windows footgun scan passed
- [x] Tool descriptions/schemas updated — N/A; the public tool contract is unchanged

## Screenshots / Logs

Before: Z.ai returned error 1210 for a text-first multimodal content list.

After: the same built-in Hermes vision path sent the first `image_url` before `text`, completed successfully, preserved later multipart ordering, and left the original message history unchanged.
