### PR TITLE
feat(gateway): harden Telegram topics and multiplex profiles

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -270,18 +270,24 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
 
 
 def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
-    """Build a profile's secret mapping from its ``<home>/.env``.
+    """Build a profile's private secret mapping without touching process env.
 
-    Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
-    global vars are intentionally NOT copied in — ``get_secret`` reads those
-    from ``os.environ`` directly, so the scope holds only profile secrets.
+    ``.env`` has precedence.  ``.op.env`` fills missing bootstrap/session
+    values exactly as the single-profile loader does before external sources
+    resolve their references.
     """
     home = Path(hermes_home)
     secrets = load_env_file(home / ".env")
+    for key, value in load_env_file(home / ".op.env").items():
+        secrets.setdefault(key, value)
 
     try:
-        from hermes_cli.env_loader import get_secret_source_values
-        external_secrets = get_secret_source_values(home)
+        from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+        # Use the same profile bootstrap/fingerprint path as the gateway's
+        # eager hydration. Calling the lower-level resolver with a different
+        # base mapping would invalidate the cache and refetch on every scope.
+        external_secrets = hydrate_profile_secret_sources(home)
     except Exception:
         external_secrets = {}
 

--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -166,6 +166,12 @@ class SecretSource(ABC):
         ``cfg`` is the source's raw config section (``secrets.<name>``)
         from config.yaml — treat every field defensively, the section
         may be malformed.  ``home_path`` is the resolved HERMES_HOME.
+
+        The registry runs ``fetch`` inside the target profile's copied context.
+        Implementations that need bootstrap credentials or subprocess settings
+        MUST read ``secret_source_environ()`` (or the scoped secret helpers),
+        never raw ``os.environ``; the latter is process-global and can cross a
+        multiplex profile boundary.
         """
 
     # -- optional hooks (defaults are correct for most sources) ------------

--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -44,7 +44,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, FrozenSet, List, MutableMapping, Optional, Sequence
+from typing import Dict, FrozenSet, List, Mapping, MutableMapping, Optional, Sequence
 
 # Bump ONLY for breaking changes to the required contract surface
 # (abstract-method signatures, FetchResult required fields).  Additive
