### PR TITLE
fix(moonshot): prune dangling required names at every schema depth

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -145,15 +145,24 @@ def _ensure_required_array(node: Dict[str, Any]) -> Dict[str, Any]:
 
     Standard JSON Schema lets you omit ``required`` when nothing is required;
     Moonshot 400s on that ("required must be an array").  Ensure the key is a
-    list.  When ``properties`` is known, prune ``required`` entries that don't
-    name a real property — defensive against dangling names, which Moonshot
-    also rejects.  Mutates and returns ``node``.
+    list, and prune ``required`` entries that don't name a real property —
+    dangling names are rejected too.  Mutates and returns ``node``.
+
+    A node with no ``properties`` knows zero property names, so EVERY entry in
+    its ``required`` is dangling.  Pruning only when ``properties`` happened to
+    be a dict left exactly that shape untouched — and it is the shape that
+    actually occurs: MCP servers routinely emit array item schemas carrying
+    ``required`` without ``properties`` (the same class is called out in
+    ``agent/gemini_schema.py``).  The top-level parameters object was rescued
+    only incidentally, because ``sanitize_moonshot_tool_parameters`` injects
+    ``properties: {}`` before this runs; nested nodes had no such rescue and
+    shipped the dangling name, 400-ing the whole request.
     """
     props = node.get("properties")
     req = node.get("required")
     if isinstance(req, list):
-        if isinstance(props, dict):
-            node["required"] = [r for r in req if r in props]
+        known = set(props) if isinstance(props, dict) else set()
+        node["required"] = [r for r in req if r in known]
     else:
         node["required"] = []
     return node

--- a/tests/agent/test_moonshot_schema_dangling_required.py
+++ b/tests/agent/test_moonshot_schema_dangling_required.py
@@ -1,0 +1,155 @@
+"""Moonshot repair must prune dangling ``required`` names at every depth.
+
+``agent/moonshot_schema`` documents that Moonshot rejects ``required`` entries
+naming a property the node does not declare. ``_ensure_required_array`` only
+pruned when the node already carried a ``properties`` dict, so a node with
+``required`` and NO ``properties`` — every entry dangling by definition — kept
+them.
+
+The top-level parameters object was rescued only incidentally, because
+``sanitize_moonshot_tool_parameters`` injects ``properties: {}`` before the
+repair runs. Nested nodes had no such rescue, and that is exactly the shape MCP
+servers emit: array item schemas carrying ``required`` without ``properties``
+(the same class is called out in ``agent/gemini_schema.py``). One such tool
+400s the entire request before any model output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.moonshot_schema import sanitize_moonshot_tool_parameters as sanitize
+
+
+def _walk(node):
+    """Yield every schema node in the repaired output."""
+    if isinstance(node, dict):
+        yield node
+        for key, val in node.items():
+            if key in {"properties", "patternProperties", "$defs", "definitions"} and isinstance(val, dict):
+                for sub in val.values():
+                    yield from _walk(sub)
+            elif key in {"anyOf", "oneOf", "allOf", "prefixItems"} and isinstance(val, list):
+                for sub in val:
+                    yield from _walk(sub)
+            elif key in {"items", "contains", "not", "additionalProperties", "propertyNames"}:
+                yield from _walk(val)
+    elif isinstance(node, list):
+        for sub in node:
+            yield from _walk(sub)
+
+
+def _dangling(out) -> list:
+    """Every (node, name) pair where required names an undeclared property."""
+    bad = []
+    for node in _walk(out):
+        req = node.get("required")
+        if not isinstance(req, list):
+            continue
+        props = node.get("properties")
+        known = set(props) if isinstance(props, dict) else set()
+        bad += [(node.get("type"), r) for r in req if r not in known]
+    return bad
+
+
+class TestNoDanglingRequiredSurvives:
+    def test_array_item_schema_with_required_and_no_properties(self):
+        """The MCP shape: items carry `required` but declare no properties."""
+        out = sanitize({
+            "type": "object",
+            "properties": {
+                "files": {"type": "array", "items": {"type": "object", "required": ["path"]}},
+            },
+            "required": ["files"],
+        })
+        assert _dangling(out) == []
+        assert out["properties"]["files"]["items"]["required"] == []
+
+    def test_nested_object_with_inferred_type(self):
+        """`required` alone infers type=object; its names are still dangling."""
+        out = sanitize({
+            "type": "object",
+            "properties": {"opts": {"required": ["mode"]}},
+            "required": [],
+        })
+        assert _dangling(out) == []
+        assert out["properties"]["opts"]["required"] == []
+
+    def test_deeply_nested_under_anyof(self):
+        out = sanitize({
+            "type": "object",
+            "properties": {
+                "target": {"anyOf": [
+                    {"type": "object", "required": ["ghost"]},
+                    {"type": "string"},
+                ]},
+            },
+            "required": ["target"],
+        })
+        assert _dangling(out) == []
+
+    def test_top_level_still_pruned(self):
+        out = sanitize({"type": "object", "required": ["missing_prop"]})
+        assert out["required"] == []
+
+
+class TestExistingBehaviourPreserved:
+    def test_valid_required_names_survive(self):
+        out = sanitize({
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+        })
+        assert out["required"] == ["a", "b"]
+
+    def test_partial_prune_keeps_the_real_name(self):
+        out = sanitize({
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a", "ghost"],
+        })
+        assert out["required"] == ["a"]
+
+    def test_missing_required_still_becomes_empty_list(self):
+        """Rule: Moonshot needs the key present even when nothing is required."""
+        out = sanitize({"type": "object", "properties": {"a": {"type": "string"}}})
+        assert out["required"] == []
+
+    def test_nested_object_keeps_its_valid_required(self):
+        out = sanitize({
+            "type": "object",
+            "properties": {
+                "cfg": {"type": "object", "properties": {"k": {"type": "string"}}, "required": ["k"]},
+            },
+            "required": ["cfg"],
+        })
+        assert out["properties"]["cfg"]["required"] == ["k"]
+
+    def test_every_object_node_carries_a_required_array(self):
+        out = sanitize({
+            "type": "object",
+            "properties": {"o": {"type": "object", "properties": {"x": {"type": "string"}}}},
+            "required": ["o"],
+        })
+        for node in _walk(out):
+            if node.get("type") == "object":
+                assert isinstance(node.get("required"), list)
+
+
+class TestRealToolSchemas:
+    def test_no_builtin_tool_produces_a_dangling_required(self):
+        import model_tools  # noqa: F401  (triggers tool discovery)
+        from tools.registry import registry
+
+        checked = 0
+        for entry in getattr(registry, "_tools", {}).values():
+            sc = entry.get("schema") if isinstance(entry, dict) else getattr(entry, "schema", None)
+            if not isinstance(sc, dict):
+                continue
+            fn = sc.get("function") if "function" in sc else sc
+            params = fn.get("parameters") if isinstance(fn, dict) else None
+            if not isinstance(params, dict):
+                continue
+            checked += 1
+            assert _dangling(sanitize(params)) == []
+        assert checked > 0


