### PR TITLE
fix(title): ignore internal user scaffolding in first-exchange gate

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,9 +33,8 @@ from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
-from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 from agent.model_metadata import is_local_endpoint
-from agent.message_content import flatten_message_text
+from agent.message_content import MAX_ITERATIONS_SUMMARY_REQUEST, flatten_message_text
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,6 +33,7 @@ from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
+from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
@@ -2107,12 +2108,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             defer_logical_completion=True,
         )
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
-    )
-    messages.append({"role": "user", "content": summary_request})
+    messages.append({"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST})
 
     try:
         # Build API messages, stripping internal-only fields

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -23,6 +23,7 @@ import sqlite3
 import re
 import time
 import uuid
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import (
@@ -4140,7 +4141,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         relying on content-prefix heuristics.  The flag is in-process only —
         the wire sanitizers strip underscore-prefixed keys before API calls.
         """
-        if not isinstance(message, dict):
+        if not isinstance(message, Mapping):
             return False
         return bool(message.get(COMPRESSED_SUMMARY_METADATA_KEY))
 
@@ -4148,17 +4149,14 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _transcript_has_real_user_turn(cls, messages: List[Dict[str, Any]]) -> bool:
         """Return whether *messages* contain a user-authored turn.
 
-        Compaction summaries can deliberately carry ``role="user"`` to keep
-        strict provider transcripts valid. The metadata/content checks prevent
-        those synthetic transport rows from becoming evidence of a real user.
+        Compaction summaries and runtime continuations can deliberately carry
+        ``role="user"`` to keep strict provider transcripts valid. The shared
+        provenance classifier prevents those transport rows from becoming
+        evidence of a real user while retaining media-bearing user input.
         """
-        for message in messages:
-            if not isinstance(message, dict) or message.get("role") != "user":
-                continue
-            if cls._is_synthetic_compression_user_turn(message):
-                continue
-            return True
-        return False
+        from agent.conversation_compression import is_real_user_message
+
+        return any(is_real_user_message(message) for message in messages)
 
     @classmethod
     def _is_synthetic_compression_user_turn(cls, message: Any) -> bool:
@@ -4167,20 +4165,23 @@ This compaction should PRIORITISE preserving all information related to the focu
         SessionDB preserves role/content but not underscore-prefixed metadata,
         so the stable todo and continuation content markers are authoritative.
         """
-        if not isinstance(message, dict) or message.get("role") != "user":
+        if not isinstance(message, Mapping) or message.get("role") != "user":
             return False
         if cls._has_compressed_summary_metadata(message):
             return True
         content = message.get("content")
         if cls._is_context_summary_content(content):
             return True
+        from agent.message_content import has_non_text_content
+
+        if has_non_text_content(content):
+            return False
         text = _content_text_for_contains(content).strip()
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
             _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
-        } or text.startswith(
-            TODO_INJECTION_HEADER + "\n"
-        )
+            TODO_INJECTION_HEADER,
+        } or text.startswith(TODO_INJECTION_HEADER + "\n")
 
     @staticmethod
     def _validate_summary_user_provenance(summary: str, has_user_turn: bool) -> None:
@@ -4953,12 +4954,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         If the conversation has fewer than *n* user messages, the earliest
         available user message is used without error.
 
-        Only REAL actionable user turns count toward N — the collector uses
-        the same ``_is_actionable_user_turn`` /
-        ``_is_synthetic_compression_user_turn`` pair as
-        ``_find_last_user_message_idx``, so blank platform echoes, compaction
-        handoffs, continuation markers, and todo-snapshot rows never consume
-        a slot (#69291 bug class).
+        Only actionable user turns count toward N. Blank platform echoes,
+        compaction handoffs, and todo-snapshot-only rows never consume a slot,
+        while structured media and active runtime notifications remain in the
+        protected tail (#69291 bug class).
 
         A user message is already a clean boundary — there is no
         tool_call/result group that spans across it, so
@@ -4969,10 +4968,9 @@ This compaction should PRIORITISE preserving all information related to the focu
         if n <= 1:
             return self._ensure_last_user_message_in_tail(messages, cut_idx, head_end)
 
-        # Collect real user message indices walking backward from end.
-        # Mirror _find_last_user_message_idx's filters: compaction handoffs,
-        # blank platform echoes, and synthetic continuation/todo rows are
-        # continuity artifacts, not real user turns.
+        # Collect actionable user message indices walking backward from end.
+        # Runtime notifications are synthetic provenance, but still carry
+        # instructions/results that the model must process before compaction.
         user_indices = []
         for i in range(len(messages) - 1, head_end - 1, -1):
             msg = messages[i]

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3267,13 +3267,18 @@ class ContextCompressor(ContextEngine):
                             parsed = args
                         _collect_paths_from_jsonish(parsed)
 
+        from agent.conversation_compression import is_real_user_message
+
         for msg in turns_to_summarize:
             role = msg.get("role", "unknown")
-            text = _compact_fallback_turn(msg.get("content"))
+            synthetic_user = role == "user" and not is_real_user_message(msg)
+            content_message = msg
+            if role == "user" and not synthetic_user:
+                content_message = (
+                    self._strip_context_summary_handoff_message(msg) or msg
+                )
+            text = _compact_fallback_turn(content_message.get("content"))
             _collect_path_mentions(text, relevant_files)
-            synthetic_user = (
-                role == "user" and self._is_synthetic_compression_user_turn(msg)
-            )
 
             turn_text = text
             turn_tool_names: list[str] = []
@@ -4285,14 +4290,15 @@ This compaction should PRIORITISE preserving all information related to the focu
         messages: List[Dict[str, Any]],
     ) -> Optional[str]:
         """Infer a compact focus hint from the most recent real user turns."""
+        from agent.conversation_compression import is_real_user_message
+
         candidates: list[str] = []
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
-            if msg.get("role") != "user":
+            if not is_real_user_message(msg):
                 continue
-            if cls._is_synthetic_compression_user_turn(msg):
-                continue
-            content = msg.get("content")
+            content_message = cls._strip_context_summary_handoff_message(msg) or msg
+            content = content_message.get("content")
             text = _redact_compaction_text(_content_text_for_contains(content).strip())
             if not text:
                 continue
@@ -4329,14 +4335,15 @@ This compaction should PRIORITISE preserving all information related to the focu
         # snapshot can never anchor on user-role scaffolding (todo
         # snapshots, truncation notices, background-process reports) —
         # the exact class of turn this grounding exists to bypass.
-        from agent.conversation_compression import _is_real_user_message
+        from agent.conversation_compression import is_real_user_message
 
         for msg in reversed(messages):
             if msg.get("role") != "user":
                 continue
-            if not _is_real_user_message(msg):
+            if not is_real_user_message(msg):
                 continue
-            content = msg.get("content")
+            content_message = cls._strip_context_summary_handoff_message(msg) or msg
+            content = content_message.get("content")
             text = _redact_compaction_text(_content_text_for_contains(content).strip())
             if not text:
                 continue

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -71,6 +71,7 @@ from agent.context_engine import (
     automatic_compaction_status_message,
     sanitize_memory_context,
 )
+from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 from agent.model_metadata import estimate_request_tokens_rough
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
 
@@ -1912,7 +1913,7 @@ _SYNTHETIC_USER_FLAGS = (
 )
 
 
-def _is_real_user_message(message: Any) -> bool:
+def is_real_user_message(message: Any) -> bool:
     """Distinguish human intent from user-role runtime scaffolding.
 
     A compaction summary pinned to ``role="user"`` (the compressor flips the
@@ -1928,11 +1929,17 @@ def _is_real_user_message(message: Any) -> bool:
     text = _message_text(message).strip()
     if not text:
         return False
+    if text == MAX_ITERATIONS_SUMMARY_REQUEST:
+        return False
     if text.startswith(_SYNTHETIC_USER_PREFIXES):
         return False
     from agent.context_compressor import ContextCompressor
 
     return not ContextCompressor._is_synthetic_compression_user_turn(message)
+
+
+# Backward-compatible private name for existing compression call sites.
+_is_real_user_message = is_real_user_message
 
 
 def _strip_stale_todo_snapshot(content: Any) -> Any:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1924,7 +1924,14 @@ def is_real_user_message(message: Any) -> bool:
         ContextCompressor._has_compressed_summary_metadata(message)
         or ContextCompressor._is_context_summary_content(content)
     ):
-        return False
+        # A compaction handoff can share a user-role carrier with protected
+        # tail content. Strip only the summary envelope and classify the
+        # preserved portion recursively; a standalone summary unwraps to
+        # ``None`` and remains internal.
+        unwrapped = ContextCompressor._strip_context_summary_handoff_message(
+            dict(message)
+        )
+        return bool(unwrapped) and is_real_user_message(unwrapped)
     if has_non_text_content(content):
         return True
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -62,6 +62,7 @@ import tempfile
 import time
 import uuid
 import threading
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -71,7 +72,11 @@ from agent.context_engine import (
     automatic_compaction_status_message,
     sanitize_memory_context,
 )
-from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+from agent.message_content import (
+    flatten_message_text,
+    has_non_text_content,
+    is_internal_user_scaffolding_text,
+)
 from agent.model_metadata import estimate_request_tokens_rough
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
 
@@ -1882,26 +1887,9 @@ def conversation_history_after_compression(
     return None
 
 
-_SYNTHETIC_USER_PREFIXES = (
-    "[System: Your previous response was truncated",
-    "[System: The previous response was cut off",
-    "[System: Your previous tool call",
-    "[Your active task list was preserved across context compression]",
-    "[IMPORTANT: Background process ",
-)
-
-
 def _message_text(message: Any) -> str:
-    content = message.get("content") if isinstance(message, dict) else None
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return "\n".join(
-            str(part.get("text") or part.get("content") or "")
-            for part in content
-            if isinstance(part, dict)
-        )
-    return ""
+    content = message.get("content") if isinstance(message, Mapping) else None
+    return flatten_message_text(content)
 
 
 _SYNTHETIC_USER_FLAGS = (
@@ -1909,6 +1897,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_empty_recovery_synthetic",
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_kanban_stop_synthetic",
     "_dropped_toolcall_nudge",
 )
 
@@ -1922,20 +1911,29 @@ def is_real_user_message(message: Any) -> bool:
     short-circuit anchor restoration with a message the model is explicitly
     told NOT to act on.
     """
-    if not isinstance(message, dict) or message.get("role") != "user":
+    if not isinstance(message, Mapping) or message.get("role") != "user":
+        return False
+    if message.get("display_kind"):
         return False
     if any(message.get(flag) for flag in _SYNTHETIC_USER_FLAGS):
         return False
+    from agent.context_compressor import ContextCompressor
+
+    content = message.get("content")
+    if (
+        ContextCompressor._has_compressed_summary_metadata(message)
+        or ContextCompressor._is_context_summary_content(content)
+    ):
+        return False
+    if has_non_text_content(content):
+        return True
+
     text = _message_text(message).strip()
     if not text:
         return False
-    if text == MAX_ITERATIONS_SUMMARY_REQUEST:
+    if ContextCompressor._is_synthetic_compression_user_turn(message):
         return False
-    if text.startswith(_SYNTHETIC_USER_PREFIXES):
-        return False
-    from agent.context_compressor import ContextCompressor
-
-    return not ContextCompressor._is_synthetic_compression_user_turn(message)
+    return not is_internal_user_scaffolding_text(text)
 
 
 # Backward-compatible private name for existing compression call sites.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -46,6 +46,15 @@ from agent.turn_context import (
 )
 from agent.turn_retry_state import TurnRetryState
 from agent.runtime_cwd import resolve_agent_cwd
+from agent.message_content import (
+    CODEX_INCOMPLETE_CONTINUATION_REQUEST,
+    DROPPED_TOOL_CALL_CONTINUATION_REQUEST,
+    EMPTY_TOOL_RESPONSE_CONTINUATION_REQUEST,
+    INTENT_ACK_CONTINUATION_REQUEST,
+    NETWORK_STREAM_CONTINUATION_REQUEST,
+    OUTPUT_LIMIT_CONTINUATION_REQUEST,
+    build_tool_call_stream_continuation_request,
+)
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
@@ -688,48 +697,10 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
 
 def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List[str]] = None) -> str:
     if is_partial_stub and dropped_tools:
