### PR TITLE
fix(trajectory): keep trajectory JSONL out of git-tracked working directories

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1468,7 +1468,20 @@ def init_agent(
     
     # Show trajectory saving status
     if agent.save_trajectories and not agent.quiet_mode:
-        print("📝 Trajectory saving enabled")
+        # Name the destination. This is the path datagen actually uses
+        # (AIAgent(save_trajectories=True)), and the file may be redirected out
+        # of a git checkout — "enabled" with no path left the user hunting for
+        # their training data. resolve_trajectory_path also reports a
+        # pre-existing in-checkout dataset here, before the run starts.
+        try:
+            from agent.trajectory import describe_trajectory_destination
+            _traj_dest = describe_trajectory_destination()
+        except Exception:  # pragma: no cover - a status line must not break init
+            _traj_dest = None
+        if _traj_dest:
+            print(f"📝 Trajectory saving enabled → {_traj_dest}")
+        else:
+            print("📝 Trajectory saving enabled")
     
     # Show ephemeral system prompt status
     if agent.ephemeral_system_prompt and not agent.quiet_mode:

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -59,10 +59,30 @@ def _notify_once(key: str, message: str, *args: Any) -> None:
         return
     _REDIRECT_WARNED.add(key)
     logger.warning(message, *args)
+    _print_notice(message, *args)
+
+
+def _print_notice(message: str, *args: Any) -> None:
+    """Put one line on stderr. Never raises — a notice must not break a turn."""
     try:
         print(f"⚠️  {message % args}", file=sys.stderr, flush=True)
     except Exception:  # pragma: no cover - a notice must never break a turn
         pass
+
+
+def _notify_every_log_once_on_terminal(key: str, message: str, *args: Any) -> None:
+    """Log *every* occurrence, but show the terminal one line per *key*.
+
+    For a repeated failure of the same write: each occurrence belongs in
+    ``errors.log`` (that is the forensic record of how many turns were lost),
+    while the terminal only needs to say it once per destination so a datagen
+    run saving every turn is not flooded.
+    """
+    logger.warning(message, *args)
+    if key in _REDIRECT_WARNED:
+        return
+    _REDIRECT_WARNED.add(key)
+    _print_notice(message, *args)
 
 
 def _explicit_work_tree() -> Optional[Path]:
@@ -411,6 +431,12 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
     **skipped** rather than written into a checkout; a skipped save is logged
     and reported on the terminal, never raised, because this runs during turn
     finalization.
+
+    A save that is *attempted* and fails (permissions, full disk, a destination
+    replaced under us) is reported the same way. Only ``logger.warning`` fired
+    before, and the CLI installs no stderr handler without ``--verbose``, so a
+    dropped turn was visible only in ``errors.log`` — the same silent-drop the
+    resolver deliberately refuses to allow.
     """
     if filename is None:
         filename = "trajectory_samples.jsonl" if completed else "failed_trajectories.jsonl"
@@ -433,4 +459,13 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
-        logger.warning("Failed to save trajectory: %s", e)
+        # Every occurrence is logged (errors.log is the record of how many
+        # turns were lost); the terminal gets one line per destination.
+        _notify_every_log_once_on_terminal(
+            f"write-failed:{filename}",
+            "This trajectory was NOT saved: writing to %s failed (%s). Later "
+            "turns will keep trying, and each failure is recorded in "
+            "errors.log. Free space or fix permissions on that path, or pass "
+            "an absolute filename to write elsewhere.",
+            filename, e,
+        )

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -7,10 +7,115 @@ the file-write logic live here.
 
 import json
 import logging
+import os
 from datetime import datetime
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+# Redirects already reported, keyed by (source, target). A datagen run appends
+# once per turn; the destination only needs to be announced once per process.
+_REDIRECT_WARNED: set[tuple[str, str]] = set()
+
+
+def _find_git_root(start: Path) -> Optional[Path]:
+    """Walk *start* and its parents looking for a ``.git`` entry.
+
+    Returns the directory containing ``.git``, or ``None`` if we reach the
+    filesystem root without finding one. Mirrors
+    ``agent.prompt_builder._find_git_root``. ``.exists()`` (not ``.is_dir()``)
+    because a linked worktree and a submodule both carry ``.git`` as a *file*
+    holding a gitdir pointer, and a transcript is just as committable there.
+    """
+    try:
+        current = start.resolve()
+    except OSError:  # pragma: no cover - defensive: unresolvable cwd
+        return None
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def _allow_git_cwd() -> bool:
+    """Read ``agent.trajectory_allow_git_cwd`` (default False).
+
+    Config is loaded lazily and read-only, per the ``moa_trace`` precedent:
+    this runs once per saved trajectory, not per tool iteration. Any failure
+    means "not allowed", which keeps the safe placement on a broken config
+    rather than falling back into the checkout.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        agent_cfg = (load_config_readonly() or {}).get("agent") or {}
+        return bool(agent_cfg.get("trajectory_allow_git_cwd", False))
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+def resolve_trajectory_path(filename: str) -> str:
+    """Keep a relative trajectory filename out of a git work tree.
+
+    ``save_trajectory`` is called from ``finalize_turn``, so its default
+    relative filename resolves against whatever CWD the agent was launched in
+    — routinely a source checkout. A full verbatim transcript (message text,
+    tool results, tool-call arguments) then lands next to the source as an
+    untracked file, one ``git add -A`` away from being published.
+
+    So when the resolved target sits inside a git work tree, place the file
+    under ``<HERMES_HOME>/trajectories/`` instead and say so. Nothing is
+    dropped or truncated — trajectories are training data and stay
+    full-fidelity; only the destination changes, to the same private directory
+    the rest of Hermes' state already uses.
+
+    Three escape hatches keep CWD placement supported:
+
+    * an **absolute** ``filename`` is honoured as-is — an explicit path is a
+      deliberate choice, not an ambient default;
+    * ``agent.trajectory_allow_git_cwd: true`` in ``config.yaml`` restores the
+      old behaviour globally;
+    * a CWD outside any git work tree (a scratch dir, ``/tmp``, a datagen box)
+      is untouched, which is the common datagen shape already.
+
+    Returns the path to write, as a string. On any unexpected failure the
+    original *filename* is returned so tracing never breaks a turn.
+    """
+    try:
+        path = Path(filename)
+        if path.is_absolute():
+            return filename
+
+        target = Path(os.getcwd()) / path
+        git_root = _find_git_root(target.parent)
+        if git_root is None or _allow_git_cwd():
+            return filename
+
+        base = get_hermes_home() / "trajectories"
+        # Preserve any relative subdirectory the caller asked for so two
+        # callers using the same basename don't collide, but never let ".."
+        # walk the write back out of the trajectories dir.
+        relative = path if ".." not in path.parts else Path(path.name)
+        redirected = base / relative
+        redirected.parent.mkdir(parents=True, exist_ok=True)
+
+        key = (str(target), str(redirected))
+        if key not in _REDIRECT_WARNED:
+            _REDIRECT_WARNED.add(key)
+            logger.warning(
+                "Trajectory would have been written inside the git work tree at %s; "
+                "writing to %s instead so a full transcript is not left in your "
+                "checkout. Set agent.trajectory_allow_git_cwd: true in config.yaml "
+                "to write to the working directory anyway, or pass an absolute path.",
+                git_root, redirected,
+            )
+        return str(redirected)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Trajectory path resolution failed (%s); using %s", e, filename)
+        return filename
 
 
 def convert_scratchpad_to_think(content: str) -> str:
@@ -37,9 +142,15 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
         completed: Whether the conversation completed successfully.
         filename: Override output filename. Defaults to trajectory_samples.jsonl
                   or failed_trajectories.jsonl based on ``completed``.
+
+    A *relative* filename that would land inside a git work tree is redirected
+    under ``<HERMES_HOME>/trajectories/`` — see :func:`resolve_trajectory_path`.
+    Absolute paths are always honoured as given.
     """
     if filename is None:
         filename = "trajectory_samples.jsonl" if completed else "failed_trajectories.jsonl"
+
+    filename = resolve_trajectory_path(filename)
 
     entry = {
         "conversations": trajectory,

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -6,8 +6,11 @@ the file-write logic live here.
 """
 
 import json
+import hashlib
 import logging
 import os
+import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -16,9 +19,68 @@ from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
-# Redirects already reported, keyed by (source, target). A datagen run appends
-# once per turn; the destination only needs to be announced once per process.
-_REDIRECT_WARNED: set[tuple[str, str]] = set()
+# Notices already delivered, keyed by a caller-supplied string. A datagen run
+# appends once per turn; each distinct notice only needs to be reported once
+# per process.
+_REDIRECT_WARNED: set[str] = set()
+
+# Dropped at the top of ``<HERMES_HOME>/trajectories/``. ``*`` ignores the
+# ``.gitignore`` itself, so this never adds a *tracked* file — it only makes
+# the directory's contents unstageable if it ever sits inside a work tree.
+_GITIGNORE_BODY = (
+    "# Hermes trajectory transcripts are private training data.\n"
+    "# '*' also ignores this file, so nothing here becomes committable\n"
+    "# even when HERMES_HOME sits inside a git work tree.\n"
+    "*\n"
+)
+
+
+class _GitRootUndetermined(Exception):
+    """The upward walk could not complete, so containment is unknown.
+
+    Distinct from "definitely not in a work tree": an unreadable ancestor or a
+    symlink loop means we cannot *prove* the target is safe, and this guard
+    exists precisely to avoid writing a full transcript into a checkout on a
+    guess.
+    """
+
+
+def _notify_once(key: str, message: str, *args: Any) -> None:
+    """Log a warning and put exactly one line on the terminal, once per process.
+
+    ``logger.warning`` alone is invisible: the real CLI logging setup
+    (``hermes_logging.setup_logging``) installs no stderr ``StreamHandler``
+    unless ``--verbose``, so a redirect the user has to know about only reached
+    ``errors.log``. One stderr line per distinct notice keeps the destination
+    discoverable without spamming a datagen run that saves every turn. stderr,
+    not stdout, so piped trajectory data is never polluted.
+    """
+    if key in _REDIRECT_WARNED:
+        return
+    _REDIRECT_WARNED.add(key)
+    logger.warning(message, *args)
+    try:
+        print(f"⚠️  {message % args}", file=sys.stderr, flush=True)
+    except Exception:  # pragma: no cover - a notice must never break a turn
+        pass
+
+
+def _explicit_work_tree() -> Optional[Path]:
+    """Honour git's own environment overrides.
+
+    ``GIT_WORK_TREE`` names the work tree outright. ``GIT_DIR`` *alone* makes
+    the current directory the work tree — verified with git itself: with only
+    ``GIT_DIR`` set, ``git rev-parse --show-toplevel`` reports the CWD and
+    ``git add`` stages a file there. CI runners and git wrappers drive a repo
+    that way from a directory with no ``.git`` of its own, and the upward walk
+    alone would find nothing and leave the transcript exposed.
+    """
+    work_tree = os.environ.get("GIT_WORK_TREE", "").strip()
+    if work_tree:
+        return Path(work_tree)
+    if os.environ.get("GIT_DIR", "").strip():
+        return Path(os.getcwd())
+    return None
 
 
 def _find_git_root(start: Path) -> Optional[Path]:
@@ -29,14 +91,34 @@ def _find_git_root(start: Path) -> Optional[Path]:
     ``agent.prompt_builder._find_git_root``. ``.exists()`` (not ``.is_dir()``)
     because a linked worktree and a submodule both carry ``.git`` as a *file*
     holding a gitdir pointer, and a transcript is just as committable there.
+
+    Raises :class:`_GitRootUndetermined` when the walk cannot complete.
+    ``Path.exists()`` swallows ``ENOENT``/``ENOTDIR`` but **not** ``EACCES``,
+    and ``Path.resolve()`` raises ``RuntimeError`` (not ``OSError``) on a
+    symlink loop, so an unreadable ancestor or a loop used to escape this
+    helper entirely and land the transcript in the repo. Neither is "no git
+    root here" — the caller has to fail closed instead of guessing.
     """
     try:
         current = start.resolve()
-    except OSError:  # pragma: no cover - defensive: unresolvable cwd
-        return None
+    except (OSError, RuntimeError) as exc:
+        raise _GitRootUndetermined(f"cannot resolve {start}: {exc}") from exc
+
+    explicit = _explicit_work_tree()
+    if explicit is not None:
+        try:
+            root = explicit.resolve()
+        except (OSError, RuntimeError) as exc:
+            raise _GitRootUndetermined(f"cannot resolve {explicit}: {exc}") from exc
+        if current == root or root in current.parents:
+            return root
+
     for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
+        try:
+            if (parent / ".git").exists():
+                return parent
+        except OSError as exc:
+            raise _GitRootUndetermined(f"cannot stat {parent / '.git'}: {exc}") from exc
     return None
 
 
@@ -57,7 +139,87 @@ def _allow_git_cwd() -> bool:
         return False
 
 
-def resolve_trajectory_path(filename: str) -> str:
+def _work_tree_key(git_root: Path) -> str:
+    """A stable per-work-tree directory name for the relocated dataset.
+
+    The pre-fix path was CWD-relative, so ``projA/`` and ``projB/`` each had
+    their own dataset. A single flat file under ``trajectories/`` would merge
+    them irreversibly — the entry schema carries no repo/session field, so
+    afterwards the two are indistinguishable. Keying the *path* per work tree
+    keeps one dataset per repo, the way it was, and follows
+    ``agent.moa_trace``'s per-session file naming.
+
+    ``<basename>-<sha256[:8]>``: the basename so the directory is recognisable,
+    the digest so ``~/a/proj`` and ``~/b/proj`` cannot land in the same place.
+    """
+    digest = hashlib.sha256(str(git_root).encode("utf-8", "surrogateescape")).hexdigest()[:8]
+    name = re.sub(r"[^A-Za-z0-9._-]", "-", git_root.name).strip("-.")
+    return f"{name[:32] or 'repo'}-{digest}"
+
+
+def _contained_relative(path: Path) -> Path:
+    """Normalize *path* so joining it can't climb out of ``trajectories/``.
+
+    ``os.path.normpath`` collapses interior ``..`` — ``a/../b/keep.jsonl``
+    becomes ``b/keep.jsonl`` instead of silently losing ``b/``, which a plain
+    ``".." in path.parts`` test did. Only a path that still escapes after
+    normalization falls back to the bare basename.
+    """
+    normalized = Path(os.path.normpath(str(path)))
+    if normalized.is_absolute() or ".." in normalized.parts:
+        return Path(path.name)
+    return normalized
+
+
+def _shield_trajectories_dir(base: Path) -> bool:
+    """Make ``trajectories/`` contents unstageable, wherever it lives.
+
+    ``HERMES_HOME`` is a documented knob and ``git init ~`` (yadm, dotfiles)
+    is a real pattern, so the redirect destination can itself sit inside a work
+    tree — moving the transcript from one checkout into another while promising
+    the opposite. A self-ignoring ``.gitignore`` closes that: measured with git,
+    ``git add -A`` stops staging the transcript and the ``.gitignore`` ignores
+    itself, so no tracked file is created. Written unconditionally so a later
+    ``git init`` over ``HERMES_HOME`` is covered too. Returns whether the
+    shield is in place, so the caller can tell the user the truth.
+    """
+    ignore = base / ".gitignore"
+    try:
+        if not ignore.exists():
+            ignore.write_text(_GITIGNORE_BODY, encoding="utf-8")
+        return True
+    except OSError:
+        return False
+
+
+def _warn_pre_existing_dataset(target: Path, redirected: Path) -> None:
+    """A dataset already in the checkout stops growing at upgrade — say so.
+
+    The worst outcome of this guard is not an empty dataset (someone notices
+    that) but a plausible-looking one that quietly stopped being appended to
+    while a pipeline kept reading it. The user's file is deliberately left
+    untouched — it is their data — and nothing is written into their checkout,
+    since not leaving files in checkouts is this fix's entire point. The signal
+    goes out of band instead: terminal, ``errors.log``, and the docs.
+    """
+    try:
+        if not (target.is_file() and target.stat().st_size > 0):
+            return
+    except OSError:  # pragma: no cover - unreadable target; nothing to claim
+        return
+    _notify_once(
+        f"stale-dataset:{target}",
+        "An existing trajectory dataset at %s will NOT receive new entries — "
+        "they now go to %s. Your file was neither moved nor modified, so a "
+        "pipeline still reading the old path will silently see a dataset that "
+        "stopped growing. Point the pipeline at the new path, concatenate the "
+        "two, or set agent.trajectory_allow_git_cwd: true in config.yaml to "
+        "keep appending to the old one.",
+        target, redirected,
+    )
+
+
+def resolve_trajectory_path(filename: str) -> Optional[str]:
     """Keep a relative trajectory filename out of a git work tree.
 
     ``save_trajectory`` is called from ``finalize_turn``, so its default
@@ -67,10 +229,11 @@ def resolve_trajectory_path(filename: str) -> str:
     untracked file, one ``git add -A`` away from being published.
 
     So when the resolved target sits inside a git work tree, place the file
-    under ``<HERMES_HOME>/trajectories/`` instead and say so. Nothing is
-    dropped or truncated — trajectories are training data and stay
+    under ``<HERMES_HOME>/trajectories/<work-tree>/`` instead and say so.
+    Nothing is dropped or truncated — trajectories are training data and stay
     full-fidelity; only the destination changes, to the same private directory
-    the rest of Hermes' state already uses.
+    the rest of Hermes' state already uses. The ``<work-tree>`` component keeps
+    one dataset per repo, as the CWD-relative path did.
 
     Three escape hatches keep CWD placement supported:
 
@@ -81,41 +244,119 @@ def resolve_trajectory_path(filename: str) -> str:
     * a CWD outside any git work tree (a scratch dir, ``/tmp``, a datagen box)
       is untouched, which is the common datagen shape already.
 
-    Returns the path to write, as a string. On any unexpected failure the
-    original *filename* is returned so tracing never breaks a turn.
+    Returns the path to write, or ``None`` meaning **do not write**. It fails
+    closed: returning the original filename on an unexpected failure would put
+    a full transcript in the checkout, which is the one outcome this guard
+    exists to prevent. ``None`` is a skipped side effect, never an exception —
+    ``save_trajectory`` runs during turn finalization and must not break a turn.
     """
     try:
         path = Path(filename)
         if path.is_absolute():
             return filename
 
-        target = Path(os.getcwd()) / path
-        git_root = _find_git_root(target.parent)
+        try:
+            cwd = Path(os.getcwd())
+        except OSError as exc:
+            # Fail closed, and note *why* this one is not merely theoretical:
+            # with an unreadable ancestor, ``os.getcwd()`` raises EACCES while a
+            # *relative* ``open()`` still succeeds — it resolves against the
+            # process's CWD file descriptor, which needs no path traversal.
+            # Measured: the write lands in the repo. So a failure here means
+            # "containment unknown, write still possible", not "nothing to
+            # protect". (A deleted CWD raises ENOENT here and could not be
+            # written to anyway, so skipping costs nothing.)
+            if _allow_git_cwd():
+                return filename
+            _notify_once(
+                f"nocwd:{filename}",
+                "Could not read the current directory (%s), so it is unknown "
+                "whether it is inside a git checkout and this trajectory was "
+                "NOT saved. A relative write can still land there, so the guard "
+                "fails closed. Pass an absolute filename, or set "
+                "agent.trajectory_allow_git_cwd: true in config.yaml.",
+                exc,
+            )
+            return None
+
+        target = cwd / path
+        try:
+            git_root = _find_git_root(target.parent)
+        except _GitRootUndetermined as exc:
+            if _allow_git_cwd():
+                return filename
+            _notify_once(
+                f"undetermined:{target}",
+                "Could not determine whether %s is inside a git work tree (%s), "
+                "so this trajectory was NOT saved. Leaving a full transcript in "
+                "a checkout is the risk this guard exists to prevent, so it "
+                "fails closed. Fix the unreadable path, pass an absolute "
+                "filename, or set agent.trajectory_allow_git_cwd: true in "
+                "config.yaml to write to the working directory anyway.",
+                target, exc,
+            )
+            return None
         if git_root is None or _allow_git_cwd():
             return filename
 
         base = get_hermes_home() / "trajectories"
-        # Preserve any relative subdirectory the caller asked for so two
-        # callers using the same basename don't collide, but never let ".."
-        # walk the write back out of the trajectories dir.
-        relative = path if ".." not in path.parts else Path(path.name)
-        redirected = base / relative
+        # One directory per work tree so two repos keep two datasets, plus any
+        # relative subdirectory the caller asked for, normalized so ".." can
+        # never walk the write back out of the trajectories dir.
+        redirected = base / _work_tree_key(git_root) / _contained_relative(path)
         redirected.parent.mkdir(parents=True, exist_ok=True)
+        shielded = _shield_trajectories_dir(base)
 
-        key = (str(target), str(redirected))
-        if key not in _REDIRECT_WARNED:
-            _REDIRECT_WARNED.add(key)
-            logger.warning(
-                "Trajectory would have been written inside the git work tree at %s; "
-                "writing to %s instead so a full transcript is not left in your "
-                "checkout. Set agent.trajectory_allow_git_cwd: true in config.yaml "
-                "to write to the working directory anyway, or pass an absolute path.",
-                git_root, redirected,
+        # Post-condition on our own destination: is *it* committable?
+        try:
+            dest_root = _find_git_root(base)
+        except _GitRootUndetermined:
+            dest_root = None
+        if dest_root is None:
+            caveat = ""
+        elif shielded:
+            caveat = (
+                f" Note: that destination is itself inside the checkout at {dest_root}, "
+                "so a self-ignoring .gitignore was written into the trajectories "
+                "directory to keep `git add -A` from staging it; if that directory is "
+                "already tracked, or to keep the data out of a checkout entirely, "
+                "point HERMES_HOME outside any git work tree."
             )
+        else:
+            caveat = (
+                f" WARNING: that destination is itself inside the checkout at {dest_root} "
+                "and the protective .gitignore could not be written, so the transcript "
+                "IS committable from there — point HERMES_HOME outside any git work tree."
+            )
+
+        _warn_pre_existing_dataset(target, redirected)
+        _notify_once(
+            f"redirect:{target}->{redirected}",
+            # "a git checkout (.git found at ...)" rather than "the git work
+            # tree at ...": a stray or broken .git entry redirects too (the safe
+            # direction), and claiming a work tree that may not exist would be
+            # a lie in exactly the case the user needs to understand.
+            "Trajectory would have been written inside a git checkout (.git found "
+            "at %s); writing to %s instead so a full transcript is not left in your "
+            "checkout. Set agent.trajectory_allow_git_cwd: true in config.yaml "
+            "to write to the working directory anyway, or pass an absolute path.%s",
+            git_root, redirected, caveat,
+        )
         return str(redirected)
-    except Exception as e:  # pragma: no cover - defensive
-        logger.debug("Trajectory path resolution failed (%s); using %s", e, filename)
-        return filename
+    except Exception as exc:
+        # Fail closed. The pre-fix behaviour here was to return *filename*,
+        # which on a read-only or full HERMES_HOME wrote the transcript into
+        # the repo and said so only at debug level — measured, and the exact
+        # outcome this guard is supposed to make impossible.
+        _notify_once(
+            f"resolve-failed:{filename}",
+            "Trajectory path resolution failed (%s), so %r was NOT saved rather "
+            "than being written to the working directory, which may be a git "
+            "checkout. Set agent.trajectory_allow_git_cwd: true in config.yaml "
+            "or pass an absolute filename to write there anyway.",
+            exc, filename,
+        )
+        return None
 
 
 def convert_scratchpad_to_think(content: str) -> str:
@@ -123,6 +364,26 @@ def convert_scratchpad_to_think(content: str) -> str:
     if not content or "<REASONING_SCRATCHPAD>" not in content:
         return content
     return content.replace("<REASONING_SCRATCHPAD>", "<think>").replace("</REASONING_SCRATCHPAD>", "</think>")
+
+
+def describe_trajectory_destination() -> str:
+    """Where trajectory saving will actually write, for a startup status line.
+
+    ``AIAgent(save_trajectories=True)`` — the path datagen uses — printed only
+    "📝 Trajectory saving enabled", with no destination, so a redirected file
+    was findable only by hunting through ``errors.log``. Pure and side-effect
+    free apart from the resolver's own directory preparation, so a status line
+    can call it safely; a skipped destination is described rather than hidden.
+    """
+    resolved = resolve_trajectory_path("trajectory_samples.jsonl")
+    if resolved is None:
+        return "destination unavailable — see warnings"
+    if resolved == "trajectory_samples.jsonl":
+        # Not redirected: the CWD-relative default, as documented.
+        return os.path.join(os.getcwd(), resolved)
+    # Redirected. Name the directory, not this one filename — a failed turn
+    # writes failed_trajectories.jsonl into the same place.
+    return f"{os.path.dirname(resolved)}{os.sep}"
 
 
 def has_incomplete_scratchpad(content: str) -> bool:
@@ -144,13 +405,21 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
                   or failed_trajectories.jsonl based on ``completed``.
 
     A *relative* filename that would land inside a git work tree is redirected
-    under ``<HERMES_HOME>/trajectories/`` — see :func:`resolve_trajectory_path`.
-    Absolute paths are always honoured as given.
+    under ``<HERMES_HOME>/trajectories/<work-tree>/`` — see
+    :func:`resolve_trajectory_path`. Absolute paths are always honoured as
+    given. If the destination cannot be determined safely the save is
+    **skipped** rather than written into a checkout; a skipped save is logged
+    and reported on the terminal, never raised, because this runs during turn
+    finalization.
     """
     if filename is None:
         filename = "trajectory_samples.jsonl" if completed else "failed_trajectories.jsonl"
 
-    filename = resolve_trajectory_path(filename)
+    resolved = resolve_trajectory_path(filename)
+    if resolved is None:
+        # Already reported by the resolver with the reason and the remedy.
+        return
+    filename = resolved
 
     entry = {
         "conversations": trajectory,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -829,8 +829,15 @@ agent:
   # file. Launched from a source checkout, that leaves an untracked
   # trajectory_samples.jsonl next to your code, one `git add -A` away from
   # being committed. By default such a write is redirected under
-  # <HERMES_HOME>/trajectories/ (nothing is dropped, only relocated) and a
-  # warning names the destination.
+  # <HERMES_HOME>/trajectories/<work-tree>/ (nothing is dropped, only
+  # relocated) and a one-time notice names the destination on the terminal.
+  # The <work-tree> component is per-repository, so two checkouts keep two
+  # datasets instead of merging into one file.
+  #
+  # Upgrading with a pipeline that already reads ./trajectory_samples.jsonl:
+  # that file is left exactly as it is and stops receiving new entries. Hermes
+  # says so on the terminal and in errors.log — repoint the pipeline at the
+  # new path, concatenate the two, or set this to true.
   #
   # Set true to restore writing to the working directory. Passing an absolute
   # filename to save_trajectory() also bypasses the redirect.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -821,6 +821,21 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Allow trajectory JSONL to be written into a git work tree (default: false).
+  #
+  # Trajectory saving (AIAgent(save_trajectories=True) /
+  # `run_agent.py --save_trajectories`) appends a full verbatim transcript —
+  # message text, tool results and tool-call arguments — to a CWD-relative
+  # file. Launched from a source checkout, that leaves an untracked
+  # trajectory_samples.jsonl next to your code, one `git add -A` away from
+  # being committed. By default such a write is redirected under
+  # <HERMES_HOME>/trajectories/ (nothing is dropped, only relocated) and a
+  # warning names the destination.
+  #
+  # Set true to restore writing to the working directory. Passing an absolute
+  # filename to save_trajectory() also bypasses the redirect.
+  # trajectory_allow_git_cwd: false
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -37,10 +37,11 @@ DEFAULT_CONFIG = {
         # a CWD-relative filename, so an agent run launched from a source
         # checkout dropped one next to the user's code, one `git add -A` from
         # being published (#77472). Default False redirects such a write under
-        # ``<HERMES_HOME>/trajectories/`` and warns with the destination;
-        # nothing is dropped or truncated, only relocated. Set True to restore
-        # writing to the working directory (passing an absolute filename also
-        # bypasses the redirect).
+        # ``<HERMES_HOME>/trajectories/<work-tree>/`` and warns with the
+        # destination; nothing is dropped or truncated, only relocated, and the
+        # per-work-tree directory keeps one dataset per repo the way the
+        # CWD-relative path did. Set True to restore writing to the working
+        # directory (passing an absolute filename also bypasses the redirect).
         "trajectory_allow_git_cwd": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -30,6 +30,18 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 500,
+        # Allow trajectory JSONL to be written into a git work tree.
+        # save_trajectory() (AIAgent(save_trajectories=True) /
+        # `run_agent.py --save_trajectories`) appends a full verbatim
+        # transcript — message text, tool results, tool-call arguments — under
+        # a CWD-relative filename, so an agent run launched from a source
+        # checkout dropped one next to the user's code, one `git add -A` from
+        # being published (#77472). Default False redirects such a write under
+        # ``<HERMES_HOME>/trajectories/`` and warns with the destination;
+        # nothing is dropped or truncated, only relocated. Set True to restore
+        # writing to the working directory (passing an absolute filename also
+        # bypasses the redirect).
+        "trajectory_allow_git_cwd": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/run_agent.py
+++ b/run_agent.py
@@ -7901,8 +7901,9 @@ def main(
         print("💾 Trajectory saving: ENABLED")
         print("   - Successful conversations → trajectory_samples.jsonl")
         print("   - Failed conversations → failed_trajectories.jsonl")
-        print("   - Inside a git work tree these are written under "
-              "<HERMES_HOME>/trajectories/ instead (agent.trajectory_allow_git_cwd: true to override)")
+        print("   - Inside a git checkout these are written under "
+              "<HERMES_HOME>/trajectories/<work-tree>/ instead "
+              "(agent.trajectory_allow_git_cwd: true to override)")
     
     # Initialize agent with provided parameters
     try:
@@ -7955,29 +7956,34 @@ def main(
         # under a relative name, so it lands in the CWD — a source checkout as
         # often as not. Route it through the same guard.
         sample_filename = resolve_trajectory_path(f"sample_{sample_id}.json")
-        
-        # Convert messages to trajectory format (same as batch_runner)
-        trajectory = agent._convert_to_trajectory_format(
-            result['messages'], 
-            user_query, 
-            result['completed']
-        )
-        
-        entry = {
-            "conversations": trajectory,
-            "timestamp": datetime.now().isoformat(),
-            "model": model,
-            "completed": result['completed'],
-            "query": user_query
-        }
-        
-        try:
-            with open(sample_filename, "w", encoding="utf-8") as f:
-                # Pretty-print JSON with indent for readability
-                f.write(json.dumps(entry, ensure_ascii=False, indent=2))
-            print(f"\n💾 Sample trajectory saved to: {sample_filename}")
-        except Exception as e:
-            print(f"\n⚠️ Failed to save sample: {e}")
+
+        # None means the guard could not place the file safely and refused to
+        # drop it in the checkout; it has already reported the reason.
+        if sample_filename is None:
+            print("\n⚠️ Sample trajectory not saved: could not place it outside a git checkout")
+        else:
+            # Convert messages to trajectory format (same as batch_runner)
+            trajectory = agent._convert_to_trajectory_format(
+                result['messages'], 
+                user_query, 
+                result['completed']
+            )
+
+            entry = {
+                "conversations": trajectory,
+                "timestamp": datetime.now().isoformat(),
+                "model": model,
+                "completed": result['completed'],
+                "query": user_query
+            }
+
+            try:
+                with open(sample_filename, "w", encoding="utf-8") as f:
+                    # Pretty-print JSON with indent for readability
+                    f.write(json.dumps(entry, ensure_ascii=False, indent=2))
+                print(f"\n💾 Sample trajectory saved to: {sample_filename}")
+            except Exception as e:
+                print(f"\n⚠️ Failed to save sample: {e}")
     
     print("\n👋 Agent execution completed!")
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -205,6 +205,7 @@ from agent.tool_result_classification import (
 )
 from agent.trajectory import (
     convert_scratchpad_to_think,
+    resolve_trajectory_path,
     save_trajectory as _save_trajectory_to_file,
 )
 from agent.tool_dispatch_helpers import (
@@ -7900,6 +7901,8 @@ def main(
         print("💾 Trajectory saving: ENABLED")
         print("   - Successful conversations → trajectory_samples.jsonl")
         print("   - Failed conversations → failed_trajectories.jsonl")
+        print("   - Inside a git work tree these are written under "
+              "<HERMES_HOME>/trajectories/ instead (agent.trajectory_allow_git_cwd: true to override)")
     
     # Initialize agent with provided parameters
     try:
@@ -7948,7 +7951,10 @@ def main(
     # Save sample trajectory to UUID-named file if requested
     if save_sample:
         sample_id = str(uuid.uuid4())[:8]
-        sample_filename = f"sample_{sample_id}.json"
+        # Same class of write as save_trajectory: a full verbatim trajectory
+        # under a relative name, so it lands in the CWD — a source checkout as
+        # often as not. Route it through the same guard.
+        sample_filename = resolve_trajectory_path(f"sample_{sample_id}.json")
         
         # Convert messages to trajectory format (same as batch_runner)
         trajectory = agent._convert_to_trajectory_format(

--- a/tests/agent/test_trajectory_git_cwd_guard.py
+++ b/tests/agent/test_trajectory_git_cwd_guard.py
@@ -559,6 +559,76 @@ def test_skipped_save_is_reported_not_raised(tmp_path, monkeypatch, hermes_home,
         f"the notice must say the trajectory was not saved: {[r.getMessage() for r in warnings]}"
 
 
+def test_failed_append_is_reported_on_the_terminal(tmp_path, monkeypatch, hermes_home, capsys):
+    """A dropped turn must be visible without ``--verbose``.
+
+    The resolver refuses to silently drop a trajectory, but the *append* can
+    still fail (permissions, full disk, destination replaced) — and that path
+    only called ``logger.warning``, which reaches no terminal because
+    ``hermes_logging.setup_logging`` installs no stderr handler unless
+    ``--verbose``. The turn was lost with nothing on screen, which is the same
+    silent drop the guard exists to prevent.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True)  # creates the destination
+    landed = _landed(hermes_home)
+    landed.chmod(stat.S_IRUSR)  # r--: the next append cannot open it
+    capsys.readouterr()  # drop the redirect notice from the first save
+
+    try:
+        save_trajectory(SAMPLE, "m", completed=True)  # must not raise
+    finally:
+        landed.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    err = capsys.readouterr().err
+    assert "NOT saved" in err, f"a lost turn must be reported on stderr: {err!r}"
+    assert str(landed) in err, "the notice must name the path that failed"
+    assert len(_jsonl(landed)) == 1, "the failed append added nothing"
+
+
+def test_repeated_append_failures_log_every_time_but_print_once(
+    tmp_path, monkeypatch, hermes_home, capsys, caplog
+):
+    """errors.log records every lost turn; the terminal says it once.
+
+    A datagen run saves every turn, so N failures must not mean N screen lines
+    — but the per-occurrence record is how a user learns how many turns were
+    lost, so the log must not be deduped.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+    landed = _landed(hermes_home)
+    landed.chmod(stat.S_IRUSR)
+    capsys.readouterr()
+
+    try:
+        with caplog.at_level("WARNING", logger="agent.trajectory"):
+            for _ in range(3):
+                save_trajectory(SAMPLE, "m", completed=True)
+    finally:
+        landed.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    logged = [r for r in caplog.records if "NOT saved" in r.getMessage()]
+    assert len(logged) == 3, f"every lost turn must be logged, got {len(logged)}"
+    assert capsys.readouterr().err.count("NOT saved") == 1, "one terminal line"
+
+
+def test_successful_save_prints_no_failure_notice(tmp_path, monkeypatch, hermes_home, capsys):
+    """The failure notice must not fire on the happy path."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    err = capsys.readouterr().err
+    assert "NOT saved" not in err, f"nothing failed, so nothing may claim it did: {err!r}"
+    assert _jsonl(_landed(hermes_home)) and True
+
+
 def test_opt_out_still_wins_when_containment_is_undetermined(tmp_path, monkeypatch, hermes_home):
     """``trajectory_allow_git_cwd: true`` means "my CWD, my choice" — always.
 

--- a/tests/agent/test_trajectory_git_cwd_guard.py
+++ b/tests/agent/test_trajectory_git_cwd_guard.py
@@ -10,12 +10,17 @@ untracked file, one ``git add -A`` away from being published. See #77472
 The contract these assert:
 
 * a relative write whose target is inside a git work tree is *relocated* under
-  ``<HERMES_HOME>/trajectories/``, byte-for-byte intact — trajectories are
-  training data, so the fix must never drop or truncate one;
+  ``<HERMES_HOME>/trajectories/<work-tree>/``, byte-for-byte intact —
+  trajectories are training data, so the fix must never drop or truncate one;
+* the ``<work-tree>`` component is per-repository, so two checkouts keep two
+  datasets instead of merging irreversibly into one file;
 * nothing is left behind in the repo;
 * a CWD outside any git work tree is untouched;
 * CWD placement stays reachable, via an absolute path or the
-  ``agent.trajectory_allow_git_cwd`` config opt-out.
+  ``agent.trajectory_allow_git_cwd`` config opt-out;
+* when the destination cannot be established safely the write is *skipped*
+  rather than falling back into the checkout, and never raises;
+* the user is told — on the terminal, not only in ``errors.log``.
 
 These exercise the real ``save_trajectory`` → ``open()`` path with real file
 I/O against a temp HERMES_HOME and a real ``git init`` repo. Nothing on the
@@ -25,6 +30,8 @@ write path is mocked.
 from __future__ import annotations
 
 import json
+import os
+import stat
 import subprocess
 from pathlib import Path
 
@@ -85,6 +92,62 @@ def _tracked_and_untracked(root: Path) -> str:
     ).stdout
 
 
+def _would_stage(root: Path) -> str:
+    """What ``git add -A`` would actually stage — exposure, not mere presence.
+
+    A file physically inside a work tree but git-ignored is not committable,
+    so ``rglob`` presence alone overstates the risk. This is the real test.
+    """
+    return subprocess.run(
+        ["git", "add", "-An", "--", "."], cwd=root,
+        capture_output=True, text=True,
+    ).stdout
+
+
+def _landed(hermes_home: Path, name: str = "trajectory_samples.jsonl") -> Path:
+    """Find the single relocated dataset, without hardcoding the work-tree key.
+
+    The key is ``<basename>-<sha256[:8]>``; asserting the literal digest would
+    be a change-detector. What matters is that exactly one dataset exists and
+    it sits under ``trajectories/``.
+    """
+    base = hermes_home / "trajectories"
+    hits = sorted(p for p in base.rglob(name) if p.is_file())
+    assert len(hits) == 1, f"expected exactly one {name} under {base}, got {hits}"
+    return hits[0]
+
+
+def _break_the_destination(hermes_home: Path) -> None:
+    """Make ``trajectories/`` impossible to create, deterministically.
+
+    A plain ``chmod`` is not enough on a cold config cache: ``_allow_git_cwd()``
+    → ``load_config()`` → ``ensure_hermes_home()`` re-creates the directory
+    skeleton and *repairs* the mode to 0700, so the write then succeeds.
+    (Worth knowing on its own — a merely read-only home often self-heals.)
+    Putting a regular *file* where ``trajectories/`` must be makes ``mkdir``
+    fail with ENOTDIR no matter the ordering, which is the same failure class as
+    a read-only or full disk and needs no permission games.
+    """
+    traj = hermes_home / "trajectories"
+    if traj.is_dir():
+        import shutil
+
+        shutil.rmtree(traj)
+    traj.write_text("not a directory\n", encoding="utf-8")
+
+
+def _staged_jsonl(root: Path) -> list[str]:
+    """Trajectory files git would offer to commit, ignoring test fixtures.
+
+    Some fixtures (symlinks, scratch dirs) legitimately show in ``git status``;
+    the exposure under test is specifically a transcript.
+    """
+    return [
+        line for line in _tracked_and_untracked(root).splitlines()
+        if ".jsonl" in line or ".json" in line
+    ]
+
+
 def test_relative_write_in_git_repo_lands_in_hermes_home(tmp_path, monkeypatch, hermes_home):
     """The default filename is relocated out of the checkout, intact."""
     repo = _git_repo(tmp_path / "repo")
@@ -92,7 +155,7 @@ def test_relative_write_in_git_repo_lands_in_hermes_home(tmp_path, monkeypatch, 
 
     save_trajectory(SAMPLE, "kimi-k2", completed=True)
 
-    landed = hermes_home / "trajectories" / "trajectory_samples.jsonl"
+    landed = _landed(hermes_home)
     assert landed.exists(), "trajectory was not written to HERMES_HOME"
 
     # Nothing left in the repo, by any name.
@@ -114,7 +177,7 @@ def test_failed_trajectory_filename_also_relocated(tmp_path, monkeypatch, hermes
 
     save_trajectory(SAMPLE, "kimi-k2", completed=False)
 
-    landed = hermes_home / "trajectories" / "failed_trajectories.jsonl"
+    landed = _landed(hermes_home, "failed_trajectories.jsonl")
     assert landed.exists()
     assert _jsonl(landed)[0]["completed"] is False
     assert _tracked_and_untracked(repo) == ""
@@ -128,7 +191,7 @@ def test_appends_accumulate_at_the_redirected_path(tmp_path, monkeypatch, hermes
     save_trajectory(SAMPLE, "m1", completed=True)
     save_trajectory(SAMPLE, "m2", completed=True)
 
-    entries = _jsonl(hermes_home / "trajectories" / "trajectory_samples.jsonl")
+    entries = _jsonl(_landed(hermes_home))
     assert [e["model"] for e in entries] == ["m1", "m2"]
 
 
@@ -162,7 +225,7 @@ def test_git_dir_as_file_still_redirects(tmp_path, monkeypatch, hermes_home):
 
     save_trajectory(SAMPLE, "kimi-k2", completed=True)
 
-    assert (hermes_home / "trajectories" / "trajectory_samples.jsonl").exists()
+    assert _landed(hermes_home).exists()
     assert list(linked.glob("*.jsonl")) == []
 
 
@@ -175,7 +238,7 @@ def test_subdirectory_deep_in_repo_redirects(tmp_path, monkeypatch, hermes_home)
 
     save_trajectory(SAMPLE, "kimi-k2", completed=True)
 
-    assert (hermes_home / "trajectories" / "trajectory_samples.jsonl").exists()
+    assert _landed(hermes_home).exists()
     assert _tracked_and_untracked(repo) == ""
 
 
@@ -224,7 +287,7 @@ def test_config_default_is_redirect(tmp_path, monkeypatch, hermes_home):
 
     save_trajectory(SAMPLE, "kimi-k2", completed=True)
 
-    assert (hermes_home / "trajectories" / "trajectory_samples.jsonl").exists()
+    assert _landed(hermes_home).exists()
     assert _tracked_and_untracked(repo) == ""
 
 
@@ -233,8 +296,11 @@ def test_documented_default_matches_the_shipped_default():
 
     ``load_config()`` deep-merges ``DEFAULT_CONFIG`` at read time, so the key
     must be declared there for the documented default to be the effective one
-    (and for `hermes update` to list it as a new option). Asserts the contract
-    between the two, not a snapshot of the value.
+    — that deep-merge is the whole reason to declare it. (It is *not* so
+    `hermes update` lists it: ``get_missing_config_fields()`` calls
+    ``load_config()``, which merges ``DEFAULT_CONFIG`` first, so a declared key
+    is never reported missing.) Asserts the contract between the two, not a
+    snapshot of the value.
     """
     from hermes_cli.config_defaults import DEFAULT_CONFIG
 
@@ -243,13 +309,15 @@ def test_documented_default_matches_the_shipped_default():
 
 
 def test_relative_subdir_is_preserved(tmp_path, monkeypatch, hermes_home):
-    """A relative subdir is kept, so two callers' basenames can't collide."""
+    """A relative subdir is kept inside the per-work-tree directory."""
     repo = _git_repo(tmp_path / "repo")
     monkeypatch.chdir(repo)
 
     save_trajectory(SAMPLE, "m", completed=True, filename="out/run1.jsonl")
 
-    assert (hermes_home / "trajectories" / "out" / "run1.jsonl").exists()
+    landed = _landed(hermes_home, "run1.jsonl")
+    assert landed.parent.name == "out", f"subdir not preserved: {landed}"
+    assert landed.parent.parent.parent == hermes_home / "trajectories"
     assert _tracked_and_untracked(repo) == ""
 
 
@@ -268,7 +336,7 @@ def test_dotdot_inside_the_tree_is_contained(tmp_path, monkeypatch, hermes_home)
     save_trajectory(SAMPLE, "m", completed=True, filename="../up.jsonl")
 
     base = (hermes_home / "trajectories").resolve()
-    landed = base / "up.jsonl"
+    landed = _landed(hermes_home, "up.jsonl")
     assert landed.exists(), "redirected write vanished"
     assert base in landed.resolve().parents, "write escaped the trajectories dir"
     assert list(repo.rglob("*.jsonl")) == []
@@ -303,7 +371,7 @@ def test_warning_names_the_destination_and_dedupes(tmp_path, monkeypatch, hermes
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert len(warnings) == 1, "redirect warning should fire once per destination"
     msg = warnings[0].getMessage()
-    assert str(hermes_home / "trajectories" / "trajectory_samples.jsonl") in msg
+    assert str(_landed(hermes_home)) in msg
     assert "trajectory_allow_git_cwd" in msg, "warning must name the opt-out"
 
 
@@ -325,18 +393,724 @@ def test_run_agent_save_sample_uses_the_same_guard(tmp_path, monkeypatch, hermes
     ``save_trajectory`` does, under a relative ``sample_<uuid>.json``, so it is
     the same leak and must resolve through the same helper. Asserted on the
     resolver against a real repo rather than by driving the fire CLI (which
-    needs a live model), plus a wiring check that the CLI path calls it.
+    needs a live model).
     """
-    import inspect
-
     import run_agent
 
     repo = _git_repo(tmp_path / "repo")
     monkeypatch.chdir(repo)
 
     resolved = Path(run_agent.resolve_trajectory_path("sample_deadbeef.json"))
-    assert resolved.parent == hermes_home / "trajectories"
+    assert resolved.name == "sample_deadbeef.json"
+    assert resolved.parent.parent == hermes_home / "trajectories", \
+        f"--save_sample was not relocated under trajectories/: {resolved}"
+    assert list(repo.rglob("*.json")) == []
 
-    src = inspect.getsource(run_agent.main)
-    assert "resolve_trajectory_path(f\"sample_" in src, \
-        "--save_sample must route its filename through resolve_trajectory_path"
+
+# ── Fail closed, never into the checkout (review item 1) ────────────────────
+#
+# The pre-fix resolver returned the *original* filename from its broad
+# ``except``, so any error on the way to deciding "is this inside a repo?"
+# wrote the full transcript into the repo and said so only at ``debug``.
+# Measured before the fix: an unreadable ancestor left ``?? locked/`` and a
+# read-only HERMES_HOME left ``?? trajectory_samples.jsonl``. For a change
+# whose entire purpose is keeping transcripts out of checkouts, the failure
+# mode has to be "refuse and say so loudly", not "silently do the unsafe
+# thing". Skipping is chosen over a fallback location because a fallback in
+# /tmp is data the OS deletes and no pipeline reads — a silent loss dressed up
+# as a save. What must never happen either way: raising, since this runs during
+# turn finalization.
+
+
+def test_unreadable_ancestor_does_not_write_into_the_repo(tmp_path, monkeypatch, hermes_home):
+    """EACCES while deciding containment must not fall back to the CWD.
+
+    ``Path.exists()`` swallows ENOENT/ENOTDIR but *not* EACCES, and with an
+    unreadable ancestor ``os.getcwd()`` raises EACCES too — while a *relative*
+    ``open()`` still succeeds, because it resolves against the process's CWD
+    file descriptor and needs no path traversal. So "cannot determine" here
+    genuinely coexists with "the write would still land in the repo".
+    """
+    repo = _git_repo(tmp_path / "repo")
+    locked = repo / "locked"
+    child = locked / "child"
+    child.mkdir(parents=True)
+    monkeypatch.chdir(child)
+
+    os.chmod(locked, 0o000)
+    try:
+        # Must not raise: a trajectory save is a side effect of finalize_turn.
+        save_trajectory(SAMPLE, "m", completed=True)
+    finally:
+        os.chmod(locked, 0o755)
+
+    assert list(repo.rglob("*.jsonl")) == [], "transcript written inside the repo"
+    assert _tracked_and_untracked(repo) == "", "transcript is committable from the repo"
+
+
+def test_eacces_during_the_upward_walk_is_not_swallowed(tmp_path, monkeypatch, hermes_home):
+    """The walk's own ``.exists()`` must not swallow EACCES.
+
+    Distinct from the case above, where ``os.getcwd()`` fails first and the walk
+    is never reached. Here the CWD is readable and only the *target's* parent is
+    locked, so the guard genuinely depends on the loop raising: swallowing the
+    error would walk past the unreadable directory, find no ``.git``, conclude
+    "not in a repo", and return the in-repo filename.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    locked = repo / "locked"
+    (locked / "child").mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    os.chmod(locked, 0o000)
+    try:
+        assert resolve_trajectory_path("locked/child/t.jsonl") is None, \
+            "an unreadable ancestor must not be read as 'not in a repo'"
+        save_trajectory(SAMPLE, "m", completed=True, filename="locked/child/t.jsonl")
+    finally:
+        os.chmod(locked, 0o755)
+
+    assert list(repo.rglob("*.jsonl")) == [], "transcript written inside the repo"
+    assert _staged_jsonl(repo) == []
+
+
+def test_unwritable_hermes_home_does_not_write_into_the_repo(tmp_path, monkeypatch, hermes_home):
+    """The plausible case: a read-only or full HERMES_HOME.
+
+    ``mkdir`` of ``trajectories/`` raises, and the pre-fix code answered that by
+    writing the transcript into the checkout instead.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    _break_the_destination(hermes_home)
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    assert list(repo.rglob("*.jsonl")) == [], "transcript written inside the repo"
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_read_only_hermes_home_does_not_write_into_the_repo(tmp_path, monkeypatch, hermes_home):
+    """The same, driven by a real permission denial rather than ENOTDIR.
+
+    The config cache is warmed first so ``ensure_hermes_home()`` cannot repair
+    the mode mid-flight — this is the ordering the reviewer measured, where the
+    pre-fix code left ``?? trajectory_samples.jsonl`` in the repo.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    trajectory._allow_git_cwd()  # warm the config cache / ensure_hermes_home
+    os.chmod(hermes_home, 0o500)  # r-x: cannot create trajectories/
+    try:
+        save_trajectory(SAMPLE, "m", completed=True)
+    finally:
+        os.chmod(hermes_home, 0o755)
+
+    assert list(repo.rglob("*.jsonl")) == [], "transcript written inside the repo"
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_symlink_loop_does_not_write_into_the_repo(tmp_path, monkeypatch, hermes_home):
+    """``Path.resolve()`` raises ``RuntimeError`` on a loop, not ``OSError``.
+
+    The pre-fix inner handler caught only ``OSError``, so the loop escaped into
+    the outer handler and returned the in-repo filename.
+
+    The assertion is on the resolver's *decision*, not just on the absence of a
+    file: here ELOOP happens to block the ``open()`` too, so "no file appeared"
+    is true even unfixed. What was broken is that the guard answered "write it
+    to the checkout" — the same wrong answer it gives in the EACCES case, where
+    the write does land. Pin the decision and the bug class is covered.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    (repo / "a").symlink_to("b")
+    (repo / "b").symlink_to("a")
+    monkeypatch.chdir(repo)
+
+    assert resolve_trajectory_path("a/t.jsonl") is None, \
+        "an unresolvable path must be refused, not answered with the in-repo filename"
+
+    trajectory._REDIRECT_WARNED.clear()
+    save_trajectory(SAMPLE, "m", completed=True, filename="a/t.jsonl")
+
+    assert list(repo.rglob("*.jsonl")) == []
+    # The loop symlinks are the fixture's own; no transcript may be committable.
+    assert _staged_jsonl(repo) == []
+
+
+def test_skipped_save_is_reported_not_raised(tmp_path, monkeypatch, hermes_home, caplog):
+    """A refusal must be loud, and must not propagate out of the save.
+
+    ``finalize_turn`` guards ``_save_trajectory`` precisely because it is a
+    fallible side effect; turning a skip into an exception would trade a leak
+    for a broken turn.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    _break_the_destination(hermes_home)
+
+    with caplog.at_level("WARNING", logger="agent.trajectory"):
+        save_trajectory(SAMPLE, "m", completed=True)  # must not raise
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings, "a skipped trajectory save must be reported at WARNING"
+    assert any("NOT saved" in r.getMessage() for r in warnings), \
+        f"the notice must say the trajectory was not saved: {[r.getMessage() for r in warnings]}"
+
+
+def test_opt_out_still_wins_when_containment_is_undetermined(tmp_path, monkeypatch, hermes_home):
+    """``trajectory_allow_git_cwd: true`` means "my CWD, my choice" — always.
+
+    Failing closed must not override an explicit opt-out, or the escape hatch
+    would evaporate in exactly the broken-environment cases where a datagen run
+    needs it.
+    """
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  trajectory_allow_git_cwd: true\n", encoding="utf-8"
+    )
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    (repo / "a").symlink_to("b")
+    (repo / "b").symlink_to("a")
+
+    assert resolve_trajectory_path("a/t.jsonl") == "a/t.jsonl"
+
+
+def test_opt_out_is_unaffected_by_a_broken_destination(tmp_path, monkeypatch, hermes_home):
+    """Failing closed must never strand a user who opted into CWD writes.
+
+    With the opt-out on, HERMES_HOME is not on the path at all, so a broken one
+    is irrelevant — datagen keeps working.
+    """
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  trajectory_allow_git_cwd: true\n", encoding="utf-8"
+    )
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    _break_the_destination(hermes_home)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    assert (repo / "trajectory_samples.jsonl").exists(), \
+        "the opt-out stopped working when HERMES_HOME was broken"
+
+
+# ── The destination must not be committable either (review item 2) ──────────
+#
+# ``HERMES_HOME`` is a documented knob and ``git init ~`` (yadm / dotfiles) is
+# a real pattern, so the redirect target can itself sit inside a work tree.
+# Measured before the fix: ``git add -A`` would stage
+# ``.hermes/trajectories/trajectory_samples.jsonl`` — the warning's promise was
+# simply false. Refusing to write there would break trajectory saving for every
+# dotfiles user, so instead the destination is made *uncommittable* with a
+# self-ignoring .gitignore, and the notice tells the truth either way.
+
+
+def test_destination_inside_a_work_tree_is_not_committable(tmp_path, monkeypatch):
+    """HERMES_HOME inside the project: relocated, and unstageable there.
+
+    Presence inside the tree is not the exposure — ``git add -A`` staging it is.
+    """
+    repo = _git_repo(tmp_path / "myproject")
+    home = repo / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (repo / "src" / "deep").mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(repo / "src" / "deep")
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    landed = _landed(home)
+    assert landed.exists(), "trajectory vanished"
+    assert _jsonl(landed)[0]["conversations"] == SAMPLE, "content must survive"
+    assert "trajectory_samples.jsonl" not in _would_stage(repo), \
+        "git add -A would stage the transcript from the destination"
+    assert ".gitignore" not in _would_stage(repo), \
+        "the protective .gitignore must not itself become a tracked file"
+
+
+def test_home_as_work_tree_destination_is_not_committable(tmp_path, monkeypatch):
+    """``git init ~`` (dotfiles): the default HERMES_HOME is in a work tree.
+
+    The transcript moved out of the *project*, which is the fix's point, but it
+    must not become committable in ``$HOME`` as a side effect.
+    """
+    fake_home = tmp_path / "home" / "dev"
+    _git_repo(fake_home)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    project = _git_repo(tmp_path / "work" / "project")
+    monkeypatch.chdir(project)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    assert _tracked_and_untracked(project) == "", "leaked into the project"
+    assert "trajectory_samples.jsonl" not in _would_stage(fake_home), \
+        "git add -A in $HOME would stage the transcript"
+
+
+def test_notice_admits_when_the_destination_is_also_in_a_checkout(tmp_path, monkeypatch, caplog):
+    """The warning must not promise more than it delivers.
+
+    "so a full transcript is not left in your checkout" is misleading when the
+    destination is in one too; the user needs to know, and needs the remedy.
+    """
+    repo = _git_repo(tmp_path / "proj")
+    home = repo / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.chdir(repo)
+
+    with caplog.at_level("WARNING", logger="agent.trajectory"):
+        save_trajectory(SAMPLE, "m", completed=True)
+
+    msg = " ".join(r.getMessage() for r in caplog.records)
+    assert str(repo) in msg, "the notice must name the checkout the destination is in"
+    assert "HERMES_HOME" in msg, "the notice must name the remedy"
+
+
+def test_no_gitignore_side_effect_claim_when_destination_is_clean(tmp_path, monkeypatch, hermes_home, caplog):
+    """The normal install must not be told about a problem it doesn't have."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    with caplog.at_level("WARNING", logger="agent.trajectory"):
+        save_trajectory(SAMPLE, "m", completed=True)
+
+    msg = " ".join(r.getMessage() for r in caplog.records)
+    assert "itself inside the checkout" not in msg, \
+        f"spurious destination caveat on a clean HERMES_HOME: {msg}"
+
+
+# ── The notice has to reach a terminal (review item 3) ──────────────────────
+#
+# ``hermes_logging.setup_logging`` installs no stderr StreamHandler unless
+# --verbose, so ``logger.warning`` alone reached ``errors.log`` and nothing
+# else. Measured before the fix: zero lines on the terminal, one in errors.log.
+
+
+def test_redirect_notice_reaches_stderr_once(tmp_path, monkeypatch, hermes_home, capsys):
+    """One line on the terminal, naming the destination, exactly once.
+
+    Once per process, not per write: a datagen run saves every turn, and the
+    dedupe is a contract of its own (see
+    ``test_warning_names_the_destination_and_dedupes``).
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+    save_trajectory(SAMPLE, "m", completed=True)
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    err = capsys.readouterr().err
+    landed = _landed(hermes_home)
+    assert str(landed) in err, f"destination never reached the terminal: {err!r}"
+    assert err.count("Trajectory would have been written") == 1, \
+        f"notice should appear once per process, got:\n{err}"
+    # stderr, not stdout: piped trajectory data must stay clean.
+    assert "Trajectory would have been written" not in capsys.readouterr().out
+
+
+def test_status_line_destination_is_where_the_write_lands(tmp_path, monkeypatch, hermes_home):
+    """``AIAgent(save_trajectories=True)`` is the path datagen uses.
+
+    It printed "📝 Trajectory saving enabled" with no destination, so a
+    redirected file was findable only by hunting through ``errors.log``. The
+    contract: what the startup line reports is where the bytes actually go.
+    Asserted on the helper the status block calls, because ``init_agent()``
+    needs credentials and a live provider to construct.
+    """
+    from agent.trajectory import describe_trajectory_destination
+
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    described = describe_trajectory_destination()
+    save_trajectory(SAMPLE, "m", completed=True)
+    landed = _landed(hermes_home)
+
+    assert Path(described) == landed.parent, \
+        f"status line says {described!r} but the write landed at {landed}"
+    assert str(hermes_home) in described, "the reported destination is not under HERMES_HOME"
+
+
+def test_status_line_names_the_cwd_when_nothing_is_redirected(tmp_path, monkeypatch, hermes_home):
+    """Outside a checkout the line must name the real CWD file, not a bare name.
+
+    "trajectory_samples.jsonl" alone is what the user already couldn't find.
+    """
+    from agent.trajectory import describe_trajectory_destination
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.chdir(scratch)
+
+    described = describe_trajectory_destination()
+
+    assert Path(described).is_absolute(), f"not an absolute location: {described!r}"
+    assert Path(described) == scratch / "trajectory_samples.jsonl"
+
+
+def test_status_line_admits_an_unavailable_destination(tmp_path, monkeypatch, hermes_home):
+    """A skipped destination must be described, not reported as a real path."""
+    from agent.trajectory import describe_trajectory_destination
+
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    _break_the_destination(hermes_home)
+
+    assert "unavailable" in describe_trajectory_destination()
+
+
+# ── An existing pipeline must not go quietly stale (review item 4) ──────────
+#
+# The highest-severity finding: a pre-existing ./trajectory_samples.jsonl keeps
+# its plausible content and simply stops growing, so a pipeline reads a frozen
+# dataset forever. Worse than an empty one, which someone notices.
+#
+# The tension: the most discoverable place for a pointer is next to the stale
+# file — inside the checkout — but creating a file there is the very thing this
+# PR exists to stop, and the stale file is the user's data so it must not be
+# moved or rewritten. Resolved by keeping the signal entirely out-of-band: a
+# distinct, once-per-process notice on the terminal *and* in errors.log, naming
+# both paths and all three remedies, plus the docs. Nothing in the checkout is
+# created, moved, or modified.
+
+
+def test_pre_existing_in_repo_dataset_is_reported(tmp_path, monkeypatch, hermes_home, capsys, caplog):
+    """Upgrading with a dataset already in the checkout must be impossible to miss."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    stale = repo / "trajectory_samples.jsonl"
+    stale.write_text(
+        json.dumps({"conversations": SAMPLE, "model": "old", "completed": True}) + "\n",
+        encoding="utf-8",
+    )
+    before = stale.read_bytes()
+
+    with caplog.at_level("WARNING", logger="agent.trajectory"):
+        save_trajectory(SAMPLE, "new-model", completed=True)
+
+    err = capsys.readouterr().err
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    for where in (err, logged):
+        assert str(stale) in where, f"the stale dataset path was not named: {where!r}"
+        assert "NOT receive new entries" in where, \
+            f"the divergence was not stated plainly: {where!r}"
+
+    # The user's data is untouched — not moved, not appended to, not rewritten.
+    assert stale.read_bytes() == before, "the user's existing dataset was modified"
+
+    # And nothing new was created in their checkout, which is the PR's point.
+    assert _tracked_and_untracked(repo) == "?? trajectory_samples.jsonl\n", \
+        f"the guard added something to the checkout: {_tracked_and_untracked(repo)!r}"
+
+    # New entries went to the relocated dataset.
+    assert [e["model"] for e in _jsonl(_landed(hermes_home))] == ["new-model"]
+
+
+def test_stale_notice_is_silent_when_there_is_no_prior_dataset(tmp_path, monkeypatch, hermes_home, capsys):
+    """A fresh install has no divergence, so it must not be warned about one."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    err = capsys.readouterr().err
+    assert "NOT receive new entries" not in err, f"spurious staleness notice: {err!r}"
+
+
+def test_empty_pre_existing_file_is_not_reported_as_a_dataset(tmp_path, monkeypatch, hermes_home, capsys):
+    """A zero-byte leftover is not a dataset anyone is reading."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    (repo / "trajectory_samples.jsonl").write_text("", encoding="utf-8")
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    assert "NOT receive new entries" not in capsys.readouterr().err
+
+
+# ── Two repos keep two datasets (review item 5) ─────────────────────────────
+#
+# The pre-fix path was CWD-relative, so projA/ and projB/ each had their own
+# dataset. A single flat file merges them irreversibly: the entry schema has no
+# cwd/repo/session field, so afterwards the only discriminator is ``model``,
+# often identical. Measured before the fix: one file, two entries, no way back.
+#
+# Chosen fix: key the *path* per work tree, not add a provenance field to the
+# entry. The JSONL is a documented format consumed by training pipelines, so
+# widening the schema has a much larger blast radius — and it would write repo
+# paths into the dataset itself, which is a privacy regression in a PR about
+# not leaking local context. Path keying also restores exactly what users had
+# (one dataset per repo) and follows ``agent.moa_trace``'s per-session naming.
+
+
+def test_two_repos_keep_separate_datasets(tmp_path, monkeypatch, hermes_home):
+    """The merge has to be impossible, not merely documented."""
+    repo_a = _git_repo(tmp_path / "project-alpha")
+    repo_b = _git_repo(tmp_path / "project-beta")
+
+    monkeypatch.chdir(repo_a)
+    save_trajectory([{"from": "human", "value": "ALPHA"}], "m", completed=True)
+    monkeypatch.chdir(repo_b)
+    save_trajectory([{"from": "human", "value": "BETA"}], "m", completed=True)
+
+    found = sorted((hermes_home / "trajectories").rglob("trajectory_samples.jsonl"))
+    assert len(found) == 2, f"two repos must not share one dataset: {found}"
+
+    by_content = {_jsonl(p)[0]["conversations"][0]["value"]: p for p in found}
+    assert set(by_content) == {"ALPHA", "BETA"}
+    assert len(_jsonl(by_content["ALPHA"])) == 1, "alpha's dataset picked up beta's entry"
+    assert len(_jsonl(by_content["BETA"])) == 1, "beta's dataset picked up alpha's entry"
+
+
+def test_same_basename_repos_do_not_collide(tmp_path, monkeypatch, hermes_home):
+    """``~/a/proj`` and ``~/b/proj`` share a basename but are different repos.
+
+    A basename-only key would silently merge them, which is the bug again.
+    """
+    left = _git_repo(tmp_path / "a" / "proj")
+    right = _git_repo(tmp_path / "b" / "proj")
+
+    monkeypatch.chdir(left)
+    save_trajectory([{"from": "human", "value": "LEFT"}], "m", completed=True)
+    monkeypatch.chdir(right)
+    save_trajectory([{"from": "human", "value": "RIGHT"}], "m", completed=True)
+
+    found = sorted((hermes_home / "trajectories").rglob("trajectory_samples.jsonl"))
+    assert len(found) == 2, f"same-basename repos collided: {found}"
+
+
+def test_same_relative_subdir_in_two_repos_does_not_collide(tmp_path, monkeypatch, hermes_home):
+    """The claim the old comment made, now actually true.
+
+    Pre-fix, ``out/run.jsonl`` from two repos landed in one
+    ``trajectories/out/run.jsonl`` — measured, merged.
+    """
+    repo_a = _git_repo(tmp_path / "proj-a")
+    repo_b = _git_repo(tmp_path / "proj-b")
+
+    monkeypatch.chdir(repo_a)
+    save_trajectory([{"from": "human", "value": "A"}], "m", completed=True, filename="out/run.jsonl")
+    monkeypatch.chdir(repo_b)
+    save_trajectory([{"from": "human", "value": "B"}], "m", completed=True, filename="out/run.jsonl")
+
+    found = sorted((hermes_home / "trajectories").rglob("out/run.jsonl"))
+    assert len(found) == 2, f"same subdir in two repos still collides: {found}"
+    assert {_jsonl(p)[0]["conversations"][0]["value"] for p in found} == {"A", "B"}
+
+
+def test_one_repo_keeps_one_dataset_across_subdirectories(tmp_path, monkeypatch, hermes_home):
+    """Per *work tree*, not per CWD: one project is one dataset.
+
+    Runs from ``repo/`` and ``repo/src/deep/`` are the same project and must
+    accumulate together, or the guard would fragment a dataset instead.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    deep = repo / "src" / "deep"
+    deep.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.chdir(repo)
+    save_trajectory(SAMPLE, "from-root", completed=True)
+    monkeypatch.chdir(deep)
+    save_trajectory(SAMPLE, "from-deep", completed=True)
+
+    landed = _landed(hermes_home)
+    assert [e["model"] for e in _jsonl(landed)] == ["from-root", "from-deep"]
+
+
+def test_work_tree_key_is_stable_and_filesystem_safe(tmp_path):
+    """Same repo → same directory every process; no path separators leak in.
+
+    Stability is what makes appends accumulate across runs; a key derived from
+    anything per-process would scatter one project across many datasets.
+    """
+    repo = tmp_path / "My Repo (v2)"
+    repo.mkdir()
+    first = trajectory._work_tree_key(repo)
+    assert first == trajectory._work_tree_key(repo), "key is not stable"
+    assert trajectory._work_tree_key(tmp_path / "other") != first
+    assert "/" not in first and "\\" not in first and " " not in first
+    assert first.strip(". ") == first, "key must not start/end with dot or space (Windows)"
+
+
+def test_entry_schema_is_unchanged(tmp_path, monkeypatch, hermes_home):
+    """No provenance field was added to the documented format.
+
+    Keying the path was chosen precisely to avoid widening a schema that
+    training pipelines consume — and to keep repo paths out of the dataset.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    entry = _jsonl(_landed(hermes_home))[0]
+    assert set(entry) == {"conversations", "timestamp", "model", "completed"}
+    assert str(repo) not in json.dumps(entry), "a repo path leaked into the dataset"
+
+
+# ── Item 7 nits ─────────────────────────────────────────────────────────────
+
+
+def test_notice_does_not_claim_a_work_tree_that_may_not_exist(tmp_path, monkeypatch, hermes_home, caplog):
+    """A stray ``.git`` redirects (safe direction) — but isn't a work tree.
+
+    Naming "the git work tree at X" for a path that git would not recognise is
+    a lie in exactly the case the user has to reason about.
+    """
+    fake = tmp_path / "not-really-a-repo"
+    fake.mkdir()
+    (fake / ".git").write_text("this is not a gitdir pointer\n", encoding="utf-8")
+    monkeypatch.chdir(fake)
+
+    with caplog.at_level("WARNING", logger="agent.trajectory"):
+        save_trajectory(SAMPLE, "m", completed=True)
+
+    assert _landed(hermes_home).exists(), "a stray .git should still redirect"
+    msg = " ".join(r.getMessage() for r in caplog.records)
+    assert "git work tree at" not in msg, f"notice claims a work tree that may not exist: {msg}"
+    assert ".git found at" in msg, f"notice should state what was actually observed: {msg}"
+
+
+def test_git_env_vars_are_honoured(tmp_path, monkeypatch, hermes_home):
+    """``GIT_DIR`` alone makes the CWD the work tree — verified with git itself.
+
+    With only ``GIT_DIR`` set, ``git rev-parse --show-toplevel`` reports the CWD
+    and ``git add`` stages a file there, so a wrapper or CI runner driving a
+    repo this way from a ``.git``-less directory got no protection at all.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.chdir(scratch)
+
+    # Sanity-check the premise against real git rather than assuming it.
+    toplevel = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], cwd=scratch,
+        env={**os.environ, "GIT_DIR": str(repo / ".git")},
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert Path(toplevel).resolve() == scratch.resolve()
+
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    assert _landed(hermes_home).exists(), "GIT_DIR-driven work tree got no protection"
+    assert list(scratch.glob("*.jsonl")) == []
+
+
+def test_git_work_tree_env_var_is_honoured(tmp_path, monkeypatch, hermes_home):
+    """``GIT_WORK_TREE`` names the work tree outright."""
+    repo = _git_repo(tmp_path / "repo")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.chdir(scratch)
+    monkeypatch.setenv("GIT_DIR", str(repo / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(scratch))
+
+    save_trajectory(SAMPLE, "m", completed=True)
+
+    assert _landed(hermes_home).exists()
+    assert list(scratch.glob("*.jsonl")) == []
+
+
+def test_interior_dotdot_keeps_the_subdirectory(tmp_path, monkeypatch, hermes_home):
+    """``a/../b/keep.jsonl`` must keep ``b/``, not silently drop it.
+
+    ``".." not in path.parts`` flattened the whole path to its basename, so a
+    caller's requested subdirectory vanished without a word.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True, filename="a/../b/keep.jsonl")
+
+    landed = _landed(hermes_home, "keep.jsonl")
+    assert landed.parent.name == "b", f"interior '..' dropped the subdir: {landed}"
+
+
+def test_escaping_dotdot_is_still_contained(tmp_path, monkeypatch, hermes_home):
+    """Normalizing interior ``..`` must not become an escape hatch.
+
+    Two distinct cases, both correct:
+
+    * a ``..`` chain that resolves *outside* any work tree needs no protection
+      and is honoured as-is (there is no checkout to leak into);
+    * a ``..`` path that is still inside the tree is redirected, and must land
+      under ``trajectories/`` rather than climbing back out of it.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    nested = repo / "src" / "a"
+    nested.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(nested)
+
+    # Escapes every repo -> left alone, by design (verified: git_root is None).
+    outside = resolve_trajectory_path("../../../../../../tmp/pwned.jsonl")
+    assert outside == "../../../../../../tmp/pwned.jsonl"
+
+    # Still inside the tree -> redirected, and contained.
+    base = (hermes_home / "trajectories").resolve()
+    for candidate in ("../up.jsonl", "a/../../b/keep.jsonl", "./x/../y.jsonl"):
+        trajectory._REDIRECT_WARNED.clear()
+        resolved = resolve_trajectory_path(candidate)
+        assert resolved is not None, f"{candidate} was skipped unexpectedly"
+        assert base in Path(resolved).resolve().parents, \
+            f"{candidate} escaped trajectories/: {resolved}"
+
+
+# ── Docs must match shipped behaviour (review item 6) ───────────────────────
+
+
+# The reference pages must carry the full contract (destination + opt-out); the
+# guide pages must at least not send a datagen user to a path that stops
+# receiving entries, and must point at the reference for the rest.
+DOCS_REFERENCE = (
+    "website/docs/developer-guide/trajectory-format.md",
+    "website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/trajectory-format.md",
+)
+DOCS_GUIDE = (
+    "website/docs/guides/python-library.md",
+    "website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/python-library.md",
+)
+DOCS = DOCS_REFERENCE + DOCS_GUIDE
+
+
+@pytest.mark.parametrize("rel", DOCS)
+def test_docs_name_the_redirect_destination(rel):
+    """These are the snippets a datagen user copies.
+
+    English *and* the zh-Hans mirrors: a page that still says the file is in the
+    working directory sends the reader to a path that stops receiving entries.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    text = (repo_root / rel).read_text(encoding="utf-8")
+    assert "<HERMES_HOME>/trajectories/" in text, f"{rel} does not name the destination"
+
+
+@pytest.mark.parametrize("rel", DOCS_REFERENCE)
+def test_reference_docs_name_the_opt_out(rel):
+    """The reference page is where the escape hatch has to be discoverable."""
+    repo_root = Path(__file__).resolve().parents[2]
+    text = (repo_root / rel).read_text(encoding="utf-8")
+    assert "trajectory_allow_git_cwd" in text, f"{rel} does not name the config key"
+
+
+@pytest.mark.parametrize("rel", DOCS_REFERENCE)
+def test_trajectory_format_doc_drops_the_plain_cwd_claim(rel):
+    """"written to files in the current working directory" is now conditional.
+
+    The unqualified claim was the line a datagen user trusted, and the upgrade
+    path (a pre-existing dataset that stops growing) has to be written down —
+    the terminal notice scrolls away, the docs don't.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    text = (repo_root / rel).read_text(encoding="utf-8")
+    assert "Trajectories are written to files in the current working directory:" not in text
+    assert "轨迹写入当前工作目录下的文件：" not in text
+    assert ("Upgrading an existing pipeline" in text) or ("升级既有流水线" in text), \
+        f"{rel} does not document the upgrade/staleness path"

--- a/tests/agent/test_trajectory_git_cwd_guard.py
+++ b/tests/agent/test_trajectory_git_cwd_guard.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
@@ -291,7 +292,7 @@ def test_config_default_is_redirect(tmp_path, monkeypatch, hermes_home):
     assert _tracked_and_untracked(repo) == ""
 
 
-def test_documented_default_matches_the_shipped_default():
+def test_documented_default_matches_the_shipped_default(hermes_home):
     """``DEFAULT_CONFIG`` is what the read path resolves through.
 
     ``load_config()`` deep-merges ``DEFAULT_CONFIG`` at read time, so the key
@@ -301,11 +302,28 @@ def test_documented_default_matches_the_shipped_default():
     ``load_config()``, which merges ``DEFAULT_CONFIG`` first, so a declared key
     is never reported missing.) Asserts the contract between the two, not a
     snapshot of the value.
+
+    Two assertions, two different jobs:
+
+    * the *drift* invariant — whatever ``DEFAULT_CONFIG`` declares is what the
+      reader resolves to on a config-less home. ``is`` rather than ``==`` so a
+      truthy non-bool in either place is a failure, not a coincidence;
+    * the *direction* — stated once, and only here: this guard is a security
+      default, so "off unless the user opts in" is the contract, not a tunable.
+      A future PR flipping the shipped default to ``true`` should have to
+      delete this line and argue for it.
     """
     from hermes_cli.config_defaults import DEFAULT_CONFIG
 
-    assert DEFAULT_CONFIG["agent"]["trajectory_allow_git_cwd"] is False
-    assert trajectory._allow_git_cwd() is False
+    assert not (hermes_home / "config.yaml").exists(), "premise: no user override"
+    assert trajectory._allow_git_cwd() is DEFAULT_CONFIG["agent"]["trajectory_allow_git_cwd"], (
+        "the read path must resolve to the declared default; a value only in "
+        "cli-config.yaml.example is not merged at read time"
+    )
+    assert trajectory._allow_git_cwd() is False, (
+        "CWD placement must stay opt-in: defaulting this on puts a full "
+        "verbatim transcript back in the user's checkout"
+    )
 
 
 def test_relative_subdir_is_preserved(tmp_path, monkeypatch, hermes_home):
@@ -1134,6 +1152,20 @@ def test_escaping_dotdot_is_still_contained(tmp_path, monkeypatch, hermes_home):
 
 
 # ── Docs must match shipped behaviour (review item 6) ───────────────────────
+#
+# Scope, deliberately narrow: the only doc claim asserted here is one *derived
+# from the code at runtime* — the destination ``resolve_trajectory_path``
+# actually produces — plus the config key that turns the guard off. Both are
+# identifiers, so they can only disagree with the docs when the code and the
+# docs genuinely disagree; a faithful reword of the surrounding prose is free.
+#
+# Known gap, worth stating rather than papering over: these live in the Python
+# lane, and ``scripts/ci/classify_changes.py`` emits ``python=false`` for a
+# docs-only diff (``website/`` is in ``_PY_SKIP``). So a PR that *only* edits
+# these pages does not run them — they catch the code→docs direction (a rename
+# that leaves the docs stale, which does run the Python lane), not the
+# docs→code one. That is precisely why the assertions are derived from code:
+# the direction they can actually enforce is the one they now assert.
 
 
 # The reference pages must carry the full contract (destination + opt-out); the
@@ -1150,37 +1182,74 @@ DOCS_GUIDE = (
 DOCS = DOCS_REFERENCE + DOCS_GUIDE
 
 
-@pytest.mark.parametrize("rel", DOCS)
-def test_docs_name_the_redirect_destination(rel):
-    """These are the snippets a datagen user copies.
+def _doc_text(rel: str) -> str:
+    return (Path(__file__).resolve().parents[2] / rel).read_text(encoding="utf-8")
 
-    English *and* the zh-Hans mirrors: a page that still says the file is in the
-    working directory sends the reader to a path that stops receiving entries.
+
+def _names_token(text: str, token: str) -> bool:
+    """Does *text* name *token* as a whole path component / filename?
+
+    A bare ``in`` is too weak to be a real check here: renaming the default
+    dataset to ``samples.jsonl`` still substring-matches the documented
+    ``trajectory_samples.jsonl``, so the assertion passed against code that no
+    longer wrote that file (found by mutating the source and watching this test
+    stay green). Require a non-word character on the left and no word character
+    or ``.`` continuing on the right, so ``traject`` does not match
+    ``trajectories`` and ``samples.jsonl`` does not match
+    ``trajectory_samples.jsonl``, while the delimiters docs actually use around
+    a path — space, ``/``, backtick, quote, ``<``, line start — all do.
     """
-    repo_root = Path(__file__).resolve().parents[2]
-    text = (repo_root / rel).read_text(encoding="utf-8")
-    assert "<HERMES_HOME>/trajectories/" in text, f"{rel} does not name the destination"
+    return re.search(rf"(?:(?<=\W)|^){re.escape(token)}(?![\w.])", text) is not None
+
+
+@pytest.mark.parametrize("rel", DOCS)
+def test_docs_name_the_destination_the_code_produces(rel, tmp_path, monkeypatch, hermes_home):
+    """The pages a datagen user copies must name where the write actually lands.
+
+    Derived, not frozen: run the real ``resolve_trajectory_path`` in a real git
+    work tree, read the directory component and the default dataset filename
+    *off the resolved path*, and require the docs to contain those. Rename
+    ``trajectories/`` or the default filename in ``agent/trajectory.py`` and
+    all four pages fail until they are updated; reword the prose around them
+    and nothing fails, because no prose is asserted.
+
+    English *and* the zh-Hans mirrors: a page that still points at the working
+    directory sends the reader to a path that stops receiving entries, and a
+    directory name is not translated, so the same derived token applies to both.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    # Everything asserted below comes off a real write: save_trajectory owns
+    # the default filename (completed → samples) and resolve_trajectory_path
+    # owns the directory. Found by globbing HERMES_HOME itself — deliberately
+    # NOT via the ``_landed`` helper, which knows the name ``trajectories``
+    # and would make the derivation circular (rename the directory in the
+    # code and this test must fail on the doc assertion, not on the helper).
+    save_trajectory(SAMPLE, "m", completed=True)
+    hits = [p for p in hermes_home.resolve().rglob("*.jsonl") if p.is_file()]
+    assert len(hits) == 1, f"expected exactly one dataset under {hermes_home}, got {hits}"
+    landed = hits[0]
+    relative = landed.relative_to(hermes_home.resolve())
+    directory, filename = relative.parts[0], landed.name
+
+    text = _doc_text(rel)
+    assert _names_token(text, directory), (
+        f"{rel} does not name the {directory}/ destination the code writes to"
+    )
+    assert _names_token(text, filename), (
+        f"{rel} does not name {filename}, the dataset file the code writes"
+    )
 
 
 @pytest.mark.parametrize("rel", DOCS_REFERENCE)
 def test_reference_docs_name_the_opt_out(rel):
-    """The reference page is where the escape hatch has to be discoverable."""
-    repo_root = Path(__file__).resolve().parents[2]
-    text = (repo_root / rel).read_text(encoding="utf-8")
-    assert "trajectory_allow_git_cwd" in text, f"{rel} does not name the config key"
+    """The reference page is where the escape hatch has to be discoverable.
 
-
-@pytest.mark.parametrize("rel", DOCS_REFERENCE)
-def test_trajectory_format_doc_drops_the_plain_cwd_claim(rel):
-    """"written to files in the current working directory" is now conditional.
-
-    The unqualified claim was the line a datagen user trusted, and the upgrade
-    path (a pre-existing dataset that stops growing) has to be written down —
-    the terminal notice scrolls away, the docs don't.
+    A config key is an identifier, not prose: ``_allow_git_cwd()`` reads this
+    exact string, so the docs naming something else is a real defect, and
+    rewording the paragraph around it is not.
     """
-    repo_root = Path(__file__).resolve().parents[2]
-    text = (repo_root / rel).read_text(encoding="utf-8")
-    assert "Trajectories are written to files in the current working directory:" not in text
-    assert "轨迹写入当前工作目录下的文件：" not in text
-    assert ("Upgrading an existing pipeline" in text) or ("升级既有流水线" in text), \
-        f"{rel} does not document the upgrade/staleness path"
+    assert "trajectory_allow_git_cwd" in _doc_text(rel), (
+        f"{rel} does not name the config key the code reads"
+    )

--- a/tests/agent/test_trajectory_git_cwd_guard.py
+++ b/tests/agent/test_trajectory_git_cwd_guard.py
@@ -1,0 +1,342 @@
+"""Trajectory JSONL must not be dropped inside a git work tree.
+
+``save_trajectory`` is called from ``finalize_turn`` with a *relative* default
+filename, so it resolves against whatever CWD the agent was launched in —
+routinely a source checkout. That left a full verbatim transcript (message
+text, tool results, tool-call arguments) next to the user's source as an
+untracked file, one ``git add -A`` away from being published. See #77472
+(cluster R-DUMP).
+
+The contract these assert:
+
+* a relative write whose target is inside a git work tree is *relocated* under
+  ``<HERMES_HOME>/trajectories/``, byte-for-byte intact — trajectories are
+  training data, so the fix must never drop or truncate one;
+* nothing is left behind in the repo;
+* a CWD outside any git work tree is untouched;
+* CWD placement stays reachable, via an absolute path or the
+  ``agent.trajectory_allow_git_cwd`` config opt-out.
+
+These exercise the real ``save_trajectory`` → ``open()`` path with real file
+I/O against a temp HERMES_HOME and a real ``git init`` repo. Nothing on the
+write path is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import agent.trajectory as trajectory
+from agent.trajectory import resolve_trajectory_path, save_trajectory
+
+# A transcript with content that must survive the relocation verbatim: the
+# whole point of a trajectory is full fidelity for training.
+SAMPLE = [
+    {"from": "human", "value": "deploy with token ghp_EXAMPLENOTREAL"},
+    {"from": "gpt", "value": "<think>reasoning kept</think>done — 日本語 & \"quotes\""},
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_dedupe():
+    """The redirect warning dedupes per process; keep tests independent."""
+    trajectory._REDIRECT_WARNED.clear()
+    yield
+    trajectory._REDIRECT_WARNED.clear()
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir with no config.yaml (default config)."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _git_repo(root: Path) -> Path:
+    """Create a real git work tree at *root* with one committed file."""
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    (root / "src").mkdir()
+    (root / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=t",
+         "commit", "-qm", "init"],
+        cwd=root, check=True,
+    )
+    return root
+
+
+def _jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _tracked_and_untracked(root: Path) -> str:
+    """Everything git would offer to commit — the actual exposure."""
+    return subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root,
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def test_relative_write_in_git_repo_lands_in_hermes_home(tmp_path, monkeypatch, hermes_home):
+    """The default filename is relocated out of the checkout, intact."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo / "src")
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True)
+
+    landed = hermes_home / "trajectories" / "trajectory_samples.jsonl"
+    assert landed.exists(), "trajectory was not written to HERMES_HOME"
+
+    # Nothing left in the repo, by any name.
+    assert list(repo.rglob("*.jsonl")) == []
+    assert _tracked_and_untracked(repo) == "", "trajectory is committable from the repo"
+
+    # Full fidelity: the relocation must not drop or truncate the transcript.
+    entries = _jsonl(landed)
+    assert len(entries) == 1
+    assert entries[0]["conversations"] == SAMPLE
+    assert entries[0]["model"] == "kimi-k2"
+    assert entries[0]["completed"] is True
+
+
+def test_failed_trajectory_filename_also_relocated(tmp_path, monkeypatch, hermes_home):
+    """The ``completed=False`` filename is the same class of leak."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=False)
+
+    landed = hermes_home / "trajectories" / "failed_trajectories.jsonl"
+    assert landed.exists()
+    assert _jsonl(landed)[0]["completed"] is False
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_appends_accumulate_at_the_redirected_path(tmp_path, monkeypatch, hermes_home):
+    """Repeated turns append to one relocated file, not one file per turn."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo / "src")
+
+    save_trajectory(SAMPLE, "m1", completed=True)
+    save_trajectory(SAMPLE, "m2", completed=True)
+
+    entries = _jsonl(hermes_home / "trajectories" / "trajectory_samples.jsonl")
+    assert [e["model"] for e in entries] == ["m1", "m2"]
+
+
+def test_non_git_cwd_is_left_alone(tmp_path, monkeypatch, hermes_home):
+    """Outside a work tree there is nothing to protect — don't move the file.
+
+    This is the common datagen shape (a scratch dir / a datagen box) and the
+    guard must not disturb it.
+    """
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    assert not (scratch / ".git").exists()
+    monkeypatch.chdir(scratch)
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True)
+
+    assert (scratch / "trajectory_samples.jsonl").exists()
+    assert not (hermes_home / "trajectories").exists()
+
+
+def test_git_dir_as_file_still_redirects(tmp_path, monkeypatch, hermes_home):
+    """A linked worktree / submodule carries ``.git`` as a *file*.
+
+    A transcript is just as committable there, so an ``is_dir()`` check would
+    miss a real leak.
+    """
+    linked = tmp_path / "linked"
+    linked.mkdir()
+    (linked / ".git").write_text("gitdir: /elsewhere/.git/worktrees/linked\n", encoding="utf-8")
+    monkeypatch.chdir(linked)
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True)
+
+    assert (hermes_home / "trajectories" / "trajectory_samples.jsonl").exists()
+    assert list(linked.glob("*.jsonl")) == []
+
+
+def test_subdirectory_deep_in_repo_redirects(tmp_path, monkeypatch, hermes_home):
+    """The walk finds the root from any depth, not just the repo root."""
+    repo = _git_repo(tmp_path / "repo")
+    deep = repo / "src" / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    monkeypatch.chdir(deep)
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True)
+
+    assert (hermes_home / "trajectories" / "trajectory_samples.jsonl").exists()
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_absolute_path_inside_repo_is_honoured(tmp_path, monkeypatch, hermes_home):
+    """An explicit absolute path is a deliberate choice, not an ambient default.
+
+    This is the per-call escape hatch: a caller who really wants the file in a
+    checkout can still put it there.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+    explicit = repo / "src" / "wanted.jsonl"
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True, filename=str(explicit))
+
+    assert explicit.exists(), "an absolute path must not be redirected"
+    assert _jsonl(explicit)[0]["conversations"] == SAMPLE
+    assert not (hermes_home / "trajectories").exists()
+
+
+def test_config_opt_out_restores_cwd_write(tmp_path, monkeypatch, hermes_home):
+    """``agent.trajectory_allow_git_cwd: true`` restores the old behaviour.
+
+    Written as a real config.yaml under the temp HERMES_HOME and read through
+    the real loader, so this covers the config plumbing too.
+    """
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  trajectory_allow_git_cwd: true\n", encoding="utf-8"
+    )
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo / "src")
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True)
+
+    assert (repo / "src" / "trajectory_samples.jsonl").exists()
+    assert not (hermes_home / "trajectories").exists()
+
+
+def test_config_default_is_redirect(tmp_path, monkeypatch, hermes_home):
+    """An explicit ``false`` and an absent key must behave the same."""
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  trajectory_allow_git_cwd: false\n", encoding="utf-8"
+    )
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "kimi-k2", completed=True)
+
+    assert (hermes_home / "trajectories" / "trajectory_samples.jsonl").exists()
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_documented_default_matches_the_shipped_default():
+    """``DEFAULT_CONFIG`` is what the read path resolves through.
+
+    ``load_config()`` deep-merges ``DEFAULT_CONFIG`` at read time, so the key
+    must be declared there for the documented default to be the effective one
+    (and for `hermes update` to list it as a new option). Asserts the contract
+    between the two, not a snapshot of the value.
+    """
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["agent"]["trajectory_allow_git_cwd"] is False
+    assert trajectory._allow_git_cwd() is False
+
+
+def test_relative_subdir_is_preserved(tmp_path, monkeypatch, hermes_home):
+    """A relative subdir is kept, so two callers' basenames can't collide."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    save_trajectory(SAMPLE, "m", completed=True, filename="out/run1.jsonl")
+
+    assert (hermes_home / "trajectories" / "out" / "run1.jsonl").exists()
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_dotdot_inside_the_tree_is_contained(tmp_path, monkeypatch, hermes_home):
+    """A ``..`` path still inside the work tree is redirected, and flattened.
+
+    Flattening matters: joining the raw ``..`` onto the trajectories dir would
+    let the write climb back out of it.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    nested = repo / "src" / "a"
+    nested.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(nested)
+
+    # ../up.jsonl -> repo/src/up.jsonl: still in the tree, so still a leak.
+    save_trajectory(SAMPLE, "m", completed=True, filename="../up.jsonl")
+
+    base = (hermes_home / "trajectories").resolve()
+    landed = base / "up.jsonl"
+    assert landed.exists(), "redirected write vanished"
+    assert base in landed.resolve().parents, "write escaped the trajectories dir"
+    assert list(repo.rglob("*.jsonl")) == []
+    assert _tracked_and_untracked(repo) == ""
+
+
+def test_dotdot_resolving_outside_the_tree_is_left_alone(tmp_path, monkeypatch, hermes_home):
+    """A relative path that lands outside any work tree needs no protection.
+
+    The guard keys off the *resolved* target, not merely the CWD, so pointing
+    out of the checkout is honoured rather than second-guessed.
+    """
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo / "src")
+
+    # ../../outside.jsonl -> tmp_path/outside.jsonl, which is not in a repo.
+    save_trajectory(SAMPLE, "m", completed=True, filename="../../outside.jsonl")
+
+    assert (tmp_path / "outside.jsonl").exists()
+    assert not (hermes_home / "trajectories").exists()
+
+
+def test_warning_names_the_destination_and_dedupes(tmp_path, monkeypatch, hermes_home, caplog):
+    """The user must be able to find their training data, without log spam."""
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    with caplog.at_level("WARNING", logger="agent.trajectory"):
+        save_trajectory(SAMPLE, "m", completed=True)
+        save_trajectory(SAMPLE, "m", completed=True)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1, "redirect warning should fire once per destination"
+    msg = warnings[0].getMessage()
+    assert str(hermes_home / "trajectories" / "trajectory_samples.jsonl") in msg
+    assert "trajectory_allow_git_cwd" in msg, "warning must name the opt-out"
+
+
+def test_resolver_is_pure_for_absolute_and_non_git(tmp_path, monkeypatch, hermes_home):
+    """``resolve_trajectory_path`` returns its input when there's nothing to do."""
+    scratch = tmp_path / "plain"
+    scratch.mkdir()
+    monkeypatch.chdir(scratch)
+    assert resolve_trajectory_path("t.jsonl") == "t.jsonl"
+
+    abs_path = str(tmp_path / "anywhere.jsonl")
+    assert resolve_trajectory_path(abs_path) == abs_path
+
+
+def test_run_agent_save_sample_uses_the_same_guard(tmp_path, monkeypatch, hermes_home):
+    """``run_agent.py --save_sample`` writes the same content class to the CWD.
+
+    It builds its payload from ``_convert_to_trajectory_format`` exactly like
+    ``save_trajectory`` does, under a relative ``sample_<uuid>.json``, so it is
+    the same leak and must resolve through the same helper. Asserted on the
+    resolver against a real repo rather than by driving the fire CLI (which
+    needs a live model), plus a wiring check that the CLI path calls it.
+    """
+    import inspect
+
+    import run_agent
+
+    repo = _git_repo(tmp_path / "repo")
+    monkeypatch.chdir(repo)
+
+    resolved = Path(run_agent.resolve_trajectory_path("sample_deadbeef.json"))
+    assert resolved.parent == hermes_home / "trajectories"
+
+    src = inspect.getsource(run_agent.main)
+    assert "resolve_trajectory_path(f\"sample_" in src, \
+        "--save_sample must route its filename through resolve_trajectory_path"

--- a/website/docs/developer-guide/trajectory-format.md
+++ b/website/docs/developer-guide/trajectory-format.md
@@ -8,12 +8,47 @@ Source files: `agent/trajectory.py`, `run_agent.py` (search for `_save_trajector
 
 ## File Naming Convention
 
-Trajectories are written to files in the current working directory:
+Trajectories are written to the current working directory, **unless** that
+directory is inside a git checkout — see the warning below:
 
 | File | When |
 |------|------|
 | `trajectory_samples.jsonl` | Conversations that completed successfully (`completed=True`) |
 | `failed_trajectories.jsonl` | Conversations that failed or were interrupted (`completed=False`) |
+
+:::warning Inside a git checkout, the destination changes
+
+A trajectory is a **full verbatim transcript** — message text, tool results and
+tool-call arguments. When the current working directory is inside a git work
+tree, writing that next to your source leaves an untracked file one
+`git add -A` away from being published, so Hermes writes it under
+`<HERMES_HOME>/trajectories/<work-tree>/` instead (`~/.hermes/trajectories/…`
+by default) and prints a one-time notice naming the destination.
+
+- Nothing is dropped or truncated — only the destination changes.
+- `<work-tree>` is per-repository (`<basename>-<hash>`), so two checkouts keep
+  two datasets rather than merging into one file.
+- An **absolute** `filename` is always honoured as given, and
+  `agent.trajectory_allow_git_cwd: true` in `config.yaml` restores writing to
+  the working directory globally.
+- If the destination cannot be prepared safely (unreadable path, unwritable
+  `HERMES_HOME`), the save is **skipped** and reported rather than written into
+  your checkout.
+
+**Upgrading an existing pipeline:** a `./trajectory_samples.jsonl` already in
+your checkout is left exactly as it is and stops receiving new entries. Hermes
+says so on the terminal and in `errors.log` on the first save. Repoint the
+pipeline at the new path, concatenate the two files, or set
+`agent.trajectory_allow_git_cwd: true`.
+
+To find the active destination, list `trajectories/` under your Hermes home
+(`~/.hermes` by default; `hermes profile` prints the active one):
+
+```bash
+ls -R ~/.hermes/trajectories
+```
+
+:::
 
 The batch runner (`batch_runner.py`) writes to a custom output file per batch
 (e.g., `batch_001_output.jsonl`) with additional metadata fields.
@@ -194,6 +229,8 @@ def load_trajectories(path: str):
     return entries
 
 # Filter to successful completions only
+# Inside a git checkout the file lives under
+# <HERMES_HOME>/trajectories/<work-tree>/ — see "File Naming Convention".
 successful = [e for e in load_trajectories("trajectory_samples.jsonl")
               if e.get("completed")]
 
@@ -206,6 +243,9 @@ training_data = [e["conversations"] for e in successful]
 ```python
 from datasets import load_dataset
 
+# Point data_files at the path Hermes reported when saving; inside a git
+# checkout that is <HERMES_HOME>/trajectories/<work-tree>/trajectory_samples.jsonl
+# rather than the working directory.
 ds = load_dataset("json", data_files="trajectory_samples.jsonl")
 ```
 

--- a/website/docs/guides/python-library.md
+++ b/website/docs/guides/python-library.md
@@ -151,7 +151,11 @@ agent = AIAgent(
 )
 
 agent.chat("Write a Python function to sort a list")
-# Saves to trajectory_samples.jsonl in ShareGPT format
+# Saves to trajectory_samples.jsonl in ShareGPT format.
+# Inside a git checkout, that write is redirected under
+# <HERMES_HOME>/trajectories/<work-tree>/ instead, so a full verbatim
+# transcript is not left next to your source. The destination is printed on
+# startup; see the Trajectory Format guide for the details and the opt-out.
 ```
 
 Each conversation is appended as a single JSONL line, making it easy to collect datasets from automated runs.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/trajectory-format.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/trajectory-format.md
@@ -7,12 +7,42 @@ Hermes Agent 以 ShareGPT 兼容的 JSONL 格式保存对话轨迹，用于训�
 
 ## 文件命名规范
 
-轨迹写入当前工作目录下的文件：
+轨迹写入当前工作目录下的文件，**除非**该目录位于 git 检出目录内——见下方提示：
 
 | 文件 | 时机 |
 |------|------|
 | `trajectory_samples.jsonl` | 成功完成的对话（`completed=True`） |
 | `failed_trajectories.jsonl` | 失败或被中断的对话（`completed=False`） |
+
+:::warning 在 git 检出目录内，写入位置会改变
+
+轨迹是**完整逐字的对话记录**——消息正文、工具返回结果以及工具调用参数。
+当前工作目录位于 git 工作树内时，把它写在源码旁边会留下一个未跟踪文件，
+距离被 `git add -A` 提交只有一步之遥。因此 Hermes 会改为写入
+`<HERMES_HOME>/trajectories/<work-tree>/`（默认即 `~/.hermes/trajectories/…`），
+并打印一次性提示告知实际位置。
+
+- 不会丢弃或截断任何内容——只改变写入位置。
+- `<work-tree>` 按仓库区分（`<目录名>-<哈希>`），因此两个检出目录各自保留一份
+  数据集，而不会合并进同一个文件。
+- **绝对路径**的 `filename` 始终按原样使用；在 `config.yaml` 中设置
+  `agent.trajectory_allow_git_cwd: true` 可全局恢复写入工作目录。
+- 若无法安全准备目标位置（路径不可读、`HERMES_HOME` 不可写），本次保存会被
+  **跳过**并给出提示，而不会写进你的检出目录。
+
+**升级既有流水线：**检出目录中已存在的 `./trajectory_samples.jsonl` 会被原样保留，
+并且不再接收新条目。首次保存时 Hermes 会在终端和 `errors.log` 中说明这一点。
+请将流水线指向新路径、把两个文件拼接起来，或设置
+`agent.trajectory_allow_git_cwd: true`。
+
+查看当前实际位置：列出 Hermes 主目录（默认 `~/.hermes`，`hermes profile`
+会打印当前生效的目录）下的 `trajectories/`：
+
+```bash
+ls -R ~/.hermes/trajectories
+```
+
+:::
 
 批量运行器（`batch_runner.py`）按批次写入自定义输出文件
 （例如 `batch_001_output.jsonl`），并附带额外的元数据字段。
@@ -184,6 +214,8 @@ def load_trajectories(path: str):
     return entries
 
 # Filter to successful completions only
+# 在 git 检出目录内，该文件位于
+# <HERMES_HOME>/trajectories/<work-tree>/ —— 参见“文件命名规范”。
 successful = [e for e in load_trajectories("trajectory_samples.jsonl")
               if e.get("completed")]
 
@@ -196,6 +228,9 @@ training_data = [e["conversations"] for e in successful]
 ```python
 from datasets import load_dataset
 
+# 请把 data_files 指向 Hermes 在保存时提示的路径；在 git 检出目录内，
+# 该路径是 <HERMES_HOME>/trajectories/<work-tree>/trajectory_samples.jsonl，
+# 而不是工作目录。
 ds = load_dataset("json", data_files="trajectory_samples.jsonl")
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/python-library.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/python-library.md
@@ -151,7 +151,10 @@ agent = AIAgent(
 )
 
 agent.chat("Write a Python function to sort a list")
-# 以 ShareGPT 格式保存到 trajectory_samples.jsonl
+# 以 ShareGPT 格式保存到 trajectory_samples.jsonl。
+# 在 git 检出目录内，该写入会被重定向到
+# <HERMES_HOME>/trajectories/<work-tree>/，以免把完整逐字的对话记录
+# 留在源码旁边。启动时会打印实际位置；详情与关闭方式见《轨迹格式》文档。
 ```
 
 每次对话以单行 JSONL 的形式追加写入，便于从自动化运行中收集数据集。


### PR DESCRIPTION
## What does this PR do?

`agent/trajectory.py`'s `save_trajectory()` opens a **bare relative filename**, so
it resolves against whatever CWD the agent was launched in:

```python
filename = "trajectory_samples.jsonl" if completed else "failed_trajectories.jsonl"
...
with open(filename, "a", encoding="utf-8") as f:   # ← CWD, not HERMES_HOME
```

It is called from `finalize_turn` (`agent/turn_finalizer.py:250` → `run_agent.py`
`_save_trajectory` → `agent/trajectory.py`), so an agent run started inside a
source checkout appends a **full verbatim transcript** — message text, tool
results and tool-call arguments — next to the user's code as an untracked
`trajectory_samples.jsonl`, one `git add -A` away from being published.

This PR resolves a relative filename through a new `resolve_trajectory_path()`
first. When the resolved target sits inside a git work tree, the write goes
under `<HERMES_HOME>/trajectories/<work-tree>/` instead, and a one-time notice
names the destination on the terminal.

**Redirect, not refusal — deliberately.** Trajectories are training data and
exist to be full-fidelity, so refusing to write them by default would silently
break legitimate datagen runs inside a checkout. Nothing here is dropped,
truncated or redacted; only the destination changes, to the private directory
the rest of Hermes' state already uses. `agent/moa_trace.py` — the sibling
writer in the same issue cluster, carrying the same class of data — already
defaults under `<HERMES_HOME>/moa-traces/`, so this makes trajectory the
consistent case rather than the outlier.

**A user who wants trajectories in the CWD keeps three supported paths:**

| Path | Behaviour |
| --- | --- |
| absolute `filename=` | honoured as-is — an explicit path is a deliberate choice, not an ambient default |
| `agent.trajectory_allow_git_cwd: true` | restores the old behaviour globally |
| CWD outside any git work tree | untouched (a scratch dir, `/tmp`, a datagen box — already the common datagen shape) |

The knob is a `config.yaml` behavioural setting with a documented default in
`hermes_cli/config_defaults.py`, per `AGENTS.md`. **No new `HERMES_*` env var.**

### One dataset per work tree — not one flat shared file

The pre-fix path was CWD-relative, so `projA/` and `projB/` each accumulated
their own dataset. A single flat file under `trajectories/` would have merged
them **irreversibly**: the entry schema carries no `cwd`/repo/session field, so
after the merge the only discriminator is `model`, which is usually identical.

The relocated path is therefore keyed per work tree:

```
<HERMES_HOME>/trajectories/<basename>-<sha256(git_root)[:8]>/trajectory_samples.jsonl
```

Basename so the directory is recognisable, digest so `~/a/proj` and `~/b/proj`
cannot land in the same place. This follows `agent/moa_trace.py:128`, which keys
its trace file per session.

**Why key the path instead of adding a provenance field to the entry.** The
JSONL is a documented format consumed by training pipelines
(`website/docs/developer-guide/trajectory-format.md`), so widening the schema
has a much larger blast radius than changing a directory name — and a
`cwd`/repo field would write local filesystem paths *into the dataset*, which is
a privacy regression in a PR whose whole purpose is not leaking local context.
Path keying also restores exactly the shape users already had. The entry schema
is unchanged and asserted so by a test.

### Failing closed

If containment cannot be established — unreadable ancestor, symlink loop,
unwritable or full `HERMES_HOME` — `resolve_trajectory_path()` returns `None`
and **the save is skipped**, reported on the terminal and in `errors.log`. It
never writes into the checkout as a fallback, which was the pre-fix behaviour.

Skipping is chosen over falling back to a scratch location because a transcript
in `/tmp` is data the OS deletes and no pipeline reads — a silent loss dressed
up as a save. A skip is a returned decision, **never an exception**:
`save_trajectory` is a side effect of turn finalization, and turning a failed
trace into a raise would trade a leak for a broken turn.

### Scope boundary vs our other open PRs

This PR is about *where* the file is written. It does not change file modes:

- **#77520** — creates `trajectory_samples.jsonl` / `failed_trajectories.jsonl`
  `0600` and adds both to `.gitignore`. That protects *this repo's* checkout and
  the file's *permissions*; it does nothing for a user's own project where
  Hermes actually runs. Both PRs edit `agent/trajectory.py`: #77520 rewrites the
  `open()` call inside the `try`, this one assigns `filename` above it.
  `resolve_trajectory_path` runs *before* `open_private_append`, so the
  relocated file still lands `0600` when both are in — composition verified.
  Adjacent, not conflicting — whichever lands second may need a trivial rebase.
- **#77655** — modes for the remaining transcript artifacts, incl.
  `batch_runner.py`. Disjoint files from this PR.
- **#78395** — also edits `cli-config.yaml.example` and
  `hermes_cli/config_defaults.py`. **Checked: no textual collision.** In the
  example its hunk is `@@ -727,6 +727,23 @@ session_reset:`, mine is
  `@@ -823,0 +824,15 @@ agent:`; in `config_defaults.py` it appends inside the
  `sessions` block, mine inside `agent`. Either merge order applies cleanly.

**Directory mode, for the record:** `mkdir(parents=True, exist_ok=True)` creates
`trajectories/` at `0755` inside a `0700` `HERMES_HOME`, so the parent still
gates access and (with #77520) the file itself is `0600`.
`agent/moa_trace.py:127` does the same, so this is consistent with existing
code. Deliberately **not** tightened here — it would collide with
#77520/#77655's directory-mode work.

### Upgrading an existing pipeline (please read if you collect trajectories)

If you already have a `./trajectory_samples.jsonl` in a checkout, **it is left
exactly as it is and stops receiving new entries.** That is the nastiest
possible failure mode — worse than an empty dataset, because the file still
exists with plausible content and simply stops growing while a pipeline keeps
reading it. So Hermes now prints a distinct one-time notice naming both paths
and the three ways out (repoint the pipeline, concatenate, or set the opt-out),
logs it to `errors.log`, and documents it in the trajectory-format guide.

Your file is **not** moved or modified — it is your data — and nothing new is
created in your checkout, because not leaving files in checkouts is the entire
point of this change. The signal is deliberately out-of-band for that reason.

### Bug class: what I included and what I left out

**Included** `run_agent.py --save_sample`. It builds its payload from the same
`_convert_to_trajectory_format` under a relative `sample_<uuid>.json` and
`open(...,"w")`s it into the CWD — the same leak, so it routes through the same
helper.

**Deliberately left out** `batch_runner.py`'s `Path("data") / run_name`. It is
CWD-relative too, but it is not the same bug: it is the *primary declared
output* of an explicitly-invoked CLI tool, the path is printed on startup
(`Output directory: …`), and `--resume` re-derives it to glob `batch_*.jsonl`
and rebuild the completed-prompt set (`batch_runner.py:745`). It also passes
`save_trajectories=False` (`batch_runner.py:331`), so it never routes through
`save_trajectory` at all. Relocating it would silently orphan every in-progress
run — a "fix" that breaks the feature it protects. Happy to revisit batch output
placement as its own change if maintainers want it.

## Related Issue

Refs #77472

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/trajectory.py` — `resolve_trajectory_path()` (returns `Optional[str]`;
  `None` = do not write), `_find_git_root()` (mirrors `agent/prompt_builder.py`'s
  helper; `.exists()` so a linked worktree/submodule `.git` **file** counts;
  raises `_GitRootUndetermined` when the walk can't complete),
  `_explicit_work_tree()` (`GIT_DIR`/`GIT_WORK_TREE`), `_work_tree_key()`,
  `_contained_relative()`, `_shield_trajectories_dir()`,
  `_warn_pre_existing_dataset()`, `_notify_once()`,
  `describe_trajectory_destination()`, and `_allow_git_cwd()` (lazy read-only
  config read, per the `moa_trace` precedent).
- `agent/agent_init.py` — the `save_trajectories` status line now names the
  destination instead of a bare "Trajectory saving enabled".
- `run_agent.py` — `--save_sample` routed through the same helper and handles a
  skipped destination; `--save_trajectories` banner updated.
- `hermes_cli/config_defaults.py` — `agent.trajectory_allow_git_cwd: False`.
- `cli-config.yaml.example` — documents the key and the upgrade path.
- `website/docs/developer-guide/trajectory-format.md`,
  `website/docs/guides/python-library.md` **and both `zh-Hans` mirrors** — the
  docs said trajectories are written to the CWD and the copy-paste snippets
  (`load_trajectories(...)`, `data_files=...`) pointed at that path.
- `tests/agent/test_trajectory_git_cwd_guard.py` — 54 tests.

## How to Test

Measured before → after with a frozen timestamp so the comparison is exact,
same throwaway git repo, real `save_trajectory()` in a subprocess from
`repo/src` with `HERMES_HOME` pointed at a temp dir:

```
###### BEFORE (upstream/main, pre-PR) ######
  BEFORE landed: BEFORE-repo/src/trajectory_samples.jsonl
  BEFORE sha256: 966b8a4f90056500433e763749e5d94942c7f51af4e0fbedfef60982b9aafeb2  bytes: 5313
  BEFORE repo status: ?? src/trajectory_samples.jsonl
###### AFTER (this branch) ######
  AFTER landed: AFTER-home/trajectories/AFTER-repo-fe2feb65/trajectory_samples.jsonl
  AFTER sha256: 966b8a4f90056500433e763749e5d94942c7f51af4e0fbedfef60982b9aafeb2  bytes: 5313
  AFTER repo status: (clean)
###### BYTE COMPARISON ######
  cmp: IDENTICAL — relocation is byte-for-byte lossless
```

Identical sha256 on both sides is the point: the transcript is unchanged, it
just isn't in your repo any more. (Payload includes CJK, escaped quotes, a
backslash, a tab and a 5 KB tool result.)

Reproduce by hand:

```bash
cd $(mktemp -d) && git init -q . && mkdir src && cd src
python -c "from agent.trajectory import save_trajectory; \
  save_trajectory([{'from':'human','value':'secret'},{'from':'gpt','value':'ok'}],'m',True)"
git status --porcelain        # before: ?? src/trajectory_samples.jsonl / after: clean
ls -R ~/.hermes/trajectories  # after: <repo>-<hash>/trajectory_samples.jsonl
```

Automated:

```bash
./scripts/run_tests.sh tests/agent/test_trajectory_git_cwd_guard.py
# 54 passed
```

Tests exercise the real `save_trajectory()` → `open()` path against a real
`git init` repo and a temp `HERMES_HOME` — nothing on the write path is mocked.
Exposure is asserted with `git status --porcelain` **and** `git add -An`, since a
file physically inside a work tree but git-ignored is not actually committable.

**Teeth check** — the same tests against the previous head of this branch
(`4cf34daf3`): **31 failed, 21 passed**, so every behaviour added in this round
is pinned. Against unmodified `upstream/main` the module doesn't import at all.
Per finding: fail-closed 6, destination post-condition 4, terminal notice 4,
staleness 1, per-work-tree keying 6 (+2 shared), docs 8.

**Mutation testing** — 12 mutants, all caught: identity resolver (32 failed),
`_find_git_root`→`None` (31), inverted opt-out (35), restore fail-open (4),
swallow EACCES in the walk (1), skip the destination `.gitignore` (2), log-only
notice (2), drop the staleness notice (1), flat shared path (5), basename-only
key (1), ignore `GIT_DIR`/`GIT_WORK_TREE` (2), re-flatten interior `..` (1).

**Blast radius** — the same 86 test files as before: **2220 passed, 2 failed**
(was 2183/2; the +37 is this round's new tests). Both failures
(`tests/tools/test_wake_word.py::test_openwakeword_ensures_base_models_for_custom_path`,
`tests/tools/test_web_providers.py::…test_web_extract_tool_runs_discovery_before_registry_lookup`)
reproduce identically on a clean `upstream/main` worktree — pre-existing,
unrelated. Plus all 26 test files that reference trajectory saving: 496 passed,
0 failed.

**Concurrency** — two processes appending simultaneously to one dataset (same
repo), 40 entries × 40 KB and 15 × 1 MB, plus the two-repo case: zero corrupt
lines, zero lost entries, exact per-model counts in every configuration.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests (`./scripts/run_tests.sh`, CI parity) and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (trajectory-format + python-library
      guides and both `zh-Hans` mirrors, docstrings, banners)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] N/A — no architecture/workflow change
- [x] Cross-platform considered — see below
- [x] N/A — no tool schema change

### Cross-platform

`pathlib` only (`Path.resolve()`, `.parents`, `.exists()`, `.parts`) plus
`os.getcwd()`/`os.path.normpath` — no POSIX-only calls, no `chmod`, no shell out
on the write path (`git` is only invoked inside the tests, which follow 12
existing test files that do the same). `get_hermes_home()` already resolves
`%LOCALAPPDATA%\hermes` on Windows, so the redirect target is correct there. The
work-tree key is restricted to `[A-Za-z0-9._-]` and stripped of leading/trailing
dots and spaces, so it is a valid directory name on Windows too.
`scripts/check-windows-footguns.py` is clean on all changed files. The
`.git`-as-a-file case matters on every platform (linked worktrees, submodules).

**Windows append atomicity — untested, stated honestly.** The no-corruption
result above rests on POSIX `O_APPEND`, where each `write()` to a file opened
`"a"` is atomic with respect to the file offset. **Windows emulates append with
seek-then-write**, so concurrent appends to a *shared* file are a materially
different risk profile there, and I have not tested it — I'm on macOS and cannot.
Two notes on scope:

- This is **not** a regression introduced here. `save_trajectory` has always
  appended to a single shared path; the pre-fix path was shared per CWD, this
  one is shared per work tree.
- Per-work-tree keying **reduces** the sharing surface in the common case: two
  different projects no longer contend for one file at all. What remains is two
  processes in the *same* repo, which was already the pre-existing shape.

If a maintainer wants belt-and-braces on Windows, an `msvcrt.locking()` /
`portalocker` wrapper around the append would be the fix, but that is a separate
change to the write call (which #77520 is already rewriting) and I'd rather not
land untested platform-specific locking inside a placement fix.

Behaviour verified on macOS 15 arm64 / Python 3.11; the logic is
platform-independent and should hold on Linux and WSL2 — I have not run the
suite on Windows or WSL2.