@@ -275,6 +275,36 @@ def scrub_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text or "")
 
 
+def secret_source_environ() -> Mapping[str, str]:
+    """Return the current source's isolated env, failing closed in multiplex."""
+    try:
+        from agent.secret_sources.registry import current_secret_source_fetch_env
+    except ImportError:
+        scoped = None
+    else:
+        scoped = current_secret_source_fetch_env()
+    if scoped is not None:
+        return scoped
+
+    # Keep the original source-environment context hook working for legacy
+    # callers/plugins.  The registry hook above is authoritative for the
+    # profile-scoped fetch path, while this fallback preserves the
+    # non-multiplex API introduced by the upstream side of this merge.
+    legacy = _SOURCE_ENVIRONMENT.get()
+    if legacy is not None:
+        return legacy
+
+    try:
+        from agent.secret_scope import is_multiplex_active
+    except ImportError:
+        multiplex_active = False
+    else:
+        multiplex_active = is_multiplex_active()
+    if multiplex_active:
+        return {}
+    return os.environ
+
+
 def run_secret_cli(
     argv: Sequence[str],
     *,
@@ -302,11 +332,25 @@ def run_secret_cli(
     surface); returns the completed process otherwise — callers own
     returncode interpretation.
     """
-    base_keep = ("PATH", "HOME", "USERPROFILE", "SYSTEMROOT", "TMPDIR", "TEMP",
-                 "LANG", "LC_ALL", "XDG_CONFIG_HOME", "XDG_DATA_HOME")
+    # These are operational process settings, not profile credentials.  In
+    # an isolated fetch they must come from the process environment even if a
+    # profile .env contains an override; in particular a profile must not
+    # redirect helper subprocesses to another HERMES_HOME.
+    base_keep = (
+        "PATH", "HOME", "USERPROFILE", "SYSTEMROOT", "TMPDIR", "TEMP",
+        "LANG", "LC_ALL", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+        "HERMES_HOME", "HERMES_PROFILE", "HERMES_PROFILE_NAME",
+    )
+    scoped_env = secret_source_environ()
+
     env: Dict[str, str] = {}
-    for key in (*base_keep, *allow_env):
+    for key in base_keep:
         val = os.environ.get(key)
+        if val is not None:
+            env[key] = val
+    allowed_source = scoped_env
+    for key in allow_env:
+        val = allowed_source.get(key)
         if val is not None:
             env[key] = val
     if extra_env:

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -45,7 +45,7 @@ import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, MutableMapping, Optional, Tuple, cast
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -57,8 +57,7 @@ from agent.secret_sources._cache import (
     FetchResult,
     is_valid_env_name as _is_valid_env_name,
 )
-from agent.secret_sources.base import ErrorKind, SecretSource
-from agent.secret_sources.base import get_source_environment
+from agent.secret_sources.base import ErrorKind, SecretSource, secret_source_environ
 
 logger = logging.getLogger(__name__)
 
@@ -668,41 +667,22 @@ def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
     cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
-    # bws child intentionally receives the access token.  Under a profile-local
-    # fetch it must not inherit sibling credentials from process-global env.
-    source_env = get_source_environment()
-    if source_env is os.environ:
-        from tools.environments.local import build_subprocess_env
+    # The child gets only its own bootstrap token plus an optional endpoint;
+    # never the process-wide post-dotenv credential set from another profile.
+    from agent.secret_sources.base import run_secret_cli
 
-        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    else:
-        env = dict(source_env)
-    env["BWS_ACCESS_TOKEN"] = access_token
-    # Make sure we're not echoing telemetry / colour codes into json.
-    env.setdefault("NO_COLOR", "1")
-    # Region / self-hosted support.  bws defaults to https://vault.bitwarden.com
-    # (US Cloud); EU Cloud users need https://vault.bitwarden.eu, and
-    # self-hosted users need their own URL.  When unset, fall back to whatever
-    # BWS_SERVER_URL the caller already had in their shell env (preserved by
-    # the copy above) so manual overrides keep working too.
-    if server_url:
-        env["BWS_SERVER_URL"] = server_url
+    extra_env = {"BWS_ACCESS_TOKEN": access_token}
+    effective_server_url = server_url.strip()
+    if not effective_server_url:
+        effective_server_url = secret_source_environ().get("BWS_SERVER_URL", "").strip()
+    if effective_server_url:
+        extra_env["BWS_SERVER_URL"] = effective_server_url
 
-    try:
-        proc = subprocess.run(  # noqa: S603 — bws path is trusted
-            cmd,
-            env=env,
-            capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
-            timeout=_BWS_RUN_TIMEOUT,
-            stdin=subprocess.DEVNULL,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            f"bws timed out after {_BWS_RUN_TIMEOUT}s fetching secrets"
-        ) from exc
-    except OSError as exc:
-        raise RuntimeError(f"failed to invoke bws: {exc}") from exc
+    proc = run_secret_cli(
+        cmd,
+        extra_env=extra_env,
+        timeout=_BWS_RUN_TIMEOUT,
+    )
 
     if proc.returncode != 0:
         # bws writes auth/network errors to stderr as a Rust error-report
@@ -782,7 +762,8 @@ def apply_bitwarden_secrets(
     if not enabled:
         return result
 
-    access_token = os.environ.get(access_token_env, "").strip()
+    target_env = cast(MutableMapping[str, str], secret_source_environ())
+    access_token = target_env.get(access_token_env, "").strip()
     if not access_token:
         result.error = (
             f"secrets.bitwarden.enabled is true but {access_token_env} is "
@@ -831,10 +812,10 @@ def apply_bitwarden_secrets(
             # token as a BSM secret too.
             result.skipped.append(key)
             continue
-        if not override_existing and os.environ.get(key):
+        if not override_existing and target_env.get(key):
             result.skipped.append(key)
             continue
-        os.environ[key] = value
+        target_env[key] = value
         result.applied.append(key)
 
     return result
@@ -913,8 +894,9 @@ class BitwardenSource(SecretSource):
         cfg = cfg if isinstance(cfg, dict) else {}
         result = FetchResult()
 
+        source_env = secret_source_environ()
         access_token_env = str(cfg.get("access_token_env") or "BWS_ACCESS_TOKEN")
-        access_token = get_source_environment().get(access_token_env, "").strip()
+        access_token = source_env.get(access_token_env, "").strip()
         if not access_token:
             result.error = (
                 f"secrets.bitwarden.enabled is true but {access_token_env} is "
@@ -962,7 +944,11 @@ class BitwardenSource(SecretSource):
                 project_id=project_id,
                 binary=binary,
                 cache_ttl_seconds=ttl,
-                server_url=str(cfg.get("server_url", "") or "").strip(),
+                server_url=str(
+                    cfg.get("server_url", "")
+                    or source_env.get("BWS_SERVER_URL", "")
+                    or ""
+                ).strip(),
                 home_path=home_path,
                 encrypted_cache_enabled=encrypted_enabled,
                 encrypted_cache_max_stale_seconds=encrypted_max_stale,

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -79,6 +79,18 @@ _BWS_CHECKSUM_NAME = f"bws-sha256-checksums-{_BWS_VERSION}.txt"
 # How long to wait for bws subprocesses and HTTP downloads, in seconds.
 _BWS_DOWNLOAD_TIMEOUT = 60
 _BWS_RUN_TIMEOUT = 30
+_BWS_OPERATIONAL_ENV = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+)
 
 # In-process cache so repeated load_hermes_dotenv() calls (CLI startup,
 # gateway hot-reload, test suites) don't re-fetch from BSM.
@@ -671,12 +683,17 @@ def _run_bws_list(
     # never the process-wide post-dotenv credential set from another profile.
     from agent.secret_sources.base import run_secret_cli
 
+    source_env = secret_source_environ()
     extra_env = {"BWS_ACCESS_TOKEN": access_token}
     effective_server_url = server_url.strip()
     if not effective_server_url:
-        effective_server_url = secret_source_environ().get("BWS_SERVER_URL", "").strip()
+        effective_server_url = source_env.get("BWS_SERVER_URL", "").strip()
     if effective_server_url:
         extra_env["BWS_SERVER_URL"] = effective_server_url
+    for name in _BWS_OPERATIONAL_ENV:
+        value = source_env.get(name, "")
+        if value:
+            extra_env[name] = value
 
     proc = run_secret_cli(
         cmd,

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -39,12 +39,15 @@ import signal as _signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, MutableMapping, Optional, cast
 
 # Reuse the exact result shape the bitwarden source returns so
 # hermes_cli.env_loader can consume both providers identically.
-from agent.secret_sources.base import ErrorKind, SecretSource
-from agent.secret_sources.base import get_source_environment
+from agent.secret_sources.base import (
+    ErrorKind,
+    SecretSource,
+    secret_source_environ,
+)
 from agent.secret_sources.bitwarden import FetchResult
 
 __all__ = [
@@ -181,18 +184,47 @@ def _run_helper(
         return None
 
     # User-configured secret-helper command: runs with the user's full shell
-    # env by design (it may need any credential to resolve the secret).
-    source_env = get_source_environment()
-    if source_env is os.environ:
-        # Legacy single-profile startup intentionally preserves the existing
-        # helper contract, which may rely on the user's full environment.
-        from tools.environments.local import build_subprocess_env
+    # env by design (it may need any credential to resolve the secret).  An
+    # isolated multiplex-profile fetch is the exception: start from the normal
+    # scrubbed child environment, then add only that profile's own values so a
+    # secondary helper cannot inherit the primary profile's credentials.
+    from tools.environments.local import build_subprocess_env
+    fetch_env = secret_source_environ()
+    if fetch_env is os.environ:
         env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
     else:
-        # A multiplex profile must never inherit sibling secrets from the
-        # process-global environment.  hydrate_profile_secret_sources seeds
-        # only global-safe values plus this profile's own .env.
-        env = dict(source_env)
+        # Operational/process-home keys are always taken from the parent
+        # process.  A profile .env may contain arbitrary helper inputs, but it
+        # must not redirect the helper to a profile-specific HOME/HERMES_HOME.
+        base_keep = (
+            "PATH",
+            "HOME",
+            "USERPROFILE",
+            "SYSTEMROOT",
+            "TMPDIR",
+            "TEMP",
+            "LANG",
+            "LC_ALL",
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+            "HERMES_HOME",
+            "HERMES_PROFILE",
+            "HERMES_PROFILE_NAME",
+        )
+        env = {}
+        for key in base_keep:
+            value = os.environ.get(key)
+            if isinstance(value, str):
+                env[key] = value
+        env.update({
+            key: value
+            for key, value in fetch_env.items()
+            if (
+                isinstance(key, str)
+                and key not in base_keep
+                and isinstance(value, str)
+            )
+        })
     env["HERMES_SECRET_KEY"] = secret_key
 
     try:
@@ -350,6 +382,7 @@ def apply_command_secrets(
         )
         return result
 
+    target_env = cast(MutableMapping[str, str], secret_source_environ())
     if _is_windows():
         result.warnings.append(
             "the 'command' secret source is POSIX-only (needs /bin/sh); "
@@ -383,11 +416,11 @@ def apply_command_secrets(
             # them would flow into an Authorization header → guaranteed 401.
             result.skipped.append(key)
             continue
-        if not override_existing and os.environ.get(key):
+        if not override_existing and target_env.get(key):
             # Process env / .env win — same precedence as bitwarden.
             result.skipped.append(key)
             continue
-        os.environ[key] = value
+        target_env[key] = value
         result.applied.append(key)
 
     return result

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -46,7 +46,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, MutableMapping, Optional, Tuple, cast
 
 from agent.secret_sources._cache import (
     CachedFetch,
@@ -54,8 +54,7 @@ from agent.secret_sources._cache import (
     FetchResult,
     is_valid_env_name,
 )
-from agent.secret_sources.base import ErrorKind, SecretSource
-from agent.secret_sources.base import get_source_environment
+from agent.secret_sources.base import ErrorKind, SecretSource, secret_source_environ
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +182,7 @@ def _auth_fingerprint(token_env: str) -> str:
     previous identity is never served under a new one.  Never logged or
     displayed; the raw token never leaves this hash.
     """
-    source_env = get_source_environment()
+    source_env = secret_source_environ()
     parts: List[str] = [
         f"token={source_env.get(token_env, '')}",
         f"account={source_env.get('OP_ACCOUNT', '')}",
@@ -240,10 +239,16 @@ def _scrub(text: str) -> str:
 
 def _op_child_env(token_value: str) -> Dict[str, str]:
     """Build a minimal allowlisted environment for the ``op`` child process."""
-    source_env = get_source_environment()
+    source_env = secret_source_environ()
     env: Dict[str, str] = {}
     for key in _OP_ENV_ALLOWLIST:
-        val = source_env.get(key)
+        if key.startswith("OP_"):
+            val = source_env.get(key)
+        else:
+            # PATH/home/config-directory settings are process operational
+            # state, not profile auth.  Keep them anchored to the parent
+            # process so a profile override cannot redirect ``op``.
+            val = os.environ.get(key)
         if val is not None:
             env[key] = val
     # Desktop / interactive session credentials.
@@ -343,7 +348,7 @@ def fetch_onepassword_secrets(
     if not valid:
         return {}, warnings
 
-    token_value = get_source_environment().get(token_env, "").strip()
+    token_value = secret_source_environ().get(token_env, "").strip()
     cache_key: _CacheKey = (
         _auth_fingerprint(token_env),
         account or "",
@@ -421,6 +426,7 @@ def apply_onepassword_secrets(
     if not enabled:
         return result
 
+    target_env = cast(MutableMapping[str, str], secret_source_environ())
     valid, warnings = _validate_references(env)
     result.warnings.extend(warnings)
 
@@ -431,7 +437,7 @@ def apply_onepassword_secrets(
             # Never let a resolved secret clobber the very token used to auth.
             result.skipped.append(name)
             continue
-        if not override_existing and os.environ.get(name):
+        if not override_existing and target_env.get(name):
             result.skipped.append(name)
             continue
         refs_to_fetch[name] = ref
@@ -479,11 +485,11 @@ def apply_onepassword_secrets(
             if name not in result.skipped:
                 result.skipped.append(name)
             continue
-        if not override_existing and os.environ.get(name):
+        if not override_existing and target_env.get(name):
             if name not in result.skipped:
                 result.skipped.append(name)
             continue
-        os.environ[name] = value
+        target_env[name] = value
         result.applied.append(name)
 
     return result

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -249,12 +249,12 @@ def _fetch_with_timeout(
                 reset_source_environment(legacy_token)
             _FETCH_ENV.reset(fetch_token)
 
+    # ThreadPoolExecutor does not propagate ContextVars.  Capture the caller's
+    # profile home and secret scope before crossing the worker boundary; the
+    # worker then adds the explicit per-fetch environment on top.
+    caller_context = copy_context()
     try:
-        # ThreadPoolExecutor workers do not inherit ContextVars.  Snapshot
-        # the caller's context explicitly so profile/home/secret context is
-        # present while the source fetch (and any helper it calls) runs.
-        fetch_context = copy_context()
-        future = executor.submit(fetch_context.run, _fetch_in_scope)
+        future = executor.submit(caller_context.run, _fetch_in_scope)
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -30,9 +30,10 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
+from contextvars import ContextVar, copy_context
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, MutableMapping, Optional
+from typing import Dict, List, Mapping, MutableMapping, Optional
 
 from agent.secret_sources.base import (
     SECRET_SOURCE_API_VERSION,
@@ -50,6 +51,19 @@ logger = logging.getLogger(__name__)
 # insertion order, which doubles as the default apply order.
 _SOURCES: Dict[str, SecretSource] = {}
 _BUILTINS_LOADED = False
+
+# An explicit ``apply_all(..., environ=...)`` call is an isolated resolution
+# pass (used by multiplexed profile secret scopes).  Propagate that private
+# environment into each fetch worker so sources that spawn helpers can avoid
+# inheriting another profile's process-global credentials.
+_FETCH_ENV: ContextVar[Optional[Mapping[str, str]]] = ContextVar(
+    "_SECRET_SOURCE_FETCH_ENV", default=None
+)
+
+
+def current_secret_source_fetch_env() -> Optional[Mapping[str, str]]:
+    """Return the isolated environment for the active source fetch, if any."""
+    return _FETCH_ENV.get()
 
 
 @dataclass
@@ -198,8 +212,10 @@ def _reset_registry_for_tests() -> None:
 
 
 def _fetch_with_timeout(
-    source: SecretSource, cfg: dict, home_path: Path,
-    environ: MutableMapping[str, str],
+    source: SecretSource,
+    cfg: dict,
+    home_path: Path,
+    fetch_env: Optional[Mapping[str, str]] = None,
 ) -> FetchResult:
     """Run source.fetch() under a wall-clock budget; never raises.
 
@@ -213,15 +229,32 @@ def _fetch_with_timeout(
     executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=1, thread_name_prefix=f"secret-src-{source.name}"
     )
-    try:
-        def _fetch() -> FetchResult:
-            token = set_source_environment(environ)
-            try:
-                return source.fetch(cfg, home_path)
-            finally:
-                reset_source_environment(token)
+    def _fetch_in_scope() -> FetchResult:
+        fetch_token = _FETCH_ENV.set(fetch_env)
+        legacy_token = None
+        if fetch_env is not None:
+            # Preserve the upstream source-environment hook for plugins that
+            # still call get_source_environment(), while the hardening hook
+            # remains authoritative for bundled sources.
+            legacy_env = (
+                fetch_env
+                if isinstance(fetch_env, MutableMapping)
+                else dict(fetch_env)
+            )
+            legacy_token = set_source_environment(legacy_env)
+        try:
+            return source.fetch(cfg, home_path)
+        finally:
+            if legacy_token is not None:
+                reset_source_environment(legacy_token)
+            _FETCH_ENV.reset(fetch_token)
 
-        future = executor.submit(_fetch)
+    try:
+        # ThreadPoolExecutor workers do not inherit ContextVars.  Snapshot
+        # the caller's context explicitly so profile/home/secret context is
+        # present while the source fetch (and any helper it calls) runs.
+        fetch_context = copy_context()
+        future = executor.submit(fetch_context.run, _fetch_in_scope)
         try:
             result = future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
@@ -359,6 +392,7 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     """
     import os as _os
 
+    isolated_fetch_env = dict(environ) if environ is not None else None
     env = environ if environ is not None else _os.environ
     report = ApplyReport()
 
@@ -386,7 +420,9 @@ def apply_all(secrets_cfg: dict, home_path: Path,
     for source in ordered:
         cfg = secrets_cfg.get(source.name)
         cfg = cfg if isinstance(cfg, dict) else {}
-        result = _fetch_with_timeout(source, cfg, home_path, env)
+        result = _fetch_with_timeout(
+            source, cfg, home_path, fetch_env=isolated_fetch_env
+        )
         fetches.append((source, cfg, result))
         try:
             for var in source.protected_env_vars(cfg):

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -151,6 +151,12 @@ class GatewayAuthorizationMixin:
             # fail and suppress streamed delivery for those profiles.
             adapters = getattr(self, "adapters", None) or {}
             return adapters.get(Platform.RELAY)
+        stamped_transport_profile = getattr(source, "_transport_profile", None)
+        if isinstance(stamped_transport_profile, str) and stamped_transport_profile.strip():
+            return self._authorization_adapter(
+                getattr(source, "platform", None),
+                stamped_transport_profile.strip(),
+            )
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
         return self._authorization_adapter(
@@ -194,8 +200,8 @@ class GatewayAuthorizationMixin:
                 if adapter is profile_adapters.get(platform):
                     return profile
         stamped_transport_profile = getattr(source, "_transport_profile", None)
-        if stamped_transport_profile:
-            return str(stamped_transport_profile)
+        if isinstance(stamped_transport_profile, str) and stamped_transport_profile.strip():
+            return stamped_transport_profile.strip()
         return getattr(source, "profile", None)
 
     def _adapter_authorization_is_upstream(
@@ -514,7 +520,23 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and _platform_gate_env(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            allow_bots_policy = None
+            try:
+                adapter = self._adapter_for_source(source)
+                if adapter is not None:
+                    extra = (
+                        getattr(getattr(adapter, "config", None), "extra", None)
+                        or {}
+                    )
+                    allow_bots_policy = extra.get("allow_bots")
+            except Exception:
+                allow_bots_policy = None
+            if allow_bots_policy is None and allow_bots_var:
+                allow_bots_policy = _platform_gate_env(allow_bots_var, "none")
+            if str(allow_bots_policy or "none").lower() in {
+                "mentions",
+                "all",
+            }:
                 return True
 
         if not user_id:

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -32,14 +32,18 @@ def _auth_env(name: str, default: str = "") -> str:
     """Read allowlist/auth env; prefer profile secret_scope under multiplex."""
     if not name:
         return default
+    multiplex_active = False
     try:
-        from agent.secret_scope import get_secret
+        from agent.secret_scope import get_secret, is_multiplex_active
 
-        val = get_secret(name)
-        if val is not None and str(val).strip():
-            return str(val).strip()
+        multiplex_active = is_multiplex_active()
+        value = get_secret(name)
+        if value is not None:
+            return str(value).strip()
     except Exception:
         pass
+    if multiplex_active:
+        return default
     return (os.getenv(name) or default).strip()
 
 
@@ -189,6 +193,9 @@ class GatewayAuthorizationMixin:
             ).items():
                 if adapter is profile_adapters.get(platform):
                     return profile
+        stamped_transport_profile = getattr(source, "_transport_profile", None)
+        if stamped_transport_profile:
+            return str(stamped_transport_profile)
         return getattr(source, "profile", None)
 
     def _adapter_authorization_is_upstream(
@@ -369,18 +376,27 @@ class GatewayAuthorizationMixin:
         return False
 
     def _pairing_store_for(self, source: "SessionSource"):
-        """Pick the per-profile PairingStore for a source, falling back to global.
+        """Pick the PairingStore for a source without crossing profile boundaries.
 
-        In a multiplexing gateway, each profile owns its own pairing whitelist
-        so isolation is preserved. When the source has no profile (single-
-        profile gateway, or a path that hasn't stamped profile yet) or the
-        profile isn't registered, fall back to ``self.pairing_store`` (the
-        global default) so existing behavior is preserved.
+        Unstamped and active-profile sources retain the primary store for
+        single-profile compatibility. In multiplex mode, a stamped non-active
+        profile with no registered store fails closed instead of inheriting the
+        primary profile's approved-user whitelist.
         """
         per_profile = getattr(self, "pairing_stores", None) or {}
-        profile = getattr(source, "profile", None)
+        profile = self._adapter_profile_for_source(source)
         if profile and profile in per_profile:
             return per_profile[profile]
+        if profile and getattr(
+            getattr(self, "config", None), "multiplex_profiles", False
+        ):
+            try:
+                active_name_fn = getattr(self, "_active_profile_name", None)
+                active = active_name_fn() if callable(active_name_fn) else None
+            except Exception:
+                active = None
+            if not active or profile != active:
+                return None
         return getattr(self, "pairing_store", None)
 
     def _is_user_authorized(self, source: SessionSource) -> bool:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -204,6 +204,15 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
     return default
 
 
+def _normalize_stt_echo_format(value: Any, default: str = "legacy") -> str:
+    """Normalize the user-facing STT transcript echo presentation mode."""
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"legacy", "transcript_md"}:
+            return normalized
+    return default
+
+
 def _normalize_notice_delivery(value: Any, default: str = "public") -> str:
     """Normalize notice delivery mode to a supported value."""
     if isinstance(value, str):
@@ -913,6 +922,7 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    stt_echo_format: str = "legacy"  # "legacy" or copy-friendly Telegram "transcript_md"
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -1066,6 +1076,7 @@ class GatewayConfig:
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
+            "stt_echo_format": self.stt_echo_format,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -1126,6 +1137,13 @@ class GatewayConfig:
         if stt_echo_transcripts is None:
             stt_echo_transcripts = (
                 data.get("stt", {}).get("echo_transcripts")
+                if isinstance(data.get("stt"), dict)
+                else None
+            )
+        stt_echo_format = data.get("stt_echo_format")
+        if stt_echo_format is None:
+            stt_echo_format = (
+                data.get("stt", {}).get("echo_format")
                 if isinstance(data.get("stt"), dict)
                 else None
             )
@@ -1204,6 +1222,7 @@ class GatewayConfig:
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
+            stt_echo_format=_normalize_stt_echo_format(stt_echo_format),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1590,6 +1590,15 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "topic_prompts" in platform_cfg:
+                    topic_prompts = platform_cfg["topic_prompts"]
+                    if isinstance(topic_prompts, dict):
+                        bridged["topic_prompts"] = {
+                            str(k): ({str(nk): nv for nk, nv in v.items()} if isinstance(v, dict) else v)
+                            for k, v in topic_prompts.items()
+                        }
+                    else:
+                        bridged["topic_prompts"] = topic_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "typing_indicator" in platform_cfg:

--- a/gateway/inflight_journal.py
+++ b/gateway/inflight_journal.py
@@ -1,0 +1,113 @@
+"""Minimal durable journal for accepted inbound gateway messages.
+
+The journal deliberately stores routing metadata only: never message bodies,
+transcripts, sender names, credentials, or media paths.  It exists solely so a
+cold gateway restart can tell the originating chat/topic that processing was
+interrupted before a final delivery obligation was created.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_SCHEMA_VERSION = 1
+
+
+def _home() -> Path:
+    configured = os.environ.get("HERMES_HOME", "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".hermes"
+
+
+def _root() -> Path:
+    return _home() / "runtime" / "inflight"
+
+
+def _platform_value(event: Any) -> str:
+    platform = getattr(getattr(event, "source", None), "platform", None)
+    value = getattr(platform, "value", platform)
+    return str(value or "unknown").strip().lower()
+
+
+def _record_path(event: Any) -> Path:
+    source = getattr(event, "source", None)
+    platform = _platform_value(event)
+    identity = "\0".join(
+        [
+            platform,
+            str(getattr(source, "chat_id", "") or ""),
+            str(getattr(source, "thread_id", "") or ""),
+            str(getattr(event, "message_id", "") or ""),
+        ]
+    )
+    digest = hashlib.sha256(identity.encode("utf-8", errors="replace")).hexdigest()
+    return _root() / platform / f"{digest}.json"
+
+
+def claim_inflight(event: Any) -> str:
+    """Atomically persist an accepted message's non-content routing metadata."""
+    source = getattr(event, "source", None)
+    path = _record_path(event)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    message_type = getattr(event, "message_type", None)
+    message_type = getattr(message_type, "value", message_type)
+    record = {
+        "version": _SCHEMA_VERSION,
+        "platform": _platform_value(event),
+        "chat_id": str(getattr(source, "chat_id", "") or ""),
+        "thread_id": str(getattr(source, "thread_id", "") or ""),
+        "message_id": str(getattr(event, "message_id", "") or ""),
+        "message_type": str(message_type or "unknown"),
+        "phase": "accepted",
+        "process_id": os.getpid(),
+        "started_at": time.time(),
+    }
+    tmp = path.with_suffix(f".tmp-{os.getpid()}")
+    payload = json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        os.chmod(tmp, 0o600)
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+    return str(path)
+
+
+def clear_inflight(token: str | Path | None) -> bool:
+    """Acknowledge a record, rejecting paths outside the journal root."""
+    if not token:
+        return True
+    try:
+        root = _root().resolve()
+        path = Path(token).resolve()
+        if path != root and root not in path.parents:
+            return False
+        path.unlink(missing_ok=True)
+        return not path.exists()
+    except OSError:
+        return False
+
+
+def list_inflight(platform: str) -> list[dict[str, Any]]:
+    """Return valid records for one platform, oldest first, with path tokens."""
+    directory = _root() / str(platform).strip().lower()
+    if not directory.is_dir():
+        return []
+    records: list[dict[str, Any]] = []
+    for path in directory.glob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict) or data.get("version") != _SCHEMA_VERSION:
+                continue
+            if data.get("platform") != str(platform).strip().lower():
+                continue
+            data["_token"] = str(path)
+            records.append(data)
+        except (OSError, ValueError, TypeError):
+            continue
+    records.sort(key=lambda item: (float(item.get("started_at", 0.0)), item.get("_token", "")))
+    return records

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -47,6 +47,26 @@ _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
 
 
+def _processing_error_content(config, error: Exception) -> str:
+    """Build a user-visible blocker without exposing exception text."""
+    error_type = type(error).__name__
+    extra = getattr(config, "extra", {}) or {}
+    template = extra.get("processing_error_message") if isinstance(extra, dict) else None
+    if isinstance(template, str) and template.strip():
+        try:
+            return template.format(
+                error_type=error_type,
+                error_detail="details available in gateway logs",
+            )
+        except (KeyError, ValueError, IndexError):
+            logger.warning("Invalid processing_error_message template; using default")
+    return (
+        f"Sorry, I encountered an error ({error_type}).\n"
+        "The technical details are available in the gateway logs.\n"
+        "Try again or use /reset to start a fresh session."
+    )
+
+
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
     value = getattr(platform, "value", platform)
@@ -2455,6 +2475,7 @@ def merge_pending_message_event(
     """
     existing = pending_messages.get(session_key)
     if existing:
+        _merge_event_inflight_tokens(existing, event)
         existing_is_photo = getattr(existing, "message_type", None) == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
         existing_has_media = bool(existing.media_urls)
@@ -2497,6 +2518,17 @@ def merge_pending_message_event(
             return
 
     pending_messages[session_key] = event
+
+
+def _merge_event_inflight_tokens(target: MessageEvent, incoming: MessageEvent) -> None:
+    """Carry every accepted-message recovery marker into a merged turn."""
+    combined: list[str] = []
+    for source in (target, incoming):
+        for token in getattr(source, "_gateway_inflight_tokens", []) or []:
+            if token and token not in combined:
+                combined.append(str(token))
+    if combined:
+        setattr(target, "_gateway_inflight_tokens", combined)
 
 
 # Error substrings that indicate a transient *connection* failure worth retrying.
@@ -3919,18 +3951,7 @@ class BasePlatformAdapter(ABC):
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
-        """Send a batch of images.
-
-        Accepts ``http(s)://``, ``file://`` URIs in the first tuple
-        element.
-
-        Default implementation sends each item individually,
-        routing animated GIFs through ``send_animation`` and local
-        files through ``send_image_file``.
-
-        Override in subclasses to bundle into a single native API call
-        (e.g. Signal's multi-attachment RPC)
-        """
+        """Send multiple images sequentially; adapters may override batching."""
         from urllib.parse import unquote as _unquote
 
         for image_url, alt_text in images:
@@ -3968,6 +3989,22 @@ class BasePlatformAdapter(ABC):
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+
+    async def send_multiple_images_tracked(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> Optional[SendResult]:
+        """Optional aggregate result without changing the legacy adapter API.
+
+        Platforms that can report per-batch outcomes should override this.
+        Legacy adapters retain their existing ``send_multiple_images`` contract
+        and return ``None``, which leaves global processing accounting unchanged.
+        """
+        await self.send_multiple_images(chat_id, images, metadata, human_delay)
+        return None
 
     async def send_image(
         self,
@@ -5232,6 +5269,7 @@ class BasePlatformAdapter(ABC):
             )
             store[session_key] = state
         else:
+            _merge_event_inflight_tokens(state.event, event)
             if event.text:
                 state.event.text = (
                     f"{state.event.text}\n{event.text}"
@@ -5405,6 +5443,15 @@ class BasePlatformAdapter(ABC):
             task.add_done_callback(self._expected_cancelled_tasks.discard)
         return True
 
+    async def enrich_message_context(self, event: MessageEvent) -> MessageEvent:
+        """Optional per-platform context enrichment before the agent handler.
+
+        The default is a no-op.  It is deliberately awaited inside the
+        background processing task, after typing has started, so slow external
+        context sources cannot delay the user's activity signal.
+        """
+        return event
+
     async def cancel_session_processing(
         self,
         session_key: str,
@@ -5551,6 +5598,71 @@ class BasePlatformAdapter(ABC):
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
+    def _claim_event_inflight(self, event: MessageEvent) -> None:
+        """Persist one accepted non-command event before queue/debounce routing."""
+        if not self.config.extra.get("inflight_recovery_enabled"):
+            return
+        if event.get_command():
+            return
+        if getattr(event, "_gateway_inflight_tokens", None):
+            return
+        try:
+            from gateway.inflight_journal import claim_inflight
+            setattr(event, "_gateway_inflight_tokens", [claim_inflight(event)])
+        except Exception:
+            logger.warning(
+                "[%s] Could not persist inbound in-flight marker",
+                self.name,
+                exc_info=True,
+            )
+
+    def _transfer_event_inflight_to_active_turn(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        turn_generation: object,
+    ) -> None:
+        """Make a successfully steered event part of the active turn obligation."""
+        tokens = list(getattr(event, "_gateway_inflight_tokens", []) or [])
+        if not tokens:
+            return
+        active = getattr(self, "_gateway_active_inflight_tokens", None)
+        if active is None:
+            active = {}
+            setattr(self, "_gateway_active_inflight_tokens", active)
+        active.setdefault((session_key, turn_generation), set()).update(tokens)
+        setattr(event, "_gateway_inflight_tokens", [])
+
+    def _clear_event_inflight(
+        self,
+        event: MessageEvent,
+        session_key: Optional[str] = None,
+        turn_generation: Optional[object] = None,
+    ) -> bool:
+        """Clear all markers merged into a completed turn, retaining failures."""
+        tokens = list(getattr(event, "_gateway_inflight_tokens", []) or [])
+        if session_key and turn_generation is not None:
+            active = getattr(self, "_gateway_active_inflight_tokens", {})
+            tokens.extend(active.pop((session_key, turn_generation), set()))
+        if not tokens:
+            return True
+        retained: list[str] = []
+        try:
+            from gateway.inflight_journal import clear_inflight
+            for token in tokens:
+                if not clear_inflight(token):
+                    retained.append(token)
+        except Exception:
+            retained = tokens
+        setattr(event, "_gateway_inflight_tokens", retained)
+        if retained:
+            logger.warning(
+                "[%s] Could not clear %d inbound in-flight marker(s)",
+                self.name,
+                len(retained),
+            )
+        return not retained
+
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
@@ -5580,6 +5692,7 @@ class BasePlatformAdapter(ABC):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+        self._claim_event_inflight(event)
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
@@ -5688,6 +5801,7 @@ class BasePlatformAdapter(ABC):
                         )
                         response = await self._message_handler(event)
                         _text, _eph_ttl = self._unwrap_ephemeral(response)
+                        _r = None
                         if _text:
                             _r = await self._send_with_retry(
                                 chat_id=event.source.chat_id,
@@ -5701,6 +5815,8 @@ class BasePlatformAdapter(ABC):
                                     message_id=_r.message_id,
                                     ttl_seconds=_eph_ttl,
                                 )
+                        if not _text or getattr(_r, "success", False):
+                            self._clear_event_inflight(event)
                     except Exception as e:
                         logger.error(
                             "[%s] Clarify text-intercept dispatch failed: %s",
@@ -5710,7 +5826,30 @@ class BasePlatformAdapter(ABC):
 
             if self._busy_session_handler is not None:
                 try:
+                    generation_map = getattr(
+                        self, "_gateway_inflight_turn_generations", {}
+                    )
+                    busy_generation = generation_map.get(session_key)
                     if await self._busy_session_handler(event, session_key):
+                        disposition = getattr(
+                            event, "_gateway_busy_disposition", "delivered"
+                        )
+                        if disposition == "active_turn":
+                            # No await occurs between this generation check and
+                            # transfer, so a completed/replaced turn cannot
+                            # receive the marker after its final clear.
+                            if (
+                                busy_generation is not None
+                                and generation_map.get(session_key)
+                                is busy_generation
+                            ):
+                                self._transfer_event_inflight_to_active_turn(
+                                    event,
+                                    session_key,
+                                    busy_generation,
+                                )
+                        elif disposition != "queued":
+                            self._clear_event_inflight(event)
                         return
                 except Exception as e:
                     logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
@@ -5785,17 +5924,28 @@ class BasePlatformAdapter(ABC):
 
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
+        turn_generation = object()
+        generation_map = getattr(
+            self, "_gateway_inflight_turn_generations", None
+        )
+        if generation_map is None:
+            generation_map = {}
+            setattr(self, "_gateway_inflight_turn_generations", generation_map)
+        generation_map[session_key] = turn_generation
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        delivery_failed = False
 
         def _record_delivery(result):
-            nonlocal delivery_attempted, delivery_succeeded
+            nonlocal delivery_attempted, delivery_succeeded, delivery_failed
             if result is None:
                 return
             delivery_attempted = True
             if getattr(result, "success", False):
                 delivery_succeeded = True
+            else:
+                delivery_failed = True
 
         # Reuse the interrupt event set by handle_message() (which marks
         # the session active before spawning this task to prevent races).
@@ -5830,8 +5980,18 @@ class BasePlatformAdapter(ABC):
                 typing_task,
                 metadata=_thread_metadata,
             )
+
+        # Direct unit/integration callers may enter here without handle_message();
+        # claim idempotently so the production and test paths share semantics.
+        self._claim_event_inflight(event)
+
+        def _clear_inflight_marker() -> None:
+            self._clear_event_inflight(
+                event, session_key, turn_generation
+            )
         
         try:
+            event = await self.enrich_message_context(event)
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)
@@ -6017,6 +6177,7 @@ class BasePlatformAdapter(ABC):
                             caption=telegram_tts_caption,
                             metadata=_final_thread_metadata,
                         )
+                        _record_delivery(tts_result)
                         _tts_caption_delivered = bool(
                             telegram_tts_caption and getattr(tts_result, "success", False)
                         )
@@ -6136,13 +6297,15 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
+                        image_result = await self.send_multiple_images_tracked(
                             chat_id=event.source.chat_id,
                             images=images,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
+                        _record_delivery(image_result)
                     except Exception as batch_err:
+                        _record_delivery(SendResult(success=False, error=str(batch_err)))
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
 
@@ -6178,13 +6341,15 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
+                        image_result = await self.send_multiple_images_tracked(
                             chat_id=event.source.chat_id,
                             images=_batch,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
                         )
+                        _record_delivery(image_result)
                     except Exception as batch_err:
+                        _record_delivery(SendResult(success=False, error=str(batch_err)))
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
                 if _non_image_media:
@@ -6223,6 +6388,7 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
 
+                        _record_delivery(media_result)
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
                             await self._notify_media_delivery_failure(
@@ -6232,6 +6398,7 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
                     except Exception as media_err:
+                        _record_delivery(SendResult(success=False, error=str(media_err)))
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
 
                 # Send auto-detected local non-image files as native attachments
@@ -6252,6 +6419,7 @@ class BasePlatformAdapter(ABC):
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
+                        _record_delivery(file_result)
                         if not file_result.success:
                             logger.warning(
                                 "[%s] Failed to send local file (%s): %s",
@@ -6265,6 +6433,7 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
                     except Exception as file_err:
+                        _record_delivery(SendResult(success=False, error=str(file_err)))
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
                 # A3 (#29346): if a non-empty response produced nothing
@@ -6297,6 +6466,13 @@ class BasePlatformAdapter(ABC):
                 event,
                 ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
             )
+            journal_delivery_complete = (
+                delivery_attempted
+                and delivery_succeeded
+                and not delivery_failed
+            ) or (not delivery_attempted and not bool(response))
+            if journal_delivery_complete:
+                _clear_inflight_marker()
 
             # The active drain owns debounce state. If a queue-mode timer has
             # not fired yet, force-flush into _pending_messages here and let
@@ -6354,18 +6530,14 @@ class BasePlatformAdapter(ABC):
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
             try:
-                error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-                await self.send(
+                _notice_result = await self.send(
                     chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
-                    ),
+                    content=_processing_error_content(self.config, e),
                     metadata=_thread_metadata,
                 )
+                if getattr(_notice_result, "success", False):
+                    _clear_inflight_marker()
             except Exception as notify_err:
                 logger.error(
                     "[%s] Failed to send error notification to user: %s",
@@ -6418,6 +6590,14 @@ class BasePlatformAdapter(ABC):
                 metadata=_thread_metadata,
                 stop_attempts=1,
             )
+            # Active-turn markers that were not acknowledged by this turn
+            # must remain durable for restart recovery, but must never leak
+            # into a later turn and be cleared by its successful delivery.
+            getattr(self, "_gateway_active_inflight_tokens", {}).pop(
+                (session_key, turn_generation), None
+            )
+            if generation_map.get(session_key) is turn_generation:
+                generation_map.pop(session_key, None)
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.
             await self._flush_text_debounce_now(session_key)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6841,9 +6841,10 @@ class BasePlatformAdapter(ABC):
             auto_thread_created=auto_thread_created,
             auto_thread_initial_name=auto_thread_initial_name,
         )
-        # In-process transport provenance is deliberately not serialized by
-        # SessionSource.to_dict(). The live receiving adapter is authoritative
-        # for this turn even when profile_routes selects a different runtime.
+        # Keep the live receiving adapter as in-process provenance for this turn,
+        # even when profile_routes selects a different runtime.  The weakref is
+        # never serialized; the profile-scoped gateway handler stamps the
+        # serializable transport owner used by replay and delayed delivery.
         source._transport_adapter_ref = weakref.ref(self)
         return source
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25361,6 +25361,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
                             session_key or "?",
                         )
+                    if first_response and not _intentional_silence:
+                        _queued_delivery_event = MessageEvent(
+                            text="",
+                            message_type=MessageType.TEXT,
+                            source=source,
+                            message_id=event_message_id,
+                        )
+                        await self._deliver_media_from_response(
+                            first_response,
+                            _queued_delivery_event,
+                            adapter,
+                        )
                     # Release deferred bg-review notifications now that the
                     # first response has been delivered.  Pop from the
                     # adapter's callback dict (prevents double-fire in

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15820,7 +15820,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             try:
                                 await _echo_adapter.send(
                                     source.chat_id,
-                                    f'🎙️ "{_tx}"',
+                                    self._format_stt_transcript_echo(_tx),
                                     metadata=_echo_meta,
                                 )
                             except Exception as _echo_exc:
@@ -18981,6 +18981,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
+    def _format_stt_transcript_echo(self, transcript: str) -> str:
+        """Format a raw STT echo without changing the transcript itself."""
+        if getattr(self.config, "stt_echo_format", "legacy") == "transcript_md":
+            return f"```\n{transcript}\n```"
+        return f'🎙️ "{transcript}"'
+
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
         audio_path = None
@@ -21490,7 +21496,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 await adapter.send(
                     source.chat_id,
-                    f'🎙️ "{tx}"',
+                    self._format_stt_transcript_echo(tx),
                     metadata=metadata,
                 )
             except Exception as echo_exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8647,8 +8647,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
+                setattr(event, "_gateway_busy_disposition", "queued")
                 message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
             else:
+                setattr(event, "_gateway_busy_disposition", "delivered")
                 message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
 
             await adapter._send_with_retry(
@@ -8873,6 +8875,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # merge semantics for media.
         if not steered and not redirected:
             self._queue_or_replace_pending_event(session_key, event)
+            setattr(event, "_gateway_busy_disposition", "queued")
+        else:
+            # Steer/redirect becomes part of the currently running turn; its
+            # marker is cleared only when that turn's final delivery succeeds.
+            setattr(event, "_gateway_busy_disposition", "active_turn")
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
@@ -17399,27 +17406,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
-            # Stop persistent typing indicator now that the agent is done.
-            # Slack AI status is scoped to a thread/workspace, so preserve the
-            # same routing metadata used by the response delivery path.
-            try:
-                _typing_adapter = self._adapter_for_source(source)
-                _stop_with_metadata = getattr(
-                    type(_typing_adapter), "_stop_typing_with_metadata", None
-                )
-                _stop_typing = getattr(type(_typing_adapter), "stop_typing", None)
-                if _typing_adapter and callable(_stop_with_metadata):
-                    await _typing_adapter._stop_typing_with_metadata(
-                        source.chat_id,
-                        self._thread_metadata_for_source(
-                            source, self._reply_anchor_for_event(event)
-                        ),
-                    )
-                elif _typing_adapter and callable(_stop_typing):
-                    await _typing_adapter.stop_typing(source.chat_id)
-            except Exception:
-                pass
-
             if not self._is_session_run_current(_quick_key, run_generation):
                 logger.info(
                     "Discarding stale agent result for %s — generation %d is no longer current",
@@ -18013,25 +17999,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return response
             
         except Exception as e:
-            # Stop typing indicator on error too, retaining Slack thread/workspace
-            # routing so a failed turn cannot leave its status visible.
-            try:
-                _err_adapter = self._adapter_for_source(source)
-                _stop_with_metadata = getattr(
-                    type(_err_adapter), "_stop_typing_with_metadata", None
-                )
-                _stop_typing = getattr(type(_err_adapter), "stop_typing", None)
-                if _err_adapter and callable(_stop_with_metadata):
-                    await _err_adapter._stop_typing_with_metadata(
-                        source.chat_id,
-                        self._thread_metadata_for_source(
-                            source, self._reply_anchor_for_event(event)
-                        ),
-                    )
-                elif _err_adapter and callable(_stop_typing):
-                    await _err_adapter.stop_typing(source.chat_id)
-            except Exception:
-                pass
+            # Keep the adapter-owned typing refresh alive: this safe error
+            # response is delivered by the outer platform pipeline.
             logger.exception("Agent error in session %s", session_key)
             # Crash-resilience for failures that happen before AIAgent enters
             # run_conversation() (for example: provider/httpx client init
@@ -23507,8 +23476,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         *,
         on_missing_cursor: str,
     ) -> "tuple[Any, Optional[Callable[[], None]]]":
-        """Build the shared ``StreamConsumerConfig`` and the optional
-        Telegram pause-typing closure used by both agent-run paths.
+        """Build the shared ``StreamConsumerConfig``.
 
         ``on_missing_cursor`` controls how platforms whose adapter sets
         ``SUPPORTS_MESSAGE_EDITING = False`` are handled — both semantics
@@ -23518,17 +23486,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         - ``"raise"`` (in-process agent path): raise ``RuntimeError`` so
           the caller's ``except`` skips streaming entirely.
 
-        Returns ``(consumer_cfg, pause_typing_before_finalize)``.
+        The second tuple item is retained for call-site compatibility, but is
+        always ``None``. The outer platform lifecycle owns typing cleanup and
+        stops it only after the final send/edit has completed.
         """
         from gateway.stream_consumer import StreamConsumerConfig
 
         _pause_typing_before_finalize = None
-        if source.platform == Platform.TELEGRAM and hasattr(adapter, "pause_typing_for_chat"):
-            def _pause_typing_before_finalize(
-                _adapter=adapter,
-                _chat_id=source.chat_id,
-            ) -> None:
-                _adapter.pause_typing_for_chat(_chat_id)
         # Platforms that don't support editing sent messages
         # (e.g. QQ, WeChat) should skip streaming entirely —
         # without edit support, the consumer sends a partial

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -84,6 +84,10 @@ _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
+
+class _ProfileResolutionDenied(RuntimeError):
+    """An explicitly routed profile cannot be served without crossing scope."""
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -13534,9 +13538,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_home = Path(get_hermes_home())
 
         async def _handler(event):
-            try:
-                source = getattr(event, "source", None)
-                if source is not None:
+            source = getattr(event, "source", None)
+            if source is not None:
+                try:
                     setattr(source, "_transport_profile", profile_name)
                     if preserve_route:
                         source.profile = (
@@ -13544,8 +13548,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                     else:
                         source.profile = profile_name
-            except Exception:
-                pass
+                except Exception:
+                    logger.warning(
+                        "Dropping message after profile-route resolution failed "
+                        "for transport profile %s",
+                        profile_name,
+                        exc_info=True,
+                    )
+                    return None
             with _profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 
@@ -18781,8 +18791,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if success:
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
-            if hasattr(adapter, "_voice_sources"):
-                adapter._voice_sources[guild_id] = event.source.to_dict()
+            voice_sources = getattr(adapter, "_voice_sources", None)
+            if voice_sources is not None:
+                voice_sources[guild_id] = event.source.to_dict(
+                    include_transport=True
+                )
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
@@ -23982,7 +23995,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_exists,
         )
         from hermes_constants import get_hermes_home
-        
+
+        multiplex = (
+            getattr(getattr(self, "config", None), "multiplex_profiles", False)
+            is True
+        )
+
         # Track whether a profile was explicitly requested (vs. falling back to default)
         explicit_profile = None
         try:
@@ -23997,28 +24015,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 name = get_active_profile_name() or "default"
             
             profile_dir = get_profile_dir(name)
-            # Warn if an explicit profile doesn't exist on disk
+            # An explicit multiplex target is a security boundary.  A stale route
+            # or malformed source must never execute in the process/primary home.
             if explicit_profile and not profile_exists(name):
-                logger.warning(
-                    "Profile %r does not exist for source %s/%s (guild_id=%s), "
-                    "falling back to global HERMES_HOME",
-                    explicit_profile,
-                    source.platform.value,
-                    source.chat_id,
-                    getattr(source, "guild_id", None),
+                message = (
+                    f"Profile {explicit_profile!r} does not exist for source "
+                    f"{source.platform.value}/{source.chat_id}"
                 )
+                if multiplex:
+                    logger.error("%s; refusing primary-profile fallback", message)
+                    raise _ProfileResolutionDenied(message)
+                logger.warning("%s; falling back to global HERMES_HOME", message)
                 return get_hermes_home()
             return profile_dir
-        except Exception:
+        except _ProfileResolutionDenied:
+            raise
+        except Exception as exc:
             # Catch normalization errors, path errors, etc.
+            message = (
+                "Failed to resolve profile directory for source "
+                f"{source.platform.value}/{source.chat_id}: "
+                f"{explicit_profile or '(no profile)'}"
+            )
+            if multiplex:
+                logger.error("%s; refusing primary-profile fallback", message)
+                raise _ProfileResolutionDenied(message) from exc
             logger.warning(
-                "Failed to resolve profile directory for source %s/%s (guild_id=%s), "
-                "falling back to global HERMES_HOME: %s",
-                source.platform.value,
-                source.chat_id,
-                getattr(source, "guild_id", None),
-                explicit_profile or "(no profile)",
-                exc_info=True,
+                "%s; falling back to global HERMES_HOME", message, exc_info=True
             )
             return get_hermes_home()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1843,13 +1843,17 @@ def _profile_runtime_scope(profile_home: "Path"):
     from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    secret_token = None
     try:
+        hydrate_profile_secret_sources(Path(profile_home))
+        secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
         yield
     finally:
-        reset_secret_scope(secret_token)
-        reset_hermes_home_override(home_token)
+        try:
+            if secret_token is not None:
+                reset_secret_scope(secret_token)
+        finally:
+            reset_hermes_home_override(home_token)
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -2254,7 +2258,7 @@ from gateway.session_state import (
     legacy_dict_property,
     legacy_lease_token_property,
 )
-from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.authz_mixin import GatewayAuthorizationMixin, _auth_env
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
@@ -2318,20 +2322,22 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         extra = getattr(platform_config, "extra", None) or {}
         dm_policy = str(
             extra.get("dm_policy")
-            or (_getenv(dm_env, "pairing") if dm_env else "pairing")
+            or (_auth_env(dm_env, "pairing") if dm_env else "pairing")
         ).strip().lower()
         group_policy = str(
             extra.get("group_policy")
-            or (_getenv(group_env, "pairing") if group_env else "pairing")
+            or (_auth_env(group_env, "pairing") if group_env else "pairing")
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":
             continue
-        gateway_allow_all = os.getenv(
-            "GATEWAY_ALLOW_ALL_USERS", ""
-        ).lower() in {"true", "1", "yes"}
+        gateway_allow_all = _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
         platform_opted_in = gateway_allow_all or (
             allow_all_env
-            and _getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
+            and _auth_env(allow_all_env).lower() in {"true", "1", "yes"}
         )
         if platform_opted_in:
             continue
@@ -10778,7 +10784,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "dm_policy/group_policy: open on the platform."
             )
 
-        reason = _own_policy_open_startup_violation(self.config)
+        reason = self._primary_open_policy_violation()
         if reason:
             platform_value = reason.split(":", 1)[0]
             allow_all_env = None
@@ -10973,7 +10979,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     logger.warning("No adapter available for %s", _pval)
                 continue
-            
             # Set up message + fatal error handlers. Under multiplexing the
             # default profile needs the same whole-handler runtime scope as a
             # secondary profile: authorization and prompt rendering both run
@@ -12247,6 +12252,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return "default"
 
+    def _primary_open_policy_violation(self) -> Optional[str]:
+        """Evaluate the active profile's open-policy guard in its own scope."""
+        if not bool(getattr(self.config, "multiplex_profiles", False)):
+            return _own_policy_open_startup_violation(self.config)
+
+        from hermes_cli.profiles import get_profile_dir
+
+        profile_home = get_profile_dir(self._active_profile_name())
+        with _profile_runtime_scope(profile_home):
+            return _own_policy_open_startup_violation(self.config)
+
     # ── Kanban board watchers ───────────────────────────────────────────
     # The kanban notifier/dispatcher watcher loops + their helpers live in
     # GatewayKanbanWatchersMixin (gateway/kanban_watchers.py). They use only
@@ -13085,10 +13101,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         try:
             from hermes_cli.profiles import profiles_to_serve, get_active_profile_name
+            from gateway.pairing import PairingStore
         except Exception:
             return 0
 
         active = get_active_profile_name() or "default"
+        if not isinstance(getattr(self, "pairing_stores", None), dict):
+            self.pairing_stores = {}
+        primary_pairing_store = getattr(self, "pairing_store", None)
+        if primary_pairing_store is not None:
+            self.pairing_stores.setdefault(active, primary_pairing_store)
         connected = 0
         # Resource claim -> profile that owns it. Credential claims prevent two
         # profiles polling the same account; listener claims prevent sidecars
@@ -13114,6 +13136,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if profile_name == active:
                 continue  # handled by the primary startup loop
             try:
+                if profile_name not in self.pairing_stores:
+                    self.pairing_stores[profile_name] = PairingStore(
+                        profile=profile_name
+                    )
                 connected += await self._start_one_profile_adapters(
                     profile_name, profile_home, claimed
                 )
@@ -13134,7 +13160,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Record served profiles in runtime status for `hermes status`.
         try:
             from gateway.status import write_runtime_status
-            from gateway.pairing import PairingStore
             served = [active] + sorted(self._profile_adapters.keys())
             # Per-profile PairingStores so authz_mixin can route pairing
             # checks to the right whitelist. The active profile gets a store
@@ -13472,49 +13497,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Reconnect is scoped to the profile's own config and secret mapping;
         # never rebuild a secondary adapter with the default profile's credentials.
 
-    def _make_profile_message_handler(self, profile_name: str):
-        """Return a message handler that stamps source.profile then delegates.
+    def _primary_message_handler(self):
+        """Scope primary intake without overwriting a routed runtime profile."""
+        if bool(
+            getattr(getattr(self, "config", None), "multiplex_profiles", False)
+        ):
+            return self._make_profile_message_handler(
+                self._active_profile_name(),
+                preserve_route=True,
+            )
+        return self._handle_message
 
-        Auth runs inside ``_handle_message`` *before* the agent-turn scope is
-        installed. For secondary profiles under multiplex, wrap the whole
-        handler in ``_profile_runtime_scope`` so allowlists/tokens from that
-        profile's ``.env`` are visible to ``get_secret`` / authz.
+    def _make_profile_message_handler(
+        self,
+        profile_name: str,
+        *,
+        preserve_route: bool = False,
+    ):
+        """Return a profile-scoped message handler for one adapter owner.
+
+        Secondary adapters enforce their fixed owner.  The primary adapter may
+        carry a ``profile_routes`` target, so ``preserve_route`` keeps that
+        runtime/session profile while separately stamping transport ownership.
         """
         from hermes_cli.profiles import get_profile_dir
 
         try:
-            profile_home = get_profile_dir(profile_name)
+            # The primary/default adapter belongs to the gateway process's
+            # active runtime home, including an installed ContextVar override.
+            # Named profiles continue through the canonical profile resolver.
+            if profile_name == "default":
+                profile_home = Path(get_hermes_home())
+            else:
+                profile_home = get_profile_dir(profile_name)
         except Exception:
-            profile_home = None
+            profile_home = Path(get_hermes_home())
 
         async def _handler(event):
             try:
-                if getattr(event, "source", None) is not None and not event.source.profile:
-                    event.source.profile = profile_name
+                source = getattr(event, "source", None)
+                if source is not None:
+                    setattr(source, "_transport_profile", profile_name)
+                    if preserve_route:
+                        source.profile = (
+                            self._profile_name_for_source(source) or profile_name
+                        )
+                    else:
+                        source.profile = profile_name
             except Exception:
                 pass
-            if profile_home is not None:
-                with _profile_runtime_scope(profile_home):
-                    return await self._handle_message(event)
-            return await self._handle_message(event)
-
-        return _handler
-
-    def _make_default_profile_message_handler(self):
-        """Scope a multiplexed default-profile message from ingress onward."""
-        profile_home = Path(get_hermes_home())
-
-        async def _handler(event):
             with _profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 
         return _handler
 
-    def _primary_message_handler(self):
-        """Return the correctly scoped handler for a primary adapter."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return self._make_default_profile_message_handler()
-        return self._handle_message
 
     @staticmethod
     def _adapter_credential_claim(
@@ -13745,10 +13781,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         full auth chain — platform allowlists, group allowlists, pairing
         store, allow-all flags — stays the single source of truth.
 
-        ``profile_name`` binds the callback to the secondary adapter's own
-        multiplex profile, so its ``SessionSource`` resolves that profile's
-        secret scope instead of falling back to the active profile.
+        ``profile_name`` binds the callback to the adapter's own multiplex
+        profile, so its ``SessionSource`` resolves that profile's secret scope
+        instead of falling back to process-global credentials.
         """
+        if profile_name is None and bool(
+            getattr(getattr(self, "config", None), "multiplex_profiles", False)
+        ):
+            profile_name = self._active_profile_name()
+
         def check(
             user_id: str,
             chat_type: Optional[str] = None,
@@ -13763,6 +13804,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id=user_id,
                 profile=profile_name,
             )
+            if profile_name:
+                from hermes_cli.profiles import get_profile_dir
+
+                with _profile_runtime_scope(get_profile_dir(profile_name)):
+                    return self._is_user_authorized(source)
             return self._is_user_authorized(source)
         return check
 
@@ -14344,7 +14390,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source.chat_type == "dm"
                 and self._get_unauthorized_dm_behavior(
                     source.platform,
-                    profile=source.profile,
+                    profile=self._adapter_profile_for_source(source),
                 )
                 == "pair"
             ):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -191,18 +191,6 @@ class SessionSource:
     auto_thread_created: bool = False
     auto_thread_initial_name: Optional[str] = None
 
-    # Discord auto-thread session-continuity signal. Set by the connector on an
-    # inbound CHANNEL message (no thread_id yet) that its auto-thread policy WILL
-    # deliver into a newly-created thread. A Discord thread created from a message
-    # reuses that message's id as the thread id, so the connector knows the id
-    # before the thread exists. The gateway keys the session on this so a
-    # channel message and its thread follow-ups share ONE session: the channel
-    # message INITIATES it (keyed on the prospective thread id), and later
-    # messages arriving in that thread (real thread_id == this value) CONTINUE
-    # it. Without this, every channel message collapses into one parent-channel
-    # session and only the first auto-thread ever gets an auto-title/rename.
-    prospective_thread_id: Optional[str] = None
-
     # Internal, wire-INVISIBLE trust signal: True when this event was delivered
     # to the gateway over the per-instance-authenticated relay WebSocket (the
     # Team Gateway connector). The connector authenticates the gateway's socket
@@ -215,6 +203,33 @@ class SessionSource:
     # deliberately excluded from ``to_dict``/``from_dict`` so a peer can never
     # forge it across the wire or have it restored from persistence.
     delivered_via_upstream_relay: bool = False
+
+    # Discord auto-thread session-continuity signal. Set by the connector on an
+    # inbound CHANNEL message (no thread_id yet) that its auto-thread policy WILL
+    # deliver into a newly-created thread. A Discord thread created from a message
+    # reuses that message's id as the thread id, so the connector knows the id
+    # before the thread exists. The gateway keys the session on this so a
+    # channel message and its thread follow-ups share ONE session: the channel
+    # message INITIATES it (keyed on the prospective thread id), and later
+    # messages arriving in that thread (real thread_id == this value) CONTINUE
+    # it. Without this, every channel message collapses into one parent-channel
+    # session and only the first auto-thread ever gets an auto-title/rename.
+    # This field intentionally follows the relay flag so older positional
+    # constructors keep their established argument positions.
+    prospective_thread_id: Optional[str] = None
+
+    # Internal transport provenance. ``profile`` may name a routed runtime
+    # while replies and authorization stay bound to the receiving adapter.
+    # Keep these fields after every pre-existing public field so legacy
+    # positional constructors retain their original argument positions.
+    # ``dataclasses.replace`` then preserves both fields automatically. The
+    # weakref is never serialized; trusted local state may opt in to persisting
+    # the non-secret owner profile for replay/delayed delivery. Live inbound
+    # handlers overwrite that stamp before authorization.
+    _transport_adapter_ref: Any = field(default=None, repr=False, compare=False)
+    _transport_profile: Optional[str] = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         # D-Q2.5 dual-field reconciliation: `scope_id` is canonical, `guild_id`
@@ -247,7 +262,7 @@ class SessionSource:
         
         return ", ".join(parts)
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, *, include_transport: bool = False) -> Dict[str, Any]:
         d = {
             "platform": self.platform.value,
             "chat_id": self.chat_id,
@@ -276,6 +291,8 @@ class SessionSource:
             d["message_id"] = self.message_id
         if self.profile:
             d["profile"] = self.profile
+        if include_transport and self._transport_profile:
+            d["transport_profile"] = self._transport_profile
         if self.auto_thread_created:
             d["auto_thread_created"] = True
         if self.auto_thread_initial_name:
@@ -303,6 +320,7 @@ class SessionSource:
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
             profile=data.get("profile"),
+            _transport_profile=data.get("transport_profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
             prospective_thread_id=data.get("prospective_thread_id"),
@@ -899,7 +917,7 @@ class SessionEntry:
             # unsanitized dict directly on the entry.
             result["model_override"] = sanitize_model_override(self.model_override)
         if self.origin:
-            result["origin"] = self.origin.to_dict()
+            result["origin"] = self.origin.to_dict(include_transport=True)
         return result
     
     @classmethod
@@ -2000,7 +2018,7 @@ class SessionStore:
         try:
             origin_json = None
             try:
-                origin_json = json.dumps(source.to_dict())
+                origin_json = json.dumps(source.to_dict(include_transport=True))
             except Exception:
                 pass
             recorder(

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import codecs
 import io
+import hashlib
 import os
 import sys
 import threading
@@ -40,6 +41,13 @@ _SECRET_SOURCES: dict[str, str] = {}
 # Applied values are immutable per-home snapshots.  ``os.environ`` is shared
 # across profiles and may be overwritten by a later home's source apply.
 _SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
+# Profile-scoped fetches keep their values in memory without mutating
+# ``os.environ``.  Track both attempted homes and an input fingerprint: unchanged
+# profiles avoid a helper run on every multiplexed turn, while rotated bootstrap
+# values or source config trigger a fresh isolated fetch automatically.
+_PROFILE_SECRET_SOURCE_RESOLVED_HOMES: set[str] = set()
+_PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS: dict[str, str] = {}
+_PROFILE_SECRET_SOURCE_LOCK = threading.Lock()
 
 # HERMES_HOME paths we've already pulled external secrets for during this
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
@@ -166,76 +174,139 @@ def get_secret_source_values(
     return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
 
 
+def _profile_source_bootstrap_env(home: Path) -> dict[str, str]:
+    """Build the private fetch environment used by the legacy hydrate API.
+
+    Only genuinely global deployment variables are copied from the process;
+    profile ``.env``/``.op.env`` values are then layered on top.  This mapping
+    is never assigned to ``os.environ``.
+    """
+    from agent.secret_scope import _is_global_env, load_env_file
+
+    local_env = {
+        name: value
+        for name, value in os.environ.items()
+        if _is_global_env(name)
+    }
+    local_env.update(load_env_file(home / ".env"))
+    # The 1Password service-account token may live in the gitignored
+    # ``.op.env`` bootstrap file.  ``.env`` remains authoritative on conflict.
+    for name, value in load_env_file(home / ".op.env").items():
+        local_env.setdefault(name, value)
+    # Keep the profile home available to source code that still consumes the
+    # upstream fetch-environment hook.  Subprocess builders explicitly pin
+    # process-global home/operational keys, so this cannot redirect helpers.
+    local_env["HERMES_HOME"] = str(home)
+    return local_env
+
+
 def hydrate_profile_secret_sources(
     hermes_home: str | os.PathLike,
 ) -> dict[str, str]:
-    """Resolve one profile's configured sources without mutating ``os.environ``.
+    """Resolve one profile's sources without mutating ``os.environ``.
 
-    Multiplex gateways can route a first turn to a secondary profile that has
-    never run the process-global dotenv startup path.  Resolve that profile's
-    sources against a private mapping seeded from its own ``.env`` and record
-    the usual per-home snapshot for ``build_profile_secret_scope()``.
-
-    Fail-open and once-per-home semantics intentionally mirror
-    ``_apply_external_secret_sources``.  The returned mapping contains only
-    values actually contributed by external sources, never the profile's
-    plaintext ``.env`` entries.
+    This is the upstream-compatible name used by the gateway.  It retains the
+    profile-local ``.env``/``.op.env`` bootstrap behavior while delegating the
+    cache and fingerprint policy to the hardened resolver below.
     """
-    with _SECRET_SOURCE_CACHE_LOCK:
-        return _hydrate_profile_secret_sources(Path(hermes_home))
-
-
-def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
-    """Locked implementation for :func:`hydrate_profile_secret_sources`."""
-    home_key = str(home.resolve())
-    if home_key in _APPLIED_HOMES:
-        return get_secret_source_values(home)
-
+    home = Path(hermes_home)
     try:
-        cfg = _load_secrets_config(home)
+        bootstrap = _profile_source_bootstrap_env(home)
     except Exception:  # noqa: BLE001 — external sources must not block routing
         return {}
-    if not cfg:
-        return {}
+    return resolve_profile_secret_source_values(home, bootstrap)
 
+
+def resolve_profile_secret_source_values(
+    hermes_home: str | os.PathLike,
+    base_values: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve one profile's external secrets into an isolated mapping.
+
+    A multiplexing gateway cannot load a secondary profile through
+    ``load_hermes_dotenv()`` because that mutates process-global
+    ``os.environ``.  Resolve the same configured sources against a private
+    dict instead, so the caller can install the values in a context-local
+    secret scope without exposing them to another profile or subprocess.
+    """
+    home_path = Path(hermes_home)
+    home_key = str(home_path.resolve())
+    base_snapshot = dict(base_values or {})
+    fingerprint = _profile_secret_source_input_fingerprint(
+        home_path,
+        base_snapshot,
+    )
+    with _PROFILE_SECRET_SOURCE_LOCK:
+        cached_fingerprint = _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS.get(home_key)
+        if cached_fingerprint == fingerprint:
+            return get_secret_source_values(home_path)
+
+        try:
+            cfg = _load_secrets_config(home_path)
+            if not cfg:
+                # Preserve the upstream snapshot API when a home was already
+                # hydrated by the normal (process-global) startup path.  An
+                # empty snapshot is deliberately not treated as resolved: a
+                # later profile bootstrap/config change must still be allowed
+                # to retry its own fetch.
+                existing = get_secret_source_values(home_path)
+                if existing:
+                    return existing
+                _SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
+                _PROFILE_SECRET_SOURCE_RESOLVED_HOMES.discard(home_key)
+                _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS.pop(home_key, None)
+                return {}
+            from agent.secret_sources.registry import apply_all
+
+            isolated_env = dict(base_snapshot)
+            report = apply_all(cfg, home_path, environ=isolated_env)
+            if getattr(report, "sources", None):
+                _PROFILE_SECRET_SOURCE_RESOLVED_HOMES.add(home_key)
+                _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS[home_key] = fingerprint
+            else:
+                _PROFILE_SECRET_SOURCE_RESOLVED_HOMES.discard(home_key)
+                _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS.pop(home_key, None)
+            values = {
+                name: isolated_env[name]
+                for name in getattr(report, "provenance", {})
+                if name in isolated_env
+            }
+            if values:
+                _SECRET_SOURCE_VALUES_BY_HOME[home_key] = dict(values)
+                for name, applied in report.provenance.items():
+                    _SECRET_SOURCES[name] = applied.source
+            else:
+                _SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
+            return values
+        except TypeError as exc:
+            # A few third-party/legacy test doubles implement the pre-hardening
+            # two-argument apply_all API.  Reuse an already recorded snapshot
+            # only for that explicit signature mismatch; never fall back to a
+            # global apply in a multiplex profile.
+            if "unexpected keyword argument 'environ'" in str(exc):
+                return get_secret_source_values(home_path)
+            return {}
+        except Exception:
+            return {}
+
+
+def _profile_secret_source_input_fingerprint(
+    home_path: Path,
+    base_values: dict[str, str],
+) -> str:
+    """Hash profile bootstrap values and source config for cache invalidation."""
+    digest = hashlib.sha256()
+    config_path = home_path / "config.yaml"
     try:
-        from agent.secret_scope import _is_global_env, load_env_file
-        from agent.secret_sources.registry import apply_all
-
-        local_env = {
-            name: value
-            for name, value in os.environ.items()
-            if _is_global_env(name)
-        }
-        local_env.update(load_env_file(home / ".env"))
-        # Mirror load_hermes_dotenv()'s .op.env bootstrap: the 1Password
-        # service-account token lives in <home>/.op.env (gitignored), not
-        # .env. Without seeding it here a cold profile configured for the
-        # supported .op.env flow fails 1Password hydration (sweeper review
-        # on #74549). .env values win — never override an existing key.
-        op_env = home / ".op.env"
-        if op_env.exists():
-            for _name, _value in load_env_file(op_env).items():
-                local_env.setdefault(_name, _value)
-        local_env["HERMES_HOME"] = str(home)
-        report = apply_all(cfg, home, environ=local_env)
-    except Exception:  # noqa: BLE001 — preserve fail-open startup behavior
-        return {}
-
-    if not report.sources:
-        return {}
-
-    _APPLIED_HOMES.add(home_key)
-    values: dict[str, str] = {}
-    for name, applied in report.provenance.items():
-        value = local_env.get(name)
-        if value is None:
-            continue
-        _SECRET_SOURCES[name] = applied.source
-        values[name] = value
-    if values:
-        _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
-    return dict(values)
+        digest.update(config_path.read_bytes())
+    except OSError:
+        digest.update(b"<missing-config>")
+    for key in sorted(base_values):
+        digest.update(key.encode("utf-8", errors="surrogatepass"))
+        digest.update(b"\0")
+        digest.update(base_values[key].encode("utf-8", errors="surrogatepass"))
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def reset_secret_source_cache() -> None:
@@ -251,6 +322,8 @@ def reset_secret_source_cache() -> None:
     _APPLIED_HOMES.clear()
     _SECRET_SOURCES.clear()
     _SECRET_SOURCE_VALUES_BY_HOME.clear()
+    _PROFILE_SECRET_SOURCE_RESOLVED_HOMES.clear()
+    _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -475,6 +548,30 @@ def load_hermes_dotenv(
     loaded: list[Path] = []
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+    # A multiplex gateway keeps secondary-profile credentials in a
+    # context-local secret scope.  Lazy imports during a secondary turn may
+    # call load_hermes_dotenv() again with that profile's overridden home; never
+    # let such a late call replace the primary process's os.environ.
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        process_home = Path(
+            os.environ.get("HERMES_HOME") or (Path.home() / ".hermes")
+        )
+        if (
+            is_multiplex_active()
+            and os.path.normcase(str(home_path.expanduser().resolve(strict=False)))
+            != os.path.normcase(
+                str(process_home.expanduser().resolve(strict=False))
+            )
+        ):
+            return loaded
+    except Exception:
+        # Early bootstrap can import this module before secret_scope is ready;
+        # preserve the established single-profile loader in that case.
+        pass
+
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -237,9 +237,14 @@ def resolve_profile_secret_source_values(
         base_snapshot,
     )
     with _PROFILE_SECRET_SOURCE_LOCK:
+        existing = get_secret_source_values(home_path)
         cached_fingerprint = _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS.get(home_key)
         if cached_fingerprint == fingerprint:
-            return get_secret_source_values(home_path)
+            return existing
+        if cached_fingerprint is None and existing:
+            _PROFILE_SECRET_SOURCE_INPUT_FINGERPRINTS[home_key] = fingerprint
+            _PROFILE_SECRET_SOURCE_RESOLVED_HOMES.add(home_key)
+            return existing
 
         try:
             cfg = _load_secrets_config(home_path)
@@ -840,10 +845,10 @@ def _load_secrets_config(home_path: Path) -> dict:
 
 
 def _process_hermes_home() -> Path:
-    """The HERMES_HOME the shared config cache is keyed to."""
+    """The launch-time HERMES_HOME, ignoring any profile ContextVar override."""
     try:
-        from hermes_constants import get_hermes_home
+        from hermes_constants import get_process_hermes_home
 
-        return get_hermes_home()
+        return get_process_hermes_home()
     except Exception:
         return Path.home() / ".hermes"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -27,6 +27,13 @@ from typing import Dict, List, Optional, Set, Any, Tuple
 logger = logging.getLogger(__name__)
 
 
+def _telegram_auth_env(name: str, default: str = "") -> str:
+    """Read auth policy from the active profile's fail-closed scope."""
+    from gateway.authz_mixin import _auth_env
+
+    return _auth_env(name, default)
+
+
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
     text = "" if error is None else str(error)
@@ -992,17 +999,26 @@ class TelegramAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+        if normalized_chat_type == "private":
+            normalized_chat_type = "dm"
+        elif normalized_chat_type == "supergroup":
+            normalized_chat_type = "forum" if thread_id is not None else "group"
+
+        if getattr(self, "_authorization_check", None) is not None:
+            registered_auth = self._is_sender_authorized(
+                normalized_user_id,
+                normalized_chat_type,
+                str(chat_id or normalized_user_id),
+            )
+            if registered_auth is not None:
+                return registered_auth
+
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
                 from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
 
                 source = SessionSource(
                     platform=Platform.TELEGRAM,
@@ -1020,13 +1036,17 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-        allowed_csv = _scoped_gate_env("TELEGRAM_ALLOWED_USERS").strip()
+        allowed_csv = _telegram_auth_env("TELEGRAM_ALLOWED_USERS")
         if not allowed_csv:
             # Fail-closed: no allowlist means deny by default.
             # The runner auth path in _is_user_authorized() handles
             # GATEWAY_ALLOW_ALL_USERS; this fallback must not silently
             # allow everyone (fixes #24457).
-            return _scoped_gate_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
+            return _telegram_auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {
+                "true",
+                "1",
+                "yes",
+            }
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 
@@ -1100,7 +1120,7 @@ class TelegramAdapter(BasePlatformAdapter):
             "GATEWAY_ALLOWED_USERS",
             "GATEWAY_ALLOW_ALL_USERS",
         )
-        return any(_scoped_gate_env(key).strip() for key in keys)
+        return any(_telegram_auth_env(key) for key in keys)
 
     def _should_pass_unauthorized_dm_for_pairing(self, source) -> bool:
         """Return True when an unauthorized DM must still reach gateway pairing.
@@ -1192,6 +1212,17 @@ class TelegramAdapter(BasePlatformAdapter):
                     pass
 
         if authorized is None:
+            registered_auth = None
+            if getattr(self, "_authorization_check", None) is not None:
+                registered_auth = self._is_sender_authorized(
+                    user_id,
+                    source.chat_type,
+                    source.chat_id,
+                )
+            if registered_auth is not None:
+                return registered_auth
+
+        if authorized is None:
             runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
             auth_fn = getattr(runner, "_is_user_authorized", None)
             if callable(auth_fn):
@@ -1210,7 +1241,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
 
         if authorized is None:
-            allowed_csv = _scoped_gate_env("TELEGRAM_ALLOWED_USERS").strip()
+            allowed_csv = _telegram_auth_env("TELEGRAM_ALLOWED_USERS")
             if not allowed_csv:
                 return True
             allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -16,11 +16,13 @@ import logging
 import os
 import html as _html
 import re
+import shlex
 import threading
 import time
 from contextvars import ContextVar
+from pathlib import Path
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Set, Any
+from typing import Dict, List, Optional, Set, Any, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -612,6 +614,59 @@ _POLLING_GENERATION_CONTEXT: ContextVar[Optional[int]] = ContextVar(
 
 class _PollingLifecycleAbort(RuntimeError):
     """Internal control flow for polling startup fenced by teardown."""
+
+
+def _resolve_telegram_channel_prompt(
+    extra: dict,
+    *,
+    chat_id: str,
+    thread_id: str | None,
+    chat_type: str,
+) -> str | None:
+    """Resolve collision-free additive Telegram group/topic prompts.
+
+    Defining ``topic_prompts`` opts Telegram into scoped keys of the form
+    ``<chat_id>:<thread_id>``. In that mode numeric ``channel_prompts`` keys
+    are not consulted, preventing a forum policy from leaking into a DM topic
+    or another group that happens to reuse the same thread id. Profiles without
+    ``topic_prompts`` retain the legacy cross-platform resolution.
+    """
+    from gateway.platforms.base import resolve_channel_prompt
+
+    scoped = extra.get("topic_prompts")
+    if not isinstance(scoped, dict):
+        return resolve_channel_prompt(
+            extra,
+            thread_id or chat_id,
+            chat_id if thread_id else None,
+        )
+
+    base = resolve_channel_prompt(extra, chat_id)
+    if chat_type != "group" or not thread_id:
+        return base
+
+    topic_prompt = scoped.get(f"{chat_id}:{thread_id}")
+    if topic_prompt is None:
+        nested = scoped.get(chat_id)
+        if nested is None:
+            try:
+                nested = scoped.get(int(chat_id))
+            except (TypeError, ValueError):
+                pass
+        if isinstance(nested, dict):
+            topic_prompt = nested.get(thread_id)
+            if topic_prompt is None:
+                try:
+                    topic_prompt = nested.get(int(thread_id))
+                except (TypeError, ValueError):
+                    pass
+
+    parts: list[str] = []
+    for value in (base, topic_prompt):
+        text = str(value or "").strip()
+        if text and text not in parts:
+            parts.append(text)
+    return "\n\n".join(parts) or None
 
 
 class TelegramAdapter(BasePlatformAdapter):
@@ -3571,7 +3626,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name, exc_info=True,
                 )
 
-    def _start_post_connect_housekeeping(self) -> None:
+    def _start_post_connect_housekeeping(self, *, recover_inflight: bool = False) -> None:
         """Kick off deferred post-connect housekeeping in the background.
 
         Idempotent: if a previous housekeeping task is still running (e.g. a
@@ -3581,14 +3636,76 @@ class TelegramAdapter(BasePlatformAdapter):
         if task and not task.done():
             return
         self._post_connect_task = asyncio.ensure_future(
-            self._run_post_connect_housekeeping()
+            self._run_post_connect_housekeeping(recover_inflight=recover_inflight)
         )
 
-    async def _run_post_connect_housekeeping(self) -> None:
+    async def _reconcile_inflight_journal(self) -> None:
+        """Notify original Telegram topics about turns lost to a hard restart."""
+        if not self.config.extra.get("inflight_recovery_enabled"):
+            return
+        try:
+            from gateway.inflight_journal import clear_inflight, list_inflight
+            records = list_inflight("telegram")
+        except Exception:
+            logger.warning("[%s] Could not read inbound in-flight journal", self.name, exc_info=True)
+            return
+
+        notice = (
+            "Предыдущая обработка была прервана перезапуском gateway до доставки "
+            "финального ответа. Пожалуйста, отправьте сообщение ещё раз."
+        )
+        grouped: Dict[tuple[str, str], List[dict]] = {}
+        for record in records:
+            try:
+                record_pid = record.get("process_id")
+                if record_pid is not None and int(str(record_pid)) == os.getpid():
+                    continue
+            except (TypeError, ValueError):
+                # Legacy/malformed records without an owner PID are treated as
+                # stale so an actual prior-process interruption is not lost.
+                pass
+            chat_id = str(record.get("chat_id") or "")
+            if not chat_id:
+                continue
+            thread_id = str(record.get("thread_id") or "")
+            grouped.setdefault((chat_id, thread_id), []).append(record)
+
+        for (chat_id, thread_id), group_records in grouped.items():
+            metadata = None
+            if thread_id:
+                metadata = {"message_thread_id": thread_id}
+            try:
+                result = await self.send(
+                    chat_id=chat_id,
+                    content=notice,
+                    metadata=metadata,
+                )
+                if getattr(result, "success", False):
+                    uncleared = sum(
+                        1 for record in group_records
+                        if not clear_inflight(record.get("_token"))
+                    )
+                    if uncleared:
+                        logger.warning(
+                            "[%s] Delivered restart notice but could not clear %d marker(s)",
+                            self.name,
+                            uncleared,
+                        )
+            except Exception:
+                logger.warning(
+                    "[%s] Could not deliver in-flight restart notice; retaining marker",
+                    self.name,
+                    exc_info=True,
+                )
+
+    async def _run_post_connect_housekeeping(self, *, recover_inflight: bool = False) -> None:
         """Register the command menu, surface the status indicator, and set up
         DM topics — all off the connect path so a slow Bot API call cannot blow
         the gateway connect timeout (#46298). Every step is non-fatal."""
         try:
+            if recover_inflight:
+                await self._reconcile_inflight_journal()
+
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
             # gateway command there automatically adds it to the Telegram menu.
@@ -4029,6 +4146,25 @@ class TelegramAdapter(BasePlatformAdapter):
                             pass
             await self._app.start()
 
+            # Reconcile prior-process markers before webhook/polling begins,
+            # so a same-message retry cannot overwrite a stale marker between
+            # snapshot and cleanup. Bound this startup obligation; timeout
+            # retains every marker for the next cold start.
+            if (
+                not is_reconnect
+                and self.config.extra.get("inflight_recovery_enabled")
+            ):
+                try:
+                    await asyncio.wait_for(
+                        self._reconcile_inflight_journal(),
+                        timeout=15.0,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[%s] In-flight reconciliation timed out; retaining markers",
+                        self.name,
+                    )
+
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 
@@ -4201,7 +4337,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # though polling/webhook is already live (#46298). Defer them to a
             # cancellable background task so connect() returns as soon as the
             # transport is up.
-            self._start_post_connect_housekeeping()
+            self._start_post_connect_housekeeping(recover_inflight=False)
 
             return True
             
@@ -6996,11 +7132,77 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[tuple],
+        images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
-        """Send a batch of images natively via Telegram's media group API.
+        """Preserve the public multi-image API while using tracked delivery."""
+        await self.send_multiple_images_tracked(
+            chat_id=chat_id,
+            images=images,
+            metadata=metadata,
+            human_delay=human_delay,
+        )
+
+    async def _send_images_individually_tracked(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]],
+        human_delay: float,
+    ) -> SendResult:
+        """Telegram fallback that retains per-image delivery outcomes."""
+        from urllib.parse import unquote as _unquote
+
+        outcomes: List[SendResult] = []
+        for image_url, alt_text in images:
+            if human_delay > 0:
+                await asyncio.sleep(human_delay)
+            try:
+                if image_url.startswith("file://"):
+                    result = await self.send_image_file(
+                        chat_id,
+                        _unquote(image_url[7:]),
+                        alt_text or None,
+                        metadata=metadata,
+                    )
+                elif self._is_animation_url(image_url):
+                    result = await self.send_animation(
+                        chat_id,
+                        image_url,
+                        alt_text or None,
+                        metadata=metadata,
+                    )
+                else:
+                    result = await self.send_image(
+                        chat_id,
+                        image_url,
+                        alt_text or None,
+                        metadata=metadata,
+                    )
+                outcomes.append(result)
+            except Exception as exc:
+                outcomes.append(
+                    SendResult(
+                        success=False,
+                        error=_redact_telegram_error_text(exc),
+                    )
+                )
+        return SendResult(
+            success=all(result.success for result in outcomes) if outcomes else not images,
+            error="; ".join(
+                str(result.error) for result in outcomes if not result.success
+            ),
+        )
+
+    async def send_multiple_images_tracked(
+        self,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> SendResult:
+        """Send a batch with an aggregate result for journal accounting.
 
         Telegram's ``send_media_group`` bundles up to 10 photos/videos into
         a single album. Larger batches are chunked. Animated GIFs cannot
@@ -7012,9 +7214,10 @@ class TelegramAdapter(BasePlatformAdapter):
         the base adapter's per-image loop.
         """
         if not self._bot:
-            return
+            return SendResult(success=False, error="Not connected")
         if not images:
-            return
+            return SendResult(success=True)
+        results: List[SendResult] = []
 
         try:
             from telegram import InputMediaPhoto
@@ -7023,8 +7226,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] InputMediaPhoto unavailable, falling back to per-image send: %s",
                 self.name, exc,
             )
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await self._send_images_individually_tracked(
+                chat_id, images, metadata, human_delay
+            )
 
         # Peel off animations — they need send_animation, not send_media_group
         animations: List[tuple] = []
@@ -7037,12 +7241,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # Animations: route through the base default (per-image send_animation)
         if animations:
-            await super().send_multiple_images(
-                chat_id, animations, metadata, human_delay=human_delay,
+            results.append(
+                await self._send_images_individually_tracked(
+                    chat_id, animations, metadata, human_delay
+                )
             )
 
         if not photos:
-            return
+            return SendResult(success=all(result.success for result in results))
 
         from urllib.parse import unquote as _unquote
         _thread = self._metadata_thread_id(metadata)
@@ -7067,6 +7273,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 "[%s] Skipping missing image in media group: %s",
                                 self.name, local_path,
                             )
+                            results.append(SendResult(success=False, error="Missing image path"))
                             continue
                         fh = open(local_path, "rb")
                         opened_files.append(fh)
@@ -7112,6 +7319,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "media group",
                     reset_media=_reset_opened_files,
                 )
+                results.append(SendResult(success=True))
             except Exception as e:
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s",
@@ -7119,8 +7327,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
                 # Fallback: send each photo in this chunk individually
-                await super().send_multiple_images(
-                    chat_id, chunk, metadata, human_delay=human_delay,
+                results.append(
+                    await self._send_images_individually_tracked(
+                        chat_id, chunk, metadata, human_delay
+                    )
                 )
             finally:
                 for fh in opened_files:
@@ -7128,6 +7338,11 @@ class TelegramAdapter(BasePlatformAdapter):
                         fh.close()
                     except Exception:
                         pass
+
+        return SendResult(
+            success=all(result.success for result in results) if results else False,
+            error="; ".join(str(result.error) for result in results if not result.success),
+        )
 
     async def send_image_file(
         self,
@@ -9630,6 +9845,138 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             return None
 
+    async def _enrich_reply_context(self, event: MessageEvent) -> MessageEvent:
+        """Attach bounded read-only MTProto history to a Telegram reply.
+
+        The command is opt-in through ``extra.reply_context_command``.  It runs
+        out of process so Telethon and user-account credentials remain outside
+        the Bot API process.  Any timeout, non-zero exit, malformed JSON, or
+        empty result fails open to Telegram's native single-message reply.
+        """
+        command = self.config.extra.get("reply_context_command")
+        source = getattr(event, "source", None)
+        if not (
+            command
+            and getattr(event, "reply_to_message_id", None)
+            and source is not None
+            and getattr(source, "chat_type", None) == "group"
+        ):
+            return event
+        if str(getattr(event, "text", "") or "").lstrip().startswith("/"):
+            return event
+
+        try:
+            argv = shlex.split(str(command))
+        except ValueError:
+            logger.warning("[%s] Invalid reply_context_command", self.name)
+            return event
+        if not argv:
+            return event
+
+        def _bounded_int(key: str, default: int, minimum: int, maximum: int) -> int:
+            try:
+                value = int(self.config.extra.get(key, default))
+            except (TypeError, ValueError):
+                value = default
+            return max(minimum, min(value, maximum))
+
+        max_chars = _bounded_int("reply_context_max_chars", 80000, 1000, 200000)
+        argv.extend(
+            [
+                "--chat-id", str(source.chat_id),
+                "--thread-id", str(getattr(source, "thread_id", None) or "1"),
+                "--message-id", str(getattr(event, "message_id", "") or ""),
+                "--reply-to-message-id", str(event.reply_to_message_id),
+                "--depth", str(_bounded_int("reply_context_depth", 30, 1, 30)),
+                "--neighbors", str(_bounded_int("reply_context_neighbors", 5, 0, 5)),
+                "--max-messages", str(_bounded_int("reply_context_max_messages", 100, 1, 100)),
+                "--max-chars", str(max_chars),
+            ]
+        )
+        timeout = float(_bounded_int("reply_context_timeout", 5, 1, 30))
+        proc = None
+        communicate_task = None
+
+        async def _read_limited(stream, limit: int) -> bytes:
+            if stream is None:
+                return b""
+            data = await stream.read(limit + 1)
+            if len(data) > limit:
+                raise ValueError("reply context subprocess output exceeded limit")
+            return data
+
+        async def _bounded_communicate():
+            process = proc
+            if process is None:
+                raise RuntimeError("reply context process was not started")
+            stdout_task = asyncio.create_task(
+                _read_limited(process.stdout, min(500_000, max_chars * 4 + 8192))
+            )
+            stderr_task = asyncio.create_task(_read_limited(process.stderr, 65_536))
+            try:
+                stdout, stderr = await asyncio.gather(stdout_task, stderr_task)
+                await process.wait()
+                return stdout, stderr
+            finally:
+                for task in (stdout_task, stderr_task):
+                    if not task.done():
+                        task.cancel()
+
+        async def _kill_and_reap() -> None:
+            process = proc
+            if process is None or process.returncode is not None:
+                return
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await process.wait()
+            except Exception:
+                pass
+
+        try:
+            allowed_env = {
+                "HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE",
+                "SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE",
+                "HERMES_HOME",
+            }
+            child_env = {key: value for key, value in os.environ.items() if key in allowed_env}
+            child_env.setdefault("HOME", str(Path.home()))
+            child_env.setdefault("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+            child_env["PYTHONNOUSERSITE"] = "1"
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=child_env,
+            )
+            communicate_task = asyncio.create_task(_bounded_communicate())
+            stdout, _stderr = await asyncio.wait_for(communicate_task, timeout=timeout)
+            if proc.returncode != 0 or not stdout:
+                return event
+            payload = json.loads(stdout.decode("utf-8", errors="replace"))
+            context = payload.get("context") if isinstance(payload, dict) else None
+            if payload.get("ok") and isinstance(context, str) and context.strip():
+                existing = getattr(event, "channel_context", None)
+                event.channel_context = (
+                    f"{existing}\n\n{context.strip()}" if existing else context.strip()
+                )
+        except asyncio.TimeoutError:
+            await _kill_and_reap()
+            logger.warning("[%s] MTProto reply context timed out; using native reply", self.name)
+        except Exception:
+            await _kill_and_reap()
+            logger.warning("[%s] MTProto reply context failed; using native reply", self.name, exc_info=True)
+        finally:
+            if communicate_task is not None and not communicate_task.done():
+                communicate_task.cancel()
+                await asyncio.gather(communicate_task, return_exceptions=True)
+        return event
+
+    async def enrich_message_context(self, event: MessageEvent) -> MessageEvent:
+        return await self._enrich_reply_context(event)
+
     def _build_message_event(
         self,
         message: Message,
@@ -9775,13 +10122,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     except Exception:
                         reply_to_text = None
 
-        # Per-channel/topic ephemeral prompt
-        from gateway.platforms.base import resolve_channel_prompt
+        # Per-channel/topic ephemeral prompt. Scoped Telegram topic prompts are
+        # additive with the group baseline and cannot collide with a DM or
+        # another group that reuses the same numeric thread id.
         _chat_id_str = str(chat.id)
-        _channel_prompt = resolve_channel_prompt(
+        _channel_prompt = _resolve_telegram_channel_prompt(
             self.config.extra,
-            thread_id_str or _chat_id_str,
-            _chat_id_str if thread_id_str else None,
+            chat_id=_chat_id_str,
+            thread_id=thread_id_str,
+            chat_type=chat_type,
         )
 
         return MessageEvent(
@@ -10115,7 +10464,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
     _GENERIC_MERGE_KEYS = {
         "reply_prefix", "reply_in_thread", "reply_to_mode",
         "unauthorized_dm_behavior", "notice_delivery", "require_mention",
-        "channel_skill_bindings", "channel_prompts", "gateway_restart_notification",
+        "channel_skill_bindings", "channel_prompts", "topic_prompts", "gateway_restart_notification",
         "allow_from", "allow_admin_from", "dm_policy", "group_policy",
     }
     for _k, _v in _telegram_extra.items():

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -34,6 +34,53 @@ def _telegram_auth_env(name: str, default: str = "") -> str:
     return _auth_env(name, default)
 
 
+def _telegram_profile_scope_active() -> bool:
+    """True while config is being built for a multiplex-served profile."""
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return is_multiplex_active() and current_secret_scope() is not None
+    except Exception:
+        # If scope detection itself is unavailable, prefer profile-local config
+        # over publishing policy into process-global state.
+        return True
+
+
+_TELEGRAM_POLICY_ENV_EXTRAS = {
+    "TELEGRAM_ALLOWED_USERS": "allow_from",
+    "TELEGRAM_GROUP_ALLOWED_USERS": "group_allow_from",
+    "TELEGRAM_GROUP_ALLOWED_CHATS": "group_allowed_chats",
+    "TELEGRAM_REQUIRE_MENTION": "require_mention",
+    "TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES": (
+        "observe_unmentioned_group_messages"
+    ),
+    "TELEGRAM_GUEST_MODE": "guest_mode",
+    "TELEGRAM_EXCLUSIVE_BOT_MENTIONS": "exclusive_bot_mentions",
+    "TELEGRAM_ALLOW_BOTS": "allow_bots",
+    "TELEGRAM_FREE_RESPONSE_CHATS": "free_response_chats",
+    "TELEGRAM_FREE_RESPONSE_TOPICS": "free_response_topics",
+    "TELEGRAM_ALLOWED_CHATS": "allowed_chats",
+    "TELEGRAM_ALLOWED_TOPICS": "allowed_topics",
+    "TELEGRAM_IGNORED_THREADS": "ignored_threads",
+    "TELEGRAM_REACTIONS": "reactions",
+    "TELEGRAM_PROXY": "proxy_url",
+}
+
+
+def _snapshot_telegram_policy_env(config) -> None:
+    """Freeze this profile's env-backed intake policy into its own config."""
+    extra = getattr(config, "extra", None)
+    if not isinstance(extra, dict):
+        extra = {}
+        config.extra = extra
+    for env_name, extra_name in _TELEGRAM_POLICY_ENV_EXTRAS.items():
+        value = _telegram_auth_env(env_name, "")
+        if value != "":
+            # Env retains its documented precedence over YAML, but the value is
+            # copied only into this PlatformConfig instead of process-global env.
+            extra[extra_name] = value
+
+
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
     text = "" if error is None else str(error)
@@ -299,6 +346,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_video_from_bytes,
     cache_document_from_bytes,
+    normalize_proxy_url,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
@@ -911,9 +959,11 @@ class TelegramAdapter(BasePlatformAdapter):
             if self.config.extra.get("base_url")
             else 20 * 1024 * 1024
         )
-        # Interactive model picker state per chat
-        self._model_picker_state: Dict[str, dict] = {}
-        self._choice_picker_state: Dict[str, dict] = {}
+        # Interactive picker state per exact Telegram message. Binding to the
+        # message id prevents a stale button in another routed topic of the same
+        # chat from mutating the newest picker/runtime.
+        self._model_picker_state: Dict[tuple[str, str], dict] = {}
+        self._choice_picker_state: Dict[tuple[str, str], dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -1517,6 +1567,17 @@ class TelegramAdapter(BasePlatformAdapter):
         if isinstance(configured, str):
             configured = configured.split(",")
         return parse_fallback_ip_env(",".join(str(v) for v in configured) if configured else None)
+
+    def _proxy_url_for_hosts(self, target_hosts: list[str]) -> str | None:
+        """Resolve Telegram proxy policy without crossing profile scope."""
+        configured = self.config.extra.get("proxy_url")
+        if configured:
+            return normalize_proxy_url(str(configured))
+        if _telegram_profile_scope_active():
+            # A secondary profile with no own proxy must not inherit the
+            # primary process's TELEGRAM_/HTTP(S)_PROXY policy.
+            return None
+        return resolve_proxy_url("TELEGRAM_PROXY", target_hosts=target_hosts)
 
     @staticmethod
     def _looks_like_polling_conflict(error: Exception) -> bool:
@@ -3964,7 +4025,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
 
             proxy_targets = ["api.telegram.org", *fallback_ips]
-            proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
+            proxy_url = self._proxy_url_for_hosts(proxy_targets)
             if fallback_ips and not proxy_url and not disable_fallback:
                 logger.info(
                     "[%s] Telegram fallback IPs active: %s",
@@ -5868,8 +5929,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 **self._link_preview_kwargs(),
             )
 
-            # Store picker state keyed by chat_id
-            self._model_picker_state[str(chat_id)] = {
+            state_key = (str(chat_id), str(msg.message_id))
+            self._model_picker_state[state_key] = {
                 "msg_id": msg.message_id,
                 "providers": providers,
                 "session_key": session_key,
@@ -5938,7 +5999,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 **self._link_preview_kwargs(),
             )
 
-            self._choice_picker_state[str(chat_id)] = {
+            state_key = (str(chat_id), str(msg.message_id))
+            self._choice_picker_state[state_key] = {
                 "msg_id": msg.message_id,
                 "choices": choices,
                 "session_key": session_key,
@@ -5953,15 +6015,22 @@ class TelegramAdapter(BasePlatformAdapter):
         self, query, data: str, chat_id: str
     ) -> None:
         """Handle choice picker button taps (cp:<index>)."""
-        state = self._choice_picker_state.get(chat_id)
+        query_message = getattr(query, "message", None)
+        query_message_id = getattr(query_message, "message_id", None)
+        state_key = (
+            (str(chat_id), str(query_message_id))
+            if query_message_id is not None
+            else None
+        )
+        state = self._choice_picker_state.get(state_key) if state_key else None
         if not state:
             await query.answer(text="Picker expired — run the command again.")
             return
+        assert state_key is not None
 
         # Same authorization gate as approval buttons: unauthorized users in a
         # shared group must not flip session/config state via someone else's
         # picker message.
-        query_message = getattr(query, "message", None)
         query_chat = getattr(query_message, "chat", None)
         if not self._is_callback_user_authorized(
             str(getattr(query.from_user, "id", "")),
@@ -6005,7 +6074,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 pass
         await query.answer()
-        self._choice_picker_state.pop(chat_id, None)
+        self._choice_picker_state.pop(state_key, None)
 
     _MODEL_PAGE_SIZE = 8
 
@@ -6118,9 +6187,37 @@ class TelegramAdapter(BasePlatformAdapter):
         self, query, data: str, chat_id: str
     ) -> None:
         """Handle model picker inline keyboard callbacks (mp:/mm:/mc:/mb:/mx:/mg:)."""
-        state = self._model_picker_state.get(chat_id)
+        query_message = getattr(query, "message", None)
+        query_message_id = getattr(query_message, "message_id", None)
+        state_key = (
+            (str(chat_id), str(query_message_id))
+            if query_message_id is not None
+            else None
+        )
+        state = self._model_picker_state.get(state_key) if state_key else None
         if not state:
             await query.answer(text="Picker expired — use /model again.")
+            return
+        assert state_key is not None
+
+        # Model/provider buttons mutate shared session configuration.  In a
+        # group, only a user authorized for this adapter/profile may use a
+        # picker message created by somebody else.
+        query_chat = getattr(query_message, "chat", None)
+        query_chat_type = getattr(query_chat, "type", None)
+        query_thread_id = getattr(query_message, "message_thread_id", None)
+        if not self._is_callback_user_authorized(
+            str(getattr(query.from_user, "id", "")),
+            chat_id=getattr(query_message, "chat_id", None),
+            chat_type=(
+                str(query_chat_type) if query_chat_type is not None else None
+            ),
+            thread_id=(
+                str(query_thread_id) if query_thread_id is not None else None
+            ),
+            user_name=getattr(query.from_user, "first_name", None),
+        ):
+            await query.answer(text="⛔ You are not authorized to change models.")
             return
 
         try:
@@ -6281,7 +6378,7 @@ class TelegramAdapter(BasePlatformAdapter):
             await query.answer(
                 text="Switch failed." if switch_failed else "Model switched!"
             )
-            self._model_picker_state.pop(chat_id, None)
+            self._model_picker_state.pop(state_key, None)
 
         elif data.startswith("mm:"):
             # --- Model selected: perform the switch ---
@@ -6364,7 +6461,7 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             # Clean up state
-            self._model_picker_state.pop(chat_id, None)
+            self._model_picker_state.pop(state_key, None)
 
         elif data.startswith("mpg:"):
             # --- Provider group selected: show member providers ---
@@ -6438,7 +6535,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         elif data == "mx":
             # --- Cancel ---
-            self._model_picker_state.pop(chat_id, None)
+            self._model_picker_state.pop(state_key, None)
             await query.edit_message_text(
                 text="Model selection cancelled.",
                 reply_markup=None,
@@ -8024,7 +8121,12 @@ class TelegramAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("TELEGRAM_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
+        return _telegram_auth_env("TELEGRAM_REQUIRE_MENTION", "false").lower() in {
+            "true",
+            "1",
+            "yes",
+            "on",
+        }
 
     def _telegram_observe_unmentioned_group_messages(self) -> bool:
         """Return whether skipped unmentioned group messages are stored as context.
@@ -8041,7 +8143,9 @@ class TelegramAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false").lower() in {"true", "1", "yes", "on"}
+        return _telegram_auth_env(
+            "TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false"
+        ).lower() in {"true", "1", "yes", "on"}
 
     def _telegram_guest_mode(self) -> bool:
         """Return whether non-allowlisted groups may trigger via direct @mention."""
@@ -8050,7 +8154,12 @@ class TelegramAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("TELEGRAM_GUEST_MODE", "false").lower() in {"true", "1", "yes", "on"}
+        return _telegram_auth_env("TELEGRAM_GUEST_MODE", "false").lower() in {
+            "true",
+            "1",
+            "yes",
+            "on",
+        }
 
     def _telegram_exclusive_bot_mentions(self) -> bool:
         """Return whether explicit @...bot mentions exclusively route group messages."""
@@ -8059,7 +8168,9 @@ class TelegramAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("TELEGRAM_EXCLUSIVE_BOT_MENTIONS", "true").lower() in {"true", "1", "yes", "on"}
+        return _telegram_auth_env(
+            "TELEGRAM_EXCLUSIVE_BOT_MENTIONS", "true"
+        ).lower() in {"true", "1", "yes", "on"}
 
     def _telegram_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
@@ -8174,7 +8285,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """Compile optional regex wake-word patterns for group triggers."""
         patterns = self.config.extra.get("mention_patterns")
         if patterns is None:
-            raw = os.getenv("TELEGRAM_MENTION_PATTERNS", "").strip()
+            raw = _telegram_auth_env("TELEGRAM_MENTION_PATTERNS", "").strip()
             if raw:
                 try:
                     loaded = json.loads(raw)
@@ -10181,8 +10292,13 @@ class TelegramAdapter(BasePlatformAdapter):
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
     def _reactions_enabled(self) -> bool:
-        """Check if message reactions are enabled via config/env."""
-        return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+        """Check if message reactions are enabled via profile config/env."""
+        raw = self.config.extra.get("reactions")
+        if raw is None:
+            raw = _telegram_auth_env("TELEGRAM_REACTIONS", "false")
+        if isinstance(raw, bool):
+            return raw
+        return str(raw).strip().lower() not in {"false", "0", "no", "off", ""}
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""
@@ -10302,6 +10418,7 @@ def _resolve_notifications_mode() -> str:
 def _build_adapter(config):
     """Factory wrapper that constructs TelegramAdapter and applies the
     notification mode (preserving the gateway/run.py post-construction step)."""
+    _snapshot_telegram_policy_env(config)
     adapter = TelegramAdapter(config)
     try:
         adapter._notifications_mode = _resolve_notifications_mode()
@@ -10388,17 +10505,53 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
     import json as _json
     extras: dict = {}
 
-    # Under multiplex, a secondary profile's config loads inside its runtime
-    # scope; its authorization gate values must NOT be written to the
-    # process-global env, where first-writer-wins would pin them for every
-    # other profile (issue #72348 Telegram mirror). They are seeded into
-    # PlatformConfig.extra / read via the profile secret scope instead.
-    try:
-        from agent.secret_scope import current_secret_scope, is_multiplex_active
+    if _telegram_profile_scope_active():
+        # The legacy bridge below writes YAML values into os.environ.  That is
+        # acceptable for one standalone profile, but would publish a secondary
+        # profile's auth/intake policy to every adapter in a multiplex process.
+        # Keep all such values on this profile's PlatformConfig instead.
+        for key in (
+            "disable_topic_auto_rename",
+            "allow_bots",
+            "guest_mode",
+            "free_response_chats",
+            "free_response_topics",
+            "ignored_threads",
+            "reactions",
+            "proxy_url",
+            "disable_link_previews",
+        ):
+            if key in telegram_cfg:
+                extras[key] = telegram_cfg[key]
 
-        _skip_env_bridge = bool(is_multiplex_active() and current_secret_scope() is not None)
-    except Exception:
-        _skip_env_bridge = False
+        raw_telegram_extra = telegram_cfg.get("extra")
+        telegram_extra: dict = (
+            raw_telegram_extra if isinstance(raw_telegram_extra, dict) else {}
+        )
+        generic_merge_keys = {
+            "reply_prefix",
+            "reply_in_thread",
+            "reply_to_mode",
+            "unauthorized_dm_behavior",
+            "notice_delivery",
+            "require_mention",
+            "channel_skill_bindings",
+            "channel_prompts",
+            "topic_prompts",
+            "gateway_restart_notification",
+            "allow_from",
+            "allow_admin_from",
+            "dm_policy",
+            "group_policy",
+        }
+        for key, value in telegram_extra.items():
+            if key not in generic_merge_keys:
+                extras.setdefault(key, value)
+        return extras or None
+
+    # The profile-scoped branch above returns before the legacy environment
+    # bridge. Standalone mode intentionally preserves that bridge.
+    _skip_env_bridge = False
 
     if "disable_topic_auto_rename" in telegram_cfg:
         extras.setdefault("disable_topic_auto_rename", telegram_cfg["disable_topic_auto_rename"])

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -1,4 +1,8 @@
 """Tests for the profile-scoped credential primitive (Workstream A / Phase 2)."""
+
+import os
+import shlex
+
 import pytest
 
 from agent import secret_scope as ss
@@ -217,6 +221,24 @@ class TestEnvFileParsing:
             "ANTHROPIC_API_KEY": "sk-profile"
         }
 
+    def test_build_profile_secret_scope_loads_op_bootstrap_without_overriding_env(
+        self, tmp_path
+    ):
+        (tmp_path / ".env").write_text(
+            "OP_SERVICE_ACCOUNT_TOKEN=env-token\n",
+            encoding="utf-8",
+        )
+        (tmp_path / ".op.env").write_text(
+            "OP_SERVICE_ACCOUNT_TOKEN=bootstrap-token\n"
+            "OP_SESSION_personal=session-value\n",
+            encoding="utf-8",
+        )
+
+        scope = ss.build_profile_secret_scope(tmp_path)
+
+        assert scope["OP_SERVICE_ACCOUNT_TOKEN"] == "env-token"
+        assert scope["OP_SESSION_personal"] == "session-value"
+
     def test_build_profile_secret_scope_includes_home_external_secrets(
         self, tmp_path, monkeypatch
     ):
@@ -250,7 +272,6 @@ class TestEnvFileParsing:
         )
 
         assert ss.build_profile_secret_scope(profile) == {}
-
 
 class TestApiServerListenerGlobals:
     """API_SERVER listener settings are deployment config (#69379), not
@@ -287,3 +308,79 @@ class TestApiServerListenerGlobals:
         finally:
             ss.reset_secret_scope(token)
         assert not ss._is_global_env("API_SERVER_KEY")
+    @pytest.mark.skipif(os.name == "nt", reason="command secret source is POSIX-only")
+    def test_build_profile_secret_scope_resolves_profile_command_source_in_memory(
+        self, tmp_path, monkeypatch
+    ):
+        key = "PROFILE_SCOPED_TEST_TOKEN"
+        monkeypatch.delenv(key, raising=False)
+        helper = tmp_path / "secret-helper.sh"
+        helper.write_text(
+            "#!/bin/sh\nprintf 'PROFILE_SCOPED_TEST_TOKEN=from-helper\\n'\n",
+            encoding="utf-8",
+        )
+        helper.chmod(0o700)
+        (tmp_path / "config.yaml").write_text(
+            f"secrets:\n  command:\n    enabled: true\n    command: \"'{helper}'\"\n",
+            encoding="utf-8",
+        )
+
+        scope = ss.build_profile_secret_scope(tmp_path)
+
+        assert scope[key] == "from-helper"
+        assert key not in os.environ
+
+    @pytest.mark.skipif(os.name == "nt", reason="command secret source is POSIX-only")
+    def test_profile_command_source_does_not_inherit_another_profile_secret(
+        self, tmp_path, monkeypatch
+    ):
+        key = "PROFILE_SCOPED_NO_LEAK_TOKEN"
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "foreign-token")
+        helper = tmp_path / "secret-helper.sh"
+        helper.write_text(
+            "#!/bin/sh\n"
+            "if [ \"${TELEGRAM_BOT_TOKEN:-}\" = foreign-token ]; then\n"
+            "  result=leaked\n"
+            "else\n"
+            "  result=safe\n"
+            "fi\n"
+            "printf 'PROFILE_SCOPED_NO_LEAK_TOKEN=%s\\n' \"$result\"\n",
+            encoding="utf-8",
+        )
+        helper.chmod(0o700)
+        (tmp_path / "config.yaml").write_text(
+            f"secrets:\n  command:\n    enabled: true\n    command: \"'{helper}'\"\n",
+            encoding="utf-8",
+        )
+
+        scope = ss.build_profile_secret_scope(tmp_path)
+
+        assert scope[key] == "safe"
+        assert os.environ["TELEGRAM_BOT_TOKEN"] == "foreign-token"
+
+    @pytest.mark.skipif(os.name == "nt", reason="command secret source is POSIX-only")
+    def test_build_profile_secret_scope_caches_profile_command_source(
+        self, tmp_path, monkeypatch
+    ):
+        key = "PROFILE_SCOPED_CACHE_TOKEN"
+        monkeypatch.delenv(key, raising=False)
+        counter = tmp_path / "helper-calls"
+        helper = tmp_path / "secret-helper.sh"
+        helper.write_text(
+            "#!/bin/sh\n"
+            f"printf x >> {shlex.quote(str(counter))}\n"
+            "printf 'PROFILE_SCOPED_CACHE_TOKEN=from-helper\\n'\n",
+            encoding="utf-8",
+        )
+        helper.chmod(0o700)
+        (tmp_path / "config.yaml").write_text(
+            f"secrets:\n  command:\n    enabled: true\n    command: \"'{helper}'\"\n",
+            encoding="utf-8",
+        )
+
+        first = ss.build_profile_secret_scope(tmp_path)
+        second = ss.build_profile_secret_scope(tmp_path)
+
+        assert first[key] == "from-helper"
+        assert second[key] == "from-helper"
+        assert counter.read_text(encoding="utf-8") == "x"

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -175,6 +175,7 @@ class TestBusySessionAck:
         result = await runner._handle_active_session_busy_message(event, sk)
 
         assert result is True  # handled
+        assert getattr(event, "_gateway_busy_disposition", None) == "queued"
         # Verify ack was sent
         adapter._send_with_retry.assert_called_once()
         call_kwargs = adapter._send_with_retry.call_args
@@ -217,6 +218,7 @@ class TestBusySessionAck:
 
         # VERIFY: No queueing — successful steer must NOT replay as next turn
         mock_merge.assert_not_called()
+        assert getattr(event, "_gateway_busy_disposition", None) == "active_turn"
 
         # VERIFY: Ack mentions steer wording
         adapter._send_with_retry.assert_called_once()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -371,6 +371,28 @@ class TestLoadGatewayConfig:
             config.platforms[Platform.SLACK].typing_status_text == "chasing yarn…"
         )
 
+    def test_telegram_topic_prompts_bridge_into_extra_with_string_keys(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "    topic_prompts:\n"
+            "      -1001:\n"
+            "        17: SCOPED BOOKS\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["topic_prompts"] == {
+            "-1001": {"17": "SCOPED BOOKS"}
+        }
+
     def test_multiplex_profiles_from_nested_gateway_section(self, tmp_path, monkeypatch):
         """``gateway.multiplex_profiles: true`` (the nested form written by
         ``hermes config set gateway.multiplex_profiles true``) must enable

--- a/tests/gateway/test_inflight_journal.py
+++ b/tests/gateway/test_inflight_journal.py
@@ -1,0 +1,364 @@
+import asyncio
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import gateway.inflight_journal as journal
+from gateway.config import Platform, PlatformConfig
+from gateway.inflight_journal import claim_inflight, clear_inflight, list_inflight
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _event(text="private raw text must not be stored"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.VOICE,
+        message_id="88",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="429731663",
+            thread_id="3",
+            message_id="88",
+        ),
+    )
+
+
+def _adapter():
+    return _StubAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="t",
+            extra={"inflight_recovery_enabled": True},
+        ),
+        Platform.TELEGRAM,
+    )
+
+
+def test_journal_persists_only_routing_metadata(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token = claim_inflight(_event())
+    record = list_inflight("telegram")[0]
+    assert record["chat_id"] == "-1001"
+    assert record["thread_id"] == "3"
+    assert record["message_id"] == "88"
+    assert record["message_type"] == "voice"
+    assert isinstance(record["process_id"], int)
+    serialized = json.dumps(record, ensure_ascii=False)
+    assert "private raw text" not in serialized
+    assert "429731663" not in serialized
+    assert clear_inflight(token) is True
+    assert list_inflight("telegram") == []
+
+
+def test_clear_failure_is_reported_and_path_is_retained(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token = claim_inflight(_event())
+    original_unlink = Path.unlink
+
+    def fail_target(self, *args, **kwargs):
+        if str(self) == token:
+            raise PermissionError("blocked")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_target)
+    assert clear_inflight(token) is False
+    assert Path(token).exists()
+
+
+def test_clear_rejects_path_outside_journal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    outside = tmp_path / "outside.txt"
+    outside.write_text("keep")
+    assert clear_inflight(outside) is False
+    assert outside.read_text() == "keep"
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SimpleNamespace(success=True)
+
+    async def send_document(self, chat_id, file_path, **kwargs):
+        return getattr(self, "document_result", SimpleNamespace(success=True, error=None))
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+async def _run_background(adapter, event):
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    await adapter._process_message_background(event, session_key)
+
+
+@pytest.mark.asyncio
+async def test_normal_background_delivery_clears_journal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    adapter.send_typing = AsyncMock(return_value=None)
+    adapter._send_with_retry = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter._message_handler = AsyncMock(return_value="ok")
+    await _run_background(adapter, _event("hello"))
+    assert list_inflight("telegram") == []
+
+
+@pytest.mark.asyncio
+async def test_failed_background_delivery_retains_journal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    adapter.send_typing = AsyncMock(return_value=None)
+    adapter._send_with_retry = AsyncMock(return_value=SimpleNamespace(success=False))
+    adapter._message_handler = AsyncMock(return_value="ok")
+    await _run_background(adapter, _event("hello"))
+    assert len(list_inflight("telegram")) == 1
+
+
+@pytest.mark.asyncio
+async def test_mixed_text_and_failed_attachment_retains_journal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    media = tmp_path / "result.txt"
+    media.write_text("artifact")
+    adapter = _adapter()
+    adapter.send_typing = AsyncMock(return_value=None)
+    adapter._send_with_retry = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter.document_result = SimpleNamespace(success=False, error="upload failed")
+    adapter._message_handler = AsyncMock(return_value=f"done\nMEDIA:{media}")
+    await _run_background(adapter, _event("hello"))
+    assert len(list_inflight("telegram")) == 1
+
+
+@pytest.mark.asyncio
+async def test_attachment_only_success_clears_journal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    media = tmp_path / "result.txt"
+    media.write_text("artifact")
+    adapter = _adapter()
+    adapter.send_typing = AsyncMock(return_value=None)
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media}")
+    await _run_background(adapter, _event("hello"))
+    assert list_inflight("telegram") == []
+
+
+@pytest.mark.asyncio
+async def test_busy_queued_messages_are_journaled_before_background(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    adapter._message_handler = AsyncMock(return_value="ok")
+    first = _event("one")
+    first.message_type = MessageType.PHOTO
+    first.message_id = "101"
+    second = _event("two")
+    second.message_type = MessageType.PHOTO
+    second.message_id = "102"
+    session_key = build_session_key(first.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._session_tasks[session_key] = asyncio.current_task()
+    try:
+        await adapter.handle_message(first)
+        await adapter.handle_message(second)
+        assert len(list_inflight("telegram")) == 2
+        pending = adapter._pending_messages[session_key]
+        assert len(getattr(pending, "_gateway_inflight_tokens")) == 2
+    finally:
+        adapter._pending_messages.clear()
+        adapter._active_sessions.clear()
+        adapter._session_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_production_busy_disposition_keeps_queued_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    adapter.set_message_handler(AsyncMock(return_value="done"))
+
+    async def _busy(event, _session_key):
+        setattr(event, "_gateway_busy_disposition", "queued")
+        return True
+
+    adapter.set_busy_session_handler(_busy)
+    event = _event()
+    event.message_id = "queued-production"
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    current = asyncio.current_task()
+    assert current is not None
+    adapter._session_tasks[session_key] = current
+    try:
+        await adapter.handle_message(event)
+        assert len(list_inflight("telegram")) == 1
+    finally:
+        adapter._session_tasks.pop(session_key, None)
+        adapter._active_sessions.pop(session_key, None)
+
+
+@pytest.mark.asyncio
+async def test_steered_marker_clears_with_active_turn_final_delivery(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    adapter.set_message_handler(AsyncMock(return_value="done"))
+
+    async def _busy(event, _session_key):
+        setattr(event, "_gateway_busy_disposition", "active_turn")
+        return True
+
+    adapter.set_busy_session_handler(_busy)
+    event = _event()
+    event.message_id = "steered-production"
+    session_key = build_session_key(event.source)
+    generation = object()
+    setattr(adapter, "_gateway_inflight_turn_generations", {session_key: generation})
+    adapter._active_sessions[session_key] = asyncio.Event()
+    current = asyncio.current_task()
+    assert current is not None
+    adapter._session_tasks[session_key] = current
+    try:
+        await adapter.handle_message(event)
+        assert len(list_inflight("telegram")) == 1
+        active_event = _event()
+        active_event.message_id = "active-original"
+        adapter._clear_event_inflight(active_event, session_key, generation)
+        assert list_inflight("telegram") == []
+    finally:
+        adapter._session_tasks.pop(session_key, None)
+        adapter._active_sessions.pop(session_key, None)
+
+
+@pytest.mark.asyncio
+async def test_steer_completion_race_leaves_marker_durable(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    event = _event()
+    event.message_id = "steer-race"
+    session_key = build_session_key(event.source)
+    old_generation = object()
+    generation_map = {session_key: old_generation}
+    setattr(adapter, "_gateway_inflight_turn_generations", generation_map)
+
+    async def _busy(event_arg, _session_key):
+        setattr(event_arg, "_gateway_busy_disposition", "active_turn")
+        generation_map[session_key] = object()
+        return True
+
+    adapter.set_message_handler(AsyncMock(return_value="done"))
+    adapter.set_busy_session_handler(_busy)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    current = asyncio.current_task()
+    assert current is not None
+    adapter._session_tasks[session_key] = current
+    try:
+        await adapter.handle_message(event)
+        assert len(list_inflight("telegram")) == 1
+        active = getattr(adapter, "_gateway_active_inflight_tokens", {})
+        assert (session_key, old_generation) not in active
+    finally:
+        adapter._session_tasks.pop(session_key, None)
+        adapter._active_sessions.pop(session_key, None)
+
+
+@pytest.mark.asyncio
+async def test_failed_active_turn_marker_is_not_cleared_by_next_turn(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _adapter()
+    session_key = build_session_key(_event().source)
+
+    async def failed_handler(_event_arg):
+        generation_map = getattr(adapter, "_gateway_inflight_turn_generations")
+        generation = generation_map[session_key]
+        steered = _event()
+        steered.message_id = "steered-failed"
+        adapter._claim_event_inflight(steered)
+        adapter._transfer_event_inflight_to_active_turn(
+            steered, session_key, generation
+        )
+        return "not delivered"
+
+    failed_turn = _event()
+    failed_turn.message_id = "failed-active"
+    adapter.send_typing = AsyncMock(return_value=None)
+    adapter._send_with_retry = AsyncMock(return_value=SimpleNamespace(success=False))
+    adapter._message_handler = failed_handler
+    await adapter._process_message_background(failed_turn, session_key)
+    assert len(list_inflight("telegram")) == 2
+
+    next_turn = _event()
+    next_turn.message_id = "next-success"
+    adapter._send_with_retry = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter._message_handler = AsyncMock(return_value="delivered")
+    await adapter._process_message_background(next_turn, session_key)
+    records = list_inflight("telegram")
+    assert len(records) == 2
+    assert {record["message_id"] for record in records} == {
+        "steered-failed",
+        "failed-active",
+    }
+
+
+@pytest.mark.asyncio
+async def test_telegram_startup_reconciliation_deduplicates_topic_notices(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(journal.os, "getpid", lambda: 111)
+    first = _event()
+    claim_inflight(first)
+    second = _event()
+    second.message_id = "89"
+    claim_inflight(second)
+    monkeypatch.setattr(journal.os, "getpid", lambda: 222)
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="t", extra={"inflight_recovery_enabled": True})
+    )
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True))
+    await adapter._reconcile_inflight_journal()
+    adapter.send.assert_awaited_once()
+    kwargs = adapter.send.await_args.kwargs
+    assert kwargs["chat_id"] == "-1001"
+    assert kwargs["metadata"]["message_thread_id"] == "3"
+    assert "прервана" in kwargs["content"]
+    assert list_inflight("telegram") == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_failed_recovery_notice_remains_for_next_restart(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(journal.os, "getpid", lambda: 111)
+    claim_inflight(_event())
+    monkeypatch.setattr(journal.os, "getpid", lambda: 222)
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="t", extra={"inflight_recovery_enabled": True})
+    )
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=False))
+    await adapter._reconcile_inflight_journal()
+    assert len(list_inflight("telegram")) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_skips_marker_claimed_by_current_process(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(journal.os, "getpid", lambda: 333)
+    claim_inflight(_event())
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="t", extra={"inflight_recovery_enabled": True})
+    )
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True))
+    await adapter._reconcile_inflight_journal()
+    adapter.send.assert_not_awaited()
+    assert len(list_inflight("telegram")) == 1
+
+
+def test_cold_start_reconciles_before_polling_accepts_updates():
+    source = inspect.getsource(TelegramAdapter.connect)
+    reconcile_at = source.index("self._reconcile_inflight_journal()")
+    polling_at = source.index("self._start_polling_resilient(")
+    assert reconcile_at < polling_at

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -3,13 +3,15 @@ import logging
 import asyncio
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource
 
 
 class _FakeAdapter:
@@ -74,6 +76,90 @@ class TestCredentialFingerprint:
 
 class TestProfileMessageHandler:
     @pytest.mark.asyncio
+    async def test_primary_handler_scopes_auth_without_clobbering_route(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.secret_scope import get_secret
+
+        default_home = tmp_path / "default"
+        default_home.mkdir()
+        x100_home = tmp_path / "x100"
+        x100_home.mkdir()
+        (default_home / ".env").write_text(
+            "PRIMARY_SCOPE_MARKER=default-scope\n"
+            "TELEGRAM_ALLOWED_USERS=owner\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: x100_home if name == "x100" else default_home,
+        )
+        monkeypatch.setattr(
+            "gateway.run.get_hermes_home",
+            lambda: default_home,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name",
+            lambda: "default",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_exists",
+            lambda name: True,
+        )
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        from gateway.profile_routing import parse_profile_routes
+
+        runner.config.profile_routes = parse_profile_routes([
+            {
+                "name": "x100-topic",
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "thread_id": "1787",
+                "profile": "x100",
+            }
+        ])
+        runner._active_profile_name = MagicMock(return_value="default")
+        runner.adapters = {}
+        runner._profile_adapters = {}
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+        runner.pairing_stores = {"default": runner.pairing_store}
+        seen = {}
+
+        async def fake_handle(event):
+            seen["profile"] = event.source.profile
+            seen["secret"] = get_secret("PRIMARY_SCOPE_MARKER")
+            seen["authorized"] = runner._is_user_authorized(event.source)
+            seen["target_home"] = runner._resolve_profile_home_for_source(
+                event.source
+            )
+            return "ok"
+
+        runner._handle_message = fake_handle
+        handler = runner._primary_message_handler()
+        event = MessageEvent(
+            text="hello",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="-1001",
+                chat_type="group",
+                user_id="owner",
+                thread_id="1787",
+                profile="stale-profile",
+            ),
+        )
+
+        assert await handler(event) == "ok"
+        assert seen == {
+            "profile": "x100",
+            "secret": "default-scope",
+            "authorized": True,
+            "target_home": x100_home,
+        }
+
+    @pytest.mark.asyncio
     async def test_stamps_profile_on_unstamped_source(self):
         runner = GatewayRunner.__new__(GatewayRunner)
         seen = {}
@@ -93,6 +179,29 @@ class TestProfileMessageHandler:
 
         result = await handler(_Evt())
         assert result == "ok"
+        assert seen["profile"] == "coder"
+
+
+    @pytest.mark.asyncio
+    async def test_overwrites_stale_profile_on_owned_adapter(self):
+        """An adapter owned by one profile cannot route a stale foreign stamp."""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        seen = {}
+
+        async def _fake_handle(event):
+            seen["profile"] = event.source.profile
+            return "ok"
+
+        runner._handle_message = _fake_handle
+        handler = runner._make_profile_message_handler("coder")
+
+        class _Src:
+            profile = "default"
+
+        class _Evt:
+            source = _Src()
+
+        assert await handler(_Evt()) == "ok"
         assert seen["profile"] == "coder"
 
 
@@ -273,6 +382,47 @@ class TestSecondaryProfileConfigHandling:
         assert "webhook" in message
         assert "telegram" not in message
         assert "reviewer" not in runner._profile_adapters
+
+    @pytest.mark.asyncio
+    async def test_pairing_store_exists_before_secondary_connect(self, monkeypatch):
+        """Polling must never start before the profile's own whitelist exists."""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._failed_platforms = {}
+        runner._profile_adapters = {}
+        runner.pairing_store = MagicMock()
+        runner.pairing_stores = {}
+        personal_store = MagicMock()
+
+        async def fake_start_one(profile_name, profile_home, claimed):
+            assert runner.pairing_stores["default"] is runner.pairing_store
+            assert runner.pairing_stores[profile_name] is personal_store
+            runner._profile_adapters[profile_name] = {}
+            return 1
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [
+                ("default", Path("/tmp/default")),
+                ("personal", Path("/tmp/personal")),
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name",
+            lambda: "default",
+        )
+        monkeypatch.setattr(
+            "gateway.pairing.PairingStore",
+            lambda profile=None: personal_store,
+        )
+        monkeypatch.setattr(runner, "_start_one_profile_adapters", fake_start_one)
+        monkeypatch.setattr(
+            "gateway.status.write_runtime_status",
+            lambda **kwargs: None,
+        )
+
+        assert await runner._start_secondary_profile_adapters() == 1
 
     @pytest.mark.asyncio
     async def test_multiplexer_skips_bad_profile_and_continues(self, monkeypatch, caplog):
@@ -493,5 +643,4 @@ class TestFeishuPortBindingConditional:
 
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected
-
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -160,6 +160,39 @@ class TestProfileMessageHandler:
         }
 
     @pytest.mark.asyncio
+    async def test_primary_route_resolution_error_drops_stale_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """A resolver failure must not execute a forged/stale foreign profile."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: tmp_path / name,
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._active_profile_name = MagicMock(return_value="default")
+        runner._profile_name_for_source = MagicMock(
+            side_effect=RuntimeError("route lookup failed")
+        )
+        runner._handle_message = AsyncMock(return_value="must-not-run")
+        event = MessageEvent(
+            text="hello",
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="-1001",
+                chat_type="group",
+                user_id="owner",
+                profile="foreign-stale-profile",
+            ),
+        )
+
+        result = await runner._primary_message_handler()(event)
+
+        assert result is None
+        runner._handle_message.assert_not_awaited()
+        assert event.source._transport_profile == "default"
+
+    @pytest.mark.asyncio
     async def test_stamps_profile_on_unstamped_source(self):
         runner = GatewayRunner.__new__(GatewayRunner)
         seen = {}

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -77,6 +77,23 @@ class TestProfilePathResolutionUnderMultiplexScope:
             (p / "state").mkdir(parents=True, exist_ok=True)
         return prof_a, prof_b
 
+    def test_scope_resets_home_when_secret_build_fails(self, tmp_path, monkeypatch):
+        from gateway.run import _profile_runtime_scope
+        from hermes_constants import get_hermes_home
+
+        original_home = get_hermes_home()
+
+        def _boom(_home):
+            raise RuntimeError("secret scope build failed")
+
+        monkeypatch.setattr("agent.secret_scope.build_profile_secret_scope", _boom)
+
+        with pytest.raises(RuntimeError, match="secret scope build failed"):
+            with _profile_runtime_scope(tmp_path / "broken-profile"):
+                pass
+
+        assert get_hermes_home() == original_home
+
     def test_skills_dir_follows_multiplex_scope(self, tmp_path):
         from gateway.run import _profile_runtime_scope
         import tools.skills_hub as sh

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -5,9 +5,12 @@ interpolation) rather than mocking it, proving the property that matters: two
 profiles with different keys never see each other's, and an unscoped read in
 multiplex mode fails closed instead of leaking.
 """
-import pytest
 
+import os
+import shlex
 from pathlib import Path
+
+import pytest
 
 from agent import secret_scope as ss
 
@@ -164,5 +167,77 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
+
+
+class TestProfileExternalSecretSourceScope:
+    """A secondary gateway profile resolves its own helper-backed token."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="command secret source is POSIX-only")
+    def test_gateway_config_uses_profile_helper_without_mutating_process_env(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.config import Platform, load_gateway_config
+        from gateway.run import _profile_runtime_scope
+
+        default_home = tmp_path / "default"
+        profile_home = tmp_path / "personal"
+        default_home.mkdir()
+        profile_home.mkdir()
+        helper = profile_home / "secret-helper.sh"
+        helper.write_text(
+            "#!/bin/sh\nprintf 'TELEGRAM_BOT_TOKEN=secondary-token\\n'\n",
+            encoding="utf-8",
+        )
+        helper.chmod(0o700)
+        (profile_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    enabled: true\n"
+            "secrets:\n"
+            "  command:\n"
+            "    enabled: true\n"
+            f"    command: {shlex.quote(str(helper))}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "primary-token")
+        ss.set_multiplex_active(True)
+
+        with _profile_runtime_scope(profile_home):
+            profile_config = load_gateway_config()
+
+        assert profile_config.platforms[Platform.TELEGRAM].token == "secondary-token"
+        assert os.environ["TELEGRAM_BOT_TOKEN"] == "primary-token"
+
+
+def test_profile_runtime_scope_resets_home_when_hydration_fails(monkeypatch, tmp_path):
+    """Scope setup failures must not leak the home override."""
+    import hermes_constants
+    from gateway import run as gateway_run
+    from hermes_cli import env_loader
+
+    home_token = object()
+    reset_tokens = []
+    monkeypatch.setattr(
+        hermes_constants,
+        "set_hermes_home_override",
+        lambda _home: home_token,
+    )
+    monkeypatch.setattr(
+        hermes_constants,
+        "reset_hermes_home_override",
+        lambda token: reset_tokens.append(token),
+    )
+
+    def _fail_hydration(_home):
+        raise RuntimeError("hydration failed")
+
+    monkeypatch.setattr(env_loader, "hydrate_profile_secret_sources", _fail_hydration)
+
+    with pytest.raises(RuntimeError, match="hydration failed"):
+        with gateway_run._profile_runtime_scope(tmp_path):
+            raise AssertionError("scope body should not run")
+
+    assert reset_tokens == [home_token]
 
 

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -279,6 +279,40 @@ def test_bot_allowance_never_falls_back_to_process_env_in_multiplex(monkeypatch)
         ss.set_multiplex_active(False)
 
 
+def test_bot_allowance_uses_transport_profile_config(monkeypatch):
+    """Profile-local YAML policy must work without a process-global env bridge."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    personal_adapter = MagicMock()
+    personal_adapter.config = PlatformConfig(extra={"allow_bots": "all"})
+    runner._profile_adapters = {
+        "personal": {Platform.TELEGRAM: personal_adapter}
+    }
+    runner.pairing_stores = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=None,
+        chat_id="-100-personal",
+        chat_type="group",
+        profile="personal",
+        is_bot=True,
+        _transport_profile="personal",
+    )
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert runner._is_user_authorized(source) is True
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
 def test_unauthorized_dm_behavior_never_inherits_process_allowlist(monkeypatch):
     """A primary allowlist must not force secondary unknown DMs into ignore mode."""
     from agent import secret_scope as ss
@@ -304,14 +338,18 @@ def test_unauthorized_dm_behavior_never_inherits_process_allowlist(monkeypatch):
 
 def test_routed_source_uses_transport_pairing_store():
     """A topic route changes runtime profile, not the receiving bot's whitelist."""
+    import dataclasses
     import weakref
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(multiplex_profiles=True)
     primary_adapter = MagicMock()
+    routed_adapter = MagicMock()
     runner.adapters = {Platform.TELEGRAM: primary_adapter}
-    runner._profile_adapters = {"x100": {}}
+    runner._profile_adapters = {
+        "x100": {Platform.TELEGRAM: routed_adapter}
+    }
     runner._active_profile_name = lambda: "default"
     runner.pairing_store = MagicMock(name="primary-pairing")
     routed_pairing = MagicMock(name="routed-profile-pairing")
@@ -327,8 +365,91 @@ def test_routed_source_uses_transport_pairing_store():
         profile="x100",
     )
     setattr(source, "_transport_adapter_ref", weakref.ref(primary_adapter))
+    source._transport_profile = "default"
+    source = dataclasses.replace(source, thread_id="recovered-topic")
 
     assert runner._pairing_store_for(source) is runner.pairing_store
+    assert runner._adapter_for_source(source) is primary_adapter
+    assert "_transport_adapter_ref" not in source.to_dict()
+    assert "transport_profile" not in source.to_dict()
+
+    persisted = source.to_dict(include_transport=True)
+    assert persisted["transport_profile"] == "default"
+    restored = SessionSource.from_dict(persisted)
+    assert restored._transport_adapter_ref is None
+    assert runner._pairing_store_for(restored) is runner.pairing_store
+    assert runner._adapter_for_source(restored) is primary_adapter
+
+
+def test_unknown_explicit_profile_does_not_fall_back_to_global_home(
+    tmp_path, monkeypatch
+):
+    """A stale or malformed route must not execute in the primary profile."""
+    from gateway.run import GatewayRunner
+    from gateway.config import GatewayConfig, Platform
+    from gateway.session import SessionSource
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: tmp_path / name,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_exists",
+        lambda name: False,
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: tmp_path / "primary",
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="owner",
+        chat_id="chat",
+        chat_type="group",
+        profile="missing-profile",
+    )
+
+    with pytest.raises(RuntimeError, match="missing-profile"):
+        runner._resolve_profile_home_for_source(source)
+
+
+def test_unknown_explicit_profile_keeps_legacy_fallback_outside_multiplex(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+    from gateway.config import GatewayConfig, Platform
+    from gateway.session import SessionSource
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=False)
+    primary_home = tmp_path / "primary"
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: tmp_path / name,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_exists",
+        lambda name: False,
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_hermes_home",
+        lambda: primary_home,
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="owner",
+        chat_id="chat",
+        chat_type="group",
+        profile="missing-profile",
+    )
+
+    assert runner._resolve_profile_home_for_source(source) == primary_home
 
 
 def test_secondary_pairing_never_falls_back_to_primary_store(monkeypatch):

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -114,6 +114,310 @@ def test_adapter_auth_check_stamps_secondary_profile(monkeypatch):
     assert captured["profile"] == "coder"
 
 
+def test_primary_adapter_auth_check_uses_active_profile_scope(tmp_path, monkeypatch):
+    """The active adapter must remain authorized after multiplex fail-closed mode."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    default_home = tmp_path / "default"
+    default_home.mkdir()
+    (default_home / ".env").write_text(
+        "TELEGRAM_ALLOWED_USERS=primary-user\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "foreign-process-user")
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "default",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: default_home,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {"default": runner.pairing_store}
+    check = runner._make_adapter_auth_check(Platform.TELEGRAM)
+
+    ss.set_multiplex_active(True)
+    try:
+        assert check("primary-user", "dm", "primary-user") is True
+        assert check("foreign-process-user", "dm", "foreign-process-user") is False
+    finally:
+        ss.set_multiplex_active(False)
+
+
+def test_adapter_auth_check_reads_secondary_profile_allowlist(tmp_path, monkeypatch):
+    """A profile-bound callback must not fall back to the primary allowlist."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    default_home = tmp_path / "default"
+    personal_home = tmp_path / "personal"
+    default_home.mkdir()
+    personal_home.mkdir()
+    (personal_home / ".env").write_text(
+        "TELEGRAM_ALLOWED_USERS=personal-user\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "primary-user")
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: personal_home,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {}
+    check = runner._make_adapter_auth_check(
+        Platform.TELEGRAM,
+        profile_name="personal",
+    )
+
+    ss.set_multiplex_active(True)
+    try:
+        assert check("personal-user", "dm", "personal-user") is True
+        assert check("primary-user", "dm", "primary-user") is False
+    finally:
+        ss.set_multiplex_active(False)
+
+
+def test_auth_env_never_falls_back_to_process_env_in_multiplex(monkeypatch):
+    from agent import secret_scope as ss
+    from gateway.authz_mixin import _auth_env
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "primary-user")
+    ss.set_multiplex_active(True)
+    try:
+        assert _auth_env("TELEGRAM_ALLOWED_USERS") == ""
+
+        token = ss.set_secret_scope({})
+        try:
+            assert _auth_env("TELEGRAM_ALLOWED_USERS") == ""
+        finally:
+            ss.reset_secret_scope(token)
+
+        token = ss.set_secret_scope({"TELEGRAM_ALLOWED_USERS": "profile-user"})
+        try:
+            assert _auth_env("TELEGRAM_ALLOWED_USERS") == "profile-user"
+        finally:
+            ss.reset_secret_scope(token)
+    finally:
+        ss.set_multiplex_active(False)
+
+
+def test_group_chat_allowlist_never_falls_back_to_process_env_in_multiplex(
+    monkeypatch,
+):
+    """A secondary profile must not inherit the primary profile's chat grant."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-100-primary")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=None,
+        chat_id="-100-primary",
+        chat_type="group",
+        profile="personal",
+    )
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert runner._is_user_authorized(source) is False
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_bot_allowance_never_falls_back_to_process_env_in_multiplex(monkeypatch):
+    """A secondary profile must not inherit the primary profile's bot policy."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "all")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=None,
+        chat_id="-100-personal",
+        chat_type="group",
+        profile="personal",
+        is_bot=True,
+    )
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert runner._is_user_authorized(source) is False
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_unauthorized_dm_behavior_never_inherits_process_allowlist(monkeypatch):
+    """A primary allowlist must not force secondary unknown DMs into ignore mode."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "primary-user")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert runner._get_unauthorized_dm_behavior(
+            Platform.TELEGRAM,
+            profile="personal",
+        ) == "pair"
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_routed_source_uses_transport_pairing_store():
+    """A topic route changes runtime profile, not the receiving bot's whitelist."""
+    import weakref
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    primary_adapter = MagicMock()
+    runner.adapters = {Platform.TELEGRAM: primary_adapter}
+    runner._profile_adapters = {"x100": {}}
+    runner._active_profile_name = lambda: "default"
+    runner.pairing_store = MagicMock(name="primary-pairing")
+    routed_pairing = MagicMock(name="routed-profile-pairing")
+    runner.pairing_stores = {
+        "default": runner.pairing_store,
+        "x100": routed_pairing,
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="owner",
+        profile="x100",
+    )
+    setattr(source, "_transport_adapter_ref", weakref.ref(primary_adapter))
+
+    assert runner._pairing_store_for(source) is runner.pairing_store
+
+
+def test_secondary_pairing_never_falls_back_to_primary_store(monkeypatch):
+    """Missing secondary pairing state must deny, not reuse the primary store."""
+    from agent import secret_scope as ss
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner._active_profile_name = lambda: "default"
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner.pairing_stores = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="primary-paired-user",
+        chat_id="primary-paired-user",
+        chat_type="dm",
+        profile="personal",
+    )
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert runner._is_user_authorized(source) is False
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_primary_open_policy_guard_uses_active_profile_scope(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    default_home = tmp_path / "default"
+    default_home.mkdir()
+    (default_home / ".env").write_text(
+        "GATEWAY_ALLOW_ALL_USERS=true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir",
+        lambda name: default_home,
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.platforms = {
+        Platform.WECOM: PlatformConfig(
+            enabled=True,
+            extra={"dm_policy": "open"},
+        ),
+    }
+    runner._active_profile_name = lambda: "default"
+
+    assert runner._primary_open_policy_violation() is None
+
+
+def test_secondary_open_policy_ignores_primary_allow_all(monkeypatch):
+    """Primary allow-all must not satisfy a secondary profile's startup guard."""
+    from agent import secret_scope as ss
+    from gateway.run import _own_policy_open_startup_violation
+
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    secondary_cfg = GatewayConfig(multiplex_profiles=True)
+    secondary_cfg.platforms = {
+        Platform.WECOM: PlatformConfig(
+            enabled=True,
+            extra={"dm_policy": "open"},
+        ),
+    }
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert _own_policy_open_startup_violation(secondary_cfg) is not None
+    finally:
+        ss.reset_secret_scope(token)
+
+    token = ss.set_secret_scope({"GATEWAY_ALLOW_ALL_USERS": "true"})
+    try:
+        assert _own_policy_open_startup_violation(secondary_cfg) is None
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation

--- a/tests/gateway/test_processing_error_message.py
+++ b/tests/gateway/test_processing_error_message.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+from gateway.platforms.base import _processing_error_content
+
+
+def test_processing_error_content_uses_opt_in_localized_template_without_leaking_detail():
+    config = SimpleNamespace(
+        extra={
+            "processing_error_message": (
+                "Не смог завершить задачу на этапе обработки ({error_type}). "
+                "Повторите сообщение или используйте /reset."
+            )
+        }
+    )
+    content = _processing_error_content(config, RuntimeError("private filesystem detail"))
+    assert "Не смог завершить" in content
+    assert "RuntimeError" in content
+    assert "private filesystem detail" not in content
+
+
+def test_processing_error_content_preserves_default_when_not_configured():
+    config = SimpleNamespace(extra={})
+    content = _processing_error_content(config, ValueError("bad input"))
+    assert "Sorry, I encountered an error (ValueError)." in content
+    assert "bad input" not in content
+    assert "gateway logs" in content
+    assert "/reset" in content
+
+
+def test_processing_error_content_survives_invalid_template():
+    config = SimpleNamespace(extra={"processing_error_message": "broken {missing}"})
+    content = _processing_error_content(config, KeyError("x"))
+    assert "Sorry, I encountered an error" in content

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -97,16 +97,6 @@ class TestAuthzAllowAllScope:
         finally:
             ss.reset_secret_scope(tok)
 
-    @pytest.mark.xfail(
-        reason=(
-            "gateway/authz_mixin.py still reads the platform allow-all flag via "
-            "_auth_env, which falls through to os.environ on a scoped miss; the "
-            "scope-authoritative gate (_platform_gate_env semantics) for the "
-            "remaining authz_mixin reads lands in a separate PR. Flips green "
-            "when that PR converts the allow-all read."
-        ),
-        strict=True,
-    )
     def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
         # The PRIMARY profile opted in via os.environ; the secondary profile's
         # scope has no opt-in. The secondary must NOT inherit the primary's

--- a/tests/gateway/test_run_progress_interrupt.py
+++ b/tests/gateway/test_run_progress_interrupt.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource
 
 
@@ -25,6 +25,7 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
     def __init__(self, platform=Platform.TELEGRAM):
         super().__init__(PlatformConfig(enabled=True, token="***"), platform)
         self.sent = []
+        self.documents = []
         self.edits = []
         self.typing = []
 
@@ -37,6 +38,19 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
     async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
         self.sent.append({"chat_id": chat_id, "content": content})
         return SendResult(success=True, message_id="progress-1")
+
+    async def send_document(
+        self,
+        chat_id,
+        file_path,
+        caption=None,
+        file_name=None,
+        reply_to=None,
+        metadata=None,
+        **kwargs,
+    ) -> SendResult:
+        self.documents.append(str(file_path))
+        return SendResult(success=True, message_id="document-1")
 
     async def edit_message(self, chat_id, message_id, content) -> SendResult:
         self.edits.append({"message_id": message_id, "content": content})
@@ -153,7 +167,7 @@ def _make_runner(adapter):
     return runner
 
 
-async def _run_once(monkeypatch, tmp_path, agent_cls, session_id):
+async def _run_once(monkeypatch, tmp_path, agent_cls, session_id, setup=None):
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 
     fake_dotenv = types.ModuleType("dotenv")
@@ -179,13 +193,16 @@ async def _run_once(monkeypatch, tmp_path, agent_cls, session_id):
         chat_type="group",
         thread_id="17585",
     )
+    session_key = "agent:main:telegram:group:-1001:17585"
+    if setup is not None:
+        setup(adapter, source, session_key)
     result = await runner._run_agent(
         message="hi",
         context_prompt="",
         history=[],
         source=source,
         session_id=session_id,
-        session_key="agent:main:telegram:group:-1001:17585",
+        session_key=session_key,
     )
     return adapter, result
 
@@ -216,6 +233,54 @@ async def test_partial_empty_agent_response_is_normalized(monkeypatch, tmp_path)
     assert result["final_response"] != "⚠️ Response truncated due to output length limit"
     assert result["partial"] is True
     assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_queued_follow_up_delivers_explicit_media(monkeypatch, tmp_path):
+    """A queued notification must not drop MEDIA from the completed turn."""
+    toolkit = tmp_path / "toolkit.md"
+    toolkit.write_text("complete toolkit", encoding="utf-8")
+    state = {}
+
+    class QueuedMediaAgent:
+        calls = 0
+
+        def __init__(self, **kwargs):
+            self.tools = []
+            self._interrupt_requested = False
+
+        @property
+        def is_interrupted(self) -> bool:
+            return self._interrupt_requested
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            type(self).calls += 1
+            if type(self).calls == 1:
+                state["adapter"]._pending_messages[state["session_key"]] = MessageEvent(
+                    text="background ready",
+                    message_type=MessageType.TEXT,
+                    source=state["source"],
+                    message_id="follow-up-1",
+                )
+                return {
+                    "final_response": f"Toolkit ready\nMEDIA:{toolkit}",
+                    "messages": [],
+                    "api_calls": 1,
+                }
+            return {"final_response": "follow-up handled", "messages": [], "api_calls": 1}
+
+    def setup(adapter, source, session_key):
+        state.update(adapter=adapter, source=source, session_key=session_key)
+
+    adapter, _ = await _run_once(
+        monkeypatch,
+        tmp_path,
+        QueuedMediaAgent,
+        "sess-queued-media",
+        setup=setup,
+    )
+
+    assert adapter.documents == [str(toolkit)]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -56,6 +56,34 @@ class TestSessionSourceRoundtrip:
         assert restored.chat_id == "cli"
         assert restored.chat_type == "dm"  # default value preserved
 
+    def test_legacy_positional_fields_keep_their_original_positions(self):
+        source = SessionSource(
+            Platform.TELEGRAM,
+            "chat",
+            None,
+            "dm",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+            None,
+            None,
+            None,
+            None,
+            False,
+            None,
+            True,
+            "initial-title",
+            True,
+        )
+
+        assert source.auto_thread_created is True
+        assert source.auto_thread_initial_name == "initial-title"
+        assert source.delivered_via_upstream_relay is True
+
 
 class TestSessionSourceDescription:
     def test_local_cli(self):

--- a/tests/gateway/test_stt_transcript_echo_config.py
+++ b/tests/gateway/test_stt_transcript_echo_config.py
@@ -10,7 +10,9 @@ def test_stt_echo_transcripts_defaults_on_for_backwards_compatibility():
 
     assert cfg.stt_enabled is True
     assert cfg.stt_echo_transcripts is True
+    assert cfg.stt_echo_format == "legacy"
     assert cfg.to_dict()["stt_echo_transcripts"] is True
+    assert cfg.to_dict()["stt_echo_format"] == "legacy"
 
 
 def test_top_level_stt_echo_transcripts_takes_precedence():
@@ -20,5 +22,24 @@ def test_top_level_stt_echo_transcripts_takes_precedence():
     })
 
     assert cfg.stt_echo_transcripts is False
+
+
+def test_nested_stt_echo_format_enables_copyable_transcript_block():
+    cfg = GatewayConfig.from_dict({"stt": {"echo_format": "transcript_md"}})
+    runner = object.__new__(GatewayRunner)
+    runner.config = cfg
+
+    assert cfg.stt_echo_format == "transcript_md"
+    assert runner._format_stt_transcript_echo("Как дела?") == (
+        "```\n"
+        "Как дела?\n"
+        "```"
+    )
+
+
+def test_unknown_stt_echo_format_falls_back_to_legacy():
+    cfg = GatewayConfig.from_dict({"stt": {"echo_format": "unknown"}})
+
+    assert cfg.stt_echo_format == "legacy"
 
 

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -4,6 +4,7 @@ Verifies that unauthorized users are blocked before any text batching,
 event building, or response generation occurs.
 """
 import asyncio
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -68,6 +69,121 @@ def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="gr
         document=None,
         sticker=None,
         media_group_id=None,
+    )
+
+
+def test_profile_yaml_auth_bridge_does_not_mutate_process_env(monkeypatch):
+    """Secondary YAML policy must stay in its PlatformConfig, never os.environ."""
+    from agent import secret_scope as ss
+    from plugins.platforms.telegram.adapter import _apply_yaml_config
+
+    env_names = (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "TELEGRAM_GUEST_MODE",
+        "TELEGRAM_ALLOWED_CHATS",
+    )
+    for name in env_names:
+        monkeypatch.delenv(name, raising=False)
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        extras = _apply_yaml_config(
+            {},
+            {
+                "allow_from": ["secondary-user"],
+                "group_allow_from": ["secondary-group-user"],
+                "group_allowed_chats": ["secondary-chat"],
+                "guest_mode": True,
+                "allowed_chats": ["secondary-chat"],
+            },
+        )
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+    assert all(name not in os.environ for name in env_names)
+    assert extras is not None
+    # Core's shared-key bridge owns these values and preserves their type and
+    # top-level-over-nested precedence. The Telegram hook must not re-emit and
+    # clobber them when its result is merged afterward.
+    assert "allow_from" not in extras
+    assert "group_allow_from" not in extras
+    assert "group_allowed_chats" not in extras
+    assert extras["guest_mode"] is True
+    assert "allowed_chats" not in extras
+
+
+def test_profile_env_intake_policy_is_snapshotted_into_adapter_config(
+    monkeypatch,
+):
+    from agent import secret_scope as ss
+    from plugins.platforms.telegram.adapter import _snapshot_telegram_policy_env
+
+    monkeypatch.setenv("TELEGRAM_GUEST_MODE", "primary-value")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_CHATS", "primary-chat")
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"guest_mode": "yaml-value"},
+    )
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope(
+        {
+            "TELEGRAM_GUEST_MODE": "true",
+            "TELEGRAM_ALLOWED_CHATS": "secondary-chat",
+        }
+    )
+    try:
+        _snapshot_telegram_policy_env(config)
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+    assert config.extra["guest_mode"] == "true"
+    assert config.extra["allowed_chats"] == "secondary-chat"
+    assert os.environ["TELEGRAM_GUEST_MODE"] == "primary-value"
+    assert os.environ["TELEGRAM_ALLOWED_CHATS"] == "primary-chat"
+
+
+def test_runtime_intake_policy_fallback_is_profile_scoped(monkeypatch):
+    from agent import secret_scope as ss
+
+    monkeypatch.setenv("TELEGRAM_GUEST_MODE", "true")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_CHATS", "primary-chat")
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope(
+        {
+            "TELEGRAM_GUEST_MODE": "false",
+            "TELEGRAM_ALLOWED_CHATS": "secondary-chat",
+        }
+    )
+    try:
+        adapter = _make_adapter()
+        assert adapter._telegram_guest_mode() is False
+        assert adapter._telegram_allowed_chats() == {"secondary-chat"}
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_profile_proxy_config_does_not_fall_back_to_process_global(monkeypatch):
+    import plugins.platforms.telegram.adapter as tg_adapter
+
+    adapter = _make_adapter()
+    adapter.config.extra["proxy_url"] = "http://profile-proxy.example:8080"
+    monkeypatch.setattr(
+        tg_adapter,
+        "resolve_proxy_url",
+        lambda *args, **kwargs: "http://primary-proxy.example:8080",
+    )
+
+    assert adapter._proxy_url_for_hosts(["api.telegram.org"]) == (
+        "http://profile-proxy.example:8080"
     )
 
 

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -267,6 +267,92 @@ async def test_unauthorized_dm_with_pair_behavior_builds_event(monkeypatch):
     )
     await adapter._handle_text_message(update, SimpleNamespace())
     assert build_called is True
+def test_registered_authorization_check_precedes_process_env_for_messages(monkeypatch):
+    """A secondary adapter must use its profile-bound check at early intake."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "6940705170")
+    adapter = _make_adapter()
+
+    async def profile_handler(event):
+        return None
+
+    adapter._message_handler = profile_handler
+    adapter.set_authorization_check(
+        lambda user_id, chat_type, chat_id: user_id == "429731663"
+    )
+
+    personal_message = _make_message(
+        from_user_id=429731663,
+        chat_id=429731663,
+        chat_type="dm",
+    )
+    work_message = _make_message(
+        from_user_id=6940705170,
+        chat_id=6940705170,
+        chat_type="dm",
+    )
+
+    assert adapter._is_user_authorized_from_message(personal_message) is True
+    assert adapter._is_user_authorized_from_message(work_message) is False
+
+
+def test_message_env_fallback_is_profile_scoped_in_multiplex(monkeypatch):
+    """Env-only early intake must honor the current profile scope."""
+    from agent import secret_scope as ss
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "6940705170")
+    adapter = _make_adapter()
+    adapter._authorization_check = None
+    adapter._message_handler = None
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({"TELEGRAM_ALLOWED_USERS": "429731663"})
+    try:
+        personal_message = _make_message(
+            from_user_id=429731663,
+            chat_id=429731663,
+            chat_type="dm",
+        )
+        work_message = _make_message(
+            from_user_id=6940705170,
+            chat_id=6940705170,
+            chat_type="dm",
+        )
+        assert adapter._is_user_authorized_from_message(personal_message) is True
+        assert adapter._is_user_authorized_from_message(work_message) is False
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_group_allowed_chats_env_fallback_is_profile_scoped(monkeypatch):
+    """Observed group scope must not inherit another profile's chat grant."""
+    from agent import secret_scope as ss
+
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", "-100-primary")
+    adapter = _make_adapter()
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert adapter._telegram_group_allowed_chats() == set()
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
+
+
+def test_auth_env_configured_uses_profile_scope(monkeypatch):
+    from agent import secret_scope as ss
+
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "6940705170")
+    adapter = _make_adapter()
+
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({})
+    try:
+        assert adapter._telegram_auth_env_configured() is False
+    finally:
+        ss.reset_secret_scope(token)
+        ss.set_multiplex_active(False)
 
 
 def test_runner_auth_gets_group_user_allowlist_context(monkeypatch):

--- a/tests/gateway/test_telegram_callback_auth_fail_closed.py
+++ b/tests/gateway/test_telegram_callback_auth_fail_closed.py
@@ -86,4 +86,45 @@ class TestCallbackAuthFailClosed:
         adapter._message_handler = None
         assert adapter._is_callback_user_authorized("12345") is True
 
+    def test_registered_profile_check_precedes_process_env(self, monkeypatch):
+        """Secondary-profile buttons must not use the primary allowlist."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "6940705170")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        adapter.set_authorization_check(
+            lambda user_id, chat_type, chat_id: user_id == "429731663"
+        )
+
+        assert adapter._is_callback_user_authorized(
+            "429731663",
+            chat_id="429731663",
+            chat_type="dm",
+        ) is True
+        assert adapter._is_callback_user_authorized(
+            "6940705170",
+            chat_id="6940705170",
+            chat_type="dm",
+        ) is False
+
+    def test_env_fallback_is_profile_scoped_in_multiplex(self, monkeypatch):
+        """Fallback auth must not reuse another profile's allowlist."""
+        from agent import secret_scope as ss
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "primary-user")
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        adapter._authorization_check = None
+
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope(
+            {"TELEGRAM_ALLOWED_USERS": "personal-user"}
+        )
+        try:
+            assert adapter._is_callback_user_authorized("personal-user") is True
+            assert adapter._is_callback_user_authorized("primary-user") is False
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
 

--- a/tests/gateway/test_telegram_callback_auth_fail_closed.py
+++ b/tests/gateway/test_telegram_callback_auth_fail_closed.py
@@ -7,6 +7,7 @@ when TELEGRAM_ALLOWED_USERS is empty, instead of allowing everyone.
 import sys
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -126,5 +127,32 @@ class TestCallbackAuthFailClosed:
         finally:
             ss.reset_secret_scope(token)
             ss.set_multiplex_active(False)
+
+    @pytest.mark.asyncio
+    async def test_model_picker_callback_requires_authorized_user(self):
+        """Another group member must not mutate someone else's model picker."""
+        adapter = _make_adapter()
+        state_key = ("group", "42")
+        adapter._model_picker_state = {state_key: {"providers": []}}
+        adapter._is_callback_user_authorized = lambda *args, **kwargs: False
+        query = SimpleNamespace(
+            from_user=SimpleNamespace(id=999, first_name="Other"),
+            message=SimpleNamespace(
+                chat_id="group",
+                message_id=42,
+                chat=SimpleNamespace(type="group"),
+                message_thread_id=None,
+            ),
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+        )
+
+        await adapter._handle_model_picker_callback(query, "mx", "group")
+
+        assert state_key in adapter._model_picker_state
+        query.edit_message_text.assert_not_awaited()
+        query.answer.assert_awaited_once_with(
+            text="⛔ You are not authorized to change models."
+        )
 
 

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -70,11 +70,50 @@ class TestTelegramModelPicker:
         assert "MARKDOWN_V2" in repr(sent["parse_mode"])
         assert "provider\\_one" in sent["text"]
         assert "`model_1`" in sent["text"]
+        assert ("12345", "101") in adapter._model_picker_state
+
+    @pytest.mark.asyncio
+    async def test_choice_picker_state_is_bound_to_its_message(self):
+        adapter = _make_adapter()
+        adapter._send_message_with_thread_fallback = AsyncMock(
+            return_value=SimpleNamespace(message_id=202)
+        )
+
+        result = await adapter.send_choice_picker(
+            chat_id="12345",
+            title="Choose",
+            choices=[{"value": "fast", "label": "Fast"}],
+            session_key="s",
+            on_choice_selected=AsyncMock(),
+        )
+
+        assert result.success is True
+        assert ("12345", "202") in adapter._choice_picker_state
+
+    @pytest.mark.asyncio
+    async def test_stale_picker_message_cannot_cancel_newer_topic_state(self):
+        adapter = _make_adapter()
+        current_key = ("12345", "202")
+        adapter._model_picker_state[current_key] = {"providers": []}
+        query = SimpleNamespace(
+            message=SimpleNamespace(chat_id=12345, message_id=101),
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+        )
+
+        await adapter._handle_model_picker_callback(query, "mx", "12345")
+
+        assert current_key in adapter._model_picker_state
+        query.edit_message_text.assert_not_awaited()
+        query.answer.assert_awaited_once_with(
+            text="Picker expired — use /model again."
+        )
 
     @pytest.mark.asyncio
     async def test_back_button_escapes_dynamic_provider_label(self):
         adapter = _make_adapter()
-        adapter._model_picker_state["12345"] = {
+        adapter._authorization_check = lambda *args, **kwargs: True
+        adapter._model_picker_state[("12345", "42")] = {
             "providers": [{"slug": "provider_one", "name": "Provider One", "total_models": 1, "is_current": True}],
             "current_model": "model_1",
             "current_provider": "provider_one",
@@ -87,7 +126,9 @@ class TestTelegramModelPicker:
         query.data = "mb"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.message_id = 42
         query.from_user = MagicMock()
+        query.from_user.id = 111
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -15,7 +15,11 @@ def _make_adapter(**extra_env):
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
-    adapter.config = PlatformConfig(enabled=True, token="fake-token")
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra=dict(extra_env),
+    )
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()
     return adapter
@@ -50,6 +54,13 @@ def test_reactions_enabled_when_set_true(monkeypatch):
     """Setting TELEGRAM_REACTIONS=true enables reactions."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
+    assert adapter._reactions_enabled() is True
+
+
+def test_reactions_profile_config_overrides_process_environment(monkeypatch):
+    """A multiplex profile must use its own snapshotted policy."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = _make_adapter(reactions=True)
     assert adapter._reactions_enabled() is True
 
 

--- a/tests/gateway/test_telegram_reply_context_command.py
+++ b/tests/gateway/test_telegram_reply_context_command.py
@@ -1,0 +1,181 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class _Stream:
+    def __init__(self, data=b""):
+        self.data = data
+
+    async def read(self, limit):
+        return self.data[:limit]
+
+
+class _Process:
+    def __init__(self, stdout=b"", stderr=b"", returncode=0):
+        self.stdout = _Stream(stdout)
+        self.stderr = _Stream(stderr)
+        self._final_returncode = returncode
+        self.returncode = None
+        self.killed = False
+        self.waited = False
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        self.waited = True
+        self.returncode = -9 if self.killed else self._final_returncode
+        return self.returncode
+
+
+def _event():
+    return SimpleNamespace(
+        text="hello",
+        reply_to_message_id="7",
+        message_id="8",
+        channel_context=None,
+        source=SimpleNamespace(
+            chat_id="-1004362586179",
+            thread_id="5",
+            chat_type="group",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reply_context_command_enriches_channel_context(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/contaminated/repo/venv")
+    monkeypatch.setenv("PYTHONHOME", "/contaminated/python")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "must-not-leak")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak")
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "reply_context_command": "/runtime/python /scripts/context.py",
+                "reply_context_timeout": 5,
+                "reply_context_depth": 30,
+                "reply_context_neighbors": 5,
+                "reply_context_max_messages": 100,
+                "reply_context_max_chars": 80000,
+            },
+        )
+    )
+    proc = _Process(
+        stdout=json.dumps({"ok": True, "context": "bounded context"}).encode(),
+        returncode=0,
+    )
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as spawn:
+        event = await adapter._enrich_reply_context(_event())
+
+    assert event.channel_context == "bounded context"
+    argv = spawn.await_args.args
+    env = spawn.await_args.kwargs["env"]
+    assert argv[:2] == ("/runtime/python", "/scripts/context.py")
+    assert "PYTHONPATH" not in env
+    assert "PYTHONHOME" not in env
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert env["PYTHONNOUSERSITE"] == "1"
+    assert "--depth" in argv and argv[argv.index("--depth") + 1] == "30"
+    assert "--neighbors" in argv and argv[argv.index("--neighbors") + 1] == "5"
+    assert "--max-messages" in argv and argv[argv.index("--max-messages") + 1] == "100"
+
+
+@pytest.mark.asyncio
+async def test_reply_context_failure_falls_back_to_native_reply():
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"reply_context_command": "/runtime/python /scripts/context.py"},
+        )
+    )
+    event = _event()
+    proc = _Process(stdout=b'{"ok": false}', returncode=2)
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+        result = await adapter._enrich_reply_context(event)
+    assert result is event
+    assert result.channel_context is None
+
+
+@pytest.mark.asyncio
+async def test_reply_context_output_flood_is_killed_and_reaped():
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={
+                "reply_context_command": "/runtime/python /scripts/context.py",
+                "reply_context_max_chars": 1000,
+            },
+        )
+    )
+    proc = _Process(stdout=b"x" * 20_000)
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)):
+        result = await adapter._enrich_reply_context(_event())
+    assert result.channel_context is None
+    assert proc.killed is True
+    assert proc.waited is True
+
+
+@pytest.mark.asyncio
+async def test_reply_context_timeout_kills_and_reaps_process():
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"reply_context_command": "/runtime/python /scripts/context.py"},
+        )
+    )
+    proc = _Process(stdout=b"{}")
+    with (
+        patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)),
+        patch("asyncio.wait_for", new=AsyncMock(side_effect=asyncio.TimeoutError)),
+    ):
+        result = await adapter._enrich_reply_context(_event())
+    assert result.channel_context is None
+    assert proc.killed is True
+    assert proc.waited is True
+
+
+@pytest.mark.asyncio
+async def test_reply_context_is_skipped_without_reply_or_outside_groups():
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"reply_context_command": "/runtime/python /scripts/context.py"},
+        )
+    )
+    event = _event()
+    event.reply_to_message_id = None
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock()) as spawn:
+        result = await adapter._enrich_reply_context(event)
+    assert result is event
+    spawn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reply_context_is_skipped_for_gateway_commands():
+    adapter = TelegramAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"reply_context_command": "/runtime/python /scripts/context.py"},
+        )
+    )
+    event = _event()
+    event.text = "/reset"
+    with patch("asyncio.create_subprocess_exec", new=AsyncMock()) as spawn:
+        result = await adapter._enrich_reply_context(event)
+    assert result is event
+    spawn.assert_not_awaited()

