### PR TITLE
feat(gateway): add deterministic external-plugin card actions

### DIFF
--- a/gateway/interactive_actions.py
+++ b/gateway/interactive_actions.py
@@ -1,0 +1,1323 @@
+"""Platform-neutral interactive actions for external Hermes plugins.
+
+This module deliberately sits at the gateway/plugin edge.  Interactive
+actions are operator control-plane events, not model messages or tools.
+"""
+
+from __future__ import annotations
+
+import re
+import json
+import asyncio
+import inspect
+import logging
+import secrets
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Callable, Iterator, Literal, Mapping, cast
+
+from hermes_constants import get_hermes_home
+
+
+AuthorizationPolicy = Literal["initiator_only", "authorized_user"]
+
+logger = logging.getLogger(__name__)
+
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_SECRET_FIELD_RE = re.compile(
+    r"(?:^|_)(?:api_?key|authorization|cookie|credential|password|secret|token)(?:$|_)",
+    re.IGNORECASE,
+)
+
+
+class InteractiveActionRegistrationError(ValueError):
+    """The plugin supplied an invalid or conflicting action registration."""
+
+
+class InteractiveCardValidationError(ValueError):
+    """A platform-neutral card envelope violates the bounded public contract."""
+
+
+class InteractiveCardUnavailableError(RuntimeError):
+    """No current gateway turn is bound to the plugin capability."""
+
+
+class InteractiveCardDeliveryError(RuntimeError):
+    """A sanitized card or fallback delivery failure."""
+
+
+class InteractiveActionCapacityError(RuntimeError):
+    """The bounded profile ledger has no safe room for another action."""
+
+
+class InteractiveActionConflictError(Exception):
+    """A handler-declared terminal conflict with safe operator-facing text."""
+
+    def __init__(self, public_message: str = "") -> None:
+        super().__init__("interactive action conflict")
+        self.public_message = _sanitize_public_message(public_message)
+
+
+class InteractiveActionRetryableError(Exception):
+    """A handler-declared transient failure with safe operator-facing text."""
+
+    def __init__(self, public_message: str = "") -> None:
+        super().__init__("interactive action retryable failure")
+        self.public_message = _sanitize_public_message(public_message)
+
+
+def _sanitize_public_message(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split())[:240]
+
+
+def _bounded_text(
+    value: object,
+    *,
+    field: str,
+    limit: int,
+    allow_empty: bool = False,
+) -> str:
+    if not isinstance(value, str):
+        raise InteractiveCardValidationError(f"{field} must be text")
+    if not allow_empty and not value.strip():
+        raise InteractiveCardValidationError(f"{field} must not be empty")
+    if len(value) > limit:
+        raise InteractiveCardValidationError(f"{field} exceeds {limit} characters")
+    return value
+
+
+def _thaw_json(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _freeze_json(value: object) -> object:
+    if isinstance(value, dict):
+        return MappingProxyType({
+            key: _freeze_json(item) for key, item in value.items()
+        })
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _reject_secret_fields(value: object) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise InteractiveCardValidationError(
+                    "action payload object keys must be text"
+                )
+            normalized = re.sub(r"[^a-z0-9]+", "_", str(key).lower()).strip("_")
+            if _SECRET_FIELD_RE.search(normalized):
+                raise InteractiveCardValidationError(
+                    "action payload must not contain secret fields"
+                )
+            _reject_secret_fields(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _reject_secret_fields(item)
+
+
+def _immutable_json_object(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise InteractiveCardValidationError("action payload must be a JSON object")
+    _reject_secret_fields(value)
+    plain = _thaw_json(value)
+    try:
+        encoded = json.dumps(
+            plain,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise InteractiveCardValidationError(
+            "action payload must contain only JSON values"
+        ) from exc
+    if len(encoded) > 16_384:
+        raise InteractiveCardValidationError("action payload exceeds 16384 bytes")
+    frozen = _freeze_json(plain)
+    assert isinstance(frozen, Mapping)
+    return cast(Mapping[str, object], frozen)
+
+
+@dataclass(frozen=True)
+class InteractiveCardFact:
+    """One short label/value pair rendered by a native adapter."""
+
+    label: str
+    value: str
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.label, field="fact label", limit=80)
+        _bounded_text(self.value, field="fact value", limit=300)
+
+
+@dataclass(frozen=True)
+class InteractiveCardSection:
+    """One bounded explanatory section."""
+
+    title: str
+    body: str
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.title, field="section title", limit=80)
+        _bounded_text(self.body, field="section body", limit=1_500)
+
+
+@dataclass(frozen=True)
+class InteractiveCardAction:
+    """A plugin action whose payload remains server-side."""
+
+    label: str
+    action: str
+    external_action_id: str
+    payload: Mapping[str, object]
+    style: Literal["default", "primary", "danger"] = "default"
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.label, field="action label", limit=80)
+        _bounded_text(self.action, field="action", limit=320)
+        if "/" not in self.action:
+            raise InteractiveCardValidationError(
+                "action must be a qualified plugin action"
+            )
+        plugin_id, local_name = self.action.rsplit("/", 1)
+        try:
+            canonical_action = qualify_action_name(plugin_id, local_name)
+        except InteractiveActionRegistrationError as exc:
+            raise InteractiveCardValidationError(str(exc)) from exc
+        object.__setattr__(self, "action", canonical_action)
+        _bounded_text(
+            self.external_action_id,
+            field="external action id",
+            limit=128,
+        )
+        if self.style not in {"default", "primary", "danger"}:
+            raise InteractiveCardValidationError("unsupported action style")
+        object.__setattr__(self, "payload", _immutable_json_object(self.payload))
+
+
+@dataclass(frozen=True)
+class InteractiveCardEnvelope:
+    """Versioned, bounded data contract shared by plugins and adapters."""
+
+    version: int
+    title: str
+    summary: str
+    fallback_text: str
+    expires_in_seconds: int
+    actions: tuple[InteractiveCardAction, ...]
+    facts: tuple[InteractiveCardFact, ...] = ()
+    sections: tuple[InteractiveCardSection, ...] = ()
+
+    def __post_init__(self) -> None:
+        if type(self.version) is not int or self.version != 1:
+            raise InteractiveCardValidationError("unsupported interactive card version")
+        _bounded_text(self.title, field="title", limit=120)
+        _bounded_text(self.summary, field="summary", limit=1_000)
+        _bounded_text(self.fallback_text, field="fallback text", limit=4_000)
+        if type(self.expires_in_seconds) is not int or not (
+            1 <= self.expires_in_seconds <= 86_400
+        ):
+            raise InteractiveCardValidationError(
+                "expires_in_seconds must be between 1 and 86400"
+            )
+        object.__setattr__(self, "facts", tuple(self.facts))
+        object.__setattr__(self, "sections", tuple(self.sections))
+        object.__setattr__(self, "actions", tuple(self.actions))
+        if len(self.facts) > 12:
+            raise InteractiveCardValidationError("card has more than 12 facts")
+        if len(self.sections) > 8:
+            raise InteractiveCardValidationError("card has more than 8 sections")
+        if not 1 <= len(self.actions) <= 5:
+            raise InteractiveCardValidationError(
+                "card must have between 1 and 5 actions"
+            )
+        if not all(isinstance(item, InteractiveCardFact) for item in self.facts):
+            raise InteractiveCardValidationError(
+                "facts must contain InteractiveCardFact values"
+            )
+        if not all(isinstance(item, InteractiveCardSection) for item in self.sections):
+            raise InteractiveCardValidationError(
+                "sections must contain InteractiveCardSection values"
+            )
+        if not all(isinstance(item, InteractiveCardAction) for item in self.actions):
+            raise InteractiveCardValidationError(
+                "actions must contain InteractiveCardAction values"
+            )
+
+
+@dataclass(frozen=True)
+class InteractiveCardOrigin:
+    """Gateway-owned origin bound to a plugin send capability."""
+
+    platform: str
+    profile_id: str
+    chat_id: str
+    thread_id: str | None
+    initiator_id: str
+    initiator_name: str
+    message_id: str
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.platform, field="origin platform", limit=64)
+        _bounded_text(self.profile_id, field="origin profile", limit=128)
+        _bounded_text(self.chat_id, field="origin chat", limit=512)
+        _bounded_text(
+            self.initiator_id,
+            field="origin initiator",
+            limit=512,
+            allow_empty=True,
+        )
+        _bounded_text(
+            self.initiator_name,
+            field="origin initiator name",
+            limit=256,
+            allow_empty=True,
+        )
+        _bounded_text(
+            self.message_id,
+            field="origin message",
+            limit=512,
+            allow_empty=True,
+        )
+        if self.thread_id is not None:
+            _bounded_text(self.thread_id, field="origin thread", limit=512)
+
+
+@dataclass(frozen=True)
+class InteractiveActionCallback:
+    """Authenticated, platform-normalized input to action dispatch."""
+
+    action_instance_id: str
+    platform: str
+    profile_id: str
+    operator_id: str
+    operator_name: str
+    chat_id: str
+    thread_id: str | None
+    card_id: str
+
+
+@dataclass(frozen=True)
+class InteractiveActionContext:
+    """Immutable context passed to an external plugin action handler."""
+
+    platform: str
+    profile_id: str
+    operator_id: str
+    operator_name: str
+    chat_id: str
+    thread_id: str | None
+    message_id: str
+    card_id: str
+    action_instance_id: str
+    external_action_id: str
+    payload: Mapping[str, object]
+
+
+InteractiveActionStatus = Literal[
+    "processing",
+    "succeeded",
+    "downstream_replay",
+    "already_processed",
+    "denied",
+    "unknown",
+    "expired",
+    "conflict",
+    "retryable_failure",
+]
+
+
+_DEFAULT_RESULT_MESSAGES: dict[str, str] = {
+    "processing": "Processing confirmation…",
+    "succeeded": "Applied successfully.",
+    "downstream_replay": "Already applied downstream.",
+    "already_processed": "Already processed.",
+    "denied": "You are not authorized to apply this confirmation.",
+    "unknown": "This confirmation is unknown or no longer available.",
+    "expired": "This confirmation has expired.",
+    "conflict": "The confirmation could not be applied because its state changed.",
+    "retryable_failure": (
+        "The confirmation could not be completed right now. "
+        "Create a new confirmation to retry."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class InteractiveActionResult:
+    """Truthful, sanitized outcome for callback UX and durable replay state."""
+
+    status: InteractiveActionStatus
+    user_message: str
+
+    def __post_init__(self) -> None:
+        if self.status not in _DEFAULT_RESULT_MESSAGES:
+            raise ValueError("invalid interactive action result status")
+        object.__setattr__(
+            self,
+            "user_message",
+            _sanitize_public_message(self.user_message)
+            or _DEFAULT_RESULT_MESSAGES[self.status],
+        )
+
+    @classmethod
+    def _make(
+        cls, status: InteractiveActionStatus, message: str = ""
+    ) -> "InteractiveActionResult":
+        return cls(
+            status=status,
+            user_message=_sanitize_public_message(message)
+            or _DEFAULT_RESULT_MESSAGES[status],
+        )
+
+    @classmethod
+    def processing(cls, message: str = "") -> "InteractiveActionResult":
+        return cls._make("processing", message)
+
+    @classmethod
+    def succeeded(cls, message: str = "") -> "InteractiveActionResult":
+        return cls._make("succeeded", message)
+
+    @classmethod
+    def downstream_replay(cls, message: str = "") -> "InteractiveActionResult":
+        return cls._make("downstream_replay", message)
+
+    @classmethod
+    def already_processed(cls) -> "InteractiveActionResult":
+        return cls._make("already_processed")
+
+    @classmethod
+    def denied(cls) -> "InteractiveActionResult":
+        return cls._make("denied")
+
+    @classmethod
+    def unknown(cls) -> "InteractiveActionResult":
+        return cls._make("unknown")
+
+    @classmethod
+    def expired(cls) -> "InteractiveActionResult":
+        return cls._make("expired")
+
+    @classmethod
+    def conflict(cls, message: str = "") -> "InteractiveActionResult":
+        return cls._make("conflict", message)
+
+    @classmethod
+    def retryable_failure(cls, message: str = "") -> "InteractiveActionResult":
+        return cls._make("retryable_failure", message)
+
+
+@dataclass(frozen=True)
+class PreparedInteractiveCard:
+    """Opaque action IDs reserved before native card delivery."""
+
+    action_instance_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class InteractiveCardDelivery:
+    """Bounded receipt returned to the external plugin."""
+
+    mode: Literal["native", "fallback"]
+    message_id: str
+    action_instance_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _StoredAction:
+    action_instance_id: str
+    plugin_action: str
+    external_action_id: str
+    authorization_policy: AuthorizationPolicy
+    profile_id: str
+    platform: str
+    chat_id: str
+    thread_id: str | None
+    initiator_id: str
+    initiator_name: str
+    message_id: str
+    card_id: str | None
+    payload_json: str
+    state: str
+    outcome: str | None
+    expires_at: float
+
+    def handler_context(
+        self, callback: InteractiveActionCallback
+    ) -> InteractiveActionContext:
+        payload = json.loads(self.payload_json)
+        return InteractiveActionContext(
+            platform=self.platform,
+            profile_id=self.profile_id,
+            operator_id=callback.operator_id,
+            operator_name=callback.operator_name,
+            chat_id=self.chat_id,
+            thread_id=self.thread_id,
+            message_id=self.message_id,
+            card_id=self.card_id or "",
+            action_instance_id=self.action_instance_id,
+            external_action_id=self.external_action_id,
+            payload=_immutable_json_object(payload),
+        )
+
+
+@dataclass(frozen=True)
+class _ClaimResult:
+    status: Literal["claimed", "already_processed", "denied", "unknown", "expired"]
+    record: _StoredAction | None = None
+
+
+@dataclass(frozen=True)
+class ClaimedInteractiveAction:
+    """Opaque manager-owned claim passed from callback ACK to completion."""
+
+    callback: InteractiveActionCallback
+    record: _StoredAction
+    registration: InteractiveActionRegistration
+
+
+class SQLiteInteractiveActionStorage:
+    """Bounded profile-safe SQLite action ledger with atomic claims."""
+
+    _RETENTION_SECONDS = 7 * 24 * 60 * 60
+    _MAX_ROWS = 1_000
+    # Feishu's synchronous card callback waits at most three seconds for
+    # authorization + claim.  Database contention must fail inside that
+    # window so the adapter can return a truthful retryable result instead of
+    # timing out while a claim later succeeds invisibly.
+    _SQLITE_TIMEOUT_SECONDS = 0.5
+    _REQUIRED_COLUMNS = frozenset({
+        "action_instance_id",
+        "plugin_action",
+        "external_action_id",
+        "authorization_policy",
+        "profile_id",
+        "platform",
+        "chat_id",
+        "thread_id",
+        "initiator_id",
+        "initiator_name",
+        "message_id",
+        "card_id",
+        "payload_json",
+        "state",
+        "outcome",
+        "expires_at",
+        "created_at",
+        "updated_at",
+    })
+
+    def __init__(self, db_path: Path | str | Callable[[], Path] | None = None) -> None:
+        self._db_path_provider: Callable[[], Path]
+        if db_path is None:
+            self._db_path_provider = lambda: get_hermes_home() / "state.db"
+        elif callable(db_path):
+            self._db_path_provider = cast(Callable[[], Path], db_path)
+        else:
+            resolved_path = Path(db_path)
+            self._db_path_provider = lambda: resolved_path
+        self._lock = threading.Lock()
+        self._schema_ready_paths: set[str] = set()
+
+    def _path(self) -> Path:
+        return self._db_path_provider()
+
+    def _connect(self) -> sqlite3.Connection:
+        path = self._path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            path,
+            timeout=self._SQLITE_TIMEOUT_SECONDS,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        try:
+            from hermes_state import apply_wal_with_fallback
+
+            apply_wal_with_fallback(conn, db_label="state.db (interactive_actions)")
+            path_key = str(path.resolve(strict=False))
+            if path_key not in self._schema_ready_paths:
+                self._ensure_schema(conn)
+                self._schema_ready_paths.add(path_key)
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
+    @classmethod
+    def _schema_columns(cls, conn: sqlite3.Connection) -> set[str]:
+        return {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(interactive_actions)")
+        }
+
+    @classmethod
+    def _schema_is_current(cls, conn: sqlite3.Connection) -> bool:
+        columns = cls._schema_columns(conn)
+        if not cls._REQUIRED_COLUMNS.issubset(columns):
+            return False
+        indexes = {
+            str(row[1])
+            for row in conn.execute("PRAGMA index_list(interactive_actions)")
+        }
+        return "idx_interactive_actions_expiry" in indexes
+
+    @classmethod
+    def _ensure_schema(cls, conn: sqlite3.Connection) -> None:
+        """Create or migrate the ledger without racing another process.
+
+        The read-only fast path avoids taking a schema write lock on every
+        callback after restart.  The transaction then re-checks all schema
+        facts after ``BEGIN IMMEDIATE`` so concurrent old-schema migrations
+        cannot both attempt the same ``ALTER TABLE``.
+        """
+
+        if cls._schema_is_current(conn):
+            return
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS interactive_actions (
+                    action_instance_id TEXT PRIMARY KEY,
+                    plugin_action TEXT NOT NULL,
+                    external_action_id TEXT NOT NULL,
+                    authorization_policy TEXT NOT NULL DEFAULT 'initiator_only',
+                    profile_id TEXT NOT NULL,
+                    platform TEXT NOT NULL,
+                    chat_id TEXT NOT NULL,
+                    thread_id TEXT,
+                    initiator_id TEXT NOT NULL,
+                    initiator_name TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    card_id TEXT,
+                    payload_json TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    outcome TEXT,
+                    expires_at REAL NOT NULL,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL
+                )"""
+            )
+            columns = cls._schema_columns(conn)
+            if "authorization_policy" not in columns:
+                conn.execute(
+                    """ALTER TABLE interactive_actions
+                       ADD COLUMN authorization_policy TEXT NOT NULL
+                       DEFAULT 'initiator_only'"""
+                )
+                columns.add("authorization_policy")
+            missing = cls._REQUIRED_COLUMNS - columns
+            if missing:
+                missing_names = ", ".join(sorted(missing))
+                raise sqlite3.DatabaseError(
+                    f"interactive_actions schema is missing columns: {missing_names}"
+                )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_interactive_actions_expiry
+                   ON interactive_actions(expires_at, state)"""
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+    @staticmethod
+    def _row(row: sqlite3.Row | None) -> _StoredAction | None:
+        if row is None:
+            return None
+        return _StoredAction(
+            action_instance_id=row["action_instance_id"],
+            plugin_action=row["plugin_action"],
+            external_action_id=row["external_action_id"],
+            authorization_policy=row["authorization_policy"],
+            profile_id=row["profile_id"],
+            platform=row["platform"],
+            chat_id=row["chat_id"],
+            thread_id=row["thread_id"],
+            initiator_id=row["initiator_id"],
+            initiator_name=row["initiator_name"],
+            message_id=row["message_id"],
+            card_id=row["card_id"],
+            payload_json=row["payload_json"],
+            state=row["state"],
+            outcome=row["outcome"],
+            expires_at=float(row["expires_at"]),
+        )
+
+    def reserve(
+        self,
+        rows: list[
+            tuple[
+                str,
+                InteractiveCardAction,
+                InteractiveActionRegistration,
+            ]
+        ],
+        *,
+        origin: InteractiveCardOrigin,
+        expires_at: float,
+        now: float,
+    ) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                self._prune(conn, now)
+                count = int(
+                    conn.execute("SELECT COUNT(*) FROM interactive_actions").fetchone()[
+                        0
+                    ]
+                )
+                if count + len(rows) > self._MAX_ROWS:
+                    raise InteractiveActionCapacityError(
+                        "interactive action ledger reached its bounded capacity"
+                    )
+                for instance_id, action, registration in rows:
+                    payload_json = json.dumps(
+                        _thaw_json(action.payload),
+                        ensure_ascii=False,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                    conn.execute(
+                        """INSERT INTO interactive_actions (
+                            action_instance_id, plugin_action, external_action_id,
+                            authorization_policy,
+                            profile_id, platform, chat_id, thread_id,
+                            initiator_id, initiator_name, message_id, card_id,
+                            payload_json, state, outcome, expires_at,
+                            created_at, updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?,
+                                  'awaiting_delivery', NULL, ?, ?, ?)""",
+                        (
+                            instance_id,
+                            action.action,
+                            action.external_action_id,
+                            registration.authorization_policy,
+                            origin.profile_id,
+                            origin.platform,
+                            origin.chat_id,
+                            origin.thread_id,
+                            origin.initiator_id,
+                            origin.initiator_name,
+                            origin.message_id,
+                            payload_json,
+                            expires_at,
+                            now,
+                            now,
+                        ),
+                    )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    def _prune(self, conn: sqlite3.Connection, now: float) -> None:
+        cutoff = now - self._RETENTION_SECONDS
+        conn.execute(
+            """DELETE FROM interactive_actions
+               WHERE updated_at < ? AND state IN ('finished', 'expired', 'delivery_failed')""",
+            (cutoff,),
+        )
+        # A crash between reserve/send/activate leaves an awaiting-delivery
+        # row; a crash after claim leaves a processing row that must never be
+        # executed again.  Retain both long enough for audit/replay safety,
+        # then discard them so repeated crashes cannot permanently exhaust the
+        # bounded ledger.
+        conn.execute(
+            """DELETE FROM interactive_actions
+               WHERE (state='processing' AND updated_at < ?)
+                  OR (state IN ('active', 'awaiting_delivery') AND expires_at < ?)""",
+            (cutoff, cutoff),
+        )
+        conn.execute(
+            """UPDATE interactive_actions
+               SET state='expired', updated_at=?
+               WHERE state IN ('active', 'awaiting_delivery') AND expires_at <= ?""",
+            (now, now),
+        )
+        count = int(
+            conn.execute("SELECT COUNT(*) FROM interactive_actions").fetchone()[0]
+        )
+        overflow = count - self._MAX_ROWS
+        if overflow > 0:
+            conn.execute(
+                """DELETE FROM interactive_actions WHERE action_instance_id IN (
+                       SELECT action_instance_id FROM interactive_actions
+                       WHERE state IN ('finished', 'expired', 'delivery_failed')
+                       ORDER BY updated_at ASC LIMIT ?
+                   )""",
+                (overflow,),
+            )
+
+    def activate(
+        self, action_instance_ids: tuple[str, ...], *, card_id: str, now: float
+    ) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                for instance_id in action_instance_ids:
+                    cursor = conn.execute(
+                        """UPDATE interactive_actions
+                           SET state='active', card_id=?, updated_at=?
+                           WHERE action_instance_id=? AND state='awaiting_delivery'""",
+                        (card_id, now, instance_id),
+                    )
+                    if cursor.rowcount != 1:
+                        raise RuntimeError("interactive action could not be activated")
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    def fail_delivery(
+        self, action_instance_ids: tuple[str, ...], *, now: float
+    ) -> None:
+        if not action_instance_ids:
+            return
+        placeholders = ",".join("?" for _ in action_instance_ids)
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    f"""UPDATE interactive_actions
+                        SET state='delivery_failed', updated_at=?
+                        WHERE state='awaiting_delivery'
+                          AND action_instance_id IN ({placeholders})""",  # noqa: S608 - placeholders only
+                    (now, *action_instance_ids),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+    def get(self, action_instance_id: str) -> _StoredAction | None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT * FROM interactive_actions WHERE action_instance_id=?",
+                    (action_instance_id,),
+                ).fetchone()
+                return self._row(row)
+            finally:
+                conn.close()
+
+    def claim(self, callback: InteractiveActionCallback, *, now: float) -> _ClaimResult:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT * FROM interactive_actions WHERE action_instance_id=?",
+                    (callback.action_instance_id,),
+                ).fetchone()
+                record = self._row(row)
+                if record is None:
+                    conn.rollback()
+                    return _ClaimResult("unknown")
+                if record.state in {"processing", "finished"}:
+                    conn.rollback()
+                    return _ClaimResult("already_processed", record)
+                if now >= record.expires_at:
+                    conn.execute(
+                        """UPDATE interactive_actions
+                           SET state='expired', updated_at=?
+                           WHERE action_instance_id=? AND state IN ('active', 'awaiting_delivery')""",
+                        (now, callback.action_instance_id),
+                    )
+                    conn.commit()
+                    return _ClaimResult("expired", record)
+                binding_matches = (
+                    record.state == "active"
+                    and callback.profile_id == record.profile_id
+                    and callback.platform == record.platform
+                    and callback.chat_id == record.chat_id
+                    # Feishu callback payloads do not always expose the topic
+                    # root. When absent, the verified outbound card ID is the
+                    # thread anchor; when present, require an exact match.
+                    and (
+                        callback.thread_id is None
+                        or callback.thread_id == record.thread_id
+                    )
+                    and callback.card_id == record.card_id
+                )
+                if not binding_matches:
+                    conn.rollback()
+                    return _ClaimResult("denied", record)
+                cursor = conn.execute(
+                    """UPDATE interactive_actions
+                       SET state='processing', updated_at=?
+                       WHERE action_instance_id=? AND state='active'""",
+                    (now, callback.action_instance_id),
+                )
+                if cursor.rowcount != 1:
+                    conn.rollback()
+                    return _ClaimResult("already_processed", record)
+                conn.commit()
+                return _ClaimResult("claimed", record)
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    def finish(
+        self,
+        action_instance_id: str,
+        *,
+        result: InteractiveActionResult,
+        now: float,
+    ) -> None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                cursor = conn.execute(
+                    """UPDATE interactive_actions
+                       SET state='finished', outcome=?, updated_at=?
+                       WHERE action_instance_id=? AND state='processing'""",
+                    (result.status, now, action_instance_id),
+                )
+                if cursor.rowcount != 1:
+                    raise RuntimeError(
+                        "interactive action final state was not persisted"
+                    )
+                conn.commit()
+            finally:
+                conn.close()
+
+
+class InteractiveActionManager:
+    """Small orchestration seam for plugin registration, ledger and execution."""
+
+    def __init__(
+        self,
+        *,
+        storage: SQLiteInteractiveActionStorage | None = None,
+        registrations: Mapping[str, InteractiveActionRegistration]
+        | Callable[[], Mapping[str, InteractiveActionRegistration]],
+        clock: Callable[[], float] = time.time,
+        id_source: Callable[[], str] = lambda: secrets.token_urlsafe(24),
+    ) -> None:
+        self.storage = storage or SQLiteInteractiveActionStorage()
+        self._registrations_provider: Callable[
+            [], Mapping[str, InteractiveActionRegistration]
+        ]
+        if callable(registrations):
+            self._registrations_provider = cast(
+                Callable[[], Mapping[str, InteractiveActionRegistration]],
+                registrations,
+            )
+        else:
+            static_registrations = cast(
+                Mapping[str, InteractiveActionRegistration],
+                registrations,
+            )
+            self._registrations_provider = lambda: static_registrations
+        self._clock = clock
+        self._id_source = id_source
+
+    def _registry(self) -> Mapping[str, InteractiveActionRegistration]:
+        return self._registrations_provider()
+
+    def prepare_card(
+        self,
+        *,
+        plugin_id: str,
+        envelope: InteractiveCardEnvelope,
+        origin: InteractiveCardOrigin,
+    ) -> PreparedInteractiveCard:
+        if not isinstance(envelope, InteractiveCardEnvelope):
+            raise InteractiveCardValidationError("invalid interactive card envelope")
+        if not origin.initiator_id.strip() or not origin.message_id.strip():
+            raise InteractiveCardValidationError(
+                "native interactive cards require a stable initiator and origin message"
+            )
+        plugin_id = str(plugin_id or "").strip().lower()
+        registrations = self._registry()
+        action_registrations: dict[str, InteractiveActionRegistration] = {}
+        for action in envelope.actions:
+            registration = registrations.get(action.action)
+            if registration is None or registration.plugin_id != plugin_id:
+                raise InteractiveActionRegistrationError(
+                    f"interactive action {action.action!r} is not registered by {plugin_id!r}"
+                )
+            action_registrations[action.action] = registration
+        rows: list[
+            tuple[
+                str,
+                InteractiveCardAction,
+                InteractiveActionRegistration,
+            ]
+        ] = []
+        seen: set[str] = set()
+        for action in envelope.actions:
+            instance_id = str(self._id_source() or "").strip()
+            if not instance_id or len(instance_id) > 128 or instance_id in seen:
+                raise InteractiveCardValidationError(
+                    "id source returned an invalid action instance id"
+                )
+            seen.add(instance_id)
+            rows.append((instance_id, action, action_registrations[action.action]))
+        now = self._clock()
+        self.storage.reserve(
+            rows,
+            origin=origin,
+            expires_at=now + envelope.expires_in_seconds,
+            now=now,
+        )
+        return PreparedInteractiveCard(tuple(row[0] for row in rows))
+
+    def activate_card(self, prepared: PreparedInteractiveCard, *, card_id: str) -> None:
+        _bounded_text(card_id, field="card id", limit=512)
+        self.storage.activate(
+            prepared.action_instance_ids,
+            card_id=card_id,
+            now=self._clock(),
+        )
+
+    def fail_card_delivery(self, prepared: PreparedInteractiveCard) -> None:
+        self.storage.fail_delivery(prepared.action_instance_ids, now=self._clock())
+
+    def _record_delivery_failure(self, prepared: PreparedInteractiveCard) -> None:
+        """Best-effort terminalization that never masks the delivery error."""
+
+        try:
+            self.fail_card_delivery(prepared)
+        except Exception:
+            logger.warning("Interactive card delivery-failure persistence failed")
+
+    async def deliver_card(
+        self,
+        *,
+        plugin_id: str,
+        envelope: InteractiveCardEnvelope,
+        origin: InteractiveCardOrigin,
+        adapter: Any,
+        metadata: Mapping[str, object] | None = None,
+    ) -> InteractiveCardDelivery:
+        """Deliver a native card or exact fallback through the current adapter."""
+
+        delivery_metadata = dict(metadata) if metadata else None
+        if not bool(getattr(adapter, "supports_interactive_cards", False)):
+            try:
+                result = await adapter.send(
+                    chat_id=origin.chat_id,
+                    content=envelope.fallback_text,
+                    reply_to=origin.message_id or None,
+                    metadata=delivery_metadata,
+                )
+            except Exception as exc:
+                raise InteractiveCardDeliveryError(
+                    "interactive card fallback could not be delivered"
+                ) from exc
+            if not getattr(result, "success", False):
+                raise InteractiveCardDeliveryError(
+                    "interactive card fallback could not be delivered"
+                )
+            return InteractiveCardDelivery(
+                mode="fallback",
+                message_id=str(getattr(result, "message_id", None) or ""),
+            )
+
+        try:
+            prepared = self.prepare_card(
+                plugin_id=plugin_id,
+                envelope=envelope,
+                origin=origin,
+            )
+        except Exception as exc:
+            raise InteractiveCardDeliveryError(
+                "interactive card could not be prepared for delivery"
+            ) from exc
+        try:
+            result = await adapter.send_interactive_card(
+                chat_id=origin.chat_id,
+                envelope=envelope,
+                action_instance_ids=prepared.action_instance_ids,
+                reply_to=origin.message_id,
+                metadata=delivery_metadata,
+            )
+        except Exception as exc:
+            self._record_delivery_failure(prepared)
+            raise InteractiveCardDeliveryError(
+                "interactive card could not be delivered"
+            ) from exc
+        if not getattr(result, "success", False) or not getattr(
+            result, "message_id", None
+        ):
+            self._record_delivery_failure(prepared)
+            raise InteractiveCardDeliveryError(
+                "interactive card could not be delivered"
+            )
+        card_id = str(result.message_id)
+        try:
+            self.activate_card(prepared, card_id=card_id)
+        except Exception as exc:
+            self._record_delivery_failure(prepared)
+            try:
+                disabled = await adapter.update_interactive_card(
+                    chat_id=origin.chat_id,
+                    card_id=card_id,
+                    result=InteractiveActionResult.retryable_failure(
+                        "This confirmation is unavailable. Create a new confirmation."
+                    ),
+                )
+                if not getattr(disabled, "success", False):
+                    logger.warning(
+                        "Interactive card activation failed and the delivered card disable was rejected"
+                    )
+            except Exception:
+                logger.warning(
+                    "Interactive card activation failed and the delivered card could not be disabled"
+                )
+            raise InteractiveCardDeliveryError(
+                "interactive card could not be activated after delivery"
+            ) from exc
+        return InteractiveCardDelivery(
+            mode="native",
+            message_id=card_id,
+            action_instance_ids=prepared.action_instance_ids,
+        )
+
+    async def dispatch(
+        self,
+        callback: InteractiveActionCallback,
+        *,
+        gateway_authorize: Callable[[], bool],
+    ) -> InteractiveActionResult:
+        claim = self.claim_action(
+            callback,
+            gateway_authorize=gateway_authorize,
+        )
+        if isinstance(claim, InteractiveActionResult):
+            return claim
+        return await self.execute_claimed(claim)
+
+    def claim_action(
+        self,
+        callback: InteractiveActionCallback,
+        *,
+        gateway_authorize: Callable[[], bool],
+    ) -> InteractiveActionResult | ClaimedInteractiveAction:
+        """Authorize and atomically claim without running plugin code."""
+
+        if (
+            not callback.operator_id.strip()
+            or not callback.action_instance_id.strip()
+            or len(callback.action_instance_id) > 128
+        ):
+            return InteractiveActionResult.denied()
+        try:
+            authorized = gateway_authorize() is True
+        except Exception:
+            authorized = False
+        if not authorized:
+            return InteractiveActionResult.denied()
+
+        record = self.storage.get(callback.action_instance_id)
+        if record is None:
+            return InteractiveActionResult.unknown()
+        registration = self._registry().get(record.plugin_action)
+        if registration is None:
+            return InteractiveActionResult.unknown()
+        if (
+            record.authorization_policy != "authorized_user"
+            or registration.authorization_policy != "authorized_user"
+        ) and callback.operator_id != record.initiator_id:
+            return InteractiveActionResult.denied()
+
+        claim = self.storage.claim(callback, now=self._clock())
+        if claim.status == "already_processed":
+            return InteractiveActionResult.already_processed()
+        if claim.status == "denied":
+            return InteractiveActionResult.denied()
+        if claim.status == "expired":
+            return InteractiveActionResult.expired()
+        if claim.status != "claimed" or claim.record is None:
+            return InteractiveActionResult.unknown()
+
+        return ClaimedInteractiveAction(
+            callback=callback,
+            record=claim.record,
+            registration=registration,
+        )
+
+    async def execute_claimed(
+        self,
+        claim: ClaimedInteractiveAction,
+    ) -> InteractiveActionResult:
+        """Run one already-claimed handler and durably record its final state."""
+
+        context = claim.record.handler_context(claim.callback)
+        result = await self._run_handler(claim.registration.handler, context)
+        self.storage.finish(
+            claim.callback.action_instance_id,
+            result=result,
+            now=self._clock(),
+        )
+        return result
+
+    async def _run_handler(
+        self,
+        handler: Callable,
+        context: InteractiveActionContext,
+    ) -> InteractiveActionResult:
+        try:
+            if inspect.iscoroutinefunction(handler):
+                value = await handler(context)
+            else:
+                value = await asyncio.to_thread(handler, context)
+                if inspect.isawaitable(value):
+                    value = await value
+            if value is None:
+                return InteractiveActionResult.succeeded()
+            if isinstance(value, InteractiveActionResult) and value.status in {
+                "succeeded",
+                "downstream_replay",
+                "conflict",
+                "retryable_failure",
+            }:
+                return value
+            logger.warning("Interactive action handler returned an invalid result type")
+            return InteractiveActionResult.retryable_failure()
+        except InteractiveActionConflictError as exc:
+            return InteractiveActionResult.conflict(exc.public_message)
+        except InteractiveActionRetryableError as exc:
+            return InteractiveActionResult.retryable_failure(exc.public_message)
+        except Exception as exc:
+            logger.warning(
+                "Interactive action handler failed (%s)",
+                type(exc).__name__,
+            )
+            return InteractiveActionResult.retryable_failure()
+
+
+InteractiveCardSender = Callable[..., object]
+_CURRENT_CARD_SENDER: ContextVar[InteractiveCardSender | None] = ContextVar(
+    "hermes_interactive_card_sender",
+    default=None,
+)
+
+
+@contextmanager
+def bind_interactive_card_sender(sender: InteractiveCardSender) -> Iterator[None]:
+    """Bind the current gateway destination without exposing its identifiers."""
+
+    if not callable(sender):
+        raise TypeError("interactive card sender must be callable")
+    token = _CURRENT_CARD_SENDER.set(sender)
+    try:
+        yield
+    finally:
+        _CURRENT_CARD_SENDER.reset(token)
+
+
+def send_current_interactive_card(
+    *,
+    plugin_id: str,
+    envelope: InteractiveCardEnvelope,
+) -> object:
+    """Send through the current gateway turn or fail closed outside one."""
+
+    sender = _CURRENT_CARD_SENDER.get()
+    if sender is None:
+        raise InteractiveCardUnavailableError(
+            "interactive cards are only available during a current gateway turn"
+        )
+    if not isinstance(envelope, InteractiveCardEnvelope):
+        raise InteractiveCardValidationError(
+            "send_interactive_card requires an InteractiveCardEnvelope"
+        )
+    return sender(plugin_id=plugin_id, envelope=envelope)
+
+
+@dataclass(frozen=True)
+class InteractiveActionRegistration:
+    """One plugin-owned action handler and its authorization policy."""
+
+    qualified_name: str
+    plugin_id: str
+    handler: Callable
+    authorization_policy: AuthorizationPolicy
+
+
+def qualify_action_name(plugin_id: str, action_name: str) -> str:
+    """Validate and return ``<plugin-id>/<action>``.
+
+    A plugin may pass its local action name or its already-qualified name.  It
+    may never register into another plugin's namespace.
+    """
+
+    plugin_id = str(plugin_id or "").strip().lower()
+    raw = str(action_name or "").strip().lower()
+    plugin_parts = plugin_id.split("/")
+    if (
+        not 1 <= len(plugin_parts) <= 4
+        or len(plugin_id) > 255
+        or not all(_NAME_RE.fullmatch(part) for part in plugin_parts)
+    ):
+        raise InteractiveActionRegistrationError("invalid plugin namespace")
+
+    if "/" in raw:
+        prefix = f"{plugin_id}/"
+        if not raw.startswith(prefix):
+            raise InteractiveActionRegistrationError(
+                "interactive action namespace must match the registering plugin"
+            )
+        action = raw[len(prefix) :]
+    else:
+        action = raw
+
+    if not _NAME_RE.fullmatch(action):
+        raise InteractiveActionRegistrationError(
+            "interactive action must match [a-z0-9][a-z0-9._-]{0,63}"
+        )
+    return f"{plugin_id}/{action}"
+
+
+def build_registration(
+    *,
+    plugin_id: str,
+    action_name: str,
+    handler: Callable,
+    authorization_policy: str,
+) -> InteractiveActionRegistration:
+    """Validate one public registration request."""
+
+    if not callable(handler):
+        raise InteractiveActionRegistrationError(
+            "interactive action handler must be callable"
+        )
+    if authorization_policy not in {"initiator_only", "authorized_user"}:
+        raise InteractiveActionRegistrationError(
+            "authorization policy must be initiator_only or authorized_user"
+        )
+    qualified = qualify_action_name(plugin_id, action_name)
+    return InteractiveActionRegistration(
+        qualified_name=qualified,
+        plugin_id=qualified.rsplit("/", 1)[0],
+        handler=handler,
+        authorization_policy=authorization_policy,  # type: ignore[arg-type]
+    )

--- a/gateway/interactive_actions.py
+++ b/gateway/interactive_actions.py
@@ -340,6 +340,7 @@ InteractiveActionStatus = Literal[
     "expired",
     "conflict",
     "retryable_failure",
+    "unknown_outcome",
 ]
 
 
@@ -354,7 +355,11 @@ _DEFAULT_RESULT_MESSAGES: dict[str, str] = {
     "conflict": "The confirmation could not be applied because its state changed.",
     "retryable_failure": (
         "The confirmation could not be completed right now. "
-        "Create a new confirmation to retry."
+        "Use the same confirmation to retry."
+    ),
+    "unknown_outcome": (
+        "Hermes could not verify whether this confirmation took effect. "
+        "Do not retry it; verify the downstream state first."
     ),
 }
 
@@ -422,6 +427,10 @@ class InteractiveActionResult:
     def retryable_failure(cls, message: str = "") -> "InteractiveActionResult":
         return cls._make("retryable_failure", message)
 
+    @classmethod
+    def unknown_outcome(cls) -> "InteractiveActionResult":
+        return cls._make("unknown_outcome")
+
 
 @dataclass(frozen=True)
 class PreparedInteractiveCard:
@@ -456,6 +465,7 @@ class _StoredAction:
     payload_json: str
     state: str
     outcome: str | None
+    user_message: str
     expires_at: float
 
     def handler_context(
@@ -479,7 +489,14 @@ class _StoredAction:
 
 @dataclass(frozen=True)
 class _ClaimResult:
-    status: Literal["claimed", "already_processed", "denied", "unknown", "expired"]
+    status: Literal[
+        "claimed",
+        "processing",
+        "finished",
+        "denied",
+        "unknown",
+        "expired",
+    ]
     record: _StoredAction | None = None
 
 
@@ -518,6 +535,7 @@ class SQLiteInteractiveActionStorage:
         "payload_json",
         "state",
         "outcome",
+        "user_message",
         "expires_at",
         "created_at",
         "updated_at",
@@ -554,6 +572,7 @@ class SQLiteInteractiveActionStorage:
             path_key = str(path.resolve(strict=False))
             if path_key not in self._schema_ready_paths:
                 self._ensure_schema(conn)
+                self._reconcile_processing_from_prior_process(conn)
                 self._schema_ready_paths.add(path_key)
         except Exception:
             conn.close()
@@ -609,6 +628,7 @@ class SQLiteInteractiveActionStorage:
                     payload_json TEXT NOT NULL,
                     state TEXT NOT NULL,
                     outcome TEXT,
+                    user_message TEXT NOT NULL DEFAULT '',
                     expires_at REAL NOT NULL,
                     created_at REAL NOT NULL,
                     updated_at REAL NOT NULL
@@ -622,6 +642,12 @@ class SQLiteInteractiveActionStorage:
                        DEFAULT 'initiator_only'"""
                 )
                 columns.add("authorization_policy")
+            if "user_message" not in columns:
+                conn.execute(
+                    """ALTER TABLE interactive_actions
+                       ADD COLUMN user_message TEXT NOT NULL DEFAULT ''"""
+                )
+                columns.add("user_message")
             missing = cls._REQUIRED_COLUMNS - columns
             if missing:
                 missing_names = ", ".join(sorted(missing))
@@ -631,6 +657,49 @@ class SQLiteInteractiveActionStorage:
             conn.execute(
                 """CREATE INDEX IF NOT EXISTS idx_interactive_actions_expiry
                    ON interactive_actions(expires_at, state)"""
+            )
+            for status, message in _DEFAULT_RESULT_MESSAGES.items():
+                conn.execute(
+                    """UPDATE interactive_actions
+                       SET user_message=?
+                       WHERE state='finished' AND outcome=? AND user_message=''""",
+                    (message, status),
+                )
+            conn.execute(
+                """UPDATE interactive_actions
+                   SET outcome='already_processed', user_message=?
+                   WHERE state='finished' AND outcome IS NULL""",
+                (_DEFAULT_RESULT_MESSAGES["already_processed"],),
+            )
+            conn.execute(
+                """UPDATE interactive_actions
+                   SET state='active'
+                   WHERE state='finished' AND outcome='retryable_failure'"""
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+    @classmethod
+    def _reconcile_processing_from_prior_process(
+        cls,
+        conn: sqlite3.Connection,
+    ) -> None:
+        """Terminalize crash-left processing rows once for this storage startup."""
+
+        if conn.execute(
+            "SELECT 1 FROM interactive_actions WHERE state='processing' LIMIT 1"
+        ).fetchone() is None:
+            return
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                """UPDATE interactive_actions
+                   SET state='finished', outcome='unknown_outcome',
+                       user_message=?, updated_at=?
+                   WHERE state='processing'""",
+                (_DEFAULT_RESULT_MESSAGES["unknown_outcome"], time.time()),
             )
             conn.commit()
         except Exception:
@@ -657,6 +726,7 @@ class SQLiteInteractiveActionStorage:
             payload_json=row["payload_json"],
             state=row["state"],
             outcome=row["outcome"],
+            user_message=row["user_message"],
             expires_at=float(row["expires_at"]),
         )
 
@@ -837,21 +907,8 @@ class SQLiteInteractiveActionStorage:
                 if record is None:
                     conn.rollback()
                     return _ClaimResult("unknown")
-                if record.state in {"processing", "finished"}:
-                    conn.rollback()
-                    return _ClaimResult("already_processed", record)
-                if now >= record.expires_at:
-                    conn.execute(
-                        """UPDATE interactive_actions
-                           SET state='expired', updated_at=?
-                           WHERE action_instance_id=? AND state IN ('active', 'awaiting_delivery')""",
-                        (now, callback.action_instance_id),
-                    )
-                    conn.commit()
-                    return _ClaimResult("expired", record)
                 binding_matches = (
-                    record.state == "active"
-                    and callback.profile_id == record.profile_id
+                    callback.profile_id == record.profile_id
                     and callback.platform == record.platform
                     and callback.chat_id == record.chat_id
                     # Feishu callback payloads do not always expose the topic
@@ -866,6 +923,24 @@ class SQLiteInteractiveActionStorage:
                 if not binding_matches:
                     conn.rollback()
                     return _ClaimResult("denied", record)
+                if record.state == "processing":
+                    conn.rollback()
+                    return _ClaimResult("processing", record)
+                if record.state == "finished":
+                    conn.rollback()
+                    return _ClaimResult("finished", record)
+                if now >= record.expires_at:
+                    conn.execute(
+                        """UPDATE interactive_actions
+                           SET state='expired', updated_at=?
+                           WHERE action_instance_id=? AND state IN ('active', 'awaiting_delivery')""",
+                        (now, callback.action_instance_id),
+                    )
+                    conn.commit()
+                    return _ClaimResult("expired", record)
+                if record.state != "active":
+                    conn.rollback()
+                    return _ClaimResult("denied", record)
                 cursor = conn.execute(
                     """UPDATE interactive_actions
                        SET state='processing', updated_at=?
@@ -874,7 +949,7 @@ class SQLiteInteractiveActionStorage:
                 )
                 if cursor.rowcount != 1:
                     conn.rollback()
-                    return _ClaimResult("already_processed", record)
+                    return _ClaimResult("processing", record)
                 conn.commit()
                 return _ClaimResult("claimed", record)
             except Exception:
@@ -889,21 +964,25 @@ class SQLiteInteractiveActionStorage:
         *,
         result: InteractiveActionResult,
         now: float,
-    ) -> None:
+    ) -> bool:
+        next_state = "active" if result.status == "retryable_failure" else "finished"
         with self._lock:
             conn = self._connect()
             try:
                 cursor = conn.execute(
                     """UPDATE interactive_actions
-                       SET state='finished', outcome=?, updated_at=?
+                       SET state=?, outcome=?, user_message=?, updated_at=?
                        WHERE action_instance_id=? AND state='processing'""",
-                    (result.status, now, action_instance_id),
+                    (
+                        next_state,
+                        result.status,
+                        _sanitize_public_message(result.user_message),
+                        now,
+                        action_instance_id,
+                    ),
                 )
