### PR TITLE
fix(gateway): tolerate sub-2s start-time drift in PID-reuse liveness guard (#78498)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -504,9 +504,30 @@ def _pid_from_record(record: Optional[dict[str, Any]], key: str = "pid") -> Opti
         return None
 
 
+# Drift tolerance for the start-time PID-reuse guard, in fingerprint units.
+# On macOS/Windows the fingerprint is ``psutil.create_time()`` quantized to
+# centiseconds, and that value can shift by ~1s for the *same* live process
+# across a psutil upgrade in the venv or an NTP step adjustment (issue #78498) --
+# strict equality then rejects the live PID as "recycled" and the dashboard
+# reports a healthy gateway as stopped.  200 centiseconds (~2s) absorbs that
+# drift while staying far below any realistic PID-recycling window; the
+# cmdline/profile identity checks still gate on top.  On Linux the /proc
+# start-time (integer clock ticks since boot) never drifts, so the tolerance is
+# inert there and only same-source values are ever compared.
+_START_TIME_DRIFT_TOLERANCE = 200
+
+
 def _start_times_conflict(recorded_start: Any, current_start: Any) -> bool:
-    """PID-reuse guard: True only when BOTH start times are known and differ."""
-    return None not in (recorded_start, current_start) and current_start != recorded_start
+    """PID-reuse guard: True only when BOTH start times are known and differ
+    beyond :data:`_START_TIME_DRIFT_TOLERANCE` (absorbs sub-2s create_time drift
+    on the same live process; issue #78498). Non-numeric fingerprints fall back
+    to strict inequality."""
+    if None in (recorded_start, current_start):
+        return False
+    try:
+        return abs(current_start - recorded_start) > _START_TIME_DRIFT_TOLERANCE
+    except (TypeError, ValueError):
+        return current_start != recorded_start
 
 
 def _live_pid_from_record(record: Optional[dict[str, Any]]) -> Optional[int]:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -325,6 +325,31 @@ def get_process_start_time(pid: int) -> Optional[int]:
     return _get_process_start_time(pid)
 
 
+# Drift tolerance for the start-time PID-reuse guard, in fingerprint units.
+# On macOS/Windows the fingerprint is ``psutil.create_time()`` quantized to
+# centiseconds, and that value can shift by ~1s for the *same* live process
+# across a psutil upgrade in the venv or an NTP step adjustment (issue #78498) —
+# strict equality then rejects the live PID as "recycled" and the dashboard
+# reports a healthy gateway as stopped.  200 centiseconds (~2s) absorbs that
+# drift while staying far below any realistic PID-recycling window; the
+# cmdline/profile identity checks still gate on top.  On Linux the /proc
+# start-time (integer clock ticks since boot) never drifts, so the tolerance is
+# inert there and only same-source values are ever compared.
+_START_TIME_DRIFT_TOLERANCE = 200
+
+
+def _start_times_match(recorded: Optional[int], current: Optional[int]) -> bool:
+    """Whether two start-time fingerprints identify the same live process.
+
+    Returns True when either side is unknown (``None``) — the guard rejects only
+    on a *positive* mismatch, never on missing data — or when the two
+    fingerprints are within :data:`_START_TIME_DRIFT_TOLERANCE` of each other.
+    """
+    if recorded is None or current is None:
+        return True
+    return abs(recorded - current) <= _START_TIME_DRIFT_TOLERANCE
+
+
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
@@ -1082,11 +1107,7 @@ def runtime_status_pid_is_live(record: Optional[dict[str, Any]]) -> bool:
         return False
     recorded_start = (record or {}).get("start_time")
     current_start = _get_process_start_time(pid)
-    if (
-        recorded_start is not None
-        and current_start is not None
-        and current_start != recorded_start
-    ):
+    if not _start_times_match(recorded_start, current_start):
         return False
     return True
 
@@ -1322,11 +1343,7 @@ def get_runtime_status_running_pid(
 
     recorded_start = payload.get("start_time")
     current_start = _get_process_start_time(pid)
-    if (
-        recorded_start is not None
-        and current_start is not None
-        and current_start != recorded_start
-    ):
+    if not _start_times_match(recorded_start, current_start):
         return None
 
     if _record_matches_live_gateway_pid(payload, pid, expected_home=expected_home):
@@ -2189,7 +2206,7 @@ def get_running_pid(
 
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)
-        if recorded_start is not None and current_start is not None and current_start != recorded_start:
+        if not _start_times_match(recorded_start, current_start):
             continue
 
         if _record_matches_live_gateway_pid(record, pid):

--- a/tests/gateway/test_78498_start_time_drift_tolerance.py
+++ b/tests/gateway/test_78498_start_time_drift_tolerance.py
@@ -1,0 +1,64 @@
+"""Regression tests for #78498.
+
+The gateway liveness PID-reuse guard compared start-time fingerprints with
+strict equality.  On macOS/Windows the fingerprint comes from
+``psutil.create_time()`` quantized to centiseconds, and that value can shift by
+~1s for the *same* live process across a psutil upgrade in the venv or an NTP
+step adjustment.  Every liveness probe then rejected the live PID as recycled
+and the dashboard reported a healthy gateway as ``gateway_running: false``.
+
+The unified guard (``_start_times_conflict``) now tolerates a small (~2s) drift
+while still catching a genuine PID reuse (fingerprints far apart), with the
+cmdline/profile identity checks gating on top.  The deliberate strict-identity
+force-kill path (``_start_times_agree``, 1ms) is intentionally left untouched.
+"""
+
+from gateway import status
+
+
+class TestStartTimesConflict:
+    def test_tolerates_drift_but_catches_reuse(self):
+        """No conflict within the drift tolerance or when a fingerprint is
+        unknown (``None`` -> never a positive mismatch); a gap beyond the
+        tolerance (a recycled PID) is still a conflict."""
+        tol = status._START_TIME_DRIFT_TOLERANCE
+        assert status._start_times_conflict(1000, 1000) is False
+        assert status._start_times_conflict(1000, 1000 - tol) is False
+        assert status._start_times_conflict(1000, 1000 + tol) is False
+        assert status._start_times_conflict(1000, 1000 - (tol + 1)) is True
+        assert status._start_times_conflict(1000, 1000 + (tol + 1)) is True
+        # Unknown on either side must not be treated as a conflict.
+        assert status._start_times_conflict(None, 1000) is False
+        assert status._start_times_conflict(1000, None) is False
+        assert status._start_times_conflict(None, None) is False
+
+
+class TestLivePidFromRecordDrift:
+    """``_live_pid_from_record`` is the chokepoint feeding both liveness read
+    paths (``runtime_status_pid_is_live`` and ``get_running_pid``)."""
+
+    def _record(self, recorded: int) -> dict:
+        return {"pid": 4242, "start_time": recorded}
+
+    def test_tolerates_subsecond_start_time_drift(self, monkeypatch):
+        """A sub-2s drift for the SAME live process must still resolve the PID.
+        ``psutil.create_time()`` shifted ~1s (100 centiseconds) after a psutil
+        upgrade / NTP step; strict equality wrongly rejected the PID."""
+        recorded = 178526682901  # observed at spawn (issue #78498)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        # Same live process reads back exactly 1.00s (100 centiseconds) lower.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: recorded - 100)
+
+        assert status._live_pid_from_record(self._record(recorded)) == 4242
+        assert status.runtime_status_pid_is_live(self._record(recorded)) is True
+
+    def test_still_rejects_large_start_time_gap(self, monkeypatch):
+        """A start-time gap beyond the drift tolerance is a genuinely different
+        process on a recycled PID and must remain rejected."""
+        recorded = 178526682901
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        # 5s apart -> a different process; the guard must still reject it.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: recorded - 500)
+
+        assert status._live_pid_from_record(self._record(recorded)) is None
+        assert status.runtime_status_pid_is_live(self._record(recorded)) is False

--- a/tests/gateway/test_78498_start_time_drift_tolerance.py
+++ b/tests/gateway/test_78498_start_time_drift_tolerance.py
@@ -1,0 +1,71 @@
+"""Regression tests for #78498.
+
+The gateway liveness PID-reuse guard compared start-time fingerprints with
+strict equality.  On macOS/Windows the fingerprint comes from
+``psutil.create_time()`` quantized to centiseconds, and that value can shift by
+~1s for the *same* live process across a psutil upgrade in the venv or an NTP
+step adjustment.  Every liveness probe then rejected the live PID as recycled
+and the dashboard reported a healthy gateway as ``gateway_running: false``.
+
+The guard now tolerates a small (~2s) drift while still catching a genuine PID
+reuse (fingerprints far apart), with the cmdline/profile identity checks gating
+on top.
+"""
+
+from gateway import status
+
+
+class TestStartTimesMatch:
+    def test_tolerates_drift_but_catches_reuse(self):
+        """Matches within the drift tolerance and on a ``None`` on either side
+        (unknown fingerprint → never a positive mismatch), but rejects a gap
+        beyond the tolerance (a recycled PID)."""
+        tol = status._START_TIME_DRIFT_TOLERANCE
+        assert status._start_times_match(1000, 1000) is True
+        assert status._start_times_match(1000, 1000 - tol) is True
+        assert status._start_times_match(1000, 1000 + tol) is True
+        assert status._start_times_match(1000, 1000 - (tol + 1)) is False
+        assert status._start_times_match(1000, 1000 + (tol + 1)) is False
+        # Unknown on either side must not be treated as a mismatch.
+        assert status._start_times_match(None, 1000) is True
+        assert status._start_times_match(1000, None) is True
+        assert status._start_times_match(None, None) is True
+
+
+class TestRuntimeStatusRunningPidDrift:
+    def _payload(self, recorded: int) -> dict:
+        return {
+            "pid": 4242,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": recorded,
+        }
+
+    def test_tolerates_subsecond_start_time_drift(self, monkeypatch):
+        """A sub-2s drift for the SAME live process must still be reported
+        running.  ``psutil.create_time()`` shifted ~1s (100 centiseconds) after
+        a psutil upgrade / NTP step; strict equality wrongly rejected the PID.
+        """
+        recorded = 178526682901  # observed at spawn (issue #78498)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes gateway run"
+        )
+        # Same live process reads back exactly 1.00s (100 centiseconds) lower.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: recorded - 100)
+
+        assert status.get_runtime_status_running_pid(self._payload(recorded)) == 4242
+
+    def test_still_rejects_large_start_time_gap(self, monkeypatch):
+        """A start-time gap beyond the drift tolerance is a genuinely different
+        process on a recycled PID and must remain rejected."""
+        recorded = 178526682901
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes gateway run"
+        )
+        # 5s apart → a different process; the guard must still reject it.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: recorded - 500)
+
+        assert status.get_runtime_status_running_pid(self._payload(recorded)) is None


