### PR TITLE
fix(acp): pre-import numpy before the ACP stdio feeder to avoid a Windows CRT loader deadlock

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -37,6 +37,24 @@ import sys
 from pathlib import Path
 from hermes_constants import get_hermes_home
 
+# Windows CRT loader-deadlock guard: acp.stdio._start_stdin_feeder parks a
+# buffered ``sys.stdin.buffer.readline()`` on a background thread. On piped
+# stdin (how every ACP client spawns us) that read sits inside ucrtbase
+# holding a CRT stdio lock. Loading an extension DLL whose DllMain touches
+# stdio — numpy's libscipy_openblas64_, pulled in lazily by the holographic
+# memory plugin at agent build — then deadlocks inside LdrLoadDll waiting on
+# that same lock, and the client's request times out (Buzz: 60s, every turn).
+# Import numpy here, before any ACP reader thread exists, so the DLL load
+# happens while stdin is untouched. POSIX has no CRT lock — Windows only.
+# ponytail: guards the one proven DLL (numpy); a different stdio-touching
+# DllMain imported mid-turn would need the same pre-import, or the feeder
+# switched to unbuffered os.read() upstream.
+if sys.platform == "win32":
+    try:
+        import numpy  # noqa: F401
+    except Exception:
+        pass
+
 
 # Methods clients send as periodic liveness probes. They are not part of the
 # ACP schema, so the acp router correctly returns JSON-RPC -32601 to the


### PR DESCRIPTION
## Problem

On Windows, every Buzz/ACP turn can hang forever during agent construction. The client (e.g. Buzz's `buzz-acp` harness) times out (`Request timeout — agent did not respond within 60s`) on every single turn. `agent.log` shows the signature: `OpenAI client created` → browser `check_fn` warnings → silence; `tool_search activated` is never reached.

## Root cause

A Windows CRT loader deadlock between two things the ACP path uniquely combines:

1. `acp.stdio._start_stdin_feeder` parks a **buffered `sys.stdin.buffer.readline()` on a background thread**. On piped stdin (how every ACP client spawns the agent) that read sits inside `ucrtbase` holding a CRT stdio lock.
2. The holographic memory provider lazily **imports numpy during agent build** (`init_agent → load_memory_provider`). The DllMain of numpy's `libscipy_openblas64_*.dll` touches stdio and blocks on that same lock inside `LdrLoadDll` — forever.

`py-spy dump --native` taken while hung shows the main thread in `LdrLoadDll → libscipy_openblas64_ DllMain → ucrtbase → RtlSleepConditionVariableCS`, with the feeder thread inside `ReadFile(stdin)` via the CRT.

Minimal repro (Windows, `python repro.py` with stdin attached to a pipe, e.g. `sleep 60 | python repro.py`):

```python
import sys, threading, time
threading.Thread(target=lambda: sys.stdin.buffer.readline(), daemon=True).start()
time.sleep(1)
import numpy  # hangs forever; without the thread it imports in ~0.2s
print("ok")
```

CLI (`hermes chat`, stdin = console) and the messaging gateway (no ACP stdio feeder) are unaffected — which is why this only surfaces for ACP clients.

## Fix

Import numpy at `acp_adapter/entry.py` module level (win32 only, guarded) — before any ACP reader thread exists, so the DLL load happens while stdin is untouched. Harmless when numpy is absent.

## Verification

Before: `session/new` hung >169s, 3/3 runs (minimal ACP client, initialize → session/new → prompt). After: full turn completes in ~15s, 3/3 runs; a live Buzz Desktop deployment confirms every turn now completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