-                if cursor.rowcount != 1:
-                    raise RuntimeError(
-                        "interactive action final state was not persisted"
-                    )
                 conn.commit()
+                return cursor.rowcount == 1
             finally:
                 conn.close()
 
@@ -1149,7 +1228,15 @@ class InteractiveActionManager:
             return InteractiveActionResult.denied()
 
         claim = self.storage.claim(callback, now=self._clock())
-        if claim.status == "already_processed":
+        if claim.status == "processing":
+            return InteractiveActionResult.processing()
+        if claim.status == "finished" and claim.record is not None:
+            outcome = claim.record.outcome
+            if outcome in _DEFAULT_RESULT_MESSAGES:
+                return InteractiveActionResult(
+                    status=cast(InteractiveActionStatus, outcome),
+                    user_message=claim.record.user_message,
+                )
             return InteractiveActionResult.already_processed()
         if claim.status == "denied":
             return InteractiveActionResult.denied()
@@ -1171,13 +1258,33 @@ class InteractiveActionManager:
         """Run one already-claimed handler and durably record its final state."""
 
         context = claim.record.handler_context(claim.callback)
-        result = await self._run_handler(claim.registration.handler, context)
-        self.storage.finish(
+        try:
+            result = await self._run_handler(claim.registration.handler, context)
+        except asyncio.CancelledError:
+            try:
+                self.mark_unknown_outcome(claim)
+            except Exception as exc:
+                logger.warning(
+                    "Interactive action cancellation persistence failed (%s)",
+                    type(exc).__name__,
+                )
+            raise
+        if not self.storage.finish(
             claim.callback.action_instance_id,
             result=result,
             now=self._clock(),
-        )
+        ):
+            raise RuntimeError("interactive action final state was not persisted")
         return result
