### PR TITLE
fix(security): redact credentials from outbound webhook payloads

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -84,6 +84,12 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib import error as urlerror
 from urllib import request as urlrequest
 
+from agent.redact import redact_sensitive_text
+
+#: Depth bound for payload redaction. Hook extras are shallow dicts; this only
+#: exists so a pathological structure cannot cause unbounded recursion.
+_REDACT_MAX_DEPTH = 12
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 10
@@ -428,7 +434,49 @@ def _serialize_payload(
         .isoformat()
         .replace("+00:00", "Z"),
     }
-    return json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8")
+    return json.dumps(
+        _redact_payload(payload), ensure_ascii=False, default=str
+    ).encode("utf-8")
+
+
+def _redact_payload(value: Any) -> Any:
+    """Mask credentials in every string reachable from an outbound payload.
+
+    ``tool_input`` and the per-event extras carry raw tool arguments and tool
+    output — ``export OPENAI_API_KEY=...``, ``curl -H "Authorization: ..."``,
+    the contents of a written ``.env``. The terminal path masks exactly this
+    material before the model or the session DB sees it; without the same pass
+    here an outbound webhook ships it verbatim to a receiver outside the trust
+    boundary, in cleartext when the configured URL is plain ``http://``.
+
+    Redaction walks the structure and rewrites the *leaf strings* rather than
+    the serialised body. Masking the finished JSON text corrupts the envelope:
+    a mask emitted inside a quoted value can introduce characters that break
+    the string, and a receiver that cannot parse the delivery has merely traded
+    a leak for an outage. Walking first means ``json.dumps`` re-escapes every
+    value afterwards, so the envelope is always well formed.
+
+    Recursion is depth-bounded; anything deeper is serialised by ``default=str``
+    anyway. Redaction never raises — a failure to mask one value must not drop
+    an entire delivery, and the surrounding values are still masked.
+    """
+    return _redact_value(value, 0)
+
+
+def _redact_value(value: Any, depth: int) -> Any:
+    if depth > _REDACT_MAX_DEPTH:
+        return value
+    if isinstance(value, str):
+        try:
+            return redact_sensitive_text(value)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("payload redaction failed for one value", exc_info=True)
+            return value
+    if isinstance(value, dict):
+        return {k: _redact_value(v, depth + 1) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact_value(v, depth + 1) for v in value]
+    return value
 
 
 def _build_delivery(

--- a/tests/agent/test_outbound_webhook_redaction.py
+++ b/tests/agent/test_outbound_webhook_redaction.py
@@ -1,0 +1,118 @@
+"""Outbound webhook payloads must not carry credentials off-box.
+
+``tool_input`` and the per-event extras contain raw tool arguments and tool
+output — ``export OPENAI_API_KEY=...``, ``curl -H "Authorization: ..."``, the
+body of a written ``.env``. The terminal path masks exactly this material
+before the model or the session DB sees it. Without the same pass here an
+outbound delivery ships it verbatim to a receiver outside the trust boundary,
+in cleartext when the configured URL is plain ``http://``.
+
+The envelope must survive redaction: masking the serialised JSON text can
+break a quoted value, and a receiver that cannot parse the delivery has traded
+a leak for an outage.
+
+All tokens are synthesised.
+"""
+
+import json
+import secrets
+
+import pytest
+
+from agent.outbound_webhooks import _serialize_payload
+
+TOKEN = "sk-" + secrets.token_hex(24)
+BEARER = "Bearer " + secrets.token_hex(20)
+
+
+def _body(kwargs, event="pre_tool_call"):
+    return _serialize_payload(event, kwargs, "delivery-test").decode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"tool_name": "terminal",
+                      "args": {"command": f"export OPENAI_API_KEY={TOKEN}"}},
+                     id="env-assignment"),
+        pytest.param({"tool_name": "terminal",
+                      "args": {"command": f'export K="{TOKEN}"'}},
+                     id="quoted-value"),
+        pytest.param({"tool_name": "write_file",
+                      "args": {"path": "/tmp/.env",
+                               "content": f"A=1\nKEY={TOKEN}\nB=2"}},
+                     id="multiline-file-body"),
+        pytest.param({"tool_name": "terminal", "args": {"command": "ls"},
+                      "result": {"env": {"OPENAI_API_KEY": TOKEN}}},
+                     id="nested-in-result"),
+        pytest.param({"tool_name": "write_file",
+                      "args": {"path": "/tmp/c.json",
+                               "content": json.dumps({"api_key": TOKEN})}},
+                     id="json-inside-json"),
+        pytest.param({"tool_name": "terminal",
+                      "args": {"command": f"echo € {TOKEN} ✓"}},
+                     id="unicode-neighbours"),
+    ],
+)
+def test_credentials_do_not_reach_the_wire(kwargs):
+    body = _body(kwargs)
+    assert TOKEN not in body
+
+
+def test_authorization_header_is_masked_without_breaking_json():
+    """The bearer shape is the one that corrupted a whole-body redaction."""
+    body = _body({"tool_name": "terminal",
+                  "args": {"command": f'curl -H "Authorization: {BEARER}" https://a/b'}})
+    assert BEARER.split()[-1] not in body
+    json.loads(body)  # must still parse
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"tool_name": "terminal", "args": {"command": f"export K={TOKEN}"}},
+        {"tool_name": "read_file", "args": {"path": "/tmp/notes.md"}},
+        {"tool_name": "terminal", "args": {}},
+        {"tool_name": "terminal", "args": {"command": "ls"},
+         "result": {"deep": {"deeper": {"deepest": TOKEN}}}},
+    ],
+)
+def test_envelope_stays_valid_json(kwargs):
+    parsed = json.loads(_body(kwargs))
+    for key in ("hook_event_name", "tool_name", "tool_input", "session_id",
+                "cwd", "extra", "delivery_id", "timestamp"):
+        assert key in parsed
+
+
+def test_non_secret_content_is_preserved():
+    """Redaction must not mangle ordinary tool arguments."""
+    body = _body({"tool_name": "terminal",
+                  "args": {"command": "git log --oneline -5"}})
+    assert "git log --oneline -5" in body
+    body = _body({"tool_name": "read_file", "args": {"path": "/tmp/notes.md"}})
+    assert "/tmp/notes.md" in body
+
+
+def test_signature_covers_the_redacted_body():
+    """The HMAC must be computed over what is actually sent."""
+    import hashlib
+    import hmac as hmac_mod
+
+    from agent.outbound_webhooks import _build_delivery, iter_configured_targets
+
+    secret = "test-signing-secret"
+    target = next(iter(iter_configured_targets(
+        {"hooks": {"outbound": [{"url": "https://example.invalid/hook",
+                                 "events": ["pre_tool_call"],
+                                 "secret": secret}]}})))
+    body = _serialize_payload(
+        "pre_tool_call",
+        {"tool_name": "terminal", "args": {"command": f"export K={TOKEN}"}},
+        "delivery-test",
+    )
+    delivery = _build_delivery("pre_tool_call", target, body, "delivery-test")
+
+    assert delivery["body"] == body
+    assert TOKEN not in body.decode("utf-8")
+    expected = hmac_mod.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    assert delivery["headers"]["X-Hermes-Signature-256"] == f"sha256={expected}"


