### PR TITLE
feat(skills): raise SKILL_PROMPT_DESC_LIMIT 60->240

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -830,7 +830,7 @@ def resolve_skill_config_values(
 
 # ── Description extraction ────────────────────────────────────────────────
 
-SKILL_PROMPT_DESC_LIMIT = 60
+SKILL_PROMPT_DESC_LIMIT = 240
 
 
 def _normalize_skill_description(frontmatter: Dict[str, Any]) -> str:


### PR DESCRIPTION
# PR: feat(skills): raise SKILL_PROMPT_DESC_LIMIT to 240

## What

Raise the skill-description character limit baked into the system prompt
from 60 → 240 characters.

## Why

- The current 60-char limit truncates real-world skill descriptions, leaving
  the model with sentence fragments instead of usable trigger signals.
- Issue #429 ("Skill Lifecycle Quality") explicitly flags this as a problem
  and discusses raising the limit to 200 chars. We pick 240 (4× the current
  cap) for headroom; the model is free to ignore extra detail.
- This is the single highest-leverage change among the 4 customizations
  in this user's local fork. Other customizations (snapshot v3, alwaysApply,
  [MANDATORY] tag) layer on top of this and are kept in the fork until
  upstream indicates direction.

## Diff

```diff
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -827,7 +827,7 @@ def resolve_skill_config_values(

 # ── Description extraction ────────────────────────────────────────────────

-SKILL_PROMPT_DESC_LIMIT = 60
+SKILL_PROMPT_DESC_LIMIT = 240
```

## Risk

- **Prompt size**: 60→240 on ~90 skills is ~16K extra chars in the system
  prompt. Not free, but not catastrophic. (cf. issue #429 estimates 12K for
  60→200 on the same skill count.)
- **Backward compat**: descriptions > 240 chars get truncated to 237 + "...",
  matching the existing behavior. No breaking change for callers.
- **No behavior change for short descriptions** — they still render in full.

## Test plan

- [x] existing `test_prompt_builder.py::test_skill_desc_truncation` updated
      to assert 240-char cap (this is what `patches/0002-*.patch` covers)
- [x] ran `python patches/audit-fork-upstream.py` against main — confirmed
      0/4 customizations adopted (this is the only customization submitted
      in this PR; v3 / alwaysApply / MANDATORY tag stay in the fork)
- [x] `git apply --check --3way` on current upstream main: clean

## Related

- Issue #429 — Skill Lifecycle Quality (open, discusses 60→200)
- This user's local fork: `Rosenls/hermes-env` tracks the remaining 3
  customizations (snapshot v3 / alwaysApply / MANDATORY tag) which depend
  on this change being merged first.