+
+    def mark_unknown_outcome(self, claim: ClaimedInteractiveAction) -> bool:
+        """Terminalize a still-processing claim without overwriting a result."""
+
+        return self.storage.finish(
+            claim.callback.action_instance_id,
+            result=InteractiveActionResult.unknown_outcome(),
+            now=self._clock(),
+        )
 
     async def _run_handler(
         self,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2734,6 +2734,12 @@ class BasePlatformAdapter(ABC):
     # site.
     interactive_resume: bool = True
 
+    # Native platform-neutral plugin card support. Unsupported adapters keep
+    # this false and use ``send_interactive_card``'s exact-text fallback via
+    # their ordinary ``send`` path. No clickable action ledger is created for
+    # that path; the gateway manager checks this flag before reserving IDs.
+    supports_interactive_cards: bool = False
+
     # Back-reference to the running ``GatewayRunner``, injected by
     # ``gateway/run.py`` after the adapter is created. Adapters consume it via
     # ``getattr(self, "gateway_runner", None)`` for cross-platform delivery and
@@ -3494,6 +3500,38 @@ class BasePlatformAdapter(ABC):
             SendResult with success status and message ID
         """
         pass
+
+    async def send_interactive_card(
+        self,
+        *,
+        chat_id: str,
+        envelope: Any,
+        action_instance_ids: tuple[str, ...] = (),
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an exact fallback on adapters without native card support."""
+
+        return await self.send(
+            chat_id=chat_id,
+            content=envelope.fallback_text,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def update_interactive_card(
+        self,
+        *,
+        chat_id: str,
+        card_id: str,
+        result: Any,
+    ) -> SendResult:
+        """Update native card state; unsupported adapters fail explicitly."""
+
+        return SendResult(
+            success=False,
+            error="interactive card updates are not supported",
+        )
 
     # Default: the adapter treats ``finalize=True`` on edit_message as a
     # no-op and is happy to have the stream consumer skip redundant final

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3525,6 +3525,7 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         card_id: str,
         result: Any,
+        action_instance_id: Optional[str] = None,
     ) -> SendResult:
         """Update native card state; unsupported adapters fail explicitly."""
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4062,6 +4062,71 @@ class TurnRunner:
                     ctx._cleanup_msg_ids.append(str(mid))
             _fut.add_done_callback(_track_status_id)
 
+    def _send_interactive_card_sync(self, *, plugin_id: str, envelope: Any) -> Any:
+        """Bridge a plugin hook in the agent thread to the current gateway turn."""
+        from gateway.interactive_actions import (
+            InteractiveCardOrigin,
+            InteractiveCardUnavailableError,
+        )
+        from hermes_cli.profiles import get_active_profile_name
+
+        ctx = self._ctx
+        if not ctx._interactive_card_sender_active or not ctx._run_still_current():
+            raise InteractiveCardUnavailableError(
+                "the current gateway turn is no longer active"
+            )
+        adapter = self._runner._adapter_for_source(ctx.source)
+        if adapter is None or ctx._loop_for_step is None:
+            raise InteractiveCardUnavailableError(
+                "the current gateway turn has no delivery adapter"
+            )
+        try:
+            caller_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            caller_loop = None
+        if caller_loop is ctx._loop_for_step:
+            raise InteractiveCardUnavailableError(
+                "interactive card delivery cannot synchronously block the gateway loop"
+            )
+        source = ctx.source
+        origin = InteractiveCardOrigin(
+            platform=source.platform.value,
+            profile_id=str(
+                getattr(source, "profile", None)
+                or get_active_profile_name()
+                or "default"
+            ),
+            chat_id=str(source.chat_id or ""),
+            thread_id=str(source.thread_id) if source.thread_id else None,
+            initiator_id=str(source.user_id or ""),
+            initiator_name=str(source.user_name or source.user_id or ""),
+            message_id=str(ctx.event_message_id or source.message_id or ""),
+        )
+        future = safe_schedule_threadsafe(
+            self._runner._interactive_action_manager.deliver_card(
+                plugin_id=plugin_id,
+                envelope=envelope,
+                origin=origin,
+                adapter=adapter,
+                metadata=dict(ctx._status_thread_metadata)
+                if ctx._status_thread_metadata
+                else None,
+            ),
+            ctx._loop_for_step,
+            logger=logger,
+            log_message="interactive card delivery scheduling error",
+        )
+        if future is None:
+            raise InteractiveCardUnavailableError(
+                "the current gateway turn could not schedule card delivery"
+            )
+        try:
+            return future.result(timeout=30)
+        except Exception as exc:
+            raise InteractiveCardUnavailableError(
+                "interactive card delivery failed for the current gateway turn"
+            ) from exc
+
     def run_sync(self):
         ctx = self._ctx
         # Historical note: as a nested closure this body declared
@@ -5080,7 +5145,17 @@ class TurnRunner:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
-            result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+            from gateway.interactive_actions import bind_interactive_card_sender
+
+            ctx._interactive_card_sender_active = True
+            try:
+                with bind_interactive_card_sender(self._send_interactive_card_sync):
+                    result = agent.run_conversation(
+                        _api_run_message,
+                        **_conversation_kwargs,
+                    )
+            finally:
+                ctx._interactive_card_sender_active = False
         finally:
             unregister_gateway_notify(_approval_session_key)
             # Cancel any pending clarify entries so blocked agent
@@ -5531,6 +5606,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # sites are untouched when multiplexing is off (this dict is empty).
         # Populated by _start_secondary_profile_adapters().
         self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
+        # External-plugin interactive actions stay at the gateway edge: one
+        # process-wide orchestrator, with profile-resolved state.db storage on
+        # each operation and no agent-loop/model-tool surface.
+        from gateway.interactive_actions import InteractiveActionManager
+        from hermes_cli.plugins import get_plugin_manager
+
+        self._interactive_action_manager = InteractiveActionManager(
+            registrations=lambda: get_plugin_manager().get_interactive_actions(),
+        )
+        self._interactive_action_tasks: set[asyncio.Task] = set()
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -23009,6 +23094,144 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
             )
+
+    async def _begin_interactive_action_from_adapter(
+        self,
+        *,
+        callback: Any,
+        source: SessionSource,
+        adapter: BasePlatformAdapter,
+    ) -> Any:
+        """Authorize and durably claim a normalized platform callback.
+
+        The adapter has already authenticated the platform callback. This
+        method applies the normal gateway operator authorization, then the
+        plugin policy and atomic ledger claim. Only a successful claim returns
+        Processing; plugin code runs in a separate task and never enters the
+        transcript/model path.
+        """
+        from gateway.interactive_actions import (
+            InteractiveActionCallback,
+            InteractiveActionResult,
+            ClaimedInteractiveAction,
+        )
+        from dataclasses import replace
+
+        manager = self._interactive_action_manager
+
+        source_platform = getattr(getattr(source, "platform", None), "value", "")
+        source_chat_id = str(getattr(source, "chat_id", "") or "")
+        source_operator_id = str(getattr(source, "user_id", "") or "")
+        source_card_id = str(getattr(source, "message_id", "") or "")
+        if (
+            not isinstance(callback, InteractiveActionCallback)
+            or callback.platform != source_platform
+            or callback.chat_id != source_chat_id
+            or callback.operator_id != source_operator_id
+            or callback.card_id != source_card_id
+        ):
+            return InteractiveActionResult.denied()
+
+        # ``build_source`` stamps route-selected profiles, but a secondary
+        # multiplex adapter with no matching route is still owned by its own
+        # profile.  Derive that ownership by adapter identity; never trust the
+        # adapter-supplied callback profile (which may reflect the process-wide
+        # active profile instead).
+        effective_profile = str(getattr(source, "profile", None) or "").strip()
+        if not effective_profile:
+            primary = (getattr(self, "adapters", None) or {}).get(source.platform)
+            if adapter is primary:
+                effective_profile = self._active_profile_name()
+            else:
+                for profile_name, profile_adapters in (
+                    getattr(self, "_profile_adapters", None) or {}
+                ).items():
+                    if adapter is profile_adapters.get(source.platform):
+                        effective_profile = str(profile_name)
+                        break
+        if not effective_profile:
+            return InteractiveActionResult.denied()
+        source.profile = effective_profile
+        callback = replace(callback, profile_id=effective_profile)
+
+        def _claim() -> Any:
+            return manager.claim_action(
+                callback,
+                gateway_authorize=lambda: self._is_user_authorized(source),
+            )
+
+        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+                claim = _claim()
+        else:
+            claim = _claim()
+        if isinstance(claim, InteractiveActionResult):
+            return claim
+        if not isinstance(claim, ClaimedInteractiveAction):
+            return InteractiveActionResult.retryable_failure()
+
+        task = asyncio.create_task(
+            self._complete_interactive_action(
+                claim=claim,
+                source=source,
+                adapter=adapter,
+            ),
+            name=f"interactive-action:{callback.action_instance_id[:32]}",
+        )
+        tasks = getattr(self, "_interactive_action_tasks", None)
+        if not isinstance(tasks, set):
+            tasks = set()
+            self._interactive_action_tasks = tasks
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+        return InteractiveActionResult.processing()
+
+    async def _complete_interactive_action(
+        self,
+        *,
+        claim: Any,
+        source: SessionSource,
+        adapter: BasePlatformAdapter,
+    ) -> None:
+        """Execute claimed plugin work and replace Processing with final truth."""
+        # Give the platform callback thread a chance to return its inline
+        # Processing card before an especially fast handler edits the same
+        # message to its final state.
+        await asyncio.sleep(0.05)
+        manager = self._interactive_action_manager
+        try:
+            if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                with _profile_runtime_scope(
+                    self._resolve_profile_home_for_source(source)
+                ):
+                    result = await manager.execute_claimed(claim)
+            else:
+                result = await manager.execute_claimed(claim)
+        except Exception as exc:
+            logger.warning(
+                "Interactive action completion persistence failed (%s)",
+                type(exc).__name__,
+            )
+            return
+
+        update_failure_type = "rejected"
+        for attempt in range(3):
+            try:
+                update = await adapter.update_interactive_card(
+                    chat_id=claim.record.chat_id,
+                    card_id=claim.record.card_id or "",
+                    result=result,
+                )
+                if getattr(update, "success", False):
+                    return
+            except Exception as exc:
+                update_failure_type = type(exc).__name__
+            if attempt < 2:
+                await asyncio.sleep(0.25 * (2**attempt))
+        logger.warning(
+            "Interactive action final card update failed after 3 attempts (%s)",
+            update_failure_type,
+        )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5616,6 +5616,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             registrations=lambda: get_plugin_manager().get_interactive_actions(),
         )
         self._interactive_action_tasks: set[asyncio.Task] = set()
+        self._interactive_action_task_claims: dict[
+            asyncio.Task, tuple[Any, SessionSource]
+        ] = {}
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -11986,6 +11989,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._systemd_watchdog = None
         await watchdog.stop()
 