-        tool_list = ", ".join(dropped_tools[:3])
-        return (
-            "[System: Your previous tool call "
-            f"({tool_list}) was too large and "
-            "the stream timed out before it "
-            "could be delivered. Do NOT retry "
-            "the same tool call with the same "
-            "large content. Instead, break the "
-            "content into multiple smaller tool "
-            "calls (e.g. use multiple patch calls "
-            "or write smaller files). Each tool "
-            "call's arguments must be under ~8K "
-            "tokens to avoid stream timeouts.]"
-        )
-    elif is_partial_stub:
-        return (
-            "[System: The previous response was cut off by a "
-            "network error mid-stream. Continue exactly where "
-            "you left off. Do not restart or repeat prior text. "
-            "Finish the answer directly.]"
-        )
-    else:
-        return (
-            "[System: Your previous response was truncated by the output "
-            "length limit. Continue exactly where you left off. Do not "
-            "restart or repeat prior text. Finish the answer directly.]"
-        )
-
-
-# Continuation nudge for Codex/Responses turns that came back with only
-# internal reasoning (no visible content, no tool calls).  When the interim
-# assistant message also carries no encrypted reasoning items and no
-# replayable message items, _chat_messages_to_responses_input emits nothing
-# for it — a bare retry would be byte-identical to the request that just
-# failed, so the model (observed: grok-4.20 on xai-oauth) deterministically
-# repeats the reasoning-only response until the retry budget is exhausted.
-_CODEX_INCOMPLETE_NUDGE = (
-    "[System: Your previous response contained only internal reasoning and "
-    "never produced a visible answer or tool call. Do not keep thinking. "
-    "Produce your final answer as plain text now (or make the tool call "
-    "you were planning).]"
-)
+        return build_tool_call_stream_continuation_request(dropped_tools)
+    if is_partial_stub:
+        return NETWORK_STREAM_CONTINUATION_REQUEST
+    return OUTPUT_LIMIT_CONTINUATION_REQUEST
 
 
 # Shared recovery hint appended to every content-policy refusal message. Both
