### PR TITLE
feat(delegate_task): accept an optional per-call model

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7480,6 +7480,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            model=function_args.get("model"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2782,6 +2782,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2861,6 +2862,35 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Per-call model override: lets a workspace/skill run its delegated work under
+    # a chosen model (the per-workspace model-role feature). Provider-prefixed ids
+    # (with '/') resolve via the runtime provider resolver; plain/:cloud ids keep
+    # the inherited endpoint and just swap the model. No-op when `model` is absent.
+    if isinstance(model, str) and model.strip():
+        _ov_model = model.strip()
+        if _ov_model != (creds.get("model") or ""):
+            if "/" in _ov_model:
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    _ov_rt = resolve_runtime_provider(
+                        requested=creds.get("provider") or None,
+                        target_model=_ov_model,
+                    )
+                    creds = {
+                        "model": _ov_model,
+                        "provider": _ov_rt.get("provider"),
+                        "base_url": _ov_rt.get("base_url"),
+                        "api_key": _ov_rt.get("api_key"),
+                        "api_mode": _ov_rt.get("api_mode"),
+                    }
+                except Exception as _ov_exc:
+                    logger.warning(
+                        "delegate_task: could not resolve model override %r (%s); "
+                        "keeping default model %r", _ov_model, _ov_exc, creds.get("model"),
+                    )
+            else:
+                creds = {**creds, "model": _ov_model}
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -3788,6 +3818,15 @@ DELEGATE_TASK_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model id for the subagent. A provider-prefixed id "
+                    "(e.g. 'anthropic/claude-fable-5') resolves through the "
+                    "runtime provider resolver; a plain id keeps the inherited "
+                    "endpoint and swaps only the model. Omit to inherit."
+                ),
+            },
             "goal": {
                 "type": "string",
                 "description": (


### PR DESCRIPTION
## What

Adds an optional `model` parameter to `delegate_task`, so a caller can run one delegated subagent under a specific model instead of always inheriting `delegation.model` from config.

Four small changes:

- `tools/delegate_tool.py` — `model: Optional[str] = None` on the `delegate_task` signature
- `tools/delegate_tool.py` — resolve the override into `creds` (a provider-prefixed id goes through `resolve_runtime_provider`; a plain id keeps the inherited endpoint and swaps only the model)
- `tools/delegate_tool.py` — the corresponding `model` property on `DELEGATE_TASK_SCHEMA`
- `run_agent.py` — pass `function_args.get("model")` through at the tool call site, alongside the existing `role`

## Why

The plumbing is already there — it just isn't reachable. `_build_child_progress_callback` already accepts and forwards a `model` (`kw["model"] = model`), and `effective_model_for_cb = model or getattr(parent_agent, "model", None)` already anticipates a per-call value. What is missing is the parameter on the public tool and the one line that carries it from the tool call into the delegation.

The use case: an orchestrator that fans work out to several subagents where each subagent should run on a *different* model — a cheap model for mechanical passes, a stronger one for review. Today that requires either one gateway per model or a config edit between runs, because `delegation.model` is a single global pin.

`model` is omitted by default and the behaviour is unchanged when it is absent, so this is additive.

## Notes

- The resolver call passes `requested=creds.get("provider") or None`, so it respects whatever provider the caller is already configured for rather than forcing a particular one.
- A failure to resolve an override logs a warning and keeps the configured model, rather than failing the delegation.
- `role` and `model` are independent: `role` still selects the child's behaviour profile, `model` only chooses what it runs on.

Happy to adjust naming, the resolution strategy, or split this into smaller commits if you'd prefer.
