### PR TITLE
fix: lifecycle guard crashes on referenced scripts with embedded NUL byte paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -331,6 +331,12 @@ def _contains_unsafe_gateway_action(
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+            # The remote fallback may return raw binary decoded as text (e.g.
+            # `cat` of an ELF executable). NUL bytes mean binary — treat as
+            # "nothing to scan", mirroring the local-path NUL guard above,
+            # so a binary can't explode the recursion or false-positive.
+            if script_text and "\x00" in script_text:
+                script_text = None
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths. ValueError: a path containing an
+        # embedded NUL byte (e.g. a binary's decoded contents tokenized as a
+        # path) — os.open raises ValueError for those, and a guarded path
+        # must never crash the guard (#76762). Treat both as "nothing to scan".
         return None, False
     try:
         metadata = os.fstat(descriptor)


### PR DESCRIPTION
## Bug
`cron/lifecycle_guard.py` crashes with `ValueError: embedded null byte` inside `_read_referenced_script` when a command references a script whose scanned contents yield a path containing a NUL byte.

Observed on the `terminal` tool: any command referencing certain scripts (e.g. `python /home/user/scripts/bitaxe_thermal_guard.py`) fails with:

```
File "cron/lifecycle_guard.py", line 260, in _read_referenced_script
    descriptor = os.open(path, flags)
ValueError: embedded null byte
```

## Root cause
`_iter_referenced_shell_scripts` can yield a path containing an embedded NUL byte (binary/decoded content tokenized as a path — the exact case #76762 documents). `_contains_unsafe_gateway_action` already guards `script_path.resolve()` with `except (OSError, ValueError)` (lines 315-320), but then passes the **original** `script_path` to `_read_referenced_script`, whose `os.open` only catches `OSError`. `os.open` raises `ValueError` for NUL-containing paths, which escapes and crashes the guard (and therefore the tool call).

## Fix
Catch `ValueError` alongside `OSError` in `_read_referenced_script` and treat it as "nothing to scan" — consistent with the documented intent that a guarded path must never crash the guard.

## Test
- `_read_referenced_script(Path("/path/to/file\x00foo"))` now returns `(None, False)` instead of raising.
- Normal script scanning unaffected.