### PR TITLE
fix(terminal): let Buzz-managed agents inherit the BUZZ CLI credentials the harness hands them

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -331,6 +331,21 @@ def _build_provider_env_blocklist() -> frozenset:
     # It arrives via the registry loop above (anthropic api_key_env_vars),
     # so remove it explicitly.
     blocked.discard("CLAUDE_CODE_OAUTH_TOKEN")
+    # Buzz-ACP managed agents (this process spawned by Buzz Desktop's buzz-acp
+    # harness) receive BUZZ_PRIVATE_KEY / BUZZ_RELAY_URL / BUZZ_AUTH_TAG in the
+    # process env ON PURPOSE: the platform's reply-delivery contract is the
+    # model driving the `buzz` CLI from the terminal (block/buzz#2698 — final
+    # session text is NOT delivered to the channel). The bundled buzz platform
+    # plugin registers these names as "messaging" credentials, which would
+    # strip them here and silently break every reply. Mirror the
+    # CLAUDE_CODE_OAUTH_TOKEN exception above: when this process is a
+    # Buzz-managed agent (BUZZ_MANAGED_AGENT is set by the harness), the vars
+    # are the harness's deliberate hand-off to the agent, not a Hermes-managed
+    # secret. Gateway/CLI/kanban processes never carry BUZZ_MANAGED_AGENT, so
+    # the platform-plugin secret (path ③, ~/.hermes/.env) stays stripped there.
+    if os.environ.get("BUZZ_MANAGED_AGENT"):
+        for _buzz_var in ("BUZZ_PRIVATE_KEY", "BUZZ_RELAY_URL", "BUZZ_AUTH_TAG"):
+            blocked.discard(_buzz_var)
     return frozenset(blocked)
 
 


### PR DESCRIPTION
## Problem

When Hermes runs as a **Buzz-managed agent** (Buzz Desktop → `buzz-acp` harness → `hermes acp`), every reply silently fails to reach the channel. The model correctly tries `buzz messages send` from the terminal tool (per the harness's `[Base]` prompt and block/buzz#2698 — final session text is *not* delivered to the channel), but the CLI dies with:

```
{"error":"auth_error","message":"auth error: BUZZ_PRIVATE_KEY is required (use --private-key or set env var)"}
```

The harness *does* hand `BUZZ_PRIVATE_KEY` / `BUZZ_RELAY_URL` / `BUZZ_AUTH_TAG` to the agent process on purpose — that is the platform's reply-delivery contract. But the bundled buzz platform plugin registers those names as "messaging" credentials, so the terminal env blocklist strips them unconditionally, and the CLI can never authenticate. Every reply is lost while the activity panel happily streams the answer.

## Fix

Mirror the existing `CLAUDE_CODE_OAUTH_TOKEN` exception: when the process itself is a Buzz-managed agent (`BUZZ_MANAGED_AGENT` is set — only the Buzz Desktop harness sets it), `discard` the three BUZZ CLI vars from the blocklist. The variables are the harness's deliberate hand-off to the agent, not a Hermes-managed secret in that context.

Scope safety: gateway / CLI / cron / kanban processes never carry `BUZZ_MANAGED_AGENT`, so the path-3 platform secret (`BUZZ_PRIVATE_KEY` from `~/.hermes/.env` used by the native buzz gateway plugin) remains stripped there exactly as before.

## Verification

- Unit-style: with `BUZZ_MANAGED_AGENT=1` the three vars survive `_make_run_env`; without it they are stripped (unchanged behavior).
- End-to-end: in a live Buzz Desktop deployment, a channel mention now produces `buzz messages send` → `{"accepted":true,"event_id":…}` and the reply renders in the channel (previously: silent loss on every turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
