### PR TITLE
fix(buzz): thread replies crossing between threads in a channel

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1056,6 +1056,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=self._thread_id_from_event(event),
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1204,6 +1205,41 @@ class BuzzAdapter(BasePlatformAdapter):
         while len(seen) > _SEEN_CAP:
             seen.popitem(last=False)
 
+    @staticmethod
+    def _thread_id_from_event(event: dict) -> Optional[str]:
+        """Extract the Buzz thread root id from a message's ``e`` tags.
+
+        Buzz threads are keyed by their ROOT event id (``buzz messages
+        thread --event <root>``). A message inside a thread carries
+        ``["e", <root>, "", "root"]`` (thread root) plus optionally
+        ``["e", <parent>, "", "reply"]`` (immediate parent). A direct reply
+        to a top-level message carries only the ``reply`` tag, whose target
+        IS the root. Top-level messages carry no ``e`` tags at all. Some
+        relays/clients emit the older 3-element form ``["e", <id>, "root"]``
+        (marker in position 2, no relay URL) — both shapes are accepted.
+
+        Returning the ROOT (not the parent) keeps every message in one
+        thread on the same session key — the reply-only fallback covers the
+        depth-2 case where root == parent. Without this, all threads in a
+        channel collapse into ONE session key (thread_id is None) and the
+        gateway's busy interrupt/queue machinery crosses events between
+        threads (reply A lands in thread B and vice versa).
+        """
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return None
+        root_id = None
+        reply_id = None
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) < 2 or tag[0] != "e":
+                continue
+            marker = str(tag[3]) if len(tag) > 3 else (str(tag[2]) if len(tag) > 2 else "")
+            if marker == "root" and not root_id:
+                root_id = str(tag[1])
+            elif marker == "reply" and not reply_id:
+                reply_id = str(tag[1])
+        return root_id or reply_id
+
     def _mark_seen(self, channel_id: str, event_id: str) -> None:
         state = self._channel_state.get(channel_id)
         if state is not None:
@@ -1219,6 +1255,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1230,6 +1267,7 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -251,6 +251,127 @@ class TestMentionGating:
         assert adapter._dispatched == []
 
 
+# ── Thread routing (root e-tag → session thread_id) ──────────────────────
+#
+# Buzz threads are keyed by their ROOT event id (`buzz messages thread
+# --event <root>`).  The adapter must propagate it as thread_id on the
+# dispatched source, otherwise every thread in a channel collapses into one
+# session key and the gateway's busy interrupt/queue machinery crosses
+# events between threads (reply A lands in thread B and vice versa).
+
+
+class TestThreadRouting:
+
+    @pytest.fixture
+    def adapter(self):
+        a = _make_adapter()
+        a._dispatched = []
+
+        async def capture(**kwargs):
+            a._dispatched.append(kwargs)
+
+        a._dispatch_message = capture
+        a._message_handler = AsyncMock()
+        a._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        return a
+
+    async def _poll_with(self, adapter, *events):
+        cli = _ScriptedCli()
+        cli.script("messages", "get", list(events))
+        adapter._run_cli = cli
+        await adapter._poll_channel(CHANNEL)
+
+    def test_thread_id_from_event_root_tag(self):
+        """Deep thread reply → the ``root`` e-tag wins."""
+        ev = {"tags": [["h", CHANNEL], ["e", "ROOTID", "", "root"], ["e", "PARENTID", "", "reply"]]}
+        assert BuzzAdapter._thread_id_from_event(ev) == "ROOTID"
+
+    def test_thread_id_from_event_depth2_reply_only(self):
+        """Direct reply to a top-level message → the ``reply`` target IS the root."""
+        ev = {"tags": [["h", CHANNEL], ["e", "ROOTID", "", "reply"]]}
+        assert BuzzAdapter._thread_id_from_event(ev) == "ROOTID"
+
+    def test_thread_id_from_event_three_element_tag(self):
+        """3-element e-tag (no relay URL) — marker lives in position 2."""
+        ev = {"tags": [["e", "ROOTID", "root"]]}
+        assert BuzzAdapter._thread_id_from_event(ev) == "ROOTID"
+        ev = {"tags": [["e", "PARENTID", "reply"]]}
+        assert BuzzAdapter._thread_id_from_event(ev) == "PARENTID"
+
+    def test_thread_id_from_event_top_level(self):
+        """Top-level message (no e-tags) → no thread."""
+        assert BuzzAdapter._thread_id_from_event({"tags": [["h", CHANNEL]]}) is None
+
+    def test_thread_id_from_event_missing_tags(self):
+        """Missing/malformed tags never crash."""
+        assert BuzzAdapter._thread_id_from_event({}) is None
+        assert BuzzAdapter._thread_id_from_event({"tags": None}) is None
+        assert BuzzAdapter._thread_id_from_event({"tags": ["not-a-tag"]}) is None
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_dispatches_with_thread_id(self, adapter):
+        """A reply inside a thread carries the ROOT id as thread_id."""
+        root = "r" * 64
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, content="hey @Chip, in thread",
+                          created_at=10, reply_to="PARENT",
+                          root=root),
+        )
+        assert len(adapter._dispatched) == 1
+        assert adapter._dispatched[0]["thread_id"] == root
+
+    @pytest.mark.asyncio
+    async def test_top_level_message_dispatches_without_thread_id(self, adapter):
+        await self._poll_with(
+            adapter,
+            _tagged_event("e1", CHANNEL, content="hey @Chip top level", created_at=10),
+        )
+        assert len(adapter._dispatched) == 1
+        assert adapter._dispatched[0]["thread_id"] is None
+
+    def test_session_keys_isolate_threads_and_keep_top_level(self):
+        """E2E on the real resolution chain: adapter.build_source →
+        gateway.session.build_session_key.  The reported bug: two threads in
+        one channel collapsed into ONE session key (thread_id was None), so
+        the gateway's busy interrupt/queue machinery crossed events between
+        them.  With thread_id propagated, each thread must get its own key,
+        and top-level messages must NOT share the threaded sessions."""
+        from gateway.session import build_session_key
+
+        adapter = _make_adapter()
+        thread_a_root = "aa" + ("1" * 62)
+        thread_b_root = "bb" + ("2" * 62)
+        source_a = adapter.build_source(
+            chat_id=CHANNEL, chat_type="group",
+            user_id=OTHER_PUBKEY, user_name="other",
+            thread_id=thread_a_root,
+        )
+        source_b = adapter.build_source(
+            chat_id=CHANNEL, chat_type="group",
+            user_id=OTHER_PUBKEY, user_name="other",
+            thread_id=thread_b_root,
+        )
+        source_top = adapter.build_source(
+            chat_id=CHANNEL, chat_type="group",
+            user_id=OTHER_PUBKEY, user_name="other",
+        )
+        key_a = build_session_key(source_a)
+        key_b = build_session_key(source_b)
+        key_top = build_session_key(source_top)
+
+        # Thread A and thread B must never share a session (the bug).
+        assert key_a != key_b
+        # Thread keys are stable per root and carry the root id.
+        assert thread_a_root in key_a
+        assert thread_b_root in key_b
+        # Top-level messages keep their own channel-scoped session — they are
+        # not pulled into either thread's conversation.
+        assert key_top not in (key_a, key_b)
+        assert thread_a_root not in key_top
+        assert thread_b_root not in key_top
+
+
 # ── DM classification via p-tags (issue #68871) ──────────────────────────
 #
 # `buzz dms list` returns [] on some hosted relays, so DM conversations leak
