### PR TITLE
fix(doctor): flag web tool readiness when selected provider is not configured

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -159,6 +159,63 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+def _doctor_web_capability_status():
+    """Per-capability readiness for the web toolset (issue #78412).
+
+    The web registry gate (``check_web_api_key``) treats the *explicitly
+    selected* provider as available even when it cannot initialize — that is
+    intentional so dispatchers can surface a precise "X_API_KEY is not set"
+    error instead of silently rerouting — but it made doctor print a green
+    ``✓ web`` while the first ``web_search`` call fails deterministically.
+
+    Returns a list of ``(label, detail, ok)`` tuples covering ``web search``
+    and ``web extract`` when the user has explicitly selected a backend
+    (``web.search_backend`` / ``web.extract_backend`` / ``web.backend``), or
+    ``None`` when nothing is explicitly configured (doctor then keeps the
+    plain toolset-level line) or when the web toolset is intentionally
+    disabled (no actionable warnings for disabled toolsets).
+
+    Resolution mirrors the runtime dispatchers
+    (``tools.web_tools._get_search_backend`` / ``_get_extract_backend``) and
+    readiness uses the same side-effect-free availability probe
+    (``tools.web_tools._is_backend_available``), so the verdict matches what
+    an actual ``web_search`` / ``web_extract`` call would do.
+    """
+    enabled = _enabled_cli_toolsets_for_doctor()
+    if enabled is not None and "web" not in enabled:
+        return None
+    try:
+        from tools.web_tools import (
+            _get_extract_backend,
+            _get_search_backend,
+            _is_backend_available,
+            _load_web_config,
+        )
+    except Exception:
+        return None
+    try:
+        cfg = _load_web_config()
+        explicit = (cfg.get("backend") or "").strip()
+    except Exception:
+        return None
+
+    lines = []
+    for capability, resolver in (
+        ("search", _get_search_backend),
+        ("extract", _get_extract_backend),
+    ):
+        selected = (cfg.get(f"{capability}_backend") or "").strip() or explicit
+        if not selected:
+            continue
+        backend = resolver()
+        label = f"web {capability}"
+        if _is_backend_available(backend):
+            lines.append((label, f"({backend})", True))
+        else:
+            lines.append((label, f"({selected} selected; provider not configured)", False))
+    return lines or None
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     updated_available = list(available)
@@ -2540,6 +2597,19 @@ def run_doctor(args):
         
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})
+            if tid == "web":
+                # Issue #78412: web's registry gate reports the explicitly
+                # selected provider as available even when it cannot
+                # initialize, so doctor must report per-capability readiness
+                # instead of a green check that overstates provider health.
+                capability_status = _doctor_web_capability_status()
+                if capability_status is not None:
+                    for label, detail, ok in capability_status:
+                        if ok:
+                            check_ok(label, detail)
+                        else:
+                            check_warn(label, detail)
+                    continue
             check_ok(info.get("name", tid), _doctor_tool_availability_detail(tid))
         
         for item in unavailable:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -166,6 +166,125 @@ class TestDoctorToolAvailabilityOverrides:
         assert unavailable == [kanban_entry]
 
 
