### PR TITLE
fix(desktop): stage macOS package rebuild away from live release

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -189,6 +189,12 @@ import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
+import {
+  buildDesktopUpdateArgs,
+  buildMacPublishScript,
+  resolveStagedMacApp,
+  validateMacUpdatePaths
+} from './update-macos-publish'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
@@ -201,6 +207,7 @@ import {
   sandboxPreflight
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
+import { probeDesktopUpdateRuntime } from './update-runtime-identity'
 import {
   resolveStagedUpdaterBinary,
   spawnUpdaterProcess,
@@ -2476,6 +2483,29 @@ async function checkUpdates() {
     }
   }
 
+  // The checkout selected above is only the launcher identity. The venv can
+  // import Hermes from a different immutable generation via editable finder
+  // metadata. In that split-brain state `hermes update` ignores this cwd,
+  // derives its project root from the imported package, and fails after doing
+  // pre-update work because the generation intentionally has no .git. Resolve
+  // the effective runtime identity before offering the Git update at all.
+  const runtime = probeDesktopUpdateRuntime(updateRoot, { isWindows: IS_WINDOWS })
+
+  if (!runtime.supported) {
+    rememberLog(
+      `[updates] refusing git updater: launcher=${runtime.updateRoot} runtime=${runtime.runtimeRoot || 'unknown'} kind=${runtime.kind}`
+    )
+
+    return {
+      supported: false,
+      reason: runtime.kind,
+      message: runtime.message,
+      hermesRoot: updateRoot,
+      runtimeRoot: runtime.runtimeRoot,
+      branch
+    }
+  }
+
   branch = await resolveHealedBranch(updateRoot, branch)
   const originUrl = await getOriginUrl(updateRoot)
 
@@ -2847,6 +2877,24 @@ async function applyUpdates(opts = {}) {
   updateInFlight = true
 
   try {
+    const updateRoot = resolveUpdateRoot()
+    const runtime = probeDesktopUpdateRuntime(updateRoot, { isWindows: IS_WINDOWS })
+
+    if (!runtime.supported) {
+      rememberLog(
+        `[updates] refusing git updater: launcher=${runtime.updateRoot} runtime=${runtime.runtimeRoot || 'unknown'} kind=${runtime.kind}`
+      )
+      emitUpdateProgress({ stage: 'error', message: runtime.message, error: runtime.kind, percent: null })
+
+      return {
+        ok: false,
+        error: runtime.kind,
+        message: runtime.message,
+        hermesRoot: updateRoot,
+        runtimeRoot: runtime.runtimeRoot
+      }
+    }
+
     const updater = resolveUpdaterBinary()
 
     if (!updater && !IS_WINDOWS) {
@@ -2870,7 +2918,6 @@ async function applyUpdates(opts = {}) {
       // silently switch a bb/gui (or any non-main) install off-branch. Mirror
       // the GUI button's contract: append --branch <current> for non-main
       // checkouts, keep it bare for main so the card stays clean.
-      const updateRoot = resolveUpdateRoot()
       let command = 'hermes update'
 
       try {
@@ -2915,7 +2962,6 @@ async function applyUpdates(opts = {}) {
     })
     repairMacUpdaterHelper(updater)
 
-    const updateRoot = resolveUpdateRoot()
     const { branch: configuredBranch } = readDesktopUpdateConfig()
     const branch = await resolveHealedBranch(updateRoot, configuredBranch || DEFAULT_UPDATE_BRANCH)
     const updaterArgs = ['--update', '--branch', branch]
@@ -3363,11 +3409,15 @@ async function applyUpdatesPosixInApp(opts: any) {
 
   emitUpdateProgress({ stage: 'update', message: 'Updating Hermes (git + dependencies)…', percent: 10 })
 
-  const updated = (await runStreamedUpdate(hermes, ['update', '--yes', ...branchArgs], {
-    cwd: updateRoot,
-    env,
-    stage: 'update'
-  })) as any
+  const updated = (await runStreamedUpdate(
+    hermes,
+    buildDesktopUpdateArgs(branchArgs),
+    {
+      cwd: updateRoot,
+      env,
+      stage: 'update'
+    }
+  )) as any
 
   if (updated.code !== 0) {
     emitUpdateProgress({ stage: 'error', message: 'hermes update failed.', error: updated.error || 'update-failed' })
@@ -3377,6 +3427,16 @@ async function applyUpdatesPosixInApp(opts: any) {
 
   emitUpdateProgress({ stage: 'rebuild', message: 'Rebuilding the desktop app…', percent: 60 })
 
+  // macOS package production is transaction-isolated. The old Desktop and
+  // helpers may keep app.asar mapped until quit, so electron-builder must not
+  // touch apps/desktop/release (the running bundle) during this process.
+  const macStageRoot = IS_MAC
+    ? fs.mkdtempSync(path.join(HERMES_HOME, 'desktop-update-stage-'))
+    : null
+  const rebuildArgs = macStageRoot
+    ? buildDesktopUpdateArgs([], { stageRoot: macStageRoot })
+    : ['desktop', '--build-only']
+
   // Retry-once: a first rebuild can fail on a still-settling tree or a
   // self-healed (network-blocked) Electron download; a second run builds clean
   // off the healed dist so we reach the swap+relaunch below instead of bailing.
@@ -3385,10 +3445,13 @@ async function applyUpdatesPosixInApp(opts: any) {
       emitUpdateProgress({ stage: 'rebuild', message: 'Retrying the desktop rebuild…', percent: 60 })
     }
 
-    return runStreamedUpdate(hermes, ['desktop', '--build-only'], { cwd: updateRoot, env, stage: 'rebuild' })
+    return runStreamedUpdate(hermes, rebuildArgs, { cwd: updateRoot, env, stage: 'rebuild' })
   })
 
   if (rebuilt.code !== 0) {
+    if (macStageRoot) {
+      fs.rmSync(macStageRoot, { recursive: true, force: true })
+    }
     emitUpdateProgress({
       stage: 'error',
       message: 'Backend updated, but the desktop rebuild failed. Restart Hermes to retry.',
@@ -3516,49 +3579,46 @@ async function applyUpdatesPosixInApp(opts: any) {
     }
   }
 
-  const rebuiltApp = [
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
-    path.join(updateRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
-  ].find(directoryExists)
-
+  const rebuiltApp = macStageRoot ? resolveStagedMacApp(macStageRoot) : null
   const targetApp = runningAppBundle()
 
-  // No bundle to swap (dev run, Linux AppImage, or unresolved paths): the
-  // backend is updated; the next launch picks up the rebuilt GUI.
-  if (!rebuiltApp || !targetApp) {
+  // A packaged macOS update without an exact staged candidate and running
+  // target cannot be published honestly. Preserve the stage for forensics and
+  // fail closed instead of falling back to a live-release search.
+  if (!macStageRoot || !rebuiltApp || !targetApp) {
     emitUpdateProgress({
-      stage: 'done',
-      message: 'Backend updated. Restart Hermes to load the new version.',
-      percent: 100
+      stage: 'error',
+      message: 'Backend updated, but the staged desktop app could not be published.',
+      error: 'staged-app-unavailable',
+      percent: null
     })
 
-    return { ok: true, backendUpdated: true, rebuiltApp: rebuiltApp || null }
+    return { ok: false, backendUpdated: true, error: 'staged app unavailable', rebuiltApp, stageRoot: macStageRoot }
   }
 
   emitUpdateProgress({ stage: 'restart', message: 'Installing the updated app and restarting…', percent: 95 })
 
-  // Detached swapper: wait for THIS process to exit (so the bundle is free),
-  // ditto the rebuilt app over the running one, clear quarantine, relaunch.
-  const swapScript = `#!/bin/bash
-set -u
-APP_PID=${process.pid}
-SRC=${shellQuote(rebuiltApp)}
-DST=${shellQuote(targetApp)}
-for _ in $(seq 1 240); do
-  kill -0 "$APP_PID" 2>/dev/null || break
-  sleep 0.5
-done
-if [ "$SRC" != "$DST" ]; then
-  if /usr/bin/ditto "$SRC" "$DST.hermes-update-new"; then
-    rm -rf "$DST.hermes-update-old" 2>/dev/null || true
-    mv "$DST" "$DST.hermes-update-old" 2>/dev/null || rm -rf "$DST"
-    mv "$DST.hermes-update-new" "$DST"
-    rm -rf "$DST.hermes-update-old" 2>/dev/null || true
-  fi
-fi
-/usr/bin/xattr -dr com.apple.quarantine "$DST" 2>/dev/null || true
-/usr/bin/open "$DST"
-`
+  let swapScript
+
+  try {
+    validateMacUpdatePaths({ stageRoot: macStageRoot, candidateApp: rebuiltApp, targetApp })
+    swapScript = buildMacPublishScript({
+      pid: process.pid,
+      stageRoot: macStageRoot,
+      candidateApp: rebuiltApp,
+      targetApp
+    })
+  } catch (err) {
+    emitUpdateProgress({
+      stage: 'error',
+      message: 'Backend updated, but staged app validation failed.',
+      error: err.message || 'staged-app-invalid',
+      percent: null
+    })
+    rememberLog(`[updates] refusing mac publish: ${err.message}; staged app at ${rebuiltApp}`)
+
+    return { ok: false, backendUpdated: true, error: 'staged app invalid', rebuiltApp, stageRoot: macStageRoot }
+  }
 
   const scriptPath = path.join(app.getPath('temp'), `hermes-desktop-update-${Date.now()}.sh`)
 
@@ -3566,23 +3626,36 @@ fi
     fs.writeFileSync(scriptPath, swapScript, { mode: 0o755 })
   } catch (err) {
     emitUpdateProgress({
-      stage: 'done',
-      message: 'Backend + app updated. Restart Hermes to load the new version.',
-      percent: 100
+      stage: 'error',
+      message: 'Backend updated, but the safe app publisher could not be prepared.',
+      error: err.message || 'publisher-write-failed',
+      percent: null
     })
     rememberLog(`[updates] could not write swap script: ${err.message}; rebuilt app at ${rebuiltApp}`)
 
-    return { ok: true, backendUpdated: true, rebuiltApp }
+    return { ok: false, backendUpdated: true, error: 'publisher write failed', rebuiltApp, stageRoot: macStageRoot }
   }
 
-  const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' })
-  child.unref()
+  try {
+    const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' })
+    child.unref()
+  } catch (err) {
+    emitUpdateProgress({
+      stage: 'error',
+      message: 'Backend updated, but the safe app publisher could not start.',
+      error: err.message || 'publisher-spawn-failed',
+      percent: null
+    })
+    rememberLog(`[updates] could not launch mac publisher: ${err.message}; staged app at ${rebuiltApp}`)
+
+    return { ok: false, backendUpdated: true, error: 'publisher spawn failed', rebuiltApp, stageRoot: macStageRoot }
+  }
   rememberLog(`[updates] launched mac swap+relaunch: ${scriptPath} (${rebuiltApp} -> ${targetApp})`)
 
   isQuittingForHandoff = true
   setTimeout(() => app.quit(), 600)
 
-  return { ok: true, handedOff: true, rebuiltApp, targetApp }
+  return { ok: true, handedOff: true, rebuiltApp, targetApp, stageRoot: macStageRoot }
 }
 
 function readJson(filePath) {

--- a/apps/desktop/electron/update-macos-publish.test.ts
+++ b/apps/desktop/electron/update-macos-publish.test.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import {
+  buildDesktopUpdateArgs,
+  buildMacPublishScript,
+  resolveStagedMacApp,
+  validateMacUpdatePaths
+} from './update-macos-publish'
+
+function makeExecutable(file: string, body: string) {
+  fs.writeFileSync(file, `#!/bin/bash\nset -eu\n${body}\n`, { mode: 0o755 })
+}
+
+function runPublisher(root: string, script: string) {
+  const file = path.join(root, 'publisher.sh')
+  fs.writeFileSync(file, script, { mode: 0o755 })
+  return spawnSync('/bin/bash', [file])
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-mac-publish-test-'))
+  const stage = path.join(root, 'stage')
+  const candidate = path.join(stage, 'mac-arm64', 'Hermes.app')
+  const target = path.join(root, 'Applications', 'Hermes.app')
+  for (const app of [candidate, target]) {
+    const executable = path.join(app, 'Contents', 'MacOS', 'Hermes')
+    fs.mkdirSync(path.dirname(executable), { recursive: true })
+    fs.writeFileSync(executable, app === candidate ? 'new' : 'old', { mode: 0o755 })
+  }
+  return { root, stage, candidate, target }
+}
+
+test('Desktop update argv suppresses autonomous build and stages only macOS packaging', () => {
+  assert.deepEqual(buildDesktopUpdateArgs(['--branch', 'main']), [
+    'update',
+    '--yes',
+    '--skip-desktop-build',
+    '--branch',
+    'main'
+  ])
+  assert.deepEqual(buildDesktopUpdateArgs([], { updateOnly: true }), ['update', '--yes', '--skip-desktop-build'])
+  assert.deepEqual(buildDesktopUpdateArgs([], { stageRoot: '/tmp/txn' }), [
+    'desktop',
+    '--build-only',
+    '--output-dir',
+    '/tmp/txn'
+  ])
+  assert.deepEqual(buildDesktopUpdateArgs([]), ['update', '--yes', '--skip-desktop-build'])
+})
+
+test('staged candidate resolution searches only the explicit output root', () => {
+  const { root, stage, candidate } = fixture()
+  try {
+    assert.equal(resolveStagedMacApp(stage, fs.existsSync), candidate)
+    assert.equal(resolveStagedMacApp(path.join(root, 'other'), fs.existsSync), null)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('stage, candidate, target, and rollback paths must be non-aliasing', () => {
+  const { root, stage, candidate, target } = fixture()
+  try {
+    const safe = validateMacUpdatePaths({ stageRoot: stage, candidateApp: candidate, targetApp: target })
+    assert.equal(safe.candidateApp, fs.realpathSync(candidate))
+    assert.throws(
+      () => validateMacUpdatePaths({ stageRoot: stage, candidateApp: candidate, targetApp: candidate }),
+      /distinct/
+    )
+    assert.throws(
+      () => validateMacUpdatePaths({ stageRoot: stage, candidateApp: target, targetApp: target }),
+      /inside staging root/
+    )
+    assert.throws(
+      () => validateMacUpdatePaths({ stageRoot: root, candidateApp: candidate, targetApp: target }),
+      /must not contain target/
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publisher makes no target or sibling write while old app pid is alive', () => {
+  const { root, stage, candidate, target } = fixture()
+  const oldContents = fs.readFileSync(path.join(target, 'Contents', 'MacOS', 'Hermes'), 'utf8')
+  try {
+    const script = buildMacPublishScript({
+      pid: process.pid,
+      stageRoot: stage,
+      candidateApp: candidate,
+      targetApp: target,
+      waitIterations: 1,
+      waitSeconds: 0
+    })
+    const result = runPublisher(root, script)
+    assert.notEqual(result.status, 0)
+    assert.equal(fs.readFileSync(path.join(target, 'Contents', 'MacOS', 'Hermes'), 'utf8'), oldContents)
+    assert.equal(fs.existsSync(`${target}.hermes-update-new`), false)
+    assert.equal(fs.existsSync(`${target}.hermes-update-old`), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publisher swaps staged app after exit, relaunches exact target, and safely cleans stage', () => {
+  const { root, stage, candidate, target } = fixture()
+  const copy = path.join(root, 'copy.sh')
+  const open = path.join(root, 'open.sh')
+  const xattr = path.join(root, 'xattr.sh')
+  const startupProbe = path.join(root, 'startup-probe.sh')
+  const opened = path.join(root, 'opened.txt')
+  makeExecutable(copy, '/bin/cp -R "$1" "$2"')
+  makeExecutable(open, `printf '%s' "$1" > ${JSON.stringify(opened)}`)
+  makeExecutable(xattr, 'exit 0')
+  makeExecutable(startupProbe, 'exit 0')
+  try {
+    const script = buildMacPublishScript({
+      pid: 99999999,
+      stageRoot: stage,
+      candidateApp: candidate,
+      targetApp: target,
+      tools: { copy, open, xattr, startupProbe }
+    })
+    const result = runPublisher(root, script)
+    assert.equal(result.status, 0, result.stderr.toString())
+    assert.equal(fs.readFileSync(path.join(target, 'Contents', 'MacOS', 'Hermes'), 'utf8'), 'new')
+    assert.equal(fs.readFileSync(opened, 'utf8'), fs.realpathSync(target))
+    assert.equal(fs.existsSync(`${target}.hermes-update-old`), false)
+    assert.equal(fs.existsSync(stage), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publisher copy failure is fail-closed and preserves old target', () => {
+  const { root, stage, candidate, target } = fixture()
+  const copy = path.join(root, 'copy-fail.sh')
+  makeExecutable(copy, 'exit 7')
+  try {
+    const script = buildMacPublishScript({
+      pid: 99999999,
+      stageRoot: stage,
+      candidateApp: candidate,
+      targetApp: target,
+      tools: { copy }
+    })
+    const result = runPublisher(root, script)
+    assert.notEqual(result.status, 0)
+    assert.equal(fs.readFileSync(path.join(target, 'Contents', 'MacOS', 'Hermes'), 'utf8'), 'old')
+    assert.equal(fs.existsSync(`${target}.hermes-update-old`), false)
+    assert.equal(fs.existsSync(stage), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publisher rolls back when final target validation fails', () => {
+  const { root, stage, candidate, target } = fixture()
+  const copy = path.join(root, 'copy.sh')
+  const validate = path.join(root, 'validate.sh')
+  const counter = path.join(root, 'validate-count')
+  makeExecutable(copy, '/bin/cp -R "$1" "$2"')
+  makeExecutable(
+    validate,
+    `n=0; [ -f ${JSON.stringify(counter)} ] && n=$(/bin/cat ${JSON.stringify(counter)}); n=$((n+1)); printf '%s' "$n" > ${JSON.stringify(counter)}; [ "$n" -eq 1 ]`
+  )
+  try {
+    const script = buildMacPublishScript({
+      pid: 99999999,
+      stageRoot: stage,
+      candidateApp: candidate,
+      targetApp: target,
+      tools: { copy, validate }
+    })
+    const result = runPublisher(root, script)
+    assert.notEqual(result.status, 0)
+    assert.equal(fs.readFileSync(path.join(target, 'Contents', 'MacOS', 'Hermes'), 'utf8'), 'old')
+    assert.equal(fs.existsSync(`${target}.hermes-update-old`), false)
+    assert.equal(fs.existsSync(stage), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publisher prefers direct executable launch when open does not yield a process', () => {
+  const { root, stage, candidate, target } = fixture()
+  const copy = path.join(root, 'copy.sh')
+  const open = path.join(root, 'open.sh')
+  const xattr = path.join(root, 'xattr.sh')
+  const startupProbe = path.join(root, 'startup-probe.sh')
+  const opened = path.join(root, 'opened.txt')
+  const launched = path.join(root, 'launched.txt')
+  makeExecutable(copy, '/bin/cp -R "$1" "$2"')
+  makeExecutable(open, `printf '%s' "$1" > ${JSON.stringify(opened)}; exit 0`)
+  makeExecutable(xattr, 'exit 0')
+  // Become healthy only after the target EXE has been executed (direct launch).
+  makeExecutable(
+    startupProbe,
+    `if [ -f ${JSON.stringify(launched)} ]; then exit 0; fi; exit 1`
+  )
+  const exe = path.join(candidate, 'Contents', 'MacOS', 'Hermes')
+  // Must remain a long-lived probe marker writer; do not use set -e body failures.
+  fs.writeFileSync(
+    exe,
+    `#!/bin/bash\nprintf 'launched' > ${JSON.stringify(launched)}\n# keep a background heart so pgrep-like probes that exec this binary are ok\nexit 0\n`,
+    { mode: 0o755 }
+  )
+  try {
+    const script = buildMacPublishScript({
+      pid: 99999999,
+      stageRoot: stage,
+      candidateApp: candidate,
+      targetApp: target,
+      tools: { copy, open, xattr, startupProbe }
+    })
+    const result = runPublisher(root, script)
+    assert.equal(
+      result.status,
+      0,
+      `status=${result.status} out=${result.stdout?.toString?.() || ''} err=${result.stderr?.toString?.() || ''}`
+    )
+    assert.equal(fs.existsSync(launched), true)
+    assert.equal(fs.existsSync(`${target}.hermes-update-old`), false)
+    assert.equal(fs.existsSync(stage), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}, 20_000)

--- a/apps/desktop/electron/update-macos-publish.ts
+++ b/apps/desktop/electron/update-macos-publish.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+function isWithin(child, parent) {
+  const relative = path.relative(parent, child)
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+}
+
+function buildDesktopUpdateArgs(
+  branchArgs: string[] = [],
+  options: { stageRoot?: string } = {},
+) {
+  if (options.stageRoot) {
+    return ['desktop', '--build-only', '--output-dir', options.stageRoot]
+  }
+  return ['update', '--yes', '--skip-desktop-build', ...branchArgs]
+}
+
+function regexEscape(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function resolveStagedMacApp(stageRoot, exists = fs.existsSync) {
+  if (!stageRoot || !path.isAbsolute(stageRoot)) {
+    return null
+  }
+  return [
+    path.join(stageRoot, 'mac-arm64', 'Hermes.app'),
+    path.join(stageRoot, 'mac', 'Hermes.app')
+  ].find(candidate => exists(candidate)) || null
+}
+
+function validateMacUpdatePaths({ stageRoot, candidateApp, targetApp }) {
+  if (![stageRoot, candidateApp, targetApp].every(value => value && path.isAbsolute(value))) {
+    throw new Error('macOS update paths must be absolute')
+  }
+  const stage = fs.realpathSync(stageRoot)
+  const candidate = fs.realpathSync(candidateApp)
+  const target = fs.realpathSync(targetApp)
+  const next = `${target}.hermes-update-new`
+  const previous = `${target}.hermes-update-old`
+
+  if (!isWithin(candidate, stage)) {
+    throw new Error('candidate app must be inside staging root')
+  }
+  if (candidate === target) {
+    throw new Error('candidate and target app must be distinct')
+  }
+  if (isWithin(target, stage) || isWithin(next, stage) || isWithin(previous, stage)) {
+    throw new Error('staging root must not contain target or rollback paths')
+  }
+  return { stageRoot: stage, candidateApp: candidate, targetApp: target, nextApp: next, previousApp: previous }
+}
+
+function buildMacPublishScript({
+  pid,
+  stageRoot,
+  candidateApp,
+  targetApp,
+  waitIterations = 240,
+  waitSeconds = 0.5,
+  tools = {},
+}: {
+  pid: number
+  stageRoot: string
+  candidateApp: string
+  targetApp: string
+  waitIterations?: number
+  waitSeconds?: number
+  tools?: {
+    copy?: string
+    open?: string
+    xattr?: string
+    validate?: string | null
+    startupProbe?: string | null
+  }
+}) {
+  const safe = validateMacUpdatePaths({ stageRoot, candidateApp, targetApp })
+  const copy = tools.copy || '/usr/bin/ditto'
+  const open = tools.open || '/usr/bin/open'
+  const xattr = tools.xattr || '/usr/bin/xattr'
+  const validate = tools.validate || null
+  const startupProbe = tools.startupProbe || null
+  const validateBody = validate
+    ? `${shellQuote(validate)} "$1"`
+    : '[ -x "$1/Contents/MacOS/Hermes" ]'
+  const targetReaderPattern = regexEscape(`${safe.targetApp}${path.sep}`)
+  const targetExecutable = path.join(safe.targetApp, 'Contents', 'MacOS', 'Hermes')
+  const targetExecutablePattern = regexEscape(targetExecutable)
+  const startupProbeBody = startupProbe
+    ? `${shellQuote(startupProbe)} "$1"`
+    : `/usr/bin/pgrep -f ${shellQuote(targetExecutablePattern)} >/dev/null 2>&1`
+
+  return `#!/bin/bash
+set -u
+APP_PID=${Number(pid)}
+STAGE=${shellQuote(safe.stageRoot)}
+SRC=${shellQuote(safe.candidateApp)}
+DST=${shellQuote(safe.targetApp)}
+NEW=${shellQuote(safe.nextApp)}
+OLD=${shellQuote(safe.previousApp)}
+EXE=${shellQuote(targetExecutable)}
+validate_app() {
+  ${validateBody}
+}
+bundle_readers_alive() {
+  if [ "$APP_PID" -gt 0 ] && kill -0 "$APP_PID" 2>/dev/null; then
+    return 0
+  fi
+  /usr/bin/pgrep -f ${shellQuote(targetReaderPattern)} >/dev/null 2>&1
+}
+startup_ok() {
+  ${startupProbeBody}
+}
+rollback() {
+  /bin/rm -rf -- "$DST" 2>/dev/null || true
+  if [ "$HAD_TARGET" -eq 1 ] && [ -e "$OLD" ]; then
+    /bin/mv -- "$OLD" "$DST" 2>/dev/null || true
+  fi
+  /bin/rm -rf -- "$NEW" 2>/dev/null || true
+}
+direct_launch() {
+  # LaunchServices 'open' can return success without a durable process.
+  # Fall back to the packaged executable under nohup when probes stay dark.
+  if [ -x "$EXE" ]; then
+    /usr/bin/nohup "$EXE" >/dev/null 2>&1 &
+    return 0
+  fi
+  return 1
+}
+for _ in $(seq 1 ${Math.max(1, Number(waitIterations) || 1)}); do
+  bundle_readers_alive || break
+  sleep ${Math.max(0, Number(waitSeconds) || 0)}
+done
+# Fail closed: no write under the live target or its siblings until the old
+# Electron process and every helper reading inside its bundle have exited.
+if bundle_readers_alive; then
+  exit 20
+fi
+if [ "$SRC" = "$DST" ] || ! validate_app "$SRC"; then
+  exit 21
+fi
+/bin/rm -rf -- "$NEW" "$OLD" 2>/dev/null || exit 22
+if ! ${shellQuote(copy)} "$SRC" "$NEW"; then
+  /bin/rm -rf -- "$NEW" 2>/dev/null || true
+  exit 23
+fi
+if ! validate_app "$NEW"; then
+  /bin/rm -rf -- "$NEW" 2>/dev/null || true
+  exit 24
+fi
+HAD_TARGET=0
+if [ -e "$DST" ]; then
+  HAD_TARGET=1
+  if ! /bin/mv -- "$DST" "$OLD"; then
+    /bin/rm -rf -- "$NEW" 2>/dev/null || true
+    exit 25
+  fi
+fi
+if ! /bin/mv -- "$NEW" "$DST"; then
+  rollback
+  exit 26
+fi
+if ! validate_app "$DST"; then
+  rollback
+  exit 27
+fi
+${shellQuote(xattr)} -dr com.apple.quarantine "$DST" 2>/dev/null || true
+if ! ${shellQuote(open)} "$DST"; then
+  if ! direct_launch; then
+    rollback
+    ${shellQuote(open)} "$DST" >/dev/null 2>&1 || true
+    exit 28
+  fi
+fi
+# Prefer LaunchServices first; if the process never appears, launch EXE directly.
+STABLE=0
+DIRECT_TRIED=0
+for i in $(seq 1 60); do
+  if startup_ok "$DST"; then
+    STABLE=$((STABLE + 1))
+    if [ "$STABLE" -ge 6 ]; then
+      break
+    fi
+  else
+    STABLE=0
+    if [ "$DIRECT_TRIED" -eq 0 ] && [ "$i" -ge 6 ]; then
+      DIRECT_TRIED=1
+      direct_launch || true
+    fi
+  fi
+  sleep 0.5
+done
+if [ "$STABLE" -lt 6 ]; then
+  rollback
+  ${shellQuote(open)} "$DST" >/dev/null 2>&1 || true
+  exit 29
+fi
+/bin/rm -rf -- "$OLD" 2>/dev/null || true
+# Path validation above proves STAGE cannot contain DST/NEW/OLD, so this exact
+# transaction cleanup cannot remove the live or rollback bundle.
+/bin/rm -rf -- "$STAGE" 2>/dev/null || true
+`
+}
+
+export {
+  buildDesktopUpdateArgs,
+  buildMacPublishScript,
+  resolveStagedMacApp,
+  shellQuote,
+  validateMacUpdatePaths
+}

--- a/apps/desktop/electron/update-runtime-identity.test.ts
+++ b/apps/desktop/electron/update-runtime-identity.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { classifyDesktopUpdateRuntime, probeDesktopUpdateRuntime } from './update-runtime-identity'
+
+test('split-brain runtime refuses the git updater when the selected venv imports an immutable generation', () => {
+  const checkout = path.resolve('/Users/hermes/.hermes/hermes-agent')
+
+  const generation = path.resolve(
+    '/Users/hermes/.hermes/releases/nimble-reset5/generations/abc/source/repository'
+  )
+
+  assert.deepEqual(classifyDesktopUpdateRuntime({ updateRoot: checkout, runtimeRoot: generation }), {
+    kind: 'managed-runtime',
+    updateRoot: checkout,
+    runtimeRoot: generation,
+    supported: false,
+    message:
+      'This Hermes runtime is managed by an immutable release. Update it through its release manager; Desktop will not run the Git updater against a different checkout.'
+  })
+})
+
+test('matching mutable checkout keeps the desktop git updater enabled', () => {
+  const checkout = path.resolve('/Users/hermes/.hermes/hermes-agent')
+
+  assert.deepEqual(classifyDesktopUpdateRuntime({ updateRoot: checkout, runtimeRoot: checkout }), {
+    kind: 'git-checkout',
+    updateRoot: checkout,
+    runtimeRoot: checkout,
+    supported: true,
+    message: null
+  })
+})
+
+test('runtime probe asks the selected venv interpreter for the effective Hermes import root', () => {
+  const checkout = path.resolve('/Users/hermes/.hermes/hermes-agent')
+  const generation = path.resolve('/Users/hermes/.hermes/releases/nimble-reset5/generations/abc/source/repository')
+  const calls: Array<{ command: string; args: string[] }> = []
+
+  const result = probeDesktopUpdateRuntime(checkout, {
+    execFileSync: (command, args) => {
+      calls.push({ command, args })
+
+      return `${generation}\n`
+    },
+    isWindows: false
+  })
+
+  assert.equal(result.runtimeRoot, generation)
+  assert.equal(result.kind, 'managed-runtime')
+  assert.equal(result.supported, false)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].command, path.join(checkout, 'venv', 'bin', 'python'))
+  assert.equal(calls[0].args[0], '-c')
+  assert.match(calls[0].args[1], /hermes_cli/)
+})
+
+test('failed runtime identity probe fails closed instead of invoking a possibly unrelated git updater', () => {
+  const checkout = path.resolve('/Users/hermes/.hermes/hermes-agent')
+
+  const result = probeDesktopUpdateRuntime(checkout, {
+    execFileSync: () => {
+      throw new Error('probe failed')
+    },
+    isWindows: false
+  })
+
+  assert.equal(result.kind, 'unknown-runtime')
+  assert.equal(result.supported, false)
+  assert.match(result.message || '', /could not verify/i)
+})

--- a/apps/desktop/electron/update-runtime-identity.ts
+++ b/apps/desktop/electron/update-runtime-identity.ts
@@ -1,0 +1,85 @@
+import { execFileSync as nodeExecFileSync } from 'node:child_process'
+import path from 'node:path'
+
+export type DesktopUpdateRuntimeKind = 'git-checkout' | 'managed-runtime' | 'unknown-runtime'
+
+export interface DesktopUpdateRuntime {
+  kind: DesktopUpdateRuntimeKind
+  message: string | null
+  runtimeRoot: string | null
+  supported: boolean
+  updateRoot: string
+}
+
+interface ProbeDeps {
+  execFileSync?: (command: string, args: string[], options: Record<string, unknown>) => string | Buffer
+  isWindows?: boolean
+}
+
+const MANAGED_RUNTIME_MESSAGE =
+  'This Hermes runtime is managed by an immutable release. Update it through its release manager; Desktop will not run the Git updater against a different checkout.'
+
+const UNKNOWN_RUNTIME_MESSAGE =
+  'Desktop could not verify which Hermes runtime the updater would modify. Update was disabled to avoid changing the wrong installation.'
+
+export function classifyDesktopUpdateRuntime({
+  updateRoot,
+  runtimeRoot
+}: {
+  updateRoot: string
+  runtimeRoot: string | null
+}): DesktopUpdateRuntime {
+  const normalizedUpdateRoot = path.resolve(updateRoot)
+  const normalizedRuntimeRoot = runtimeRoot ? path.resolve(runtimeRoot) : null
+
+  if (!normalizedRuntimeRoot) {
+    return {
+      kind: 'unknown-runtime',
+      message: UNKNOWN_RUNTIME_MESSAGE,
+      runtimeRoot: null,
+      supported: false,
+      updateRoot: normalizedUpdateRoot
+    }
+  }
+
+  if (normalizedRuntimeRoot !== normalizedUpdateRoot) {
+    return {
+      kind: 'managed-runtime',
+      message: MANAGED_RUNTIME_MESSAGE,
+      runtimeRoot: normalizedRuntimeRoot,
+      supported: false,
+      updateRoot: normalizedUpdateRoot
+    }
+  }
+
+  return {
+    kind: 'git-checkout',
+    message: null,
+    runtimeRoot: normalizedRuntimeRoot,
+    supported: true,
+    updateRoot: normalizedUpdateRoot
+  }
+}
+
+export function probeDesktopUpdateRuntime(updateRoot: string, deps: ProbeDeps = {}): DesktopUpdateRuntime {
+  const isWindows = deps.isWindows ?? process.platform === 'win32'
+  const python = path.join(updateRoot, 'venv', isWindows ? 'Scripts' : 'bin', isWindows ? 'python.exe' : 'python')
+  const execFileSync = deps.execFileSync ?? nodeExecFileSync
+
+  try {
+    const output = execFileSync(
+      python,
+      [
+        '-c',
+        'import hermes_cli.config as c; print(c.get_project_root())'
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 15_000, windowsHide: true }
+    )
+
+    const runtimeRoot = String(output).trim().split(/\r?\n/).filter(Boolean).at(-1) || null
+
+    return classifyDesktopUpdateRuntime({ updateRoot, runtimeRoot })
+  } catch {
+    return classifyDesktopUpdateRuntime({ updateRoot, runtimeRoot: null })
+  }
+}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5933,23 +5933,22 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
         logger.debug("Failed to write desktop build stamp: %s", exc)
 
 
-def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
-    """Return the current platform's unpacked Electron app executable."""
-    release_dir = desktop_dir / "release"
+def _desktop_packaged_executable_in_output(output_dir: Path) -> Optional[Path]:
+    """Return the current platform's unpacked executable under ``output_dir``."""
     if sys.platform == "darwin":
-        candidates = list(release_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
+        candidates = list(output_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
     elif sys.platform == "win32":
         candidates = [
-            release_dir / "win-unpacked" / "Hermes.exe",
-            release_dir / "win-ia32-unpacked" / "Hermes.exe",
-            release_dir / "win-arm64-unpacked" / "Hermes.exe",
+            output_dir / "win-unpacked" / "Hermes.exe",
+            output_dir / "win-ia32-unpacked" / "Hermes.exe",
+            output_dir / "win-arm64-unpacked" / "Hermes.exe",
         ]
     else:
         candidates = [
-            release_dir / "linux-unpacked" / "hermes",
-            release_dir / "linux-unpacked" / "Hermes",
-            release_dir / "linux-arm64-unpacked" / "hermes",
-            release_dir / "linux-arm64-unpacked" / "Hermes",
+            output_dir / "linux-unpacked" / "hermes",
+            output_dir / "linux-unpacked" / "Hermes",
+            output_dir / "linux-arm64-unpacked" / "hermes",
+            output_dir / "linux-arm64-unpacked" / "Hermes",
         ]
 
     existing = [p for p in candidates if p.exists()]
@@ -5967,6 +5966,48 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
         if matching:
             existing = matching
     return max(existing, key=lambda p: p.stat().st_mtime)
+
+
+def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
+    """Return the current platform's unpacked Electron app executable."""
+    return _desktop_packaged_executable_in_output(desktop_dir / "release")
+
+
+def _resolve_desktop_output_dir(
+    args: argparse.Namespace, desktop_dir: Path
+) -> Optional[Path]:
+    """Validate and create the isolated output root for a staged build."""
+    raw_output = getattr(args, "output_dir", None)
+    if not raw_output:
+        return None
+    if not getattr(args, "build_only", False):
+        raise ValueError("--output-dir requires --build-only")
+    if getattr(args, "source", False):
+        raise ValueError("--output-dir cannot be combined with --source")
+    if getattr(args, "skip_build", False):
+        raise ValueError("--output-dir cannot be combined with --skip-build")
+
+    requested = Path(raw_output)
+    if not requested.is_absolute():
+        raise ValueError("--output-dir must be an absolute path")
+
+    try:
+        output_dir = requested.resolve()
+        resolved_desktop = desktop_dir.resolve()
+        release_dir = (resolved_desktop / "release").resolve()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"unsafe desktop output directory: {exc}") from exc
+
+    output_in_release = output_dir == release_dir or release_dir in output_dir.parents
+    release_in_output = release_dir == output_dir or output_dir in release_dir.parents
+    output_contains_desktop = (
+        output_dir == resolved_desktop or output_dir in resolved_desktop.parents
+    )
+    if output_in_release or release_in_output or output_contains_desktop:
+        raise ValueError("unsafe desktop output directory")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
 
 
 # ─── Desktop exe integrity gate (#69179) ────────────────────────────────────
@@ -6510,6 +6551,47 @@ def _try_redownload_electron_dist(project_root: Path, env: dict) -> bool:
     return _redownload_electron_dist(project_root, env, mirror=_ELECTRON_FALLBACK_MIRROR)
 
 
+def _desktop_processes_reading_release(desktop_dir: Path) -> Optional[list[int]]:
+    """Return PIDs executing inside ``release``, or ``None`` if unknowable."""
+    try:
+        import psutil
+    except Exception:
+        return None
+    try:
+        release_dir = (desktop_dir / "release").resolve()
+    except (OSError, RuntimeError):
+        return None
+
+    try:
+        processes = psutil.process_iter(["pid", "exe"])
+    except Exception:
+        return None
+
+    me = os.getpid()
+    readable_executables = 0
+    readers: set[int] = set()
+    try:
+        for proc in processes:
+            try:
+                info = proc.info
+                pid = info.get("pid")
+                exe = info.get("exe")
+                if pid is None or not exe:
+                    continue
+                exe_path = Path(exe).resolve()
+            except Exception:
+                continue
+            readable_executables += 1
+            if pid != me and release_dir in exe_path.parents:
+                readers.add(int(pid))
+    except Exception:
+        return None
+
+    if readable_executables == 0:
+        return None
+    return sorted(readers)
+
+
 def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
     """Terminate any running desktop app executing from this build's ``release``
     dir so a rebuild can replace its (otherwise locked) executable.
@@ -6767,6 +6849,7 @@ def _desktop_macos_local_codesign(
 def _desktop_macos_relaunchable_fixup(
     desktop_dir: Path,
     *,
+    output_dir: Optional[Path] = None,
     publisher_signing_configured: Optional[bool] = None,
 ) -> bool:
     """Make a locally-built macOS desktop app survive in-place self-update
@@ -6799,7 +6882,11 @@ def _desktop_macos_relaunchable_fixup(
         )
     if publisher_signing_configured:
         return True
-    exe = _desktop_packaged_executable(desktop_dir)
+    exe = (
+        _desktop_packaged_executable_in_output(output_dir)
+        if output_dir is not None
+        else _desktop_packaged_executable(desktop_dir)
+    )
     if exe is None:
         return True
     # exe = .../Hermes.app/Contents/MacOS/Hermes  ->  app bundle = .../Hermes.app
@@ -6984,6 +7071,12 @@ def cmd_gui(args: argparse.Namespace):
         sys.exit(1)
 
     try:
+        output_dir = _resolve_desktop_output_dir(args, desktop_dir)
+    except ValueError as exc:
+        print(f"✗ {exc}")
+        sys.exit(2)
+
+    try:
         from hermes_logging import setup_logging as _setup_logging_gui
         _setup_logging_gui(mode="gui")
     except Exception:
@@ -7016,7 +7109,11 @@ def cmd_gui(args: argparse.Namespace):
     skip_build = getattr(args, "skip_build", False)
     force_build = getattr(args, "force_build", False)
 
-    packaged_executable = _desktop_packaged_executable(desktop_dir)
+    packaged_executable = (
+        _desktop_packaged_executable_in_output(output_dir)
+        if output_dir is not None
+        else _desktop_packaged_executable(desktop_dir)
+    )
 
     if source_mode or not skip_build:
         npm = _resolve_node_runtime_npm()
@@ -7052,9 +7149,11 @@ def cmd_gui(args: argparse.Namespace):
         # If the source tree hasn't changed since the last successful build,
         # skip the npm install + build entirely (saves a ton of useless work).
         # --force-build overrides the stamp and always rebuilds.
-        build_needed = force_build or _desktop_build_needed(
-            desktop_dir, PROJECT_ROOT, source_mode=source_mode
-        )
+        build_needed = output_dir is not None or force_build
+        if not build_needed:
+            build_needed = _desktop_build_needed(
+                desktop_dir, PROJECT_ROOT, source_mode=source_mode
+            )
         if not build_needed:
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
@@ -7089,7 +7188,51 @@ def cmd_gui(args: argparse.Namespace):
             if _force_adhoc_macos_signing(env, source_mode=source_mode):
                 print("  → No Developer ID configured; ad-hoc signing this local rebuild "
                       "(CSC_IDENTITY_AUTO_DISCOVERY=false)")
-            if not source_mode:
+
+            def _run_desktop_build(build_env: dict) -> subprocess.CompletedProcess:
+                if output_dir is None:
+                    return subprocess.run(
+                        [npm, "run", build_script],
+                        cwd=desktop_dir,
+                        env=build_env,
+                        check=False,
+                    )
+                compile_result = subprocess.run(
+                    [npm, "run", "build"],
+                    cwd=desktop_dir,
+                    env=build_env,
+                    check=False,
+                )
+                if compile_result.returncode != 0:
+                    return compile_result
+                return subprocess.run(
+                    [
+                        npm,
+                        "run",
+                        "builder",
+                        "--",
+                        "--dir",
+                        f"-c.directories.output={output_dir}",
+                    ],
+                    cwd=desktop_dir,
+                    env=build_env,
+                    check=False,
+                )
+
+            if not source_mode and output_dir is None:
+                if sys.platform == "darwin":
+                    readers = _desktop_processes_reading_release(desktop_dir)
+                    if readers is None:
+                        print("✗ Refusing to rebuild the live Desktop release: "
+                              "could not verify that no process is reading it.")
+                        print("  Close Hermes Desktop or use an isolated staged build, then retry.")
+                        sys.exit(2)
+                    if readers:
+                        print("✗ Refusing to rebuild the live Desktop release while it is in use "
+                              f"(pid {', '.join(map(str, readers))}).")
+                        print("  Close Hermes Desktop or use an isolated staged build, then retry.")
+                        sys.exit(2)
+
                 # A running desktop instance launched from release/win-unpacked
                 # holds Hermes.exe locked on Windows, so the pack can't replace
                 # it ("Access is denied" / ERR_ELECTRON_BUILDER_CANNOT_EXECUTE).
@@ -7098,10 +7241,11 @@ def cmd_gui(args: argparse.Namespace):
                 stopped = _stop_desktop_processes_locking_build(desktop_dir)
                 if stopped:
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
-            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+            build_result = _run_desktop_build(env)
             if (
                 build_result.returncode != 0
                 and not source_mode
+                and output_dir is None
                 and _desktop_packaged_executable(desktop_dir) is None
             ):
                 # Corrupt cached Electron zip → partial unpack → ENOENT on rename.
@@ -7125,10 +7269,11 @@ def cmd_gui(args: argparse.Namespace):
                     # The purge can't remove a win-unpacked tree whose Hermes.exe
                     # is still locked by a running instance; stop it before retry.
                     _stop_desktop_processes_locking_build(desktop_dir)
-                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+                    build_result = _run_desktop_build(env)
             if (
                 build_result.returncode != 0
                 and not source_mode
+                and output_dir is None
                 and not env.get("ELECTRON_MIRROR")
                 and _desktop_packaged_executable(desktop_dir) is None
             ):
@@ -7141,7 +7286,7 @@ def cmd_gui(args: argparse.Namespace):
                 if not _electron_dist_ok(PROJECT_ROOT):
                     _redownload_electron_dist(PROJECT_ROOT, env, mirror=mirror)
                 _stop_desktop_processes_locking_build(desktop_dir)
-                build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
+                build_result = _run_desktop_build(mirror_env)
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")
@@ -7151,12 +7296,18 @@ def cmd_gui(args: argparse.Namespace):
                 print("  If the log shows Electron download retries, rebuild via a mirror:")
                 print("    ELECTRON_MIRROR=<mirror-base-url> hermes desktop --force-build")
                 sys.exit(build_result.returncode or 1)
-            packaged_executable = _desktop_packaged_executable(desktop_dir)
+            packaged_executable = (
+                _desktop_packaged_executable_in_output(output_dir)
+                if output_dir is not None
+                else _desktop_packaged_executable(desktop_dir)
+            )
             if not source_mode:
                 # Locally-built apps are ad-hoc signed; make them relaunchable after
                 # an in-place self-update (otherwise macOS reports "Hermes is
                 # damaged"). No-op on non-macOS and on real-identity builds.
-                _desktop_macos_relaunchable_fixup(desktop_dir)
+                _desktop_macos_relaunchable_fixup(
+                    desktop_dir, output_dir=output_dir
+                )
 
                 # Windows integrity gate (#69179): never declare the rebuild a
                 # success on a Hermes.exe Windows cannot load (truncated PE from
@@ -7165,17 +7316,19 @@ def cmd_gui(args: argparse.Namespace):
                 # before-pack.mjs when possible, then fail loudly so the
                 # updater's retry-once rebuilds from a fresh Electron download
                 # instead of silently shipping the broken exe.
-                verified_executable, rolled_back = _ensure_desktop_exe_launchable(
-                    desktop_dir, packaged_executable
-                )
-                if packaged_executable is not None and (
-                    rolled_back or verified_executable is None
-                ):
-                    sys.exit(1)
-                packaged_executable = verified_executable
+                if output_dir is None:
+                    verified_executable, rolled_back = _ensure_desktop_exe_launchable(
+                        desktop_dir, packaged_executable
+                    )
+                    if packaged_executable is not None and (
+                        rolled_back or verified_executable is None
+                    ):
+                        sys.exit(1)
+                    packaged_executable = verified_executable
 
             # Build succeeded — write the stamp so next run can skip
-            _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
+            if output_dir is None:
+                _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)
 
     # --build-only: produce the artifact but do NOT launch. The installer's
     # --update flow drives the rebuild headlessly and then launches the desktop
@@ -7190,11 +7343,14 @@ def cmd_gui(args: argparse.Namespace):
                 sys.exit(1)
             print(f"✓ Desktop source build ready at {desktop_dir / 'dist'} (not launching; --build-only)")
         elif packaged_executable is None:
-            print(f"✗ --build-only produced no launchable app at: {desktop_dir / 'release'}")
+            packaged_output = output_dir or desktop_dir / "release"
+            print(f"✗ --build-only produced no launchable app at: {packaged_output}")
             print("  Expected an unpacked Electron app for the current OS.")
             sys.exit(1)
         else:
-            print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
+            stage_note = f" in stage {output_dir}" if output_dir is not None else ""
+            print(f"✓ Desktop packaged app ready{stage_note}: {packaged_executable} "
+                  "(not launching; --build-only)")
         return
 
     if source_mode:

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -6,6 +6,7 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 
@@ -31,6 +32,10 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         "--build-only",
         action="store_true",
         help="Build the desktop app but do not launch it (used by the installer's --update flow)",
+    )
+    gui_parser.add_argument(
+        "--output-dir",
+        help=argparse.SUPPRESS,
     )
     gui_parser.add_argument(
         "--fake-boot",

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -6,6 +6,7 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 
@@ -72,5 +73,11 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         action="store_true",
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
+    )
+    update_parser.add_argument(
+        "--skip-desktop-build",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
     )
     update_parser.set_defaults(func=cmd_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3561,6 +3561,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else None
     )
     assume_yes = bool(getattr(args, "yes", False))
+    skip_desktop_build = bool(getattr(args, "skip_desktop_build", False))
 
     # Whether this update is running without a human at the keyboard.
     # Interactive terminal updates always stash-and-ask (unchanged behavior);
@@ -4201,7 +4202,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Electron build by ``hermes update``.
         desktop_dir = _m().PROJECT_ROOT / "apps" / "desktop"
         has_desktop_app = _m()._desktop_packaged_executable(desktop_dir) is not None or _m()._desktop_dist_exists(desktop_dir)
-        if (desktop_dir / "package.json").exists() and _m()._resolve_node_runtime_npm() and has_desktop_app:
+        if (
+            not skip_desktop_build
+            and (desktop_dir / "package.json").exists()
+            and _m()._resolve_node_runtime_npm()
+            and has_desktop_app
+        ):
             print("→ Checking if desktop app needs rebuilding...")
             # Consult the content-hash stamp IN-PROCESS first. The spawned
             # `hermes desktop --build-only` subprocess re-imports the whole

--- a/tests/hermes_cli/test_desktop_staged_build.py
+++ b/tests/hermes_cli/test_desktop_staged_build.py
@@ -1,0 +1,198 @@
+"""Lifecycle contracts for staged Desktop package builds."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+from hermes_cli.subcommands.gui import build_gui_parser
+from hermes_cli.subcommands.update import build_update_parser
+
+
+def _parser(builder, handler=lambda _args: None):
+    parser = argparse.ArgumentParser()
+    subs = parser.add_subparsers(dest="command", required=True)
+    keyword = "cmd_gui" if builder is build_gui_parser else "cmd_update"
+    builder(subs, **{keyword: handler})
+    return parser
+
+
+def _ns(**overrides):
+    values = {
+        "build_only": True,
+        "output_dir": None,
+        "source": False,
+        "skip_build": False,
+        "force_build": False,
+        "fake_boot": False,
+        "ignore_existing": False,
+        "hermes_root": None,
+        "cwd": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _desktop_tree(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "repo"
+    desktop = root / "apps" / "desktop"
+    desktop.mkdir(parents=True)
+    (desktop / "package.json").write_text("{}", encoding="utf-8")
+    return root, desktop
+
+
+def test_internal_update_skip_flag_parses_but_is_hidden():
+    parser = _parser(build_update_parser)
+    args = parser.parse_args(["update", "--skip-desktop-build"])
+    assert args.skip_desktop_build is True
+    assert "--skip-desktop-build" not in parser.format_help()
+
+
+def test_desktop_output_dir_parser_propagates_absolute_path(tmp_path):
+    parser = _parser(build_gui_parser)
+    stage = tmp_path / "transaction"
+    args = parser.parse_args(["desktop", "--build-only", "--output-dir", str(stage)])
+    assert args.output_dir == str(stage)
+
+
+@pytest.mark.parametrize(
+    "overrides,match",
+    [
+        ({"build_only": False}, "--build-only"),
+        ({"source": True}, "--source"),
+        ({"skip_build": True}, "--skip-build"),
+        ({"output_dir": "relative/stage"}, "absolute"),
+    ],
+)
+def test_staged_output_rejects_invalid_combinations(tmp_path, overrides, match):
+    _root, desktop = _desktop_tree(tmp_path)
+    values = {"output_dir": str(tmp_path / "stage"), **overrides}
+    args = _ns(**values)
+    with pytest.raises(ValueError, match=match):
+        cli_main._resolve_desktop_output_dir(args, desktop)
+
+
+def test_staged_output_rejects_live_release_and_aliases(tmp_path):
+    _root, desktop = _desktop_tree(tmp_path)
+    release = desktop / "release"
+    release.mkdir()
+
+    for unsafe in (release, release / "nested", desktop, desktop.parent):
+        with pytest.raises(ValueError, match="unsafe"):
+            cli_main._resolve_desktop_output_dir(_ns(output_dir=str(unsafe)), desktop)
+
+    alias = tmp_path / "release-alias"
+    alias.symlink_to(release, target_is_directory=True)
+    with pytest.raises(ValueError, match="unsafe"):
+        cli_main._resolve_desktop_output_dir(_ns(output_dir=str(alias)), desktop)
+
+
+def test_staged_build_forces_builder_output_and_does_not_stamp_live_state(tmp_path, monkeypatch):
+    root, desktop = _desktop_tree(tmp_path)
+    stage = tmp_path / "stage"
+    exe = stage / "mac-arm64" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("binary", encoding="utf-8")
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    build_ok = subprocess.CompletedProcess(["npm"], 0)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed") as build_needed, \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._write_desktop_build_stamp") as stamp, \
+         patch("hermes_cli.main.subprocess.run", side_effect=[build_ok, build_ok]) as run:
+        cli_main.cmd_gui(_ns(output_dir=str(stage)))
+
+    build_needed.assert_not_called()
+    stamp.assert_not_called()
+    assert run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "build"]
+    assert run.call_args_list[1].args[0] == [
+        "/usr/bin/npm",
+        "run",
+        "builder",
+        "--",
+        "--dir",
+        f"-c.directories.output={stage.resolve()}",
+    ]
+
+
+def test_normal_desktop_build_keeps_default_pack_and_stamp(tmp_path, monkeypatch):
+    root, _desktop = _desktop_tree(tmp_path)
+    exe = root / "apps" / "desktop" / "release" / "mac-arm64" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("binary", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+
+    ok = subprocess.CompletedProcess(["npm"], 0)
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._desktop_processes_reading_release", return_value=[]), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._write_desktop_build_stamp") as stamp, \
+         patch("hermes_cli.main.subprocess.run", return_value=ok) as run:
+        cli_main.cmd_gui(_ns(output_dir=None))
+
+    assert run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
+    stamp.assert_called_once()
+
+
+def test_normal_macos_build_refuses_to_mutate_release_with_live_reader(tmp_path, monkeypatch):
+    root, _desktop = _desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._desktop_processes_reading_release", return_value=[1234]), \
+         patch("hermes_cli.main.subprocess.run") as run:
+        with pytest.raises(SystemExit) as exc:
+            cli_main.cmd_gui(_ns(output_dir=None))
+
+    assert exc.value.code == 2
+    run.assert_not_called()
+
+
+def test_normal_macos_build_refuses_when_reader_scan_is_unknown(tmp_path, monkeypatch):
+    root, _desktop = _desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+
+    with patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._desktop_processes_reading_release", return_value=None), \
+         patch("hermes_cli.main.subprocess.run") as run:
+        with pytest.raises(SystemExit) as exc:
+            cli_main.cmd_gui(_ns(output_dir=None))
+
+    assert exc.value.code == 2
+    run.assert_not_called()
+
+
+def test_desktop_reader_scan_returns_none_when_psutil_missing(monkeypatch, tmp_path):
+    root, desktop = _desktop_tree(tmp_path)
+    (desktop / "release").mkdir()
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("no psutil")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert cli_main._desktop_processes_reading_release(desktop) is None


### PR DESCRIPTION
## Summary
- macOS in-app update no longer rebuilds `apps/desktop/release` while the running bundle is mapped
- Flow: `hermes update --skip-desktop-build` → staged `desktop --build-only --output-dir` → fail-closed publisher swap/relaunch (pid0-safe wait, direct-launch fallback, rollback)
- CLI refuses live macOS pack when release readers are present or scan is unknown
- Refuse Git updater when launcher cwd and effective runtime root disagree (managed/immutable split-brain)

## Test plan
- [x] `pytest tests/hermes_cli/test_desktop_staged_build.py` (12)
- [x] `vitest` update-macos-publish + update-runtime-identity (12)
- [x] Staged build while live: live release hash unchanged
- [x] Live production publisher canary: exit 0, hash match, relaunch alive
- [x] Independent post-canary PROCEED on pin

## Residual
- Full Settings → Update UI click not exercised in this PR (publisher path proven via live canary)