### PR TITLE
fix(cron): tolerate embedded NUL byte in referenced script paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: embedded NUL byte in the path (a binary's decoded
+        # contents tokenized as a path). A guarded path must never crash
+        # the guard (#76762) — treat it as "nothing to scan".
         return None, False
     try:
         metadata = os.fstat(descriptor)


### PR DESCRIPTION
Fixes crash of the terminal tool with `Failed to execute command: embedded null byte` when `_HERMES_GATEWAY=1` and a command references a binary via absolute path (e.g. `uv pip install --python /path/venv/bin/python ...`).

## Root cause
`_read_referenced_script()` called `os.open(path)` catching only `OSError`. When the guard tokenizes a binary's decoded contents as a shell command, the recursion can produce a path containing a NUL byte. `os.open()` then raises `ValueError: embedded null byte`, which crashed the guard and blocked the whole command.

Upstream #76762 fixed the `resolve()` site but not `os.open()` — this patch mirrors the same protection on the remaining site.

## Change
Catch `(OSError, ValueError)` in `_read_referenced_script()` and treat a NUL-bearing path as "nothing to scan" (binary, not a referenced shell script), consistent with the existing NUL-in-content skip.

## Tests
Manual reproduction: command referencing an absolute binary path no longer crashes the terminal tool. Existing test suite unaffected.