### PR TITLE
fix(file): stop misclassifying large CJK UTF-8 files as binary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -259,6 +259,8 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
             command,
             shell=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             input=kwargs.get("stdin_data"),
         )
@@ -673,3 +675,24 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_large_chinese_utf8_read_not_binary(self, tmp_path):
+        """E2E: a large Chinese UTF-8 file must read as text, not binary.
+
+        Reproduces the original bug: ``read_file`` samples with
+        ``head -c 1000`` (a byte count), which splits a 3-byte CJK character
+        at the boundary; the terminal's ``errors="replace"`` decode turns the
+        fragment into a spurious trailing U+FFFD, which previously made
+        ``_is_likely_binary`` return True for every large CJK file.
+        """
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        path = tmp_path / "chinese.txt"
+        # ~2400 bytes of pure CJK — well past the 1000-byte sample window.
+        path.write_bytes(("你好世界这是一个测试" * 80).encode("utf-8"))
+
+        result = ops.read_file(str(path))
+        assert result.is_binary is False, (
+            f"Chinese UTF-8 file misclassified as binary (error={result.error!r})"
+        )
+        assert result.content is not None
+        assert "你好世界" in result.content

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -35,8 +35,12 @@ class TestIsLikelyBinary:
 
 
     def test_just_above_threshold(self, ops):
-        """301/1000 = 30.1% non-printable → should be binary."""
-        sample = "\x00" * 301 + "a" * 699
+        """301/1000 = 30.1% non-printable control chars → should be binary.
+
+        Uses \\x01 (SOH) rather than NUL so it exercises the 30% ratio rule
+        specifically — NUL is now a hard binary signal (zero-byte detection).
+        """
+        sample = "\x01" * 301 + "a" * 699
         assert ops._is_likely_binary("data.xyz", content_sample=sample) is True
 
     def test_tabs_and_newlines_excluded(self, ops):
@@ -46,10 +50,67 @@ class TestIsLikelyBinary:
 
     def test_content_sample_longer_than_1000(self, ops):
         """Only the first 1000 characters should be analysed."""
-        # First 1000 chars: 200 NUL + 800 printable = 20% → not binary
-        # Remaining 1000 chars: all NUL → ignored by [:1000] slice
-        sample = "\x00" * 200 + "a" * 800 + "\x00" * 1000
+        # First 1000 chars: 200 control chars + 800 printable = 20% → not binary
+        # Remaining 1000 chars: all control chars → ignored by [:1000] slice.
+        # Uses \\x01 (not NUL) so it tests the ratio + slice, not zero-byte.
+        sample = "\x01" * 200 + "a" * 800 + "\x01" * 1000
         assert ops._is_likely_binary("file.xyz", content_sample=sample) is False
