### PR TITLE
fix(gateway): stop table-to-bullets rendering from deleting repeated columns

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -352,11 +352,23 @@ def _render_table_block(table_block: list[str]) -> str:
     rendered_groups: list[str] = []
     for index, row in enumerate(table_block[2:], start=1):
         cells = split_markdown_table_row(row)
+        heading_pos = None
         if has_row_label_col:
             heading = cells[0] if cells and cells[0] else f"Row {index}"
             data_cells = cells[1:]
         else:
-            heading = next((cell for cell in cells if cell), f"Row {index}")
+            # Remember WHICH cell became the heading, not just its text. The
+            # bullet to drop is the one that produced the heading — matching on
+            # value instead dropped every OTHER cell that happened to hold the
+            # same string, silently deleting real columns from the message.
+            # ``| prod | us-east | prod |`` under ``Env | Region | Status``
+            # rendered as "**prod** / • Region: us-east" — the Status column
+            # was gone. Repeated values are the norm in the status and
+            # comparison tables agents emit.
+            heading_pos = next(
+                (pos for pos, cell in enumerate(cells) if cell), None
+            )
+            heading = cells[heading_pos] if heading_pos is not None else f"Row {index}"
             data_cells = cells
 
         if len(data_cells) < len(headers):
@@ -365,8 +377,8 @@ def _render_table_block(table_block: list[str]) -> str:
             data_cells = data_cells[: len(headers)]
 
         bullets: list[str] = []
-        for header, value in zip(headers, data_cells):
-            if not has_row_label_col and value == heading:
+        for pos, (header, value) in enumerate(zip(headers, data_cells)):
+            if not has_row_label_col and pos == heading_pos:
                 continue
             bullets.append(f"• {header}: {value}")
 

--- a/tests/gateway/test_table_bullets_repeated_values.py
+++ b/tests/gateway/test_table_bullets_repeated_values.py
@@ -1,0 +1,106 @@
+"""Converting a GFM table to bullets must not delete columns.
+
+``_render_table_block`` renders each row as a bold heading plus one bullet per
+column, and drops the bullet that merely repeats the heading. It identified that
+bullet by comparing VALUES::
+
+    if not has_row_label_col and value == heading:
+        continue
+
+The heading is the row's first non-empty cell, so any OTHER cell holding the
+same string matched too and was silently dropped. Repeated values are the norm
+in the status and comparison tables agents emit, so a real column disappeared
+from the delivered message with no error and no trace.
+
+Skipping by position keeps the intended de-duplication and nothing else.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.helpers import convert_table_to_bullets
+
+
+class TestRepeatedValuesKeepTheirColumns:
+    def test_value_equal_to_the_row_heading_is_still_rendered(self):
+        out = convert_table_to_bullets(
+            "| Env | Region | Status |\n"
+            "|---|---|---|\n"
+            "| prod | us-east | prod |\n"
+        )
+        assert "• Region: us-east" in out
+        assert "• Status: prod" in out          # was silently dropped
+        assert out.startswith("**prod**")
+        assert "• Env: prod" not in out         # the heading's own bullet
+
+    def test_second_column_repeating_the_first(self):
+        out = convert_table_to_bullets(
+            "| Name | Alias |\n|---|---|\n| bob | bob |\n"
+        )
+        assert "• Alias: bob" in out
+        assert "• Name: bob" not in out
+
+    def test_three_way_repeat_keeps_both_non_heading_cells(self):
+        out = convert_table_to_bullets(
+            "| A | B | C |\n|---|---|---|\n| x | x | x |\n"
+        )
+        assert out.count("• ") == 2
+        assert "• B: x" in out
+        assert "• C: x" in out
+
+    def test_every_data_cell_reaches_the_output(self):
+        """Contract: one bullet per column, minus the heading's own."""
+        table = (
+            "| Model | Vision | Tools | Notes |\n"
+            "|---|---|---|---|\n"
+            "| kimi | yes | yes | kimi |\n"
+        )
+        out = convert_table_to_bullets(table)
+        assert out.count("• ") == 3
+        for expected in ("• Vision: yes", "• Tools: yes", "• Notes: kimi"):
+            assert expected in out
+
+
+class TestUnchangedBehaviour:
+    def test_ordinary_table_is_unaffected(self):
+        out = convert_table_to_bullets(
+            "| Feature | Free | Pro |\n"
+            "|---|---|---|\n"
+            "| Export | Yes | Yes |\n"
+            "| API | No | Yes |\n"
+        )
+        assert "**Export**" in out and "**API**" in out
+        assert "• Free: Yes" in out and "• Pro: Yes" in out
+        assert "• Feature: Export" not in out
+        assert "• Free: No" in out
+
+    def test_leading_empty_cell_still_picks_the_first_non_empty_heading(self):
+        out = convert_table_to_bullets(
+            "| A | B | C |\n|---|---|---|\n|  | x | y |\n"
+        )
+        assert out.startswith("**x**")
+        assert "• B: x" not in out       # B produced the heading
+        assert "• C: y" in out
+        assert "• A: " in out
+
+    def test_row_label_column_layout_is_untouched(self):
+        """One extra leading cell => explicit row-label mode, no value match."""
+        out = convert_table_to_bullets(
+            "| Free | Pro |\n"
+            "|---|---|\n"
+            "| Export | Yes | Yes |\n"
+        )
+        assert out.startswith("**Export**")
+        assert "• Free: Yes" in out and "• Pro: Yes" in out
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "no table here at all",
+            "| only | header |\n|---|---|\n",
+            "```\n| A | B |\n|---|---|\n| x | x |\n```\n",
+        ],
+    )
+    def test_non_tables_and_fenced_tables_pass_through(self, text):
+        assert convert_table_to_bullets(text) == text