### PR DESCRIPTION
## What does this PR do?

`agent/moonshot_schema` documents that Moonshot rejects `required` entries
naming a property the node does not declare. `_ensure_required_array` only
pruned when the node already carried a `properties` dict:

```python
if isinstance(req, list):
    if isinstance(props, dict):
        node["required"] = [r for r in req if r in props]
```

A node with `required` and **no** `properties` knows zero property names, so
every entry is dangling by definition — and that branch left them untouched.

The top-level parameters object was rescued only *incidentally*, because
`sanitize_moonshot_tool_parameters` injects `properties: {}` before the repair
runs. Nested nodes had no such rescue — and that is precisely the shape MCP
servers emit: array item schemas carrying `required` without `properties`. The
same class is called out in `agent/gemini_schema.py`:

> MCP servers routinely emit this shape (e.g. the GitHub remote MCP's array
> item schemas carry `required` without `properties`), and **one bad tool
> schema fails the ENTIRE request before any model output.**

On Moonshot it surfaces as
`tools.function.parameters is not a valid moonshot flavored json schema`.

### Reproduction (before this PR)

```python
sanitize_moonshot_tool_parameters({
    "type": "object",
    "properties": {
        "files": {"type": "array", "items": {"type": "object", "required": ["path"]}}
    },
    "required": ["files"],
})
```

```text
top level                -> {"type":"object","required":[], ...}        pruned
items (no properties)    -> {"type":"object","required":["path"]}       DANGLING, shipped
inferred object          -> {"required":["y"],"type":"object"}          DANGLING, shipped
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/moonshot_schema.py`** — `_ensure_required_array` prunes against the
  empty set when `properties` is absent or not a dict, so `required` becomes the
  empty array Moonshot's own rule 3 requires instead of shipping a name it will
  reject. Nodes with real properties keep their valid names unchanged.
- **`tests/agent/test_moonshot_schema_dangling_required.py`** — 10 tests.

## How to Test

Configure a Kimi/Moonshot provider and connect an MCP server whose tool takes an
array of objects (the GitHub remote MCP is the documented example).

- **Before:** every request 400s with
  `tools.function.parameters is not a valid moonshot flavored json schema`.
- **After:** the item schema ships `"required": []` and the request is accepted.

## Test Results

New file `tests/agent/test_moonshot_schema_dangling_required.py` — 10 tests. A
`_walk` helper checks the invariant at **every** node of the repaired output,
not just the root:

| Group | Covers |
|---|---|
| `TestNoDanglingRequiredSurvives` | the MCP array-item shape; a node whose `type` is *inferred* from `required` alone; a node nested under `anyOf`; the top level still pruned |
| `TestExistingBehaviourPreserved` | valid names survive; partial prune keeps the real name; a missing `required` still becomes `[]`; nested objects keep their valid `required`; every object node still carries a `required` array |
| `TestRealToolSchemas` | all 88 built-in tool schemas produce zero dangling names |

Red-without-fix, with only `agent/moonshot_schema.py` reverted:

```text
3 failed, 7 passed
```

With the fix:

```text
10 passed in 1.16s
```

**Regression sweep**

```text
test_moonshot_schema.py + new file:   47 passed
ruff check agent/moonshot_schema.py:  All checks passed
```