+
+    # --- CJK truncation regression ------------------------------------------
+    # `head -c 1000` counts BYTES; a UTF-8 CJK char is 3 bytes, so byte 1000
+    # splits a character and errors="replace" turns the fragment into a
+    # spurious U+FFFD at the *tail* of the sample. That artifact used to make
+    # every large Chinese/Japanese/Korean UTF-8 file look binary. These tests
+    # build the exact sample the terminal produces and assert it is treated as
+    # text.
+
+    def test_chinese_utf8_head_truncation_not_binary(self, ops):
+        """Simulate `head -c 1000` on a large Chinese UTF-8 file."""
+        chinese = ("你好世界这是一个测试" * 80)  # ~2400 bytes of CJK
+        sample_bytes = chinese.encode("utf-8")[:1000]      # head -c 1000
+        truncated = sample_bytes.decode("utf-8", errors="replace")
+        # Sanity: the truncation did produce a trailing replacement char…
+        assert truncated.endswith("\ufffd")
+        # …which must NOT be treated as binary.
+        assert ops._is_likely_binary("zh.txt", content_sample=truncated) is False
+
+    def test_japanese_utf8_head_truncation_not_binary(self, ops):
+        """Same regression for 3-byte Japanese hiragana/katakana/kanji."""
+        jp = "こんにちは世界テスト" * 80
+        truncated = jp.encode("utf-8")[:1000].decode("utf-8", errors="replace")
+        assert truncated.endswith("\ufffd")
+        assert ops._is_likely_binary("ja.txt", content_sample=truncated) is False
+
+    def test_emoji_4byte_truncation_not_binary(self, ops):
+        """4-byte sequences (emoji, astral plane) also split at 1000 bytes."""
+        emoji = "😀😀😀😀😀" * 300
+        truncated = emoji.encode("utf-8")[:1000].decode("utf-8", errors="replace")
+        assert ops._is_likely_binary("emo.txt", content_sample=truncated) is False
+
+    # --- Genuine binary & mojibake still caught -----------------------------
+
+    def test_null_byte_flagged_binary(self, ops):
+        """VSCode-style zero-byte detection: NUL anywhere → binary."""
+        png = bytes([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) \
+              + b"\x00\x00\x00\x0dIHDR" + b"\x00" * 20 + b"data"
+        sample = png.decode("utf-8", errors="replace")
+        assert ops._is_likely_binary("image.dat", content_sample=sample) is True
+
+    def test_body_replacement_char_flagged_binary(self, ops):
+        """Non-trailing U+FFFD (real non-UTF-8 / GBK mojibake) stays binary.
+
+        A GBK file decoded as UTF-8 yields U+FFFD throughout the body, not just
+        at the tail — this must still be flagged so a read→edit→write round-trip
+        can't overwrite the original bytes with mojibake.
+        """
+        gbk = "你好世界".encode("gbk").decode("utf-8", errors="replace")
+        assert "\ufffd" in gbk
+        assert ops._is_likely_binary("gbk.txt", content_sample=gbk) is True
+
+    def test_replacement_char_only_at_tail_is_text(self, ops):
+        """A single trailing U+FFFD (pure truncation artifact) is text."""
+        sample = "普通文本内容" + "\ufffd"
+        assert ops._is_likely_binary("zh.txt", content_sample=sample) is False
 
 
 # =========================================================================

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -892,23 +892,31 @@ class ShellFileOperations(FileOperations):
         if ext in BINARY_EXTENSIONS:
             return True
         
-        # Content analysis: >30% non-printable chars = binary
+        # Content analysis: zero-byte detection (primary) + truncation-safe
+        # replacement-char fallback (secondary).
         if content_sample:
-            # Undecodable bytes: the terminal env decodes stdout with
-            # errors="replace", so any non-UTF-8 byte arrives here already
-            # turned into U+FFFD. That char is "printable" (ord 65533), so the
-            # non-printable ratio below never catches it — and returning the
-            # lossy text would let a read→edit→write round-trip silently
-            # overwrite the original bytes with mojibake. Treat a file whose
-            # sample carries the replacement char as binary (read-only) so the
-            # agent can't corrupt it. Legitimate UTF-8 text effectively never
-            # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            sample = content_sample[:1000]
+
+            # NUL byte = strong binary signal. 0x00 is valid UTF-8, so it
+            # survives the terminal's errors="replace" decode as U+0000 —
+            # unlike U+FFFD this never depends on decode/truncation, and no
+            # common text encoding puts 0x00 in content.
+            if "\x00" in sample:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+
+            # Genuine non-UTF-8 bytes decode to U+FFFD (mojibake) — still flag
+            # those so read→edit→write can't corrupt the file. BUT `head -c
+            # 1000` counts bytes, not chars: it splits a 3-byte CJK char into a
+            # spurious trailing U+FFFD. Ignore a FFFD that is only the last
+            # char; real mojibake is spread through the body.
+            body = sample[:-1] if sample.endswith("\ufffd") else sample
+            if "\ufffd" in body:
+                return True
+
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
-        
+            return non_printable / max(len(sample), 1) > 0.30
+
         return False
     
     def _is_image(self, path: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes #78443.

`read_file` / `read_file_raw` misclassified any sufficiently large CJK / multi-byte UTF-8 file as binary. Root cause: the binary probe samples with `head -c 1000` (a **byte** count), but `_is_likely_binary` checks for `U+FFFD` in the **decoded** string. Byte 1000 splits a 3-byte CJK character, and the terminal's `errors="replace"` decode turns the trailing fragment into a spurious `U+FFFD` → false positive. ASCII/Latin was unaffected (1 byte = 1 char), so it went unnoticed.

## Approach

Adopt VSCode's encoding-agnostic heuristic (NUL-byte detection) as the primary signal, and keep `U+FFFD` as a fallback that is safe against the truncation artifact:

1. **Primary — NUL byte**: `"\x00" in sample` → binary. `0x00` is valid UTF-8, so it survives the terminal's `errors="replace"` decode as `U+0000` across every backend (local / docker / ssh / persistent shell). No common text encoding puts `0x00` in content, so this never depends on decoding or truncation.
2. **Fallback — `U+FFFD`, truncation-safe**: genuine non-UTF-8 / mojibake (GBK, Latin-1) still decodes to `U+FFFD` throughout the body and is still flagged (preserving the read→edit→write mojibake-corruption guard). But a `U+FFFD` that is **only the last character** of the sample is ignored — a `head -c` cut can produce at most one trailing replacement char, whereas real non-UTF-8 content is spread through the body.
3. **Unchanged**: `>30%` non-printable control-char ratio.

## Verification

Reproduced the bug first, then confirmed the fix:

```
chinese = ("你好世界这是一个测试" * 80)          # ~2400 bytes, valid UTF-8
sample  = chinese.encode("utf-8")[:1000]         # what `head -c 1000` reads
decoded = sample.decode("utf-8", errors="replace")
decoded.endswith("\ufffd")                       # True <- spurious, was flagged binary
```

| Content | Before | After |
|---|---|---|
| Large Chinese/Japanese/Korean UTF-8 | ❌ binary (false positive) | ✅ text |
| Large emoji (4-byte) UTF-8 | ❌ binary | ✅ text |
| ASCII / Latin-accented UTF-8 | ✅ text | ✅ text |
| Real binary (PNG w/ NUL bytes) | ✅ binary | ✅ binary |
| GBK / Latin-1 mojibake | ✅ binary | ✅ binary (guard preserved) |

## Tests

- New unit tests in `test_file_operations_edge_cases.py`: CJK/JP/emoji head-truncation → text; NUL → binary; body-FFFD (GBK) → binary; trailing-only FFFD → text.
- New E2E test in `test_file_operations.py`: writes a real >1000-byte Chinese file and asserts `read_file` does **not** return `is_binary`.
- Updated two existing tests that used `\x00` as generic non-printable filler to use `\x01`, so they actually exercise the 30% ratio rule instead of the new NUL short-circuit.
- Fixed `make_real_subprocess_env` to decode with `encoding="utf-8", errors="replace"` like the real local env (`tools/environments/local.py`) — it previously raised `UnicodeDecodeError` on truncated/binary output.

```
scripts/run_tests.sh tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_operations.py
# 2 files, 73 tests passed, 0 failed
```
