### PR TITLE
fix: guard terminal lifecycle scan against binary paths with NUL bytes

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths. ValueError: embedded NUL byte
+        # from a binary's decoded contents tokenized as a path — a
+        # guarded path must never crash the guard (#76762).
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2545,6 +2545,15 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
+                                # A NUL byte means this is a binary (ELF/Mach-O/PE),
+                                # not a shell script — decoding it with
+                                # errors="replace" preserves the NULs, and the
+                                # guard's recursive scan would tokenize machine
+                                # code into junk paths and crash on embedded NUL
+                                # bytes. Mirror the binary check in
+                                # lifecycle_guard._read_referenced_script.
+                                if b"\x00" in data:
+                                    return None
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
                     pass


### PR DESCRIPTION
## What
Commands invoking a binary by path (e.g. `venv/bin/python -c ...`) crash the terminal tool.

## Repro
Run any command where the executable token is a path containing `/` that resolves to a binary, e.g.:
```bash
~/.hermes/hermes-agent/venv/bin/python -c "import os"
```
The terminal tool raises `ValueError: embedded null byte` from `os.open` inside the lifecycle guard, before the command ever runs.

## Root cause
Two-part chain:
1. `cron/lifecycle_guard.py` — `_read_referenced_script` correctly detects binaries (NUL bytes) and returns `None`, but the terminal tool's `_read_script_in_env` fallback **re-reads the binary as UTF-8 with `errors="replace"`**, which preserves literal NUL bytes in the decoded text.
2. The recursive scan then tokenizes machine code as shell commands, producing a path token containing `\x00`. `os.open(path, ...)` raises `ValueError` (embedded null byte) — not `OSError` — so the guard's `except OSError` misses it and the whole terminal tool crashes.

The guard's own comment states the invariant: *"a guarded path must never crash the guard (#76762)."* It was fixed for `Path.resolve` but not for the `os.open` two lines above.

## Fix
- `cron/lifecycle_guard.py`: catch `(OSError, ValueError)` on `os.open` so a NUL-byte path fails closed instead of crashing the guard.
- `tools/terminal_tool.py`: `_read_script_in_env` now skips files containing NUL bytes (binaries), mirroring the binary check in `_read_referenced_script`, so machine code never enters the scan at all.

## Verification
- Reproduced the crash on current `main` with the exact command above.
- After the fix, the guard returns `False` (no crash) for binary-path commands, and normal commands (`ffmpeg -version`, `ls`, `echo`) behave unchanged.

---
*This PR was prepared with AI assistance (Hermes Agent / Perkins).*