### PR TITLE
fix(approvals): project wrappers so prefix deny matches real commands

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -873,6 +873,17 @@ class TestGitDestructiveOps:
             assert dangerous is True, cmd
             assert word in desc.lower(), cmd
 
+    def test_git_push_force_with_global_options_detected(self):
+        """Global options before the subcommand must not hide force-push."""
+        for cmd in (
+            "git -C /tmp/repo push --force origin main",
+            "git -C/tmp/repo push --force origin main",
+            "git -c push.default=simple push --force origin main",
+            "git --git-dir=/tmp/repo.git push -f origin main",
+        ):
+            dangerous, _, desc = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+            assert "force" in desc.lower(), cmd
 
     def test_safe_git_ops_not_flagged(self):
         for cmd in ("git status", "git push origin main"):

--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -56,6 +56,62 @@ class TestMatchUserDenyRule:
         deny_config(["git push --force*"])
         assert mod._match_user_deny_rule('git pu""sh --force origin main') is not None
 
+    def test_compound_command_suffix_matches_prefix_deny(self, deny_config):
+        """Prefix deny must see the real command after && / ; / |."""
+        deny_config(["git push --force*"])
+        assert mod._match_user_deny_rule(
+            "echo hi && git push --force origin main"
+        ) == "git push --force*"
+        assert mod._match_user_deny_rule(
+            "cd /tmp; git push --force origin main"
+        ) is not None
+
+    def test_env_and_sudo_wrappers_match_prefix_deny(self, deny_config):
+        deny_config(["git push --force*"])
+        assert mod._match_user_deny_rule(
+            "env X=1 git push --force origin main"
+        ) == "git push --force*"
+        assert mod._match_user_deny_rule(
+            "env -i PATH=/usr/bin git push --force origin main"
+        ) is not None
+        assert mod._match_user_deny_rule(
+            "sudo -E git push --force origin main"
+        ) is not None
+
+    def test_git_global_options_before_push_match_prefix_deny(self, deny_config):
+        """git -C / -c / --git-dir must not hide a denied subcommand."""
+        deny_config(["git push --force*", "git push -f *"])
+        assert mod._match_user_deny_rule(
+            "git -C /tmp/repo push --force origin main"
+        ) == "git push --force*"
+        assert mod._match_user_deny_rule(
+            "git -C/tmp/repo push --force origin main"
+        ) is not None
+        assert mod._match_user_deny_rule(
+            "git -c push.default=simple push --force origin main"
+        ) is not None
+        assert mod._match_user_deny_rule(
+            "git --git-dir=/tmp/repo.git push -f origin main"
+        ) is not None
+
+    def test_wrapper_plus_git_global_options_still_denied(self, deny_config):
+        deny_config(["git push --force*"])
+        assert mod._match_user_deny_rule(
+            "env X=1 git -C /tmp/repo push --force origin main"
+        ) is not None
+        assert mod._match_user_deny_rule(
+            "echo prep && sudo git -C /tmp/repo push --force origin main"
+        ) is not None
+
+    def test_non_force_push_with_wrappers_still_passes(self, deny_config):
+        deny_config(["git push --force*", "git push -f *"])
+        assert mod._match_user_deny_rule(
+            "env X=1 git -C /tmp/repo push origin main"
+        ) is None
+        assert mod._match_user_deny_rule(
+            "echo hi && git push origin main"
+        ) is None
+
 
 class TestDenyBeatsYolo:
     def test_deny_blocks_under_yolo_env(self, deny_config, clean_env, monkeypatch):
@@ -133,3 +189,21 @@ class TestDenyOrdering:
         assert "git push --force*" in msg
         assert "retry" in msg.lower()
         assert "rephrase" in msg.lower()
+
+    def test_gateway_path_blocks_git_c_force_push(self, deny_config, clean_env):
+        deny_config(["git push --force*"])
+        result = mod.check_all_command_guards(
+            "git -C /tmp/repo push --force origin main", "local"
+        )
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    def test_gateway_path_blocks_env_wrapped_force_push_under_yolo(
+            self, deny_config, clean_env, monkeypatch):
+        deny_config(["git push --force*"])
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+        result = mod.check_dangerous_command(
+            "env X=1 git push --force origin main", "local"
+        )
+        assert result["approved"] is False
+        assert result.get("user_deny") is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1189,6 +1189,37 @@ _SUDO_OPTIONS_WITH_ARG = {
     "-p", "--prompt",
     "-u", "--user",
 }