--- a/tests/gateway/test_telegram_scoped_topic_prompts.py
+++ b/tests/gateway/test_telegram_scoped_topic_prompts.py
@@ -1,0 +1,64 @@
+from plugins.platforms.telegram.adapter import _resolve_telegram_channel_prompt
+
+
+def _extra():
+    return {
+        "channel_prompts": {
+            "-1001": "GROUP BASELINE",
+            "17": "LEGACY GLOBAL BOOKS",
+        },
+        "topic_prompts": {
+            "-1001:17": "SCOPED BOOKS POLICY",
+        },
+    }
+
+
+def test_scoped_topic_prompt_is_additive_with_group_baseline():
+    prompt = _resolve_telegram_channel_prompt(
+        _extra(), chat_id="-1001", thread_id="17", chat_type="group"
+    )
+    assert prompt == "GROUP BASELINE\n\nSCOPED BOOKS POLICY"
+
+
+def test_unknown_future_topic_falls_back_to_group_baseline():
+    prompt = _resolve_telegram_channel_prompt(
+        _extra(), chat_id="-1001", thread_id="99", chat_type="group"
+    )
+    assert prompt == "GROUP BASELINE"
+
+
+def test_same_thread_id_in_another_group_does_not_receive_scoped_or_legacy_prompt():
+    prompt = _resolve_telegram_channel_prompt(
+        _extra(), chat_id="-2002", thread_id="17", chat_type="group"
+    )
+    assert prompt is None
+
+
+def test_dm_topic_with_same_thread_id_does_not_receive_group_topic_prompt():
+    prompt = _resolve_telegram_channel_prompt(
+        _extra(), chat_id="429731663", thread_id="17", chat_type="dm"
+    )
+    assert prompt is None
+
+
+def test_legacy_resolution_remains_when_scoped_surface_is_absent():
+    prompt = _resolve_telegram_channel_prompt(
+        {"channel_prompts": {"-1001": "BASE", "17": "LEGACY"}},
+        chat_id="-1001",
+        thread_id="17",
+        chat_type="group",
+    )
+    assert prompt == "LEGACY"
+
+
+def test_nested_integer_yaml_keys_resolve_after_normalization():
+    prompt = _resolve_telegram_channel_prompt(
+        {
+            "channel_prompts": {-1001: "GROUP BASELINE"},
+            "topic_prompts": {-1001: {17: "SCOPED BOOKS POLICY"}},
+        },
+        chat_id="-1001",
+        thread_id="17",
+        chat_type="group",
+    )
+    assert prompt == "SCOPED BOOKS POLICY"

