### PR TITLE
fix(cli): approvals suggest — strip comment lines before deriving allowlist globs

### DIFF
--- a/hermes_cli/approvals_suggest.py
+++ b/hermes_cli/approvals_suggest.py
@@ -250,6 +250,18 @@ def scan_approval_history(
 # Normalize -> aggregate -> rank -> exclude
 # ---------------------------------------------------------------------------
 
+def _strip_comment_lines(command: str) -> str:
+    """Drop full-line shell comments (lines whose first non-space char is ``#``).
+
+    Comment lines carry no executable content, but a leading one used to
+    become the glob anchor — producing meaningless allowlist proposals like
+    ``# Patch *`` for commands that were really ``python3 -c ...``.
+    """
+    return "\n".join(
+        line for line in command.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
 def normalize_command(command: str) -> str:
     """Fold user/hermes home prefixes and collapse whitespace.
 
@@ -261,7 +273,8 @@ def normalize_command(command: str) -> str:
         _rewrite_resolved_user_home,
     )
 
-    folded = _rewrite_resolved_user_home(_rewrite_resolved_hermes_home(command))
+    executable = _strip_comment_lines(command)
+    folded = _rewrite_resolved_user_home(_rewrite_resolved_hermes_home(executable))
     return " ".join(folded.split())
 
 

--- a/tests/hermes_cli/test_approvals_suggest.py
+++ b/tests/hermes_cli/test_approvals_suggest.py
@@ -161,6 +161,21 @@ class TestNormalizeAndGlob:
         assert derive_glob("git push --force origin main") == "git push *"
         assert derive_glob("docker restart web") == "docker restart *"
 
+    def test_derive_glob_skips_leading_comment_lines(self):
+        cmd = "# Patch the binary at 0xA026E0\npython3 -c \"import struct\""
+        assert derive_glob(normalize_command(cmd)) == "python3 *"
+
+    def test_derive_glob_comment_only_command_has_no_anchor(self):
+        assert derive_glob(normalize_command("# nothing but a comment")) is None
+
+    def test_derive_glob_indented_comment_line_also_skipped(self):
+        cmd = "   # indented comment\n\ngit status"
+        assert derive_glob(normalize_command(cmd)) == "git status *"
+
+    def test_normalize_keeps_inline_hash_tokens(self):
+        normalized = normalize_command("echo a#b")
+        assert normalized == "echo a#b"
+
 
     def test_derive_glob_never_anchors_unsafe_binaries(self):
         assert derive_glob("rm -rf ./build") is None


### PR DESCRIPTION
## Symptom

On a real session DB, `hermes approvals suggest` ranks meaningless globs keyed on **shell comment words** at the top of its allowlist proposal — e.g. `# Patch *`, `# Nuclear *`, `# Restore *`. On my production `state.db` (957MB, 90 days), **15 of the top 20 proposals were comment-anchored garbage**, drowning the actual signal.

Root cause: approved commands whose text starts with a full-line shell comment (a common style for documenting one-off scripts):

```
# Patch IEDSettings IsPro getter at 0xA026E0
python3 -c "import struct, ..."
```

`normalize_command()` collapses all whitespace (including newlines) **without dropping comment lines**, so `derive_glob()` anchors on `tokens[0] == "#"` + `tokens[1] == "Patch"` → `# Patch *`.

## Fix

`normalize_command()` now strips full-line shell comments (lines whose first non-space character is `#`) before folding, so globs anchor on the first **executable** token. Comment-only commands normalize to empty and correctly yield no glob. Inline `#` inside a command line is untouched.

`hermes_cli/approvals_suggest.py` — `derive_glob()` at line 280 is where the bad anchor manifested; the fix is one level up in `normalize_command()` so the class-key and example paths benefit too.

## Evidence

**Reproduction on current main** (`f5be923`, clean clone):

```
'# Patch IEDSettings...\npython3 -c "import struct"'  -> derive_glob: '# Patch *'   ❌
'# Nuclear option...\npython3 -c "import os"'          -> derive_glob: '# Nuclear *' ❌
'# nothing but a comment'                              -> derive_glob: '# nothing but a comment *' ❌
'git push origin main'                                 -> derive_glob: 'git push *'    ✅ (unchanged)
```

**A/B pytest** (`tests/hermes_cli/test_approvals_suggest.py`, 4 new regression tests):

| | unpatched main | with fix |
|---|---|---|
| 3 new comment-anchor tests | **FAIL** (bug confirmed) | pass |
| inline-hash test | pass | pass |
| 12 pre-existing tests | pass | pass |
| **full file** | — | **16/16 pass** |

**E2E on real production state.db** (957MB, `--days 90`, same command before/after):

| | proposals | top entries |
|---|---|---|
| before | 20 | `# Verify *` 31×, `# Restore *` 28×, `# Re-search *` 26×, `# Nuclear: *` 19×, … |
| after | **3** | `python3 *` **1015×**, `~/.hermes/tmp/venv2/bin/python *` 18×, `/tmp/pilvenv/bin/python *` 2× |

The real approval frequency (`python3 *` at 1015 approvals) was completely buried under comment noise before the fix.
