### PR TITLE
feat(banner): show recent upstream commits when behind

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -273,6 +273,28 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     return None
 
 
+def get_recent_upstream_commits(repo_dir: Optional[Path] = None, count: int = 5) -> list[str]:
+    """Return the last ``count`` commit subjects from HEAD..origin/main.
+
+    Returns an empty list if the repo isn't a git checkout, the fetch
+    hasn't been done, or there are no commits behind.
+    """
+    repo_dir = repo_dir or _resolve_repo_dir()
+    if repo_dir is None:
+        return []
+    try:
+        result = subprocess.run(
+            ["git", "log", "--oneline", f"-{count}", "HEAD..origin/main"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5, cwd=str(repo_dir),
+        )
+    except Exception:
+        return []
+    if result.returncode != 0 or not result.stdout:
+        return []
+    return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -867,6 +889,24 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                     f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
                     f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
                 )
+                # Show recent upstream commits
+                recent = get_recent_upstream_commits(count=5)
+                if recent:
+                    right_lines.append("")
+                    right_lines.append(f"[bold {accent}]Recent Commits[/]")
+                    for commit_line in recent:
+                        parts = commit_line.split(" ", 1)
+                        if len(parts) == 2:
+                            short_hash, subject = parts
+                            right_lines.append(
+                                f"[dim {dim}]{short_hash[:8]}[/] [{text}]{subject}[/]"
+                            )
+                        else:
+                            right_lines.append(f"[dim {dim}]{commit_line}[/]")
+                    if behind > 5:
+                        right_lines.append(
+                            f"[dim {dim}]... and {behind - 5} more commits[/]"
+                        )
             else:
                 # UPDATE_AVAILABLE_NO_COUNT: nix-built hermes; we know an update
                 # exists but not by how much, and we don't know how the user


### PR DESCRIPTION
## Summary

When the welcome banner reports N commits behind, also show the last 5 commit subjects from `HEAD..origin/main` so users can see what's new without running `git log` manually.

## Changes

- **New function** `get_recent_upstream_commits(repo_dir, count=5)` — runs `git log --oneline -5 HEAD..origin/main` with a 5-second timeout. Returns an empty list on any failure (no checkout, offline, shallow clone, etc.) — same defensive pattern as the rest of the update-check machinery.
- **Banner section** — when behind > 0, after the "⚠ N commits behind" line, shows a "Recent Commits" section with dimmed short hashes and commit subjects, plus a "... and N more commits" footer when there are more than 5.

## Example output

```
⚠ 335 commits behind — run hermes update to update

Recent Commits
f5be9236 refactor(xai): simplify _xai_prefers_native_web_search to use registry
29eba9cb test(xai): cover Firecrawl vs native web_search on Responses
d2772b42 fix(xai): honor configured web search backend on Responses path
b8b17b8c fix: wire HermesConsoleModal WS into stale-token reload guard
19e697d9 fix: update ChatPage test import for react-router v7
... and 330 more commits
```

## Design decisions

- Uses the same `_resolve_repo_dir()` helper as the existing update check, so it works with both local checkouts and the profile-scoped fallback.
- The commit hash is dimmed, the subject uses the banner's text color — consistent with the rest of the banner's color scheme.
- Only shown when there are actual commits behind (not on the up-to-date or no-checkout paths).
- No new imports or dependencies — uses `subprocess.run` with the same encoding/error handling as the existing git helpers.