### PR DESCRIPTION
## What does this PR do?

`_render_table_block` turns each GFM table row into a bold heading plus one
bullet per column, and drops the bullet that merely repeats the heading. It
found that bullet by comparing **values**:

```python
if not has_row_label_col and value == heading:
    continue
```

The heading is the row's *first non-empty cell*, so every **other** cell holding
the same string matched the condition too and was skipped. A real column
vanished from the delivered message — silently, with no error and no trace:

```text
input                                     rendered (before)
| Env  | Region  | Status |               **prod**
|------|---------|--------|               • Region: us-east
| prod | us-east | prod   |
                                          ← "• Status: prod" is gone
```

Repeated values are the norm in the tables agents actually emit — yes/yes
capability rows, ✅/❌ matrices, a column echoing the row name, an `Env`/`Status`
pair that both read `prod`. Every markdown-stripping platform that routes
through `convert_table_to_bullets` delivered the truncated message.

The condition dates to 70c834a74 (2026-06-13, *refactor: extract shared GFM
table→bullet helpers into helpers.py*), which consolidated Telegram's renderer
into the shared helper and carried the value comparison across unchanged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/platforms/helpers.py`** — remember which cell *became* the heading
  and skip it by **position** instead of by value. The intended de-duplication
  is unchanged; nothing else is dropped. The row-label-column layout
  (`has_row_label_col`) never used the value comparison and is untouched.
- **`tests/gateway/test_table_bullets_repeated_values.py`** — 10 tests.

## How to Test

```python
from gateway.platforms.helpers import convert_table_to_bullets

print(convert_table_to_bullets(
    "| Env | Region | Status |\n|---|---|---|\n| prod | us-east | prod |\n"
))
```

**Before**

```text
**prod**
• Region: us-east
```

**After**

```text
**prod**
• Region: us-east
• Status: prod
```

## Test Results

New file `tests/gateway/test_table_bullets_repeated_values.py` — 10 tests
driving the real `convert_table_to_bullets`:

| Group | Covers |
|---|---|
| `TestRepeatedValuesKeepTheirColumns` | a cell equal to the row heading is still rendered; a second column repeating the first; a three-way repeat keeps both non-heading cells; the contract "one bullet per column, minus the heading's own" |
| `TestUnchangedBehaviour` | ordinary tables unaffected; a leading empty cell still picks the first non-empty heading and skips *that* column; the row-label-column layout untouched; non-tables and fenced tables pass through verbatim |

Red-without-fix, with only `gateway/platforms/helpers.py` reverted:

```text
4 failed, 6 passed
```

With the fix:

```text
10 passed in 5.09s
```

**Regression sweep**

```text
table / helper / markdown suites + new file:   18 passed
ruff check gateway/platforms/helpers.py:       All checks passed
```

Whole `tests/gateway/` directory, both sides on the same `main`, comparing the
**failure sets** rather than counts:

```text
baseline (change stashed):  71 failures
with this fix:              71 failures
new failures introduced:    none
```

The two sets are byte-identical — the pre-existing failures live in unrelated
files that this change does not touch.