### PR TITLE
fix(scripts): use unclaimable noreply identity for Hermes agent email

### DIFF
--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -64,7 +64,7 @@ IGNORED_EMAILS = {
     "noreply@github.com",
     "noreply@nousresearch.com",
     "cursoragent@cursor.com",
-    "hermes@nousresearch.com",
+    "hermes-agent[bot]@users.noreply.github.com",
     "hermes-audit@example.com",
     "nousbot@nousresearch.com",
     "hermes@habibilabs.dev",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1228,7 +1228,7 @@ LEGACY_AUTHOR_MAP = {
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",
-    "hermes@nousresearch.com": "NousResearch",
+    "hermes-agent[bot]@users.noreply.github.com": "NousResearch",
     "reginaldasr@gmail.com": "ReginaldasR",
     "ntconguit@gmail.com": "0xharryriddle",
     "agent@wildcat.local": "ericnicolaides",
@@ -2296,7 +2296,7 @@ def parse_coauthors(body: str) -> list:
         return []
     # AI/bot emails to ignore in co-author trailers
     _ignored_emails = {"noreply@anthropic.com", "noreply@github.com",
-                       "cursoragent@cursor.com", "hermes@nousresearch.com"}
+                       "cursoragent@cursor.com", "hermes-agent[bot]@users.noreply.github.com"}
     _ignored_names = re.compile(r"^(Claude|Copilot|Cursor Agent|GitHub Actions?|dependabot|renovate)", re.IGNORECASE)
     pattern = re.compile(r"Co-authored-by:\s*(.+?)\s*<([^>]+)>", re.IGNORECASE)
     results = []


### PR DESCRIPTION
## Summary

The Hermes agent git identity email `hermes@nousresearch.com` is registered to a real GitHub account (`Rafa-Ross`), so GitHub's email→user resolution attributes every commit (author *or* `Co-authored-by` trailer) carrying that email to that unrelated person — including commits made by other people's Hermes instances. This misattributes community work and reads as impersonation on commit pages.

This PR replaces the colliding address with the unclaimable noreply-style identity `hermes-agent[bot]@users.noreply.github.com` in the repo's release/audit tooling, so the canonical Hermes agent identity is a noreply address that cannot be registered by a human account.

## Root Cause

`hermes@nousresearch.com` is registered as an email on a real GitHub account. GitHub resolves commit emails to account profiles, so any commit with that email is attributed to that account. Static check: `gh api "search/commits?q=author-email:hermes@nousresearch.com"` — every hit (across multiple unrelated users' repos) has `author.login: "Rafa-Ross"`, regardless of who actually ran the agent.

The old email was still referenced in repo tooling (`scripts/contributor_audit.py` and `scripts/release.py`), keeping the colliding address as the canonical bot identity.

## Change

- `scripts/contributor_audit.py`: `IGNORED_EMAILS` entry `hermes@nousresearch.com` → `hermes-agent[bot]@users.noreply.github.com`
- `scripts/release.py`: `LEGACY_AUTHOR_MAP` entry `"hermes@nousresearch.com": "NousResearch"` → `"hermes-agent[bot]@users.noreply.github.com": "NousResearch"`
- `scripts/release.py`: `parse_coauthors()` `_ignored_emails` set entry `hermes@nousresearch.com` → `hermes-agent[bot]@users.noreply.github.com`

No runtime code hardcodes the identity (it comes from the user's git config); these three script locations were the only remaining references to the colliding email in the repo.

## Verification

- `pytest tests/scripts/test_contributor_map.py` → 7 passed
- `grep -rn "hermes@nousresearch.com"` → 0 remaining references in the tree

Closes #78374
