### PR TITLE
fix(gateway): tolerate ~1s start-time fingerprint drift in PID-reuse guard

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -325,6 +325,35 @@ def get_process_start_time(pid: int) -> Optional[int]:
     return _get_process_start_time(pid)
 
 
+#: Tolerance for comparing start-time fingerprints, in fingerprint units:
+#: centiseconds on macOS/Windows (psutil), clock ticks on Linux (typically
+#: 100Hz) — ~2 seconds either way.  See ``_start_times_match``.
+_START_TIME_TOLERANCE = 200
+
+
+def _start_times_match(recorded: Any, current: Any) -> bool:
+    """Return True when two start-time fingerprints identify the same process.
+
+    Strict equality proved too brittle on the psutil path (macOS/Windows):
+    ``create_time()`` for the *same* live process can shift by ~1s across a
+    psutil upgrade or an NTP step adjustment.  Observed in the field: a
+    long-running macOS gateway recorded its fingerprint at spawn, a later venv
+    update moved psutil's derivation by exactly 1s, and every subsequent
+    liveness probe rejected the live PID — the dashboard reported a running
+    gateway (platforms connected, heartbeat fresh) as "stopped".
+
+    A 2s window keeps the PID-reuse guard effective: a false positive requires
+    the OS to recycle the same PID onto a new process whose start instant lands
+    within 2s of the original's, and the surrounding command-line/profile
+    checks must also misidentify it.  Non-numeric fingerprints (defensive:
+    hand-edited state files) fall back to strict equality.
+    """
+    try:
+        return abs(float(current) - float(recorded)) <= _START_TIME_TOLERANCE
+    except (TypeError, ValueError):
+        return current == recorded
+
+
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
@@ -1085,7 +1114,7 @@ def runtime_status_pid_is_live(record: Optional[dict[str, Any]]) -> bool:
     if (
         recorded_start is not None
         and current_start is not None
-        and current_start != recorded_start
+        and not _start_times_match(recorded_start, current_start)
     ):
         return False
     return True
@@ -1325,7 +1354,7 @@ def get_runtime_status_running_pid(
     if (
         recorded_start is not None
         and current_start is not None
-        and current_start != recorded_start
+        and not _start_times_match(recorded_start, current_start)
     ):
         return None
 
@@ -2189,7 +2218,7 @@ def get_running_pid(
 
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)
-        if recorded_start is not None and current_start is not None and current_start != recorded_start:
+        if recorded_start is not None and current_start is not None and not _start_times_match(recorded_start, current_start):
             continue
 
         if _record_matches_live_gateway_pid(record, pid):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -247,6 +247,55 @@ class TestGatewayRuntimeStatus:
                 == 139
             ), cmdline
 
+    def test_runtime_status_running_pid_tolerates_small_start_time_drift(self, monkeypatch):
+        """Regression (macOS field report): psutil ``create_time()`` for the SAME
+        live process shifted by exactly 1s (100 centiseconds) after a venv
+        psutil upgrade, so the strict-equality PID-reuse guard rejected the
+        live gateway and the dashboard reported it "stopped" while its
+        platforms were connected and its heartbeat fresh.  Fingerprints within
+        ``_START_TIME_TOLERANCE`` must be treated as the same process.
+        """
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 178526682901,
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_get_process_start_time", lambda pid: 178526682801
+        )
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes gateway run --replace"
+        )
+
+        assert status.get_runtime_status_running_pid(payload) == 139
+
+    def test_runtime_status_running_pid_still_rejects_large_start_time_mismatch(
+        self, monkeypatch
+    ):
+        """A fingerprint gap far beyond the drift tolerance is a genuinely
+        recycled PID and must still be rejected."""
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 178526682901,
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_get_process_start_time", lambda pid: 178526682901 + 360_000
+        )
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes gateway run --replace"
+        )
+
+        assert status.get_runtime_status_running_pid(payload) is None
+
 
     def test_command_line_belongs_to_profile_normalizes_separators(self):
         """A Windows argv renders HERMES_HOME with backslashes while the


### PR DESCRIPTION
## What does this PR do?

Fixes a false "gateway stopped" report for a live, healthy gateway. The PID-reuse guard compares start-time fingerprints with strict equality, but on macOS the fingerprint comes from `psutil.Process(pid).create_time()`, which can shift by ~1s for the *same* live process across a psutil upgrade in the venv or an NTP step adjustment. Observed in the field (macOS mini, Hermes 0.17.0, psutil 7.2.2): recorded `178526682901` vs live `178526682801` — exactly 1.00s apart with identical sub-second fraction — so every liveness probe rejected the live PID and the dashboard showed `gateway_running: false` while WhatsApp was connected and the heartbeat fresh. Impact is worst when `gateway.pid`/`gateway.lock` are absent (e.g. after a `--replace` handoff), leaving the `gateway_state.json` fallback as the only liveness path.

The fix compares fingerprints with a 2s tolerance (`_START_TIME_TOLERANCE = 200` — centiseconds on macOS/Windows, clock ticks on Linux). A false positive would require the OS to recycle the same PID onto a process whose start instant lands within 2s of the original's, *and* the existing command-line/profile identity checks to also misidentify it. Non-numeric fingerprints fall back to strict equality.

## Related Issue

Fixes #78498

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py`: new `_start_times_match()` helper + `_START_TIME_TOLERANCE`; the three strict-equality sites (`get_running_pid`, `get_runtime_status_running_pid`, `record_is_live_gateway`) now use it.
- `tests/gateway/test_status.py`: regression test reproducing the field failure (1s drift on a live, cmdline-matching gateway must be reported running — fails on main, passes with the fix), plus a test that a large mismatch (genuine PID recycling) is still rejected.

## How to Test

1. `pytest tests/gateway/test_status.py -q` → 53 passed (51 on main + 2 new).
2. Revert `gateway/status.py` only → `test_runtime_status_running_pid_tolerates_small_start_time_drift` fails, demonstrating the bug.
3. Live repro: on a running macOS gateway, edit the recorded `start_time` in `gateway_state.json` by ±100 → before this fix `/api/status` reports `stopped`; with it, `running`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full suite run locally: 24310 passed; the ~1k failures observed were reproduced identically without this change (missing optional service deps in a minimal venv; every sampled failing file passes in isolation). `tests/gateway/` target area is green.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0) — live gateway on a Mac mini
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tolerance units hold on both /proc (ticks) and psutil (centiseconds) paths
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A