### PR TITLE
 clamp session listing limit before SQLite fetch

### DIFF
--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -65,8 +65,15 @@ def query_session_listing(
     ``SessionDB.list_sessions_rich``) and ordered by most-recent activity;
     unnamed sessions stay visible since an id match may be the only handle.
     """
+    try:
+        limit_n = int(limit)
+    except (TypeError, ValueError):
+        limit_n = 10
+    # Cap before fetch_limit = limit * 4 — negative SQL LIMIT is unbounded in
+    # SQLite, and a huge positive can force expensive compression-chain CTEs.
+    limit_n = max(1, min(limit_n, 500))
     query_source = None if include_all_sources else source
-    fetch_limit = max(limit * 4, limit)
+    fetch_limit = max(limit_n * 4, limit_n)
     search = (search_query or "").strip()
     rows = session_db.list_sessions_rich(
         source=query_source,
@@ -83,7 +90,7 @@ def query_session_listing(
         if not include_unnamed and not row.get("title") and not search:
             continue
         result.append(row)
-        if len(result) >= limit:
+        if len(result) >= limit_n:
             break
     return result
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -135,3 +135,57 @@ class TestQuerySessionListingLaneScope:
         )
 
         assert [row["id"] for row in rows] == ["foreign_59"]
+
+
+class TestQuerySessionListingLimitClamp:
+    def test_negative_limit_does_not_fetch_unbounded(self, monkeypatch):
+        calls: list[dict] = []
+
+        class StubDB:
+            def list_sessions_rich(self, **kwargs):
+                calls.append(kwargs)
+                return [
+                    {"id": f"s{i}", "title": f"T{i}", "preview": "", "source": "cli"}
+                    for i in range(20)
+                ]
+
+        rows = query_session_listing(StubDB(), source="cli", limit=-5)
+        assert len(rows) == 1
+        assert calls[0]["limit"] == 4  # max(1 * 4, 1)
+
+    def test_excessive_limit_is_capped(self, monkeypatch):
+        calls: list[dict] = []
+
+        class StubDB:
+            def list_sessions_rich(self, **kwargs):
+                calls.append(kwargs)
+                return [
+                    {"id": f"s{i}", "title": f"T{i}", "preview": "", "source": "cli"}
+                    for i in range(600)
+                ]
+
+        rows = query_session_listing(StubDB(), source="cli", limit=10_000_000)
+        assert len(rows) == 500
+        assert calls[0]["limit"] == 2000  # max(500 * 4, 500)
+
+    def test_zero_limit_floors_to_one(self):
+        class StubDB:
+            def list_sessions_rich(self, **kwargs):
+                return [
+                    {"id": "s1", "title": "A", "preview": "", "source": "cli"},
+                    {"id": "s2", "title": "B", "preview": "", "source": "cli"},
+                ]
+
+        rows = query_session_listing(StubDB(), source="cli", limit=0)
+        assert len(rows) == 1
+
+    def test_invalid_limit_uses_default(self):
+        calls: list[dict] = []
+
+        class StubDB:
+            def list_sessions_rich(self, **kwargs):
+                calls.append(kwargs)
+                return [{"id": "s1", "title": "A", "preview": "", "source": "cli"}]
+
+        query_session_listing(StubDB(), source="cli", limit="nope")
+        assert calls[0]["limit"] == 40  # max(10 * 4, 10)


### PR DESCRIPTION
## Summary
- Clamp shared `query_session_listing` `limit` to 1–500 (default 10) before `fetch_limit = limit * 4` hits `list_sessions_rich`. Negative SQL `LIMIT` is unbounded in SQLite; oversized positives force expensive compression-chain CTE work.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.

