### PR TITLE
fix(cli): skip skills count in sessions sidebar endpoint (#78325)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -739,7 +739,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
 _SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
-_SKILL_COUNT_TTL_SECONDS = 30.0
+_SKILL_COUNT_TTL_SECONDS = 300.0
 
 
 def _skills_dir_signature(skills_dir: Path) -> float:
@@ -875,8 +875,15 @@ def write_profile_meta(
 # CRUD operations
 # ---------------------------------------------------------------------------
 
-def list_profiles() -> List[ProfileInfo]:
-    """Return info for all profiles, including the default."""
+def list_profiles(*, skip_skills: bool = False) -> List[ProfileInfo]:
+    """Return info for all profiles, including the default.
+
+    When *skip_skills* is True the ``skill_count`` field is left at 0
+    and the per-profile ``rglob("SKILL.md")`` walk is skipped entirely.
+    Callers that only need profile names and paths (e.g. the sessions
+    sidebar endpoint) should pass ``skip_skills=True`` to avoid the
+    potentially expensive directory traversal.
+    """
     profiles = []
     wrapper_dir = _get_wrapper_dir()
 
@@ -894,7 +901,7 @@ def list_profiles() -> List[ProfileInfo]:
             model=model,
             provider=provider,
             has_env=(default_home / ".env").exists(),
-            skill_count=_count_skills(default_home),
+            skill_count=0 if skip_skills else _count_skills(default_home),
             distribution_name=dist_name,
             distribution_version=dist_version,
             distribution_source=dist_source,
@@ -934,7 +941,7 @@ def list_profiles() -> List[ProfileInfo]:
                 model=model,
                 provider=provider,
                 has_env=(entry / ".env").exists(),
-                skill_count=_count_skills(entry),
+                skill_count=0 if skip_skills else _count_skills(entry),
                 alias_path=alias_path if (alias_path and alias_path.exists()) else None,
                 alias_name=alias_name,
                 distribution_name=dist_name,

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -99,7 +99,7 @@ def get_profiles_sessions(
         targets.append((name, home))
     else:
         try:
-            infos = profiles_mod.list_profiles()
+            infos = profiles_mod.list_profiles(skip_skills=True)
             targets = [(info.name, info.path) for info in infos]
         except Exception:
             _log.exception("GET /api/profiles/sessions: list_profiles failed")


### PR DESCRIPTION
## Summary
Fixes #78325.

The `GET /api/profiles/sessions` endpoint (which populates the Desktop SESSIONS sidebar) calls `list_profiles()` which runs `_count_skills()` — a recursive `rglob("SKILL.md")` walk over 100K+ files — for every profile. The endpoint only uses `(name, path)` and never reads the skill count. This causes ~41s startup delay.

## Changes

### `hermes_cli/profiles.py`
- Add `skip_skills: bool = False` parameter to `list_profiles()`. When `True`, `skill_count` is left at 0 and the `rglob` walk is skipped entirely.
- Increase `_SKILL_COUNT_TTL_SECONDS` from 30s to 300s so the cache outlives the 60s desktop cron ticker interval (previously every tick was a guaranteed cache miss).

### `hermes_cli/web_routers/profiles.py`
- Pass `skip_skills=True` in the sessions sidebar endpoint.

## Testing
- `python3 -m py_compile hermes_cli/profiles.py` — OK
- `python3 -m py_compile hermes_cli/web_routers/profiles.py` — OK
- The `list_profiles()` default (`skip_skills=False`) preserves existing behavior for all other callers.