### PR DESCRIPTION
Outbound webhook events carry `tool_input` and the per-event extras straight
from the hook kwargs. Those hold raw tool arguments and tool output —
`export OPENAI_API_KEY=…`, `curl -H "Authorization: …"`, the body of a written
`.env`. `agent/outbound_webhooks.py` imports no redactor, so a delivery ships
them verbatim to a receiver **outside the trust boundary** — in cleartext when
the configured URL is plain `http://`, a case the config parser already warns
about:

> `hooks.outbound[0].url uses plain http:// — payloads (including tool inputs)
> travel unencrypted.`

The terminal path masks exactly this material before the model or the session
DB sees it. This closes that asymmetry.

## Reproduced end to end, not at unit level

Registered a target against a real local HTTP listener, emitted `pre_tool_call`
through the normal hook path, and read what the server received:

```
deliveries received on the wire: 1
full credential present in the delivered body: True     <- before
full credential present in the delivered body: False    <- after
payload keys delivered: cwd, delivery_id, extra, hook_event_name,
                        session_id, timestamp, tool_input, tool_name
```

The key was a synthesised 51-character `sk-…`; nothing real was used.

## Why leaf-string redaction rather than masking the body

Masking the serialised JSON text corrupts the envelope — a mask emitted inside
a quoted value can break the string. A payload-shape sweep caught it:

| shape | mask the body | walk the payload |
|---|---|---|
| plain / quoted / multiline / unicode / nested / JSON-in-JSON | valid JSON | valid JSON |
| `Authorization: Bearer …` | **invalid JSON** | valid JSON |
| **totals** | 1/10 unparseable | **0/10 unparseable** |

A receiver that cannot parse the delivery has only traded a leak for an outage.
Walking the structure first lets `json.dumps` re-escape every value, so the
envelope is well formed by construction.

Both approaches masked 10/10 keys — the difference is entirely in whether the
delivery survives.

## Details

- Redaction happens before serialisation; the HMAC is computed after, so
  `X-Hermes-Signature-256` covers exactly the bytes that are sent (asserted in
  the tests).
- Recursion is depth-bounded (12); hook extras are shallow, this only stops a
  pathological structure.
- A redaction failure on one value is logged and skipped rather than dropping
  the delivery.

## Tests

`tests/agent/test_outbound_webhook_redaction.py`, 13 cases: six payload shapes
that must not leak, the Authorization shape asserted to both mask and parse,
envelope-integrity checks over all eight payload keys, non-secret arguments
preserved verbatim, and the signature-covers-the-redacted-body invariant.

Verified against clean `upstream/main`: **8 of the new tests fail there**, so
they exercise the fix rather than passing regardless. On this branch the new
file plus the existing `test_outbound_webhooks.py` are green — 44 tests, 0
failures.

## Limits, stated plainly

`redact_sensitive_text` masks recognised credential shapes. An opaque
site-specific secret with no distinctive prefix still passes through — this
closes the asymmetry with the terminal path, it does not make the payload
provably secret-free. There is also no opt-out, so an operator who deliberately
wants raw payloads for debugging loses that; happy to add a per-target flag if
you'd prefer.
