### PR TITLE
fix(cli): reap session-owned background processes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1268,6 +1268,16 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     except Exception as e:
         logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
 
+    # ``AIAgent.close`` owns per-session teardown, including process-registry
+    # cleanup.  One-shot CLI invocations (and therefore Kanban workers) reach
+    # this path directly; omitting close here lets their background process
+    # trees outlive the worker even though the agent knows the owning session.
+    try:
+        if _active_agent_ref and hasattr(_active_agent_ref, "close"):
+            _active_agent_ref.close()
+    except Exception as e:
+        logger.warning("CLI cleanup agent close failed: %s", e, exc_info=True)
+
 
 def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:
     if not _single_query_finalize_attempted_session_ids:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4217,7 +4217,7 @@ class AIAgent:
         # 1. Kill background processes for this task
         try:
             from tools.process_registry import process_registry
-            process_registry.kill_all(task_id=task_id)
+            process_registry.kill_all(task_id=task_id, session_key=task_id)
         except Exception:
             pass
 

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -52,6 +52,10 @@ def test_session_finalize_on_cleanup(mock_finalize_session):
 
     cli_mod._run_cleanup()
 
+    # A one-shot CLI/Kanban worker is a real session boundary. Its active
+    # agent must close so session-owned background process trees are reaped.
+    mock_agent.close.assert_called_once_with()
+
     assert any(
         not c.args
         and c.kwargs["session_id"] == "cleanup-session-id"

--- a/tests/tools/test_process_registry_session_cleanup.py
+++ b/tests/tools/test_process_registry_session_cleanup.py
@@ -1,0 +1,159 @@
+"""Regression tests for session-owned background process cleanup.
+
+Top-level terminal processes share ``task_id='default'`` but retain the
+originating agent session in ``session_key``.  Kanban one-shot workers must be
+able to reap those processes when their agent closes.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+import threading
+import time
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.process_registry import ProcessRegistry, ProcessSession
+
+
+def _session(sid: str, *, task_id: str, session_key: str) -> ProcessSession:
+    return ProcessSession(
+        id=sid,
+        command="sleep 60",
+        task_id=task_id,
+        session_key=session_key,
+        started_at=time.time(),
+        process=MagicMock(),
+        pid=4242,
+    )
+
+
+def test_kill_all_can_select_shared_sandbox_process_by_session_key(monkeypatch):
+    registry = ProcessRegistry()
+    owned = _session("proc_owned", task_id="default", session_key="kanban-session")
+    foreign = _session("proc_foreign", task_id="default", session_key="other-session")
+    registry._running = {owned.id: owned, foreign.id: foreign}
+
+    killed: list[str] = []
+
+    def fake_kill(
+        session_id: str,
+        *,
+        source: str,
+        consume_output: bool = False,
+    ):
+        assert consume_output is False
+        killed.append(session_id)
+        return {"status": "killed"}
+
+    monkeypatch.setattr(registry, "kill_process", fake_kill)
+
+    assert registry.kill_all(session_key="kanban-session") == 1
+    assert killed == ["proc_owned"]
+
+
+def test_kill_all_combines_task_and_session_ownership_without_regression(monkeypatch):
+    registry = ProcessRegistry()
+    by_task = _session("proc_task", task_id="isolated-task", session_key="other")
+    by_session = _session("proc_session", task_id="default", session_key="kanban-session")
+    unrelated = _session("proc_unrelated", task_id="default", session_key="other")
+    registry._running = {
+        by_task.id: by_task,
+        by_session.id: by_session,
+        unrelated.id: unrelated,
+    }
+
+    killed: list[str] = []
+
+    def fake_kill(
+        session_id: str,
+        *,
+        source: str,
+        consume_output: bool = False,
+    ):
+        assert consume_output is False
+        killed.append(session_id)
+        return {"status": "killed"}
+
+    monkeypatch.setattr(registry, "kill_process", fake_kill)
+
+    assert registry.kill_all(
+        task_id="isolated-task", session_key="kanban-session"
+    ) == 2
+    assert killed == ["proc_task", "proc_session"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process liveness assertion")
+def test_session_scoped_cleanup_terminates_real_background_process(tmp_path):
+    psutil = pytest.importorskip("psutil")
+    registry = ProcessRegistry()
+    session = registry.spawn_local(
+        command="sleep 60",
+        cwd=str(tmp_path),
+        task_id="default",
+        session_key="kanban-session",
+    )
+    try:
+        assert session.pid is not None
+        assert psutil.pid_exists(session.pid)
+
+        assert registry.kill_all(session_key="kanban-session") == 1
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and psutil.pid_exists(session.pid):
+            time.sleep(0.05)
+        assert not psutil.pid_exists(session.pid)
+    finally:
+        registry.kill_all()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX lifecycle E2E")
+def test_one_shot_cli_cleanup_reaps_session_owned_process(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    """Exercise CLI -> AIAgent.close -> ProcessRegistry with a real process."""
+    import cli as cli_mod
+    from run_agent import AIAgent
+    from tools.process_registry import process_registry
+
+    session_key = f"kanban-e2e-{uuid.uuid4()}"
+    command = (
+        f"{shlex.quote(sys.executable)} -c "
+        f"{shlex.quote('import time; time.sleep(60)')}"
+    )
+    process_session = process_registry.spawn_local(
+        command,
+        task_id="default",
+        session_key=session_key,
+    )
+    process = process_session.process
+    assert process is not None
+    assert process.poll() is None
+
+    agent = object.__new__(AIAgent)
+    setattr(agent, "session_id", session_key)
+    setattr(agent, "_active_children", set())
+    setattr(agent, "_active_children_lock", threading.Lock())
+    setattr(agent, "client", None)
+    setattr(agent, "_end_session_on_close", False)
+    setattr(agent, "_session_db", None)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cli_mod, "_cleanup_done", False)
+    monkeypatch.setattr(cli_mod, "_active_agent_ref", agent)
+
+    try:
+        cli_mod._run_cleanup(notify_session_finalize=False)
+        deadline = time.monotonic() + 5
+        while process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert process.poll() is not None
+    finally:
+        if process.poll() is None:
+            process_registry.kill_all(session_key=session_key)
+            process.wait(timeout=5)

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -114,7 +114,8 @@ class TestAgentCloseMethod:
                 agent.close()
 
                 mock_registry.kill_all.assert_called_once_with(
-                    task_id="test-close-cleanup"
+                    task_id="test-close-cleanup",
+                    session_key="test-close-cleanup",
                 )
                 mock_cleanup_vm.assert_called_once_with("test-close-cleanup")
                 mock_cleanup_browser.assert_called_once_with("test-close-cleanup")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1992,17 +1992,30 @@ class ProcessRegistry:
         self,
         task_id: Optional[str] = None,
         *,
+        session_key: Optional[str] = None,
         exclude_ids: frozenset = frozenset(),
         source: str = "kill_all",
         consume_output: bool = False,
     ) -> int:
-        """Kill all running processes, optionally filtered by task_id. Returns count killed."""
+        """Kill owned running processes and return the count killed.
+
+        ``task_id`` preserves the historical sandbox-wide ownership filter.
+        ``session_key`` scopes cleanup to the originating agent session.  When
+        both are provided, a process matching either ownership dimension is
+        selected.  The OR is intentional: top-level local terminal processes
+        share ``task_id='default'`` while retaining their real owner in
+        ``session_key``.
+        """
         with self._lock:
             targets = [
                 s for s in self._running.values()
-                if (task_id is None or s.task_id == task_id)
+                if not s.exited
+                and (
+                    (task_id is None and session_key is None)
+                    or (task_id is not None and s.task_id == task_id)
+                    or (session_key is not None and s.session_key == session_key)
+                )
                 and s.id not in exclude_ids
-                and not s.exited
             ]
 
         killed = 0


### PR DESCRIPTION
## Summary
- call `AIAgent.close()` at one-shot CLI shutdown so its lifecycle cleanup actually runs
- extend `ProcessRegistry.kill_all()` with optional `session_key` ownership while preserving `exclude_ids`, source, and output-consumption semantics
- cover task-owned, session-owned, unrelated, real-process, and full CLI lifecycle paths

## Bug
Top-level terminal processes are registered with `task_id="default"` and the owning agent session in `session_key`. `AIAgent.close()` filtered only by its `session_id` as a task ID, and one-shot CLI shutdown did not call `close()` at all. A Kanban worker could therefore finish while its preview server or other tracked background process survived.

## Invariant
Closing agent session `S` reaps active tracked processes where `task_id == S` OR `session_key == S`, without touching unrelated sessions.

## Verification
- `93 passed` on current `main` across ProcessRegistry, zombie cleanup, CLI lifecycle, and gateway shutdown suites
- real process E2E covers `cli._run_cleanup -> AIAgent.close -> ProcessRegistry.kill_all` with temporary `HERMES_HOME`
- `ruff check` passed
- `git diff --check` passed