--- a/tests/gateway/test_typing_until_final_delivery.py
+++ b/tests/gateway/test_typing_until_final_delivery.py
@@ -1,0 +1,50 @@
+import inspect
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+def _stream_config():
+    return SimpleNamespace(
+        edit_interval=0.1,
+        buffer_threshold=1,
+        cursor=" ▉",
+        fresh_final_after_seconds=5.0,
+        transport="edit",
+    )
+
+
+def test_telegram_stream_finalize_does_not_pause_typing_before_final_delivery():
+    runner = object.__new__(GatewayRunner)
+    source = SimpleNamespace(platform=Platform.TELEGRAM, chat_id="-1001", chat_type="group")
+    adapter = SimpleNamespace(
+        SUPPORTS_MESSAGE_EDITING=True,
+        pause_typing_for_chat=lambda _chat_id: None,
+    )
+
+    _cfg, before_finalize = runner._build_stream_consumer_config(
+        source,
+        _stream_config(),
+        adapter,
+        on_missing_cursor="raise",
+    )
+
+    assert before_finalize is None
+
+
+def test_agent_completion_path_does_not_stop_typing_before_response_delivery():
+    source = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    after_agent = source.split("agent_result = await self._run_agent", 1)[1]
+    before_response = after_agent.split("response = agent_result.get", 1)[0]
+
+    assert "stop_typing" not in before_response
+    assert "_stop_typing_with_metadata" not in before_response
+    assert ".stop_typing(" not in before_response
+
+
+def test_agent_error_path_keeps_typing_for_outer_safe_error_delivery():
+    source = inspect.getsource(GatewayRunner._handle_message_with_agent)
+    error_tail = source.split("except Exception as e:", 1)[1]
+    error_prefix = error_tail.split("logger.exception", 1)[0]
+    assert "stop_typing" not in error_prefix

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -218,6 +218,45 @@ class TestHelpers:
 
         assert env["SEEN_TOKEN"] == "secondary-token"
 
