### PR TITLE
fix(security): block writes to every credential store the read guard hides

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -25,10 +25,40 @@ def _hermes_root_path() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+# Credential / secret stores that live under HERMES_HOME (and, when a profile
+# is active, ALSO under the global Hermes root — a profile session must not
+# reach the root copies either, #15981 / #14157).
+#
+# ONE list feeds both guards. They used to be maintained separately and had
+# drifted: the read guard blocked ``auth.json``, ``auth.lock``,
+# ``webhook_subscriptions.json``, ``auth/google_oauth.json`` and the plaintext
+# ``cache/bws_cache.json``, none of which the write guard knew about — so the
+# agent could not READ its own OAuth store but could freely OVERWRITE it,
+# destroying every provider login. In the other direction the write guard knew
+# only the ENCRYPTED ``cache/bws_cache.enc.json`` while the read guard knew
+# only the plaintext spelling, so each list was missing the other's file.
+# Both spellings are real (``agent/secret_sources/bitwarden.py``).
+HERMES_CREDENTIAL_FILE_NAMES: tuple[str, ...] = (
+    "auth.json",
+    "auth.lock",
+    ".anthropic_oauth.json",
+    ".env",
+    "webhook_subscriptions.json",
+    os.path.join("auth", "google_oauth.json"),
+    os.path.join("cache", "bws_cache.json"),
+    os.path.join("cache", "bws_cache.enc.json"),
+)
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
     hermes_root = _hermes_root_path()
