### PR TITLE
fix(search): quote the whole token so session_search finds paths and emails

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1149,10 +1149,37 @@ class SessionSearchMixin:
         # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning
         # ``chat-send`` into ``chat AND send`` and ``P2.2`` into ``p2 AND 2``.
-        # Quoting preserves phrase semantics.  A single pass avoids the
-        # double-quoting bug that would occur if dotted, hyphenated and underscored
-        # patterns were applied sequentially (e.g. ``my-app.config``).
-        sanitized = re.sub(r"\b(\w+(?:[._-]\w+)+)\b", r'"\1"', sanitized)
+        # Quoting preserves phrase semantics.
+        #
+        # Quote the WHOLE whitespace-delimited token, not the dotted run
+        # inside it.  A substring rewrite leaves the surrounding separator
+        # outside the quotes and produces a query FTS5 cannot parse at all:
+        # ``scripts/deploy.sh`` became ``scripts/"deploy.sh"`` →
+        # ``fts5: syntax error near "/"``, and the search layer swallows
+        # OperationalError into zero results.  Same for ``user@example.com``
+        # (``user@"example.com"``) and ``61.2%`` (``"61.2"%``) — file paths,
+        # emails and percentages, i.e. exactly the terms this step exists to
+        # make matchable.  Quoting the full token keeps the separator inside
+        # the phrase, where FTS5's tokenizer splits it like any other
+        # non-word character and the phrase matches.
+        def _quote_token(tok: str) -> str:
+            # Placeholders for already-quoted phrases, and anything that
+            # somehow still carries a quote, are left exactly as they are.
+            if "\x00" in tok or '"' in tok:
+                return tok
+            # A trailing ``*`` is FTS5's prefix operator and must stay
+            # OUTSIDE the phrase or it degrades to a literal asterisk.
+            stem, star = (tok[:-1], "*") if tok.endswith("*") else (tok, "")
+            if not re.search(r"\w[._-]\w", stem):
+                return tok
+            return f'"{stem}"{star}'
+
+        # Split keeping the separators so tabs/newlines/runs of spaces survive
+        # byte-for-byte (callers compare sanitizer output).
+        sanitized = "".join(
+            part if i % 2 else _quote_token(part)
+            for i, part in enumerate(re.split(r"(\s+)", sanitized))
+        )
 
         # Step 6: Restore preserved quoted phrases
         for i, quoted in enumerate(_quoted_parts):

