### PR TITLE
feat(providers): add Nexforce Router model provider plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@
 # Get your key at: https://openrouter.ai/keys
 # OPENROUTER_API_KEY=
 
+# =============================================================================
+# LLM PROVIDER (Nexforce Router)
+# =============================================================================
+# OpenAI-compatible gateway: one key routes to Anthropic, OpenAI, Google,
+# DeepSeek, Moonshot, Zhipu and Workers AI models, with per-key fallback and
+# cost control. Get your key at:
+#   https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys
+# NEXFORCE_API_KEY=
+
 # Default model is configured in ~/.hermes/config.yaml (model.default).
 # Use 'hermes model' or 'hermes setup' to change it.
 # LLM_MODEL is no longer read from .env — this line is kept for reference only.

--- a/plugins/model-providers/nexforce/__init__.py
+++ b/plugins/model-providers/nexforce/__init__.py
@@ -1,0 +1,37 @@
+"""Nexforce Router provider profile.
+
+Nexforce Router is an OpenAI-compatible inference gateway: one endpoint and
+one API key dispatch to Anthropic, OpenAI, Google, DeepSeek, Moonshot,
+Zhipu and Cloudflare Workers AI models, with per-key fallback chains and
+cost control. The catalog is served live at ``/v1/models`` (public without
+a key). Requests may be attributed per agent via the ``X-Nexforce-Agent``
+header; Hermes sets it to its own agent name so usage shows up separately
+in the Nexforce console.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+nexforce = ProviderProfile(
+    name="nexforce",
+    aliases=("nexforce-router",),
+    display_name="Nexforce Router",
+    description="Nexforce Router (OpenAI-compatible multi-provider endpoint)",
+    signup_url="https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys",
+    env_vars=("NEXFORCE_API_KEY",),
+    base_url="https://router.nexforce.ai/v1",
+    models_url="https://router.nexforce.ai/v1/models",
+    auth_type="api_key",
+    default_headers={"X-Nexforce-Agent": "hermes-agent"},
+    default_aux_model="deepseek/deepseek-v4-flash",
+    fallback_models=(
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "deepseek/deepseek-v4-flash",
+        "google/gemini-3.6-flash",
+        "z-ai/glm-5",
+    ),
+)
+
+register_provider(nexforce)

--- a/plugins/model-providers/nexforce/plugin.yaml
+++ b/plugins/model-providers/nexforce/plugin.yaml
@@ -1,0 +1,5 @@
+name: nexforce-provider
+kind: model-provider
+version: 1.0.0
+description: Nexforce Router (OpenAI-compatible multi-provider endpoint)
+author: vitti


### PR DESCRIPTION
## Summary

This PR brings **Nexforce Router** to Hermes — **Latin America's largest AI inference router**. Hermes users get a single API key and endpoint (`https://router.nexforce.ai/v1`) that reaches **Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu and Cloudflare Workers AI** models, with per-key fallback chains and per-key cost control.

What makes it a great fit for the region:

- **Local billing & compliance.** Invoicing, taxes, and payment infrastructure are handled locally for each country in the region, so teams get compliant, locally-issued invoices without the FX and procurement friction of paying a foreign provider.
- **Cost control per key.** Fallback chains, rate limits, and spend caps are configured per API key — you always know which model answered and what it cost.
- **Full transparency.** Response headers `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` disclose exactly which model served each request.
- **One catalog, live.** `GET /v1/models` is public (no key) — verified live: 139 models across Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu and Cloudflare Workers AI. Hermes fetches it automatically for the model picker.
- **`nexforce/smart-route`** — a special model id that lets the router pick a capability-equivalent model per request.

## Changes

- `plugins/model-providers/nexforce/__init__.py` — declarative `ProviderProfile` (no core edits; auto-wires into the provider registry, `hermes model` picker, `hermes setup`/`hermes doctor`, and auxiliary-model resolution). Sends `X-Nexforce-Agent: hermes-agent` so usage shows up per-agent in the Nexforce console.
- `plugins/model-providers/nexforce/plugin.yaml` — manifest (`kind: model-provider`).
- `.env.example` — `NEXFORCE_API_KEY` block.

## Getting started

1. Get a key at the [Nexforce console](https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys) (format `nfc_...`).
2. Set `NEXFORCE_API_KEY` in `~/.hermes/.env`.
3. Run `hermes model`, pick **Nexforce Router**, and choose any model from the live catalog — or let `nexforce/smart-route` decide for you.

## Verification

- Plugin discovery registers the profile; live `/v1/models` fetch returns 139 models.
- Auto-extension confirmed for `CANONICAL_PROVIDERS`, `PROVIDER_REGISTRY`, and `OPTIONAL_ENV_VARS`.
- `scripts/run_tests.sh tests/providers/ -q` — 7 files, 47 tests passed.
- `ruff check plugins/model-providers/nexforce/` — clean.