@@ -5876,7 +5847,8 @@ def run_conversation(
                         _already_nudged = (
                             isinstance(_last_msg, dict)
                             and _last_msg.get("role") == "user"
-                            and _last_msg.get("content") == _CODEX_INCOMPLETE_NUDGE
+                            and _last_msg.get("content")
+                            == CODEX_INCOMPLETE_CONTINUATION_REQUEST
                         )
                         # Alternation guard: the nudge is a user-role message,
                         # so it may only follow an assistant message. When the
@@ -5892,7 +5864,7 @@ def run_conversation(
                         if not _already_nudged and _last_is_assistant:
                             messages.append({
                                 "role": "user",
-                                "content": _CODEX_INCOMPLETE_NUDGE,
+                                "content": CODEX_INCOMPLETE_CONTINUATION_REQUEST,
                             })
                     if not agent.quiet_mode:
                         agent._vprint(f"{agent.log_prefix}↻ Codex response incomplete; continuing turn ({agent._codex_incomplete_retries}/3)")
@@ -6670,11 +6642,7 @@ def run_conversation(
                         messages.append(_nudge_msg)
                         messages.append({
                             "role": "user",
-                            "content": (
-                                "You just executed tool calls but returned an "
-                                "empty response. Please process the tool "
-                                "results above and continue with the task."
-                            ),
+                            "content": EMPTY_TOOL_RESPONSE_CONTINUATION_REQUEST,
                             "_empty_recovery_synthetic": True,
                         })
                         continue
@@ -6907,10 +6875,7 @@ def run_conversation(
 
                     continue_msg = {
                         "role": "user",
-                        "content": (
-                            "[System: Continue now. Execute the required tool calls and only "
-                            "send your final answer after completing the task.]"
-                        ),
+                        "content": INTENT_ACK_CONTINUATION_REQUEST,
                     }
                     messages.append(continue_msg)
                     agent._session_messages = messages
@@ -6973,11 +6938,7 @@ def run_conversation(
                     messages.append(final_msg)
                     messages.append({
                         "role": "user",
-                        "content": (
-                            "Your previous turn indicated a tool call but none was "
-                            "included. Do not narrate a plan or restate intent — issue "
-                            "the actual tool call now to continue the task."
-                        ),
+                        "content": DROPPED_TOOL_CALL_CONTINUATION_REQUEST,
                         "_dropped_toolcall_nudge": True,
                     })
                     agent._session_messages = messages

--- a/agent/internal_user_messages.py
+++ b/agent/internal_user_messages.py
@@ -1,7 +1,0 @@
-"""Stable content markers for Hermes-authored user-role messages."""
-
-MAX_ITERATIONS_SUMMARY_REQUEST = (
-    "You've reached the maximum number of tool-calling iterations allowed. "
-    "Please provide a final response summarizing what you've found and accomplished so far, "
-    "without calling any more tools."
-)

--- a/agent/internal_user_messages.py
+++ b/agent/internal_user_messages.py
@@ -1,0 +1,7 @@
+"""Stable content markers for Hermes-authored user-role messages."""
+
+MAX_ITERATIONS_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished so far, "
+    "without calling any more tools."
+)

--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -94,6 +94,13 @@ _WATCH_DISABLED_RE = re.compile(
     r"Falling back to notify_on_complete semantics; you'll get exactly one "
     r"notification when the process exits\.\]\Z"
 )
+_CLI_HANDOFF_PREFIX = '[Session was just handed off from CLI ("'
+_CLI_HANDOFF_SUFFIX = (
+    '") to this channel. The full prior conversation history is loaded above. '
+    "Briefly confirm you're working here and summarize what we were working on, "
+    "so the user can continue from this device.]"
+)
+_CLI_HANDOFF_TITLE_RE = re.compile(r"[^\r\n]{1,512}\Z")
 
 
 def _field(value: Any, key: str) -> Any:
@@ -166,6 +173,74 @@ def build_tool_call_stream_continuation_request(tool_names: Iterable[str]) -> st
     )
 
 
+def build_resume_recovery_note(
+    reason: str | None,
+    message: str = "",
+    *,
+    interactive: bool = True,
+) -> str:
+    """Build the recovery note for an interrupted gateway turn."""
+
+    reason_phrase = (
+        "a gateway restart"
+        if reason == "restart_timeout"
+        else "a gateway shutdown"
+        if reason == "shutdown_timeout"
+        else "a gateway interruption"
+    )
+    if message:
+        resume_guidance = (
+            "Address the user's NEW message below FIRST and focus "
+            "on what the user is asking now."
+        )
+        tail_guidance = (
+            "Do NOT re-execute old tool calls — skip any "
+            "unfinished work from the conversation history."
+        )
+    elif interactive:
+        resume_guidance = (
+            "Report to the user that the session was restored "
+            "successfully and ask what they would like to do next."
+        )
+        tail_guidance = (
+            "Do NOT re-execute old tool calls — skip any "
+            "unfinished work from the conversation history."
+        )
+    else:
+        resume_guidance = (
+            "No user is present on this non-interactive platform, "
+            "so do NOT emit a 'session restored' acknowledgement "
+            "or ask questions. Review the conversation history and "
+            "CONTINUE the interrupted task to completion."
+        )
+        tail_guidance = (
+            "Do NOT re-run tool calls whose results already "
+            "appear in the history — resume from the first step "
+            "that has no recorded result."
+        )
+    return (
+        f"[System note: The previous turn was interrupted by "
+        f"{reason_phrase}; the gateway is now back online. "
+        f"Any restart/shutdown command in the history has already "
+        f"run — do NOT re-execute or verify it. {resume_guidance} "
+        f"{tail_guidance}]"
+        + (f"\n\n{message}" if message else "")
+    )
+
+
+_PURE_RESUME_RECOVERY_NOTES = frozenset(
+    build_resume_recovery_note(reason, "", interactive=interactive)
+    for reason in ("restart_timeout", "shutdown_timeout", None)
+    for interactive in (True, False)
+)
+
+
+def build_cli_handoff_notice(cli_title: str) -> str:
+    """Build the synthetic user-role notice for a CLI-to-gateway handoff."""
+
+    return _CLI_HANDOFF_PREFIX + str(cli_title) + _CLI_HANDOFF_SUFFIX
+
+
 def _is_tool_call_stream_continuation(text: str) -> bool:
     if not (
         text.startswith(_TOOL_CALL_STREAM_CONTINUATION_PREFIX)
@@ -210,6 +285,31 @@ def _is_background_process_notification(text: str) -> bool:
     return False
 
 
+def _is_pure_resume_recovery_note(text: str) -> bool:
+    return text in _PURE_RESUME_RECOVERY_NOTES
+
+
+def _is_cli_handoff_notice(text: str) -> bool:
+    if not (
+        text.startswith(_CLI_HANDOFF_PREFIX)
+        and text.endswith(_CLI_HANDOFF_SUFFIX)
+    ):
+        return False
+    title = text[len(_CLI_HANDOFF_PREFIX) : -len(_CLI_HANDOFF_SUFFIX)]
+    return bool(title.strip() and _CLI_HANDOFF_TITLE_RE.fullmatch(title))
+
+
+def _is_goal_continuation_request(text: str) -> bool:
+    # Lazy import avoids coupling the lightweight content helpers to goal
+    # state/database setup during module initialization.
+    try:
+        from hermes_cli.goals import is_goal_continuation_prompt
+
+        return is_goal_continuation_prompt(text)
+    except Exception:
+        return False
+
+
 def is_internal_user_scaffolding_text(text: str) -> bool:
     """Recognize stable Hermes-authored user-role wire formats narrowly."""
 
@@ -219,4 +319,7 @@ def is_internal_user_scaffolding_text(text: str) -> bool:
         or _is_tool_call_stream_continuation(normalized)
         or _is_async_delegation_notification(normalized)
         or _is_background_process_notification(normalized)
+        or _is_pure_resume_recovery_note(normalized)
+        or _is_cli_handoff_notice(normalized)
+        or _is_goal_continuation_request(normalized)
     )

--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -1,11 +1,99 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+import re
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 
 _NON_TEXT_PART_TYPES = {"image", "image_url", "input_image", "audio", "input_audio"}
+_TEXT_PART_TYPES = {"text", "input_text", "output_text", "summary_text"}
 _TEXT_KEYS = ("text", "content", "input_text", "output_text", "summary_text")
+
+MAX_ITERATIONS_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished so far, "
+    "without calling any more tools."
+)
+NETWORK_STREAM_CONTINUATION_REQUEST = (
+    "[System: The previous response was cut off by a network error mid-stream. "
+    "Continue exactly where you left off. Do not restart or repeat prior text. "
+    "Finish the answer directly.]"
+)
+OUTPUT_LIMIT_CONTINUATION_REQUEST = (
+    "[System: Your previous response was truncated by the output length limit. "
+    "Continue exactly where you left off. Do not restart or repeat prior text. "
+    "Finish the answer directly.]"
+)
+CODEX_INCOMPLETE_CONTINUATION_REQUEST = (
+    "[System: Your previous response contained only internal reasoning and "
+    "never produced a visible answer or tool call. Do not keep thinking. "
+    "Produce your final answer as plain text now (or make the tool call "
+    "you were planning).]"
+)
+INTENT_ACK_CONTINUATION_REQUEST = (
+    "[System: Continue now. Execute the required tool calls and only "
+    "send your final answer after completing the task.]"
+)
+EMPTY_TOOL_RESPONSE_CONTINUATION_REQUEST = (
+    "You just executed tool calls but returned an empty response. Please process "
+    "the tool results above and continue with the task."
+)
+DROPPED_TOOL_CALL_CONTINUATION_REQUEST = (
+    "Your previous turn indicated a tool call but none was included. Do not "
+    "narrate a plan or restate intent — issue the actual tool call now to "
+    "continue the task."
+)
+
+EXACT_INTERNAL_USER_REQUESTS = frozenset(
+    {
+        MAX_ITERATIONS_SUMMARY_REQUEST,
+        NETWORK_STREAM_CONTINUATION_REQUEST,
+        OUTPUT_LIMIT_CONTINUATION_REQUEST,
+        CODEX_INCOMPLETE_CONTINUATION_REQUEST,
+        INTENT_ACK_CONTINUATION_REQUEST,
+        EMPTY_TOOL_RESPONSE_CONTINUATION_REQUEST,
+        DROPPED_TOOL_CALL_CONTINUATION_REQUEST,
+    }
+)
+
+_TOOL_CALL_STREAM_CONTINUATION_PREFIX = "[System: Your previous tool call ("
+_TOOL_CALL_STREAM_CONTINUATION_SUFFIX = (
+    ") was too large and the stream timed out before it could be delivered. "
+    "Do NOT retry the same tool call with the same large content. Instead, "
+    "break the content into multiple smaller tool calls (e.g. use multiple "
+    "patch calls or write smaller files). Each tool call's arguments must be "
+    "under ~8K tokens to avoid stream timeouts.]"
+)
+_TOOL_NAMES_WIRE_RE = re.compile(r"[^\r\n)]{1,256}\Z")
+_ASYNC_SINGLE_HEADER_RE = re.compile(
+    r"\[ASYNC DELEGATION COMPLETE — [^\]\r\n]{1,256}\]\Z"
+)
+_ASYNC_BATCH_HEADER_RE = re.compile(
+    r"\[ASYNC DELEGATION BATCH COMPLETE — [^\]\r\n]{1,256}\]\Z"
+)
+_ASYNC_SINGLE_INTRO = (
+    "A background subagent you dispatched earlier has finished. You may have "
+    "moved on since dispatching it; the full task source is below so you can "
+    "act on the result or re-dispatch if things have changed."
+)
+_ASYNC_BATCH_INTRO_RE = re.compile(
+    r"A background fan-out of \d+ subagent\(s\) you dispatched earlier has "
+    r"finished\. All ran in parallel and waited on each other; their "
+    r"consolidated results are below\. You may have moved on since dispatching "
+    r"— act on these or re-dispatch if things have changed\.\Z"
+)
+_BACKGROUND_WATCH_HEADER_RE = re.compile(
+    r'\[IMPORTANT: Background process [^\r\n]+ matched watch pattern "[^\r\n]*"\.\Z'
+)
+_BACKGROUND_COMPLETION_HEADER_RE = re.compile(
+    r"\[IMPORTANT: Background process [^\r\n]+ \(exit code [^\r\n]+\)\.\Z"
+)
+_WATCH_DISABLED_RE = re.compile(
+    r"\[IMPORTANT: Watch patterns disabled for process [^\r\n]+ — \d+ "
+    r"consecutive rate-limit windows triggered \(min spacing [0-9.]+s\)\. "
+    r"Falling back to notify_on_complete semantics; you'll get exactly one "
+    r"notification when the process exits\.\]\Z"
+)
 
 
 def _field(value: Any, key: str) -> Any:
@@ -44,7 +132,91 @@ def flatten_message_text(content: Any, *, sep: str = "\n") -> str:
     text = _text_from_part(content)
     if text:
         return text
+    if isinstance(content, Mapping) or any(
+        hasattr(content, key) for key in ("type", *_TEXT_KEYS)
+    ):
+        return ""
     try:
         return str(content)
     except Exception:
         return ""
+
+
+def has_non_text_content(content: Any) -> bool:
+    """Return whether content carries a structured non-text input part."""
+
+    parts = content if isinstance(content, list) else [content]
+    for part in parts:
+        if part is None or isinstance(part, str):
+            continue
+        part_type = str(_field(part, "type") or "").strip().lower()
+        if part_type and part_type not in _TEXT_PART_TYPES:
+            return True
+    return False
+
+
+def build_tool_call_stream_continuation_request(tool_names: Iterable[str]) -> str:
+    """Build the bounded recovery request for a tool call cut off in flight."""
+
+    tool_list = ", ".join(str(name) for name in list(tool_names)[:3])
+    return (
+        _TOOL_CALL_STREAM_CONTINUATION_PREFIX
+        + tool_list
+        + _TOOL_CALL_STREAM_CONTINUATION_SUFFIX
+    )
+
+
+def _is_tool_call_stream_continuation(text: str) -> bool:
+    if not (
+        text.startswith(_TOOL_CALL_STREAM_CONTINUATION_PREFIX)
+        and text.endswith(_TOOL_CALL_STREAM_CONTINUATION_SUFFIX)
+    ):
+        return False
+    tool_names = text[
+        len(_TOOL_CALL_STREAM_CONTINUATION_PREFIX) :
+        -len(_TOOL_CALL_STREAM_CONTINUATION_SUFFIX)
+    ]
+    return bool(_TOOL_NAMES_WIRE_RE.fullmatch(tool_names))
+
+
+def _is_async_delegation_notification(text: str) -> bool:
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return False
+    if _ASYNC_SINGLE_HEADER_RE.fullmatch(lines[0]):
+        return (
+            lines[1] == _ASYNC_SINGLE_INTRO
+            and any(line.startswith("Original goal:") for line in lines[2:])
+            and "--- RESULT ---" in lines[2:]
+        )
+    if _ASYNC_BATCH_HEADER_RE.fullmatch(lines[0]):
+        return bool(
+            _ASYNC_BATCH_INTRO_RE.fullmatch(lines[1])
+            and any(line.startswith("Role: ") for line in lines[2:])
+        )
+    return False
+
+
+def _is_background_process_notification(text: str) -> bool:
+    if _WATCH_DISABLED_RE.fullmatch(text):
+        return True
+    header, separator, body = text.partition("\n")
+    if not separator or not body.startswith("Command: ") or not text.endswith("]"):
+        return False
+    if _BACKGROUND_WATCH_HEADER_RE.fullmatch(header):
+        return "\nMatched output:\n" in body
+    if _BACKGROUND_COMPLETION_HEADER_RE.fullmatch(header):
+        return "\nOutput:\n" in body
+    return False
+
+
+def is_internal_user_scaffolding_text(text: str) -> bool:
+    """Recognize stable Hermes-authored user-role wire formats narrowly."""
+
+    normalized = (text or "").strip()
+    return (
+        normalized in EXACT_INTERNAL_USER_REQUESTS
+        or _is_tool_call_stream_continuation(normalized)
+        or _is_async_delegation_notification(normalized)
+        or _is_background_process_notification(normalized)
+    )

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -380,7 +380,7 @@ def maybe_auto_title(
     user_msg_count = sum(
         1 for message in (conversation_history or []) if is_real_user_message(message)
     )
-    if user_msg_count > 2:
+    if not 1 <= user_msg_count <= 2:
         return
 
     # Config read comes after the cheap first-exchange guard so the file

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -6,7 +6,8 @@ adds latency to the user-facing reply.
 
 import logging
 import threading
-from typing import Callable, Optional
+from collections.abc import Mapping
+from typing import Any, Callable, Optional
 
 from agent.auxiliary_client import call_llm
 
@@ -363,6 +364,7 @@ def maybe_auto_title(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    current_user_turn: Optional[Mapping[str, Any]] = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -374,6 +376,29 @@ def maybe_auto_title(
         return
 
     from agent.conversation_compression import is_real_user_message
+
+    # A background completion can re-enter a session after an earlier human
+    # turn.  Counting genuine history alone would make that internal trigger
+    # eligible to title the conversation from its notification text.  Reuse
+    # the same provenance classifier for the current trigger, retaining any
+    # explicit synthetic/display metadata carried by its history row.
+    classified_current_turn: Mapping[str, Any] = (
+        current_user_turn
+        if current_user_turn is not None
+        else {"role": "user", "content": user_message}
+    )
+    if current_user_turn is None:
+        for message in reversed(conversation_history or []):
+            get = getattr(message, "get", None)
+            if (
+                callable(get)
+                and get("role") == "user"
+                and get("content") == user_message
+            ):
+                classified_current_turn = message
+                break
+    if not is_real_user_message(classified_current_turn):
+        return
 
     # Long turns can add Hermes-authored user-role scaffolding. Count only
     # genuine user intent so those internal rows cannot close the title gate.

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -373,11 +373,13 @@ def maybe_auto_title(
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    # Count user messages in history to detect first exchange.
-    # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
-    user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
+    from agent.conversation_compression import is_real_user_message
+
+    # Long turns can add Hermes-authored user-role scaffolding. Count only
+    # genuine user intent so those internal rows cannot close the title gate.
+    user_msg_count = sum(
+        1 for message in (conversation_history or []) if is_real_user_message(message)
+    )
     if user_msg_count > 2:
         return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -60,6 +60,7 @@ from agent.conversation_compression import (
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from agent.interrupt_compat import request_hard_interrupt
+from agent.message_content import build_cli_handoff_notice, build_resume_recovery_note
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -933,75 +934,6 @@ def _is_fresh_gateway_interruption(
         return True
     current = time.time() if now is None else now
     return current - timestamp <= window
-
-
-def build_resume_recovery_note(
-    reason: Optional[str],
-    message: str = "",
-    *,
-    interactive: bool = True,
-) -> str:
-    """Build the resume-pending recovery system note for an interrupted turn.
-
-    ``reason`` is the session's ``resume_reason`` (``restart_timeout``,
-    ``shutdown_timeout``, or anything else → generic interruption phrasing).
-    ``message`` is the user's NEW message text; empty means this is the
-    startup auto-resume turn synthesized by
-    ``_schedule_resume_pending_sessions`` with no human message attached.
-
-    ``interactive`` selects the empty-message guidance: on interactive
-    platforms a human is present, so "report the restore and ask what next"
-    is right.  On non-interactive event platforms (webhook, API server —
-    adapters with ``interactive_resume = False``) nobody can answer; the
-    resumed turn must instead complete the interrupted work, or the task is
-    silently abandoned behind a "restored" acknowledgement that goes
-    nowhere (#57056).
-    """
-    reason_phrase = (
-        "a gateway restart"
-        if reason == "restart_timeout"
-        else "a gateway shutdown"
-        if reason == "shutdown_timeout"
-        else "a gateway interruption"
-    )
-    if message:
-        resume_guidance = (
-            "Address the user's NEW message below FIRST and focus "
-            "on what the user is asking now."
-        )
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
-        )
-    elif interactive:
-        resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
-        )
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
-        )
-    else:
-        resume_guidance = (
-            "No user is present on this non-interactive platform, "
-            "so do NOT emit a 'session restored' acknowledgement "
-            "or ask questions. Review the conversation history and "
-            "CONTINUE the interrupted task to completion."
-        )
-        tail_guidance = (
-            "Do NOT re-run tool calls whose results already "
-            "appear in the history — resume from the first step "
-            "that has no recorded result."
-        )
-    return (
-        f"[System note: The previous turn was interrupted by "
-        f"{reason_phrase}; the gateway is now back online. "
-        f"Any restart/shutdown command in the history has already "
-        f"run — do NOT re-execute or verify it. {resume_guidance} "
-        f"{tail_guidance}]"
-        + (f"\n\n{message}" if message else "")
-    )
 
 
 # Assistant-message fields that must survive transcript replay so multi-turn
@@ -5313,6 +5245,10 @@ class TurnRunner:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+            if ctx.persist_user_display_kind:
+                _conversation_kwargs["persist_user_display_kind"] = (
+                    ctx.persist_user_display_kind
+                )
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
             unregister_gateway_notify(_approval_session_key)
@@ -5532,6 +5468,25 @@ class TurnRunner:
             try:
                 from agent.title_generator import maybe_auto_title
                 all_msgs = ctx.result_holder[0].get("messages", []) if ctx.result_holder[0] else []
+                current_user_turn = None
+                current_user_idx = getattr(agent, "_persist_user_message_idx", None)
+                if ctx.persist_user_display_kind:
+                    # Explicit event provenance wins over positional recovery:
+                    # compression can rebuild/re-anchor the returned list, but
+                    # an internal MessageEvent remains internal regardless of
+                    # which model-facing wrapper was applied to its text.
+                    current_user_turn = {
+                        "role": "user",
+                        "content": ctx.message,
+                        "display_kind": ctx.persist_user_display_kind,
+                    }
+                elif (
+                    isinstance(current_user_idx, int)
+                    and 0 <= current_user_idx < len(all_msgs)
+                    and isinstance(all_msgs[current_user_idx], dict)
+                    and all_msgs[current_user_idx].get("role") == "user"
+                ):
+                    current_user_turn = all_msgs[current_user_idx]
                 # In Gateway mode, auto-title failures must NOT be
                 # surfaced as user-visible messages (fixes #23246).
                 # Log them at debug level only — they are not actionable
@@ -5561,6 +5516,7 @@ class TurnRunner:
                         getattr(agent, "model", None) == _title_model
                         and getattr(agent, "provider", None) == _title_provider
                     )) if agent else None,
+                    "current_user_turn": current_user_turn,
                 }
                 if self._runner._is_telegram_topic_lane(ctx.source):
                     maybe_auto_title_kwargs["title_callback"] = lambda title: self._runner._schedule_telegram_topic_title_rename(
@@ -11752,12 +11708,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so the synthetic turn isn't queued behind a stale running flag.
         self._release_running_agent_state(session_key)
 
-        synthetic_text = (
-            f"[Session was just handed off from CLI (\"{cli_title}\") to this "
-            f"channel. The full prior conversation history is loaded above. "
-            f"Briefly confirm you're working here and summarize what we were "
-            f"working on, so the user can continue from this device.]"
-        )
+        synthetic_text = build_cli_handoff_notice(cli_title)
 
         synthetic_event = MessageEvent(
             text=synthetic_text,
@@ -16295,6 +16246,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _redact_pii = False
         persist_user_message = None
         persist_user_timestamp = None
+        persist_user_display_kind = (
+            "hidden" if getattr(event, "internal", False) else None
+        )
         try:
             _pcfg = _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
@@ -17395,6 +17349,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_display_kind=persist_user_display_kind,
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
@@ -17839,6 +17794,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         else ts
                     ),
                 }
+                if persist_user_display_kind:
+                    _user_entry["display_kind"] = persist_user_display_kind
                 if event.message_id:
                     _user_entry["message_id"] = str(event.message_id)
                 # Dedupe: skip if this platform message_id is already in the
@@ -17881,6 +17838,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             else ts
                         ),
                     }
