### PR TITLE
fix(api): return 502 for failed responses runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5255,7 +5255,50 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=500,
                 )
 
-        final_response = _resolve_media_to_data_urls(result.get("final_response", ""))
+        final_response = _resolve_media_to_data_urls(result.get("final_response") or "")
+        is_partial = bool(result.get("partial"))
+        is_failed = bool(result.get("failed"))
+        completed = bool(result.get("completed", True))
+        raw_err_msg = result.get("error")
+        err_msg = _redact_api_error_text(raw_err_msg) if raw_err_msg else raw_err_msg
+
+        # Resolve the effective session ID before handling failures. Successful
+        # responses persist it for future chaining, while failure responses are not
+        # stored but still expose the same session metadata in response headers.
+        # This also prevents previous_response_id chaining from resuming a
+        # pre-rotation session after compression.
+        _effective_session_id = session_id
+        _result_sid = result.get("session_id") if isinstance(result, dict) else None
+        if isinstance(_result_sid, str) and _result_sid:
+            _effective_session_id = _result_sid
+
+        response_headers = {"X-Hermes-Session-Id": _effective_session_id}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
+
+        # Return an OpenAI-style error envelope when the agent reports a failed
+        # run, rather than rendering its internal failure text as assistant output.
+        if is_failed:
+            err_body = _openai_error(
+                err_msg or "Agent run did not produce a response.",
+                err_type="server_error",
+                code="agent_incomplete",
+            )
+            err_body["error"]["hermes"] = {
+                "completed": completed,
+                "partial": is_partial,
+                "failed": is_failed,
+            }
+            response_headers["X-Hermes-Completed"] = "false"
+            response_headers["X-Hermes-Partial"] = (
+                "true" if is_partial else "false"
+            )
+            return web.json_response(
+                err_body,
+                status=502,
+                headers=response_headers,
+            )
+
         if not final_response:
             final_response = _redact_api_error_text(result.get("error", "(No response generated)"))
 
@@ -5270,16 +5313,6 @@ class APIServerAdapter(BasePlatformAdapter):
             result,
             final_response,
         )
-
-        # Persist the effective session ID surfaced by _run_agent so that
-        # compression-triggered session rotations propagate to the stored
-        # response and the X-Hermes-Session-Id header.  Without this,
-        # previous_response_id chaining keeps resuming the pre-rotation
-        # session and re-triggers compression on every subsequent request.
-        _effective_session_id = session_id
-        _result_sid = result.get("session_id") if isinstance(result, dict) else None
-        if isinstance(_result_sid, str) and _result_sid:
-            _effective_session_id = _result_sid
 
         # Build output items from the current turn only.  AIAgent returns a
         # full transcript in result["messages"], while older/mocked paths may