--- a/tests/hermes_state/test_fts_query_separator_tokens.py
+++ b/tests/hermes_state/test_fts_query_separator_tokens.py
@@ -1,0 +1,123 @@
+"""session_search must find file paths, emails and percentages.
+
+``_sanitize_fts5_query`` quotes dotted/hyphenated terms so FTS5's tokenizer
+does not split ``chat-send`` into ``chat AND send``. It matched the dotted run
+with ``\\b(\\w+(?:[._-]\\w+)+)\\b`` and quoted **that substring**, which is not
+the whole token whenever the term also contains a separator ``\\w`` does not
+cover (``/``, ``@``, ``%``, ``\\``):
+
+    scripts/deploy.sh  ->  scripts/"deploy.sh"
+    user@example.com   ->  user@"example.com"
+    61.2%              ->  "61.2"%
+
+Each of those leaves the separator outside the quotes, where FTS5 rejects it:
+``fts5: syntax error near "/"``. The search layer swallows
+``sqlite3.OperationalError`` into an empty result, so the tool reported "no
+matches" for content that was sitting in the transcript — file paths, emails
+and percentages, i.e. exactly the terms this step exists to make matchable.
+
+Quoting the whole token keeps the separator inside the phrase, where the
+tokenizer splits it like any other non-word character.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+_sanitize = SessionDB._sanitize_fts5_query
+
+
+@pytest.fixture
+def fts():
+    """A real FTS5 table — the parse error only exists inside SQLite."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE VIRTUAL TABLE t USING fts5(content)")
+    for doc in (
+        "the deploy script lives at scripts/deploy.sh and needs sudo",
+        "user@example.com asked about the API key rotation",
+        "coverage rose from 61.2% to 78.9% this sprint",
+        "we fixed the bug in hermes-agent yesterday",
+        "check the file my-app.config.ts for the setting",
+    ):
+        conn.execute("INSERT INTO t(content) VALUES (?)", (doc,))
+    yield conn
+    conn.close()
+
+
+def _hits(conn, query: str) -> int:
+    return len(
+        conn.execute(
+            "SELECT rowid FROM t WHERE t MATCH ?", (_sanitize(query),)
+        ).fetchall()
+    )
+
+
+class TestSeparatorTokensAreMatchable:
+    @pytest.mark.parametrize(
+        "query",
+        ["scripts/deploy.sh", "user@example.com", "61.2%"],
+    )
+    def test_query_parses_and_finds_its_document(self, fts, query):
+        # Before the fix this raised OperationalError, which the search layer
+        # turns into zero results.
+        assert _hits(fts, query) == 1
+
+    @pytest.mark.parametrize(
+        "query",
+        ["scripts/deploy.sh", "user@example.com", "61.2%"],
+    )
+    def test_the_whole_token_is_quoted_not_a_slice(self, query):
+        assert _sanitize(query) == f'"{query}"'
+
+
+class TestPreviouslyWorkingQueriesStillWork:
+    @pytest.mark.parametrize(
+        "query",
+        ["deploy.sh", "hermes-agent", "my-app.config.ts"],
+    )
+    def test_plain_dotted_and_hyphenated_terms(self, fts, query):
+        assert _sanitize(query) == f'"{query}"'
+        assert _hits(fts, query) == 1
+
+    def test_prefix_operator_stays_outside_the_phrase(self):
+        """A trailing * is FTS5's prefix operator, not a literal asterisk."""
+        assert _sanitize("deploy*") == "deploy*"
+        assert _sanitize("my-app.config*") == '"my-app.config"*'
+
+    def test_plain_words_are_untouched(self):
+        assert _sanitize("hello world") == "hello world"
+        assert _sanitize("retry loop") == "retry loop"
+
+    def test_whitespace_runs_survive(self):
+        """Colon stripping leaves a double space; the rejoin must not eat it."""
+        assert _sanitize("TODO: fix") == "TODO  fix"
+        assert _sanitize("a\tb") == "a\tb"
+
+    def test_dangling_operators_and_bare_stars_still_handled(self):
+        assert _sanitize("hello AND") == "hello"
+        assert _sanitize("OR world") == "world"
+        assert _sanitize("***") == ""
+
+    def test_balanced_quoted_phrase_is_preserved_verbatim(self, fts):
+        assert _sanitize('"deploy script"') == '"deploy script"'
+        assert _hits(fts, '"deploy script"') == 1
+
+
+class TestEverySanitizedQueryIsParsable:
+    """The sanitizer's stated job: never hand FTS5 something it rejects."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "scripts/deploy.sh", "user@example.com", "61.2%", "deploy.sh",
+            "hermes-agent", "my-app.config.ts", "TODO: fix", "C++",
+            "foo(bar)", "^start", "3-way", "deploy*", "hello AND",
+            "a/b/c.d", "x@y.z/w", "1.2.3-rc.1", "path\\to\\file.txt",
+        ],
+    )
+    def test_no_operational_error(self, fts, query):
+        fts.execute("SELECT rowid FROM t WHERE t MATCH ?", (_sanitize(query),))


### PR DESCRIPTION
## What does this PR do?

`_sanitize_fts5_query` wraps dotted/hyphenated terms in quotes so FTS5's
tokenizer does not split `chat-send` into `chat AND send`. It located the dotted
run with `\b(\w+(?:[._-]\w+)+)\b` and quoted **that substring** — which is not
the whole token whenever the term also contains a separator `\w` does not cover
(`/`, `@`, `%`, `\`):

| query | sanitizer produced |
|---|---|
| `scripts/deploy.sh` | `scripts/"deploy.sh"` |
| `user@example.com` | `user@"example.com"` |
| `61.2%` | `"61.2"%` |

Each leaves the separator **outside** the quotes, where FTS5 rejects the query
outright:

```text
sqlite3.OperationalError: fts5: syntax error near "/"
```

`hermes_state_search` catches `sqlite3.OperationalError` and returns an empty
result, so `session_search` reported **"no matches" for text sitting in the
transcript**. The failure is silent — the agent concludes the conversation
never happened and re-derives work it already did.

The terms it breaks are exactly the ones this step exists to make matchable:
**file paths, emails, and percentages/versions.**

### Reproduction (before this PR)

Seed a real `SessionDB` and search for text that is demonstrably present:

```text
query                     hits  sanitized
deploy.sh                    1  '"deploy.sh"'
scripts/deploy.sh            0  'scripts/"deploy.sh"'      <- present in corpus
hermes-agent                 1  '"hermes-agent"'
user@example.com             0  'user@"example.com"'       <- present in corpus
my-app.config.ts             1  '"my-app.config.ts"'
61.2%                        0  '"61.2"%'                  <- present in corpus
```

Isolating the parse in a bare FTS5 table confirms the mechanism:

```text
input                current sanitizer         result
scripts/deploy.sh    'scripts/"deploy.sh"'     ERR: fts5: syntax error near "/"
user@example.com     'user@"example.com"'      ERR: fts5: syntax error near "@"
61.2%                '"61.2"%'                 ERR: fts5: syntax error near "%"
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_state_search.py`** — Step 5 now quotes the whole
  whitespace-delimited token rather than the dotted run inside it. The separator
  then sits **inside** the phrase, where FTS5's tokenizer splits it like any
  other non-word character and the phrase matches.
  - A trailing `*` is kept **outside** the quotes so it stays FTS5's prefix
    operator instead of degrading to a literal asterisk
    (`my-app.config*` → `"my-app.config"*`).
  - Tokens holding a preserved-phrase placeholder or an existing `"` are left
    untouched.
  - The split/rejoin goes through `re.split(r"(\s+)")` so tabs, newlines and
    runs of spaces survive byte-for-byte (the colon-stripping step deliberately
    leaves a double space, and callers compare sanitizer output).
- **`tests/hermes_state/test_fts_query_separator_tokens.py`** — 31 tests.

### Scope

Only the malformed-output defect. Tokens with no `\w[._-]\w` run — `$100`,
`baz[0]`, `#77406` — still pass through unchanged. Making *those* matchable is
a separate design question about which characters the sanitizer should quote at
all; it is not a query it currently corrupts, so it is deliberately out of scope
here.

## How to Test

1. Have a session whose transcript mentions a path, e.g. `scripts/deploy.sh`.
2. Run `session_search` (or `/search`) for `scripts/deploy.sh`.
3. **Before:** zero results — the MATCH never executed, it raised and was
   swallowed. **After:** the message is returned.

## Test Results

New file `tests/hermes_state/test_fts_query_separator_tokens.py` — 31 tests
against a **real FTS5 table**, because the parse error only exists inside
SQLite:

| Group | Covers |
|---|---|
| `TestSeparatorTokensAreMatchable` | the three broken shapes parse *and* return their document; the whole token is quoted, not a slice |
| `TestPreviouslyWorkingQueriesStillWork` | plain dotted/hyphenated terms still match; prefix `*` stays an operator; plain words untouched; whitespace runs preserved; dangling `AND`/`OR` and bare `***` still handled; a balanced quoted phrase survives verbatim |
| `TestEverySanitizedQueryIsParsable` | the sanitizer's stated contract — 17 query shapes, none may raise `OperationalError` |

Red-without-fix, with only `hermes_state_search.py` reverted:

```text
12 failed, 19 passed
```

With the fix:

```text
31 passed in 0.65s
```

**Regression sweep**

```text
tests/test_hermes_state.py + tests/hermes_state/:   251 passed
ruff check hermes_state_search.py:                  All checks passed
```

The `search_files` tool suites report `18 failed, 110 passed` **identically with
and without this change** — they exercise the ripgrep/grep file-content tool,
which shares no code with FTS session search.