+    def test_fetch_worker_inherits_profile_context(self, tmp_path, monkeypatch):
+        """Executor isolation must preserve the caller's profile ContextVars."""
+        from agent import secret_scope as ss
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        process_home = tmp_path / "process"
+        profile_home = tmp_path / "profile"
+        monkeypatch.setenv("HERMES_HOME", str(process_home))
+        observed = {}
+
+        def _fetch(cfg, home):
+            observed["home"] = get_hermes_home()
+            observed["secret"] = ss.get_secret("SCOPE_MARKER")
+            return FetchResult()
+
+        reg.register_source(_make_source(fetch_fn=_fetch))
+        home_token = set_hermes_home_override(str(profile_home))
+        secret_token = ss.set_secret_scope({"SCOPE_MARKER": "profile-secret"})
+        ss.set_multiplex_active(True)
+        try:
+            reg.apply_all(
+                {"dummy": {"enabled": True}},
+                profile_home,
+                environ={"SCOPE_MARKER": "profile-secret"},
+            )
+        finally:
+            ss.set_multiplex_active(False)
+            ss.reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
+        assert observed == {
+            "home": profile_home,
+            "secret": "profile-secret",
+        }
+
     def test_run_secret_cli_fails_closed_without_fetch_context_in_multiplex(
         self, monkeypatch
     ):