+class TestDoctorWebProviderReadiness:
+    """Issue #78412: web must not get a green check when its selected provider is not ready."""
+
+    def _patch_web_tools(self, monkeypatch, cfg, availability=None):
+        """Stub tools.web_tools resolution so tests avoid real env/config reads."""
+        import tools.web_tools as wt
+
+        availability = availability or {}
+        monkeypatch.setattr(wt, "_load_web_config", lambda: cfg)
+        monkeypatch.setattr(
+            wt, "_get_search_backend",
+            lambda: (cfg.get("search_backend") or "").strip() or (cfg.get("backend") or "").strip() or "firecrawl",
+        )
+        monkeypatch.setattr(
+            wt, "_get_extract_backend",
+            lambda: (cfg.get("extract_backend") or "").strip() or (cfg.get("backend") or "").strip() or "firecrawl",
+        )
+        monkeypatch.setattr(wt, "_is_backend_available", lambda backend: availability.get(backend, False))
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"web"})
+
+    def test_explicit_provider_without_credentials_warns(self, monkeypatch):
+        cfg = {"backend": "firecrawl", "search_backend": "", "extract_backend": ""}
+        self._patch_web_tools(monkeypatch, cfg, availability={})
+
+        status = doctor._doctor_web_capability_status()
+
+        assert status == [
+            ("web search", "(firecrawl selected; provider not configured)", False),
+            ("web extract", "(firecrawl selected; provider not configured)", False),
+        ]
+
+    def test_configured_provider_is_green(self, monkeypatch):
+        cfg = {"backend": "firecrawl", "search_backend": "", "extract_backend": ""}
+        self._patch_web_tools(monkeypatch, cfg, availability={"firecrawl": True})
+
+        status = doctor._doctor_web_capability_status()
+
+        assert status == [
+            ("web search", "(firecrawl)", True),
+            ("web extract", "(firecrawl)", True),
+        ]
+
+    def test_mixed_search_ready_extract_unconfigured(self, monkeypatch):
+        cfg = {"backend": "", "search_backend": "ddgs", "extract_backend": "firecrawl"}
+        self._patch_web_tools(monkeypatch, cfg, availability={"ddgs": True})
+
+        status = doctor._doctor_web_capability_status()
+
+        assert status == [
+            ("web search", "(ddgs)", True),
+            ("web extract", "(firecrawl selected; provider not configured)", False),
+        ]
+
+    def test_ddgs_selected_but_package_absent_warns(self, monkeypatch):
+        cfg = {"backend": "", "search_backend": "ddgs", "extract_backend": ""}
+        self._patch_web_tools(monkeypatch, cfg, availability={})
+
+        status = doctor._doctor_web_capability_status()
+
+        assert status == [
+            ("web search", "(ddgs selected; provider not configured)", False),
+        ]
+
+    def test_no_explicit_backend_keeps_toolset_line(self, monkeypatch):
+        cfg = {"backend": "", "search_backend": "", "extract_backend": ""}
+        self._patch_web_tools(monkeypatch, cfg, availability={"tavily": True})
+
+        assert doctor._doctor_web_capability_status() is None
+
+    def test_disabled_web_gets_no_provider_warning(self, monkeypatch):
+        cfg = {"backend": "firecrawl", "search_backend": "", "extract_backend": ""}
+        self._patch_web_tools(monkeypatch, cfg, availability={})
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"terminal"})
+
+        assert doctor._doctor_web_capability_status() is None
+
+    def test_doctor_output_warns_instead_of_green_check(self, monkeypatch, tmp_path):
+        """End-to-end: Tool Availability shows a warning, never '✓ web'."""
+        import tools.web_tools as wt
+
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("web:\n  backend: firecrawl\n", encoding="utf-8")
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        monkeypatch.setattr(wt, "_load_web_config", lambda: {"backend": "firecrawl", "search_backend": "", "extract_backend": ""})
+        monkeypatch.setattr(wt, "_get_search_backend", lambda: "firecrawl")
+        monkeypatch.setattr(wt, "_get_extract_backend", lambda: "firecrawl")
+        monkeypatch.setattr(wt, "_is_backend_available", lambda backend: False)
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"web"})
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (["web"], []),
+            TOOLSET_REQUIREMENTS={"web": {"name": "web"}},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        out = buf.getvalue()
+        assert "⚠ web search (firecrawl selected; provider not configured)" in out
+        assert "⚠ web extract (firecrawl selected; provider not configured)" in out
+        assert "✓ web\n" not in out
+        assert "✓ web search" not in out
+
+
 
 
 class TestHonchoDoctorConfigDetection:


### PR DESCRIPTION
## Summary

`hermes doctor` reported `✓ web` in **Tool Availability** whenever the web toolset was enabled and a backend was explicitly selected, even when that provider could not initialize (e.g. `firecrawl` selected with no `FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` and no managed credentials). This made "tool installed" look like "provider ready", although the first `web_search` call fails deterministically. Doctor now reports `web search` and `web extract` readiness separately, mirroring the runtime resolution path.

## Root Cause

The web registry gate (`tools.web_tools.check_web_api_key`) resolves the *explicitly selected* provider via `agent.web_search_registry.get_active_search_provider()` / `get_active_extract_provider()`. That resolution intentionally ignores `is_available()` so dispatchers can surface a precise "`X_API_KEY` is not set" error instead of silently rerouting — but `check_web_api_key()` then treats a resolved provider as "available", so the web toolset passes the registry gate and doctor prints a green check even when the selected provider has no credentials.

## Change

`hermes_cli/doctor.py` special-cases the `web` toolset in the Tool Availability section:

- When the user has explicitly selected a backend (`web.search_backend` / `web.extract_backend` / `web.backend`), each capability is resolved through the same runtime path (`tools.web_tools._get_search_backend` / `_get_extract_backend`) and probed with the same side-effect-free availability check (`_is_backend_available`).
- Ready providers get a green per-capability line: `✓ web search (ddgs)`.
- Selected-but-unconfigured providers get a warning instead of a green check: `⚠ web search (firecrawl selected; provider not configured)`.
- Toolsets with no explicit backend selection keep the plain toolset-level line (`✓ web`).
- Intentionally disabled web toolsets produce no new actionable warnings.
- No other toolset behavior changes.

## Verification

Reproduced the issue with a clean `HERMES_HOME` (`web.backend=firecrawl`, web enabled, no credentials):

| Scenario | Before | After |
|---|---|---|
| firecrawl selected, no creds | `✓ web` | `⚠ web search (firecrawl selected; provider not configured)` + `⚠ web extract (…)` |
| firecrawl selected, key set | `✓ web` | `✓ web search (firecrawl)` + `✓ web extract (firecrawl)` |
| ddgs search + firecrawl extract, no creds | `✓ web` | mixed per-capability status |
| web disabled | `✓ web` | `✓ web` (no actionable provider warning) |

Added 7 regression tests in `tests/hermes_cli/test_doctor.py`: explicit provider without credentials → warning; configured provider → green; mixed capability status; ddgs selected but package absent → search warning; no explicit backend keeps the toolset line; disabled web gets no provider warning; end-to-end doctor output never shows `✓ web` for an unready provider. Full `tests/hermes_cli/test_doctor.py` suite passes (56 passed).

Closes #78412
