### PR TITLE
fix(update): clear stale SQLite sidecars before auto-restoring state.db

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -722,6 +722,27 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
+def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
+    """Delete the WAL / shared-memory / rollback-journal files next to *db_path*.
+
+    Call this immediately before overwriting a database file with a snapshot
+    image. Quick snapshots are produced by ``backup._safe_copy_db`` through
+    ``sqlite3.backup()``, so the image is already checkpointed and owns no WAL —
+    which is exactly why ``backup._EXCLUDED_SUFFIXES`` refuses to ship sidecars
+    inside a snapshot. Copying the image over the destination replaces only the
+    main database file, so any ``-wal`` / ``-shm`` left behind by the *old*
+    database (a crashed writer, or a second Hermes process the updater's drain
+    did not stop) survives and is replayed over the fresh image on the next
+    open. The result passes ``PRAGMA integrity_check`` while serving the old
+    database's contents, and the first checkpoint folds it in permanently.
+
+    Removing them is safe here specifically: they belong to a database the
+    caller has already declared corrupt and is about to discard.
+    """
+    for suffix in ("-wal", "-shm", "-journal"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -1033,6 +1054,7 @@ def _update_via_zip(args):
                                 try:
                                     import shutil as _shutil
 
+                                    _clear_stale_sqlite_sidecars(_state_path)
                                     _shutil.copy2(_snap_state, _state_path)
                                     _restored_ok = verify_sqlite_integrity(
                                         _state_path,
@@ -4304,6 +4326,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 try:
                                     import shutil as _shutil
 
+                                    _clear_stale_sqlite_sidecars(_state_path)
                                     _shutil.copy2(_snap_state, _state_path)
                                     _restored_ok = verify_sqlite_integrity(
                                         _state_path,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -743,6 +743,27 @@ def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
         db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
 
 
+def _restore_state_db_from_snapshot(state_path: Path, snap_state: Path) -> bool:
+    """Replace *state_path* with the snapshot image at *snap_state*.
+
+    Shared by both post-update auto-restore paths (the ZIP update and the git
+    pull). The destination's stale sidecars are cleared before the copy, so the
+    restored image cannot be silently overwritten by the corrupt database's WAL
+    replay — see :func:`_clear_stale_sqlite_sidecars`.
+
+    Returns ``True`` when the restored file passes an integrity check. Raises
+    ``OSError`` if the copy itself fails, which callers already report.
+    """
+    from hermes_cli.backup import verify_sqlite_integrity
+
+    _clear_stale_sqlite_sidecars(state_path)
+    shutil.copy2(snap_state, state_path)
+    restored = verify_sqlite_integrity(
+        state_path, check_header=True, run_pragma=True
+    )
+    return bool(restored.get("valid"))
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -1052,16 +1073,9 @@ def _update_via_zip(args):
                             )
                             if _snap_ok.get("valid"):
                                 try:
-                                    import shutil as _shutil
-
-                                    _clear_stale_sqlite_sidecars(_state_path)
-                                    _shutil.copy2(_snap_state, _state_path)
-                                    _restored_ok = verify_sqlite_integrity(
-                                        _state_path,
-                                        check_header=True,
-                                        run_pragma=True,
-                                    )
-                                    if _restored_ok.get("valid"):
+                                    if _restore_state_db_from_snapshot(
+                                        _state_path, _snap_state
+                                    ):
                                         print(
                                             "  ✓ Auto-restored from snapshot "
                                             f"{_snap_dir.name}"
@@ -4324,16 +4338,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             )
                             if _snap_ok.get("valid"):
                                 try:
-                                    import shutil as _shutil
-
-                                    _clear_stale_sqlite_sidecars(_state_path)
-                                    _shutil.copy2(_snap_state, _state_path)
-                                    _restored_ok = verify_sqlite_integrity(
-                                        _state_path,
-                                        check_header=True,
-                                        run_pragma=True,
-                                    )
-                                    if _restored_ok.get("valid"):
+                                    if _restore_state_db_from_snapshot(
+                                        _state_path, _snap_state
+                                    ):
                                         print(
                                             "  ✓ Auto-restored from pre-update "
                                             f"snapshot ({_pre_snap_id})"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -895,6 +895,27 @@ def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
         db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
 
 
+def _restore_state_db_from_snapshot(state_path: Path, snap_state: Path) -> bool:
+    """Replace *state_path* with the snapshot image at *snap_state*.
+
+    Shared by both post-update auto-restore paths (the ZIP update and the git
+    pull). The destination's stale sidecars are cleared before the copy, so the
+    restored image cannot be silently overwritten by the corrupt database's WAL
+    replay — see :func:`_clear_stale_sqlite_sidecars`.
+
+    Returns ``True`` when the restored file passes an integrity check. Raises
+    ``OSError`` if the copy itself fails, which callers already report.
+    """
+    from hermes_cli.backup import verify_sqlite_integrity
+
+    _clear_stale_sqlite_sidecars(state_path)
+    shutil.copy2(snap_state, state_path)
+    restored = verify_sqlite_integrity(
+        state_path, check_header=True, run_pragma=True
+    )
+    return bool(restored.get("valid"))
+
+
 def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -1228,16 +1249,9 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
                             )
                             if _snap_ok.get("valid"):
                                 try:
-                                    import shutil as _shutil
-
-                                    _clear_stale_sqlite_sidecars(_state_path)
-                                    _shutil.copy2(_snap_state, _state_path)
-                                    _restored_ok = verify_sqlite_integrity(
-                                        _state_path,
-                                        check_header=True,
-                                        run_pragma=True,
-                                    )
-                                    if _restored_ok.get("valid"):
+                                    if _restore_state_db_from_snapshot(
+                                        _state_path, _snap_state
+                                    ):
                                         print(
                                             "  ✓ Auto-restored from snapshot "
                                             f"{_snap_dir.name}"
@@ -5308,16 +5322,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             )
                             if _snap_ok.get("valid"):
                                 try:
-                                    import shutil as _shutil
-
-                                    _clear_stale_sqlite_sidecars(_state_path)
-                                    _shutil.copy2(_snap_state, _state_path)
-                                    _restored_ok = verify_sqlite_integrity(
-                                        _state_path,
-                                        check_header=True,
-                                        run_pragma=True,
-                                    )
-                                    if _restored_ok.get("valid"):
+                                    if _restore_state_db_from_snapshot(
+                                        _state_path, _snap_state
+                                    ):
                                         print(
                                             "  ✓ Auto-restored from pre-update "
                                             f"snapshot ({_pre_snap_id})"

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -872,6 +872,27 @@ def _update_complete_message(pre_version: str | None) -> str:
     if post_version:
         return f"✓ Update complete! (v{post_version})"
     return "✓ Update complete!"
+ 
+ 
+def _clear_stale_sqlite_sidecars(db_path: Path) -> None:
+    """Delete the WAL / shared-memory / rollback-journal files next to *db_path*.
+
+    Call this immediately before overwriting a database file with a snapshot
+    image. Quick snapshots are produced by ``backup._safe_copy_db`` through
+    ``sqlite3.backup()``, so the image is already checkpointed and owns no WAL —
+    which is exactly why ``backup._EXCLUDED_SUFFIXES`` refuses to ship sidecars
+    inside a snapshot. Copying the image over the destination replaces only the
+    main database file, so any ``-wal`` / ``-shm`` left behind by the *old*
+    database (a crashed writer, or a second Hermes process the updater's drain
+    did not stop) survives and is replayed over the fresh image on the next
+    open. The result passes ``PRAGMA integrity_check`` while serving the old
+    database's contents, and the first checkpoint folds it in permanently.
+
+    Removing them is safe here specifically: they belong to a database the
+    caller has already declared corrupt and is about to discard.
+    """
+    for suffix in ("-wal", "-shm", "-journal"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
 
 
 def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
@@ -1209,6 +1230,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
                                 try:
                                     import shutil as _shutil
 
+                                    _clear_stale_sqlite_sidecars(_state_path)
                                     _shutil.copy2(_snap_state, _state_path)
                                     _restored_ok = verify_sqlite_integrity(
                                         _state_path,
@@ -5288,6 +5310,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 try:
                                     import shutil as _shutil
 
+                                    _clear_stale_sqlite_sidecars(_state_path)
                                     _shutil.copy2(_snap_state, _state_path)
                                     _restored_ok = verify_sqlite_integrity(
                                         _state_path,

--- a/tests/hermes_cli/test_update_state_autorestore.py
+++ b/tests/hermes_cli/test_update_state_autorestore.py
@@ -18,14 +18,16 @@ These tests exercise REAL SQLite files, in WAL mode, with a genuinely hot
 sidecar.
 """
 
-import ast
 import shutil
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from hermes_cli.update_cmd import _clear_stale_sqlite_sidecars
+from hermes_cli.update_cmd import (
+    _clear_stale_sqlite_sidecars,
+    _restore_state_db_from_snapshot,
+)
 
 OLD_ROWS = 201
 SNAPSHOT_ROWS = 400
@@ -174,61 +176,38 @@ def test_clear_removes_every_sidecar_suffix_and_spares_the_database(tmp_path):
     assert db_path.read_bytes() == b"main-db"
 
 
-def test_both_auto_restore_call_sites_clear_sidecars_first():
-    """Bind the fix to the production call sites, not just the helper.
+def test_restore_helper_serves_snapshot_rows_over_a_hot_wal(
+    live_db_with_hot_wal, snapshot_db
+):
+    """The shared restore helper is what both update paths call.
 
-    Both auto-restore blocks (the ZIP-update path and the git-pull path) copy
-    the snapshot with ``_shutil.copy2(_snap_state, _state_path)``. Each one must
-    be immediately preceded by the sidecar clear, or the helper is dead code.
+    It must clear, copy and verify as one unit: after it returns, the database
+    has to hold the SNAPSHOT's rows even though the destination still owned a
+    hot WAL from the corrupt database.
     """
-    source = Path(__file__).resolve().parents[2] / "hermes_cli" / "update_cmd.py"
-    tree = ast.parse(source.read_text(encoding="utf-8"))
+    assert _restore_state_db_from_snapshot(live_db_with_hot_wal, snapshot_db) is True
 
-    guarded = 0
-    for node in ast.walk(tree):
-        body = getattr(node, "body", None)
-        if not isinstance(body, list):
-            continue
-        for previous, statement in zip(body, body[1:]):
-            if not _is_snapshot_copy(statement):
-                continue
-            assert _is_sidecar_clear(previous), (
-                "auto-restore at line "
-                f"{statement.lineno} copies the snapshot without clearing the "
-                "destination's stale SQLite sidecars first"
-            )
-            guarded += 1
-
-    assert guarded == 2, f"expected 2 auto-restore call sites, found {guarded}"
+    assert _row_count(live_db_with_hot_wal) == SNAPSHOT_ROWS
+    for suffix in ("-wal", "-shm", "-journal"):
+        assert not _sidecar(live_db_with_hot_wal, suffix).exists()
 
 
-def _is_snapshot_copy(statement) -> bool:
-    call = _expression_call(statement)
-    if call is None:
-        return False
-    func = call.func
-    return (
-        isinstance(func, ast.Attribute)
-        and func.attr == "copy2"
-        and isinstance(func.value, ast.Name)
-        and func.value.id == "_shutil"
-        and bool(call.args)
-        and isinstance(call.args[0], ast.Name)
-        and call.args[0].id == "_snap_state"
-    )
+def test_restore_helper_reports_failure_when_the_restored_copy_is_corrupt(tmp_path):
+    """A snapshot that does not survive the copy must return False, so the
+    caller prints the failure branch instead of claiming success."""
+    state_path = tmp_path / "state.db"
+    state_path.write_bytes(b"whatever")
+    bad_snapshot = tmp_path / "bad-snapshot.db"
+    bad_snapshot.write_bytes(b"\x00" * 4096)
+
+    assert _restore_state_db_from_snapshot(state_path, bad_snapshot) is False
 
 
-def _is_sidecar_clear(statement) -> bool:
-    call = _expression_call(statement)
-    if call is None:
-        return False
-    return (
-        isinstance(call.func, ast.Name)
-        and call.func.id == "_clear_stale_sqlite_sidecars"
-    )
+def test_restore_helper_propagates_copy_errors(tmp_path):
+    """A missing snapshot raises OSError, which both call sites already catch
+    and report as 'Auto-restore file copy failed'."""
+    state_path = tmp_path / "state.db"
+    state_path.write_bytes(b"whatever")
 
-
-def _expression_call(statement):
-    if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Call):
-        return statement.value
-    return None
+    with pytest.raises(OSError):
+        _restore_state_db_from_snapshot(state_path, tmp_path / "does-not-exist.db")

--- a/tests/hermes_cli/test_update_state_autorestore.py
+++ b/tests/hermes_cli/test_update_state_autorestore.py
@@ -1,0 +1,234 @@
+"""Auto-restore of state.db must not inherit the corrupt database's WAL.
+
+The post-update integrity guard added for #68474 restores ``state.db`` from a
+pre-update quick snapshot with a plain ``shutil.copy2``. The snapshot image is
+produced by ``backup._safe_copy_db`` via ``sqlite3.backup()``, so it is already
+checkpointed and owns no WAL — which is why ``backup._EXCLUDED_SUFFIXES``
+deliberately refuses to ship ``-wal`` / ``-shm`` / ``-journal`` inside a
+snapshot.
+
+Copying that image over the live path replaces only the main database file. A
+``state.db-wal`` left behind by the *old* database — a crashed writer, or a
+second Hermes holder the updater's drain did not stop — survives the copy and is
+replayed over the fresh image on the next open. The restored file then passes
+``PRAGMA integrity_check`` while serving the discarded database's contents, so
+the CLI prints "✓ Auto-restored from snapshot" over data the user has lost.
+
+These tests exercise REAL SQLite files, in WAL mode, with a genuinely hot
+sidecar.
+"""
+
+import ast
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.update_cmd import _clear_stale_sqlite_sidecars
+
+OLD_ROWS = 201
+SNAPSHOT_ROWS = 400
+
+
+def _sidecar(db_path: Path, suffix: str) -> Path:
+    return db_path.with_name(db_path.name + suffix)
+
+
+@pytest.fixture()
+def live_db_with_hot_wal(tmp_path):
+    """A WAL-mode database whose committed rows live in an UNCHECKPOINTED
+    ``-wal``, exactly as a force-killed writer leaves them on disk.
+
+    A clean ``close()`` checkpoints and unlinks the WAL, so the on-disk trio is
+    copied aside while the connection is still open and put back afterwards.
+    """
+    live = tmp_path / "state.db"
+    holding = tmp_path / "_killed_writer_state"
+    holding.mkdir()
+
+    conn = sqlite3.connect(live)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.executemany(
+        "INSERT INTO sessions (name) VALUES (?)",
+        [(f"old{i}",) for i in range(OLD_ROWS)],
+    )
+    conn.commit()
+    for suffix in ("", "-wal", "-shm"):
+        src = _sidecar(live, suffix)
+        if src.exists():
+            shutil.copy2(src, holding / (live.name + suffix))
+    conn.close()
+
+    for suffix in ("", "-wal", "-shm"):
+        held = holding / (live.name + suffix)
+        if held.exists():
+            shutil.copy2(held, _sidecar(live, suffix))
+
+    assert _sidecar(live, "-wal").exists(), "fixture failed to leave a hot WAL"
+    return live
+
+
+@pytest.fixture()
+def snapshot_db(tmp_path):
+    """A consistent, checkpointed image owning no WAL — what
+    ``backup._safe_copy_db`` produces through ``sqlite3.backup()``."""
+    source_path = tmp_path / "_snapshot_source.db"
+    snapshot = tmp_path / "state-snapshots" / "20260804-pre-update" / "state.db"
+    snapshot.parent.mkdir(parents=True)
+
+    source = sqlite3.connect(source_path)
+    source.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT)")
+    source.executemany(
+        "INSERT INTO sessions (name) VALUES (?)",
+        [(f"snap{i}",) for i in range(SNAPSHOT_ROWS)],
+    )
+    source.commit()
+    destination = sqlite3.connect(snapshot)
+    source.backup(destination)
+    destination.close()
+    source.close()
+    source_path.unlink()
+
+    assert not _sidecar(snapshot, "-wal").exists()
+    return snapshot
+
+
+def _row_count(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_restore_over_hot_wal_serves_snapshot_rows(live_db_with_hot_wal, snapshot_db):
+    """The restored database must contain the SNAPSHOT's rows, not the WAL's.
+
+    Without clearing the sidecars the copy silently loses every restored row:
+    SQLite replays the old WAL and serves the discarded database instead.
+    """
+    _clear_stale_sqlite_sidecars(live_db_with_hot_wal)
+    shutil.copy2(snapshot_db, live_db_with_hot_wal)
+
+    assert _row_count(live_db_with_hot_wal) == SNAPSHOT_ROWS
+
+
+def test_stale_wal_is_not_left_beside_the_restored_file(
+    live_db_with_hot_wal, snapshot_db
+):
+    """No sidecar from the discarded database may survive the restore."""
+    _clear_stale_sqlite_sidecars(live_db_with_hot_wal)
+    shutil.copy2(snapshot_db, live_db_with_hot_wal)
+
+    for suffix in ("-wal", "-shm", "-journal"):
+        assert not _sidecar(live_db_with_hot_wal, suffix).exists()
+
+
+def test_torn_restore_is_what_the_guard_prevents(live_db_with_hot_wal, snapshot_db):
+    """Pin the SQLite behaviour that makes the guard necessary.
+
+    Copying the snapshot over a database that still owns a hot WAL yields a file
+    that reports ``integrity_check`` clean — so the CLI's ``_restored_ok`` test
+    passes and it prints success — while serving the OLD row set.
+    """
+    from hermes_cli.backup import verify_sqlite_integrity
+
+    shutil.copy2(snapshot_db, live_db_with_hot_wal)  # no sidecar clearing
+
+    assert (
+        verify_sqlite_integrity(
+            live_db_with_hot_wal, check_header=True, run_pragma=True
+        ).get("valid")
+        is True
+    )
+    assert _row_count(live_db_with_hot_wal) == OLD_ROWS
+    assert _row_count(live_db_with_hot_wal) != SNAPSHOT_ROWS
+
+
+def test_clear_is_a_noop_when_no_sidecars_exist(tmp_path):
+    """A snapshot-clean destination must not raise (``missing_ok``)."""
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE t (a INTEGER)")
+    conn.commit()
+    conn.close()
+
+    _clear_stale_sqlite_sidecars(db_path)
+
+    assert db_path.exists()
+
+
+def test_clear_removes_every_sidecar_suffix_and_spares_the_database(tmp_path):
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"main-db")
+    for suffix in ("-wal", "-shm", "-journal"):
+        _sidecar(db_path, suffix).write_bytes(b"stale")
+
+    _clear_stale_sqlite_sidecars(db_path)
+
+    for suffix in ("-wal", "-shm", "-journal"):
+        assert not _sidecar(db_path, suffix).exists()
+    assert db_path.read_bytes() == b"main-db"
+
+
+def test_both_auto_restore_call_sites_clear_sidecars_first():
+    """Bind the fix to the production call sites, not just the helper.
+
+    Both auto-restore blocks (the ZIP-update path and the git-pull path) copy
+    the snapshot with ``_shutil.copy2(_snap_state, _state_path)``. Each one must
+    be immediately preceded by the sidecar clear, or the helper is dead code.
+    """
+    source = Path(__file__).resolve().parents[2] / "hermes_cli" / "update_cmd.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+
+    guarded = 0
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list):
+            continue
+        for previous, statement in zip(body, body[1:]):
+            if not _is_snapshot_copy(statement):
+                continue
+            assert _is_sidecar_clear(previous), (
+                "auto-restore at line "
+                f"{statement.lineno} copies the snapshot without clearing the "
+                "destination's stale SQLite sidecars first"
+            )
+            guarded += 1
+
+    assert guarded == 2, f"expected 2 auto-restore call sites, found {guarded}"
+
+
+def _is_snapshot_copy(statement) -> bool:
+    call = _expression_call(statement)
+    if call is None:
+        return False
+    func = call.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "copy2"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "_shutil"
+        and bool(call.args)
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "_snap_state"
+    )
+
+
+def _is_sidecar_clear(statement) -> bool:
+    call = _expression_call(statement)
+    if call is None:
+        return False
+    return (
+        isinstance(call.func, ast.Name)
+        and call.func.id == "_clear_stale_sqlite_sidecars"
+    )
+
+
+def _expression_call(statement):
+    if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Call):
+        return statement.value
+    return None


### PR DESCRIPTION
## What does this PR do?

The post-update integrity guard added for #68474 restores `state.db` from a pre-update quick snapshot with a plain `shutil.copy2`, at both auto-restore sites in `hermes_cli/update_cmd.py` — the ZIP-update path in `_update_via_zip` and the git-pull path in `_cmd_update_impl`. Neither clears the destination's SQLite sidecars first, so a restore can silently serve the *old, corrupt* database while reporting success.

The snapshot image is produced by `backup._safe_copy_db` through `sqlite3.backup()`, so it is already checkpointed and owns no WAL. **The repo already states this invariant against itself**, in the very file that produces the snapshot — `hermes_cli/backup.py:74-84` (`_EXCLUDED_SUFFIXES`):

> SQLite sidecar files — the backup takes a consistent snapshot of ``*.db`` via ``sqlite3.backup()``, so shipping the live WAL / shared-memory / rollback-journal alongside would pair a fresh snapshot with stale sidecar state and produce a torn restore on the next open.

The backup side excludes sidecars for exactly that reason. The restore side never cleared the destination's.

`copy2` replaces only the main database file. A `state.db-wal` belonging to the old database survives the copy and is replayed over the fresh image on the next open. The restored file then passes `PRAGMA integrity_check`, so `_restored_ok.get("valid")` is true and the CLI prints `✓ Auto-restored from snapshot …` over data the user has just lost. The first subsequent checkpoint folds the stale WAL in permanently, destroying the snapshot's contents for good.

**Reproduced against real SQLite** (this is the new test's scenario): restoring a 400-row snapshot over a database that still owns a hot `-wal` yields

- **0 of the 400 snapshot rows visible** — all 201 visible rows come from the old WAL
- `PRAGMA integrity_check` → `ok`
- the CLI prints `✓ Auto-restored from snapshot`

User-visible symptom: *"`hermes update` said my state.db was corrupt, then said it auto-restored from the pre-update snapshot — but my sessions are still gone. It reported success."*

A hot `-wal` is reachable at precisely this moment: a second Hermes holder the updater's drain did not stop (desktop app, gateway in another container, a second CLI), or the crash / ENOSPC event that corrupted `state.db` in the first place — i.e. the very trigger for this code path.

Deleting the destination's sidecars is safe *here specifically*: they belong to a database the caller has already declared corrupt and is about to discard. This is deliberately the opposite of `preflight_db_writability`, which correctly refuses to delete a live WAL (`hermes_state.py:1203-1207`: *"Do NOT delete the -wal file — it contains committed data…"*).

## Related Issue

Context: #68474 (the issue that introduced this auto-restore guard) — **already closed**, so this PR intentionally carries no `Fixes #` line. This hardens the guard that issue produced; there is no separate open issue for the sidecar defect.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py:715` — new helper `_clear_stale_sqlite_sidecars(db_path)`, unlinking `-wal` / `-shm` / `-journal` with `missing_ok=True`.
- `hermes_cli/update_cmd.py:736` — new helper `_restore_state_db_from_snapshot(state_path, snap_state)`, performing clear → copy → verify as one unit and returning whether the restored file passes its integrity check.
- `hermes_cli/update_cmd.py:1066` — the ZIP-update auto-restore now calls that helper.
- `hermes_cli/update_cmd.py:4330` — the git-pull auto-restore now calls the same helper.
- `tests/hermes_cli/test_update_state_autorestore.py` — new regression test (8 cases) against real WAL-mode SQLite.

The two auto-restore blocks were byte-identical, so routing both through one helper makes the clear-before-copy ordering hold by construction and *shrinks* the code at both call sites. Both calls remain inside the existing `try:` whose `except OSError` already reports auto-restore failures, so a sidecar that cannot be unlinked (e.g. a Windows share-violation from a live holder) surfaces through the existing error path rather than a new one.

### Root-cause sweep — every site that shares this cause

I grepped the repo for snapshot-over-live-database copies rather than fixing only the reported one:

| Site | Shares the root cause? | Action |
| --- | --- | --- |
| `update_cmd.py:1066` (ZIP auto-restore) | Yes | **Fixed** |
| `update_cmd.py:4330` (git-pull auto-restore) | Yes | **Fixed** |
| `update_cmd.py` ~`:2634` (post-snapshot check) | No — verifies the snapshot, never copies onto the live path | Excluded |
| `backup.py:1570` (`_restore_cron_jobs_if_emptied`) | No — restores `jobs.json`, not a SQLite database | Excluded |
| `backup.py` `restore_quick_snapshot` | Same shape, but already contested by open PRs (see below) | **Deliberately not touched** |

### In-repo precedent for the idiom (unchanged by this PR)

- `hermes_cli/session_recovery.py:61` — `_SIDECAR_SUFFIXES = ("", "-wal", "-shm", "-journal")`
- `hermes_cli/kanban_db.py:1777` and `:1848` — sidecar-aware quarantine/backup of a corrupt DB
- `hermes_cli/profile_distribution.py:105-107` — enumerates `state.db-shm` / `state.db-wal` explicitly
- `hermes_state.py:1128` — moves `-wal`/`-shm` alongside the DB "so a fresh open is clean"

## How to Test

1. Run the new regression test:
   ```
   pytest tests/hermes_cli/test_update_state_autorestore.py -v
   ```
   8 passed.

2. **Red before the fix.** Deleting the sidecar clear from inside `_restore_state_db_from_snapshot` — so the production sequence becomes the old copy-then-verify — fails the guard behaviourally, not with an `ImportError`:
   ```
   FAILED test_restore_helper_serves_snapshot_rows_over_a_hot_wal
   E   AssertionError: assert 201 == 400
   ```
   `201 == 400` is the data loss itself: the snapshot's 400 rows are gone and the discarded database's 201 rows are being served. Neutralizing `_clear_stale_sqlite_sidecars` instead fails three cases the same way.

3. **Green after the fix.** `8 passed`.

4. Adjacent suites, unchanged: `pytest tests/hermes_cli/test_state_db_guard.py tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py tests/hermes_cli/test_cmd_update.py -q` → 79 passed.

5. `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_update_state_autorestore.py` → All checks passed. The new test file is `ruff format` clean; `update_cmd.py` was left unformatted because it already fails `ruff format` on clean `main` and this change adds no new formatting diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — *not ticked honestly: `tests/hermes_cli/` has a large pre-existing failure baseline on clean `main` (e.g. all of `test_managed_uv.py` and `test_webhook_cli.py`). I verified the failures I hit are identical with and without this change — same 5 `test_managed_uv.py` failures in the same selection either way — and are unrelated to the touched code.*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries a docstring explaining why deleting sidecars is safe at this call site and unsafe generally
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — `Path.unlink(missing_ok=True)` is portable; on Windows a sidecar held open by another process raises `PermissionError`, a subclass of `OSError`, which the enclosing handler already reports as an auto-restore failure instead of crashing the update
- [x] N/A — no tool descriptions or schemas changed

## Related / Positioning

This **complements #72085** (@necoweb3, *"fix(backup): clear stale SQLite sidecars on snapshot restore"*), which identified this same defect class first and covers it in `hermes_cli/backup.py`. Credit for naming the class belongs there.

The two are disjoint, and deliberately so:

- **#72085 covers `hermes_cli/backup.py`; this PR covers only the two `hermes_cli/update_cmd.py` auto-restore sites**, which no open PR currently reaches.
- #72085's `hermes_cli/main.py` hunks target coordinates that no longer exist — that code has since moved into `hermes_cli/update_cmd.py` (`git show origin/main:hermes_cli/main.py | grep -n "_snap_state"` returns nothing), which is why it currently shows as conflicting. So its patch cannot reach the sites fixed here even once rebased.
- I deliberately did **not** touch `hermes_cli/backup.py`. Its `restore_quick_snapshot` path is already contested by open work (#72085, #65960, #78288), and duplicating it here would only create overlap. If #72085 lands first, this PR still applies cleanly — the files do not intersect.