### PR DESCRIPTION
## Problem

Fixes #78498.

The dashboard (and every liveness probe backed by `gateway/status.py`) reported a healthy, long-running gateway as **stopped** (`gateway_running: false`, `gateway_state: stopped`) while the process was alive with a fresh `gateway_state.json` heartbeat.

**Root cause:** the PID-reuse guard compares start-time fingerprints with strict equality. On macOS/Windows the fingerprint comes from `psutil.Process(pid).create_time()`, and that value can shift by ~1s for the *same* live process across a psutil upgrade in the venv (or an NTP step). Observed for the same PID:

- recorded at spawn: `178526682901`
- read back later:   `178526682801`

Exactly 100 centiseconds (1.00s) apart. Every read-path probe (`get_running_pid`, `get_runtime_status_running_pid`, `runtime_status_pid_is_live`) then rejected the live PID as recycled. It's worst when `gateway.pid`/`gateway.lock` are absent (e.g. after a `--replace` handoff), where the `gateway_state.json` fallback is the only liveness path.

## Fix

Introduce a shared `_start_times_match(recorded, current)` helper with a **2s (200-centisecond) drift tolerance** and apply it to the three liveness **read** paths:

- `runtime_status_pid_is_live`
- `get_runtime_status_running_pid`
- `get_running_pid`

The tolerance stays far below any realistic PID-recycling window, and the existing cmdline/profile identity checks still gate on top (defense in depth). On Linux the `/proc` start-time (integer clock ticks since boot) never drifts, so the tolerance is inert there and only same-source values are ever compared.

The deliberate strict-identity **lock-ownership / marker** paths (`acquire_scoped_lock`, `release_*_scoped_lock`, planned-stop/takeover markers) are intentionally left unchanged — those encode a different safety property and are out of scope for this liveness fix.

## Tests

`tests/gateway/test_78498_start_time_drift_tolerance.py`:
- `_start_times_match` matches within tolerance / on `None`, rejects beyond tolerance.
- `get_runtime_status_running_pid` now reports running under the exact 1.00s drift from the issue, and still rejects a 5s gap (genuine reuse).

Existing `tests/gateway/test_status.py` (54 tests, incl. the PID-reuse regressions) still pass.

> Note: the arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.
