### PR TITLE
fix(cron): lifecycle guard crashes with 'embedded null byte' instead of failing open — kills terminal tool (#78256)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -260,6 +260,14 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         descriptor = os.open(path, flags)
     except OSError:
         return None, False
+    except ValueError:
+        # A path the OS cannot even represent — an embedded NUL byte from a
+        # token parsed out of scanned content (#78256). #76762 covered the
+        # NUL-in-*contents* case below and Path.resolve, but ``os.open``
+        # itself raises ValueError (not OSError) for NUL-in-*path*, which
+        # crashed the whole guard instead of failing open. Same semantics as
+        # an unreadable file: nothing to scan.
+        return None, False
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
@@ -268,7 +276,7 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         # chunk tells us if this is a binary (NUL bytes) that should be
         # skipped as "nothing to scan" rather than failing closed (#76762).
         data = os.read(descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1)
-    except OSError:
+    except (OSError, ValueError):
         return None, False
     finally:
         os.close(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -857,3 +857,43 @@ class TestCronCreateLifecycleBlockExtra:
         assert rc == 1
         out = capsys.readouterr().out
         assert "Blocked" in out
+
+
+class TestNulByteReferencedPathFailsOpen:
+    """#78256: a referenced-script path carrying an embedded NUL byte must be
+    skipped ("nothing to scan"), not crash the guard. #76762 established the
+    fail-open contract for NUL bytes in scanned *contents* and Path.resolve,
+    but ``os.open()`` raises ValueError (not OSError) for NUL in the *path*
+    itself — which escaped the OSError-only handler and took down the whole
+    terminal tool for commands like ``python -m pip --version`` whose
+    recursive scan produced such a token."""
+
+    def test_read_referenced_script_nul_path_fails_open(self):
+        from pathlib import Path
+        from cron.lifecycle_guard import _read_referenced_script
+
+        text, unsafe = _read_referenced_script(Path("x\x00y"))
+        assert text is None
+        assert unsafe is False
+
+    def test_guard_survives_nul_byte_in_referenced_script_path(self):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        # A sourced path with an embedded NUL: previously ValueError from
+        # os.open crashed the guard (and the terminal tool call around it).
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "source /tmp/e\x00vil.sh"
+        ) is False
+
+    def test_guard_still_blocks_real_lifecycle_script(self, tmp_path):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n")
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash {script}"
+        ) is True


### PR DESCRIPTION
## Summary

Any terminal command whose recursive script-scan produces a path token with an embedded NUL byte crashes the **entire lifecycle guard** — and the terminal tool call around it — with an unhandled `ValueError: embedded null byte` (#78256; reporter hits it on every `python -m pip …` from inside a v0.20.0 gateway). One-line-class fix restoring the fail-open contract #76762 established.

## Root cause

`_read_referenced_script()` (`cron/lifecycle_guard.py:260`) catches only `OSError` around `os.open()` — but CPython raises **`ValueError`** (not `OSError`) for a NUL byte *in the path itself*:

```python
>>> os.open("a\x00b", os.O_RDONLY)
ValueError: embedded null byte
```

#76762 handled NUL bytes in scanned *contents* (binary detection) and in `Path.resolve` — this is the third member of the same class, one call earlier. Reproducible on current main without any environment specifics:

```python
>>> contains_gateway_lifecycle_command_or_referenced_script("source /tmp/e\x00vil.sh")
ValueError: embedded null byte     # before — crashes guard + terminal tool
False                              # after — fail-open skip, per #76762 semantics
```

## Changes

- `cron/lifecycle_guard.py`: `os.open` gets an explicit `except ValueError` (documented — NUL-in-path is "a path the OS cannot even represent", same semantics as unreadable); the fstat/read block broadened to `(OSError, ValueError)`.
- `tests/hermes_cli/test_gateway_restart_loop.py`: `TestNulByteReferencedPathFailsOpen` — unit (NUL path → `(None, False)`), end-to-end (guard survives the NUL-carrying command), and a positive control (real lifecycle script still blocked).

## Validation

| | before | after |
|---|---|---|
| `_read_referenced_script(Path("x\x00y"))` | `ValueError` escapes | `(None, False)` |
| guard on `source /tmp/e\x00vil.sh` | crash — terminal tool dies | `False` (nothing to scan) |
| guard on script containing `hermes gateway restart` | blocked | blocked (unchanged) |
| `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py` | 2 new tests fail | 85 passed, 0 failed |

## Scope notes

Fail-open here is the guard's documented design (#76762): a token the OS can't even represent as a path is by definition not a readable shell script — there is nothing to scan, and a crashed guard blocks *every* command, which is strictly worse than skipping one unscannable token. The reporter's exact NUL source (their `pip` launcher shape) isn't needed to fix the class: any NUL-carrying token now takes the same skip path as unreadable files.

Fixes #78256.
