### PR TITLE
fix(config): recognize cron script timeout

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2233,6 +2233,11 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Timeout (seconds) for a no-agent cron script. Also overridable via
+        # HERMES_CRON_SCRIPT_TIMEOUT. Keep this in sync with
+        # cron.scheduler._DEFAULT_SCRIPT_TIMEOUT so config set recognizes the
+        # same setting the scheduler reads.
+        "script_timeout_seconds": 3600,
         # Timeout (seconds) for SessionDB() init inside cron jobs.
         # SessionDB opens/migrates state.db synchronously and has no timeout
         # of its own against a wedged sqlite3.connect. An unbounded hang here

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -104,6 +104,13 @@ class TestConfigYamlRouting:
         config = _read_config(_isolated_hermes_home)
         assert "python:3.12" in config
 
+    def test_cron_script_timeout_is_recognized(self, _isolated_hermes_home, capsys):
+        """The script timeout read by cron must be accepted by config set."""
+        set_config_value("cron.script_timeout_seconds", "600")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)


### PR DESCRIPTION
## Summary
- Add `cron.script_timeout_seconds` to the recognized cron configuration defaults.
- Cover `hermes config set cron.script_timeout_seconds 600` with a regression test.

## Test plan
- `uv run --extra dev pytest tests/hermes_cli/test_set_config_value.py -q`
- Temp-home CLI check: `hermes config set/get cron.script_timeout_seconds`