### PR TITLE
clamp list_quick_snapshots limit to 1-500

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1376,6 +1376,15 @@ def list_quick_snapshots(
     hermes_home: Optional[Path] = None,
 ) -> List[Dict[str, Any]]:
     """List existing quick state snapshots, most recent first."""
+    try:
+        limit_n = int(limit)
+    except (TypeError, ValueError):
+        limit_n = 20
+    # Keep listing bounded — zero/negative stops after the first row via
+    # ``len(results) >= limit``, and huge limits force reading every
+    # manifest under state-snapshots/.
+    limit_n = max(1, min(limit_n, 500))
+
     root = _quick_snapshot_root(hermes_home)
     if not root.exists():
         return []
@@ -1391,7 +1400,7 @@ def list_quick_snapshots(
                     results.append(json.load(f))
             except (json.JSONDecodeError, OSError):
                 results.append({"id": d.name, "file_count": 0, "total_size": 0})
-        if len(results) >= limit:
+        if len(results) >= limit_n:
             break
 
     return results

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_list_quick_snapshots_limit_clamp.py
+++ b/tests/hermes_cli/test_list_quick_snapshots_limit_clamp.py
@@ -1,0 +1,41 @@
+"""Clamp list_quick_snapshots pagination before scanning manifests."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_cli.backup import list_quick_snapshots
+
+
+def _seed_snapshots(home, n: int) -> None:
+    root = home / "state-snapshots"
+    root.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        d = root / f"20260101T{i:06d}Z"
+        d.mkdir()
+        (d / "manifest.json").write_text(
+            json.dumps({"id": d.name, "file_count": 1, "total_size": 1}),
+            encoding="utf-8",
+        )
+
+
+def test_list_quick_snapshots_clamps_zero_and_negative(tmp_path):
+    _seed_snapshots(tmp_path, 5)
+    assert len(list_quick_snapshots(limit=0, hermes_home=tmp_path)) == 1
+    assert len(list_quick_snapshots(limit=-5, hermes_home=tmp_path)) == 1
+
+
+def test_list_quick_snapshots_clamps_excessive_limit(tmp_path):
+    _seed_snapshots(tmp_path, 520)
+    rows = list_quick_snapshots(limit=10_000_000, hermes_home=tmp_path)
+    assert len(rows) == 500
+
+
+def test_list_quick_snapshots_default_limit(tmp_path):
+    _seed_snapshots(tmp_path, 30)
+    assert len(list_quick_snapshots(hermes_home=tmp_path)) == 20
+
+
+def test_list_quick_snapshots_invalid_limit_uses_default(tmp_path):
+    _seed_snapshots(tmp_path, 25)
+    assert len(list_quick_snapshots(limit="nope", hermes_home=tmp_path)) == 20


### PR DESCRIPTION
## Summary
- Clamp `list_quick_snapshots` `limit` to 1–500 (default 20). Zero/negative values stop after the first row via `len(results) >= limit`; oversized limits force reading every snapshot manifest.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.

