### PR TITLE
fix(discord): add space separator after bare URLs in agent output (#78359)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -39,6 +39,29 @@ _DISCORD_MARKDOWN_LINK_LABEL_RE = re.compile(r"([\\\[\]])")
 _DISCORD_URL_LABEL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
 
 
+# Bare URL ending in a common file extension, not inside a markdown link
+# or inline code, with following run-on text (letter or punctuation+letter)
+# that Discord's link parser would absorb into the URL.
+_BARE_URL_RUNON_RE = re.compile(
+    r"(?<![\(`])"                          # not inside markdown link or inline code
+    r"(https?://[^\s)<>`]+"               # URL without parens/brackets/backtick
+    r"\.(?:html|htm(?!l)|php|js(?!o)|json|xml|css|pdf|txt|md|aspx?|jsp|cgi|svg|png|jpe?g|gif|mp[34]|zip|tar|gz)"
+    r")([.,;:!?]*[A-Za-z])"              # extension + optional punctuation + letter
+)
+
+
+def _ensure_url_trailing_space(text: str) -> str:
+    """Insert a space after bare URLs that run directly into following text.
+
+    Discord's link parser absorbs trailing punctuation and text into the URL
+    (e.g. ``/index.htmlReview`` becomes one link).  A single trailing space
+    prevents this without altering the visible content (issue #78359).
+    Skips URLs inside markdown links ``[text](url)``, angle brackets ``<url>``,
+    and inline code.
+    """
+    return _BARE_URL_RUNON_RE.sub(r"\1 \2", text)
+
+
 def _format_discord_markdown_link(label: str, url: str) -> str:
     """Return a Discord Markdown link whose label is not itself a URL.
 
@@ -5334,10 +5357,13 @@ class DiscordAdapter(BasePlatformAdapter):
         """Format message for Discord.
 
         Converts GFM markdown tables to bullet-list groups since Discord
-        does not render pipe tables natively.
+        does not render pipe tables natively.  Also ensures bare URLs are
+        followed by a whitespace separator so Discord's link parser does
+        not absorb trailing text into the URL (issue #78359).
         """
         if not content:
             return content
+        content = _ensure_url_trailing_space(content)
         return convert_table_to_bullets(content)
 
     async def _run_simple_slash(


### PR DESCRIPTION
## Summary
Fixes #78359.

When the agent emits a bare URL followed immediately by text (e.g. `/index.htmlReview`), Discord's link parser absorbs the trailing text into the URL, producing a broken link.

## Changes
- `plugins/platforms/discord/adapter.py`: Add `_ensure_url_trailing_space()` helper and call it from `format_message()`.

## How it works
The regex detects URLs ending in common file extensions (`html`, `json`, `css`, `pdf`, `txt`, `md`, `svg`, `png`, `jpg`, `gif`, `mp4`, `mp3`, `zip`, `tar`, `gz`, `php`, `js`, `xml`, `aspx`, `jsp`, `cgi`) followed by a letter or punctuation+letter, and inserts a single trailing space.

URLs inside markdown links `[text](url)`, angle brackets `<url>`, and inline code are skipped.

Uses negative lookahead `(?!l)` / `(?!o)` to prevent partial extension matching when the regex engine backtracks (e.g. `htm` matching inside `html`, `js` matching inside `json`).

## Testing
Verified with 14 test cases covering:
- Direct run-on (`htmlReview` → `html Review`)
- Punctuation run-on (`html.Example` → `html .Example`)
- Already-spaced URLs (no change)
- Markdown links (skipped)
- Angle brackets (skipped)
- Inline code (skipped)
- Multiple URLs in one message
- Various extensions (html, json, css, js, htm)
