### PR TITLE
feat(openrouter): surface latest aliases in model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1560,6 +1560,32 @@ def fetch_openrouter_models(
             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
         curated.append((preferred_id, desc))
 
+    # Surface OpenRouter "latest" aliases for already-curated models.
+    #
+    # OpenRouter registers rolling aliases (e.g. `~deepseek/deepseek-v4-flash-latest`)
+    # that track the newest checkpoint in a model family. They are real, callable
+    # catalog entries with their own pricing and tool support, but they appear in
+    # the live /v1/models response under a `~`-prefixed id that is never part of the
+    # curated allowlist — so they were previously invisible in the picker even
+    # though the model they point at was curated. Relying on the alias_target field
+    # (which OpenRouter sets to the concrete checkpoint the alias resolves to)
+    # keeps the picker current without hardcoding each alias into the manifest:
+    # any curated model that gains a `~latest` alias will surface automatically.
+    curated_ids = {mid for mid, _ in curated}
+    for item in live_items:
+        if not isinstance(item, dict):
+            continue
+        alias_id = str(item.get("id") or "").strip()
+        if not alias_id.startswith("~") or alias_id in curated_ids:
+            continue
+        target = item.get("alias_target") or {}
+        target_slug = str(target.get("slug") or "").strip()
+        if not target_slug or target_slug not in curated_ids:
+            continue
+        if not _openrouter_model_supports_tools(item):
+            continue
+        curated.append((alias_id, "latest"))
+
     if not curated:
         return list(_openrouter_catalog_cache or fallback)
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -101,6 +101,129 @@ class TestFetchOpenRouterModels:
         # Image-only model advertised supported_parameters WITHOUT tools → must be dropped.
         assert "google/gemini-3-pro-image-preview" not in ids
 
+    def test_surfaces_latest_alias_for_curated_models(self, monkeypatch):
+        """OpenRouter '~' latest aliases must surface when they point at a curated model.
+
+        OpenRouter registers rolling aliases like
+        `~deepseek/deepseek-v4-flash-latest` that resolve to the newest checkpoint
+        in a family (the alias_target.slug field). These are real, callable catalog
+        entries, but they never appear in the curated allowlist — so the picker
+        previously hid them even though the model they target was curated.
+        """
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"deepseek/deepseek-v4-flash-0731",'
+                    b'"pricing":{"prompt":"0.00000009","completion":"0.00000018"},'
+                    b'"supported_parameters":["tools","temperature"]},'
+                    b'{"id":"~deepseek/deepseek-v4-flash-latest",'
+                    b'"alias_target":{"slug":"deepseek/deepseek-v4-flash-0731"},'
+                    b'"pricing":{"prompt":"0.00000009","completion":"0.00000018"},'
+                    b'"supported_parameters":["tools","temperature"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [("deepseek/deepseek-v4-flash-0731", "dated snapshot of v4-flash")],
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "deepseek/deepseek-v4-flash-0731" in ids
+        assert "~deepseek/deepseek-v4-flash-latest" in ids
+        desc = dict(models).get("~deepseek/deepseek-v4-flash-latest")
+        assert desc == "latest"
+
+    def test_latest_alias_for_uncurated_target_is_not_surfaced(self, monkeypatch):
+        """A '~' alias whose target is NOT curated must stay hidden — the alias
+        only rides along when the model it resolves to is already in the picker."""
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"brandnew/brand-new-model",'
+                    b'"pricing":{"prompt":"0.00001","completion":"0.00002"},'
+                    b'"supported_parameters":["tools"]},'
+                    b'{"id":"~brandnew/brand-new-model-latest",'
+                    b'"alias_target":{"slug":"brandnew/brand-new-model"},'
+                    b'"pricing":{"prompt":"0.00001","completion":"0.00002"},'
+                    b'"supported_parameters":["tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [("deepseek/deepseek-v4-flash-0731", "dated snapshot of v4-flash")],
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "~brandnew/brand-new-model-latest" not in ids
+
+    def test_latest_alias_without_tool_support_is_not_surfaced(self, monkeypatch):
+        """Tool-support filtering must apply to '~' aliases just like any other model."""
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"deepseek/deepseek-v4-flash-0731",'
+                    b'"pricing":{"prompt":"0.00000009","completion":"0.00000018"},'
+                    b'"supported_parameters":["tools","temperature"]},'
+                    b'{"id":"~deepseek/deepseek-v4-flash-latest",'
+                    b'"alias_target":{"slug":"deepseek/deepseek-v4-flash-0731"},'
+                    b'"pricing":{"prompt":"0.00000009","completion":"0.00000018"},'
+                    b'"supported_parameters":["temperature"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [("deepseek/deepseek-v4-flash-0731", "dated snapshot of v4-flash")],
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "deepseek/deepseek-v4-flash-0731" in ids
+        assert "~deepseek/deepseek-v4-flash-latest" not in ids
+
 
 
 class TestOpenRouterToolSupportHelper:


### PR DESCRIPTION
## Summary

The OpenRouter model picker missed every rolling `~latest` alias (e.g. `~deepseek/deepseek-v4-flash-latest`). These are real, callable catalog entries with their own pricing and tool support, but they appear in OpenRouter's live `/v1/models` response under a `~`-prefixed id that is **never part of the curated allowlist** — so the picker hid them even though the model they point at was already curated.

**Example:** `~deepseek/deepseek-v4-flash-latest` resolves to `deepseek/deepseek-v4-flash-0731`, which IS on the curated list — yet only the dated snapshot showed up. Newly released checkpoints were effectively unselectable through the picker.

## Change

In `fetch_openrouter_models()` (`hermes_cli/models.py`), after building the curated list, surface any `~`-prefixed alias whose `alias_target.slug` resolves to an already-curated model, with a `"latest"` badge.

This is deliberately **dynamic rather than a hardcoded list of 11 aliases**:
- Every current `~latest` alias points at a model already on the curated list (verified against the live catalog — claude-fable/haiku/opus/sonnet, gpt, gpt-mini, gemini-flash/pro, grok, kimi, deepseek-v4-flash).
- Keying off `alias_target` fixes the whole class: any curated model that gains a `~latest` alias surfaces automatically, with **zero manifest maintenance**.
- Applies the same tool-support filter and never surfaces aliases for uncurated models, so the picker stays curated (went from 39 → 45 surfaced with the current catalog).

## Verification
- `pytest tests/hermes_cli/test_models.py` — **33 passed** (3 new tests: alias surfaces for curated target; alias hidden for uncurated target; alias hidden when no tool support)
- 32 related tests in `test_model_validation.py` + `test_list_picker_providers.py` pass
- `ruff check` clean
- E2E against the live OpenRouter catalog: all 11 `~latest` aliases now surface with the `latest` badge

## Files changed
- `hermes_cli/models.py` (+26)
- `tests/hermes_cli/test_models.py` (+123)

---

## Learnings from live validation

Built from a real repro (a user who couldn't select `~deepseek/deepseek-v4-flash-latest` in the web UI / desktop pickers even though it's callable), then validated the change end-to-end on a running Hermes deployment.

### 1. `fetch_openrouter_models()` is the single choke point for every picker

Both the **web UI** and **desktop** model pickers rebuild OpenRouter's list from `fetch_openrouter_models()` on every open (via `model_switch.py` → `list_authenticated_providers(..., for_picker=True)`). They do **not** read `model.default`/config. That's exactly why the model appeared in the dashboard (config) but never in the pickers (allowlist intersect). So this one function is the correct and complete place for the fix — no per-surface changes needed.

### 2. Verified against the live catalog: every `~latest` alias points at an already-curated model

I pulled the live `/v1/models` and checked all 11 `~`-prefixed aliases against the curated `OPENROUTER_MODELS` snapshot:

| Alias | Resolves to | Curated? |
|---|---|---|
| `~anthropic/claude-fable-latest` | `claude-fable-5` | ✅ |
| `~anthropic/claude-haiku-latest` | `claude-haiku-4.5` | ✅ |
| `~anthropic/claude-opus-latest` | `claude-opus-5` | ✅ |
| `~anthropic/claude-sonnet-latest` | `claude-sonnet-5` | ✅ |
| `~deepseek/deepseek-v4-flash-latest` | `deepseek-v4-flash-0731` | ✅ |
| `~google/gemini-flash-latest` | `gemini-3.6-flash` | ✅ |
| `~google/gemini-pro-latest` | `gemini-3.1-pro-preview` | ✅ |
| `~moonshotai/kimi-latest` | `kimi-k3` | ✅ |
| `~openai/gpt-latest` | `gpt-5.6-sol` | ✅ |
| `~openai/gpt-mini-latest` | `gpt-5.4-mini` | ✅ |
| `~x-ai/grok-latest` | `grok-4.5` | ✅ |

Every one passes the tool-support filter (`supported_parameters` includes `tools`). This is what makes the `alias_target`-keyed approach work: an alias only rides along when its target is already curated, so the picker stays curated and never accidentally surfaces a whole new uncurated family.

### 3. End-to-end on a live install → 45 models surfaced (was 39)

Running the patched `fetch_openrouter_models()` against the real OpenRouter catalog surfaced **45** models — the original 39 curated + all 11 aliases (5 base curated IDs dropped out because the live catalog no longer advertises them, which is the existing intended behavior). All 11 aliases carry the `latest` badge.

### 4. A durable no-code workaround exists for installs that can't be patched

On some deployments `/opt/hermes` is root-owned and not patchable by the operator's user. The existing **per-provider manifest override** (`model_catalog.providers.openrouter.url`) provides a config-only way to get the same behavior immediately: point it at a local manifest that includes the `~latest` aliases. `model_catalog.py` re-reads that override on every call (it skips the shared disk cache), so it's not clobbered by the 1-hour stale-while-revalidate refresh. Worth a line in the model-catalog docs so users with constrained installs know the option exists while they wait for this to ship.

### 5. Minor consideration for maintainers

Because aliases are resolved from the live catalog's `alias_target`, the picker now depends a little more on the live catalog being reachable. When it's unreachable, the code falls back to the static snapshot (which deliberately excludes `~` IDs), so aliases only appear when the live catalog is available — which is the only time they're callable anyway, so there's no practical regression.