+    hermes_credential_paths = [
+        str(base / name)
+        for base in (hermes_home, hermes_root)
+        for name in HERMES_CREDENTIAL_FILE_NAMES
+    ]
     return {
         os.path.realpath(p)
         for p in [
@@ -36,19 +66,7 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".ssh", "id_rsa"),
             os.path.join(home, ".ssh", "id_ed25519"),
             os.path.join(home, ".ssh", "config"),
-            # Active profile .env (or top-level .env when not in profile mode).
-            str(hermes_home / ".env"),
-            # Top-level .env, even when running under a profile — overwriting it
-            # leaks credentials across every profile that inherits from root (#15981).
-            str(hermes_root / ".env"),
-            # Active profile Anthropic PKCE credential store.
-            str(hermes_home / ".anthropic_oauth.json"),
-            # Top-level Anthropic PKCE credential store remains sensitive even
-            # when a profile is active; default/non-profile sessions still read it.
-            str(hermes_root / ".anthropic_oauth.json"),
-            # Bitwarden Secrets Manager encrypted disk cache.
-            str(hermes_home / "cache" / "bws_cache.enc.json"),
-            str(hermes_root / "cache" / "bws_cache.enc.json"),
+            *hermes_credential_paths,
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
@@ -271,18 +289,9 @@ def get_read_block_error(path: str) -> Optional[str]:
 
     # Credential / secret stores. Exact-file matches under either
     # HERMES_HOME or <root>.
-    credential_file_names = (
-        "auth.json",
-        "auth.lock",
-        ".anthropic_oauth.json",
-        ".env",
-        "webhook_subscriptions.json",
-        os.path.join("auth", "google_oauth.json"),
-        # Bitwarden Secrets Manager disk cache: stores plaintext secret values
-        # to avoid re-fetching across back-to-back CLI invocations. The file
-        # was introduced by #31968 but not added to this guard.
-        os.path.join("cache", "bws_cache.json"),
-    )
+    # Shared with the write denylist so the two guards cannot drift again —
+    # see HERMES_CREDENTIAL_FILE_NAMES.
+    credential_file_names = HERMES_CREDENTIAL_FILE_NAMES
     for hd in hermes_dirs:
         for name in credential_file_names:
             try:

--- a/tests/agent/test_file_safety_credential_guard_parity.py
+++ b/tests/agent/test_file_safety_credential_guard_parity.py
@@ -1,0 +1,95 @@
+"""Every credential store the read guard hides must also be write-protected.
+
+``agent/file_safety`` kept two hand-maintained lists and they had drifted. The
+read guard blocked ``auth.json``, ``auth.lock``, ``webhook_subscriptions.json``,
+``auth/google_oauth.json`` and the plaintext ``cache/bws_cache.json``; the write
+denylist knew none of them. The agent therefore could not READ its own OAuth
+store but could freely OVERWRITE it — one ``write_file`` and every provider
+login is gone, with no backup and no undo.
+
+The drift ran the other way too: the write list knew only the ENCRYPTED
+``cache/bws_cache.enc.json`` while the read list knew only the plaintext
+spelling, so each guard was missing the other's file. Both are real
+(``agent/secret_sources/bitwarden.py`` writes both).
+
+Both guards now read one list, so the pairing is asserted rather than assumed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.file_safety import (
+    HERMES_CREDENTIAL_FILE_NAMES,
+    get_read_block_error,
+    is_write_denied,
+)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+    return home
+
+
+def _touch(home: Path, rel: str) -> Path:
+    p = home / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("secret", encoding="utf-8")
+    return p
+
+
+@pytest.mark.parametrize("rel", HERMES_CREDENTIAL_FILE_NAMES)
+class TestCredentialStoresAreBlockedBothWays:
+    def test_read_is_blocked(self, hermes_home, rel):
+        assert get_read_block_error(str(_touch(hermes_home, rel))) is not None
+
+    def test_write_is_blocked(self, hermes_home, rel):
+        assert is_write_denied(str(_touch(hermes_home, rel))) is True
+
+
+class TestTheSpecificFilesThatWereWritable:
+    """Named explicitly so a future edit to the shared list can't silently
+    drop one of the five that were reachable."""
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "auth.json",
+            "auth.lock",
+            "webhook_subscriptions.json",
+            "auth/google_oauth.json",
+            "cache/bws_cache.json",
+        ],
+    )
+    def test_no_longer_overwritable(self, hermes_home, rel):
+        assert is_write_denied(str(_touch(hermes_home, rel))) is True
+
+    def test_both_bitwarden_cache_spellings_are_covered(self, hermes_home):
+        for rel in ("cache/bws_cache.json", "cache/bws_cache.enc.json"):
+            p = _touch(hermes_home, rel)
+            assert is_write_denied(str(p)) is True
+            assert get_read_block_error(str(p)) is not None
+
+
+class TestOrdinaryFilesUnaffected:
+    def test_skill_file_stays_writable(self, hermes_home):
+        assert is_write_denied(str(_touch(hermes_home, "skills/mine/SKILL.md"))) is False
+
+    def test_project_file_stays_writable(self, tmp_path, hermes_home):
+        p = tmp_path / "project" / "main.py"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        assert is_write_denied(str(p)) is False
+
+    def test_env_example_stays_writable(self, tmp_path, hermes_home):
+        p = tmp_path / "project" / ".env.example"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        assert is_write_denied(str(p)) is False


### PR DESCRIPTION
## What does this PR do?

`agent/file_safety` kept **two hand-maintained lists** of Hermes credential
files — one for the read guard, one for the write denylist — and they drifted.

### Where the drift came from

| commit | date | what it did |
|---|---|---|
| 056e00a77 | 2026-04-29 | *fix(file-safety): block read_file on HERMES_HOME credential stores (#17656)* — created the **read** guard with `auth.json`, `auth.lock`, `webhook_subscriptions.json`, `auth/google_oauth.json` |
| 4694524de | 2026-05-22 | *fix(security): restrict write access to Anthropic OAuth credential store* — added `.anthropic_oauth.json` to the **write** list |
| 4126da65a | 2026-05-25 | *fix(security): add bws_cache.json to file_safety read guard* — added the plaintext Bitwarden cache to the **read** guard |

The write list was grown independently and never received the four names
`056e00a77` put in the read list. So the agent could not READ its own OAuth
store but could freely **OVERWRITE** it — one `write_file` and every provider
login is gone, with no backup and no undo.

Measured against the real guards under a temp `HERMES_HOME`:

```text
file under HERMES_HOME            read blocked  write blocked
--------------------------------------------------------------
auth.json                                 True          False
auth.lock                                 True          False
.anthropic_oauth.json                     True           True
.env                                      True           True
webhook_subscriptions.json                True          False
auth/google_oauth.json                    True          False
cache/bws_cache.json                      True          False
cache/bws_cache.enc.json                 False           True
```

The drift ran **both** ways — see the last two rows. `4126da65a` added the
*plaintext* `bws_cache.json` to the read guard; the write list only ever had the
*encrypted* `bws_cache.enc.json`. Each guard was blind to the other's file, and
both are real: `agent/secret_sources/bitwarden.py` defines
`_DISK_CACHE_BASENAME = "bws_cache.json"` **and** `_ENCRYPTED_CACHE_BASENAME =
"bws_cache.enc.json"`, and `4126da65a`'s own message notes the plaintext one
"stores plaintext secret values".

`auth.json` is the sharpest case: it is the Nous Portal / Codex / Anthropic
OAuth store. The read guard's docstring calls these "credential / secret stores
… that the agent never needs to read directly" — but nothing stopped it from
truncating them.

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/file_safety.py`** — one source of truth,
  `HERMES_CREDENTIAL_FILE_NAMES`, now feeds **both** guards. Adding a seventh
  entry to a list that has already drifted twice would only set up the next
  drift.
- **`agent/file_safety.py`** — `build_write_denied_paths` expands that list over
  **both** the active `HERMES_HOME` and the global Hermes root — the widening
  `#15981` / `#14157` already established for `.env`, so a profile session can't
  clobber the root copies either.
- **`tests/agent/test_file_safety_credential_guard_parity.py`** — 25 tests.

Nothing outside that list changes: `~/.ssh/*`, `/etc/*`, `.netrc`, the
`mcp-tokens/` and `pairing/` prefixes, `state.db` and `sessions/` keep their
existing handling.

## How to Test

```python
from agent.file_safety import get_read_block_error, is_write_denied
p = "<HERMES_HOME>/auth.json"
get_read_block_error(p)   # blocked, before and after
is_write_denied(p)        # False before  ->  True after
```

Then confirm ordinary paths are untouched: a skill file under
`HERMES_HOME/skills/`, a project source file, and `.env.example` stay writable.

## Test Results

New file `tests/agent/test_file_safety_credential_guard_parity.py` — 25 tests
driving the real guards against a real temp `HERMES_HOME`:

| Group | Covers |
|---|---|
| `TestCredentialStoresAreBlockedBothWays` | parametrised over the shared list — every entry must be blocked for **read and write**, so the two guards cannot drift again |
| `TestTheSpecificFilesThatWereWritable` | the five that were reachable, named explicitly so a future edit can't silently drop one; plus both Bitwarden spellings |
| `TestOrdinaryFilesUnaffected` | skill files, project sources and `.env.example` stay writable |

Red-without-fix, with the write list reverted to its previous six entries (the
shared constant kept so the module still imports):

```text
11 failed, 14 passed
```

With the fix:

```text
25 passed in 0.68s
```

**Regression sweep** — file-safety, write-approval and file-tools suites, both
sides on the same `main`:

```text
baseline (change stashed):  20 failed, 132 passed
with this fix:              20 failed, 157 passed
new failures introduced:    none
```

The +25 is exactly this PR's tests. The 20 pre-existing failures are unrelated
tilde-expansion and live-file-tool cases that fail identically without this
change.

```text
ruff check agent/file_safety.py:  All checks passed
```