### PR TITLE
fix: normalize MEDIA paths for dedup to prevent duplicate delivery on Windows (#78383)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1787,6 +1787,17 @@ def _match_extensionless_path(scan_text: str, match: "re.Match") -> Optional[Tup
     return None
 
 
+def _norm_for_dedup(path: str) -> str:
+    """Normalize a file path for dedup comparison.
+
+    On Windows, ``os.path.normcase(os.path.normpath(p))`` lowercases and
+    converts forward slashes to backslashes, so the same on-disk file
+    referenced with different slash styles or casing compares equal.
+    On POSIX this is a no-op (normcase is identity).
+    """
+    return os.path.normcase(os.path.normpath(path))
+
+
 def _merge_spans(spans: list) -> list:
     """Merge overlapping/nested (start, end) spans so multi-pattern matches
     over the same tag never double-delete adjacent text."""
@@ -4525,8 +4536,9 @@ class BasePlatformAdapter(ABC):
                     # Skip a crafted ~\x00 path rather than aborting extraction
                     # and dropping every other attachment in the response.
                     continue
-                if expanded not in seen_paths:
-                    seen_paths.add(expanded)
+                norm = _norm_for_dedup(expanded)
+                if norm not in seen_paths:
+                    seen_paths.add(norm)
                     media.append((expanded, is_voice))
 
         for match in MEDIA_EXTENSIONLESS_TAG_RE.finditer(scan_content):
@@ -4537,10 +4549,11 @@ class BasePlatformAdapter(ABC):
             if resolved is None:
                 continue
             safe = resolved[0]
-            if safe not in seen_paths:
+            norm = _norm_for_dedup(safe)
+            if norm not in seen_paths:
                 _safe_ext = os.path.splitext(safe)[1].lower()
                 media.append((safe, has_voice_tag and _safe_ext in _AUDIO_EXTS))
-                seen_paths.add(safe)
+                seen_paths.add(norm)
 
         # Remove the delivered MEDIA tags from the user-visible text. Mask a
         # length-equal copy of ``cleaned`` (same union of protected regions) to


### PR DESCRIPTION
## Summary

When a `MEDIA:<path>` tag contains spaces, the primary regex (`MEDIA_TAG_CLEANUP_RE`) and the extensionless fallback (`MEDIA_EXTENSIONLESS_TAG_RE` + `_match_extensionless_path`) can both match the same on-disk file, causing it to be delivered twice.

Fixes #78383

## Root Cause

`extract_media` maintains a `seen_paths` set for dedup. When a MEDIA tag has spaces in its path (e.g. `MEDIA:D:/My Documents/Hermes Agent/xxx.md`):

1. **Primary regex** matches the full space-containing path, adds `os.path.expanduser(path)` to `seen_paths` with forward slashes: `D:/My Documents/Hermes Agent/xxx.md`
2. **Extensionless regex** truncates at the first space (`D:/My`), then `_match_extensionless_path` fuzzy-resolves it back to the same file via `validate_media_delivery_path`, which returns `Path.resolve()` with backslashes: `D:\My Documents\Hermes agent\xxx.md`
3. `seen_paths` compares raw strings — the forward-slash and backslash forms don't match, so the same file is appended twice

## Fix

Normalize paths through `os.path.normcase(os.path.normpath())` before comparing in `seen_paths`. This:
- Lowercases on Windows (case-insensitive filesystem)
- Normalizes slash direction (forward → backslash on Windows)
- Is a no-op on POSIX (`normcase` is identity)

## Changes

- Added `_norm_for_dedup()` helper function
- Updated both dedup checks in `extract_media()` to normalize before comparing/adding to `seen_paths`

## Test Plan

- [x] All 21 media extraction tests pass
- [x] All media spaced paths and dedup tests pass
- [x] Syntax check passes
- [x] Pre-existing test failures (unrelated) confirmed unchanged