+    async def _drain_interactive_action_tasks(self) -> None:
+        """Bound action completion before adapters needed for card edits close."""
+
+        current = asyncio.current_task()
+        tracked = getattr(self, "_interactive_action_tasks", None)
+        if not isinstance(tracked, set):
+            return
+        tasks = {
+            task
+            for task in tracked
+            if isinstance(task, asyncio.Task)
+            and task is not current
+            and not task.done()
+        }
+        if not tasks:
+            return
+
+        timeout = self._adapter_disconnect_timeout_secs()
+        done, pending = await asyncio.wait(tasks, timeout=max(0.0, timeout))
+        if done:
+            await asyncio.gather(*done, return_exceptions=True)
+        if not pending:
+            return
+
+        logger.warning(
+            "Timed out after %.1fs draining %d interactive action task(s); cancelling",
+            timeout,
+            len(pending),
+        )
+        claims = getattr(self, "_interactive_action_task_claims", None)
+        for task in pending:
+            bound = claims.get(task) if isinstance(claims, dict) else None
+            if bound is not None:
+                claim, source = bound
+                self._mark_interactive_action_unknown_outcome(
+                    claim=claim,
+                    source=source,
+                )
+            task.cancel()
+
+        cancellation_grace = min(max(timeout, 0.1), 1.0)
+        cancelled, stubborn = await asyncio.wait(
+            pending,
+            timeout=cancellation_grace,
+        )
+        if cancelled:
+            await asyncio.gather(*cancelled, return_exceptions=True)
+        if stubborn:
+            logger.warning(
+                "%d cancelled interactive action task(s) did not stop within %.1fs",
+                len(stubborn),
+                cancellation_grace,
+            )
+            for task in stubborn:
+                task.add_done_callback(consume_detached_task_result)
+
     async def stop(
         self,
         *,
@@ -12293,6 +12352,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self._cleanup_agent_resources_off_loop(
                         _agent, context="shutdown idle-cache"
                     )
+
+            await self._drain_interactive_action_tasks()
 
             for platform, adapter in list(self.adapters.items()):
                 await self._bounded_adapter_teardown(adapter, platform)
@@ -23183,8 +23244,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             tasks = set()
             self._interactive_action_tasks = tasks
         tasks.add(task)
-        task.add_done_callback(tasks.discard)
+        claims = getattr(self, "_interactive_action_task_claims", None)
+        if not isinstance(claims, dict):
+            claims = {}
+            self._interactive_action_task_claims = claims
+        claims[task] = (claim, source)
+        task.add_done_callback(
+            lambda completed: self._interactive_action_task_done(
+                completed,
+                claim=claim,
+                source=source,
+            )
+        )
         return InteractiveActionResult.processing()
+
+    def _interactive_action_task_done(
+        self,
+        task: asyncio.Task,
+        *,
+        claim: Any,
+        source: SessionSource,
+    ) -> None:
+        """Release task tracking and terminalize a cancelled claimed action."""
+
+        tasks = getattr(self, "_interactive_action_tasks", None)
+        if isinstance(tasks, set):
+            tasks.discard(task)
+        claims = getattr(self, "_interactive_action_task_claims", None)
+        if isinstance(claims, dict):
+            claims.pop(task, None)
+        if not task.cancelled():
+            return
+        self._mark_interactive_action_unknown_outcome(
+            claim=claim,
+            source=source,
+        )
+
+    def _mark_interactive_action_unknown_outcome(
+        self,
+        *,
+        claim: Any,
+        source: SessionSource,
+    ) -> None:
+        """Persist cancellation ambiguity without overwriting durable truth."""
+
+        manager = self._interactive_action_manager
+        try:
+            if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                with _profile_runtime_scope(
+                    self._resolve_profile_home_for_source(source)
+                ):
+                    manager.mark_unknown_outcome(claim)
+            else:
+                manager.mark_unknown_outcome(claim)
+        except Exception as exc:
+            logger.warning(
+                "Interactive action cancellation persistence failed (%s)",
+                type(exc).__name__,
+            )
 
     async def _complete_interactive_action(
         self,
@@ -23217,10 +23334,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         update_failure_type = "rejected"
         for attempt in range(3):
             try:
-                update = await adapter.update_interactive_card(
-                    chat_id=claim.record.chat_id,
-                    card_id=claim.record.card_id or "",
-                    result=result,
+                update_card = adapter.update_interactive_card
+                update_kwargs = {
+                    "chat_id": claim.record.chat_id,
+                    "card_id": claim.record.card_id or "",
+                    "result": result,
+                }
+                try:
+                    update_params = inspect.signature(update_card).parameters
+                    supports_action_id = (
+                        "action_instance_id" in update_params
+                        or any(
+                            param.kind is inspect.Parameter.VAR_KEYWORD
+                            for param in update_params.values()
+                        )
+                    )
+                except (TypeError, ValueError):
+                    supports_action_id = False
+                if supports_action_id:
+                    update_kwargs["action_instance_id"] = (
+                        claim.record.action_instance_id
+                    )
+                update = await update_card(
+                    **update_kwargs,
                 )
                 if getattr(update, "success", False):
                     return

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -118,6 +118,10 @@ class TurnContext:
     _status_adapter: Any = None
     _status_chat_id: Any = None
     _status_thread_metadata: Optional[dict] = None
+    # A copied ContextVar can outlive the thread that created it.  Keep an
+    # explicit turn-lifetime gate so a plugin-owned background thread cannot
+    # retain the bound card sender after ``run_conversation`` returns.
+    _interactive_card_sender_active: bool = False
 
     # --- extracted sibling callbacks (bound TurnRunner methods; run_sync
     #     reads them through the ctx exactly where it used to close over

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1059,6 +1059,55 @@ class PluginContext:
             action_id,
         )
 
+    # -- platform-neutral interactive actions -------------------------------
+
+    def register_interactive_action(
+        self,
+        action_name: str,
+        handler: Callable,
+        authorization_policy: str = "initiator_only",
+    ) -> str:
+        """Register a deterministic gateway-card action owned by this plugin.
+
+        ``action_name`` may be local (``"apply"``) or already qualified
+        (``"my-plugin/apply"``).  The returned qualified name is what card
+        envelopes reference.
+        """
+        from gateway.interactive_actions import (
+            InteractiveActionRegistrationError,
+            build_registration,
+        )
+
+        plugin_id = self.manifest.key or self.manifest.name
+        registration = build_registration(
+            plugin_id=plugin_id,
+            action_name=action_name,
+            handler=handler,
+            authorization_policy=authorization_policy,
+        )
+        if registration.qualified_name in self._manager._interactive_actions:
+            raise InteractiveActionRegistrationError(
+                f"interactive action {registration.qualified_name!r} is already registered"
+            )
+        self._manager._interactive_actions[registration.qualified_name] = registration
+        logger.debug(
+            "Plugin %s registered interactive action: %s",
+            self.manifest.name,
+            registration.qualified_name,
+        )
+        return registration.qualified_name
+
+    def send_interactive_card(self, envelope: Any) -> Any:
+        """Send a card to the current gateway turn's conversation.
+
+        The destination is gateway-owned.  This capability fails closed when
+        invoked outside a bound gateway turn.
+        """
+        from gateway.interactive_actions import send_current_interactive_card
+
+        plugin_id = self.manifest.key or self.manifest.name
+        return send_current_interactive_card(plugin_id=plugin_id, envelope=envelope)
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -1290,6 +1339,8 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Qualified action name -> immutable plugin-owned registration.
+        self._interactive_actions: Dict[str, Any] = {}
 
     # -----------------------------------------------------------------------
     # Public
@@ -1319,6 +1370,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._interactive_actions.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -1779,6 +1831,7 @@ class PluginManager:
             f"{_NS_PARENT}.{_slug}",
             PluginContext(manifest, self)._tool_override_allowed(""),
         )
+        _interactive_actions_before = dict(self._interactive_actions)
         try:
             if manifest.source in {"user", "project", "bundled"}:
                 module = self._load_directory_module(manifest)
@@ -1841,6 +1894,12 @@ class PluginManager:
                 )
 
         except Exception as exc:
+            # High-impact card handlers must never survive a failed plugin
+            # registration as partially-live capability. Discovery is
+            # serialized, so restoring the pre-register snapshot is atomic
+            # with respect to the plugin load sweep.
+            self._interactive_actions.clear()
+            self._interactive_actions.update(_interactive_actions_before)
             loaded.error = str(exc)
             logger.warning(
                 "Failed to load plugin '%s': %s",
@@ -1952,6 +2011,11 @@ class PluginManager:
     def has_middleware(self, kind: str) -> bool:
         """Return True when at least one callback is registered for middleware."""
         return bool(self._middleware.get(kind))
+
+    def get_interactive_actions(self) -> Dict[str, Any]:
+        """Return a snapshot of registered gateway-card actions."""
+
+        return dict(self._interactive_actions)
 
     def invoke_middleware(self, kind: str, **kwargs: Any) -> List[Any]:
         """Call registered middleware callbacks for *kind*.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2094,6 +2094,7 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id: str,
         card_id: str,
         result: Any,
+        action_instance_id: Optional[str] = None,
     ) -> SendResult:
         """Replace a plugin card with its truthful final action state."""
 
@@ -2101,7 +2102,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not card_id:
             return SendResult(success=False, error="interactive card is unavailable")
         try:
-            card = self._build_interactive_action_status_card(result)
+            card = self._build_interactive_action_status_card(
+                result,
+                action_instance_id=action_instance_id,
+            )
             body = self._build_update_message_body(
                 msg_type="interactive",
                 content=json.dumps(card, ensure_ascii=False),
@@ -2868,7 +2872,11 @@ class FeishuAdapter(BasePlatformAdapter):
         return True
 
     @staticmethod
-    def _build_interactive_action_status_card(result: Any) -> Dict[str, Any]:
+    def _build_interactive_action_status_card(
+        result: Any,
+        *,
+        action_instance_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         status = str(getattr(result, "status", "retryable_failure") or "")
         title, template = {
             "processing": ("⏳ Processing", "blue"),
@@ -2880,18 +2888,34 @@ class FeishuAdapter(BasePlatformAdapter):
             "expired": ("⌛ Expired", "grey"),
             "conflict": ("⚠️ Conflict", "orange"),
             "retryable_failure": ("⚠️ Retryable failure", "orange"),
+            "unknown_outcome": ("⚠️ Outcome unknown", "grey"),
         }.get(status, ("⚠️ Retryable failure", "orange"))
         message = str(
             getattr(result, "user_message", "The confirmation could not be completed.")
             or "The confirmation could not be completed."
         )
+        elements: List[Dict[str, Any]] = [
+            {"tag": "markdown", "content": message}
+        ]
+        if status == "retryable_failure" and action_instance_id:
+            elements.append({
+                "tag": "action",
+                "actions": [{
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": "Retry"},
+                    "type": "primary",
+                    "value": {
+                        "hermes_interactive_action_id": action_instance_id,
+                    },
+                }],
+            })
         return {
             "config": {"wide_screen_mode": True},
             "header": {
                 "title": {"content": title, "tag": "plain_text"},
                 "template": template,
             },
-            "elements": [{"tag": "markdown", "content": message}],
+            "elements": elements,
         }
 
     def _handle_plugin_interactive_action(
@@ -2947,6 +2971,7 @@ class FeishuAdapter(BasePlatformAdapter):
             "already_processed",
             "expired",
             "conflict",
+            "unknown_outcome",
         }:
             card = CallBackCard()
             card.type = "raw"

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1447,6 +1447,12 @@ class FeishuAdapter(BasePlatformAdapter):
     # is almost certain.
     _SPLIT_THRESHOLD = 4000
 
+    @property
+    def supports_interactive_cards(self) -> bool:
+        """Only the SDK-authenticated WebSocket callback path is V1-native."""
+
+        return getattr(self, "_connection_mode", "") == "websocket"
+
     # =========================================================================
     # Lifecycle — init / settings / connect / disconnect
     # =========================================================================
@@ -1998,6 +2004,132 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_plugin_interactive_card(
+        envelope: Any,
+        action_instance_ids: tuple[str, ...],
+    ) -> Dict[str, Any]:
+        """Render a platform-neutral envelope with opaque button values."""
+
+        if len(action_instance_ids) != len(envelope.actions):
+            raise ValueError("interactive card action ID count mismatch")
+        elements: List[Dict[str, Any]] = [
+            {"tag": "markdown", "content": envelope.summary},
+        ]
+        if envelope.facts:
+            facts = "\n".join(
+                f"**{fact.label}:** {fact.value}" for fact in envelope.facts
+            )
+            elements.append({"tag": "markdown", "content": facts})
+        for section in envelope.sections:
+            elements.append({
+                "tag": "markdown",
+                "content": f"**{section.title}**\n{section.body}",
+            })
+        buttons = []
+        for action, instance_id in zip(
+            envelope.actions,
+            action_instance_ids,
+            strict=True,
+        ):
+            buttons.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": action.label},
+                "type": action.style,
+                "value": {"hermes_interactive_action_id": instance_id},
+            })
+        elements.append({"tag": "action", "actions": buttons})
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": envelope.title, "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": elements,
+        }
+
+    async def send_interactive_card(
+        self,
+        *,
+        chat_id: str,
+        envelope: Any,
+        action_instance_ids: tuple[str, ...] = (),
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an external-plugin confirmation as a native Feishu card."""
+
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        try:
+            card = self._build_plugin_interactive_card(
+                envelope,
+                action_instance_ids,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=json.dumps(card, ensure_ascii=False),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(
+                response,
+                "send_interactive_card failed",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] send_interactive_card failed (%s)",
+                type(exc).__name__,
+            )
+            return SendResult(
+                success=False,
+                error="interactive card delivery failed",
+            )
+
+    async def update_interactive_card(
+        self,
+        *,
+        chat_id: str,
+        card_id: str,
+        result: Any,
+    ) -> SendResult:
+        """Replace a plugin card with its truthful final action state."""
+
+        del chat_id  # Feishu updates address the card message directly.
+        if not self._client or not card_id:
+            return SendResult(success=False, error="interactive card is unavailable")
+        try:
+            card = self._build_interactive_action_status_card(result)
+            body = self._build_update_message_body(
+                msg_type="interactive",
+                content=json.dumps(card, ensure_ascii=False),
+            )
+            request = self._build_update_message_request(
+                message_id=card_id,
+                request_body=body,
+            )
+            response = await self._run_blocking(
+                self._client.im.v1.message.update,
+                request,
+            )
+            finalized = self._finalize_send_result(
+                response,
+                "update_interactive_card failed",
+            )
+            if finalized.success:
+                finalized.message_id = card_id
+            return finalized
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] update_interactive_card failed (%s)",
+                type(exc).__name__,
+            )
+            return SendResult(
+                success=False,
+                error="interactive card update failed",
+            )
 
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.
@@ -2686,6 +2818,15 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        has_interactive_action_id = (
+            isinstance(action_value, dict)
+            and "hermes_interactive_action_id" in action_value
+        )
+        interactive_action_id = (
+            action_value.get("hermes_interactive_action_id")
+            if has_interactive_action_id
+            else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
@@ -2693,6 +2834,12 @@ class FeishuAdapter(BasePlatformAdapter):
             return self._handle_update_prompt_card_action(
                 event=event,
                 action_value=action_value,
+                loop=loop,
+            )
+        if has_interactive_action_id:
+            return self._handle_plugin_interactive_action(
+                event=event,
+                action_instance_id=str(interactive_action_id or ""),
                 loop=loop,
             )
 
@@ -2720,15 +2867,164 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
-        """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
-            return False
-        allowed_ids = set(self._admins) | set(self._allowed_group_users)
-        if not allowed_ids:
-            return True
-        return "*" in allowed_ids or normalized in allowed_ids
+    @staticmethod
+    def _build_interactive_action_status_card(result: Any) -> Dict[str, Any]:
+        status = str(getattr(result, "status", "retryable_failure") or "")
+        title, template = {
+            "processing": ("⏳ Processing", "blue"),
+            "succeeded": ("✅ Applied", "green"),
+            "downstream_replay": ("✅ Already applied", "green"),
+            "already_processed": ("ℹ️ Already processed", "blue"),
+            "denied": ("⛔ Denied", "red"),
+            "unknown": ("⚠️ Unavailable", "grey"),
+            "expired": ("⌛ Expired", "grey"),
+            "conflict": ("⚠️ Conflict", "orange"),
+            "retryable_failure": ("⚠️ Retryable failure", "orange"),
+        }.get(status, ("⚠️ Retryable failure", "orange"))
+        message = str(
+            getattr(result, "user_message", "The confirmation could not be completed.")
+            or "The confirmation could not be completed."
+        )
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title, "tag": "plain_text"},
+                "template": template,
+            },
+            "elements": [{"tag": "markdown", "content": message}],
+        }
+
+    def _handle_plugin_interactive_action(
+        self,
+        *,
+        event: Any,
+        action_instance_id: str,
+        loop: Any,
+    ) -> Any:
+        """Authorize+claim before returning an inline Processing card."""
+
+        from gateway.interactive_actions import InteractiveActionResult
+
+        if self._connection_mode != "websocket":
+            result = InteractiveActionResult.denied()
+            return self._build_interactive_action_callback_response(result)
+
+        future = None
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self._begin_plugin_interactive_action(
+                    event=event,
+                    action_instance_id=action_instance_id,
+                ),
+                loop,
+            )
+            result = future.result(timeout=3.0)
+        except Exception as exc:
+            if future is not None:
+                future.cancel()
+            logger.warning(
+                "[Feishu] interactive action claim failed (%s)",
+                type(exc).__name__,
+            )
+            result = InteractiveActionResult.retryable_failure()
+
+        return self._build_interactive_action_callback_response(result)
+
+    def _build_interactive_action_callback_response(self, result: Any) -> Any:
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        # A callback response replaces the shared card for every viewer.  A
+        # denied, unknown, or pre-claim failure must therefore leave the live
+        # confirmation untouched; otherwise any unauthorized group member
+        # could remove the initiator's buttons.  Only claimed or terminal
+        # ledger states may replace the card inline.
+        status = str(getattr(result, "status", "") or "")
+        if CallBackCard is not None and status in {
+            "processing",
+            "succeeded",
+            "downstream_replay",
+            "already_processed",
+            "expired",
+            "conflict",
+        }:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_interactive_action_status_card(result)
+            response.card = card
+        return response
+
+    async def _begin_plugin_interactive_action(
+        self,
+        *,
+        event: Any,
+        action_instance_id: str,
+    ) -> Any:
+        """Normalize SDK callback fields before entering the generic runner."""
+
+        from gateway.interactive_actions import (
+            InteractiveActionCallback,
+            InteractiveActionResult,
+        )
+
+        context = getattr(event, "context", None)
+        chat_id = str(getattr(context, "open_chat_id", "") or "")
+        card_id = str(getattr(context, "open_message_id", "") or "")
+        thread_id = str(
+            getattr(context, "open_thread_id", "")
+            or getattr(context, "open_root_id", "")
+            or ""
+        )
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        if not action_instance_id or not chat_id or not card_id or not open_id:
+            return InteractiveActionResult.denied()
+
+        sender_id = SimpleNamespace(
+            open_id=open_id,
+            user_id=str(getattr(operator, "user_id", "") or ""),
+            union_id=str(getattr(operator, "union_id", "") or ""),
+        )
+        sender_profile = await self._resolve_sender_profile(sender_id)
+        stable_operator_id = str(sender_profile.get("user_id") or "")
+        if not stable_operator_id:
+            return InteractiveActionResult.denied()
+        chat_info = await self.get_chat_info(chat_id)
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_info.get("name") or chat_id,
+            chat_type=self._resolve_source_chat_type(
+                chat_info=chat_info,
+                event_chat_type="group",
+            ),
+            user_id=stable_operator_id,
+            user_name=str(sender_profile.get("user_name") or stable_operator_id),
+            thread_id=thread_id or None,
+            user_id_alt=sender_profile.get("user_id_alt"),
+            message_id=card_id,
+        )
+        callback = InteractiveActionCallback(
+            action_instance_id=action_instance_id,
+            platform=self.platform.value,
+            # Profile ownership is gateway state, not a platform callback
+            # field. GatewayRunner overwrites this placeholder from the
+            # routed source / receiving adapter identity before any lookup.
+            profile_id="",
+            operator_id=stable_operator_id,
+            operator_name=str(sender_profile.get("user_name") or stable_operator_id),
+            chat_id=chat_id,
+            thread_id=thread_id or None,
+            card_id=card_id,
+        )
+        runner = getattr(self, "gateway_runner", None)
+        begin = getattr(runner, "_begin_interactive_action_from_adapter", None)
+        if not callable(begin):
+            return InteractiveActionResult.retryable_failure()
+        return await begin(
+            callback=callback,
+            source=source,
+            adapter=self,
+        )
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2744,8 +3040,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        user_id = str(getattr(operator, "user_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        if not self._allow_group_message(
+            sender_id,
+            state["chat_id"],
+            is_bot=False,
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2771,6 +3072,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 choice=choice,
                 user_name=user_name,
                 open_id=open_id,
+                user_id=user_id,
                 chat_id=chat_id,
             ),
         ):
@@ -2804,8 +3106,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        user_id = str(getattr(operator, "user_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        if not self._allow_group_message(
+            sender_id,
+            state["chat_id"],
+            is_bot=False,
+        ):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2828,6 +3135,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 answer,
                 user_name,
                 open_id=open_id,
+                user_id=user_id,
                 chat_id=callback_chat_id,
             ),
         ):
@@ -2850,6 +3158,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Pop approval state and unblock the waiting agent thread."""
@@ -2857,7 +3166,12 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        if not self._allow_group_message(
+            sender_id,
+            state["chat_id"],
+            is_bot=False,
+        ):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
         expected_chat_id = str(state.get("chat_id", "") or "")
@@ -2904,6 +3218,7 @@ class FeishuAdapter(BasePlatformAdapter):
         user_name: str,
         *,
         open_id: str = "",
+        user_id: str = "",
         chat_id: str = "",
     ) -> None:
         """Persist an update prompt answer for the detached update process."""
@@ -2911,11 +3226,14 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
-        if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-                logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
-                return
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        if not self._allow_group_message(
+            sender_id,
+            state["chat_id"],
+            is_bot=False,
+        ):
+            logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
+            return
         expected_chat_id = str(state.get("chat_id", "") or "")
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -334,6 +334,7 @@ class TestFeishuPluginInteractiveCard:
             ("denied", "Denied", "red"),
             ("conflict", "Conflict", "orange"),
             ("retryable_failure", "Retryable failure", "orange"),
+            ("unknown_outcome", "Outcome unknown", "grey"),
         ],
     )
     def test_status_cards_distinguish_truthful_states(
@@ -387,6 +388,42 @@ class TestFeishuPluginInteractiveCard:
         assert request.request_body.msg_type == "interactive"
         card = json.loads(request.request_body.content)
         assert card["header"]["template"] == "green"
+
+    @pytest.mark.asyncio
+    async def test_retryable_update_keeps_same_opaque_action_reclaimable(self):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+        response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="om_card"),
+        )
+        with (
+            patch.object(
+                adapter._client.im.v1.message,
+                "update",
+                return_value=response,
+            ),
+            patch.object(
+                adapter,
+                "_run_blocking",
+                new_callable=AsyncMock,
+                return_value=response,
+            ) as run_blocking,
+        ):
+            result = await adapter.update_interactive_card(
+                chat_id="oc_chat",
+                card_id="om_card",
+                result=InteractiveActionResult.retryable_failure(),
+                action_instance_id="ia_opaque_123",
+            )
+
+        assert result.success is True
+        request = run_blocking.await_args.args[1]
+        card = json.loads(request.request_body.content)
+        assert card["elements"][1]["actions"][0]["value"] == {
+            "hermes_interactive_action_id": "ia_opaque_123"
+        }
 
 
 # ===========================================================================
@@ -708,6 +745,21 @@ class TestCardActionCallbackResponse:
         )
 
         assert response.card is None
