### PR TITLE
fix(terminal): tree-kill a hung bash probe on Windows instead of blocking forever in the post-timeout reap

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -908,16 +908,36 @@ def _bash_starts(bash: str) -> bool:
         return cached
 
     try:
-        result = subprocess.run(
+        # Explicit Popen instead of subprocess.run(timeout=...): on Windows a
+        # hung probe bash can survive Popen.kill() and/or leave children
+        # holding the stdout pipe, so run()'s post-timeout reap communicate()
+        # blocks FOREVER (seen live 2026-08-04 in the Buzz/ACP spawn env: probe
+        # bash alive 7+ min, the whole agent turn frozen at env init). Kill the
+        # whole process TREE on timeout and bound the reap.
+        proc = subprocess.Popen(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             text=True, encoding="utf-8", errors="replace",
-            timeout=15,
             creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
-        ok = result.returncode == 0
+        try:
+            out, err = proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            if _IS_WINDOWS:
+                subprocess.run(
+                    ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                    capture_output=True, timeout=10,
+                )
+            else:
+                proc.kill()
+            try:
+                out, err = proc.communicate(timeout=10)
+            except Exception:
+                out, err = "", "bash probe timed out; process tree killed"
+        ok = proc.returncode == 0
         if not ok:
-            combined = f"{result.stdout or ''}{result.stderr or ''}"
+            combined = f"{out or ''}{err or ''}"
             _bash_probe_details_cache[bash] = combined.strip()[:2000]
             logger.debug("bash probe failed for %s: %s", bash, combined.strip()[:200])
     except Exception as exc:


### PR DESCRIPTION
## Problem

On Windows, the terminal tool's environment init can freeze an agent turn forever. Observed live in a Buzz/ACP deployment: the first turn calls the terminal tool, `Creating new local environment for task default...` is logged, and nothing ever follows — the probe `bash.exe` stayed alive for 7+ minutes and the turn never completed.

## Root cause

`_bash_starts()` used `subprocess.run(..., timeout=15)`. On Windows that construct is not hang-proof:

- on `TimeoutExpired`, `run()` calls `Popen.kill()` — which targets only the direct child; a wedged MSYS bash can survive it and/or leave grandchildren (`conhost`, probe children) holding the stdout pipe;
- `run()` then reaps with a **timeout-less** `communicate()`, whose reader-thread `join()` blocks until the pipe closes — i.e. forever.

py-spy of the hung process shows exactly that: `run → communicate → _communicate → join` with the probe bash still alive. Killing the probe's process tree by hand instantly unblocked the turn.

## Fix

Replace `subprocess.run` with an explicit `Popen`:
- `communicate(timeout=15)` as before;
- on timeout, kill the **whole process tree** (`taskkill /T /F` on Windows, `kill()` elsewhere);
- reap with a bounded `communicate(timeout=10)`, degrading to probe-failed instead of freezing.

A hanging probe now costs ~15s and marks the candidate as failed (the existing cache/fallback logic takes over) instead of freezing the whole turn.

## Verification

Healthy path unchanged (probe returns in ~0.1s). The previously frozen Buzz/ACP deployment now completes terminal-using turns; the pathological case degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
