### PR TITLE
fix(dashboard): link relay connector docs

### DIFF
--- a/contributors/emails/xuezhao@gmail.com
+++ b/contributors/emails/xuezhao@gmail.com
@@ -1,0 +1,1 @@
+xuezhaolan

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7839,7 +7839,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     "relay": {
         "name": "Relay (experimental)",
         "description": "Generic relay adapter fronted by the Hermes Relay connector.",
-        "docs_url": "",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/relay",
         "required_env": (),
     },
 }

--- a/tests/hermes_cli/test_relay_platform_docs_url.py
+++ b/tests/hermes_cli/test_relay_platform_docs_url.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+DOCS_URL = "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/relay"
+
+
+def test_relay_platform_override_links_to_existing_docs_page():
+    repo_root = Path(__file__).resolve().parents[2]
+    web_server_source = (repo_root / "hermes_cli" / "web_server.py").read_text()
+    docs_page = repo_root / "website" / "docs" / "user-guide" / "messaging" / "relay.md"
+
+    assert '"relay": {' in web_server_source
+    assert f'"docs_url": "{DOCS_URL}"' in web_server_source
+    assert docs_page.exists()


### PR DESCRIPTION
## Summary
- Adds the existing Relay messaging docs URL to the Relay channel metadata.
- Covers the metadata link with a small regression test that also verifies the docs page exists.

Closes #78373

## Test Plan
- python -m pytest tests/hermes_cli/test_relay_platform_docs_url.py -q -o 'addopts='
- python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_relay_platform_docs_url.py
- git diff --check
- Independent Codex diff review: no security or logic issues found