+                    if persist_user_display_kind:
+                        _user_entry["display_kind"] = persist_user_display_kind
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
                     await self.async_session_store.append_to_transcript(
@@ -17900,12 +17859,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
                     # can find earlier @bot messages by their original message_id.
                     _user_msg_id_attached = False
+                    _user_display_kind_pending = bool(persist_user_display_kind)
                     for msg in new_messages:
                         # Skip system messages (they're rebuilt each run)
                         if msg.get("role") == "system":
                             continue
                         # Add timestamp to each message for debugging
                         entry = {**msg, "timestamp": ts}
+                        if (
+                            msg.get("role") == "user"
+                            and _user_display_kind_pending
+                        ):
+                            if "display_kind" not in entry:
+                                entry["display_kind"] = persist_user_display_kind
+                            # The provenance belongs only to the initiating
+                            # event. A genuine human turn may have queued and
+                            # completed recursively behind it in this same
+                            # returned message chain.
+                            _user_display_kind_pending = False
                         if (
                             not _user_msg_id_attached
                             and msg.get("role") == "user"
@@ -18069,6 +18040,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 else time.time()
                             ),
                         }
+                        if persist_user_display_kind:
+                            _user_entry["display_kind"] = persist_user_display_kind
                         if getattr(event, "message_id", None):
                             _user_entry["message_id"] = str(event.message_id)
                         await self.async_session_store.append_to_transcript(
@@ -18700,6 +18673,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     source=source,
                     message_id=None,
                     channel_prompt=None,
+                    internal=True,
                 )
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
@@ -23868,6 +23842,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
@@ -23887,6 +23862,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
             )
 
@@ -23899,6 +23875,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
             )
 
@@ -24021,6 +23998,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
@@ -24306,6 +24284,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             moa_config=moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
+            persist_user_display_kind=persist_user_display_kind,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to
@@ -25426,6 +25405,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_message_id = None
                 next_channel_prompt = None
                 next_session_key = session_key
+                next_persist_user_display_kind = None
                 # #60671 — carry the pending event's message_type into the
                 # recursive call so queued voice turns can stream TTS and
                 # re-mark the generation for the final delivered turn.
@@ -25462,6 +25442,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
                     next_message_type = getattr(pending_event, "message_type", None)
+                    next_persist_user_display_kind = (
+                        "hidden"
+                        if getattr(pending_event, "internal", False)
+                        else None
+                    )
 
                 # Clear the completed streaming marker from the prior logical
                 # turn so the recursive turn's streaming TTS is not suppressed
@@ -25516,6 +25501,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    persist_user_display_kind=next_persist_user_display_kind,
                     message_type=next_message_type,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -91,6 +91,7 @@ class TurnContext:
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
+    persist_user_display_kind: Optional[str] = None
     user_config: Any = None
     enabled_toolsets: Any = None
     disabled_toolsets: Any = None

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -114,6 +114,47 @@ CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE = (
 )
 
 
+def _continuation_prompt_pattern(template: str, *fields: str) -> re.Pattern[str]:
+    """Compile a full-envelope matcher for a rendered continuation template."""
+
+    pattern = re.escape(template)
+    for field_name in fields:
+        token = re.escape("{" + field_name + "}")
+        pattern = pattern.replace(token, rf"(?P<{field_name}>.+?)")
+    return re.compile(rf"\A{pattern}\Z", re.DOTALL)
+
+
+_CONTINUATION_PROMPT_PATTERNS = (
+    _continuation_prompt_pattern(CONTINUATION_PROMPT_TEMPLATE, "goal"),
+    _continuation_prompt_pattern(
+        CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE,
+        "goal",
+        "contract_block",
+    ),
+    _continuation_prompt_pattern(
+        CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE,
+        "goal",
+        "subgoals_block",
+    ),
+)
+
+
+def is_goal_continuation_prompt(text: str) -> bool:
+    """Return whether *text* is one exact runtime-generated goal continuation.
+
+    The full template envelope is required. Human prose that merely quotes or
+    discusses one of these prompts therefore remains genuine user input.
+    """
+
+    if not isinstance(text, str) or not text:
+        return False
+    for pattern in _CONTINUATION_PROMPT_PATTERNS:
+        match = pattern.fullmatch(text)
+        if match and all(value.strip() for value in match.groupdict().values()):
+            return True
+    return False
+
+
 JUDGE_SYSTEM_PROMPT = (
     "You are a strict judge evaluating whether an autonomous agent has "
     "achieved a user's stated goal. You receive the goal text, the agent's "
@@ -1791,6 +1832,7 @@ __all__ = [
     "CONTINUATION_PROMPT_TEMPLATE",
     "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
     "CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE",
+    "is_goal_continuation_prompt",
     "JUDGE_USER_PROMPT_TEMPLATE",
     "JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE",
     "JUDGE_USER_PROMPT_WITH_CONTRACT_TEMPLATE",

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -817,6 +817,111 @@ def test_restored_anchor_never_creates_consecutive_user_roles() -> None:
     assert not compressed[0].get("_todo_snapshot_synthetic")
 
 
+@pytest.mark.parametrize(
+    "media_part",
+    [
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://example.test/cat.png"},
+        },
+        {"type": "input_audio", "input_audio": {"data": "AA=="}},
+    ],
+    ids=["image", "audio"],
+)
+def test_media_todo_anchor_restoration_does_not_duplicate(media_part) -> None:
+    from agent.context_compressor import ContextCompressor
+    from agent.conversation_compression import (
+        _ensure_compressed_has_user_turn,
+        is_real_user_message,
+    )
+    from tools.todo_tool import TODO_INJECTION_HEADER
+
+    original = [
+        {
+            "role": "user",
+            "content": [
+                media_part,
+                {
+                    "type": "text",
+                    "text": f"{TODO_INJECTION_HEADER}\n- [>] Finish the task",
+                },
+            ],
+        }
+    ]
+    compressed = []
+
+    _ensure_compressed_has_user_turn(original, compressed)
+    _ensure_compressed_has_user_turn(original, compressed)
+
+    assert len(compressed) == 1
+    assert is_real_user_message(compressed[0])
+    assert compressed[0]["content"][0] == media_part
+
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(model="test", quiet_mode=True)
+    assert compressor._transcript_has_real_user_turn(original)
+    assert compressor._find_last_user_message_idx(original, head_end=0) == 0
+
+    tail_history = [
+        {"role": "user", "content": "head"},
+        {"role": "assistant", "content": "reply"},
+        original[0],
+        {"role": "assistant", "content": "media handled"},
+        {"role": "user", "content": "latest"},
+    ]
+    assert (
+        compressor._ensure_last_n_user_messages_in_tail(
+            tail_history, cut_idx=4, head_end=1, n=2
+        )
+        == 2
+    )
+
+
+def test_internal_runtime_rows_do_not_establish_compressor_user_provenance() -> None:
+    from agent.context_compressor import ContextCompressor
+    from agent.message_content import MAX_ITERATIONS_SUMMARY_REQUEST
+
+    messages = [
+        {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+    ]
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(model="test", quiet_mode=True)
+
+    assert not compressor._transcript_has_real_user_turn(messages)
+    assert compressor._find_last_user_message_idx(messages, head_end=0) == 0
+
+
+def test_internal_notification_remains_an_actionable_tail_anchor() -> None:
+    from agent.context_compressor import ContextCompressor
+    from tools.process_registry import format_process_notification
+
+    notification = format_process_notification(
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg-1",
+            "goal": "Inspect the title gate",
+            "status": "completed",
+            "summary": "The classifier was audited.",
+        }
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "Inspect the title gate"},
+        {"role": "assistant", "content": "Delegating."},
+        {"role": "user", "content": notification},
+    ]
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000
+    ):
+        compressor = ContextCompressor(model="test", quiet_mode=True)
+
+    assert compressor._find_last_user_message_idx(messages, head_end=1) == 3
+
+
 
 
 def test_compression_persists_child_handoff_immediately(tmp_path: Path) -> None:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -477,6 +477,8 @@ class TestNonStringContent:
         those, the deterministic snapshot must look past it to the real ask
         (and return None when no real ask exists at all).
         """
+        from agent.message_content import OUTPUT_LIMIT_CONTINUATION_REQUEST
+
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(model="test", quiet_mode=True)
 
@@ -495,7 +497,7 @@ class TestNonStringContent:
         assert "task list was preserved" not in snapshot
 
         only_synthetic = [
-            {"role": "user", "content": "[System: Your previous response was truncated ...]"},
+            {"role": "user", "content": OUTPUT_LIMIT_CONTINUATION_REQUEST},
         ]
         assert c._latest_user_task_snapshot(only_synthetic) is None
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -501,6 +501,51 @@ class TestNonStringContent:
         ]
         assert c._latest_user_task_snapshot(only_synthetic) is None
 
+    def test_auto_focus_skips_all_shared_internal_user_scaffolding(self):
+        from agent.message_content import OUTPUT_LIMIT_CONTINUATION_REQUEST
+
+        messages = [
+            {"role": "user", "content": "fix the login bug on prod"},
+            {"role": "assistant", "content": "on it"},
+            {"role": "user", "content": OUTPUT_LIMIT_CONTINUATION_REQUEST},
+        ]
+
+        focus = ContextCompressor._derive_auto_focus_topic(messages)
+        assert focus is not None
+        assert "fix the login bug on prod" in focus
+        assert OUTPUT_LIMIT_CONTINUATION_REQUEST not in focus
+        assert (
+            ContextCompressor._derive_auto_focus_topic(
+                [{"role": "user", "content": OUTPUT_LIMIT_CONTINUATION_REQUEST}]
+            )
+            is None
+        )
+
+    def test_fallback_summary_labels_internal_rows_without_user_attribution(self):
+        from agent.context_compressor import _NO_USER_TASK_SENTINEL
+        from agent.message_content import OUTPUT_LIMIT_CONTINUATION_REQUEST
+
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=100000
+        ):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "fix the login bug on prod"},
+            {"role": "assistant", "content": "on it"},
+            {"role": "user", "content": OUTPUT_LIMIT_CONTINUATION_REQUEST},
+        ]
+        summary = c._build_static_fallback_summary(messages)
+        assert "User asked: 'fix the login bug on prod'" in summary
+        assert f"INTERNAL CONTEXT: {OUTPUT_LIMIT_CONTINUATION_REQUEST}" in summary
+        assert f"User asked: {OUTPUT_LIMIT_CONTINUATION_REQUEST!r}" not in summary
+
+        internal_only = c._build_static_fallback_summary(
+            [{"role": "user", "content": OUTPUT_LIMIT_CONTINUATION_REQUEST}]
+        )
+        assert _NO_USER_TASK_SENTINEL in internal_only
+        assert f"User asked: {OUTPUT_LIMIT_CONTINUATION_REQUEST!r}" not in internal_only
+
     def test_grounding_preserves_following_sections_across_regrounding(self):
         """The snapshot rewrite must keep later headings intact — twice.
 