+# env(1) options that consume a separate argument. Shared with the wrapper
+# peeler so `env -u FOO git ...` / `env -C /tmp git ...` still expose `git`.
+_ENV_OPTIONS_WITH_ARG = {
+    "-u", "--unset",
+    "-C", "--chdir",
+    "-S", "--split-string",
+}
+# git global options that may appear before the subcommand (git -C <path> push).
+# Used to project a canonical `git <subcommand> ...` form for prefix deny rules
+# and dangerous-pattern detection without forcing operators to write every
+# wrapper spelling into approvals.deny.
+_GIT_GLOBAL_OPTIONS_WITH_ARG = {
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--config-env",
+    "--exec-path",
+    "--super-prefix",
+}
+_GIT_GLOBAL_OPTIONS_BOOL = {
+    "--bare",
+    "--no-replace-objects",
+    "--literal-pathspecs",
+    "--glob-pathspecs",
+    "--noglob-pathspecs",
+    "--icase-pathspecs",
+    "--no-optional-locks",
+    "--no-advice",
+}
 
 _INTERPRETER_EXEC_FLAGS = {
     "python": {"-c"},
@@ -2094,6 +2125,130 @@ def _iter_shell_command_word_spans(command: str):
             break
 
 
+def _read_shell_words_from(command: str, start: int, limit: int = 32):
+    """Return up to *limit* shell words starting at *start* as (text, end) pairs."""
+    words: list[tuple[str, int]] = []
+    pos = start
+    while len(words) < limit:
+        word_start, word_end, word = _read_shell_word(command, pos)
+        if word_start == word_end:
+            break
+        words.append((word, word_end))
+        pos = word_end
+    return words
+
+
+def _wrapper_option_takes_arg(wrapper: str, option_token: str) -> bool:
+    """Whether *option_token* for *wrapper* consumes the next argv word."""
+    if "=" in option_token:
+        return False
+    name = option_token.split("=", 1)[0]
+    if wrapper == "sudo":
+        return name in _SUDO_OPTIONS_WITH_ARG
+    if wrapper == "env":
+        # Short clustered env options like -iB do not take args; only the
+        # known long/short forms with separate operands do.
+        return name in _ENV_OPTIONS_WITH_ARG
+    return False
+
+
+def _peel_leading_wrappers(words: list[str]) -> list[str]:
+    """Strip sudo/env/nohup/... and VAR=val prefixes from a command word list."""
+    i = 0
+    n = len(words)
+    while i < n:
+        raw = words[i]
+        deob = _deobfuscate_shell_word_for_detection(raw)
+        lower = deob.lower()
+        if lower in _COMMAND_WRAPPER_WORDS:
+            i += 1
+            if lower in {"sudo", "env"}:
+                while i < n:
+                    opt = _deobfuscate_shell_word_for_detection(words[i])
+                    opt_l = opt.lower()
+                    if opt_l.startswith("-"):
+                        takes_arg = _wrapper_option_takes_arg(lower, opt_l)
+                        i += 1
+                        if takes_arg and i < n:
+                            i += 1
+                        continue
+                    if lower == "env" and _ENV_ASSIGNMENT_RE.fullmatch(opt):
+                        i += 1
+                        continue
+                    break
+            continue
+        if _ENV_ASSIGNMENT_RE.fullmatch(deob):
+            i += 1
+            continue
+        break
+    return words[i:]
+
+
+def _canonical_git_command_words(words: list[str]) -> list[str] | None:
+    """Return ``['git', <subcommand>, ...]`` with global options removed.
+
+    Handles ``git -C path push --force``, glued ``-C/path``, and
+    ``--git-dir=...`` forms. Returns None when *words* is not a git
+    invocation or no subcommand remains after peeling globals.
+    """
+    if not words:
+        return None
+    first = _deobfuscate_shell_word_for_detection(words[0]).lower()
+    # Allow path-qualified git binaries ( /usr/bin/git ).
+    if first != "git" and not first.endswith("/git"):
+        return None
+    i = 1
+    n = len(words)
+    while i < n:
+        tok = _deobfuscate_shell_word_for_detection(words[i])
+        lower = tok.lower()
+        if lower == "--":
+            i += 1
+            break
+        if not lower.startswith("-"):
+            break
+        # Glued short options: -C/path or -ckey=value
+        if lower.startswith("-c") and not lower.startswith("--") and lower != "-c":
+            # -C/path or -ckey=value (no separate argv word)
+            i += 1
+            continue
+        name = lower.split("=", 1)[0]
+        if name in _GIT_GLOBAL_OPTIONS_BOOL:
+            i += 1
+            continue
+        if name in _GIT_GLOBAL_OPTIONS_WITH_ARG:
+            if "=" in lower:
+                i += 1
+            else:
+                i += 2
+            continue
+        # Unknown dashed token before subcommand — stop rather than guess.
+        break
+    if i >= n:
+        return None
+    sub = _deobfuscate_shell_word_for_detection(words[i])
+    if not sub or sub.startswith("-"):
+        return None
+    # Preserve original spelling of the remaining argv for deny/pattern match.
+    return ["git", *words[i:]]
+
+
+def _projected_command_variants_from_segment(segment: str):
+    """Yield canonical command projections for one shell command segment."""
+    words = [w for w, _ in _read_shell_words_from(segment, 0)]
+    if not words:
+        return
+    peeled = _peel_leading_wrappers(words)
+    if not peeled:
+        return
+    # Full peeled command (env/sudo/nohup stripped).
+    peeled_cmd = " ".join(peeled)
+    yield peeled_cmd
+    git_words = _canonical_git_command_words(peeled)
+    if git_words is not None:
+        yield " ".join(git_words)
+
+
 def _command_detection_variants(command: str):
     # Mask quoted newlines BEFORE normalization: normalization strips
     # backslash-escapes (\" -> ") and empty-string pairs (""), which would
@@ -2107,6 +2262,22 @@ def _command_detection_variants(command: str):
     grep_safe, _ = _grep_safe_detection_variant(normalized)
     seen = {grep_safe}
     yield grep_safe
+    # Project wrapper-peeled and git-global-option-stripped forms so prefix
+    # deny rules like ``git push --force*`` and dangerous-pattern regexes
+    # still match ``env X=1 git -C /repo push --force``.
+    pending_segments = [grep_safe, normalized]
+    while pending_segments:
+        segment = pending_segments.pop()
+        for start in _iter_shell_command_starts(segment):
+            # Slice from each real command start so compound commands
+            # (a && b ; c) expose each tail independently.
+            tail = segment[start:].lstrip()
+            if not tail:
+                continue
+            for projected in _projected_command_variants_from_segment(tail):
+                if projected and projected not in seen:
+                    seen.add(projected)
+                    yield projected
     # Program-bearing options are parsed in their owning command's context.
     # Surfacing only their payload lets the hardline floor inspect the command
     # that will actually run without promoting similar flags or quoted prose.


### PR DESCRIPTION
## Summary
- Prefix `approvals.deny` rules like `git push --force*` previously matched only the raw command string variants, so leading wrappers and git global options hid denied subcommands.
- Project wrapper-peeled and git-global-option-stripped command forms inside `_command_detection_variants`, so user deny and dangerous-pattern detection see the underlying command.
- Still fires before yolo / `approvals.mode=off`.

Covered bypass shapes:
- `git -C <path> push --force ...` / glued `-C/path` / `-c` / `--git-dir`
- `env ... git push --force ...`
- `sudo ... git push --force ...`
- compound tails: `echo hi && git push --force ...`

## Test plan
- [x] `pytest tests/tools/test_approval_deny_rules.py tests/tools/test_approval.py::TestGitDestructiveOps -q` → 43 passed
- [x] Live disk smoke with production deny list under mode=off + yolo: wrapper force-push blocked (`user_deny=True`); normal push allowed
- [ ] CI full suite