@@ -261,9 +382,11 @@ class TestMentionGating:
 
 
 def _tagged_event(event_id, channel, *, content, pubkey=OTHER_PUBKEY,
-                  created_at=1000, kind=9, p=None, reply_to=None):
+                  created_at=1000, kind=9, p=None, reply_to=None, root=None):
     """Event with the tag shapes observed on a live relay (h/p/e tags)."""
     tags = [["h", channel]]
+    if root:
+        tags.append(["e", root, "", "root"])
     if reply_to:
         tags.append(["e", reply_to, "", "reply"])
     if p:


### PR DESCRIPTION
## Summary

Fixes thread replies crossing between threads in the same Buzz channel — reply to thread A lands in thread B and vice versa.

**Root cause:** the Buzz adapter never extracted thread identity from incoming events. Buzz threads are keyed by their ROOT event id (`buzz messages thread --event <root>`); a thread reply carries `["e", <root>, "", "root"]` (+ `["e", <parent>, "", "reply"]` for the immediate parent; a direct reply to a top-level message carries only the `reply` tag whose target IS the root). The adapter's receive path ignored these tags entirely, so `build_session_key` collapsed **all threads within a channel into one session key** (`agent:main:buzz:group:<channel>:<user>`).

While thread A's turn is running, a message posted in thread B hits the same session; the gateway's busy interrupt/queue machinery treats them as one conversation and crosses the events — B's text gets injected into A's run, and the queued event's reply anchor resends under the wrong turn.

**Fix:**
- New `BuzzAdapter._thread_id_from_event(event)` — scans `event["tags"]` for `["e", <id>, "", "root"]` (thread root) and `["e", <id>, "", "reply"]` (immediate parent; for a direct reply to a top-level post this IS the root). Returns `root_id or reply_id`; `None` for top-level messages. Root (not parent) chosen because `buzz messages thread --event <ROOT>` proves the root event id is Buzz's canonical thread identity, and rooting keeps all messages from one thread on the same session key. Both the 4-element form (`["e", <id>, "", "root"]`) and the older 3-element form (`["e", <id>, "root"]`, marker in position 2, no relay URL) are accepted.
- `_dispatch_message(...)` gained `thread_id: Optional[str] = None`, forwarded into `build_source`.
- `_handle_event` passes `thread_id=self._thread_id_from_event(event)`.

Both WS and poll transports funnel through `_handle_event` → one patch covers both. `send()` already does `--reply-to <event_id>`, so final-reply anchoring stays per-event.

**Bonus:** with `thread_id` set, progress/status bubbles would also anchor in-thread if re-enabled.

## Test Plan

- New `TestThreadRouting` class in `tests/gateway/test_buzz_adapter.py` (8 cases): root-tag wins, depth-2 reply-only fallback, 3-element tag shape, top-level → None, missing/malformed tags never crash, threaded dispatch carries root as `thread_id`, top-level dispatch has `thread_id=None`.
- Verified against live relay data: marker is `tag[3]`; `('', 'root')` ×10, `('', 'reply')` ×22 across 40 sampled messages.
- Session-key isolation end-to-end simulation: OLD — both threads → identical key; NEW — each thread + top-level get distinct keys.

## Notes

- Pre-existing test failures in `tests/gateway/test_buzz_adapter.py` (`TestMentionGating::test_unaddressed_channel_message_ignored`, `TestDmClassification::test_general_reply_ptagging_self_stays_channel`, `TestDmClassification::test_channel_like_metadata_blocks_latch_even_without_mention`) fail identically on pristine `main` before this change — unrelated to thread routing.
