### PR TITLE
fix(desktop): stop watch windows draining queued prompts

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -2,6 +2,21 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as WindowsStore from '@/store/windows'
+
+const { isWatchWindowMock } = vi.hoisted(() => ({
+  isWatchWindowMock: vi.fn(() => false)
+}))
+
+vi.mock('@/store/windows', async importOriginal => {
+  const actual = await importOriginal<typeof WindowsStore>()
+
+  return {
+    ...actual,
+    isWatchWindow: isWatchWindowMock
+  }
+})
+
 import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $parkedQueueSessions,
@@ -61,6 +76,8 @@ function Harness({
 describe('useBackgroundQueueDrain', () => {
   beforeEach(() => {
     vi.useRealTimers()
+    isWatchWindowMock.mockReset()
+    isWatchWindowMock.mockReturnValue(false)
     clearAllSessionStates()
   })
 
@@ -221,5 +238,28 @@ describe('useBackgroundQueueDrain', () => {
 
     expect(submitText).toHaveBeenCalledTimes(2)
     expect(getQueuedPrompts('stored-session-a')).toHaveLength(0)
+  })
+
+  it('does not submit shared queued prompts from a spectator watch window', async () => {
+    isWatchWindowMock.mockReturnValue(true)
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => false)
+
+    enqueueQueuedPrompt('stored-session-a', { text: 'stay in the primary window', attachments: [] })
+
+    render(
+      <Harness
+        runtimeMap={runtimeMap}
+        selectedStoredSessionId="watched-child"
+        submitText={submitText}
+      />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -15,6 +15,7 @@ import {
 import { notify } from '@/store/notifications'
 import { $sessions, idsShareLineage } from '@/store/session'
 import { $workingSessionIds } from '@/store/session-states'
+import { isWatchWindow } from '@/store/windows'
 
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
 
@@ -151,7 +152,10 @@ export function useBackgroundQueueDrain({
   )
 
   useEffect(() => {
-    if (!enabled) {
+    // Watch windows are spectators for a child session driven elsewhere. They
+    // share the renderer's persisted composer queues, but must never become a
+    // second sender for those queues.
+    if (!enabled || isWatchWindow()) {
       return
     }
 


### PR DESCRIPTION
## Summary

- prevent spectator subagent watch windows from running the shared background composer-queue drain
- keep queued prompts owned by the interactive Desktop window instead of letting a watch renderer become a second sender
- add a regression test proving a watch window neither submits nor removes a queued prompt

## Root cause

Desktop renderer windows share the persisted composer queue. `useBackgroundQueueDrain` was mounted in watch windows as well as interactive windows, so opening a Sub Agent watch window could make that spectator renderer submit an unrelated queued prompt. Repeated failures produced the `Queued message not sent` notification while leaving the entry queued.

The hook now exits before draining when `isWatchWindow()` is true. Normal Desktop windows retain the existing background-drain behavior.

## Scope

This fixes the duplicate queue consumer and the resulting stuck-queue notification. It deliberately does not change subagent `session.resume`, live event mirroring, or gateway-profile routing.

## Test plan

- [x] New regression test fails before the guard (`submitText` called once from the watch renderer)
- [x] `npx vitest run src/app/session/hooks/use-background-queue-drain.test.tsx src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions.test.tsx` — 62 passed
- [x] `npm run test:ui` — 3,366 passed
- [x] `npm run typecheck`
- [x] `npm run lint` — 0 errors (88 pre-existing warnings)
- [x] `git diff --check`
