### PR TITLE
fix(security): redact the full dotted body of prefixed credentials

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -433,9 +433,29 @@ _FORM_BODY_RE = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*(?:&[A-Za-z_][A-Za-z0-9_.-]*=[^&\s]*)+$"
 )
 
-# Compile known prefix patterns into one alternation
+# Compile known prefix patterns into one alternation.
+#
+# DOTTED CONTINUATION: 53 of the 55 patterns above use a character class that
+# excludes `.`, and the trailing boundary permits a dot to end the match. Any
+# credential that carries dots INSIDE its body — Alibaba Token Plan
+# (sk-sp-<seg>.<seg>.<seg>), Google OAuth ya29., Google refresh 1//, SendGrid's
+# 3-part key, anything JWT-shaped — therefore matched only up to its first dot
+# and the remainder passed through in cleartext.
+#
+# A partial mask is worse than no mask: `sk-sp-…xxxx` reads as "redacted" to a
+# reviewer while the tail is still a working credential, and it reaches model
+# context, the session DB and the gateway transcript through 15 call sites.
+#
+# Consuming the dotted continuation is done HERE rather than by editing 53
+# character classes, so no vendor pattern can be missed. The continuation only
+# applies once a vendor prefix has already matched, so ordinary prose
+# ("file.txt", "1.2.3") is untouched.
+_DOTTED_CONTINUATION = r"(?:\.[A-Za-z0-9_-]+)*"
+
 _PREFIX_RE = re.compile(
-    r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
+    r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")"
+    + _DOTTED_CONTINUATION
+    + r"(?![A-Za-z0-9_-])"
 )
 
 

--- a/tests/agent/test_redact_dotted_bodies.py
+++ b/tests/agent/test_redact_dotted_bodies.py
@@ -1,0 +1,83 @@
+"""Dotted credential bodies must be redacted in full, for every vendor prefix.
+
+Regression cover for a class of partial masks: most entries in
+``_PREFIX_PATTERNS`` use a character class that excludes ``.``, and the
+trailing boundary lets a dot terminate the match, so a credential carrying
+dots inside its body was masked only up to its first dot.
+
+A partial mask is more dangerous than no mask: ``sk-sp-…xxxx`` reads as
+"redacted" while the tail is still a working key.
+
+All tokens here are synthesised.
+"""
+
+import secrets
+
+import pytest
+
+from agent.redact import redact_sensitive_text, redact_terminal_output
+
+
+def _seg(n: int) -> str:
+    return secrets.token_hex(n // 2)
+
+
+# Vendor prefixes that already exist in _PREFIX_PATTERNS, each given a body
+# containing dots. Before the fix every one of these leaked its tail.
+DOTTED_TOKENS = [
+    pytest.param("sk-sp-" + _seg(30) + "." + _seg(30) + "." + _seg(30),
+                 id="alibaba-token-plan"),
+    pytest.param("sk-" + _seg(24) + "." + _seg(24), id="openai-style-dotted"),
+    pytest.param("SG." + _seg(22) + "." + _seg(43), id="sendgrid-three-part"),
+    pytest.param("xoxb-" + _seg(20) + "." + _seg(20), id="slack-bot-dotted"),
+    pytest.param("ghp_" + _seg(20) + "." + _seg(20), id="github-pat-dotted"),
+    pytest.param("sk_live_" + _seg(20) + "." + _seg(20), id="stripe-live-dotted"),
+    pytest.param("hf_" + _seg(20) + "." + _seg(20), id="huggingface-dotted"),
+    pytest.param("AIza" + _seg(34) + "." + _seg(20), id="google-api-dotted"),
+]
+
+
+@pytest.mark.parametrize("token", DOTTED_TOKENS)
+def test_dotted_token_body_is_fully_masked(token):
+    """No segment of a dotted credential may survive redaction."""
+    out = redact_terminal_output(f"TOKEN={token}")
+    assert token not in out
+    for segment in token.split("."):
+        if len(segment) >= 12:
+            assert segment not in out, (
+                f"segment {segment[:8]}... survived redaction — a partial mask "
+                f"reads as redacted while the tail is still live"
+            )
+
+
+@pytest.mark.parametrize("token", DOTTED_TOKENS)
+def test_dotted_token_masked_in_prose(token):
+    """The same must hold on the sentence path, not just terminal output."""
+    out = redact_sensitive_text(f"the key is {token} and it is live")
+    assert token not in out
+
+
+def test_trailing_sentence_punctuation_is_not_consumed():
+    """A full stop ending a sentence must not be eaten as part of the token."""
+    token = "sk-sp-" + _seg(20) + "." + _seg(20)
+    out = redact_sensitive_text(f"leaked {token}.")
+    assert token not in out
+    assert out.endswith(".")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "see file.txt for details",
+        "version 1.2.3 released",
+        "run npm install --save-dev",
+        "visit example.com/path for docs",
+        "the value 3.14159 is pi",
+        "sk- is a common prefix",
+        "config at ~/.hermes/config.yaml",
+    ],
+)
+def test_ordinary_prose_is_untouched(text):
+    """Widening the match must not start masking normal text."""
+    assert redact_terminal_output(text) == text
+    assert redact_sensitive_text(text) == text