@@ -5318,9 +5351,6 @@ class APIServerAdapter(BasePlatformAdapter):
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": _effective_session_id}
-        if gateway_session_key:
-            response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1352,6 +1352,51 @@ class TestResponsesEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_failed_response_returns_502_error_envelope(self, adapter):
+        """A failed agent run returns an OpenAI error envelope."""
+        mock_result = {
+            "final_response": "API call failed after 3 retries: Connection error.",
+            "completed": False,
+            "failed": True,
+            "error": "Connection error.",
+            "failure_reason": "timeout",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": 0,
+                    },
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Reply with only the word hello.",
+                        "stream": False,
+                        "store": False,
+                    },
+                )
+
+            assert resp.status == 502
+            data = await resp.json()
+            assert data["error"]["code"] == "agent_incomplete"
+            assert "connection error" in data["error"]["message"].lower()
+            assert data["error"]["hermes"]["completed"] is False
+            assert data["error"]["hermes"]["partial"] is False
+            assert data["error"]["hermes"]["failed"] is True
+            assert resp.headers.get("X-Hermes-Completed") == "false"
+            assert resp.headers.get("X-Hermes-Partial") == "false"
+
+
+    @pytest.mark.asyncio
     async def test_previous_response_id_stores_compressed_transcript_directly(self, adapter):
         """After compression, stored history is the compressed transcript, not prior + compressed."""
         prior_history = [


### PR DESCRIPTION
## What does this PR do?

The non-streaming `/v1/responses` endpoint currently treats an agent failure as a successful response when `_run_agent` returns `failed=true`, `completed=false`, and a synthetic `final_response`, for example:

```text
API call failed after 3 retries: Connection error.
```

The endpoint returns HTTP 200 with `status: "completed"`, so API clients cannot distinguish a provider or agent failure from valid assistant output.

This PR returns HTTP 502 with an OpenAI-style `server_error` envelope and `code: "agent_incomplete"` when the agent explicitly reports `failed=true`.

The check intentionally does not treat `partial=true` alone as a hard failure. Partial results may also represent recoverable or deferred states, such as compression-lock contention.

Failed responses exit before the normal Responses API storage path, so they are not stored for later `previous_response_id` chaining.

## Related Issue

Related to #22501 and #22496.

#22775 already addressed the corresponding Chat Completions behavior. This PR focuses only on the remaining non-streaming `/v1/responses` path.

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [ ] 📝 Documentation update
* [x] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* Updated `gateway/platforms/api_server.py` to:

  * detect explicitly failed agent runs before constructing a successful Responses API object;
  * return HTTP 502 with a redacted OpenAI-style error envelope;
  * return `error.type: "server_error"` and `error.code: "agent_incomplete"`;
  * expose the Hermes `completed`, `partial`, and `failed` state in the error metadata;
  * preserve the effective session ID and `X-Hermes-*` response headers;
  * avoid storing failed responses for later chaining.

* Added a regression test to `tests/gateway/test_api_server.py` using the result shape observed during a provider connection failure.

## How to Test

1. Run the focused regression test:

   ```bash
   python -m pytest \
     tests/gateway/test_api_server.py::TestResponsesEndpoint::test_failed_response_returns_502_error_envelope \
     -q
   ```

2. Run the complete API server test file:

   ```bash
   python -m pytest tests/gateway/test_api_server.py -q
   ```

3. Start the Gateway while the configured Ollama provider is unavailable and send a non-streaming request to `/v1/responses`.

   Expected result:

   * HTTP 502
   * `error.type` is `server_error`
   * `error.code` is `agent_incomplete`
   * `X-Hermes-Completed` is `false`
   * the effective session ID is preserved
   * the failed response is not stored for chaining

4. Start Ollama and repeat the request.

   Expected result:

   * HTTP 200
   * `status` is `completed`
   * normal assistant output is returned

## Test Results

* Focused regression test: `1 passed`
* `tests/gateway/test_api_server.py`: `100 passed`
* Live provider-unavailable reproduction: HTTP 502 with the structured error envelope
* Live provider-available request: HTTP 200 with normal assistant output
* `git diff --check`: passed

The canonical full-suite runner was also executed:

```bash
HERMES_PYTHON="$HOME/.hermes/venvs/hermes-dev-check/bin/python" \
  ./scripts/run_tests.sh
```

The changed Gateway test suite is green. The full local suite still reports failures in unrelated optional-provider and platform-specific areas, including Hindsight, FAL, Daytona, Modal, Photon, and Termux.

One initially failing auxiliary-provider test was confirmed to be caused by the optional `anthropic` dependency being absent; after installing the declared `anthropic` extra, all 16 tests in that file passed.

The remaining full-suite failures were not modified as part of this focused Gateway fix.

## Checklist

### Code

* [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
* [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
* [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
* [ ] I've run `pytest tests/ -q` and all tests pass

  * `scripts/run_tests.sh` was executed. The changed Gateway test suite passes (`100 passed`), but the full local suite reports failures in unrelated optional-provider and platform-specific test areas.
* [x] I've added tests for my changes
* [x] I've tested on my platform: Ubuntu 24.04 on WSL2, Python 3.11

### Documentation & Housekeeping

* [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no documentation changes required
* [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
* [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
* [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — the HTTP response-contract change is platform-independent
* [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, a provider connection failure was returned as HTTP 200 and exposed as normal assistant output:

```text
API call failed after 3 retries: Connection error.
```

After the fix, the same failed agent result returns HTTP 502. The error body includes:

```json
{
  "error": {
    "message": "Connection error.",
    "type": "server_error",
    "code": "agent_incomplete",
    "hermes": {
      "completed": false,
      "partial": false,
      "failed": true
    }
  }
}
```

For this reproduced provider-connection failure, the response also includes:

```text
X-Hermes-Completed: false
X-Hermes-Partial: false
```

`X-Hermes-Partial` reflects the agent result and may be `true` for a failed run that is also marked partial.
