### PR TITLE
fix(tui): scope notification poller to session profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6139,6 +6139,115 @@ def test_notification_poller_delivers_owned_events(
             process_registry.completion_queue.get_nowait()
 
 
+def _delegation_delivery_row(home, delegation_id):
+    """Read one delegation's delivery columns out of *home*'s state.db."""
+    token = set_hermes_home_override(home)
+    try:
+        with ad._DB_LOCK, ad._transaction() as conn:
+            return conn.execute(
+                """SELECT delivery_state, delivery_attempts, delivered_at
+                   FROM async_delegations WHERE delegation_id=?""",
+                (delegation_id,),
+            ).fetchone()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_notification_poller_thread_acks_routed_profile_db(monkeypatch, tmp_path):
+    """The real poller thread must claim and ack in the session's profile store.
+
+    The HERMES_HOME override is a ContextVar, so a bare poller thread resolves
+    async_delegation._db_path() against the LAUNCH profile — the claim finds no
+    row there, returns None, and the completion is silently never delivered.
+    """
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profiles" / "routed"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_profile_ack",
+        "session_key": "session-a",
+        "origin_ui_session_id": "sid-profile",
+        "origin_session_id": "",
+        "status": "success",
+        "summary": "done",
+    }
+    now = time.time()
+    token = set_hermes_home_override(profile_home)
+    try:
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                """INSERT INTO async_delegations
+                   (delegation_id, origin_session, origin_ui_session_id, state,
+                    dispatched_at, completed_at, updated_at, event_json,
+                    delivery_state, delivery_attempts)
+                   VALUES (?, ?, ?, 'success', ?, ?, ?, ?, 'pending', 0)""",
+                (
+                    event["delegation_id"],
+                    event["session_key"],
+                    event["origin_ui_session_id"],
+                    now,
+                    now,
+                    now,
+                    json.dumps(event),
+                ),
+            )
+    finally:
+        reset_hermes_home_override(token)
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    turns = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text, **kwargs: turns.append((text, kwargs)),
+    )
+    session = _session(
+        session_key="session-a",
+        profile_home=str(profile_home),
+    )
+    server._sessions["sid-profile"] = session
+
+    # Spawn through the real entry point so the registry/reap bookkeeping and
+    # the thread's home binding are both exercised as production wires them.
+    stop = server._start_notification_poller("sid-profile", session)
+    worker = server._notification_pollers[-1][1]
+    assert worker.name == "tui-notif-poller-sid-profile"
+    try:
+        deadline = time.time() + 5
+        row = _delegation_delivery_row(profile_home, event["delegation_id"])
+        while row[0] != "delivered" and time.time() < deadline:
+            time.sleep(0.01)
+            row = _delegation_delivery_row(profile_home, event["delegation_id"])
+
+        assert row[0] == "delivered"
+        assert row[1] == 1
+        assert row[2] is not None
+        # The launch profile must be untouched: a claim that landed there is
+        # the bug, and it would leave the session's own row pending forever.
+        assert _delegation_delivery_row(launch_home, event["delegation_id"]) is None
+        assert len(turns) == 1
+        assert turns[0][1]["display_kind"] == "async_delegation_complete"
+        assert isolated_queue.empty()
+    finally:
+        stop.set()
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+        server._sessions.pop("sid-profile", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def _configure_immediate_prompt_run(
     monkeypatch, tmp_path, *, immediate_threads=True
 ):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4706,6 +4706,107 @@ def test_notification_poller_delivers_owned_events(
             process_registry.completion_queue.get_nowait()
 
 
+def test_notification_poller_thread_acks_routed_profile_db(monkeypatch, tmp_path):
+    """The real poller must claim and acknowledge in the session's profile store."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profiles" / "routed"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_profile_ack",
+        "session_key": "session-a",
+        "origin_ui_session_id": "sid-profile",
+        "origin_session_id": "",
+        "status": "success",
+        "summary": "done",
+    }
+    now = time.time()
+    token = set_hermes_home_override(profile_home)
+    try:
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                """INSERT INTO async_delegations
+                   (delegation_id, origin_session, origin_ui_session_id, state,
+                    dispatched_at, completed_at, updated_at, event_json,
+                    delivery_state, delivery_attempts)
+                   VALUES (?, ?, ?, 'success', ?, ?, ?, ?, 'pending', 0)""",
+                (
+                    event["delegation_id"],
+                    event["session_key"],
+                    event["origin_ui_session_id"],
+                    now,
+                    now,
+                    now,
+                    json.dumps(event),
+                ),
+            )
+    finally:
+        reset_hermes_home_override(token)
+
+    def _profile_row():
+        token = set_hermes_home_override(profile_home)
+        try:
+            with ad._DB_LOCK, ad._transaction() as conn:
+                return conn.execute(
+                    """SELECT delivery_state, delivery_attempts, delivered_at
+                       FROM async_delegations WHERE delegation_id=?""",
+                    (event["delegation_id"],),
+                ).fetchone()
+        finally:
+            reset_hermes_home_override(token)
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    turns = []
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text, **kwargs: turns.append((text, kwargs)),
+    )
+    session = _session(
+        session_key="session-a",
+        profile_home=str(profile_home),
+    )
+    server._sessions["sid-profile"] = session
+
+    stop = threading.Event()
+    worker = threading.Thread(
+        target=server._run_notification_poller_in_session_home,
+        args=(stop, "sid-profile", session),
+        daemon=True,
+    )
+    worker.start()
+    try:
+        deadline = time.time() + 5
+        row = _profile_row()
+        while row[0] != "delivered" and time.time() < deadline:
+            time.sleep(0.01)
+            row = _profile_row()
+
+        assert row[0] == "delivered"
+        assert row[1] == 1
+        assert row[2] is not None
+        assert len(turns) == 1
+        assert turns[0][1]["display_kind"] == "async_delegation_complete"
+        assert isolated_queue.empty()
+    finally:
+        stop.set()
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+        server._sessions.pop("sid-profile", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def _configure_immediate_prompt_run(
     monkeypatch, tmp_path, *, immediate_threads=True
 ):

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -604,6 +604,11 @@ class ComputeHost:
                     cwd=str(frame.get("cwd") or "") or None,
                     session_db=session_db,
                     source=frame.get("source"),
+                    # _init_session starts the notification poller, which binds
+                    # its HERMES_HOME from the session's profile_home. Set it
+                    # here rather than only on the assignment below, which lands
+                    # after that thread is already running.
+                    profile_home=profile_home or None,
                 )
             finally:
                 reset_transport(token)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10361,13 +10361,40 @@ def _wire_desktop_ui() -> None:
 _notification_pollers: list = []
 
 
+def _run_notification_poller_in_session_home(
+    stop_event: threading.Event, sid: str, session: dict
+) -> None:
+    """Run the poller bound to the profile that owns the session's durable state.
+
+    The poller claims and acknowledges delegation deliveries through
+    tools.async_delegation, whose _db_path() resolves get_hermes_home() — and
+    the HERMES_HOME override is a ContextVar, which a bare thread does not
+    inherit. Without this the poller marks events delivered in the LAUNCH
+    profile's state.db while the rows it is claiming live in the session's,
+    so a global-remote session re-delivers completions forever.
+
+    Anchored on _session_home(session) rather than on a snapshot of the
+    spawning thread's context (the propagate_context_to_thread idiom the
+    async-delegation worker uses for the same class of bug) because the spawn
+    sites do not all carry the session's override: compute_host resets it in
+    the finally that precedes its _init_session call, so a snapshot taken
+    there would capture the launch profile and reproduce the bug. The session
+    dict is authoritative on every path; read it here.
+    """
+    home_token = set_hermes_home_override(_session_home(session))
+    try:
+        _notification_poller_loop(stop_event, sid, session)
+    finally:
+        reset_hermes_home_override(home_token)
+
+
 def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     """Start the background notification poller for a TUI session."""
     _wire_agent_terminal_output()
     _wire_desktop_ui()
     stop = threading.Event()
     t = threading.Thread(
-        target=_notification_poller_loop,
+        target=_run_notification_poller_in_session_home,
         args=(stop, sid, session),
         daemon=True,
         # Stable, greppable name for debuggers and test teardowns.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9321,13 +9321,24 @@ def _wire_desktop_ui() -> None:
     _desktop_ui_wired = True
 
 
+def _run_notification_poller_in_session_home(
+    stop_event: threading.Event, sid: str, session: dict
+) -> None:
+    """Run the poller against the profile that owns the session's durable state."""
+    home_token = set_hermes_home_override(_session_home(session))
+    try:
+        _notification_poller_loop(stop_event, sid, session)
+    finally:
+        reset_hermes_home_override(home_token)
+
+
 def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     """Start the background notification poller for a TUI session."""
     _wire_agent_terminal_output()
     _wire_desktop_ui()
     stop = threading.Event()
     t = threading.Thread(
-        target=_notification_poller_loop,
+        target=_run_notification_poller_in_session_home,
         args=(stop, sid, session),
         daemon=True,
     )


### PR DESCRIPTION
## Summary

- bind each TUI notification poller to the profile home that owns its session
- keep the override active across live polling, shutdown drain, and durable delegation claim/release/complete
- add a real-thread, real-SQLite regression with separate launch and routed-profile homes

Fixes #78497

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Tests pass locally
- [x] Added tests that prove the fix is effective or that the feature works

Commands:

```bash
python -m pytest tests/test_tui_gateway_server.py::test_notification_poller_thread_acks_routed_profile_db -q
for f in tests/test_tui_gateway_server.py tests/tools/test_async_delegation.py tests/tools/test_async_delegation_fd_leak.py tests/gateway/test_async_delegation_session_binding.py tests/cli/test_cli_async_delegation_delivery.py; do python -m pytest -q "$f" || exit $?; done
python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py
python -m compileall -q tui_gateway/server.py tests/test_tui_gateway_server.py
git diff --check
```

The regression failed on unmodified current `main` by observing/acknowledging the launch home while the routed profile row remained pending, then passed with this change.

The existing `test_write_json_serializes_concurrent_writes` test was independently reproduced as flaky on untouched `f5be9236`; the baseline runner's retry passed all 517 TUI tests. It is unrelated to this change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal correctness fix with behavior captured by regression)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## AI Assistance

- [ ] None
- [ ] Light
- [ ] Moderate
- [x] Most

AI assistance was used for incident diagnosis, implementation, test construction, and review. The change was verified against isolated temporary databases and an untouched current-main baseline before publication.

## Additional Context

This is intentionally independent of the broader profile-runtime work in #78030. Current `main` already records the owning profile in `session["profile_home"]`; this PR only makes the existing notification thread honor that boundary.
