### PR TITLE
fix(scripts): use unclaimable noreply identity for Hermes agent email (follow-up)

### DIFF
--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -64,7 +64,8 @@ IGNORED_EMAILS = {
     "noreply@github.com",
     "noreply@nousresearch.com",
     "cursoragent@cursor.com",
-    "hermes-agent[bot]@users.noreply.github.com",
+    "hermes@nousresearch.com",  # legacy identity — kept for historical commits
+    "hermes-agent[bot]@users.noreply.github.com",  # canonical identity (unclaimable by humans)
     "hermes-audit@example.com",
     "nousbot@nousresearch.com",
     "hermes@habibilabs.dev",

--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -64,7 +64,7 @@ IGNORED_EMAILS = {
     "noreply@github.com",
     "noreply@nousresearch.com",
     "cursoragent@cursor.com",
-    "hermes@nousresearch.com",
+    "hermes-agent[bot]@users.noreply.github.com",
     "hermes-audit@example.com",
     "nousbot@nousresearch.com",
     "hermes@habibilabs.dev",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1228,7 +1228,7 @@ LEGACY_AUTHOR_MAP = {
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",
-    "hermes@nousresearch.com": "NousResearch",
+    "hermes-agent[bot]@users.noreply.github.com": "NousResearch",
     "reginaldasr@gmail.com": "ReginaldasR",
     "ntconguit@gmail.com": "0xharryriddle",
     "agent@wildcat.local": "ericnicolaides",
@@ -2296,7 +2296,7 @@ def parse_coauthors(body: str) -> list:
         return []
     # AI/bot emails to ignore in co-author trailers
     _ignored_emails = {"noreply@anthropic.com", "noreply@github.com",
-                       "cursoragent@cursor.com", "hermes@nousresearch.com"}
+                       "cursoragent@cursor.com", "hermes-agent[bot]@users.noreply.github.com"}
     _ignored_names = re.compile(r"^(Claude|Copilot|Cursor Agent|GitHub Actions?|dependabot|renovate)", re.IGNORECASE)
     pattern = re.compile(r"Co-authored-by:\s*(.+?)\s*<([^>]+)>", re.IGNORECASE)
     results = []

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1228,7 +1228,8 @@ LEGACY_AUTHOR_MAP = {
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",
-    "hermes-agent[bot]@users.noreply.github.com": "NousResearch",
+    "hermes@nousresearch.com": "NousResearch",  # legacy identity — historical commits
+    "hermes-agent[bot]@users.noreply.github.com": "NousResearch",  # canonical (unclaimable)
     "reginaldasr@gmail.com": "ReginaldasR",
     "ntconguit@gmail.com": "0xharryriddle",
     "agent@wildcat.local": "ericnicolaides",
@@ -2296,7 +2297,8 @@ def parse_coauthors(body: str) -> list:
         return []
     # AI/bot emails to ignore in co-author trailers
     _ignored_emails = {"noreply@anthropic.com", "noreply@github.com",
-                       "cursoragent@cursor.com", "hermes-agent[bot]@users.noreply.github.com"}
+                       "cursoragent@cursor.com", "hermes@nousresearch.com",
+                       "hermes-agent[bot]@users.noreply.github.com"}
     _ignored_names = re.compile(r"^(Claude|Copilot|Cursor Agent|GitHub Actions?|dependabot|renovate)", re.IGNORECASE)
     pattern = re.compile(r"Co-authored-by:\s*(.+?)\s*<([^>]+)>", re.IGNORECASE)
     results = []


### PR DESCRIPTION
## What does this PR do?

Follow-up to #78442 (by @webtecnica) for issue #78374 — fixes the Hermes agent git identity resolving to a real GitHub account (`Rafa-Ross`) and misattributing commits.

This branch carries webtecnica's original commit (`fix(scripts): use unclaimable noreply identity...`, 2a332c6f) **plus one follow-up commit** that preserves backward compatibility:

**Why the follow-up:** the original change *replaced* `hermes@nousresearch.com` with `hermes-agent[bot]@users.noreply.github.com` in `scripts/contributor_audit.py` and `scripts/release.py`. Historical commits (and existing `Co-authored-by: Hermes Agent <hermes@nousresearch.com>` trailers) still carry the legacy email, so removing its mapping breaks backward-compatible attribution in release/audit tooling:

- `scripts/release.py` `LEGACY_AUTHOR_MAP`: legacy key restored (historical commits → `NousResearch`), canonical noreply key added alongside
- `scripts/release.py` `parse_coauthors()` `_ignored_emails`: both emails kept
- `scripts/contributor_audit.py` `IGNORED_EMAILS`: both emails kept

## How to Test

1. `pytest tests/scripts/test_contributor_map.py` → **7 passed**
2. `python3 -m py_compile scripts/release.py scripts/contributor_audit.py` → clean
3. `grep -rn "hermes@nousresearch.com" scripts/` → references only in comment/legacy-map positions (intentional)

## Platforms Tested

- **macOS** (Apple Silicon, Python 3.11)

## Related

- Fixes #78374
- Supersedes #78442 (this branch includes webtecnica's commit with authorship preserved — if maintainers prefer, they can close #78442 in favor of this one, or cherry-pick only the follow-up commit onto it)
