### PR TITLE
floor quick-snapshot prune keep to at least 1

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1586,7 +1586,20 @@ def restore_cron_jobs_if_emptied(
 
 
 def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
-    """Remove oldest quick snapshots beyond the keep limit. Returns count deleted."""
+    """Remove oldest quick snapshots beyond the keep limit. Returns count deleted.
+
+    ``keep`` is floored to 1 because this helper is also called immediately
+    after ``create_quick_snapshot`` writes a fresh snapshot: ``keep=0`` would
+    delete *every* snapshot including the one just created (``dirs[0:]``),
+    leaving the user with nothing to restore. Same floor as
+    ``_prune_pre_update_backups``.
+    """
+    try:
+        keep_n = int(keep)
+    except (TypeError, ValueError):
+        keep_n = _QUICK_DEFAULT_KEEP
+    keep_n = max(keep_n, 1)
+
     if not root.exists():
         return 0
 
@@ -1601,7 +1614,7 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
     )
 
     deleted = 0
-    for d in dirs[keep:]:
+    for d in dirs[keep_n:]:
         try:
             shutil.rmtree(d)
             deleted += 1

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_quick_snapshots_prune_keep_floor.py
+++ b/tests/hermes_cli/test_quick_snapshots_prune_keep_floor.py
@@ -1,0 +1,56 @@
+"""keep<=0 must not wipe every quick snapshot during prune."""
+
+from __future__ import annotations
+
+from hermes_cli.backup import _prune_quick_snapshots, prune_quick_snapshots
+
+
+def _seed(root, names):
+    root.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (root / name).mkdir()
+
+
+def test_prune_quick_snapshots_keep_zero_preserves_newest(tmp_path):
+    root = tmp_path / "state-snapshots"
+    _seed(root, ["20260101T000003Z", "20260101T000002Z", "20260101T000001Z"])
+
+    deleted = _prune_quick_snapshots(root, keep=0)
+
+    remaining = sorted(p.name for p in root.iterdir() if p.is_dir())
+    assert deleted == 2
+    assert remaining == ["20260101T000003Z"]
+
+
+def test_prune_quick_snapshots_negative_keep_floors_to_one(tmp_path):
+    root = tmp_path / "state-snapshots"
+    _seed(root, ["20260101T000003Z", "20260101T000002Z", "20260101T000001Z"])
+
+    deleted = _prune_quick_snapshots(root, keep=-5)
+
+    remaining = sorted(p.name for p in root.iterdir() if p.is_dir())
+    assert deleted == 2
+    assert remaining == ["20260101T000003Z"]
+
+
+def test_prune_quick_snapshots_invalid_keep_uses_default(tmp_path):
+    root = tmp_path / "state-snapshots"
+    names = [f"20260101T{i:06d}Z" for i in range(25)]
+    _seed(root, names)
+
+    deleted = _prune_quick_snapshots(root, keep="nope")
+
+    remaining = [p for p in root.iterdir() if p.is_dir()]
+    assert len(remaining) == 20  # _QUICK_DEFAULT_KEEP
+    assert deleted == 5
+
+
+def test_prune_quick_snapshots_public_wrapper_keep_zero(tmp_path):
+    root = tmp_path / "state-snapshots"
+    _seed(root, ["20260101T000002Z", "20260101T000001Z"])
+
+    deleted = prune_quick_snapshots(keep=0, hermes_home=tmp_path)
+
+    remaining = sorted(p.name for p in root.iterdir() if p.is_dir())
+    assert deleted == 1
+    assert remaining == ["20260101T000002Z"]


### PR DESCRIPTION
## Summary
- Floor `_prune_quick_snapshots` `keep` to at least 1 (invalid values fall back to the default). `keep=0` used `dirs[0:]` and deleted every snapshot, including one just created by `create_quick_snapshot` auto-prune — same safety floor already used by `_prune_pre_update_backups`.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.