--- a/tests/secret_sources/test_secret_source_registry.py
+++ b/tests/secret_sources/test_secret_source_registry.py
@@ -191,6 +191,55 @@ class TestHelpers:
                        for k in child_env)
         assert "NO_COLOR" in child_env
 
+    def test_run_secret_cli_uses_apply_environment_not_process_globals(
+        self, tmp_path, monkeypatch
+    ):
+        """Plugin helpers inherit only the profile-local source environment."""
+        monkeypatch.setenv("PROFILE_SOURCE_TOKEN", "primary-token")
+
+        def _fetch(cfg, home):
+            proc = run_secret_cli(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os; print(os.getenv('PROFILE_SOURCE_TOKEN', ''))",
+                ],
+                allow_env=("PROFILE_SOURCE_TOKEN",),
+            )
+            return FetchResult(secrets={"SEEN_TOKEN": proc.stdout.strip()})
+
+        reg.register_source(_make_source(fetch_fn=_fetch))
+        env = {"PROFILE_SOURCE_TOKEN": "secondary-token"}
+        reg.apply_all(
+            {"dummy": {"enabled": True}},
+            tmp_path,
+            environ=env,
+        )
+
+        assert env["SEEN_TOKEN"] == "secondary-token"
+
+    def test_run_secret_cli_fails_closed_without_fetch_context_in_multiplex(
+        self, monkeypatch
+    ):
+        from agent import secret_scope as ss
+        from agent.secret_sources.base import run_secret_cli
+
+        monkeypatch.setenv("PROFILE_TOKEN", "primary-token")
+        ss.set_multiplex_active(True)
+        try:
+            proc = run_secret_cli(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os; print(os.getenv('PROFILE_TOKEN', ''))",
+                ],
+                allow_env=("PROFILE_TOKEN",),
+            )
+        finally:
+            ss.set_multiplex_active(False)
+
+        assert proc.stdout.strip() == ""
+
 
 
 

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -210,6 +210,52 @@ def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
     assert captured_env.get("BWS_SERVER_URL") == "https://vault.bitwarden.eu"
 
 
