### PR TITLE
fix(buzz): flat thread replies — anchor to thread root, not comment

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -609,7 +609,31 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        # Flat threads: prefer the thread ROOT as the reply target. Replying
+        # to a mid-thread comment makes buzz-cli resolve the root and emit
+        # root+reply e-tags, which the Buzz client renders as a NESTED
+        # sub-thread the user must click to open. Replying to the root emits
+        # a single reply e-tag → the answer stays flat inside the thread
+        # (same shape as the user's own in-thread messages). Top-level
+        # messages have no thread_id, so reply_to (the message itself) is
+        # used — a single reply tag there too.
+        #
+        # POLICY: this intentionally discards the mid-thread comment anchor
+        # whenever a thread root is known — the agent no longer replies to a
+        # specific comment inside a thread. Do not "fix" that back without
+        # accepting nested sub-threads in the Buzz client.
+        thread_id = (metadata or {}).get("thread_id") if isinstance(metadata, dict) else None
+        if reply_to and not thread_id:
+            # thread_id is only populated by _thread_id_from_event (the
+            # thread-routing fix). If a reply anchor exists but the root is
+            # missing, that fix is NOT active — the reply falls back to the
+            # comment anchor and nested sub-threads return.
+            logger.warning(
+                "Buzz: reply_to=%s present but thread_id missing — thread routing fix "
+                "inactive, reply will anchor to the comment (nested sub-thread risk)",
+                reply_to,
+            )
+        reply_target = thread_id or reply_to
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -409,6 +409,121 @@ class TestBuzzAdapterSend:
 
 
     @pytest.mark.asyncio
+    async def test_send_flat_thread_prefers_root_over_comment(self):
+        """In-thread replies must anchor to the thread ROOT, not the specific
+        comment. Replying to a mid-thread comment makes buzz-cli resolve the
+        root and emit root+reply e-tags → a nested sub-thread the user must
+        click; replying to the root emits a single reply tag → flat."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        root = "r" * 64
+        comment = "c" * 64
+        await adapter.send(CHANNEL, "answer", reply_to=comment, metadata={"thread_id": root})
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == root
+        assert comment not in args
+
+    @pytest.mark.asyncio
+    async def test_send_top_level_uses_reply_to(self):
+        """No thread root → reply to the triggering message itself (also a
+        single reply tag, flat)."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        msg_id = "m" * 64
+        await adapter.send(CHANNEL, "answer", reply_to=msg_id)
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == msg_id
+
+    @pytest.mark.asyncio
+    async def test_send_root_direct_reply_uses_root(self):
+        """reply_to == thread_id (direct reply to the root itself) — the
+        no-op path: root wins, same value either way."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        root = "r" * 64
+        await adapter.send(CHANNEL, "answer", reply_to=root, metadata={"thread_id": root})
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == root
+
+    @pytest.mark.asyncio
+    async def test_send_thread_id_without_reply_to_uses_root(self):
+        """reply_to None but thread_id set — exercises the left-hand side of
+        the `thread_id or reply_to` short-circuit."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        root = "r" * 64
+        await adapter.send(CHANNEL, "answer", metadata={"thread_id": root})
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == root
+
+    @pytest.mark.asyncio
+    async def test_send_no_anchors_omits_reply_to(self):
+        """reply_to None AND thread_id None — no --reply-to flag at all."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter.send(CHANNEL, "answer")
+
+        args, _ = cli.calls[0]
+        assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_send_metadata_without_thread_id_falls_back(self):
+        """metadata dict present but no thread_id key — the .get() fallback
+        path: reply_to still used."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        msg_id = "m" * 64
+        await adapter.send(CHANNEL, "answer", reply_to=msg_id, metadata={"other": "x"})
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == msg_id
+
+    @pytest.mark.asyncio
+    async def test_send_non_dict_metadata_does_not_crash(self):
+        """metadata is a non-dict (e.g. string) — the isinstance guard keeps
+        .get() from crashing; falls back to reply_to."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt123", "message": ""})
+        adapter._run_cli = cli
+
+        msg_id = "m" * 64
+        await adapter.send(CHANNEL, "answer", reply_to=msg_id, metadata="not-a-dict")
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == msg_id
+
+
+    @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
         img = tmp_path / "shot.png"
         img.write_bytes(b"\x89PNG fake")


### PR DESCRIPTION
## Summary

In a Buzz thread, every agent reply spawned its own clickable nested sub-thread — the user had to click each answer to read it.

**Root cause:** `BuzzAdapter.send()` anchored replies to the triggering *comment* (`--reply-to <comment>`). The buzz CLI, given a mid-thread comment, resolves the thread root and emits root+reply e-tags — the Buzz client renders that as a **nested sub-thread**. The user's own client messages carry a single `reply` e-tag to the thread root → flat. The agent's answers were structurally different (nested) for no reason.

**Fix:** `send()` now prefers `metadata.thread_id` (the thread **root**) over `reply_to` (the specific comment). Replying to the root emits a single `reply` e-tag → the answer stays flat inside the thread, same shape as the user's own in-thread messages. Top-level messages have no `thread_id`, so `reply_to` (the message itself) is used — a single reply tag there too.

**Intentional policy:** this discards the mid-thread comment anchor whenever a thread root is known — the agent no longer replies to a specific comment inside a thread. This is deliberate (flat threads are the Buzz UX convention); the code comment documents it so it isn't "fixed" back.

## Dependency

⚠️ **Requires #78415** (thread-routing fix) to be effective: `metadata.thread_id` is populated by `_thread_id_from_event` from that PR. Without it, `thread_id` is always `None` and this change falls back to the old comment anchor. That state is now **loud**, not silent: `send()` emits a `logger.warning` whenever a reply anchor is present but `thread_id` is missing, so a backport/partial apply can't silently regress. This commit itself is self-contained (compiles, tests pass) — merge #78415 first.

## Test Plan

- `TestBuzzAdapterSend` — 7 cases:
  - `test_send_flat_thread_prefers_root_over_comment` — root wins over comment
  - `test_send_top_level_uses_reply_to` — no thread → the message itself
  - `test_send_root_direct_reply_uses_root` — reply_to == thread_id (no-op path)
  - `test_send_thread_id_without_reply_to_uses_root` — left-hand side of `or` reachable
  - `test_send_no_anchors_omits_reply_to` — neither set → no `--reply-to` flag
  - `test_send_metadata_without_thread_id_falls_back` — `.get()` fallback
  - `test_send_non_dict_metadata_does_not_crash` — `isinstance` guard
- Verified against live relay data: agent reply to a top-level message carries a single `reply` e-tag post-fix; mid-thread replies carry a single `reply` tag to the root (flat).

## Notes

- Pre-existing test failures in `tests/gateway/test_buzz_adapter.py` (`TestMentionGating::test_unaddressed_channel_message_ignored`, `TestDmClassification::test_general_reply_ptagging_self_stays_channel`, `TestDmClassification::test_channel_like_metadata_blocks_latch_even_without_mention`) fail identically on pristine `main` — unrelated to this change.
- Peer-reviewed (reviewer profile): round 1 flagged the silent dependency + missing edge-case tests + undocumented policy trade-off; all addressed in round 2, **APPROVED**.
