### PR TITLE
fix(moa): preserve facade across client rebuilds

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4856,14 +4856,34 @@ class AIAgent:
                 exc,
             )
 
+    def _build_primary_client_for_active_provider(self, *, reason: str) -> Any:
+        """Build the shared client shape required by the active provider.
+
+        MoA is a virtual provider whose ``client`` is an in-process facade,
+        not an OpenAI SDK client. Generic rebuild paths (credential rotation,
+        timeout application, and dead-connection cleanup) still pass through
+        this helper, so they must preserve that provider/client invariant.
+        """
+        if (getattr(self, "provider", "") or "").strip().lower() == "moa":
+            from agent.moa_loop import build_moa_facade
+
+            return build_moa_facade(self, self.model)
+        return self._create_openai_client(
+            self._client_kwargs,
+            reason=reason,
+            shared=True,
+        )
+
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:
-                new_client = self._create_openai_client(self._client_kwargs, reason=reason, shared=True)
+                new_client = self._build_primary_client_for_active_provider(
+                    reason=reason,
+                )
             except Exception as exc:
                 logger.warning(
-                    "Failed to rebuild shared OpenAI client (%s) %s error=%s",
+                    "Failed to rebuild shared primary client (%s) %s error=%s",
                     reason,
                     self._client_log_context(),
                     exc,

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -215,6 +215,93 @@ moa:
     assert ref_event[2] == {"moa_index": 0, "moa_count": 1}
 
 
+def test_moa_generic_client_rebuild_preserves_virtual_facade(monkeypatch, tmp_path):
+    """Generic client replacement must not install a native OpenAI client.
+
+    Credential rotation and timeout/dead-connection recovery call the shared
+    replacement helper. If it rebuilds from stale fallback ``_client_kwargs``,
+    the next prepared MoA request leaks its private kwarg into the OpenAI SDK.
+    """
+    from agent.chat_completion_helpers import _dispatch_nonstreaming_api_request
+    from agent.moa_loop import MoAClient
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
+    )
+    original_client = agent.client
+    agent._client_kwargs = {
+        "api_key": "stale-fallback-key",
+        "base_url": "https://relay.example/v1",
+    }
+    monkeypatch.setattr(
+        agent,
+        "_create_openai_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("MoA replacement must rebuild its facade")
+        ),
+    )
+
+    assert agent._replace_primary_openai_client(reason="credential_rotation") is True
+    assert isinstance(agent.client, MoAClient)
+    assert agent.client is not original_client
+
+    captured = {}
+
+    def accept_prepared(prepared, api_kwargs):
+        captured["prepared"] = prepared
+        captured["api_kwargs"] = api_kwargs
+        return "aggregated"
+
+    monkeypatch.setattr(
+        agent.client.chat.completions,
+        "_call_prepared_aggregator",
+        accept_prepared,
+    )
+    prepared = {"messages": [], "guidance": "advice"}
+    result = _dispatch_nonstreaming_api_request(
+        agent,
+        {
+            "model": "review",
+            "messages": [],
+            "_moa_prepared_request": prepared,
+        },
+        make_client=lambda *_args, **_kwargs: pytest.fail(
+            "MoA dispatch must not build a request-local OpenAI client"
+        ),
+    )
+
+    assert result == "aggregated"
+    assert captured["prepared"] is prepared
+    assert "_moa_prepared_request" not in captured["api_kwargs"]
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Preserves the virtual `MoAClient` facade when Hermes rebuilds the shared primary client during credential rotation, timeout updates, or dead-connection recovery.

MoA uses an in-process facade to consume the private `_moa_prepared_request` argument. The generic `_replace_primary_openai_client()` path ignored the active provider and rebuilt a native OpenAI SDK client from stale `_client_kwargs`. The next MoA request then leaked `_moa_prepared_request` into the OpenAI SDK and crashed with `TypeError`.

The replacement path is now provider-aware: it rebuilds the MoA facade with `build_moa_facade()` for the `moa` provider while preserving the existing OpenAI client behavior for every other provider. Existing safe retirement behavior for the replaced client remains unchanged.

## Related Issue

Fixes #78382

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a provider-aware shared-client builder in `run_agent.py`.
- Preserved `MoAClient` across the generic primary-client replacement path.
- Added an end-to-end regression test covering replacement through non-streaming MoA dispatch.

## How to Test

1. Configure an MoA preset and initialize an `AIAgent` with `provider="moa"`.
2. Trigger `_replace_primary_openai_client()` as credential rotation or connection recovery would.
3. Dispatch a request containing `_moa_prepared_request` and verify the MoA facade consumes it instead of forwarding it to a native OpenAI client.

Validation performed:

- Reproduced the current-`main` failure: `TypeError: unexpected _moa_prepared_request`.
- Ran 55 targeted tests across MoA loop mode, request-client reuse, and primary-runtime restore; all passed.
- Ruff passed for both changed files.
- `git diff --check` passed.

## Duplicate Check

Searched current open PRs for `#78382`, `_moa_prepared_request`, `moa client rebuild facade`, and `moa fallback rotation`; no matching open PR was found. Earlier #70280 / #53802 covered restore and recovery paths, but not this generic replacement path.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on Windows 11
- [ ] Full `pytest tests/ -q` suite run (55 focused regression tests passed)

### Documentation & Housekeeping

- [x] Documentation changes are N/A
- [x] Config example changes are N/A
- [x] Contributor-guide changes are N/A
- [x] Tool description/schema changes are N/A
- [x] Cross-platform impact was considered; the change is provider/runtime logic with no platform-specific behavior