### PR DESCRIPTION
This builds on **#78138** (@RerankerGuo), which fixes the vendor reported in
#78128 and which I'd like to see land first — this is the same defect handled
one layer up, so if that PR is preferred I'm happy to close this one or rebase
onto it.

## The defect is structural, not per-vendor

Most entries in `_PREFIX_PATTERNS` use a character class that excludes `.`,
and the trailing boundary `(?![A-Za-z0-9_-])` lets a dot terminate the match.
Any credential carrying dots **inside its body** is therefore masked only up
to its first dot, and the remainder passes through in cleartext.

A partial mask is more dangerous than no mask at all: `sk-sp-…xxxx` reads as
"redacted" to anyone reviewing a transcript, while the tail is still a working
key. It reaches model context, the session DB and the gateway transcript
through the terminal-output call sites.

## Measured

Synthesised keys, using only prefixes that **already exist** in the pattern
list — so every row below is a vendor the redactor already claims to cover:

| dotted shape | upstream/main | #78138 | this PR |
|---|---|---|---|
| `sk-sp-` (Alibaba, the reported one) | leak | masked | masked |
| `sk-` with dots | leak | leak | masked |
| `SG.` 3-part | leak | leak | masked |
| `xoxb-` dotted | leak | leak | masked |
| `ghp_` dotted | leak | leak | masked |
| `sk_live_` dotted | leak | leak | masked |
| `hf_` dotted | leak | leak | masked |
| `AIza` dotted | leak | leak | masked |
| **total leaking** | **8/8** | **7/8** | **0/8** |

## Approach

```python
_DOTTED_CONTINUATION = r"(?:\.[A-Za-z0-9_-]+)*"

_PREFIX_RE = re.compile(
    r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")"
    + _DOTTED_CONTINUATION
    + r"(?![A-Za-z0-9_-])"
)
```

The continuation is consumed once where the alternation is compiled rather
than by editing each vendor pattern, so no existing or future prefix can be
missed. It only applies **after** a vendor prefix has already matched, which
is what keeps ordinary text safe.

## Not covered here, deliberately

`ya29.`, `1//` and bare JWTs still pass through — they have **no vendor
pattern at all**, so they are a different problem, and `ya29.`/`1//` are
already the subject of #55467 and #39697. Nothing in this PR competes with
those.

## Tests

`tests/agent/test_redact_dotted_bodies.py`, 24 cases:

- every dotted shape above, on both the terminal-output and sentence paths,
  asserting that **no segment** of the token survives
- trailing sentence punctuation is not consumed (`leaked <token>.` keeps its
  full stop)
- a negative-control set that must pass through byte-identical:
  `file.txt`, `1.2.3`, `example.com/path`, `3.14159`, `npm --save-dev`,
  `sk- is a common prefix`, `~/.hermes/config.yaml`

Verified against clean `upstream/main`: **8 of the new tests fail there**, so
they exercise the fix rather than passing regardless. On this branch the new
file plus the existing `test_redact.py` are green — 97 tests, 0 failures.
