### PR TITLE
fix(desktop): recover sessions after provider removal

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2994,7 +2994,7 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
     assert "launch_update" not in captured
 
 
-def test_stored_session_runtime_overrides_skips_bare_billing_provider():
+def test_stored_session_runtime_overrides_skips_bare_billing_provider(monkeypatch):
     """A bare billing bucket ("custom"/"auto"/"openrouter") must not be restored as the
     provider identity on resume. A custom endpoint that never used `/model` persists only
     `billing_provider="custom"`; restoring that broke `session.resume` with "No LLM provider
@@ -3015,12 +3015,56 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert ov["provider_override"] == "anthropic"
     assert ov["model_override"]["provider"] == "anthropic"
 
-    # An explicit routable provider in model_config wins over the bare billing bucket.
+    # This fixture represents a provider that is still configured; the deleted-
+    # provider regression is covered by the dedicated test above.
+    monkeypatch.setattr(
+        server,
+        "_stored_provider_is_routable",
+        lambda provider, model="": provider == "custom:myendpoint" or provider == "anthropic",
+    )
     ov = server._stored_session_runtime_overrides(
         {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
     )
     assert ov["provider_override"] == "custom:myendpoint"
     assert ov["model_override"]["provider"] == "custom:myendpoint"
+
+
+def test_stored_session_runtime_overrides_drops_deleted_provider_runtime(monkeypatch):
+    """A removed provider must not strand a stored transcript on resume.
+
+    Keep the model and session-local knobs so the Desktop can paint the session,
+    but discard the unroutable provider endpoint. The existing session-scoped
+    model picker can then switch the restored shell to a configured provider.
+    """
+    monkeypatch.setattr(
+        server,
+        "_stored_provider_is_routable",
+        lambda provider, model="": provider != "a6api",
+    )
+
+    overrides = server._stored_session_runtime_overrides(
+        {
+            "model": "gpt-5.6-sol",
+            "billing_provider": "a6api",
+            "model_config": {
+                "provider": "a6api",
+                "base_url": "https://deleted.example/v1",
+                "api_mode": "chat_completions",
+                "reasoning_config": {"enabled": True, "effort": "high"},
+                "service_tier": "priority",
+            },
+        }
+    )
+
+    assert "provider_override" not in overrides
+    assert overrides["model_override"] == {
+        "model": "gpt-5.6-sol",
+        "provider": None,
+        "base_url": None,
+        "api_mode": None,
+    }
+    assert overrides["reasoning_config_override"] == {"enabled": True, "effort": "high"}
+    assert overrides["service_tier_override"] == "priority"
 
 
 def test_stored_session_runtime_overrides_restores_explicit_normal_tier():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3586,6 +3586,41 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
 _BARE_BILLING_PROVIDERS = {"auto", "openrouter", "custom"}
 
 
+def _stored_provider_is_routable(provider: str, model: str = "") -> bool:
+    """Return whether a persisted provider identity is still configured.
+
+    Session rows outlive provider configuration. A removed custom provider must
+    not be handed back to ``_make_agent`` during Desktop resume, otherwise the
+    resume fails before the session-scoped model picker can switch it away.
+    This is deliberately a config/registry check only — it must not probe the
+    provider or require a usable credential.
+    """
+    candidate = str(provider or "").strip()
+    normalized = candidate.lower()
+    if not candidate or normalized in _BARE_BILLING_PROVIDERS:
+        return False
+
+    try:
+        from hermes_cli.runtime_provider import has_named_custom_provider
+
+        if has_named_custom_provider(candidate):
+            return True
+    except Exception:
+        logger.debug("named custom provider check failed", exc_info=True)
+
+    try:
+        from hermes_cli.auth import resolve_provider
+
+        resolved = str(resolve_provider(candidate) or "").strip().lower()
+    except Exception:
+        return False
+
+    # ``resolve_provider`` can map local aliases (ollama/vllm/...) to the
+    # generic custom runtime. Those remain valid when their session stored an
+    # endpoint; bare ``custom`` was excluded above because it has no identity.
+    return bool(resolved) and (resolved != "custom" or bool(model))
+
+
 def _stored_session_runtime_overrides(row: dict | None) -> dict:
     """Return runtime fields persisted with a stored session.
 
@@ -3653,6 +3688,16 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
                 "custom provider identity recovery failed", exc_info=True
             )
         provider = healed or ("" if not base_url else provider)
+
+    if provider and not _stored_provider_is_routable(provider, model):
+        # Keep the model in the restored session so Desktop can show the
+        # transcript and let the user choose a replacement. Do not retain the
+        # deleted provider's endpoint metadata: _make_agent applies these
+        # fields after resolving the replacement runtime and would otherwise
+        # continue routing the session to the removed endpoint.
+        provider = ""
+        base_url = ""
+        api_mode = ""
 
     if model:
         # Use the same dict-shaped override that live /model switches use so a


### PR DESCRIPTION
## Summary

When a persisted session references a provider that has since been removed from configuration, Desktop/TUI resume could restore the stale provider identity and endpoint metadata before the model picker became usable.

This change makes stored runtime restoration validate the provider identity against the current provider registry. If the provider is no longer routable, the restored session keeps its model and session-local reasoning/service-tier settings but drops the stale provider, base URL, and API mode. The session can then initialize with the current default provider and be switched through the existing session-scoped model picker.

## Scope

- Desktop/TUI stored-session runtime restoration only.
- No changes to custom endpoint CRUD or provider configuration storage.
- No credentials or API keys are persisted or restored.

## Tests

- `python -m pytest tests/test_tui_gateway_server.py -q` — 518 passed
- `python -m py_compile tui_gateway/server.py`
- `git diff --check`
