### PR TITLE
feat: non-blocking /compress — background LLM thread with input queuing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4632,6 +4632,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._agent_running = False
         self._pending_input = queue.Queue()
         self._interrupt_queue = queue.Queue()
+        # Async /compress: background thread + input queuing.
+        self._compress_in_progress = False
+        self._compress_pending = deque()
         # Tracks whether the turn that just finished was interrupted via
         # Ctrl+C. Consumed by _maybe_continue_goal_after_turn so /goal loops
         # don't auto-queue another continuation on top of a user-cancelled
@@ -11051,7 +11054,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
 
         original_count = len(self.conversation_history)
-        with self._busy_command("Compressing context...", blocks_input=False):
+        # Show busy state immediately so the TUI spinner fires, then run the
+        # LLM compression on a background thread so the user can keep typing.
+        # Input submitted during compression is queued and processed after.
+        if self._compress_in_progress:
+            print("🗜️  Compression already in progress...")
+            return
+        self._command_running = True
+        self._command_blocks_input = False
+        self._command_status = "Compressing context..."
+        self._invalidate(min_interval=0.0)
+        self._compress_in_progress = True
+        print(f"⏳ Compressing context...")
+
+        def _run_compress():
             try:
                 from agent.model_metadata import estimate_request_tokens_rough
                 from agent.manual_compression_feedback import summarize_manual_compression
@@ -11192,6 +11208,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     committed=False,
                 )
                 print(f"  ❌ Compression failed: {e}")
+            finally:
+                self._compress_in_progress = False
+                self._command_running = False
+                self._command_status = ""
+                self._invalidate(min_interval=0.0)
+                # Drain queued input that arrived during compression.
+                while self._compress_pending:
+                    payload = self._compress_pending.popleft()
+                    self._pending_input.put(payload)
+
+        import threading
+        threading.Thread(target=_run_compress, daemon=True).start()
 
 
 
@@ -15310,6 +15338,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
+                # If async /compress is running on a background thread,
+                # queue the input for processing after compression completes.
+                if self._compress_in_progress:
+                    self._compress_pending.append(
+                        (text, list(self._attached_images)) if has_images else text
+                    )
+                    self._attached_images.clear()
+                    event.app.current_buffer.reset(append_to_history=True)
+                    event.app.invalidate()
+                    _cprint(f"  🗜️  Input queued — compress in progress")
+                    return
                 # Handle /model directly on the UI thread so interactive pickers
                 # can safely use prompt_toolkit terminal handoff helpers.
                 if self._should_handle_model_command_inline(text, has_images=has_images):


### PR DESCRIPTION
## Problem
When the user runs `/compress`, the CLI becomes unresponsive until the LLM compression call completes. For large conversation histories this can take 10–30 seconds. During this time:

- The TUI spinner shows, but the input composer is effectively blocked — the user can type but hitting Enter does nothing visible until compression finishes.
- If the user submits input during compression, it is silently eaten (never processed).

This creates a sharp friction point in long sessions where `/compress` is most needed.

## Solution

Three small, targeted changes to `cli.py`:

### 1. Background thread (`_manual_compress`)
The compression LLM call is moved from the synchronous `_busy_command` context manager into a `threading.Thread(target=..., daemon=True)`. The thread:
- Sets `_compress_in_progress = True` (guard against concurrent invocations)
- Sets `_command_blocks_input = False` so the TUI composer remains fully writable
- Runs the existing compression logic **unchanged**
- In a `finally` block: resets all state flags and drains any queued input into `_pending_input`

### 2. Input queuing (`handle_enter` → `_compress_pending`)
If the user presses Enter while `_compress_in_progress` is `True`:
- The input text (with attached images) is appended to `_compress_pending` deque
- The buffer is reset and a placeholder hint "🗜️ Input queued — compress in progress" is printed
- Normal input handling is **not** invoked — avoids race conditions with compression
- After compression finishes, the `finally` block drains `_compress_pending` into `_pending_input`, which is then consumed by the normal `process_loop`

### 3. Concurrency guard
If `/compress` is issued during an already-running compression, a warning is printed and the duplicate is dropped.

## Design decisions

| Decision | Rationale |
|----------|-----------|
| `threading.Thread` (not `asyncio`) | The TUI loop is synchronous (`prompt_toolkit` event loop). Using `asyncio` would require refactoring the entire event handling pipeline. A daemon thread is the minimal, safe bolt-on. |
| `deque` for pending input | `handle_enter` runs on the UI thread; appending to a deque is lock-free in CPython thanks to the GIL. No additional synchronization needed. |
| `_busy_command` not used | `_busy_command` blocks the main thread (it `sleep`s). We bypass it entirely and set its internal state flags directly (`_command_running`, `_command_blocks_input`, `_command_status`). |
| Compress logic unchanged | The `_run_compress()` inner function wraps the **exact same** LLM call, error handling, and compression result application. Only the threading boundary is new. |
| No `Queue` for pending input | A `collections.deque` is sufficient — consumed in the `finally` block after the thread joins implicitly (daemon thread). No producer/consumer cross-thread coordination needed. |

## Changes

- `cli.py`: 40 additions, 1 deletion
- 3 insertion points: `__init__` (state vars), `_manual_compress` (threading), `handle_enter` (queuing)

## Testing

- Manual testing: `/compress` in a session with ~200 messages — TUI composer stayed responsive, text typed during compression appeared as normal after completion.
- AST parse and `py_compile` both pass on Python 3.11.
- No changes to the compression logic itself — existing `/compress` behavior is preserved.

## Compatibility

- No new dependencies (`threading`, `collections.deque` are stdlib).
- No changes to public API or configuration.
- All existing tests should continue to pass (no logic changes).