+
+    def test_unknown_outcome_replay_replaces_card_with_terminal_warning(
+        self,
+        _patch_callback_card_types,
+    ):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+        result = InteractiveActionResult.unknown_outcome()
+
+        response = adapter._build_interactive_action_callback_response(result)
+
+        assert response.card is not None
+        assert "Outcome unknown" in response.card.data["header"]["title"]["content"]
+        assert response.card.data["elements"][0]["content"] == result.user_message
 
     def test_unknown_non_hermes_action_preserves_synthetic_card_path(
         self,

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -39,7 +39,7 @@ _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
 import plugins.platforms.feishu.adapter as feishu_module
-from plugins.platforms.feishu.adapter import FeishuAdapter
+from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuGroupRule
 
 
 # ---------------------------------------------------------------------------
@@ -59,12 +59,16 @@ def _make_card_action_data(
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
     token: str = "tok_abc",
+    card_id: str = "om_card",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
     return SimpleNamespace(
         event=SimpleNamespace(
             token=token,
-            context=SimpleNamespace(open_chat_id=chat_id),
+            context=SimpleNamespace(
+                open_chat_id=chat_id,
+                open_message_id=card_id,
+            ),
             operator=SimpleNamespace(open_id=open_id),
             action=SimpleNamespace(
                 tag="button",
@@ -78,6 +82,47 @@ def _close_submitted_coro(coro, _loop):
     """Close scheduled coroutines in sync-handler tests to avoid unawaited warnings."""
     coro.close()
     return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+
+def test_pinned_sdk_card_callback_and_send_receipt_fields_match_adapter_contract():
+    callback_model = pytest.importorskip(
+        "lark_oapi.event.callback.model.p2_card_action_trigger"
+    )
+    reply_model = pytest.importorskip(
+        "lark_oapi.api.im.v1.model.reply_message_response_body"
+    )
+    create_model = pytest.importorskip(
+        "lark_oapi.api.im.v1.model.create_message_response_body"
+    )
+
+    assert {"open_chat_id", "open_message_id"}.issubset(
+        callback_model.CallBackContext._types
+    )
+    assert {"open_id", "user_id", "union_id"}.issubset(
+        callback_model.CallBackOperator._types
+    )
+    assert "message_id" in reply_model.ReplyMessageResponseBody._types
+    assert "message_id" in create_model.CreateMessageResponseBody._types
+
+    callback = callback_model.P2CardActionTrigger({
+        "event": {
+            "operator": {
+                "open_id": "ou_operator",
+                "user_id": "operator-stable-id",
+                "union_id": "on_operator",
+            },
+            "context": {
+                "open_chat_id": "oc_chat",
+                "open_message_id": "om_card",
+            },
+            "action": {
+                "value": {"hermes_interactive_action_id": "ia_opaque"},
+            },
+        }
+    })
+    assert callback.event.operator.user_id == "operator-stable-id"
+    assert callback.event.context.open_chat_id == "oc_chat"
+    assert callback.event.context.open_message_id == "om_card"
 
 
 # ===========================================================================
@@ -106,7 +151,7 @@ class TestFeishuExecApproval:
                 description="dangerous deletion",
             )
 
-        assert result.success is True
+            assert result.success is True
         assert result.message_id == "msg_001"
 
         mock_send.assert_called_once()
@@ -152,6 +197,196 @@ class TestFeishuExecApproval:
         assert state["session_key"] == "my-session-key"
         assert state["message_id"] == "msg_002"
         assert state["chat_id"] == "oc_12345"
+
+
+class TestFeishuPluginInteractiveCard:
+    """Plugin cards use opaque Hermes action-instance values only."""
+
+    def test_webhook_mode_uses_generic_fallback_instead_of_native_ledger(self):
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"connection_mode": "webhook"},
+            )
+        )
+
+        assert adapter.supports_interactive_cards is False
+
+    @pytest.mark.asyncio
+    async def test_native_render_contains_no_business_payload_in_button_values(self):
+        from gateway.interactive_actions import (
+            InteractiveCardAction,
+            InteractiveCardEnvelope,
+            InteractiveCardFact,
+            InteractiveCardSection,
+        )
+
+        adapter = _make_adapter()
+        envelope = InteractiveCardEnvelope(
+            version=1,
+            title="Apply proposal?",
+            summary="Review the commercial change.",
+            facts=(InteractiveCardFact("Customer", "Acme"),),
+            sections=(InteractiveCardSection("Terms", "CNY 120,000 / year"),),
+            fallback_text="Apply proposal for Acme in the admin console.",
+            expires_in_seconds=900,
+            actions=(
+                InteractiveCardAction(
+                    label="Apply",
+                    action="proposal-plugin/apply",
+                    external_action_id="proposal-acme-v7",
+                    payload={"proposal_id": "prop_7", "revision": 7},
+                    style="primary",
+                ),
+            ),
+        )
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="om_card"),
+        )
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_interactive_card(
+                chat_id="oc_chat",
+                envelope=envelope,
+                action_instance_ids=("ia_opaque_123",),
+                reply_to="om_trigger",
+                metadata={"thread_id": "om_root"},
+            )
+
+        assert result.success is True
+        kwargs = mock_send.await_args.kwargs
+        assert kwargs["msg_type"] == "interactive"
+        assert kwargs["reply_to"] == "om_trigger"
+        card = json.loads(kwargs["payload"])
+        buttons = [
+            action
+            for element in card["elements"]
+            if element.get("tag") == "action"
+            for action in element["actions"]
+        ]
+        assert [button["value"] for button in buttons] == [
+            {"hermes_interactive_action_id": "ia_opaque_123"}
+        ]
+        serialized_values = json.dumps(
+            [button["value"] for button in buttons],
+            ensure_ascii=False,
+        )
+        assert "prop_7" not in serialized_values
+        assert "proposal-acme-v7" not in serialized_values
+        assert "proposal-plugin/apply" not in serialized_values
+
+    @pytest.mark.asyncio
+    async def test_callback_uses_same_stable_user_identity_order_as_inbound_messages(
+        self,
+    ):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+        adapter._resolve_sender_name_from_api = AsyncMock(return_value="Alice")
+        adapter.get_chat_info = AsyncMock(
+            return_value={"name": "Sales", "type": "group"}
+        )
+        runner = SimpleNamespace(
+            _profile_name_for_source=lambda _source: None,
+            _begin_interactive_action_from_adapter=AsyncMock(
+                return_value=InteractiveActionResult.processing()
+            ),
+        )
+        adapter.gateway_runner = runner
+        event = SimpleNamespace(
+            context=SimpleNamespace(
+                open_chat_id="oc_chat",
+                open_message_id="om_card",
+            ),
+            operator=SimpleNamespace(
+                open_id="ou_app_scoped",
+                user_id="tenant-stable-user",
+                union_id="on_developer_scoped",
+            ),
+        )
+
+        result = await adapter._begin_plugin_interactive_action(
+            event=event,
+            action_instance_id="ia_opaque",
+        )
+
+        assert result.status == "processing"
+        kwargs = runner._begin_interactive_action_from_adapter.await_args.kwargs
+        assert kwargs["callback"].operator_id == "tenant-stable-user"
+        assert kwargs["source"].user_id == "tenant-stable-user"
+        assert kwargs["source"].user_id_alt == "on_developer_scoped"
+        assert kwargs["source"].message_id == "om_card"
+        assert kwargs["adapter"] is adapter
+
+    @pytest.mark.parametrize(
+        ("status", "title_fragment", "template"),
+        [
+            ("processing", "Processing", "blue"),
+            ("succeeded", "Applied", "green"),
+            ("downstream_replay", "Already applied", "green"),
+            ("already_processed", "Already processed", "blue"),
+            ("denied", "Denied", "red"),
+            ("conflict", "Conflict", "orange"),
+            ("retryable_failure", "Retryable failure", "orange"),
+        ],
+    )
+    def test_status_cards_distinguish_truthful_states(
+        self,
+        status,
+        title_fragment,
+        template,
+    ):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        result = getattr(InteractiveActionResult, status)()
+        card = FeishuAdapter._build_interactive_action_status_card(result)
+
+        assert title_fragment in card["header"]["title"]["content"]
+        assert card["header"]["template"] == template
+        if status != "succeeded":
+            assert card["header"]["title"]["content"] != "✅ Applied"
+
+    @pytest.mark.asyncio
+    async def test_final_result_updates_native_card(self):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+        response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="om_card"),
+        )
+        with (
+            patch.object(
+                adapter._client.im.v1.message,
+                "update",
+                return_value=response,
+            ),
+            patch.object(
+                adapter,
+                "_run_blocking",
+                new_callable=AsyncMock,
+                return_value=response,
+            ) as run_blocking,
+        ):
+            result = await adapter.update_interactive_card(
+                chat_id="oc_chat",
+                card_id="om_card",
+                result=InteractiveActionResult.succeeded(),
+            )
+
+        assert result.success is True
+        assert result.message_id == "om_card"
+        request = run_blocking.await_args.args[1]
+        assert request.message_id == "om_card"
+        assert request.request_body.msg_type == "interactive"
+        card = json.loads(request.request_body.content)
+        assert card["header"]["template"] == "green"
 
 
 # ===========================================================================