--- a/tests/agent/test_message_content.py
+++ b/tests/agent/test_message_content.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from agent.message_content import flatten_message_text
+from agent.message_content import flatten_message_text, has_non_text_content
+from tools.todo_tool import TODO_INJECTION_HEADER
 
 
 def test_flatten_message_text_accepts_chat_and_responses_text_parts():
@@ -23,3 +24,39 @@ def test_flatten_message_text_accepts_object_parts():
     ]
 
     assert flatten_message_text(content) == "object text\nlegacy content"
+
+
+def test_has_non_text_content_accepts_media_and_structured_parts():
+    assert has_non_text_content(
+        [{"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}]
+    )
+    assert has_non_text_content(
+        [SimpleNamespace(type="input_audio", input_audio={"data": "AA=="})]
+    )
+    assert has_non_text_content(
+        [{"type": "document", "document": {"name": "notes.pdf"}}]
+    )
+
+
+def test_has_non_text_content_rejects_text_and_blank_inputs():
+    assert not has_non_text_content("plain text")
+    assert not has_non_text_content([])
+    assert not has_non_text_content([{"type": "text", "text": "hello"}])
+    assert not has_non_text_content(SimpleNamespace(type="output_text", text="hello"))
+
+
+def test_flatten_message_text_does_not_stringify_empty_structured_parts():
+    assert flatten_message_text({}) == ""
+    assert flatten_message_text({"type": "text", "text": ""}) == ""
+    assert flatten_message_text(SimpleNamespace(type="output_text", text="")) == ""
+
+
+def test_media_with_todo_text_keeps_structured_provenance():
+    todo = f"{TODO_INJECTION_HEADER}\n- [>] Finish the task"
+    content = [
+        {"type": "image_url", "image_url": {"url": "https://example.test/a.png"}},
+        {"type": "text", "text": todo},
+    ]
+
+    assert has_non_text_content(content)
+    assert flatten_message_text(content) == todo

--- a/tests/agent/test_message_content.py
+++ b/tests/agent/test_message_content.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from agent.message_content import flatten_message_text, has_non_text_content
+from agent.message_content import (
+    build_cli_handoff_notice,
+    build_resume_recovery_note,
+    flatten_message_text,
+    has_non_text_content,
+    is_internal_user_scaffolding_text,
+)
 from tools.todo_tool import TODO_INJECTION_HEADER
 
 
@@ -60,3 +66,66 @@ def test_media_with_todo_text_keeps_structured_provenance():
 
     assert has_non_text_content(content)
     assert flatten_message_text(content) == todo
+
+
+def test_goal_continuations_match_only_complete_runtime_messages():
+    from hermes_cli.goals import (
+        CONTINUATION_PROMPT_TEMPLATE,
+        CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE,
+        CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE,
+    )
+
+    prompts = [
+        CONTINUATION_PROMPT_TEMPLATE.format(goal="Ship the title fix"),
+        CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(
+            goal="Ship the title fix",
+            contract_block="Outcome: fixed\nVerification: focused tests pass",
+        ),
+        CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+            goal="Ship the title fix",
+            subgoals_block="1. Preserve media provenance",
+        ),
+    ]
+
+    for prompt in prompts:
+        assert is_internal_user_scaffolding_text(prompt)
+        assert not is_internal_user_scaffolding_text(
+            f"Why did Hermes send this?\n{prompt}"
+        )
+        assert not is_internal_user_scaffolding_text(
+            f"{prompt}\nPlease explain that message."
+        )
+
+
+def test_pure_resume_recovery_notes_are_internal_but_new_human_text_is_not():
+    for reason in ("restart_timeout", "shutdown_timeout", "other"):
+        for interactive in (True, False):
+            note = build_resume_recovery_note(reason, "", interactive=interactive)
+            assert is_internal_user_scaffolding_text(note)
+            assert not is_internal_user_scaffolding_text(
+                f"Please explain this note:\n{note}"
+            )
+
+            note_with_human_message = build_resume_recovery_note(
+                reason,
+                "Please review the new failure",
+                interactive=interactive,
+            )
+            assert not is_internal_user_scaffolding_text(note_with_human_message)
+
+
+def test_cli_handoff_notice_matches_only_the_complete_runtime_envelope():
+    notice = build_cli_handoff_notice("Title repair")
+
+    assert is_internal_user_scaffolding_text(notice)
+    assert not is_internal_user_scaffolding_text(
+        f"Why did Hermes send this?\n{notice}"
+    )
+    assert not is_internal_user_scaffolding_text(
+        f"{notice}\nPlease explain the handoff."
+    )
+    assert not is_internal_user_scaffolding_text(build_cli_handoff_notice(""))
+    assert not is_internal_user_scaffolding_text(build_cli_handoff_notice("   "))
+    assert not is_internal_user_scaffolding_text(
+        build_cli_handoff_notice("Title\nrepair")
+    )

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -13,6 +13,8 @@ from agent.context_compressor import SUMMARY_PREFIX
 from agent.message_content import (
     EXACT_INTERNAL_USER_REQUESTS,
     MAX_ITERATIONS_SUMMARY_REQUEST,
+    build_cli_handoff_notice,
+    build_resume_recovery_note,
     build_tool_call_stream_continuation_request,
 )
 from hermes_state import SessionDB
@@ -243,6 +245,75 @@ class TestRealUserMessageClassification:
             structured,
         ):
             assert not is_real_user_message(message)