+def test_registry_fetch_uses_profile_auth_environment(monkeypatch, tmp_path):
+    """Multiplex BWS fetches must neither use nor forward primary credentials."""
+    from agent.secret_sources import registry as reg
+
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "primary-bws-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "primary-openai-key")
+    monkeypatch.setattr(bw, "find_bws", lambda **kwargs: fake_binary)
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs["env"])
+        return mock.Mock(
+            returncode=0,
+            stdout=_fake_bws_payload(
+                [{"key": "TARGET_SECRET", "value": "resolved-value"}]
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+    reg._reset_registry_for_tests()
+    monkeypatch.setattr(reg, "_ensure_builtin_sources", lambda: None)
+    reg.register_source(bw.BitwardenSource())
+    env = {"BWS_ACCESS_TOKEN": "personal-bws-token"}
+    try:
+        reg.apply_all(
+            {
+                "bitwarden": {
+                    "enabled": True,
+                    "project_id": "personal-project",
+                    "cache_ttl_seconds": 0,
+                }
+            },
+            tmp_path,
+            environ=env,
+        )
+    finally:
+        reg._reset_registry_for_tests()
+
+    assert env["TARGET_SECRET"] == "resolved-value"
+    assert captured_env["BWS_ACCESS_TOKEN"] == "personal-bws-token"
+    assert "OPENAI_API_KEY" not in captured_env
+
+
 
 
 

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -218,6 +218,7 @@ def test_registry_fetch_uses_profile_auth_environment(monkeypatch, tmp_path):
     fake_binary.write_text("")
     monkeypatch.setenv("BWS_ACCESS_TOKEN", "primary-bws-token")
     monkeypatch.setenv("OPENAI_API_KEY", "primary-openai-key")
+    monkeypatch.setenv("HTTPS_PROXY", "https://primary-proxy.invalid")
     monkeypatch.setattr(bw, "find_bws", lambda **kwargs: fake_binary)
     captured_env = {}
 
@@ -235,7 +236,11 @@ def test_registry_fetch_uses_profile_auth_environment(monkeypatch, tmp_path):
     reg._reset_registry_for_tests()
     monkeypatch.setattr(reg, "_ensure_builtin_sources", lambda: None)
     reg.register_source(bw.BitwardenSource())
-    env = {"BWS_ACCESS_TOKEN": "personal-bws-token"}
+    env = {
+        "BWS_ACCESS_TOKEN": "personal-bws-token",
+        "HTTPS_PROXY": "https://personal-proxy.invalid",
+        "NO_PROXY": "vault.internal",
+    }
     try:
         reg.apply_all(
             {
@@ -253,6 +258,8 @@ def test_registry_fetch_uses_profile_auth_environment(monkeypatch, tmp_path):
 
     assert env["TARGET_SECRET"] == "resolved-value"
     assert captured_env["BWS_ACCESS_TOKEN"] == "personal-bws-token"
+    assert captured_env["HTTPS_PROXY"] == "https://personal-proxy.invalid"
+    assert captured_env["NO_PROXY"] == "vault.internal"
     assert "OPENAI_API_KEY" not in captured_env
 
 

--- a/tests/test_command_secret_source.py
+++ b/tests/test_command_secret_source.py
@@ -139,6 +139,25 @@ def test_bare_value_helper_resolves_single_value(tmp_path):
 
 
 
+def test_command_helper_fails_closed_without_fetch_context_in_multiplex(
+    tmp_path, monkeypatch
+):
+    from agent import secret_scope as ss
+
+    helper = _write_helper(
+        tmp_path,
+        "printf '%s' \"${CMDTEST_PARENT_SECRET:-}\"",
+    )
+    monkeypatch.setenv("CMDTEST_PARENT_SECRET", "primary-secret")
+    ss.set_multiplex_active(True)
+    try:
+        value = get_command_secret(command=str(helper), key="CMDTEST_API_KEY")
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert value is None
+
+
 def test_timeout_kills_hung_helper_and_degrades_to_empty(tmp_path):
     helper = _write_helper(tmp_path, "sleep 30")
     start = time.monotonic()

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -489,6 +489,66 @@ def test_apply_external_secret_sources_survives_non_dict_section(tmp_path, monke
     assert env_loader.get_secret_source("ANYTHING") is None
 
 
+def test_secondary_profile_dotenv_does_not_mutate_multiplex_process_env(
+    tmp_path, monkeypatch
+):
+    """Late imports in a profile turn must not overwrite primary credentials."""
+    from agent import secret_scope as ss
+
+    default_home = tmp_path / "default"
+    personal_home = tmp_path / "personal"
+    default_home.mkdir()
+    personal_home.mkdir()
+    (personal_home / ".env").write_text(
+        "TELEGRAM_ALLOWED_USERS=personal-user\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "primary-user")
+    ss.set_multiplex_active(True)
+    try:
+        loaded = env_loader.load_hermes_dotenv(hermes_home=personal_home)
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert loaded == []
+    assert os.environ["TELEGRAM_ALLOWED_USERS"] == "primary-user"
+
+
+def test_profile_secret_snapshot_refreshes_when_bootstrap_changes(
+    tmp_path, monkeypatch
+):
+    """A rotated profile bootstrap must not reuse the old resolved value."""
+    from types import SimpleNamespace
+    from agent.secret_sources import registry as reg
+
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  synthetic:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+
+    def fake_apply_all(cfg, home_path, *, environ):
+        environ["TARGET_SECRET"] = environ["BOOTSTRAP_TOKEN"]
+        return SimpleNamespace(
+            sources=[SimpleNamespace(name="synthetic")],
+            provenance={"TARGET_SECRET": SimpleNamespace(source="synthetic")},
+        )
+
+    monkeypatch.setattr(reg, "apply_all", fake_apply_all)
+
+    first = env_loader.resolve_profile_secret_source_values(
+        tmp_path,
+        {"BOOTSTRAP_TOKEN": "token-a"},
+    )
+    second = env_loader.resolve_profile_secret_source_values(
+        tmp_path,
+        {"BOOTSTRAP_TOKEN": "token-b"},
+    )
+
+    assert first == {"TARGET_SECRET": "token-a"}
+    assert second == {"TARGET_SECRET": "token-b"}
+
+
 def test_apply_external_secret_sources_bad_ttl_does_not_crash(tmp_path, monkeypatch):
     """A non-numeric cache_ttl_seconds must be coerced, not crash startup."""
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -515,6 +515,25 @@ def test_secondary_profile_dotenv_does_not_mutate_multiplex_process_env(
     assert os.environ["TELEGRAM_ALLOWED_USERS"] == "primary-user"
 
 
+def test_process_hermes_home_ignores_profile_context_override(
+    tmp_path, monkeypatch
+):
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    process_home = tmp_path / "process"
+    profile_home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        assert env_loader._process_hermes_home() == process_home
+    finally:
+        reset_hermes_home_override(token)
+
+
 def test_profile_secret_snapshot_refreshes_when_bootstrap_changes(
     tmp_path, monkeypatch
 ):
@@ -547,6 +566,35 @@ def test_profile_secret_snapshot_refreshes_when_bootstrap_changes(
 
     assert first == {"TARGET_SECRET": "token-a"}
     assert second == {"TARGET_SECRET": "token-b"}
+
+
+def test_profile_resolution_retries_after_empty_process_fetch(tmp_path, monkeypatch):
+    """An earlier failed global fetch must not poison the profile snapshot."""
+    from types import SimpleNamespace
+    from agent.secret_sources import registry as reg
+
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  synthetic:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    home_key = str(tmp_path.resolve())
+    env_loader._APPLIED_HOMES.add(home_key)
+    calls = {"n": 0}
+
+    def fake_apply_all(config, home_path, *, environ):
+        calls["n"] += 1
+        environ["TARGET_SECRET"] = "fresh-profile-value"
+        return SimpleNamespace(
+            sources=[SimpleNamespace(name="synthetic")],
+            provenance={"TARGET_SECRET": SimpleNamespace(source="synthetic")},
+        )
+
+    monkeypatch.setattr(reg, "apply_all", fake_apply_all)
+
+    values = env_loader.resolve_profile_secret_source_values(tmp_path, {})
+
+    assert calls["n"] == 1
+    assert values == {"TARGET_SECRET": "fresh-profile-value"}
 
 
 def test_apply_external_secret_sources_bad_ttl_does_not_crash(tmp_path, monkeypatch):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -290,11 +290,56 @@ def test_apply_never_overrides_token_var(monkeypatch, tmp_path):
     result = op.apply_onepassword_secrets(
         enabled=True,
         env={"OP_SERVICE_ACCOUNT_TOKEN": "op://V/I/F"},
-        override_existing=True, cache_ttl_seconds=0,
+        override_existing=True,
+        cache_ttl_seconds=0,
     )
     assert "OP_SERVICE_ACCOUNT_TOKEN" in result.skipped
     assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "original"
     assert calls["n"] == 0
+
+
+def test_registry_fetch_uses_profile_auth_environment(monkeypatch, tmp_path):
+    """Multiplex fetches must not pass process-global OP auth to the child."""
+    from agent.secret_sources import registry as reg
+
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "primary-service-token")
+    monkeypatch.setenv("OP_SESSION_primary", "primary-session")
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "primary-connect-token")
+    monkeypatch.setattr(op, "find_op", lambda binary_path="": tmp_path / "op")
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs.get("env") or {})
+        return _ok("resolved-value")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    reg._reset_registry_for_tests()
+    monkeypatch.setattr(reg, "_ensure_builtin_sources", lambda: None)
+    reg.register_source(op.OnePasswordSource())
+    env = {
+        "OP_SERVICE_ACCOUNT_TOKEN": "personal-service-token",
+        "OP_SESSION_personal": "personal-session",
+    }
+    try:
+        reg.apply_all(
+            {
+                "onepassword": {
+                    "enabled": True,
+                    "cache_ttl_seconds": 0,
+                    "env": {"TARGET_SECRET": "op://Vault/Item/Field"},
+                }
+            },
+            tmp_path,
+            environ=env,
+        )
+    finally:
+        reg._reset_registry_for_tests()
+
+    assert env["TARGET_SECRET"] == "resolved-value"
+    assert captured["OP_SERVICE_ACCOUNT_TOKEN"] == "personal-service-token"
+    assert captured["OP_SESSION_personal"] == "personal-session"
+    assert "OP_SESSION_primary" not in captured
+    assert "OP_CONNECT_TOKEN" not in captured
 
 
 


### PR DESCRIPTION
## What does this PR do?

Integrates five related gateway commits onto current `main`:

1. harden Telegram topic workflows with scoped prompts, bounded reply context, final-delivery typing, and durable in-flight recovery;
2. add the opt-in copyable `transcript_md` STT echo format while preserving the legacy default;
3. deliver media before recursively draining queued follow-ups;
4. isolate multiplex profile credentials, external secret sources, runtime homes, routing, pairing, and callback authorization;
5. complete fail-closed Telegram/auth transport ownership, picker, reactions, proxy-policy, and serialization compatibility hardening.

The security boundary is profile-local: a scoped miss cannot inherit another profile's process environment, adapter, pairing store, callback state, or Telegram intake policy. Single-profile behavior remains compatible.

## Related Issue

No single issue covers the combined local recovery/integration. Related open work was reviewed for overlap, including profile-local secret hydration, Telegram callback authorization, and multiplex dotenv isolation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add Telegram topic prompt/reply-context, typing-lifecycle, and restart-recovery behavior.
- Add configurable copy-friendly STT transcript echoes.
- Preserve media delivery ordering before queued follow-up processing.
- Propagate profile scope into secret-source workers and isolate Bitwarden, 1Password, command, and dotenv hydration/caches.
- Bind inbound runtime routing separately from transport ownership and fail closed on missing secondary adapters/pairing stores.
- Keep Telegram auth gates, callbacks, pickers, reactions, and proxy policy profile-local under multiplex.
- Preserve legacy `SessionSource` positional and wire compatibility; transport provenance is local/opt-in only.
- Add regression coverage for every corrected boundary, including removal of a stale strict `xfail` that now passes.

## How to Test

1. `scripts/run_tests.sh` over all changed tests plus adjacent upstream contracts: **35 files, 495 passed, 0 failed**.
2. Combined hardening/config regression barrier: **17 files, 352 passed, 0 failed**.
3. `ruff check` + `py_compile` on all **38** changed Python files, conflict-marker scan, and `git diff --check`: **pass**.

Repository-wide suite is not absolutely green on current `main` in this macOS/dev+messaging environment:

- branch run before stale-`xfail` cleanup: **14,207 passed, 14 failed**;
- same-upstream baseline: **14,664 passed, 13 failed**;
- the 13 real failing node IDs are identical;
- the only branch-only failure was an expected strict `XPASS`; its stale marker was removed and the focused file now passes **10/10**;
- 42 additional branch collection gaps all occurred after the parallel suite removed `pytest` from its shared `.venv`; none are changed files, and the environment was restored.

`ruff format --check` remains red for pre-existing formatting debt; no broad reformat is included.

## Live verification caveat

The earlier pre-rebase tree passed a bounded two-profile Telegram matrix with rollback. The fresh-upstream tree was **not** re-canary-tested: both profiles have no configured proxy, and the current network preflight could not establish a new TLS session to Telegram either directly or through a bounded localhost CONNECT relay. The healthy Personal gateway was therefore not stopped; default remains stopped; the relay was stopped; no persistent config changed.

## Checklist

### Code

- [ ] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and documented relevant overlap above.
- [x] My PR contains only changes related to these five commits.
- [ ] The absolute repository-wide suite passes (baseline is already red; details above).
- [x] I've added tests for the changes.
- [x] Tested on macOS (Apple Silicon), Python 3.11.

### Documentation & Housekeeping

- [x] Relevant config/docstrings are updated; no separate docs change is required for this recovery PR.
- [ ] `cli-config.yaml.example` update: not included; maintainer decision requested for the new optional keys.
- [x] Cross-platform impact was considered; platform-specific full-suite failures are unchanged from baseline.
- [x] No credentials, proxy endpoints, Telegram identifiers, or raw canary contents are included.

## Screenshots / Logs

Not included: test logs contain local paths and the prior live canary contains private routing identifiers. Aggregate evidence is reported above.