@@ -207,6 +442,7 @@ class TestResolveApproval:
     @pytest.mark.asyncio
     async def test_resolves_once(self):
         adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_user1"}
         adapter._approval_state[1] = {
             "session_key": "agent:main:feishu:group:oc_12345",
             "message_id": "msg_001",
@@ -293,6 +529,70 @@ def _patch_callback_card_types(monkeypatch):
 class TestCardActionCallbackResponse:
     """Test that _on_card_action_trigger returns updated card inline."""
 
+    @pytest.mark.parametrize(
+        ("action_value", "state_attr"),
+        [
+            (
+                {"hermes_action": "approve_once", "approval_id": 9},
+                "_approval_state",
+            ),
+            (
+                {
+                    "hermes_update_prompt_action": "y",
+                    "update_prompt_id": 9,
+                },
+                "_update_prompt_state",
+            ),
+        ],
+        ids=("approval", "update-prompt"),
+    )
+    @pytest.mark.parametrize(
+        ("open_id", "is_allowed"),
+        [
+            ("ou_outsider", False),
+            ("ou_group_operator", True),
+        ],
+        ids=("outsider-denied", "group-operator-allowed"),
+    )
+    def test_group_allowlist_controls_globally_unlisted_operators(
+        self,
+        _patch_callback_card_types,
+        action_value,
+        state_attr,
+        open_id,
+        is_allowed,
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._group_rules = {
+            "oc_12345": FeishuGroupRule(
+                policy="allowlist",
+                allowlist={"ou_group_operator"},
+            )
+        }
+        getattr(adapter, state_attr)[9] = {
+            "session_key": "sess-9",
+            "message_id": "msg-9",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(action_value, open_id=open_id)
+
+        assert adapter._admins == set()
+        assert adapter._allowed_group_users == set()
+        with patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=_close_submitted_coro,
+        ) as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert (response.card is not None) is is_allowed
+        if is_allowed:
+            mock_submit.assert_called_once()
+        else:
+            mock_submit.assert_not_called()
+
     def test_drops_action_when_loop_not_ready(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = None
@@ -304,6 +604,127 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is None
         mock_submit.assert_not_called()
+
+    def test_registered_plugin_action_returns_processing_and_bypasses_synthetic_path(
+        self,
+        _patch_callback_card_types,
+    ):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter.gateway_runner = MagicMock()
+        data = _make_card_action_data(
+            {"hermes_interactive_action_id": "ia_opaque_123"},
+            open_id="ou_bob",
+        )
+        submitted = []
+
+        def submit(coro, _loop):
+            submitted.append(coro)
+            coro.close()
+            return SimpleNamespace(
+                result=lambda timeout: InteractiveActionResult.processing()
+            )
+
+        with (
+            patch("asyncio.run_coroutine_threadsafe", side_effect=submit),
+            patch.object(adapter, "_submit_on_loop") as mock_background_submit,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        assert len(submitted) == 1
+        mock_background_submit.assert_not_called()
+        assert response.card is not None
+        assert response.card.data["header"]["template"] == "blue"
+        assert "Processing" in response.card.data["header"]["title"]["content"]
+
+    def test_registered_plugin_claim_timeout_cancels_pending_work(
+        self,
+        _patch_callback_card_types,
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {"hermes_interactive_action_id": "ia_opaque_123"},
+        )
+        future = MagicMock()
+        future.result.side_effect = TimeoutError
+
+        def submit(coro, _loop):
+            coro.close()
+            return future
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=submit):
+            response = adapter._on_card_action_trigger(data)
+
+        future.cancel.assert_called_once_with()
+        assert response.card is None
+
+    @pytest.mark.parametrize("reserved_value", ["", 0, None])
+    def test_reserved_plugin_action_key_never_falls_through_to_synthetic_command(
+        self,
+        _patch_callback_card_types,
+        reserved_value,
+    ):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {"hermes_interactive_action_id": reserved_value},
+        )
+
+        with (
+            patch.object(
+                adapter,
+                "_handle_plugin_interactive_action",
+                return_value=adapter._build_interactive_action_callback_response(
+                    InteractiveActionResult.denied()
+                ),
+            ) as plugin_handler,
+            patch.object(adapter, "_submit_on_loop") as synthetic_submit,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        plugin_handler.assert_called_once()
+        assert plugin_handler.call_args.kwargs["action_instance_id"] == ""
+        synthetic_submit.assert_not_called()
+        assert response.card is None
+
+    def test_denied_plugin_click_does_not_replace_shared_card(
+        self,
+        _patch_callback_card_types,
+    ):
+        from gateway.interactive_actions import InteractiveActionResult
+
+        adapter = _make_adapter()
+
+        response = adapter._build_interactive_action_callback_response(
+            InteractiveActionResult.denied()
+        )
+
+        assert response.card is None
+
+    def test_unknown_non_hermes_action_preserves_synthetic_card_path(
+        self,
+        _patch_callback_card_types,
+    ):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data({"custom_action": "legacy"})
+
+        with patch.object(adapter, "_submit_on_loop", return_value=True) as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        mock_submit.assert_called_once()
+        submitted_coro = mock_submit.call_args.args[1]
+        submitted_coro.close()
 
     def test_returns_card_for_approve_action(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -433,6 +854,7 @@ class TestResolveUpdatePrompt:
     @pytest.mark.asyncio
     async def test_writes_response_file(self, tmp_path, monkeypatch):
         adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_user1"}
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         (tmp_path / ".hermes").mkdir()
         adapter._update_prompt_state[1] = {
@@ -441,9 +863,13 @@ class TestResolveUpdatePrompt:
             "chat_id": "oc_12345",
         }
 
-        await adapter._resolve_update_prompt(1, "y", "Alice")
+        await adapter._resolve_update_prompt(
+            1,
+            "y",
+            "Alice",
+            open_id="ou_user1",
+            chat_id="oc_12345",
+        )
 
         assert (tmp_path / ".hermes" / ".update_response").read_text() == "y"
         assert 1 not in adapter._update_prompt_state
-
-

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -95,6 +95,148 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
 
 
 @pytest.mark.asyncio
+async def test_gateway_stop_gracefully_drains_interactive_actions_before_disconnect():
+    runner, adapter = make_restart_runner()
+    runner._interactive_action_tasks = set()
+    runner._interactive_action_task_claims = {}
+    runner._adapter_disconnect_timeout_secs = lambda: 0.5
+    order = []
+
+    async def finish_action():
+        await asyncio.sleep(0.02)
+        order.append("action-finished")
+
+    action_task = asyncio.create_task(finish_action())
+    runner._interactive_action_tasks.add(action_task)
+    action_task.add_done_callback(runner._interactive_action_tasks.discard)
+
+    async def disconnect():
+        order.append("disconnect")
+
+    adapter.disconnect = disconnect
+
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+    ):
+        await runner.stop()
+    await asyncio.gather(action_task, return_exceptions=True)
+
+    assert order == ["action-finished", "disconnect"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_timeout_cancels_action_and_persists_unknown_outcome(
+    tmp_path,
+):
+    from gateway.interactive_actions import (
+        InteractiveActionCallback,
+        InteractiveActionManager,
+        InteractiveActionResult,
+        InteractiveCardAction,
+        InteractiveCardEnvelope,
+        InteractiveCardOrigin,
+        SQLiteInteractiveActionStorage,
+    )
+    from gateway.session import SessionSource
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    entered = asyncio.Event()
+
+    async def handler(_ctx):
+        entered.set()
+        await asyncio.Event().wait()
+
+    plugins = PluginManager()
+    context = PluginContext(
+        PluginManifest(name="proposal-plugin", key="proposal-plugin", source="user"),
+        plugins,
+    )
+    context.register_interactive_action("apply", handler)
+    manager = InteractiveActionManager(
+        storage=SQLiteInteractiveActionStorage(tmp_path / "state.db"),
+        registrations=plugins._interactive_actions,
+        clock=lambda: 1_000.0,
+        id_source=lambda: "ia_shutdown",
+    )
+    envelope = InteractiveCardEnvelope(
+        version=1,
+        title="Apply proposal?",
+        summary="Apply the reviewed proposal.",
+        fallback_text="Apply the reviewed proposal in the admin console.",
+        expires_in_seconds=900,
+        actions=(
+            InteractiveCardAction(
+                label="Apply",
+                action="proposal-plugin/apply",
+                external_action_id="proposal-v1",
+                payload={"proposal_id": "prop_1"},
+            ),
+        ),
+    )
+    origin = InteractiveCardOrigin(
+        platform="telegram",
+        profile_id="work",
+        chat_id="123456",
+        thread_id=None,
+        initiator_id="u1",
+        initiator_name="Alice",
+        message_id="trigger",
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=envelope,
+        origin=origin,
+    )
+    manager.activate_card(prepared, card_id="card-1")
+
+    runner, adapter = make_restart_runner()
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._interactive_action_task_claims = {}
+    runner._adapter_disconnect_timeout_secs = lambda: 0.01
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123456",
+        chat_type="dm",
+        user_id="u1",
+        user_name="Alice",
+        message_id="card-1",
+        profile="work",
+    )
+    callback = InteractiveActionCallback(
+        action_instance_id="ia_shutdown",
+        platform="telegram",
+        profile_id="work",
+        operator_id="u1",
+        operator_name="Alice",
+        chat_id="123456",
+        thread_id=None,
+        card_id="card-1",
+    )
+    adapter.update_interactive_card = AsyncMock()
+    adapter.disconnect = AsyncMock()
+    initial = await runner._begin_interactive_action_from_adapter(
+        callback=callback,
+        source=source,
+        adapter=adapter,
+    )
+    await entered.wait()
+
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+    ):
+        await runner.stop()
+
+    replay = await manager.dispatch(callback, gateway_authorize=lambda: True)
+    assert initial.status == "processing"
+    assert replay == InteractiveActionResult.unknown_outcome()
+    assert runner._interactive_action_tasks == set()
+    adapter.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_in_chat_restart_skips_home_shutdown_even_with_active_session():
     runner, adapter = make_restart_runner()
     source = make_restart_source(thread_id="42")
@@ -269,5 +411,4 @@ def test_pid_exists_zombie_via_psutil_returns_false(monkeypatch):
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert status._pid_exists(4242) is False
-
 

--- a/tests/gateway/test_interactive_actions.py
+++ b/tests/gateway/test_interactive_actions.py
@@ -1,0 +1,1468 @@
+"""Public contracts for external-plugin interactive gateway actions."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def _plugin_context(name: str, manager: PluginManager) -> PluginContext:
+    return PluginContext(
+        PluginManifest(name=name, key=name, source="user"),
+        manager,
+    )
+
+
+def test_plugin_interactive_action_registration_is_namespaced_and_conflict_safe():
+    from gateway.interactive_actions import (
+        InteractiveActionRegistrationError,
+    )
+
+    manager = PluginManager()
+    context = _plugin_context("proposal-plugin", manager)
+
+    def handler(_action_context):
+        return None
+
+    assert (
+        context.register_interactive_action("apply", handler) == "proposal-plugin/apply"
+    )
+
+    with pytest.raises(InteractiveActionRegistrationError, match="already registered"):
+        context.register_interactive_action("proposal-plugin/apply", handler)
+
+    with pytest.raises(InteractiveActionRegistrationError, match="namespace"):
+        context.register_interactive_action("another-plugin/apply", handler)
+
+
+def test_nested_plugin_registry_key_can_own_an_action_namespace():
+    manager = PluginManager()
+    context = PluginContext(
+        PluginManifest(
+            name="proposal-service",
+            key="business/proposal-service",
+            source="user",
+        ),
+        manager,
+    )
+
+    assert (
+        context.register_interactive_action("apply", lambda _ctx: None)
+        == "business/proposal-service/apply"
+    )
+
+    from gateway.interactive_actions import InteractiveCardAction
+
+    action = InteractiveCardAction(
+        label="Apply",
+        action="business/proposal-service/apply",
+        external_action_id="proposal-v1",
+        payload={"proposal_id": "prop_1"},
+    )
+    assert action.action == "business/proposal-service/apply"
+
+
+def test_plugin_manager_exposes_action_registry_as_a_snapshot():
+    manager = PluginManager()
+    context = _plugin_context("proposal-plugin", manager)
+    context.register_interactive_action("apply", lambda _ctx: None)
+
+    snapshot = manager.get_interactive_actions()
+    snapshot.clear()
+
+    assert "proposal-plugin/apply" in manager.get_interactive_actions()
+
+
+@pytest.mark.parametrize(
+    ("action_name", "handler", "policy"),
+    [
+        ("", lambda _ctx: None, "initiator_only"),
+        ("bad action", lambda _ctx: None, "initiator_only"),
+        ("apply", None, "initiator_only"),
+        ("apply", lambda _ctx: None, "owner_only"),
+    ],
+)
+def test_plugin_interactive_action_registration_rejects_invalid_contracts(
+    action_name,
+    handler,
+    policy,
+):
+    from gateway.interactive_actions import InteractiveActionRegistrationError
+
+    context = _plugin_context("proposal-plugin", PluginManager())
+
+    with pytest.raises(InteractiveActionRegistrationError):
+        context.register_interactive_action(
+            action_name,
+            handler,
+            authorization_policy=policy,
+        )
+
+
+def test_failed_plugin_registration_does_not_leave_live_action_handler(monkeypatch):
+    manager = PluginManager()
+    manifest = PluginManifest(
+        name="proposal-plugin",
+        key="proposal-plugin",
+        source="user",
+        path="/not-used",
+    )
+
+    def register(context):
+        context.register_interactive_action("apply", lambda _ctx: None)
+        raise RuntimeError("registration failed after action")
+
+    monkeypatch.setattr(
+        manager,
+        "_load_directory_module",
+        lambda _manifest: SimpleNamespace(register=register),
+    )
+
+    manager._load_plugin(manifest)
+
+    assert manager._interactive_actions == {}
+
+
+def _proposal_envelope():
+    from gateway.interactive_actions import (
+        InteractiveCardAction,
+        InteractiveCardEnvelope,
+        InteractiveCardFact,
+        InteractiveCardSection,
+    )
+
+    return InteractiveCardEnvelope(
+        version=1,
+        title="Apply pricing proposal?",
+        summary="This changes the customer contract after confirmation.",
+        facts=(InteractiveCardFact("Customer", "Acme"),),
+        sections=(
+            InteractiveCardSection(
+                title="Commercial terms",
+                body="Annual price: CNY 120,000",
+            ),
+        ),
+        fallback_text="Apply pricing proposal for Acme? Reply in the admin console.",
+        expires_in_seconds=900,
+        actions=(
+            InteractiveCardAction(
+                label="Apply proposal",
+                action="proposal-plugin/apply",
+                external_action_id="proposal-acme-v7",
+                payload={"proposal_id": "prop_7", "revision": 7},
+                style="primary",
+            ),
+        ),
+    )
+
+
+def test_post_tool_call_hook_gets_bound_send_capability_without_destination_ids():
+    from gateway.interactive_actions import bind_interactive_card_sender
+
+    manager = PluginManager()
+    context = _plugin_context("proposal-plugin", manager)
+    context.register_interactive_action("apply", lambda _ctx: None)
+    envelope = _proposal_envelope()
+    sent = []
+    transcript = [{"role": "user", "content": "validate proposal"}]
+    system_prompt = "byte-stable-system-prompt"
+    toolsets = ("proposal", "terminal")
+
+    def sender(*, plugin_id, envelope):
+        sent.append((plugin_id, envelope))
+        return "delivery-1"
+
+    def observer(*, result, **_kwargs):
+        assert result == '{"proposal_id":"prop_7"}'
+        assert context.send_interactive_card(envelope) == "delivery-1"
+
+    context.register_hook("post_tool_call", observer)
+    with bind_interactive_card_sender(sender):
+        manager.invoke_hook(
+            "post_tool_call",
+            tool_name="proposal_validate",
+            args={},
+            result='{"proposal_id":"prop_7"}',
+        )
+
+    assert sent == [("proposal-plugin", envelope)]
+    assert transcript == [{"role": "user", "content": "validate proposal"}]
+    assert system_prompt == "byte-stable-system-prompt"
+    assert toolsets == ("proposal", "terminal")
+
+
+def test_post_tool_call_worker_propagates_bound_gateway_sender(monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from gateway.interactive_actions import bind_interactive_card_sender
+    from model_tools import _emit_post_tool_call_hook
+    from tools.thread_context import propagate_context_to_thread
+    import hermes_cli.lifecycle as lifecycle
+
+    manager = PluginManager()
+    context = _plugin_context("proposal-plugin", manager)
+    context.register_interactive_action("apply", lambda _ctx: None)
+    envelope = _proposal_envelope()
+    sent = []
+
+    def sender(*, plugin_id, envelope):
+        sent.append((plugin_id, envelope))
+        return "delivery-1"
+
+    def observer(**_kwargs):
+        assert context.send_interactive_card(envelope) == "delivery-1"
+
+    context.register_hook("post_tool_call", observer)
+    monkeypatch.setattr(lifecycle, "has_hook", manager.has_hook)
+    monkeypatch.setattr(lifecycle, "invoke_hook", manager.invoke_hook)
+
+    with bind_interactive_card_sender(sender):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                propagate_context_to_thread(_emit_post_tool_call_hook),
+                function_name="proposal_validate",
+                function_args={},
+                result='{"status":"ready"}',
+            )
+            future.result(timeout=2)
+
+    assert sent == [("proposal-plugin", envelope)]
+
+
+def test_send_interactive_card_outside_gateway_turn_fails_closed():
+    from gateway.interactive_actions import InteractiveCardUnavailableError
+
+    context = _plugin_context("proposal-plugin", PluginManager())
+
+    with pytest.raises(InteractiveCardUnavailableError, match="gateway turn"):
+        context.send_interactive_card(_proposal_envelope())
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"version": 2},
+        {"version": True},
+        {"title": "x" * 121},
+        {"fallback_text": ""},
+        {"expires_in_seconds": 0},
+        {"expires_in_seconds": True},
+        {"actions": ()},
+    ],
+)
+def test_interactive_card_envelope_is_versioned_and_bounded(overrides):
+    from dataclasses import replace
+    from gateway.interactive_actions import InteractiveCardValidationError
+
+    with pytest.raises(InteractiveCardValidationError):
+        replace(_proposal_envelope(), **overrides)
+
+
+def test_interactive_action_payload_rejects_secret_like_fields():
+    from gateway.interactive_actions import (
+        InteractiveCardAction,
+        InteractiveCardValidationError,
+    )
+
+    with pytest.raises(InteractiveCardValidationError, match="secret"):
+        InteractiveCardAction(
+            label="Apply",
+            action="proposal-plugin/apply",
+            external_action_id="proposal-acme-v7",
+            payload={"proposal_id": "prop_7", "api_key": "must-not-store"},
+        )
+
+
+def test_interactive_action_payload_rejects_non_text_object_keys():
+    from gateway.interactive_actions import (
+        InteractiveCardAction,
+        InteractiveCardValidationError,
+    )
+
+    with pytest.raises(InteractiveCardValidationError, match="keys must be text"):
+        InteractiveCardAction(
+            label="Apply",
+            action="proposal-plugin/apply",
+            external_action_id="proposal-acme-v7",
+            payload={1: "ambiguous with string key"},
+        )
+
+
+def _registered_manager(
+    tmp_path,
+    handler,
+    *,
+    policy="initiator_only",
+    clock=lambda: 1_000.0,
+    instance_id="ia_instance_1",
+):
+    from gateway.interactive_actions import (
+        InteractiveActionManager,
+        SQLiteInteractiveActionStorage,
+    )
+
+    plugins = PluginManager()
+    context = _plugin_context("proposal-plugin", plugins)
+    context.register_interactive_action(
+        "apply",
+        handler,
+        authorization_policy=policy,
+    )
+    manager = InteractiveActionManager(
+        storage=SQLiteInteractiveActionStorage(tmp_path / "state.db"),
+        registrations=plugins._interactive_actions,
+        clock=clock,
+        id_source=lambda: instance_id,
+    )
+    return plugins, manager
+
+
+def _origin(**overrides):
+    from dataclasses import replace
+    from gateway.interactive_actions import InteractiveCardOrigin
+
+    value = InteractiveCardOrigin(
+        platform="feishu",
+        profile_id="work",
+        chat_id="oc_chat",
+        thread_id="om_root",
+        initiator_id="ou_initiator",
+        initiator_name="Alice",
+        message_id="om_trigger",
+    )
+    return replace(value, **overrides)
+
+
+def _callback(action_instance_id="ia_instance_1", **overrides):
+    from dataclasses import replace
+    from gateway.interactive_actions import InteractiveActionCallback
+
+    value = InteractiveActionCallback(
+        action_instance_id=action_instance_id,
+        platform="feishu",
+        profile_id="work",
+        operator_id="ou_initiator",
+        operator_name="Alice",
+        chat_id="oc_chat",
+        thread_id="om_root",
+        card_id="om_card",
+    )
+    return replace(value, **overrides)
+
+
+async def _issue_and_dispatch(manager, *, callback=None, authorize=lambda: True):
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    result = await manager.dispatch(
+        callback or _callback(),
+        gateway_authorize=authorize,
+    )
+    return prepared, result
+
+
+@pytest.mark.asyncio
+async def test_authorized_initiator_gets_exact_immutable_stored_context(tmp_path):
+    from gateway.interactive_actions import InteractiveActionResult
+
+    contexts = []
+
+    async def handler(action_context):
+        contexts.append(action_context)
+        return InteractiveActionResult.succeeded()
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared, result = await _issue_and_dispatch(manager)
+
+    assert prepared.action_instance_ids == ("ia_instance_1",)
+    assert result.status == "succeeded"
+    assert len(contexts) == 1
+    action_context = contexts[0]
+    assert action_context.platform == "feishu"
+    assert action_context.profile_id == "work"
+    assert action_context.operator_id == "ou_initiator"
+    assert action_context.operator_name == "Alice"
+    assert action_context.chat_id == "oc_chat"
+    assert action_context.thread_id == "om_root"
+    assert action_context.message_id == "om_trigger"
+    assert action_context.card_id == "om_card"
+    assert action_context.action_instance_id == "ia_instance_1"
+    assert action_context.external_action_id == "proposal-acme-v7"
+    assert dict(action_context.payload) == {"proposal_id": "prop_7", "revision": 7}
+    with pytest.raises(TypeError):
+        action_context.payload["revision"] = 8
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "callback",
+    [
+        _callback(operator_id=""),
+        _callback(operator_id="ou_attacker"),
+        _callback(chat_id="oc_other"),
+        _callback(profile_id="personal"),
+        _callback(card_id="om_tampered"),
+        _callback(action_instance_id="ia_unknown"),
+    ],
+)
+async def test_invalid_or_unauthorized_click_never_executes(tmp_path, callback):
+    calls = []
+    _plugins, manager = _registered_manager(tmp_path, lambda ctx: calls.append(ctx))
+
+    _prepared, result = await _issue_and_dispatch(manager, callback=callback)
+
+    assert result.status in {"denied", "unknown"}
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_authorization_runs_before_policy_and_handler(tmp_path):
+    events = []
+
+    def handler(_ctx):
+        events.append("handler")
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+
+    result = await manager.dispatch(
+        _callback(),
+        gateway_authorize=lambda: events.append("gateway-auth") or False,
+    )
+
+    assert result.status == "denied"
+    assert events == ["gateway-auth"]
+
+
+@pytest.mark.asyncio
+async def test_authorized_user_policy_allows_non_initiator_after_gateway_auth(tmp_path):
+    calls = []
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+        policy="authorized_user",
+    )
+
+    _prepared, result = await _issue_and_dispatch(
+        manager,
+        callback=_callback(operator_id="ou_admin", operator_name="Bob"),
+    )
+
+    assert result.status == "succeeded"
+    assert [ctx.operator_id for ctx in calls] == ["ou_admin"]
+
+
+@pytest.mark.asyncio
+async def test_action_instance_keeps_issuance_policy_across_registration_change(
+    tmp_path,
+):
+    from dataclasses import replace
+
+    calls = []
+    plugins, manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+        policy="initiator_only",
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    registration = plugins._interactive_actions["proposal-plugin/apply"]
+    plugins._interactive_actions["proposal-plugin/apply"] = replace(
+        registration,
+        authorization_policy="authorized_user",
+    )
+
+    result = await manager.dispatch(
+        _callback(operator_id="ou_admin", operator_name="Bob"),
+        gateway_authorize=lambda: True,
+    )
+
+    assert result.status == "denied"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_current_policy_tightening_also_applies_to_issued_action(tmp_path):
+    from dataclasses import replace
+
+    calls = []
+    plugins, manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+        policy="authorized_user",
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    registration = plugins._interactive_actions["proposal-plugin/apply"]
+    plugins._interactive_actions["proposal-plugin/apply"] = replace(
+        registration,
+        authorization_policy="initiator_only",
+    )
+
+    result = await manager.dispatch(
+        _callback(operator_id="ou_admin", operator_name="Bob"),
+        gateway_authorize=lambda: True,
+    )
+
+    assert result.status == "denied"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_expired_action_does_not_execute(tmp_path):
+    now = [1_000.0]
+    calls = []
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+        clock=lambda: now[0],
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    now[0] += 901
+
+    result = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+
+    assert result.status == "expired"
+    assert calls == []
+
+
+def test_ledger_coexists_with_existing_sessiondb_schema(tmp_path):
+    import sqlite3
+
+    from gateway.interactive_actions import SQLiteInteractiveActionStorage
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    session_db = SessionDB(db_path)
+    session_db.close()
+
+    storage = SQLiteInteractiveActionStorage(db_path)
+    assert storage.get("missing") is None
+
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert {"sessions", "messages", "interactive_actions"}.issubset(tables)
+
+    reopened = SessionDB(db_path)
+    reopened.close()
+
+
+def test_ledger_migrates_pre_policy_schema_without_losing_rows(tmp_path):
+    import sqlite3
+
+    from gateway.interactive_actions import SQLiteInteractiveActionStorage
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE interactive_actions (
+                action_instance_id TEXT PRIMARY KEY,
+                plugin_action TEXT NOT NULL,
+                external_action_id TEXT NOT NULL,
+                profile_id TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                thread_id TEXT,
+                initiator_id TEXT NOT NULL,
+                initiator_name TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                card_id TEXT,
+                payload_json TEXT NOT NULL,
+                state TEXT NOT NULL,
+                outcome TEXT,
+                expires_at REAL NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO interactive_actions VALUES (
+                'ia_old', 'proposal-plugin/apply', 'proposal-v1',
+                'work', 'feishu', 'oc_chat', NULL, 'ou_initiator', 'Alice',
+                'om_trigger', 'om_card', '{}', 'active', NULL, 2000, 1000, 1000
+            )"""
+        )
+
+    record = SQLiteInteractiveActionStorage(db_path).get("ia_old")
+
+    assert record is not None
+    assert record.authorization_policy == "initiator_only"
+    assert record.card_id == "om_card"
+
+
+def test_concurrent_ledger_schema_initialization_is_idempotent(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+    import sqlite3
+
+    from gateway.interactive_actions import SQLiteInteractiveActionStorage
+
+    db_path = tmp_path / "state.db"
+
+    def initialize(_index):
+        return SQLiteInteractiveActionStorage(db_path).get("missing")
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        assert list(executor.map(initialize, range(16))) == [None] * 16
+
+    with sqlite3.connect(db_path) as conn:
+        columns = [
+            row[1] for row in conn.execute("PRAGMA table_info(interactive_actions)")
+        ]
+    assert columns.count("authorization_policy") == 1
+
+
+def test_default_ledger_resolves_profile_home_on_each_operation(tmp_path):
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    from gateway.interactive_actions import (
+        InteractiveActionManager,
+        SQLiteInteractiveActionStorage,
+    )
+
+    plugins = PluginManager()
+    context = _plugin_context("proposal-plugin", plugins)
+    context.register_interactive_action("apply", lambda _ctx: None)
+    storage = SQLiteInteractiveActionStorage()
+    ids = iter(("ia_work", "ia_personal"))
+    manager = InteractiveActionManager(
+        storage=storage,
+        registrations=plugins._interactive_actions,
+        clock=lambda: 1_000.0,
+        id_source=ids.__next__,
+    )
+    work_home = tmp_path / "work"
+    personal_home = tmp_path / "personal"
+
+    token = set_hermes_home_override(work_home)
+    try:
+        manager.prepare_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(profile_id="work"),
+        )
+        assert storage.get("ia_work") is not None
+    finally:
+        reset_hermes_home_override(token)
+
+    token = set_hermes_home_override(personal_home)
+    try:
+        assert storage.get("ia_work") is None
+        manager.prepare_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(profile_id="personal"),
+        )
+        assert storage.get("ia_personal") is not None
+    finally:
+        reset_hermes_home_override(token)
+
+    assert (work_home / "state.db").exists()
+    assert (personal_home / "state.db").exists()
+
+
+def test_stale_crash_rows_do_not_exhaust_bounded_ledger_forever(tmp_path):
+    from gateway.interactive_actions import InteractiveActionManager
+
+    now = [1_000.0]
+    plugins, manager = _registered_manager(
+        tmp_path,
+        lambda _ctx: None,
+        clock=lambda: now[0],
+        instance_id="ia_first",
+    )
+    manager.storage._MAX_ROWS = 1
+    manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+
+    now[0] += (
+        _proposal_envelope().expires_in_seconds + manager.storage._RETENTION_SECONDS + 1
+    )
+    replacement = InteractiveActionManager(
+        storage=manager.storage,
+        registrations=plugins._interactive_actions,
+        clock=lambda: now[0],
+        id_source=lambda: "ia_second",
+    )
+    replacement.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+
+    assert manager.storage.get("ia_first") is None
+    assert manager.storage.get("ia_second") is not None
+
+
+def test_profile_ledger_hard_capacity_fails_closed_without_unbounded_growth(tmp_path):
+    from gateway.interactive_actions import InteractiveActionCapacityError
+
+    _plugins, manager = _registered_manager(tmp_path, lambda _ctx: None)
+    manager.storage._MAX_ROWS = 1
+    ids = iter(("ia_first", "ia_second"))
+    manager._id_source = ids.__next__
+    manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+
+    with pytest.raises(InteractiveActionCapacityError, match="capacity"):
+        manager.prepare_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(),
+        )
+
+    assert manager.storage.get("ia_first") is not None
+    assert manager.storage.get("ia_second") is None
+
+
+@pytest.mark.asyncio
+async def test_atomic_double_click_executes_handler_once(tmp_path):
+    from gateway.interactive_actions import InteractiveActionResult
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def handler(ctx):
+        calls.append(ctx)
+        entered.set()
+        await release.wait()
+        return InteractiveActionResult.succeeded()
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+
+    first = asyncio.create_task(
+        manager.dispatch(_callback(), gateway_authorize=lambda: True)
+    )
+    await entered.wait()
+    duplicate = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+    release.set()
+    completed = await first
+
+    assert completed.status == "succeeded"
+    assert duplicate.status == "already_processed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_durable_replay_after_manager_restart_never_reexecutes(tmp_path):
+    from gateway.interactive_actions import (
+        InteractiveActionManager,
+        SQLiteInteractiveActionStorage,
+    )
+
+    calls = []
+    plugins, first_manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+    )
+    await _issue_and_dispatch(first_manager)
+
+    reconstructed = InteractiveActionManager(
+        storage=SQLiteInteractiveActionStorage(tmp_path / "state.db"),
+        registrations=plugins._interactive_actions,
+        clock=lambda: 1_001.0,
+        id_source=lambda: "unused",
+    )
+    replay = await reconstructed.dispatch(
+        _callback(),
+        gateway_authorize=lambda: True,
+    )
+
+    assert replay.status == "already_processed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_factory", "expected_status", "forbidden_text"),
+    [
+        (
+            lambda result: lambda _ctx: result.downstream_replay(),
+            "downstream_replay",
+            "proposal_id",
+        ),
+        (
+            lambda result: lambda _ctx: result.conflict(),
+            "conflict",
+            "proposal_id",
+        ),
+        (
+            lambda result: lambda _ctx: result.retryable_failure(),
+            "retryable_failure",
+            "proposal_id",
+        ),
+        (
+            lambda _result: (
+                lambda _ctx: (_ for _ in ()).throw(
+                    RuntimeError("secret traceback proposal_id=prop_7")
+                )
+            ),
+            "retryable_failure",
+            "prop_7",
+        ),
+    ],
+)
+async def test_handler_outcomes_are_truthful_and_sanitized(
+    tmp_path,
+    handler_factory,
+    expected_status,
+    forbidden_text,
+):
+    from gateway.interactive_actions import InteractiveActionResult
+
+    handler = handler_factory(InteractiveActionResult)
+    _plugins, manager = _registered_manager(tmp_path, handler)
+
+    _prepared, result = await _issue_and_dispatch(manager)
+
+    assert result.status == expected_status
+    assert forbidden_text not in result.user_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_name", "expected_status", "safe_message"),
+    [
+        ("InteractiveActionConflictError", "conflict", "Proposal revision changed."),
+        (
+            "InteractiveActionRetryableError",
+            "retryable_failure",
+            "The proposal service is temporarily unavailable.",
+        ),
+    ],
+)
+async def test_typed_handler_errors_expose_only_explicit_bounded_public_text(
+    tmp_path,
+    error_name,
+    expected_status,
+    safe_message,
+):
+    import gateway.interactive_actions as actions
+
+    error_type = getattr(actions, error_name)
+
+    def handler(_ctx):
+        raise error_type(f"  {safe_message}\n")
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    _prepared, result = await _issue_and_dispatch(manager)
+
+    assert result.status == expected_status
+    assert result.user_message == safe_message
+
+
+@pytest.mark.asyncio
+async def test_unsupported_adapter_sends_exact_fallback_without_ledger_state(tmp_path):
+    sent = []
+
+    async def send(**kwargs):
+        sent.append(kwargs)
+        return SimpleNamespace(success=True, message_id="fallback-message")
+
+    adapter = SimpleNamespace(
+        supports_interactive_cards=False,
+        send=send,
+    )
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda _ctx: None,
+        instance_id="must-not-be-created",
+    )
+
+    delivery = await manager.deliver_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+        adapter=adapter,
+        metadata={"thread_id": "om_root"},
+    )
+
+    assert delivery.mode == "fallback"
+    assert delivery.action_instance_ids == ()
+    assert sent == [
+        {
+            "chat_id": "oc_chat",
+            "content": _proposal_envelope().fallback_text,
+            "reply_to": "om_trigger",
+            "metadata": {"thread_id": "om_root"},
+        }
+    ]
+    assert manager.storage.get("must-not-be-created") is None
+
+
+@pytest.mark.asyncio
+async def test_successful_fallback_does_not_require_adapter_message_id(tmp_path):
+    async def send(**_kwargs):
+        return SimpleNamespace(success=True, message_id=None)
+
+    adapter = SimpleNamespace(
+        supports_interactive_cards=False,
+        send=send,
+    )
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda _ctx: None,
+        instance_id="must-not-be-created",
+    )
+
+    delivery = await manager.deliver_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+        adapter=adapter,
+    )
+
+    assert delivery.mode == "fallback"
+    assert delivery.message_id == ""
+    assert manager.storage.get("must-not-be-created") is None
+
+
+@pytest.mark.asyncio
+async def test_fallback_delivery_does_not_require_native_identity_or_origin_message(
+    tmp_path,
+):
+    sent = []
+
+    async def send(**kwargs):
+        sent.append(kwargs)
+        return SimpleNamespace(success=True, message_id=None)
+
+    adapter = SimpleNamespace(supports_interactive_cards=False, send=send)
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda _ctx: None,
+        instance_id="must-not-be-created",
+    )
+
+    delivery = await manager.deliver_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(initiator_id="", initiator_name="", message_id=""),
+        adapter=adapter,
+    )
+
+    assert delivery.mode == "fallback"
+    assert sent[0]["content"] == _proposal_envelope().fallback_text
+    assert sent[0]["reply_to"] is None
+    assert manager.storage.get("must-not-be-created") is None
+
+
+@pytest.mark.asyncio
+async def test_native_delivery_requires_stable_initiator_and_origin_message(tmp_path):
+    from gateway.interactive_actions import InteractiveCardDeliveryError
+
+    native_send = AsyncMock()
+    adapter = SimpleNamespace(
+        supports_interactive_cards=True,
+        send_interactive_card=native_send,
+    )
+    _plugins, manager = _registered_manager(tmp_path, lambda _ctx: None)
+
+    with pytest.raises(InteractiveCardDeliveryError, match="prepared"):
+        await manager.deliver_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(initiator_id="", message_id=""),
+            adapter=adapter,
+        )
+
+    native_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_native_delivery_activates_opaque_action_only_after_send_success(
+    tmp_path,
+):
+    send_native = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="om_card")
+    )
+    adapter = SimpleNamespace(
+        supports_interactive_cards=True,
+        send_interactive_card=send_native,
+    )
+    _plugins, manager = _registered_manager(tmp_path, lambda _ctx: None)
+
+    delivery = await manager.deliver_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+        adapter=adapter,
+        metadata={"thread_id": "om_root"},
+    )
+
+    assert delivery.mode == "native"
+    assert delivery.message_id == "om_card"
+    assert delivery.action_instance_ids == ("ia_instance_1",)
+    send_native.assert_awaited_once_with(
+        chat_id="oc_chat",
+        envelope=_proposal_envelope(),
+        action_instance_ids=("ia_instance_1",),
+        reply_to="om_trigger",
+        metadata={"thread_id": "om_root"},
+    )
+    assert manager.storage.get("ia_instance_1").state == "active"
+
+
+@pytest.mark.asyncio
+async def test_native_delivery_failure_is_explicit_and_never_clickable(tmp_path):
+    from gateway.interactive_actions import InteractiveCardDeliveryError
+
+    adapter = SimpleNamespace(
+        supports_interactive_cards=True,
+        send_interactive_card=AsyncMock(
+            return_value=SimpleNamespace(
+                success=False,
+                message_id=None,
+                error="raw provider secret details",
+            )
+        ),
+    )
+    _plugins, manager = _registered_manager(tmp_path, lambda _ctx: None)
+
+    with pytest.raises(
+        InteractiveCardDeliveryError, match="could not be delivered"
+    ) as exc_info:
+        await manager.deliver_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(),
+            adapter=adapter,
+        )
+
+    assert "raw provider" not in str(exc_info.value)
+    assert manager.storage.get("ia_instance_1").state == "delivery_failed"
+
+
+@pytest.mark.asyncio
+async def test_delivery_and_failure_persistence_errors_remain_generic(
+    tmp_path,
+    monkeypatch,
+):
+    from gateway.interactive_actions import InteractiveCardDeliveryError
+
+    adapter = SimpleNamespace(
+        supports_interactive_cards=True,
+        send_interactive_card=AsyncMock(
+            side_effect=RuntimeError("provider api_key=hidden")
+        ),
+    )
+    _plugins, manager = _registered_manager(tmp_path, lambda _ctx: None)
+    monkeypatch.setattr(
+        manager,
+        "fail_card_delivery",
+        lambda _prepared: (_ for _ in ()).throw(
+            RuntimeError("state.db=/secret/profile")
+        ),
+    )
+
+    with pytest.raises(
+        InteractiveCardDeliveryError,
+        match="could not be delivered",
+    ) as exc_info:
+        await manager.deliver_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(),
+            adapter=adapter,
+        )
+
+    assert "api_key" not in str(exc_info.value)
+    assert "/secret/profile" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_native_post_send_binding_failure_disables_card_and_hides_error(
+    tmp_path,
+    monkeypatch,
+):
+    from gateway.interactive_actions import InteractiveCardDeliveryError
+
+    adapter = SimpleNamespace(
+        supports_interactive_cards=True,
+        send_interactive_card=AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="om_card")
+        ),
+        update_interactive_card=AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="om_card")
+        ),
+    )
+    _plugins, manager = _registered_manager(tmp_path, lambda _ctx: None)
+    monkeypatch.setattr(
+        manager,
+        "activate_card",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("state.db path and provider secret")
+        ),
+    )
+
+    with pytest.raises(
+        InteractiveCardDeliveryError,
+        match="could not be activated",
+    ) as exc_info:
+        await manager.deliver_card(
+            plugin_id="proposal-plugin",
+            envelope=_proposal_envelope(),
+            origin=_origin(),
+            adapter=adapter,
+        )
+
+    assert "provider secret" not in str(exc_info.value)
+    assert manager.storage.get("ia_instance_1").state == "delivery_failed"
+    disabled = adapter.update_interactive_card.await_args.kwargs["result"]
+    assert disabled.status == "retryable_failure"
+    assert "state.db" not in disabled.user_message
+
+
+def test_ledger_sqlite_contention_fails_before_platform_callback_timeout(tmp_path):
+    import sqlite3
+    import time
+    from gateway.interactive_actions import SQLiteInteractiveActionStorage
+
+    db_path = tmp_path / "state.db"
+    storage = SQLiteInteractiveActionStorage(db_path)
+    assert storage.get("initialize-schema") is None
+    locker = sqlite3.connect(db_path, timeout=0)
+    locker.execute("BEGIN IMMEDIATE")
+    started = time.monotonic()
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            storage.claim(_callback(), now=1_000.0)
+    finally:
+        elapsed = time.monotonic() - started
+        locker.rollback()
+        locker.close()
+
+    assert elapsed < 3.0
+
+
+@pytest.mark.asyncio
+async def test_gateway_callback_returns_processing_only_after_claim_and_edits_final(
+    tmp_path,
+):
+    from gateway.config import Platform
+    from gateway.interactive_actions import InteractiveActionResult
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    handled = asyncio.Event()
+
+    async def handler(_ctx):
+        handled.set()
+        return InteractiveActionResult.succeeded()
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._is_user_authorized = lambda _source: True
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    adapter = SimpleNamespace(update_interactive_card=AsyncMock())
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        user_id="ou_initiator",
+        user_name="Alice",
+        thread_id="om_root",
+        message_id="om_card",
+        profile="work",
+    )
+
+    initial = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(),
+        source=source,
+        adapter=adapter,
+    )
+
+    assert initial.status == "processing"
+    assert manager.storage.get("ia_instance_1").state == "processing"
+    await asyncio.wait_for(handled.wait(), timeout=1)
+    await asyncio.gather(*runner._interactive_action_tasks)
+    adapter.update_interactive_card.assert_awaited_once()
+    final = adapter.update_interactive_card.await_args.kwargs["result"]
+    assert final.status == "succeeded"
+    assert manager.storage.get("ia_instance_1").state == "finished"
+
+
+@pytest.mark.asyncio
+async def test_gateway_handler_failure_edits_generic_retryable_state_without_leak(
+    tmp_path,
+):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    def handler(_ctx):
+        raise RuntimeError("secret proposal_id=prop_7 api_key=hidden")
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._is_user_authorized = lambda _source: True
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    adapter = SimpleNamespace(
+        update_interactive_card=AsyncMock(return_value=SimpleNamespace(success=True))
+    )
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        user_id="ou_initiator",
+        user_name="Alice",
+        thread_id="om_root",
+        message_id="om_card",
+        profile="work",
+    )
+
+    initial = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(),
+        source=source,
+        adapter=adapter,
+    )
+    await asyncio.gather(*runner._interactive_action_tasks)
+
+    assert initial.status == "processing"
+    final = adapter.update_interactive_card.await_args.kwargs["result"]
+    assert final.status == "retryable_failure"
+    assert "prop_7" not in final.user_message
+    assert "api_key" not in final.user_message
+    assert manager.storage.get("ia_instance_1").outcome == "retryable_failure"
+
+
+@pytest.mark.asyncio
+async def test_gateway_retries_transient_final_card_edit_without_rerunning_handler(
+    tmp_path,
+):
+    from gateway.config import Platform
+    from gateway.interactive_actions import InteractiveActionResult
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    calls = []
+
+    def handler(ctx):
+        calls.append(ctx)
+        return InteractiveActionResult.succeeded()
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._is_user_authorized = lambda _source: True
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    update = AsyncMock(
+        side_effect=(
+            SimpleNamespace(success=False),
+            RuntimeError("provider secret must not escape"),
+            SimpleNamespace(success=True),
+        )
+    )
+    adapter = SimpleNamespace(update_interactive_card=update)
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        user_id="ou_initiator",
+        user_name="Alice",
+        thread_id="om_root",
+        message_id="om_card",
+        profile="work",
+    )
+
+    initial = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(),
+        source=source,
+        adapter=adapter,
+    )
+    await asyncio.gather(*runner._interactive_action_tasks)
+
+    assert initial.status == "processing"
+    assert len(calls) == 1
+    assert update.await_count == 3
+    assert manager.storage.get("ia_instance_1").outcome == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_gateway_rejects_callback_source_identity_mismatch_before_auth_or_claim():
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    class RejectUnexpectedClaim:
+        def claim_action(self, *_args, **_kwargs):
+            raise AssertionError("mismatched callback reached the claim path")
+
+    auth_calls = []
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = RejectUnexpectedClaim()
+    runner._is_user_authorized = lambda _source: auth_calls.append(True) or True
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        user_id="ou_authenticated",
+        message_id="om_card",
+        profile="work",
+    )
+
+    result = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(operator_id="ou_attacker"),
+        source=source,
+        adapter=SimpleNamespace(),
+    )
+
+    assert result.status == "denied"
+    assert auth_calls == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_denied_callback_never_claims_or_edits(tmp_path):
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    calls = []
+    _plugins, manager = _registered_manager(tmp_path, lambda ctx: calls.append(ctx))
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._is_user_authorized = lambda _source: False
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    adapter = SimpleNamespace(update_interactive_card=AsyncMock())
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        user_id="ou_initiator",
+        profile="work",
+    )
+
+    result = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(),
+        source=source,
+        adapter=adapter,
+    )
+
+    assert result.status == "denied"
+    assert manager.storage.get("ia_instance_1").state == "active"
+    assert calls == []
+    adapter.update_interactive_card.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_derives_callback_profile_from_secondary_adapter_owner(
+    tmp_path,
+    monkeypatch,
+):
+    from contextlib import nullcontext
+    from gateway.config import Platform
+    from gateway.interactive_actions import InteractiveActionResult
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    captured = []
+
+    class RecordingManager:
+        def claim_action(self, callback, *, gateway_authorize):
+            assert gateway_authorize() is True
+            captured.append(callback)
+            return InteractiveActionResult.denied()
+
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = RecordingManager()
+    runner._interactive_action_tasks = set()
+    runner._is_user_authorized = lambda _source: True
+    runner.config = SimpleNamespace(multiplex_profiles=True, profile_routes=())
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path
+    adapter = SimpleNamespace(update_interactive_card=AsyncMock())
+    runner._profile_adapters = {"work": {Platform.FEISHU: adapter}}
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        user_id="ou_initiator",
+        user_name="Alice",
+        message_id="om_card",
+    )
+    monkeypatch.setattr(
+        "gateway.run._profile_runtime_scope",
+        lambda _home: nullcontext(),
+    )
+
+    result = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(profile_id="default", thread_id=None),
+        source=source,
+        adapter=adapter,
+    )
+
+    assert result.status == "denied"
+    assert source.profile == "work"
+    assert captured[0].profile_id == "work"