+
+    def test_merged_compaction_carriers_preserve_genuine_user_provenance(self):
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+            _SUMMARY_END_MARKER,
+        )
+        from agent.conversation_compression import is_real_user_message
+
+        forced_user_leading = {
+            "role": "user",
+            "content": (
+                f"{SUMMARY_PREFIX}\nCompacted work so far.\n\n"
+                f"{_SUMMARY_END_MARKER}\n\nPlease finish the title fix"
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+        merged_into_tail = {
+            "role": "user",
+            "content": (
+                f"{_MERGED_PRIOR_CONTEXT_HEADER}\nPlease finish the title fix\n\n"
+                f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+                f"{SUMMARY_PREFIX}\nCompacted work so far."
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+        media_tail = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.test/diagram.png"},
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+                        f"{SUMMARY_PREFIX}\nCompacted work so far."
+                    ),
+                },
+            ],
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+
+        assert is_real_user_message(forced_user_leading)
+        assert is_real_user_message(merged_into_tail)
+        assert is_real_user_message(media_tail)
+
+    def test_merged_compaction_carrier_with_only_internal_tail_stays_internal(self):
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+        )
+        from agent.conversation_compression import is_real_user_message
+
+        message = {
+            "role": "user",
+            "content": (
+                f"{_MERGED_PRIOR_CONTEXT_HEADER}\n{TODO_INJECTION_HEADER}\n- [>] Continue\n\n"
+                f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+                f"{SUMMARY_PREFIX}\nCompacted work so far."
+            ),
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+
+        assert not is_real_user_message(message)
 
     def test_todo_and_compression_continuation_rows_are_internal(self):
         from collections import UserDict
@@ -789,6 +860,119 @@ class TestMaybeAutoTitle:
                 MAX_ITERATIONS_SUMMARY_REQUEST,
                 "notification handled",
                 history,
+            )
+
+        thread_cls.assert_not_called()
+
+    def test_internal_current_trigger_never_starts_a_title_thread(self):
+        from tools.process_registry import format_process_notification
+
+        notifications = [
+            format_process_notification(
+                {
+                    "type": "async_delegation",
+                    "delegation_id": "deleg-current",
+                    "goal": "Inspect the title gate",
+                    "status": "completed",
+                    "summary": "The gate counted synthetic rows.",
+                }
+            ),
+            format_process_notification(
+                {
+                    "type": "completion",
+                    "session_id": "proc-current",
+                    "command": "run focused tests",
+                    "exit_code": 0,
+                    "output": "passed",
+                }
+            ),
+        ]
+
+        with patch("agent.title_generator.threading.Thread") as thread_cls:
+            for notification in notifications:
+                history = [
+                    {"role": "user", "content": "Fix the title gate"},
+                    {"role": "assistant", "content": "I started the work."},
+                    {"role": "user", "content": notification},
+                    {"role": "assistant", "content": "The background work finished."},
+                ]
+                maybe_auto_title(
+                    MagicMock(),
+                    "sess-current-internal",
+                    notification,
+                    "The background work finished.",
+                    history,
+                )
+
+        thread_cls.assert_not_called()
+
+    def test_goal_recovery_and_handoff_current_triggers_never_start_a_title_thread(
+        self,
+    ):
+        from hermes_cli.goals import (
+            CONTINUATION_PROMPT_TEMPLATE,
+            CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE,
+            CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE,
+        )
+
+        internal_triggers = [
+            CONTINUATION_PROMPT_TEMPLATE.format(goal="Ship the fix"),
+            CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(
+                goal="Ship the fix",
+                contract_block="Outcome: fixed\nVerification: tests pass",
+            ),
+            CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+                goal="Ship the fix",
+                subgoals_block="1. Keep media genuine",
+            ),
+            build_resume_recovery_note("restart_timeout", "", interactive=True),
+            build_resume_recovery_note("shutdown_timeout", "", interactive=False),
+            build_cli_handoff_notice("Title repair"),
+        ]
+
+        with patch("agent.title_generator.threading.Thread") as thread_cls:
+            for trigger in internal_triggers:
+                history = [
+                    {"role": "user", "content": "Fix the title gate"},
+                    {"role": "assistant", "content": "I started the work."},
+                    {"role": "user", "content": trigger},
+                    {"role": "assistant", "content": "The internal turn completed."},
+                ]
+                maybe_auto_title(
+                    MagicMock(),
+                    "sess-current-runtime",
+                    trigger,
+                    "The internal turn completed.",
+                    history,
+                )
+
+        thread_cls.assert_not_called()
+
+    def test_explicit_hidden_current_turn_survives_timestamp_rendering(self):
+        clean_notification = "generic internal wake event"
+        timestamped_notification = (
+            "[Sent at 2026-08-04 10:00 UTC]\n" + clean_notification
+        )
+        current_turn = {
+            "role": "user",
+            "content": clean_notification,
+            "display_kind": "hidden",
+        }
+        history = [
+            {"role": "user", "content": "Fix the title gate"},
+            {"role": "assistant", "content": "I started the work."},
+            current_turn,
+            {"role": "assistant", "content": "The wake turn completed."},
+        ]
+
+        with patch("agent.title_generator.threading.Thread") as thread_cls:
+            maybe_auto_title(
+                MagicMock(),
+                "sess-timestamped-internal",
+                timestamped_notification,
+                "The wake turn completed.",
+                history,
+                current_user_turn=current_turn,
             )
 
         thread_cls.assert_not_called()

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -1,6 +1,5 @@
 """Tests for agent.title_generator — auto-generated session titles."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 
@@ -11,6 +10,11 @@ from agent.title_generator import (
     _title_language,
 )
 from agent.context_compressor import SUMMARY_PREFIX
+from agent.message_content import (
+    EXACT_INTERNAL_USER_REQUESTS,
+    MAX_ITERATIONS_SUMMARY_REQUEST,
+    build_tool_call_stream_continuation_request,
+)
 from hermes_state import SessionDB
 from tools.todo_tool import TODO_INJECTION_HEADER
 
@@ -192,6 +196,8 @@ class TestRealUserMessageClassification:
     """Shared classifier coverage for the title gate and compression."""
 
     def test_compaction_metadata_and_projected_content_are_internal(self):
+        from collections import UserDict
+
         from agent.context_compressor import (
             COMPRESSED_SUMMARY_METADATA_KEY,
             LEGACY_SUMMARY_PREFIX,
@@ -205,6 +211,7 @@ class TestRealUserMessageClassification:
             "content": "summary body",
             COMPRESSED_SUMMARY_METADATA_KEY: True,
         }
+        marked_mapping = UserDict(marked)
         projected = {
             "role": "user",
             "content": f"{SUMMARY_PREFIX}\nsummary body",
@@ -227,10 +234,19 @@ class TestRealUserMessageClassification:
             ],
         }
 
-        for message in (marked, projected, legacy, historical, structured):
+        for message in (
+            marked,
+            marked_mapping,
+            projected,
+            legacy,
+            historical,
+            structured,
+        ):
             assert not is_real_user_message(message)
 
     def test_todo_and_compression_continuation_rows_are_internal(self):
+        from collections import UserDict
+
         from agent.context_compressor import (
             COMPRESSION_CONTINUATION_USER_CONTENT,
             _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
@@ -239,6 +255,7 @@ class TestRealUserMessageClassification:
         from tools.todo_tool import TODO_INJECTION_HEADER
 
         messages = [
+            {"role": "user", "content": TODO_INJECTION_HEADER},
             {
                 "role": "user",
                 "content": f"{TODO_INJECTION_HEADER}\n- [>] Continue",
@@ -260,27 +277,41 @@ class TestRealUserMessageClassification:
                 "role": "user",
                 "content": _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
             },
+            UserDict(
+                {
+                    "role": "user",
+                    "content": f"{TODO_INJECTION_HEADER}\n- [>] Continue",
+                }
+            ),
         ]
 
         assert all(not is_real_user_message(message) for message in messages)
 
-    def test_exact_max_iteration_summary_request_is_internal(self):
+    def test_exact_runtime_requests_are_internal(self):
         from agent.conversation_compression import is_real_user_message
-        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 
-        assert not is_real_user_message(
-            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST}
+        for request in EXACT_INTERNAL_USER_REQUESTS:
+            assert not is_real_user_message({"role": "user", "content": request})
+            assert not is_real_user_message(
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": request}],
+                }
+            )
+
+    def test_dynamic_tool_continuation_is_matched_as_a_complete_wire_message(self):
+        from agent.conversation_compression import is_real_user_message
+
+        request = build_tool_call_stream_continuation_request(
+            ["write_file", "patch"]
         )
-        assert not is_real_user_message(
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": MAX_ITERATIONS_SUMMARY_REQUEST,
-                    }
-                ],
-            }
+
+        assert not is_real_user_message({"role": "user", "content": request})
+        assert is_real_user_message(
+            {"role": "user", "content": f"Please explain this message:\n{request}"}
+        )
+        assert is_real_user_message(
+            {"role": "user", "content": f"{request}\nWhy did Hermes send it?"}
         )
 
     def test_existing_synthetic_flags_are_internal(self):
@@ -292,15 +323,15 @@ class TestRealUserMessageClassification:
         for flag in _SYNTHETIC_USER_FLAGS:
             message = {"role": "user", "content": "runtime row", flag: True}
             assert not is_real_user_message(message), flag
+        assert "_kanban_stop_synthetic" in _SYNTHETIC_USER_FLAGS
 
-    def test_internal_phrases_inside_ordinary_user_content_remain_real(self):
+    def test_runtime_requests_inside_ordinary_user_content_remain_real(self):
         from agent.context_compressor import SUMMARY_PREFIX
         from agent.conversation_compression import is_real_user_message
-        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
         from tools.todo_tool import TODO_INJECTION_HEADER
 
         contents = [
-            f"Why did Hermes say: {MAX_ITERATIONS_SUMMARY_REQUEST}",
+            *(f'Why did Hermes say: "{request}"?' for request in EXACT_INTERNAL_USER_REQUESTS),
             f"Please explain this marker: {TODO_INJECTION_HEADER}",
             f"Please analyze this header:\n{SUMMARY_PREFIX}",
         ]
@@ -308,6 +339,185 @@ class TestRealUserMessageClassification:
         assert all(
             is_real_user_message({"role": "user", "content": content})
             for content in contents
+        )
+
+    def test_media_and_other_structured_user_inputs_are_real(self):
+        from agent.conversation_compression import is_real_user_message
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.test/cat.png"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {"data": "AA=="}}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "document", "document": {"name": "notes.pdf"}}
+                ],
+            },
+        ]
+
+        assert all(is_real_user_message(message) for message in messages)
+
+    def test_media_with_merged_todo_text_remains_real(self):
+        from agent.conversation_compression import is_real_user_message
+
+        for media_part in (
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.test/cat.png"},
+            },
+            {"type": "input_audio", "input_audio": {"data": "AA=="}},
+        ):
+            message = {
+                "role": "user",
+                "content": [
+                    media_part,
+                    {
+                        "type": "text",
+                        "text": f"{TODO_INJECTION_HEADER}\n- [>] Finish the task",
+                    },
+                ],
+            }
+            assert is_real_user_message(message)
+
+    def test_display_bookkeeping_rows_are_internal(self):
+        from agent.conversation_compression import is_real_user_message
+
+        for display_kind in (
+            "model_switch",
+            "auto_continue",
+            "async_delegation_complete",
+            "hidden",
+        ):
+            assert not is_real_user_message(
+                {
+                    "role": "user",
+                    "content": "timeline bookkeeping",
+                    "display_kind": display_kind,
+                }
+            )
+        assert is_real_user_message(
+            {"role": "user", "content": "timeline bookkeeping", "display_kind": ""}
+        )
+
+    def test_async_delegation_wire_messages_are_internal(self):
+        from agent.conversation_compression import is_real_user_message
+        from tools.process_registry import format_process_notification
+
+        single = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg-1",
+                "goal": "Inspect the title gate",
+                "status": "completed",
+                "summary": "The gate counted synthetic rows.",
+            }
+        )
+        batch = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg-batch",
+                "is_batch": True,
+                "goals": ["Inspect compression"],
+                "results": [
+                    {
+                        "task_index": 0,
+                        "status": "completed",
+                        "summary": "Compression audited.",
+                    }
+                ],
+            }
+        )
+
+        assert isinstance(single, str)
+        assert isinstance(batch, str)
+        assert not is_real_user_message({"role": "user", "content": single})
+        assert not is_real_user_message({"role": "user", "content": batch})
+
+    def test_background_process_wire_messages_are_internal(self):
+        from agent.conversation_compression import is_real_user_message
+        from tools.process_registry import format_process_notification
+
+        multiline_command = "python - <<'PY'\nprint('ok')\nPY"
+        notifications = [
+            format_process_notification(
+                {
+                    "type": "completion",
+                    "session_id": "proc-1",
+                    "command": "tests",
+                    "exit_code": 0,
+                    "output": "passed",
+                }
+            ),
+            format_process_notification(
+                {
+                    "type": "watch_match",
+                    "session_id": "proc-2",
+                    "command": "tests",
+                    "pattern": "FAILED",
+                    "output": "FAILED test_title",
+                }
+            ),
+            format_process_notification(
+                {
+                    "type": "completion",
+                    "session_id": "proc-3",
+                    "command": multiline_command,
+                    "exit_code": 0,
+                    "output": "ok",
+                }
+            ),
+            format_process_notification(
+                {
+                    "type": "watch_match",
+                    "session_id": "proc-4",
+                    "command": multiline_command,
+                    "pattern": "ok",
+                    "output": "ok",
+                }
+            ),
+        ]
+
+        assert all(isinstance(item, str) for item in notifications)
+        assert all(
+            not is_real_user_message({"role": "user", "content": item})
+            for item in notifications
+        )
+        watch_discussion = f"{notifications[-1][:-1]}\nWhy did Hermes send this?"
+        assert is_real_user_message(
+            {"role": "user", "content": watch_discussion}
+        )
+
+    def test_blank_malformed_and_non_user_rows_are_not_genuine(self):
+        from types import SimpleNamespace
+
+        from agent.conversation_compression import is_real_user_message
+
+        assert not is_real_user_message(None)
+        assert not is_real_user_message({"role": "assistant", "content": "hello"})
+        assert not is_real_user_message({"role": "user", "content": "  "})
+        assert not is_real_user_message({"role": "user", "content": []})
+        assert not is_real_user_message({"role": "user", "content": {}})
+        assert not is_real_user_message(
+            {"role": "user", "content": {"type": "text", "text": ""}}
+        )
+        assert not is_real_user_message(
+            {
+                "role": "user",
+                "content": SimpleNamespace(type="output_text", text=""),
+            }
         )
 
 
@@ -362,12 +572,10 @@ class TestMaybeAutoTitle:
             {"role": "assistant", "content": "response 3"},
         ]
 
-        with patch("agent.title_generator.auto_title_session") as mock_auto:
+        with patch("agent.title_generator.threading.Thread") as thread_cls:
             maybe_auto_title(db, "sess-1", "third", "response 3", history)
-            # Wait briefly for any thread to start
-            import time
-            time.sleep(0.1)
-            mock_auto.assert_not_called()
+
+        thread_cls.assert_not_called()
 
     def test_fires_on_first_exchange(self):
         """Should fire a background thread for the first exchange."""
@@ -408,32 +616,19 @@ class TestMaybeAutoTitle:
             },
             {
                 "role": "user",
-                "content": (
-                    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
-                    "compacted into this summary."
-                ),
+                "content": f"{SUMMARY_PREFIX}\nEarlier turns were compacted.",
             },
             {"role": "assistant", "content": "Continuing the investigation."},
             {
                 "role": "user",
-                "content": (
-                    "[Your active task list was preserved across context compression]\n"
-                    "- [>] Find the root cause"
-                ),
+                "content": f"{TODO_INJECTION_HEADER}\n- [>] Find the root cause",
             },
             {
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [{"id": "call-2"}],
             },
-            {
-                "role": "user",
-                "content": (
-                    "You've reached the maximum number of tool-calling iterations allowed. "
-                    "Please provide a final response summarizing what you've found and "
-                    "accomplished so far, without calling any more tools."
-                ),
-            },
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
             {"role": "assistant", "content": "The title gate counted scaffolding."},
         ]
 
@@ -453,12 +648,44 @@ class TestMaybeAutoTitle:
 
         mock_auto.assert_called_once()
 
+    def test_repeated_continuation_nudges_do_not_consume_the_allowance(self):
+        db = MagicMock()
+        continuation_requests = sorted(
+            EXACT_INTERNAL_USER_REQUESTS - {MAX_ITERATIONS_SUMMARY_REQUEST}
+        )
+        history = [{"role": "user", "content": "Fix the title gate"}]
+        for index, request in enumerate(continuation_requests):
+            history.extend(
+                [
+                    {"role": "assistant", "content": f"retry {index}"},
+                    {"role": "user", "content": request},
+                    {"role": "assistant", "content": f"retry {index} again"},
+                    {"role": "user", "content": request},
+                ]
+            )
+        history.append({"role": "assistant", "content": "Fixed."})
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *_args, **_kwargs: called.set()
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "Fix the title gate",
+                "Fixed.",
+                history,
+            )
+            assert called.wait(timeout=10), "auto_title thread never ran"
+
+        mock_auto.assert_called_once()
+
     def test_fires_with_two_real_user_turns_plus_internal_scaffolding(self):
         from agent.context_compressor import (
             COMPRESSION_CONTINUATION_USER_CONTENT,
             SUMMARY_PREFIX,
         )
-        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
 
         db = MagicMock()
         history = [
@@ -495,15 +722,15 @@ class TestMaybeAutoTitle:
 
         mock_auto.assert_called_once()
 
-    def test_skips_with_three_real_user_turns_plus_internal_scaffolding(self):
+    def test_skips_with_three_repeated_real_turns_plus_internal_scaffolding(self):
         from agent.context_compressor import SUMMARY_PREFIX
 
         db = MagicMock()
         history = [
-            {"role": "user", "content": "first request"},
+            {"role": "user", "content": "same request"},
             {"role": "assistant", "content": "first response"},
             {"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary body"},
-            {"role": "user", "content": "second request"},
+            {"role": "user", "content": "same request"},
             {"role": "assistant", "content": "second response"},
             {
                 "role": "user",
@@ -512,7 +739,7 @@ class TestMaybeAutoTitle:
                     "- [>] Continue"
                 ),
             },
-            {"role": "user", "content": "third request"},
+            {"role": "user", "content": "same request"},
             {"role": "assistant", "content": "third response"},
         ]
 
@@ -523,13 +750,48 @@ class TestMaybeAutoTitle:
             maybe_auto_title(
                 db,
                 "sess-1",
-                "third request",
+                "same request",
                 "third response",
                 history,
             )
 
         mock_thread.assert_not_called()
         mock_auto.assert_not_called()
+
+    def test_internal_only_history_never_starts_a_title_thread(self):
+        from tools.process_registry import format_process_notification
+
+        delegation = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg-1",
+                "goal": "Inspect the title gate",
+                "status": "completed",
+                "summary": "Done.",
+            }
+        )
+        history = [
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+            {"role": "assistant", "content": "summary"},
+            {
+                "role": "user",
+                "content": "model changed",
+                "display_kind": "model_switch",
+            },
+            {"role": "user", "content": delegation},
+            {"role": "assistant", "content": "notification handled"},
+        ]
+
+        with patch("agent.title_generator.threading.Thread") as thread_cls:
+            maybe_auto_title(
+                MagicMock(),
+                "sess-internal",
+                MAX_ITERATIONS_SUMMARY_REQUEST,
+                "notification handled",
+                history,
+            )
+
+        thread_cls.assert_not_called()
 
 
 class TestAutoTitleDuplicateHandling:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -10,7 +10,9 @@ from agent.title_generator import (
     maybe_auto_title,
     _title_language,
 )
+from agent.context_compressor import SUMMARY_PREFIX
 from hermes_state import SessionDB
+from tools.todo_tool import TODO_INJECTION_HEADER
 
 
 class TestGenerateTitle:
@@ -188,6 +190,42 @@ class TestAutoTitleSession:
 
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
+
+    def test_fires_when_first_exchange_contains_internal_user_scaffolding(self):
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "Investigate the Telegram title bug"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "done"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nCompacted work so far"},
+            {
+                "role": "user",
+                "content": f"{TODO_INJECTION_HEADER}\n- Finish the regression test",
+            },
+            {"role": "assistant", "content": "The issue is fixed."},
+        ]
+
+        with patch("agent.title_generator.threading.Thread") as thread_cls:
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "Investigate the Telegram title bug",
+                "The issue is fixed.",
+                history,
+            )
+
+        thread_cls.assert_called_once()
+        thread_cls.return_value.start.assert_called_once_with()
 
     def test_skips_if_not_first_exchange(self):
         """Should not fire for conversations with more than 2 user messages."""

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -188,6 +188,129 @@ class TestAutoTitleSession:
 
 
 
+class TestRealUserMessageClassification:
+    """Shared classifier coverage for the title gate and compression."""
+
+    def test_compaction_metadata_and_projected_content_are_internal(self):
+        from agent.context_compressor import (
+            COMPRESSED_SUMMARY_METADATA_KEY,
+            LEGACY_SUMMARY_PREFIX,
+            SUMMARY_PREFIX,
+            _HISTORICAL_SUMMARY_PREFIXES,
+        )
+        from agent.conversation_compression import is_real_user_message
+
+        marked = {
+            "role": "user",
+            "content": "summary body",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+        projected = {
+            "role": "user",
+            "content": f"{SUMMARY_PREFIX}\nsummary body",
+        }
+        legacy = {
+            "role": "user",
+            "content": f"{LEGACY_SUMMARY_PREFIX}\nsummary body",
+        }
+        historical = {
+            "role": "user",
+            "content": f"{_HISTORICAL_SUMMARY_PREFIXES[0]}\nsummary body",
+        }
+        structured = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"{SUMMARY_PREFIX}\nsummary body",
+                }
+            ],
+        }
+
+        for message in (marked, projected, legacy, historical, structured):
+            assert not is_real_user_message(message)
+
+    def test_todo_and_compression_continuation_rows_are_internal(self):
+        from agent.context_compressor import (
+            COMPRESSION_CONTINUATION_USER_CONTENT,
+            _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+        )
+        from agent.conversation_compression import is_real_user_message
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        messages = [
+            {
+                "role": "user",
+                "content": f"{TODO_INJECTION_HEADER}\n- [>] Continue",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"{TODO_INJECTION_HEADER}\n- [>] Continue",
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": COMPRESSION_CONTINUATION_USER_CONTENT,
+            },
+            {
+                "role": "user",
+                "content": _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+            },
+        ]
+
+        assert all(not is_real_user_message(message) for message in messages)
+
+    def test_exact_max_iteration_summary_request_is_internal(self):
+        from agent.conversation_compression import is_real_user_message
+        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+
+        assert not is_real_user_message(
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST}
+        )
+        assert not is_real_user_message(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": MAX_ITERATIONS_SUMMARY_REQUEST,
+                    }
+                ],
+            }
+        )
+
+    def test_existing_synthetic_flags_are_internal(self):
+        from agent.conversation_compression import (
+            _SYNTHETIC_USER_FLAGS,
+            is_real_user_message,
+        )
+
+        for flag in _SYNTHETIC_USER_FLAGS:
+            message = {"role": "user", "content": "runtime row", flag: True}
+            assert not is_real_user_message(message), flag
+
+    def test_internal_phrases_inside_ordinary_user_content_remain_real(self):
+        from agent.context_compressor import SUMMARY_PREFIX
+        from agent.conversation_compression import is_real_user_message
+        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+        from tools.todo_tool import TODO_INJECTION_HEADER
+
+        contents = [
+            f"Why did Hermes say: {MAX_ITERATIONS_SUMMARY_REQUEST}",
+            f"Please explain this marker: {TODO_INJECTION_HEADER}",
+            f"Please analyze this header:\n{SUMMARY_PREFIX}",
+        ]
+
+        assert all(
+            is_real_user_message({"role": "user", "content": content})
+            for content in contents
+        )
+
+
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
 
@@ -274,9 +397,139 @@ class TestMaybeAutoTitle:
                 runtime_validator=None,
             )
 
+    def test_fires_with_max_iteration_scaffolding(self):
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "Investigate the Telegram rename bug"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call-1"}],
+            },
+            {
+                "role": "user",
+                "content": (
+                    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were "
+                    "compacted into this summary."
+                ),
+            },
+            {"role": "assistant", "content": "Continuing the investigation."},
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] Find the root cause"
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call-2"}],
+            },
+            {
+                "role": "user",
+                "content": (
+                    "You've reached the maximum number of tool-calling iterations allowed. "
+                    "Please provide a final response summarizing what you've found and "
+                    "accomplished so far, without calling any more tools."
+                ),
+            },
+            {"role": "assistant", "content": "The title gate counted scaffolding."},
+        ]
 
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
 
+            called = threading.Event()
+            mock_auto.side_effect = lambda *args, **kwargs: called.set()
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "Investigate the Telegram rename bug",
+                "The title gate counted scaffolding.",
+                history,
+            )
+            assert called.wait(timeout=10), "auto_title thread never ran"
 
+        mock_auto.assert_called_once()
+
+    def test_fires_with_two_real_user_turns_plus_internal_scaffolding(self):
+        from agent.context_compressor import (
+            COMPRESSION_CONTINUATION_USER_CONTENT,
+            SUMMARY_PREFIX,
+        )
+        from agent.internal_user_messages import MAX_ITERATIONS_SUMMARY_REQUEST
+
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "first request"},
+            {"role": "assistant", "content": "first response"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary body"},
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] Continue"
+                ),
+            },
+            {"role": "user", "content": "second request"},
+            {"role": "assistant", "content": "working"},
+            {"role": "user", "content": COMPRESSION_CONTINUATION_USER_CONTENT},
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+            {"role": "assistant", "content": "final response"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *args, **kwargs: called.set()
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "second request",
+                "final response",
+                history,
+            )
+            assert called.wait(timeout=10), "auto_title thread never ran"
+
+        mock_auto.assert_called_once()
+
+    def test_skips_with_three_real_user_turns_plus_internal_scaffolding(self):
+        from agent.context_compressor import SUMMARY_PREFIX
+
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "first request"},
+            {"role": "assistant", "content": "first response"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\nsummary body"},
+            {"role": "user", "content": "second request"},
+            {"role": "assistant", "content": "second response"},
+            {
+                "role": "user",
+                "content": (
+                    "[Your active task list was preserved across context compression]\n"
+                    "- [>] Continue"
+                ),
+            },
+            {"role": "user", "content": "third request"},
+            {"role": "assistant", "content": "third response"},
+        ]
+
+        with (
+            patch("agent.title_generator.threading.Thread") as mock_thread,
+            patch("agent.title_generator.auto_title_session") as mock_auto,
+        ):
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "third request",
+                "third response",
+                history,
+            )
+
+        mock_thread.assert_not_called()
+        mock_auto.assert_not_called()
 
 
 class TestAutoTitleDuplicateHandling:

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -153,6 +153,78 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     )
 
 
+@pytest.mark.asyncio
+async def test_internal_event_marks_persisted_user_turn_hidden(monkeypatch, tmp_path):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": None,
+            "error": "synthetic turn stopped early",
+            "messages": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    event = _event()
+    event.internal = True
+
+    await runner._handle_message_with_agent(
+        event, _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert (
+        runner._run_agent.await_args.kwargs.get("persist_user_display_kind")
+        == "hidden"
+    )
+    persisted_user_entries = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2
+        and isinstance(call.args[1], dict)
+        and call.args[1].get("role") == "user"
+    ]
+    assert persisted_user_entries
+    assert persisted_user_entries[-1]["display_kind"] == "hidden"
+
+
+@pytest.mark.asyncio
+async def test_internal_event_does_not_hide_queued_genuine_user_turn(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "queued turn completed",
+            "messages": [
+                {"role": "user", "content": "internal wake"},
+                {"role": "assistant", "content": "wake handled"},
+                {"role": "user", "content": "genuine queued request"},
+                {"role": "assistant", "content": "queued turn completed"},
+            ],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+    event = _event()
+    event.internal = True
+
+    await runner._handle_message_with_agent(
+        event, _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    persisted_user_entries = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2
+        and isinstance(call.args[1], dict)
+        and call.args[1].get("role") == "user"
+    ]
+    assert len(persisted_user_entries) == 2
+    assert persisted_user_entries[0]["display_kind"] == "hidden"
+    assert "display_kind" not in persisted_user_entries[1]
+
+
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─
 
 
@@ -189,5 +261,3 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
 
 
 # ── Test 4: normal path (new_messages found) uses skip_db=True ────────
-
-

--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -110,6 +110,7 @@ async def test_fifo_enqueued_continuation_is_drained_without_new_user_message():
                 text=CONTINUATION_TEXT,
                 message_type=MessageType.TEXT,
                 source=src,
+                internal=True,
             )
             adapter._pending_messages[key] = cont
         return f"reply-{len(handled)}"
@@ -199,3 +200,4 @@ async def test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains(hermes_
     assert adapter._pending_messages[adapter_key].text.startswith(
         "[Continuing toward your standing goal]"
     )
+    assert adapter._pending_messages[adapter_key].internal is True

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -51,13 +51,21 @@ class CaptureAdapter(BasePlatformAdapter):
 
 class CaptureQueuedNativeImageAgent:
     calls = []
+    display_kinds = []
 
     def __init__(self, **kwargs):
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
 
-    def run_conversation(self, message, conversation_history=None, task_id=None):
+    def run_conversation(
+        self,
+        message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_display_kind=None,
+    ):
         type(self).calls.append(message)
+        type(self).display_kinds.append(persist_user_display_kind)
         return {
             "final_response": f"done-{len(type(self).calls)}",
             "messages": [],
@@ -93,6 +101,7 @@ def _make_runner(adapter):
 @pytest.mark.asyncio
 async def test_queued_followup_uses_pending_event_session_key_for_native_images(monkeypatch, tmp_path):
     CaptureQueuedNativeImageAgent.calls = []
+    CaptureQueuedNativeImageAgent.display_kinds = []
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -149,3 +158,52 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+    assert CaptureQueuedNativeImageAgent.display_kinds == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_queued_internal_followup_propagates_hidden_display_kind(
+    monkeypatch, tmp_path
+):
+    CaptureQueuedNativeImageAgent.calls = []
+    CaptureQueuedNativeImageAgent.display_kinds = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureQueuedNativeImageAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+    )
+    adapter._pending_messages["agent:main:telegram:group:-1001"] = MessageEvent(
+        text="generic internal completion",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-internal-followup",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+    assert result["final_response"] == "done-2"
+    assert CaptureQueuedNativeImageAgent.display_kinds == [None, "hidden"]

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -651,11 +651,10 @@ async def test_heavy_first_exchange_auto_title_persists_and_renames_bound_topic(
     runner = _make_runner(session_db=db)
     runner._gateway_loop = asyncio.get_running_loop()
     monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
-    monkeypatch.setattr(
-        title_generator,
-        "generate_title",
-        lambda *_args, **_kwargs: "Heavy First Turn",
-    )
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    title_response = MagicMock()
+    title_response.choices[0].message.content = "  Heavy First Turn  "
+    monkeypatch.setattr(title_generator, "call_llm", lambda **_kwargs: title_response)
 
     rename_done = threading.Event()
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -621,6 +621,99 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_heavy_first_exchange_auto_title_persists_and_renames_bound_topic(
+    tmp_path, monkeypatch
+):
+    import asyncio
+    import threading
+
+    import agent.title_generator as title_generator
+    from agent.context_compressor import SUMMARY_PREFIX
+    from tools.todo_tool import TODO_INJECTION_HEADER
+
+    session_id = "sess-heavy-title"
+    source = _make_source(thread_id="42")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session(session_id, source="telegram", user_id="208214988")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id=session_id,
+    )
+
+    binding_calls = MagicMock(wraps=db.get_telegram_topic_binding)
+    monkeypatch.setattr(db, "get_telegram_topic_binding", binding_calls)
+
+    runner = _make_runner(session_db=db)
+    runner._gateway_loop = asyncio.get_running_loop()
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(
+        title_generator,
+        "generate_title",
+        lambda *_args, **_kwargs: "Heavy First Turn",
+    )
+
+    rename_done = threading.Event()
+
+    async def record_rename(**_kwargs):
+        rename_done.set()
+
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.rename_dm_topic = AsyncMock(side_effect=record_rename)
+    callback_seen = []
+
+    def title_callback(title):
+        callback_seen.append(db.get_session_title(session_id))
+        runner._schedule_telegram_topic_title_rename(source, session_id, title)
+
+    history = [
+        {"role": "user", "content": "Fix Telegram topic auto-titling"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call-1", "type": "function"}],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "inspection complete",
+        },
+        {
+            "role": "user",
+            "content": f"{SUMMARY_PREFIX}\nEarlier investigation was compacted.",
+        },
+        {
+            "role": "user",
+            "content": f"{TODO_INJECTION_HEADER}\n- [ ] Finish the title fix",
+        },
+        {"role": "assistant", "content": "The fix is complete."},
+    ]
+
+    title_generator.maybe_auto_title(
+        db,
+        session_id,
+        "Fix Telegram topic auto-titling",
+        "The fix is complete.",
+        history,
+        title_callback=title_callback,
+    )
+
+    assert await asyncio.to_thread(rename_done.wait, 10)
+    assert callback_seen == ["Heavy First Turn"]
+    assert db.get_session_title(session_id) == "Heavy First Turn"
+    binding_calls.assert_called_once_with(chat_id="208214988", thread_id="42")
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Heavy First Turn",
+    )
+
+
+@pytest.mark.asyncio
 async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
     """Unauthorized DMs cannot flip multi-session mode on."""
     import gateway.run as gateway_run
@@ -761,4 +854,3 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 # ---------------------------------------------------------------------------
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
-

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10120,7 +10120,13 @@ def _run_prompt_submit(
                 session["running"] = True
             try:
                 _emit("message.start", sid)
-                _run_prompt_submit(rid, sid, session, goal_followup)
+                _run_prompt_submit(
+                    rid,
+                    sid,
+                    session,
+                    goal_followup,
+                    display_kind="hidden",
+                )
             except Exception as _cont_exc:
                 print(
                     f"[tui_gateway] goal continuation dispatch failed: "


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram DM Topic Mode sessions that remain on their placeholder topic name after a heavy first turn.

The title gate counted every persisted `role="user"` row. Hermes also uses that wire role for model-facing scaffolding such as compressed summaries, TODO snapshots, continuation/recovery prompts, delegation completions, and process notifications. A single human request plus two internal rows therefore looked like three human turns and skipped title generation before any title was persisted or Telegram rename callback was scheduled.

This PR makes the title gate use the same canonical genuine-user provenance classifier as compression. It keeps the intended boundary—one or two genuine human turns are eligible, three are not—and rejects an internal current trigger even when an earlier human turn exists. Structured image, audio, and document input remains genuine.

The follow-up commits add the current-trigger guard, merged-compaction handling, explicit runtime provenance, narrow producer-aligned legacy matching, and end-to-end regression coverage. I also reviewed the open approaches in #76856 and #76867; this PR covers boundary and provenance cases those patches do not.

## Related Issue

Fixes #76842

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Use `is_real_user_message()` for both first-exchange counting and current-trigger validation in `maybe_auto_title()`.
- Preserve genuine structured media and genuine content merged into compressed-summary carriers while excluding standalone internal summaries and synthetic bookkeeping rows.
- Centralize exact continuation, recovery, CLI handoff, goal continuation, delegation, and process-notification wire formats so producers and provenance checks stay aligned.
- Carry explicit hidden/internal provenance through direct, recursive, fallback, and TUI goal-continuation persistence paths without hiding a genuinely queued human turn.
- Keep compressor topic/fallback extraction aligned with the shared classifier.
- Add an end-to-end Telegram test covering generated-title normalization, persistence, callback scheduling, topic binding, and exactly one rename.

No Telegram API retry behavior is added; the failure occurs before a rename request exists.

## How to Test

1. Run the primary title, compression, gateway, media, and Telegram matrix:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/agent/test_title_generator.py \
     tests/gateway/test_telegram_topic_mode.py \
     tests/agent/test_compression_concurrent_fork.py \
     tests/agent/test_context_compressor.py \
     tests/agent/test_message_content.py \
     tests/gateway/test_internal_event_bypass_pairing.py \
     tests/gateway/test_goal_continuation_drain.py \
     tests/gateway/test_42039_duplicate_user_message.py \
     tests/gateway/test_queued_native_image_session_key.py \
     -v --tb=long
   ```

   Result: **229 passed, 0 failed**.

2. Run the follow-on compression suites and max-iteration replay checks from the issue report:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/agent/test_compressed_summary_metadata.py \
     tests/agent/test_context_compressor_zero_user_provenance.py \
     tests/agent/test_compression_rotation_state.py \
     tests/agent/test_compressor_actionable_tail_anchor.py \
     tests/agent/test_compressor_assistant_tail_anchor.py \
     -v --tb=long

   .venv/bin/python -m pytest \
     tests/run_agent/test_run_agent.py::TestHandleMaxIterations \
     tests/agent/test_api_content_sidecar.py::TestMaxIterationsSummaryReplay \
     -q -o 'addopts='
   ```

   Result: **49 passed** and **10 passed**, 0 failed.

3. Run restart/redaction boundaries and the TUI continuation suite:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/gateway/test_restart_resume_pending.py \
     tests/agent/test_compaction_redaction_boundaries.py \
     tests/tui_gateway/test_auto_continue.py \
     -v --tb=long
   ```

   Result across the same files after rebase: **31 + 8 + 15 passed**, 0 failed.

4. Run static/import/cross-platform checks for every changed Python file:

   ```bash
   git diff --check origin/main
   git diff --name-only origin/main -- '*.py' | xargs .venv/bin/ruff check
   git diff --name-only origin/main -- '*.py' | xargs .venv/bin/python -m py_compile
   .venv/bin/python scripts/check-windows-footguns.py --diff=origin/main
   ```

   Result: all checks passed; 18 changed Python files scanned; all 10 changed runtime modules import together in a fresh Python process.

5. A sanitized executable gate probe confirms:

   ```text
   heavy raw user rows=3, genuine turns=1, worker started=true
   internal current trigger, worker started=false
   genuine turns=3, worker started=false
   ```

### Test-suite note

The repository-wide suite is not checked below because this local source environment lacks optional test-only packages (`acp`, `anthropic`, and `aiohttp`), so its collection result is not authoritative. The scoped suites above are green. A broader gateway/TUI run passed 892 tests; one concurrent stdout-writer test flaked in that shared run and passed immediately when rerun alone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and docstrings only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

Not applicable. This is a pre-transport eligibility defect; the end-to-end test verifies persistence, callback, binding resolution, and exactly one Telegram rename without exposing conversation content.
