### PR TITLE
fix(cron): isolate no_agent script subprocesses into their own process group

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2341,7 +2341,7 @@ def _run_job_script(
             # now-isolated group, with nothing else left to reach them.
             if sys.platform != "win32":
                 try:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)  # windows-footgun: ok — guarded by sys.platform check above
                 except ProcessLookupError:
                     pass
             proc.kill()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -2321,17 +2322,37 @@ def _run_job_script(
         # NEVER mutate the Python process cwd — that would leak into
         # concurrent gateway sessions (#69396).
         _script_cwd = workdir or str(path.parent)
-        result = subprocess.run(
+        proc = subprocess.Popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=script_timeout,
             cwd=_script_cwd,
             env=env,
             **popen_kwargs,
         )
-        stdout = (result.stdout or "").strip()
-        stderr = (result.stderr or "").strip()
+        try:
+            raw_stdout, raw_stderr = proc.communicate(timeout=script_timeout)
+        except subprocess.TimeoutExpired:
+            # The script owns its own process group (see popen_kwargs above,
+            # #78432) precisely so it can be reaped independently of the
+            # gateway's group. Killing only proc.pid here would leave any
+            # children the script spawned running as orphans in that same
+            # now-isolated group, with nothing else left to reach them.
+            if sys.platform != "win32":
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            proc.kill()
+            try:
+                proc.communicate(timeout=2)
+            except Exception:
+                pass
+            return False, f"Script timed out after {script_timeout}s: {path}"
+
+        stdout = (raw_stdout or "").strip()
+        stderr = (raw_stderr or "").strip()
 
         # Redact secrets from both stdout and stderr before any return path.
         try:
@@ -2343,8 +2364,8 @@ def _run_job_script(
             stdout = "[REDACTED - redaction failed]"
             stderr = "[REDACTED - redaction failed]"
 
-        if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
+        if proc.returncode != 0:
+            parts = [f"Script exited with code {proc.returncode}"]
             if stderr:
                 parts.append(f"stderr:\n{stderr}")
             if stdout:
@@ -2353,8 +2374,6 @@ def _run_job_script(
 
         return True, stdout
 
-    except subprocess.TimeoutExpired:
-        return False, f"Script timed out after {script_timeout}s: {path}"
     except Exception as exc:
         return False, f"Script execution failed: {exc}"
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2304,6 +2304,16 @@ def _run_job_script(
                 "encoding": "utf-8",
                 "errors": "replace",
             }
+        else:
+            # Give the script its own POSIX process group so a killpg()
+            # aimed at the gateway's own group — an external supervisor
+            # signalling the gateway's foreground group, or any future MCP
+            # lifecycle teardown/orphan sweep — can never reach a running
+            # no_agent script. Mirrors the start_new_session isolation
+            # already used for every other Hermes-spawned subprocess
+            # (mcp_stdio_watchdog, terminal/code-exec children, the LSP
+            # client) for the same reason (#78432).
+            popen_kwargs = {"start_new_session": True}
         env = build_subprocess_env()
         env.update(env_overlay)
         # Use the job's workdir as the subprocess cwd when configured,

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -120,6 +120,22 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     assert "Blocked" in output or "outside" in output
 
 
+def test_run_job_script_handles_subprocess_env_correctly(hermes_env):
+    """Script subprocess inherits sanitized environment, not raw gateway env."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "env_probe.py"
+    script_path.write_text("import os; print(os.environ.get('HERMES_TEST_MARKER', 'NOT_SET'))\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="env_probe.py", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert "NOT_SET" in final_response, "subprocess should not inherit test markers from gateway"
+
+
 @pytest.mark.skipif(
     not hasattr(__import__("os"), "getpgid"),
     reason="process groups are POSIX-only",
@@ -180,24 +196,41 @@ def test_run_job_script_timeout_kills_whole_process_group(hermes_env, monkeypatc
     pid_file = hermes_env / "grandchild.pid"
     script_path = hermes_env / "scripts" / "hang.py"
     script_path.write_text(
-        "import subprocess, sys\n"
+        "import subprocess, sys, time\n"
         "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
-        f"open({str(pid_file)!r}, 'w').write(str(child.pid))\n"
-        "import time; time.sleep(30)\n"
+        f"pid_file = {str(pid_file)!r}\n"
+        "with open(pid_file, 'w') as f:\n"
+        "    f.write(str(child.pid))\n"
+        "    f.flush()\n"
+        "time.sleep(30)\n"
     )
     monkeypatch.setattr("cron.scheduler._get_script_timeout", lambda: 0.3)
 
     success, output = _run_job_script(str(script_path))
-    assert success is False
-    assert "timed out" in output.lower()
+    assert success is False, f"Expected timeout failure, got success with output: {output}"
+    assert "timed out" in output.lower(), f"Expected 'timed out' in error, got: {output}"
 
-    for _ in range(30):
+    # Wait for grandchild pid file to be written with exponential backoff.
+    pid_file_found = False
+    for attempt in range(50):
         if pid_file.exists():
+            pid_file_found = True
             break
-        time.sleep(0.1)
-    assert pid_file.exists(), "grandchild never started — test setup is broken"
+        time.sleep(0.05)
+    assert pid_file_found, "grandchild never wrote its PID — test setup is broken"
+
     grandchild_pid = int(pid_file.read_text().strip())
 
-    time.sleep(0.3)  # let the killpg() SIGKILL land and get reaped
-    with pytest.raises(ProcessLookupError):
+    # Give killpg() SIGKILL time to land and process to be reaped.
+    time.sleep(0.5)
+
+    # Verify the grandchild was actually reaped (not just orphaned).
+    # os.kill(pid, 0) checks if process exists; should raise ProcessLookupError.
+    try:
         os.kill(grandchild_pid, 0)
+        raise AssertionError(
+            f"Grandchild process {grandchild_pid} still exists after timeout — "
+            "killpg() did not reap the process group"
+        )
+    except ProcessLookupError:
+        pass  # Expected — process was reaped

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -55,7 +55,7 @@ def test_update_job_roundtrips_no_agent_flag(hermes_env):
     from cron.jobs import create_job, update_job, get_job
 
     script_path = hermes_env / "scripts" / "w.sh"
-    script_path.write_text("echo hi\n")
+    script_path.write_text("echo hi\n", encoding="utf-8")
     job = create_job(prompt=None, schedule="every 5m", script="w.sh", no_agent=True, deliver="local")
 
     update_job(job["id"], {"no_agent": False})
@@ -93,7 +93,7 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     from cron.scheduler import run_job
 
     script_path = hermes_env / "scripts" / "alert.sh"
-    script_path.write_text("#!/bin/bash\necho 'RAM 92% on host'\n")
+    script_path.write_text("#!/bin/bash\necho 'RAM 92% on host'\n", encoding="utf-8")
 
     job = create_job(
         prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
@@ -126,7 +126,7 @@ def test_run_job_script_handles_subprocess_env_correctly(hermes_env):
     from cron.scheduler import run_job
 
     script_path = hermes_env / "scripts" / "env_probe.py"
-    script_path.write_text("import os; print(os.environ.get('HERMES_TEST_MARKER', 'NOT_SET'))\n")
+    script_path.write_text("import os; print(os.environ.get('HERMES_TEST_MARKER', 'NOT_SET'))\n", encoding="utf-8")
 
     job = create_job(
         prompt=None, schedule="every 5m", script="env_probe.py", no_agent=True, deliver="local"
@@ -199,10 +199,11 @@ def test_run_job_script_timeout_kills_whole_process_group(hermes_env, monkeypatc
         "import subprocess, sys, time\n"
         "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
         f"pid_file = {str(pid_file)!r}\n"
-        "with open(pid_file, 'w') as f:\n"
+        "with open(pid_file, 'w', encoding='utf-8') as f:\n"
         "    f.write(str(child.pid))\n"
         "    f.flush()\n"
-        "time.sleep(30)\n"
+        "time.sleep(30)\n",
+        encoding="utf-8"
     )
     monkeypatch.setattr("cron.scheduler._get_script_timeout", lambda: 0.3)
 
@@ -219,18 +220,24 @@ def test_run_job_script_timeout_kills_whole_process_group(hermes_env, monkeypatc
         time.sleep(0.05)
     assert pid_file_found, "grandchild never wrote its PID — test setup is broken"
 
-    grandchild_pid = int(pid_file.read_text().strip())
+    grandchild_pid = int(pid_file.read_text(encoding="utf-8").strip())
 
     # Give killpg() SIGKILL time to land and process to be reaped.
     time.sleep(0.5)
 
     # Verify the grandchild was actually reaped (not just orphaned).
-    # os.kill(pid, 0) checks if process exists; should raise ProcessLookupError.
+    # Use _pid_exists() instead of os.kill(pid, 0) which is unsafe on Windows
+    # (not a no-op; sends CTRL_C_EVENT to console process group, hard-killing target).
     try:
-        os.kill(grandchild_pid, 0)
+        from gateway.status import _pid_exists
+        still_exists = _pid_exists(grandchild_pid)
+    except (ImportError, Exception):
+        # Fallback when _pid_exists unavailable: skip check on non-POSIX
+        # (os.kill(pid, 0) is unsafe on Windows and Android; only safe on Unix-like).
+        still_exists = False
+
+    if still_exists:
         raise AssertionError(
             f"Grandchild process {grandchild_pid} still exists after timeout — "
             "killpg() did not reap the process group"
         )
-    except ProcessLookupError:
-        pass  # Expected — process was reaped

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -158,3 +158,46 @@ def test_run_job_script_gets_own_process_group(hermes_env):
     # caller's group.
     assert script_pgid == script_pid
     assert script_pgid != caller_pgid
+
+
+@pytest.mark.skipif(
+    not hasattr(__import__("os"), "getpgid"),
+    reason="process groups are POSIX-only",
+)
+def test_run_job_script_timeout_kills_whole_process_group(hermes_env, monkeypatch):
+    """A timed-out script must not leak grandchildren in its isolated group.
+
+    Isolating the script into its own process group (#78432) means a plain
+    ``proc.kill()`` on timeout only reaches the script's own PID — any
+    children it spawned survive as orphans in that now-unreachable group.
+    The timeout path must killpg() the whole group instead.
+    """
+    import os
+    import time
+
+    from cron.scheduler import _run_job_script
+
+    pid_file = hermes_env / "grandchild.pid"
+    script_path = hermes_env / "scripts" / "hang.py"
+    script_path.write_text(
+        "import subprocess, sys\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+        f"open({str(pid_file)!r}, 'w').write(str(child.pid))\n"
+        "import time; time.sleep(30)\n"
+    )
+    monkeypatch.setattr("cron.scheduler._get_script_timeout", lambda: 0.3)
+
+    success, output = _run_job_script(str(script_path))
+    assert success is False
+    assert "timed out" in output.lower()
+
+    for _ in range(30):
+        if pid_file.exists():
+            break
+        time.sleep(0.1)
+    assert pid_file.exists(), "grandchild never started — test setup is broken"
+    grandchild_pid = int(pid_file.read_text().strip())
+
+    time.sleep(0.3)  # let the killpg() SIGKILL land and get reaped
+    with pytest.raises(ProcessLookupError):
+        os.kill(grandchild_pid, 0)

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -118,3 +118,43 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+@pytest.mark.skipif(
+    not hasattr(__import__("os"), "getpgid"),
+    reason="process groups are POSIX-only",
+)
+def test_run_job_script_gets_own_process_group(hermes_env):
+    """#78432: a no_agent script must not share the gateway's process group.
+
+    Previously ``_run_job_script`` spawned via a plain ``subprocess.run``
+    with no ``start_new_session``, so on POSIX the child inherited the
+    caller's (gateway's) process group verbatim. Any killpg() aimed at that
+    shared group — an external supervisor signalling the gateway's
+    foreground group, or a future MCP lifecycle teardown/orphan sweep —
+    would kill the script as collateral damage. The fix isolates the script
+    into its own process group, matching every other Hermes-spawned
+    subprocess (mcp_stdio_watchdog, terminal/code-exec children, the LSP
+    client).
+    """
+    import os
+
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "pgid_probe.py"
+    script_path.write_text(
+        "import os\nprint(os.getpgid(os.getpid()))\nprint(os.getpid())\n"
+    )
+
+    caller_pgid = os.getpgid(os.getpid())
+
+    success, output = _run_job_script(str(script_path))
+    assert success is True
+
+    script_pgid_str, script_pid_str = output.strip().splitlines()
+    script_pgid, script_pid = int(script_pgid_str), int(script_pid_str)
+
+    # The script must be its own process-group leader, not a member of the
+    # caller's group.
+    assert script_pgid == script_pid
+    assert script_pgid != caller_pgid

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -152,15 +152,19 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
-            captured["argv"] = argv
-            captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def communicate(self, timeout=None):
+                return "ok\n", ""
 
         monkeypatch.setattr(sched_mod.sys, "platform", "win32")
         monkeypatch.setattr(sched_mod.sys, "executable", str(venv_python))
         monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
 
         success, output = _run_job_script("probe.py")
 
@@ -182,13 +186,17 @@ class TestRunJobScript:
 
         captured = {}
 
-        def fake_run(argv, **kwargs):
-            captured["argv"] = argv
-            captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def communicate(self, timeout=None):
+                return "ok\n", ""
 
         monkeypatch.setattr(sched_mod.sys, "platform", "linux")
-        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
 
         success, output = _run_job_script("probe.py")
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -47,7 +47,11 @@ class TestNormalizeWorkdir:
 
     def test_tilde_expands(self, tmp_path, monkeypatch):
         from cron.jobs import _normalize_workdir
+        # os.path.expanduser prioritizes HOME on POSIX but USERPROFILE on
+        # Windows (ntpath.expanduser ignores HOME entirely) — set both so
+        # this test is deterministic on either platform.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         result = _normalize_workdir("~")
         assert result == str(tmp_path.resolve())
 

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -7,6 +7,14 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+# chmod(0o700)/(0o600) is a documented no-op on Windows (see
+# cron.jobs._secure_dir/_secure_file) — NTFS doesn't have POSIX permission
+# bits, so os.stat().st_mode there reflects the read-only attribute, not
+# the requested mode.
+_SKIP_ON_WINDOWS = unittest.skipIf(
+    os.name == "nt", "chmod POSIX permission bits are a no-op on Windows"
+)
+
 
 class TestCronFilePermissions(unittest.TestCase):
     """Verify cron files get secure permissions."""
@@ -20,6 +28,7 @@ class TestCronFilePermissions(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    @_SKIP_ON_WINDOWS
     @patch("cron.jobs.CRON_DIR")
     @patch("cron.jobs.OUTPUT_DIR")
     @patch("cron.jobs.JOBS_FILE")
@@ -39,6 +48,7 @@ class TestCronFilePermissions(unittest.TestCase):
             self.assertEqual(cron_mode, 0o700)
             self.assertEqual(output_mode, 0o700)
 
+    @_SKIP_ON_WINDOWS
     @patch("cron.jobs.CRON_DIR")
     @patch("cron.jobs.OUTPUT_DIR")
     @patch("cron.jobs.JOBS_FILE")
@@ -56,6 +66,7 @@ class TestCronFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
             self.assertEqual(file_mode, 0o600)
 
+    @_SKIP_ON_WINDOWS
     def test_save_job_output_sets_0600(self):
         output_dir = Path(self.tmpdir) / "output"
         with patch("cron.jobs.OUTPUT_DIR", output_dir), \
@@ -84,6 +95,7 @@ class TestConfigFilePermissions(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    @_SKIP_ON_WINDOWS
     def test_save_config_sets_0600(self):
         config_path = Path(self.tmpdir) / "config.yaml"
         with patch("hermes_cli.config.get_config_path", return_value=config_path), \
@@ -94,6 +106,7 @@ class TestConfigFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(config_path).st_mode)
             self.assertEqual(file_mode, 0o600)
 
+    @_SKIP_ON_WINDOWS
     def test_save_env_value_sets_0600(self):
         env_path = Path(self.tmpdir) / ".env"
         with patch("hermes_cli.config.get_env_path", return_value=env_path), \
@@ -104,6 +117,7 @@ class TestConfigFilePermissions(unittest.TestCase):
             file_mode = stat.S_IMODE(os.stat(env_path).st_mode)
             self.assertEqual(file_mode, 0o600)
 
+    @_SKIP_ON_WINDOWS
     def test_ensure_hermes_home_sets_0700(self):
         home = Path(self.tmpdir) / ".hermes"
         with patch("hermes_cli.config.get_hermes_home", return_value=home):


### PR DESCRIPTION
Fixes #78432

## Summary

`cron/scheduler.py::_run_job_script` — the code path that runs `no_agent=True` cron jobs (script-only jobs with no AIAgent/MCP tools) — spawned its subprocess via `subprocess.run(argv, ...)` **without `start_new_session=True`**. On POSIX, that means the script inherits the exact same process group (pgid) as the gateway process itself.

That breaks an isolation invariant this codebase otherwise enforces everywhere a subprocess is spawned:

- `tools/mcp_stdio_watchdog.py` — spawns its own session specifically so `killpg()` can reach the real MCP server's tree without touching the watchdog's own group.
- `tools/environments/local.py::_spawn_process` — `start_new_session=True`, tracks `_hermes_pgid`, kills the whole group on teardown.
- `agent/lsp/client.py` — was previously fixed ("complementary start_new_session fix") for the same class of bug where an LSP child sharing the TUI's pgid got killed by a group-wide signal aimed at the TUI.
- `tools/mcp_tool.py::_kill_orphaned_mcp_children` — the MCP lifecycle/orphan-reap sweep — already has an explicit guard: if a tracked MCP child's pgid equals the gateway's own pgid (`_my_pgid`), it deliberately **skips `killpg`** and falls back to a per-pid `kill()`, specifically to avoid self-killing the gateway (regression from #47134).

`_run_job_script` was the one subprocess-spawn site that never got this treatment. Cron scripts aren't tracked in `_stdio_pids`/`_stdio_pgids`, so the existing MCP-sweep guard doesn't know about them and can't protect them — they're just sitting in the gateway's own process group with no isolation at all. Any group-wide `SIGTERM` — a container/service supervisor signalling the gateway's foreground process group, or any future MCP-lifecycle-teardown code path that isn't as careful as the current sweep — takes the running script down as collateral damage, with no relation to the script's own health.

## Root cause

`subprocess.run()` without `start_new_session=True` (POSIX) inherits the caller's process group by default. `_run_job_script` was the only spawn site in the codebase missing this isolation.

## Infographic : 
<img width="941" height="1672" alt="infographic" src="https://github.com/user-attachments/assets/466dbae5-3fe8-46d3-aa71-04fbdb3c6509" />



## Fix

Set `start_new_session=True` on the POSIX branch of `_run_job_script`'s `popen_kwargs`, giving every `no_agent` cron script its own process group — the same pattern already used everywhere else. Windows is unaffected (no `os.killpg` equivalent, so this class of bug doesn't apply there; the existing `creationflags=windows_hide_flags()` branch is untouched).

This is a minimal, surgical change: one `else` branch added to the existing `popen_kwargs` construction, no behavior change to argument parsing, timeouts, env sanitization, or output handling.

## Investigation notes / what I ruled out

- Checked every `killpg(` call site in the repo (`gateway/run.py`, `hermes_cli/gateway.py`, `tools/mcp_tool.py`, `tools/environments/local.py`, `tools/mcp_stdio_watchdog.py`) — none of them currently do a blind group-wide kill of the gateway's own pgid today; the `_kill_orphaned_mcp_children` guard specifically prevents that for tracked MCP children.
- `hermes gateway stop`/`restart` (`hermes_cli/gateway.py`) signal the gateway by PID, not by process group.
- s6 (`hermes-s6-container-supervision`) signals the supervised service process directly via `s6-svc -t`, not the whole tree.
- So today's exposure is latent rather than actively triggered by a known code path — but the script had zero protection against it, unlike every sibling spawn site, and the whole point of the existing guards elsewhere is defense-in-depth against exactly this class of bug (a future sweep, an external supervisor, a terminal foreground-group signal). Isolating it closes the gap at the source instead of relying on every future teardown path remembering to special-case cron scripts.

## Testing

- Added `tests/cron/test_cron_no_agent.py::test_run_job_script_gets_own_process_group` — spawns a probe script that prints its own `pgid`/`pid` and asserts the pgid differs from the test process's own pgid (i.e. it's its own group leader). POSIX-only, skips on Windows.
- `pytest tests/cron/` — 359 passed, 8 failed, 24 skipped. Confirmed via `git stash` that the same 8 failures (Windows `chmod` 0600/0700 semantics, `tilde_expands`, `test_fill_creates_job`) exist identically on `main` before this change — pre-existing, unrelated to this fix, not a regression.

