### PR TITLE
fix(cron): scope custom credential pools to the pinned provider

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -212,6 +212,35 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
     return result
 
 
+def _resolve_cron_credential_pool_key(runtime: dict) -> Optional[str]:
+    """Return the credential-pool key for a resolved cron runtime.
+
+    Named custom endpoints share the live provider label ``custom`` but are
+    stored under ``custom:<name>``. Loading the bare ``custom`` key would merge
+    every custom_providers entry into one rotation set and let a pinned job
+    hop endpoints on 429 (#78427).
+    """
+    runtime_provider = str((runtime or {}).get("provider") or "").strip().lower()
+    if not runtime_provider:
+        return None
+    if runtime_provider != "custom":
+        return runtime_provider
+
+    from agent.credential_pool import CUSTOM_POOL_PREFIX, get_custom_provider_pool_key
+
+    requested = str((runtime or {}).get("requested_provider") or "").strip()
+    provider_name = None
+    requested_l = requested.lower()
+    if requested_l.startswith(CUSTOM_POOL_PREFIX):
+        provider_name = requested[len(CUSTOM_POOL_PREFIX):]
+    elif requested_l and requested_l not in {"custom", "auto"}:
+        provider_name = requested
+    return get_custom_provider_pool_key(
+        (runtime or {}).get("base_url"),
+        provider_name=provider_name,
+    )
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -3453,15 +3482,26 @@ def run_job(
         if runtime_provider:
             try:
                 from agent.credential_pool import load_pool
-                pool = load_pool(runtime_provider)
-                if pool.has_credentials():
-                    credential_pool = pool
-                    logger.info(
-                        "Job '%s': loaded credential pool for provider %s with %d entries",
+
+                pool_key = _resolve_cron_credential_pool_key(runtime)
+                if runtime_provider == "custom" and not pool_key:
+                    logger.debug(
+                        "Job '%s': no scoped custom pool for base_url=%r "
+                        "requested_provider=%r — not loading bare 'custom' pool",
                         job_id,
-                        runtime_provider,
-                        len(pool.entries()),
+                        runtime.get("base_url"),
+                        runtime.get("requested_provider"),
                     )
+                elif pool_key:
+                    pool = load_pool(pool_key)
+                    if pool.has_credentials():
+                        credential_pool = pool
+                        logger.info(
+                            "Job '%s': loaded credential pool for provider %s with %d entries",
+                            job_id,
+                            pool_key,
+                            len(pool.entries()),
+                        )
             except Exception as e:
                 logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
 

--- a/tests/cron/test_cron_custom_pool_key.py
+++ b/tests/cron/test_cron_custom_pool_key.py
@@ -1,0 +1,63 @@
+"""Cron credential pool key scoping for custom providers (#78427)."""
+
+from unittest.mock import patch
+
+from cron.scheduler import _resolve_cron_credential_pool_key
+
+
+def test_named_provider_passes_through():
+    assert _resolve_cron_credential_pool_key({"provider": "openai"}) == "openai"
+    assert _resolve_cron_credential_pool_key({"provider": "OpenRouter"}) == "openrouter"
+
+
+def test_empty_provider_returns_none():
+    assert _resolve_cron_credential_pool_key({}) is None
+    assert _resolve_cron_credential_pool_key({"provider": ""}) is None
+
+
+def test_custom_provider_scopes_by_name_and_base_url():
+    runtime = {
+        "provider": "custom",
+        "requested_provider": "custom:longcat",
+        "base_url": "https://longcat.example/v1",
+    }
+    with patch(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        return_value="custom:longcat",
+    ) as mock_key:
+        assert _resolve_cron_credential_pool_key(runtime) == "custom:longcat"
+        mock_key.assert_called_once_with(
+            "https://longcat.example/v1",
+            provider_name="longcat",
+        )
+
+
+def test_custom_provider_uses_requested_name_without_prefix():
+    runtime = {
+        "provider": "custom",
+        "requested_provider": "LongCat",
+        "base_url": "https://longcat.example/v1",
+    }
+    with patch(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        return_value="custom:longcat",
+    ) as mock_key:
+        assert _resolve_cron_credential_pool_key(runtime) == "custom:longcat"
+        mock_key.assert_called_once_with(
+            "https://longcat.example/v1",
+            provider_name="LongCat",
+        )
+
+
+def test_custom_provider_without_match_does_not_return_bare_custom():
+    """Regression: bare 'custom' must never be returned — that merges all pools."""
+    runtime = {
+        "provider": "custom",
+        "requested_provider": "custom",
+        "base_url": "https://unknown.example/v1",
+    }
+    with patch(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        return_value=None,
+    ):
+        assert _resolve_cron_credential_pool_key(runtime) is None


### PR DESCRIPTION
## Summary
Cron jobs loaded `load_pool("custom")`, which merges **every** `custom_providers` entry into one rotation set. A job pinned to e.g. `custom:longcat` / `LongCat-2.0` could rotate into another custom endpoint on 429, miss the model, and fall through the global fallback chain — silently leaving the pin.

## Fix
- Add `_resolve_cron_credential_pool_key(runtime)` that maps named custom endpoints to `custom:<name>` via `get_custom_provider_pool_key(base_url, provider_name=…)`.
- Prefer `requested_provider` when it is `custom:<name>` or a bare custom name.
- If no scoped key resolves, **do not** load the bare `custom` mega-pool.
- Non-custom providers unchanged.

## Test plan
- [x] `pytest tests/cron/test_cron_custom_pool_key.py -q`
- [ ] Manual: multi-`custom_providers` + `credential_pool_strategies.custom: round_robin` + cron pin — 429 should stay within the pinned provider’s keys

Fixes #78427
Related: #45244
