### PR TITLE
fix(dashboard): dedupe duplicate chat image uploads on paste

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -605,11 +605,35 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
       term.focus();
     };
+    // Dedupe identical uploads. A single paste gesture can reach this
+    // twice: the Ctrl+Shift+V keydown handler (navigator.clipboard.read)
+    // and the DOM paste event (ev.clipboardData) both upload. Calling
+    // preventDefault() on the keydown does not cancel the paste event the
+    // browser dispatches afterward, so one Ctrl+Shift+V writes the same
+    // image twice (same second, different token_hex suffix). Clipboard
+    // File objects carry empty name and lastModified=0, so fingerprint on
+    // type+size and drop any repeat inside the window.
+    const recentlyUploaded = new Map<string, number>();
+    const UPLOAD_DEDUP_WINDOW_MS = 1500;
     const uploadAndAttachImages = (files: File[]) => {
       if (!files.length) return;
+      const now = Date.now();
+      const fresh = files.filter((file) => {
+        const key = `${file.type}\0${file.size}`;
+        const last = recentlyUploaded.get(key);
+        if (last !== undefined && now - last < UPLOAD_DEDUP_WINDOW_MS) {
+          return false;
+        }
+        recentlyUploaded.set(key, now);
+        return true;
+      });
+      for (const [key, ts] of recentlyUploaded) {
+        if (now - ts > UPLOAD_DEDUP_WINDOW_MS) recentlyUploaded.delete(key);
+      }
+      if (!fresh.length) return;
       void (async () => {
         const paths: string[] = [];
-        for (const file of files) {
+        for (const file of fresh) {
           const uploaded = await uploadChatImage(file, scopedProfile);
           if (imageUploadDisposed) return;
           paths.push(uploaded.path);


### PR DESCRIPTION
## Problem

Pasting an image into the dashboard **Chat** tab wrote the image to `HERMES_HOME/images/` **twice** — two `dashboard_*_image.png` files with the same timestamp but different `token_hex` suffixes. Users see the attachment appear twice (`[[image 1]]` stacking in the composer).

## Root cause

Two independent upload paths both fire for a **single paste gesture**:

1. **The `Ctrl+Shift+V` keydown handler** (`ChatPage.tsx`) reads `navigator.clipboard.read()` and calls `uploadAndAttachImages`.
2. **The DOM `paste` event** on the xterm host (registered with `capture: true`) reads `ev.clipboardData` and calls `uploadAndAttachImages` again.

Calling `ev.preventDefault()` inside the keydown handler does **not** cancel the `paste` event the browser dispatches afterward, so both paths run and the image uploads twice within ~a second. The comment in the code assumed `preventDefault()` suppressed the DOM paste event — it doesn't.

This is the same mechanism whether the gesture is `Ctrl+Shift+V`, a context-menu paste, or any combination that surfaces both a keydown and a DOM paste.

## Fix

Add a short-window **dedupe in `uploadAndAttachImages`**, keyed on the image fingerprint (`type + size`):

- Clipboard `File` objects carry an **empty name** and `lastModified = 0`, so the existing name/lastModified-based key (in `chatImagePaste.ts`'s `imageFileKey`) can't dedupe across the two paths — the two `File` objects are distinct instances.
- Any repeat of the same image within a **1.5 s window** is dropped, collapsing the double-fire into a single upload regardless of which listener combination triggered it.
- The map prunes itself so it never grows unbounded.

This is deliberately a defensive fix at the single chokepoint both paths pass through, rather than trying to suppress one of the two browser events — which is brittle across xterm internals and browser differences.

## Verification

- `npm run typecheck` — clean (`tsc -p . --noEmit`).
- `npm run test -- --run` — **26 files / 165 tests pass.**
- `npm run lint` — fails on a pre-existing missing dev dependency (`@eslint/js` not in the tree); unrelated to this change. `npx tsc` on the file is clean.

## Repro (before)

1. Open dashboard → Chat.
2. Copy an image, `Ctrl+Shift+V` into the composer.
3. `ls ~/.hermes/images/` shows **two** `dashboard_*_image.png` for that one paste.

After: only one file per gesture.