--- a/tests/gateway/test_interactive_actions.py
+++ b/tests/gateway/test_interactive_actions.py
@@ -619,6 +619,70 @@ def test_ledger_migrates_pre_policy_schema_without_losing_rows(tmp_path):
     assert record.card_id == "om_card"
 
 
+@pytest.mark.asyncio
+async def test_ledger_migrates_existing_schema_and_replays_safe_terminal_result(
+    tmp_path,
+):
+    import sqlite3
+
+    from gateway.interactive_actions import (
+        InteractiveActionManager,
+        InteractiveActionResult,
+        SQLiteInteractiveActionStorage,
+    )
+
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE interactive_actions (
+                action_instance_id TEXT PRIMARY KEY,
+                plugin_action TEXT NOT NULL,
+                external_action_id TEXT NOT NULL,
+                authorization_policy TEXT NOT NULL DEFAULT 'initiator_only',
+                profile_id TEXT NOT NULL,
+                platform TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                thread_id TEXT,
+                initiator_id TEXT NOT NULL,
+                initiator_name TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                card_id TEXT,
+                payload_json TEXT NOT NULL,
+                state TEXT NOT NULL,
+                outcome TEXT,
+                expires_at REAL NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO interactive_actions VALUES (
+                'ia_instance_1', 'proposal-plugin/apply', 'proposal-v1',
+                'initiator_only', 'work', 'feishu', 'oc_chat', 'om_root',
+                'ou_initiator', 'Alice', 'om_trigger', 'om_card', '{}',
+                'finished', 'conflict', 2000, 1000, 1000
+            )"""
+        )
+
+    plugins = PluginManager()
+    context = _plugin_context("proposal-plugin", plugins)
+    context.register_interactive_action("apply", lambda _ctx: None)
+    manager = InteractiveActionManager(
+        storage=SQLiteInteractiveActionStorage(db_path),
+        registrations=plugins._interactive_actions,
+        clock=lambda: 1_001.0,
+    )
+
+    replay = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+
+    assert replay == InteractiveActionResult.conflict()
+    with sqlite3.connect(db_path) as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(interactive_actions)")
+        }
+    assert "user_message" in columns
+
+
 def test_concurrent_ledger_schema_initialization_is_idempotent(tmp_path):
     from concurrent.futures import ThreadPoolExecutor
     import sqlite3
@@ -638,6 +702,7 @@ def test_concurrent_ledger_schema_initialization_is_idempotent(tmp_path):
             row[1] for row in conn.execute("PRAGMA table_info(interactive_actions)")
         ]
     assert columns.count("authorization_policy") == 1
+    assert columns.count("user_message") == 1
 
 
 def test_default_ledger_resolves_profile_home_on_each_operation(tmp_path):
@@ -783,23 +848,99 @@ async def test_atomic_double_click_executes_handler_once(tmp_path):
     completed = await first
 
     assert completed.status == "succeeded"
-    assert duplicate.status == "already_processed"
+    assert duplicate.status == "processing"
     assert len(calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_durable_replay_after_manager_restart_never_reexecutes(tmp_path):
+@pytest.mark.parametrize("state", ["processing", "finished"])
+@pytest.mark.parametrize(
+    "copied_callback",
+    [
+        _callback(card_id="om_copied_card"),
+        _callback(chat_id="oc_other"),
+        _callback(profile_id="personal"),
+        _callback(platform="slack"),
+        _callback(thread_id="om_other_thread"),
+    ],
+    ids=("wrong-card", "wrong-chat", "wrong-profile", "wrong-platform", "wrong-thread"),
+)
+async def test_processing_and_finished_replay_require_original_card_binding(
+    tmp_path,
+    state,
+    copied_callback,
+):
+    from gateway.interactive_actions import (
+        ClaimedInteractiveAction,
+        InteractiveActionResult,
+    )
+
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda _ctx: InteractiveActionResult.succeeded(
+            "Proposal applied from the original card."
+        ),
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+
+    if state == "processing":
+        claim = manager.claim_action(_callback(), gateway_authorize=lambda: True)
+        assert isinstance(claim, ClaimedInteractiveAction)
+        expected_original = InteractiveActionResult.processing()
+    else:
+        expected_original = await manager.dispatch(
+            _callback(),
+            gateway_authorize=lambda: True,
+        )
+
+    copied_replay = await manager.dispatch(
+        copied_callback,
+        gateway_authorize=lambda: True,
+    )
+    original_replay = await manager.dispatch(
+        _callback(),
+        gateway_authorize=lambda: True,
+    )
+
+    assert copied_replay == InteractiveActionResult.denied()
+    assert original_replay == expected_original
+
+
+@pytest.mark.asyncio
+async def test_durable_replay_after_manager_restart_returns_exact_sanitized_result(
+    tmp_path,
+):
     from gateway.interactive_actions import (
         InteractiveActionManager,
+        InteractiveActionResult,
         SQLiteInteractiveActionStorage,
     )
 
     calls = []
+
+    def handler(ctx):
+        calls.append(ctx)
+        return InteractiveActionResult.succeeded(
+            "  Proposal applied.\nReceipt 42.  "
+        )
+
     plugins, first_manager = _registered_manager(
         tmp_path,
-        lambda ctx: calls.append(ctx),
+        handler,
     )
-    await _issue_and_dispatch(first_manager)
+    _prepared, completed = await _issue_and_dispatch(first_manager)
+    assert completed == InteractiveActionResult.succeeded(
+        "Proposal applied. Receipt 42."
+    )
+    assert (
+        first_manager.storage.get("ia_instance_1").user_message
+        == "Proposal applied. Receipt 42."
+    )
 
     reconstructed = InteractiveActionManager(
         storage=SQLiteInteractiveActionStorage(tmp_path / "state.db"),
@@ -812,8 +953,117 @@ async def test_durable_replay_after_manager_restart_never_reexecutes(tmp_path):
         gateway_authorize=lambda: True,
     )
 
-    assert replay.status == "already_processed"
+    assert replay == completed
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_retryable_failure_reactivates_same_bound_action_for_success(tmp_path):
+    from gateway.interactive_actions import InteractiveActionResult
+
+    calls = []
+
+    def handler(ctx):
+        calls.append(ctx)
+        if len(calls) == 1:
+            return InteractiveActionResult.retryable_failure(
+                "Proposal service is temporarily unavailable."
+            )
+        return InteractiveActionResult.succeeded("Proposal applied on retry.")
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+
+    transient = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+    after_transient = manager.storage.get("ia_instance_1")
+    retried = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+
+    assert transient == InteractiveActionResult.retryable_failure(
+        "Proposal service is temporarily unavailable."
+    )
+    assert after_transient.state == "active"
+    assert after_transient.outcome == "retryable_failure"
+    assert retried == InteractiveActionResult.succeeded(
+        "Proposal applied on retry."
+    )
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_handler_persists_terminal_unknown_outcome(tmp_path):
+    from gateway.interactive_actions import InteractiveActionResult
+
+    entered = asyncio.Event()
+
+    async def handler(_ctx):
+        entered.set()
+        await asyncio.Event().wait()
+
+    _plugins, manager = _registered_manager(tmp_path, handler)
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    task = asyncio.create_task(
+        manager.dispatch(_callback(), gateway_authorize=lambda: True)
+    )
+    await entered.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    replay = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+    assert replay == InteractiveActionResult.unknown_outcome()
+    assert manager.storage.get("ia_instance_1").state == "finished"
+
+
+@pytest.mark.asyncio
+async def test_storage_startup_reconciles_prior_processing_to_unknown_outcome(
+    tmp_path,
+):
+    from gateway.interactive_actions import (
+        ClaimedInteractiveAction,
+        InteractiveActionManager,
+        InteractiveActionResult,
+        SQLiteInteractiveActionStorage,
+    )
+
+    calls = []
+    plugins, first_manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+    )
+    prepared = first_manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    first_manager.activate_card(prepared, card_id="om_card")
+    claim = first_manager.claim_action(
+        _callback(),
+        gateway_authorize=lambda: True,
+    )
+    assert isinstance(claim, ClaimedInteractiveAction)
+    assert first_manager.storage.get("ia_instance_1").state == "processing"
+
+    restarted = InteractiveActionManager(
+        storage=SQLiteInteractiveActionStorage(tmp_path / "state.db"),
+        registrations=plugins._interactive_actions,
+        clock=lambda: 1_001.0,
+    )
+    replay = await restarted.dispatch(_callback(), gateway_authorize=lambda: True)
+
+    assert replay == InteractiveActionResult.unknown_outcome()
+    assert restarted.storage.get("ia_instance_1").state == "finished"
+    assert calls == []
 
 
 @pytest.mark.asyncio
@@ -1207,7 +1457,13 @@ async def test_gateway_callback_returns_processing_only_after_claim_and_edits_fi
     runner._interactive_action_tasks = set()
     runner._is_user_authorized = lambda _source: True
     runner.config = SimpleNamespace(multiplex_profiles=False)
-    adapter = SimpleNamespace(update_interactive_card=AsyncMock())
+    updates = []
+
+    async def update_interactive_card(*, chat_id, card_id, result):
+        updates.append((chat_id, card_id, result))
+        return SimpleNamespace(success=True)
+
+    adapter = SimpleNamespace(update_interactive_card=update_interactive_card)
     source = SessionSource(
         platform=Platform.FEISHU,
         chat_id="oc_chat",
@@ -1229,10 +1485,135 @@ async def test_gateway_callback_returns_processing_only_after_claim_and_edits_fi
     assert manager.storage.get("ia_instance_1").state == "processing"
     await asyncio.wait_for(handled.wait(), timeout=1)
     await asyncio.gather(*runner._interactive_action_tasks)
-    adapter.update_interactive_card.assert_awaited_once()
-    final = adapter.update_interactive_card.await_args.kwargs["result"]
+    assert len(updates) == 1
+    final = updates[0][2]
     assert final.status == "succeeded"
     assert manager.storage.get("ia_instance_1").state == "finished"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "let_task_start",
+    [False, True],
+    ids=("before-task-start", "during-initial-sleep"),
+)
+async def test_gateway_cancellation_during_initial_sleep_marks_unknown_outcome(
+    tmp_path,
+    let_task_start,
+):
+    from gateway.config import Platform
+    from gateway.interactive_actions import InteractiveActionResult
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    calls = []
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda ctx: calls.append(ctx),
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._is_user_authorized = lambda _source: True
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    adapter = SimpleNamespace(update_interactive_card=AsyncMock())
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        user_id="ou_initiator",
+        user_name="Alice",
+        thread_id="om_root",
+        message_id="om_card",
+        profile="work",
+    )
+
+    initial = await runner._begin_interactive_action_from_adapter(
+        callback=_callback(),
+        source=source,
+        adapter=adapter,
+    )
+    task = next(iter(runner._interactive_action_tasks))
+    if let_task_start:
+        await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert initial.status == "processing"
+    replay = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+    assert replay == InteractiveActionResult.unknown_outcome()
+    assert calls == []
+    adapter.update_interactive_card.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancellation_during_final_card_update_preserves_finish(
+    tmp_path,
+):
+    from gateway.config import Platform
+    from gateway.interactive_actions import InteractiveActionResult
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    update_started = asyncio.Event()
+
+    async def update_interactive_card(**_kwargs):
+        update_started.set()
+        await asyncio.Event().wait()
+
+    _plugins, manager = _registered_manager(
+        tmp_path,
+        lambda _ctx: InteractiveActionResult.succeeded(
+            "Proposal applied before card refresh."
+        ),
+    )
+    prepared = manager.prepare_card(
+        plugin_id="proposal-plugin",
+        envelope=_proposal_envelope(),
+        origin=_origin(),
+    )
+    manager.activate_card(prepared, card_id="om_card")
+    runner = object.__new__(GatewayRunner)
+    runner._interactive_action_manager = manager
+    runner._interactive_action_tasks = set()
+    runner._interactive_action_task_claims = {}
+    runner._is_user_authorized = lambda _source: True
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    adapter = SimpleNamespace(update_interactive_card=update_interactive_card)
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        user_id="ou_initiator",
+        user_name="Alice",
+        thread_id="om_root",
+        message_id="om_card",
+        profile="work",
+    )
+
+    await runner._begin_interactive_action_from_adapter(
+        callback=_callback(),
+        source=source,
+        adapter=adapter,
+    )
+    await update_started.wait()
+    task = next(iter(runner._interactive_action_tasks))
+    assert manager.storage.get("ia_instance_1").outcome == "succeeded"
+
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    replay = await manager.dispatch(_callback(), gateway_authorize=lambda: True)
+
+    assert replay == InteractiveActionResult.succeeded(
+        "Proposal applied before card refresh."
+    )
+    assert manager.storage.get("ia_instance_1").outcome == "succeeded"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -10,6 +10,8 @@ itself (that's covered by test_run_progress_topics.py et al.).
 
 import asyncio
 import queue as queue_mod
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -64,3 +66,95 @@ class TestTurnRunner:
         ctx = TurnContext(progress_queue=queue_mod.Queue())
         runner = _make_runner(ctx)  # stub adapter resolver returns None
         assert asyncio.run(runner.send_progress_messages()) is None
+
+    @pytest.mark.asyncio
+    async def test_interactive_card_sender_binds_current_turn_destination(self):
+        from gateway.config import Platform
+        from gateway.run import TurnRunner
+        from gateway.session import SessionSource
+
+        manager = SimpleNamespace(deliver_card=AsyncMock(return_value="delivery-1"))
+        adapter = SimpleNamespace()
+
+        class _Runner:
+            _interactive_action_manager = manager
+
+            def _adapter_for_source(self, _source):
+                return adapter
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_current",
+            user_id="ou_current",
+            user_name="Alice",
+            thread_id="om_root",
+            message_id="om_source",
+            profile="work",
+        )
+        ctx = TurnContext(
+            source=source,
+            event_message_id="om_trigger",
+            _run_still_current=lambda: True,
+            _status_thread_metadata={"thread_id": "om_root"},
+            _interactive_card_sender_active=True,
+        )
+        ctx._loop_for_step = asyncio.get_running_loop()
+        turn = TurnRunner(_Runner(), ctx)
+
+        delivery = await asyncio.to_thread(
+            turn._send_interactive_card_sync,
+            plugin_id="proposal-plugin",
+            envelope=SimpleNamespace(),
+        )
+
+        assert delivery == "delivery-1"
+        kwargs = manager.deliver_card.await_args.kwargs
+        assert kwargs["plugin_id"] == "proposal-plugin"
+        assert kwargs["adapter"] is adapter
+        assert kwargs["origin"].platform == "feishu"
+        assert kwargs["origin"].profile_id == "work"
+        assert kwargs["origin"].chat_id == "oc_current"
+        assert kwargs["origin"].thread_id == "om_root"
+        assert kwargs["origin"].initiator_id == "ou_current"
+        assert kwargs["origin"].message_id == "om_trigger"
+
+    def test_interactive_card_sender_rejects_a_copied_context_after_turn_end(self):
+        from gateway.interactive_actions import InteractiveCardUnavailableError
+        from gateway.run import TurnRunner
+
+        ctx = TurnContext(
+            _run_still_current=lambda: True,
+            _interactive_card_sender_active=False,
+        )
+        turn = TurnRunner(object(), ctx)
+
+        with pytest.raises(InteractiveCardUnavailableError, match="no longer active"):
+            turn._send_interactive_card_sync(
+                plugin_id="proposal-plugin",
+                envelope=SimpleNamespace(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_interactive_card_sender_never_deadlocks_gateway_loop(self):
+        from gateway.interactive_actions import InteractiveCardUnavailableError
+        from gateway.run import TurnRunner
+
+        adapter = SimpleNamespace()
+
+        class _Runner:
+            def _adapter_for_source(self, _source):
+                return adapter
+
+        ctx = TurnContext(
+            source=SimpleNamespace(),
+            _run_still_current=lambda: True,
+            _interactive_card_sender_active=True,
+            _loop_for_step=asyncio.get_running_loop(),
+        )
+        turn = TurnRunner(_Runner(), ctx)
+
+        with pytest.raises(InteractiveCardUnavailableError, match="gateway loop"):
+            turn._send_interactive_card_sync(
+                plugin_id="proposal-plugin",
+                envelope=SimpleNamespace(),
+            )

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -621,6 +621,153 @@ All callbacks should accept `**kwargs` for forward compatibility. If a hook call
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
 
+### Send a gateway confirmation card
+
+An external plugin can turn its own validated `post_tool_call` result into one
+high-impact operator confirmation without adding a model tool or injecting a
+message into the conversation. Register one namespaced action at startup, then
+use the gateway-turn-bound `send_interactive_card` capability from the hook:
+
+```python
+import json
+
+from gateway.interactive_actions import (
+    InteractiveActionConflictError,
+    InteractiveActionResult,
+    InteractiveActionRetryableError,
+    InteractiveCardAction,
+    InteractiveCardEnvelope,
+    InteractiveCardFact,
+)
+
+
+async def apply_proposal(action_context):
+    # The immutable payload came from Hermes's server-side ledger, not the button.
+    proposal_id = action_context.payload["proposal_id"]
+    revision = action_context.payload["revision"]
+
+    try:
+        outcome = await proposal_service.apply_once(
+            proposal_id=proposal_id,
+            revision=revision,
+            idempotency_key=action_context.external_action_id,
+            operator_id=action_context.operator_id,
+        )
+    except ProposalRevisionConflict:
+        raise InteractiveActionConflictError("The proposal revision changed.")
+    except ProposalServiceUnavailable:
+        raise InteractiveActionRetryableError(
+            "The proposal service is temporarily unavailable."
+        )
+
+    if outcome.already_applied:
+        return InteractiveActionResult.downstream_replay()
+    return InteractiveActionResult.succeeded()
+
+
+def register(ctx):
+    action_name = ctx.register_interactive_action(
+        "apply",
+        apply_proposal,
+        authorization_policy="initiator_only",  # the default
+    )
+
+    def after_tool(*, tool_name, result, **_kwargs):
+        if tool_name != "proposal_validate":
+            return
+        validated = json.loads(result)
+        if validated.get("status") != "ready_for_confirmation":
+            return
+
+        ctx.send_interactive_card(
+            InteractiveCardEnvelope(
+                version=1,
+                title="Apply pricing proposal?",
+                summary="This changes the customer contract after confirmation.",
+                facts=(
+                    InteractiveCardFact("Customer", validated["customer_name"]),
+                    InteractiveCardFact("Revision", str(validated["revision"])),
+                ),
+                fallback_text=(
+                    "Apply the validated pricing proposal in the admin console."
+                ),
+                expires_in_seconds=900,
+                actions=(
+                    InteractiveCardAction(
+                        label="Apply proposal",
+                        action=action_name,
+                        external_action_id=validated["idempotency_key"],
+                        payload={
+                            "proposal_id": validated["proposal_id"],
+                            "revision": validated["revision"],
+                        },
+                        style="primary",
+                    ),
+                ),
+            )
+        )
+
+    ctx.register_hook("post_tool_call", after_tool)
+```
+
+`authorization_policy` has two V0 values:
+
+| Policy | Who may click |
+|---|---|
+| `initiator_only` | Only the stable platform user ID that originated the gateway turn. This is the default. |
+| `authorized_user` | Any operator who passes the gateway's normal authorization for that platform/chat. |
+
+The handler receives an immutable `InteractiveActionContext`: verified
+platform and profile IDs, stable operator ID/name, chat/thread, originating
+message, card message, opaque action-instance ID, your stable
+`external_action_id`, and the immutable server-stored payload. It never
+receives a Feishu SDK object or another adapter's raw callback.
+
+Security and delivery contract:
+
+- `send_interactive_card()` has no destination arguments. It is available only
+  during the current gateway turn (including `post_tool_call`) and fails closed
+  elsewhere.
+- The V1 envelope is bounded: 1–5 actions, a 1–86,400 second expiry, bounded
+  text/section counts, and at most 16 KiB of JSON payload per action. Payload
+  fields that look like passwords, tokens, API keys, cookies, credentials, or
+  other secrets are rejected. Do not put secrets in visible card text either.
+- Native buttons contain only an opaque Hermes action-instance ID. The plugin
+  action name, `external_action_id`, and business payload stay in the
+  profile-local `state.db` ledger.
+- Hermes binds the action to the profile, platform, chat/thread, originating
+  message, delivered card, initiator, registered action, and issuance-time
+  policy. Normal gateway authorization and the policy both run before the
+  atomic claim and before plugin code.
+- One action instance is claimed once. Double clicks, callback retries, and a
+  gateway restart do not run the handler again. A process failure after claim
+  remains fail-closed as already processed; Hermes does not claim network-wide
+  exactly-once execution. Use `external_action_id` as the downstream
+  idempotency key and return `downstream_replay()` when that system reports an
+  earlier success.
+- Handler outcomes are `succeeded`, `downstream_replay`, `conflict`, or
+  `retryable_failure`. Unexpected exceptions are hidden behind generic text.
+  Typed conflict/retryable exceptions expose only the bounded public message
+  you deliberately provide; never include payload or exception internals.
+- Feishu WebSocket renders a native card and updates it from Processing to the
+  truthful final state, retrying a transient final edit three times. If every
+  edit fails, the durable claim still prevents replay; another click resolves
+  inline as Already processed. A denied, unknown, or pre-claim failure never
+  replaces the shared card, so an unauthorized viewer cannot remove live
+  buttons. Other adapters send `fallback_text` exactly through their normal
+  text-send path and create no clickable ledger state (and therefore do not
+  require a native initiator or source-message ID).
+- Native delivery is two-phase: Hermes reserves opaque IDs, sends the card,
+  then binds the provider's returned card-message ID. If that final bind fails,
+  Hermes marks the reservation unusable when possible and best-effort replaces
+  the delivered card with a non-actionable failure state. The profile-local
+  schema is created/migrated transactionally alongside existing `state.db`
+  tables; stale crash rows are retained fail-closed, then pruned after the
+  bounded retention window.
+- `post_tool_call` remains observational: sending a card does not replace the
+  tool result or mutate the transcript, cached system prompt, toolsets, or
+  message roles.
+
 ### `pre_llm_call` context injection
 
 This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -739,31 +739,37 @@ Security and delivery contract:
   message, delivered card, initiator, registered action, and issuance-time
   policy. Normal gateway authorization and the policy both run before the
   atomic claim and before plugin code.
-- One action instance is claimed once. Double clicks, callback retries, and a
-  gateway restart do not run the handler again. A process failure after claim
-  remains fail-closed as already processed; Hermes does not claim network-wide
-  exactly-once execution. Use `external_action_id` as the downstream
-  idempotency key and return `downstream_replay()` when that system reports an
-  earlier success.
+- One action instance has at most one active claim. Concurrent clicks return
+  Processing without running the handler again. Terminal outcomes and their
+  sanitized messages are replayed exactly; a process failure after claim is
+  recovered as a terminal Unknown outcome and is never executed again. Hermes
+  does not claim network-wide exactly-once execution. Use `external_action_id`
+  as the downstream idempotency key and return `downstream_replay()` when that
+  system reports an earlier success.
 - Handler outcomes are `succeeded`, `downstream_replay`, `conflict`, or
   `retryable_failure`. Unexpected exceptions are hidden behind generic text.
   Typed conflict/retryable exceptions expose only the bounded public message
-  you deliberately provide; never include payload or exception internals.
+  you deliberately provide; never include payload or exception internals. A
+  retryable failure reactivates the same bound action and Feishu retains a
+  Retry button; all profile, chat, card, operator, expiry, and policy checks run
+  again before the next atomic claim.
 - Feishu WebSocket renders a native card and updates it from Processing to the
   truthful final state, retrying a transient final edit three times. If every
-  edit fails, the durable claim still prevents replay; another click resolves
-  inline as Already processed. A denied, unknown, or pre-claim failure never
-  replaces the shared card, so an unauthorized viewer cannot remove live
-  buttons. Other adapters send `fallback_text` exactly through their normal
-  text-send path and create no clickable ledger state (and therefore do not
-  require a native initiator or source-message ID).
+  terminal edit fails, another authenticated callback on the original bound
+  card reconstructs the durable final status and sanitized message. A denied,
+  unknown, or pre-claim failure never replaces the shared card, so an
+  unauthorized viewer cannot remove live buttons. Other adapters send
+  `fallback_text` exactly through their normal text-send path and create no
+  clickable ledger state (and therefore do not require a native initiator or
+  source-message ID).
 - Native delivery is two-phase: Hermes reserves opaque IDs, sends the card,
   then binds the provider's returned card-message ID. If that final bind fails,
   Hermes marks the reservation unusable when possible and best-effort replaces
   the delivered card with a non-actionable failure state. The profile-local
   schema is created/migrated transactionally alongside existing `state.db`
-  tables; stale crash rows are retained fail-closed, then pruned after the
-  bounded retention window.
+  tables. Shutdown drains action tasks before disconnecting adapters; cancelled
+  claims and processing rows found after a process crash become terminal
+  Unknown outcomes. Stale rows are pruned after the bounded retention window.
 - `post_tool_call` remains observational: sending a card does not replace the
   tool result or mutate the transcript, cached system prompt, toolsets, or
   message roles.

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -286,11 +286,14 @@ are authenticated by the Feishu connection, checked by normal gateway
 authorization plus the plugin's action policy, and atomically claimed from the
 profile-local ledger. They bypass `/card`, the model, and the conversation
 transcript. The card first shows **Processing** only after authorization and a
-successful claim, then is replaced with Applied, Already processed, Expired,
-Conflict, or Retryable failure. A denied, unknown, or pre-claim failure does
-not replace the shared card, so an unauthorized viewer cannot remove the
-initiator's live buttons. Hermes retries transient final-card edits three
-times; the durable claim remains fail-closed if Feishu still rejects the edit.
+successful claim, then is replaced with Applied, Downstream replay, Expired,
+Conflict, Retryable failure, or Outcome unknown. Retryable failures retain a
+button for another authenticated claim of the same bound action. Terminal
+status and sanitized text are stored durably and replayed exactly after callback
+retries or restart. A denied, unknown, or pre-claim failure does not replace the
+shared card, so an unauthorized viewer cannot remove the initiator's live
+buttons. Hermes retries transient final-card edits three times and drains active
+actions before disconnecting the adapter during shutdown.
 See [Build a Hermes Plugin — Send a gateway
 confirmation card](/developer-guide/plugins#send-a-gateway-confirmation-card).
 

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -277,11 +277,32 @@ Grant the `application:bot.basic_info:read` scope to display peer bot names; wit
 
 ## Interactive Card Actions
 
-When users click buttons or interact with interactive cards sent by the bot, the adapter routes these as synthetic `/card` command events:
+Feishu has two deliberately separate card-action paths.
+
+In WebSocket mode, cards created by an external plugin through Hermes's
+registered interactive action API carry only an opaque
+`hermes_interactive_action_id`. Their callbacks
+are authenticated by the Feishu connection, checked by normal gateway
+authorization plus the plugin's action policy, and atomically claimed from the
+profile-local ledger. They bypass `/card`, the model, and the conversation
+transcript. The card first shows **Processing** only after authorization and a
+successful claim, then is replaced with Applied, Already processed, Expired,
+Conflict, or Retryable failure. A denied, unknown, or pre-claim failure does
+not replace the shared card, so an unauthorized viewer cannot remove the
+initiator's live buttons. Hermes retries transient final-card edits three
+times; the durable claim remains fail-closed if Feishu still rejects the edit.
+See [Build a Hermes Plugin — Send a gateway
+confirmation card](/developer-guide/plugins#send-a-gateway-confirmation-card).
+
+Webhook-mode Feishu is not a V1 native adapter for external-plugin actions; it
+uses the envelope's exact fallback text and creates no clickable action state.
+
+All other, unregistered card values preserve the legacy generic behavior and
+route as synthetic `/card` command events:
 
 - Button clicks become: `/card button {"key": "value", ...}`
 - The action's `value` payload from the card definition is included as JSON.
-- Card actions are deduplicated with a 15-minute window to prevent double processing.
+- Generic card actions are deduplicated with a 15-minute window to prevent double processing.
 
 Gateway-driven update prompts use a native Feishu `Yes` / `No` card instead of falling back to plain text replies. When `hermes update --gateway` needs confirmation, the adapter records the selected answer in Hermes's `.update_response` file and replaces the card inline with a resolved state.
 


### PR DESCRIPTION
## Summary

Add a platform-neutral interactive-card/action seam for external Hermes plugins, with a native Feishu implementation.

This lets an external plugin render a deterministic confirmation card from the current gateway turn and handle its button callback without routing the click through the model or synthetic chat messages.

## Security and behavior

- opaque callback IDs only; plugin payloads remain in a profile-scoped SQLite ledger
- bounded payloads, secret-key rejection, expiry and bounded retention
- immutable payload + external action ID passed to the handler
- normal gateway authorization plus `initiator_only` / `authorized_user` policy
- atomic claim before side effect; duplicate/restart clicks cannot execute twice
- callback is bound to profile/platform/chat/thread/card and bypasses transcript/model/tool routing
- Feishu returns inline Processing and asynchronously edits to applied/replay/conflict/retryable states
- unsupported platforms receive the plugin's exact deterministic fallback text
- existing Feishu approval/update-prompt actions retain full per-group authorization policy
- no new model-callable tool and no prompt mutation

## External plugin API

- `PluginContext.register_interactive_action(...)`
- `PluginContext.send_interactive_card(...)`
- immutable card/action/result contracts in `gateway.interactive_actions`

The send capability is available only during the active gateway turn (including `post_tool_call` observers).

## Verification

- targeted changed-path suite: 8 files, 168 tests passed
- core interactive/Feishu suite: 97 tests passed
- Ruff checks on all touched Python files passed
- `git diff --check` passed
- full `tests/gateway` run reached 1,409 passing tests; its failures were reproduced on the untouched base revision and are environment/pre-existing (optional platform dependencies, proxy/SSRF mock behavior, readiness/systemd environment)

## Documentation

- external plugin developer guide includes registration, delivery, callback and threat-model guidance
- Feishu guide documents WebSocket-only native actions and deterministic text fallback
