### PR TITLE
fix: preserve named provider identity across runtime consumers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2198,7 +2198,11 @@ class HermesACPAgent(acp.Agent):
             provider = getattr(state.agent, "provider", None) or "auto"
             return f"Current model: {model}\nProvider: {provider}"
 
-        current_provider = getattr(state.agent, "provider", None) or "openrouter"
+        current_provider = (
+            getattr(state.agent, "requested_provider", None)
+            or getattr(state.agent, "provider", None)
+            or "openrouter"
+        )
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
 
         state.model = new_model
@@ -2443,15 +2447,27 @@ class HermesACPAgent(acp.Agent):
         """Switch the model for a session (called by ACP protocol)."""
         state = self.session_manager.get_session(session_id)
         if state:
-            current_provider = getattr(state.agent, "provider", None)
+            current_transport_provider = getattr(state.agent, "provider", None)
+            current_requested_provider = (
+                getattr(state.agent, "requested_provider", None)
+                or current_transport_provider
+                or "openrouter"
+            )
             requested_provider, resolved_model = self._resolve_model_selection(
                 model_id,
-                current_provider or "openrouter",
+                current_requested_provider,
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
-            current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
-            current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            provider_changed = bool(
+                current_transport_provider
+                and requested_provider != current_requested_provider
+            )
+            current_base_url = (
+                None if provider_changed else getattr(state.agent, "base_url", None)
+            )
+            current_api_mode = (
+                None if provider_changed else getattr(state.agent, "api_mode", None)
+            )
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -423,10 +423,13 @@ class SessionManager:
         model_str = str(state.model) if state.model else None
         session_meta = {"cwd": state.cwd}
         provider = getattr(state.agent, "provider", None)
+        requested_provider = getattr(state.agent, "requested_provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
         if isinstance(provider, str) and provider.strip():
             session_meta["provider"] = provider.strip()
+        if isinstance(requested_provider, str) and requested_provider.strip():
+            session_meta["requested_provider"] = requested_provider.strip()
         if isinstance(base_url, str) and base_url.strip():
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
@@ -526,7 +529,11 @@ class SessionManager:
                 meta = json.loads(mc)
                 if isinstance(meta, dict):
                     cwd = meta.get("cwd", ".")
-                    requested_provider = meta.get("provider") or requested_provider
+                    requested_provider = (
+                        meta.get("requested_provider")
+                        or meta.get("provider")
+                        or requested_provider
+                    )
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
             except (json.JSONDecodeError, TypeError):
@@ -637,6 +644,12 @@ class SessionManager:
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
+                    "requested_provider": (
+                        runtime.get("requested_provider")
+                        or requested_provider
+                        or config_provider
+                        or runtime.get("provider")
+                    ),
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -677,6 +677,7 @@ def init_agent(
                 credential_pool,
                 agent.provider,
                 base_url=agent.base_url,
+                provider_name=getattr(agent, "requested_provider", None),
             ):
                 agent._credential_pool = None
         except Exception:
@@ -1011,6 +1012,8 @@ def init_agent(
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex Responses API streaming.
     agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = ""
     agent._is_anthropic_oauth = False
 
     # Resolve per-provider / per-model request timeout once up front so
@@ -1259,9 +1262,46 @@ def init_agent(
                     for _fb in _fb_entries:
                         try:
                             from hermes_cli.fallback_config import resolve_entry_api_key
+                            from hermes_cli.runtime_provider import resolve_runtime_provider
                             _fb_explicit_key = resolve_entry_api_key(_fb)
+                            _fb_runtime = {}
+                            _fb_transport = str(_fb.get("provider") or "").strip().lower()
+                            _fb_requested = _fb_transport
+                            _fb_api_mode = "chat_completions"
+                            # Identity resolution is advisory for availability:
+                            # if config/auth lookup is unavailable, still let
+                            # resolve_provider_client decide whether this entry
+                            # can actually be used.
+                            try:
+                                _candidate_runtime = resolve_runtime_provider(
+                                    requested=str(_fb.get("provider") or ""),
+                                    target_model=str(_fb.get("model") or ""),
+                                    explicit_base_url=_fb.get("base_url"),
+                                    explicit_api_key=_fb_explicit_key,
+                                )
+                                if isinstance(_candidate_runtime, dict):
+                                    _fb_runtime = _candidate_runtime
+                                    _fb_transport = str(
+                                        _fb_runtime.get("provider") or _fb_transport
+                                    ).strip().lower()
+                                    _fb_requested = str(
+                                        _fb_runtime.get("requested_provider") or _fb["provider"]
+                                    ).strip().lower()
+                                    _fb_api_mode = str(
+                                        _fb_runtime.get("api_mode") or _fb_api_mode
+                                    ).strip().lower()
+                            except Exception as _identity_exc:
+                                logger.debug(
+                                    "Init fallback identity resolution failed for %s: %s",
+                                    _fb.get("provider"), _identity_exc,
+                                )
+                            _fb_api_mode = str(
+                                _fb_runtime.get("api_mode") or _fb_api_mode
+                            ).strip().lower()
+                            if _fb_api_mode in {"bedrock_converse", "codex_app_server"}:
+                                continue
                             _fb_client, _fb_model = resolve_provider_client(
-                                _fb["provider"], model=_fb["model"], raw_codex=True,
+                                str(_fb.get("provider") or ""), model=str(_fb.get("model") or ""), raw_codex=True,
                                 explicit_base_url=_fb.get("base_url"),
                                 explicit_api_key=_fb_explicit_key,
                             )
@@ -1272,13 +1312,73 @@ def init_agent(
                             )
                             continue
                         if _fb_client is not None:
-                            agent.provider = _fb["provider"]
+                            from hermes_cli.model_switch import _canonical_requested_provider_identity
+                            agent.provider = _fb_transport
+                            agent.requested_provider = _canonical_requested_provider_identity(
+                                _fb_transport, _fb_requested
+                            )
                             agent.model = _fb_model or _fb["model"]
+                            agent.api_mode = _fb_api_mode
                             agent._fallback_activated = True
-                            client_kwargs = {
-                                "api_key": _fb_client.api_key,
-                                "base_url": str(_fb_client.base_url),
-                            }
+                            # Match runtime fallback adoption: only bind a pool
+                            # that belongs to the exact fallback identity and
+                            # still contains credentials.  An empty pool must
+                            # not poison recovery by occupying the slot.
+                            fallback_pool_key = _fb_transport
+                            if _fb_transport == "custom":
+                                named_identity = str(_fb_requested or "").strip()
+                                if named_identity and named_identity.lower() != "custom":
+                                    fallback_pool_key = f"custom:{named_identity.removeprefix('custom:').replace(' ', '-').lower()}"
+                            runtime_pool = _fb_runtime.get("credential_pool")
+                            runtime_pool_provider = str(
+                                getattr(runtime_pool, "provider", "") or ""
+                            ).strip().lower()
+                            runtime_pool_matches = (
+                                runtime_pool is not None
+                                and runtime_pool_provider == str(fallback_pool_key or "").lower()
+                            )
+                            runtime_pool_has_credentials = False
+                            if runtime_pool_matches:
+                                try:
+                                    runtime_pool_has_credentials = bool(
+                                        runtime_pool.has_credentials()
+                                    )
+                                except Exception:
+                                    runtime_pool_has_credentials = False
+                            if runtime_pool_matches and runtime_pool_has_credentials:
+                                agent._credential_pool = runtime_pool
+                            elif fallback_pool_key:
+                                try:
+                                    from agent.credential_pool import load_pool
+                                    loaded_pool = load_pool(fallback_pool_key)
+                                    if loaded_pool and loaded_pool.has_credentials():
+                                        agent._credential_pool = loaded_pool
+                                except Exception as _pool_exc:
+                                    logger.debug(
+                                        "Init fallback pool load failed for %s: %s",
+                                        fallback_pool_key,
+                                        _pool_exc,
+                                    )
+                            # A runtime resolver may have selected a native
+                            # Anthropic wire mode for a named custom endpoint.
+                            # Build that client directly instead of routing the
+                            # endpoint through OpenAI chat completions.
+                            if _fb_api_mode == "anthropic_messages":
+                                from agent.anthropic_adapter import build_anthropic_client
+                                agent._anthropic_api_key = _fb_client.api_key or ""
+                                agent._anthropic_base_url = str(_fb_client.base_url)
+                                agent._anthropic_client = build_anthropic_client(
+                                    agent._anthropic_api_key,
+                                    agent._anthropic_base_url,
+                                    timeout=_provider_timeout,
+                                )
+                                agent.client = None
+                                client_kwargs = {}
+                            else:
+                                client_kwargs = {
+                                    "api_key": _fb_client.api_key,
+                                    "base_url": str(_fb_client.base_url),
+                                }
                             if _provider_timeout is not None:
                                 client_kwargs["timeout"] = _provider_timeout
                             _fb_headers = getattr(_fb_client, "_custom_headers", None)
@@ -1360,32 +1460,38 @@ def init_agent(
         except Exception:
             logger.debug("custom-provider TLS resolution skipped", exc_info=True)
 
-        agent.api_key = client_kwargs.get("api_key", "")
-        agent.base_url = client_kwargs.get("base_url", agent.base_url)
-        try:
-            from agent.ssl_guard import verify_ca_bundle_with_fallback
+        if agent.api_mode == "anthropic_messages" and getattr(agent, "_anthropic_client", None) is not None:
+            # Native Anthropic routes own their client; do not replace it with an
+            # OpenAI-compatible client in the shared post-resolution path.
+            agent.client = None
+            agent._client_kwargs = {}
+        else:
+            agent.api_key = client_kwargs.get("api_key", "")
+            agent.base_url = client_kwargs.get("base_url", agent.base_url)
+            try:
+                from agent.ssl_guard import verify_ca_bundle_with_fallback
 
-            verify_ca_bundle_with_fallback()
-            agent.client = agent._create_openai_client(client_kwargs, reason="agent_init", shared=True)
-            if not agent.quiet_mode:
-                print(f"🤖 AI Agent initialized with model: {agent.model}")
-                if base_url:
-                    print(f"🔗 Using custom base URL: {base_url}")
-                # ``api_key`` may be a callable Entra ID bearer
-                # provider (Azure Foundry). The OpenAI SDK mints a
-                # fresh JWT per request internally — the banner
-                # never invokes or inspects the callable.
-                from agent.azure_identity_adapter import is_token_provider
+                verify_ca_bundle_with_fallback()
+                agent.client = agent._create_openai_client(client_kwargs, reason="agent_init", shared=True)
+                if not agent.quiet_mode:
+                    print(f"🤖 AI Agent initialized with model: {agent.model}")
+                    if base_url:
+                        print(f"🔗 Using custom base URL: {base_url}")
+                    # ``api_key`` may be a callable Entra ID bearer
+                    # provider (Azure Foundry). The OpenAI SDK mints a
+                    # fresh JWT per request internally — the banner
+                    # never invokes or inspects the callable.
+                    from agent.azure_identity_adapter import is_token_provider
 
-                key_used = client_kwargs.get("api_key", "none")
-                if is_token_provider(key_used):
-                    print("🔑 Using credentials: Microsoft Entra ID")
-                elif isinstance(key_used, str) and key_used and key_used != "dummy-key" and len(key_used) > 12:
-                    print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
-                else:
-                    print("⚠️  Warning: API key appears invalid or missing")
-        except Exception as e:
-            raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
+                    key_used = client_kwargs.get("api_key", "none")
+                    if is_token_provider(key_used):
+                        print("🔑 Using credentials: Microsoft Entra ID")
+                    elif isinstance(key_used, str) and key_used and key_used != "dummy-key" and len(key_used) > 12:
+                        print(f"🔑 Using API key: {key_used[:8]}...{key_used[-4:]}")
+                    else:
+                        print("⚠️  Warning: API key appears invalid or missing")
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
 
     # Keep a stable identity for the pool entry that supplied this runtime.
     # OAuth refreshes can replace the runtime token before a failed request is

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -972,7 +972,10 @@ def recover_with_credential_pool(
                 from agent.credential_pool import get_custom_provider_pool_key
                 _agent_base = (getattr(agent, "base_url", "") or "").strip()
                 _custom_match = bool(_agent_base) and (
-                    (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
+                    (get_custom_provider_pool_key(
+                        _agent_base,
+                        provider_name=getattr(agent, "requested_provider", None),
+                    ) or "").strip().lower()
                     == pool_provider
                 )
             except Exception:
@@ -1486,20 +1489,41 @@ def restore_primary_runtime(agent) -> bool:
     # pool-rebind block below via ``prefetched_primary_pool`` so the load
     # happens at most once per restore.
     prefetched_primary_pool = None
+    primary_provider = ""
+    primary_requested_provider = ""
+    primary_pool_provider = ""
     try:
         primary_provider = str(
             (agent._primary_runtime or {}).get("provider") or ""
         ).strip().lower()
+        primary_requested_provider = str(
+            (agent._primary_runtime or {}).get("requested_provider") or ""
+        ).strip()
+        primary_pool_provider = primary_provider
+        if primary_provider == "custom":
+            try:
+                from agent.credential_pool import get_custom_provider_pool_key
+
+                primary_pool_provider = (
+                    get_custom_provider_pool_key(
+                        str((agent._primary_runtime or {}).get("base_url") or ""),
+                        provider_name=primary_requested_provider or None,
+                    )
+                    or primary_provider
+                )
+            except Exception:
+                primary_pool_provider = primary_provider
         pool = getattr(agent, "_credential_pool", None)
         if not credential_pool_matches_provider(
             pool,
             primary_provider,
             base_url=str((agent._primary_runtime or {}).get("base_url") or ""),
+            provider_name=primary_requested_provider or None,
         ):
             from agent.credential_pool import load_pool
 
             prefetched_primary_pool = (
-                load_pool(primary_provider) if primary_provider else None
+                load_pool(primary_pool_provider) if primary_pool_provider else None
             )
             pool = prefetched_primary_pool
         next_at = getattr(pool, "next_available_at", lambda: None)()
@@ -1605,8 +1629,14 @@ def restore_primary_runtime(agent) -> bool:
             try:
                 from agent.credential_pool import get_custom_provider_pool_key
 
+                primary_requested_provider = str(
+                    rt.get("requested_provider") or ""
+                ).strip()
                 primary_key = (
-                    get_custom_provider_pool_key(str(rt.get("base_url") or "")) or ""
+                    get_custom_provider_pool_key(
+                        str(rt.get("base_url") or ""),
+                        provider_name=primary_requested_provider or None,
+                    ) or ""
                 ).strip().lower()
                 pool_matches_primary = bool(primary_key) and primary_key == pool_provider
             except Exception:
@@ -1622,7 +1652,9 @@ def restore_primary_runtime(agent) -> bool:
                 else:
                     from agent.credential_pool import load_pool
 
-                    agent._credential_pool = load_pool(primary_provider)
+                    agent._credential_pool = load_pool(
+                        primary_pool_provider or primary_provider
+                    )
             except Exception as exc:
                 logger.warning(
                     "Restore could not reload primary credential pool for %s: %s",
@@ -1662,8 +1694,14 @@ def restore_primary_runtime(agent) -> bool:
                     try:
                         from agent.credential_pool import get_custom_provider_pool_key
                         primary_base_url = str(rt.get("base_url") or "").strip()
+                        primary_requested_provider = str(
+                            rt.get("requested_provider") or ""
+                        ).strip()
                         primary_key = (
-                            get_custom_provider_pool_key(primary_base_url) or ""
+                            get_custom_provider_pool_key(
+                                primary_base_url,
+                                provider_name=primary_requested_provider or None,
+                            ) or ""
                         ).strip().lower()
                         entry_matches_primary = bool(primary_key) and primary_key == entry_provider
                     except Exception:
@@ -2351,7 +2389,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
-def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
+def switch_model(
+    agent,
+    new_model,
+    new_provider,
+    api_key='',
+    base_url='',
+    api_mode='',
+    requested_provider=None,
+):
     """Switch the model/provider in-place for a live agent.
 
     Called by the /model command handlers (CLI and gateway) after
@@ -2389,6 +2435,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    old_requested_provider = getattr(agent, "requested_provider", old_provider)
+    effective_requested_provider = (
+        str(requested_provider).strip()
+        if requested_provider is not None and str(requested_provider).strip()
+        else new_provider
+    )
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -2449,7 +2501,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # ── Swap core runtime fields ──
         agent.model = new_model
         agent.provider = new_provider
-        agent.requested_provider = new_provider
+        agent.requested_provider = effective_requested_provider
         # Use the new base_url when provided. When it's empty AND the
         # provider is actually changing, do NOT fall back to the current
         # (old provider's) URL — that silently pairs the new provider label
@@ -2489,20 +2541,44 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # actually changed (or the pool was missing) — re-selecting the same
         # provider must not churn the pool reference. A reload failure is
         # logged + swallowed: the switch itself must still complete.
-        old_norm = (old_provider or "").strip().lower()
-        new_norm = (new_provider or "").strip().lower()
-        if old_norm != new_norm or getattr(agent, "_credential_pool", None) is None:
-            # A pool bound to the old provider is worse than no pool: the
-            # recovery guard rejects it and every later 401/429 skips rotation.
+        pool_key = new_provider
+        if new_norm_provider == "custom":
+            named_identity = str(effective_requested_provider or "").strip()
+            if named_identity and named_identity.lower() != "custom":
+                try:
+                    from agent.credential_pool import get_custom_provider_pool_key
+                    pool_key = get_custom_provider_pool_key(
+                        base_url or "",
+                        provider_name=named_identity,
+                    )
+                except Exception:
+                    pool_key = None
+            else:
+                pool_key = "custom"
+        existing_pool_provider = str(
+            getattr(getattr(agent, "_credential_pool", None), "provider", "") or ""
+        ).strip().lower()
+        identity_changed = (
+            old_norm_provider == "custom"
+            and new_norm_provider == "custom"
+            and str(old_requested_provider or "").strip().lower()
+            != str(effective_requested_provider or "").strip().lower()
+        )
+        if (
+            old_norm_provider != new_norm_provider
+            or identity_changed
+            or getattr(agent, "_credential_pool", None) is None
+            or (pool_key and existing_pool_provider != str(pool_key).strip().lower())
+        ):
             agent._credential_pool = None
             agent._credential_pool_entry_id = None
             try:
                 from agent.credential_pool import load_pool
-                agent._credential_pool = load_pool(new_provider)
+                if pool_key:
+                    agent._credential_pool = load_pool(pool_key)
             except Exception as _pool_exc:  # noqa: BLE001
                 logger.warning(
-                    "switch_model: credential pool reload failed for %s (%s); "
-                    "continuing without pool rotation this turn",
+                    "switch_model: credential pool reload failed for %s (%s); continuing without pool rotation this turn",
                     new_provider, _pool_exc,
                 )
         # ── Build new client ──

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -59,6 +59,11 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         parent_api_mode = "codex_responses"
     parent = {
         "provider": agent.provider,
+        "requested_provider": (
+            parent_runtime.get("requested_provider")
+            or getattr(agent, "requested_provider", None)
+            or agent.provider
+        ),
         "model": agent.model,
         "api_key": parent_runtime.get("api_key") or None,
         "base_url": parent_runtime.get("base_url") or None,
@@ -95,6 +100,11 @@ def _resolve_review_runtime(agent: Any) -> Dict[str, Any]:
         )
         return {
             "provider": rp.get("provider") or task_provider,
+            "requested_provider": (
+                rp.get("requested_provider")
+                or rp.get("provider")
+                or task_provider
+            ),
             "model": rp.get("model") or task_model,
             "api_key": rp.get("api_key"),
             "base_url": rp.get("base_url"),
@@ -789,6 +799,11 @@ def _run_review_in_thread(
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,
+                requested_provider=(
+                    _rt.get("requested_provider")
+                    or _rt.get("provider")
+                    or agent.provider
+                ),
                 api_mode=_rt.get("api_mode"),
                 base_url=_rt.get("base_url") or None,
                 api_key=_rt.get("api_key") or None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1692,6 +1692,42 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
 
 
 
+def _resolve_fallback_runtime_identity(
+    configured_provider: str,
+    model: str,
+    *,
+    explicit_base_url: Optional[str],
+    explicit_api_key: Optional[str],
+) -> tuple[str, str, Dict[str, Any]]:
+    """Resolve fallback transport separately from its durable provider identity."""
+    configured = str(configured_provider or "").strip().lower()
+    runtime: Dict[str, Any] = {}
+    transport = configured
+    requested = configured
+    try:
+        from hermes_cli.model_switch import _canonical_requested_provider_identity
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        resolved = resolve_runtime_provider(
+            requested=configured,
+            target_model=model,
+            explicit_base_url=explicit_base_url,
+            explicit_api_key=explicit_api_key,
+        )
+        if isinstance(resolved, dict):
+            runtime = resolved
+        resolved_transport = str(runtime.get("provider") or configured).strip().lower()
+        if resolved_transport:
+            transport = resolved_transport
+            requested = _canonical_requested_provider_identity(
+                transport,
+                str(runtime.get("requested_provider") or configured or transport),
+            )
+    except Exception as exc:
+        logger.debug("Fallback runtime identity resolution failed for %s: %s", configured, exc)
+    return transport, requested, runtime
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1794,29 +1830,31 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         )
         return agent._try_activate_fallback(reason)
 
-    # Use centralized router for client construction.
-    # raw_codex=True because the main agent needs direct responses.stream()
-    # access for Codex providers.
+    from hermes_cli.fallback_config import resolve_entry_api_key
+    fb_base_url_hint = (fb.get("base_url") or "").strip() or None
+    fb_api_key_hint = resolve_entry_api_key(fb)
+    fb_transport, fb_requested_provider, fb_runtime = _resolve_fallback_runtime_identity(
+        fb_provider,
+        fb_model,
+        explicit_base_url=fb_base_url_hint,
+        explicit_api_key=fb_api_key_hint,
+    )
+    resolved_mode = str(fb_runtime.get("api_mode") or "").strip().lower()
+    if resolved_mode in {"bedrock_converse", "codex_app_server"}:
+        unavailable.add(fb_key)
+        logger.warning("Fallback skip: %s/%s uses unsupported native runtime %s", fb_requested_provider, fb_model, resolved_mode)
+        return agent._try_activate_fallback(reason)
+
+    # Use the configured provider name for client construction: named custom
+    # entries are looked up by durable identity, while the live agent stores
+    # the resolved transport separately.
     try:
         from agent.auxiliary_client import resolve_provider_client
-        # Pass base_url and api_key from fallback config so custom
-        # endpoints (e.g. Ollama Cloud) resolve correctly instead of
-        # falling through to OpenRouter defaults.
-        from hermes_cli.fallback_config import resolve_entry_api_key
-
-        fb_base_url_hint = (fb.get("base_url") or "").strip() or None
-        fb_api_key_hint = resolve_entry_api_key(fb)
-        # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
-        # when no explicit key is in the fallback config. Host match
-        # (not substring) — see GHSA-76xc-57q6-vm5m.
-        if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
-            from agent.secret_scope import get_secret
-
-            fb_api_key_hint = get_secret("OLLAMA_API_KEY") or None
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+        )
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -1881,57 +1919,64 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model = agent.model
         old_provider = agent.provider
+        if (
+            fb_transport == "custom"
+            and str(fb_runtime.get("api_mode") or "").strip().lower() in {
+                "chat_completions", "codex_responses", "anthropic_messages"
+            }
+        ):
+            fb_api_mode = str(fb_runtime.get("api_mode")).strip().lower()
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
         # the stale value from the previous model.  See #22387.
         agent._config_context_length = None
         agent.model = fb_model
-        agent.provider = fb_provider
-        agent.requested_provider = fb_provider
+        # Preserve runtime transport and durable requested identity separately.
+        agent.provider = fb_transport
+        agent.requested_provider = fb_requested_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
 
-        # Rebind the credential pool to the fallback provider when the provider
-        # changes.  Keeping the primary pool attached would make downstream
-        # recovery (rate_limit / billing / auth) mutate the wrong credential
-        # set and can overwrite the fallback's base_url back to the primary
-        # endpoint.  See #33163.
-        #
-        # When the fallback shares the pool's provider (e.g. both openrouter
-        # entries with different routing) the pool is preserved.  When the
-        # providers differ, load the fallback provider's own pool if one exists
-        # so provider-specific rotation continues to work after the switch.
+        # Rebind the credential pool to the fallback's exact effective route.
+        fallback_pool_key = fb_transport
+        if fb_transport == "custom":
+            named_identity = str(fb_requested_provider or "").strip()
+            if named_identity and named_identity.lower() != "custom":
+                try:
+                    from agent.credential_pool import get_custom_provider_pool_key
+                    fallback_pool_key = get_custom_provider_pool_key(
+                        fb_base_url,
+                        provider_name=named_identity,
+                    )
+                except Exception:
+                    fallback_pool_key = None
         _existing_pool = getattr(agent, "_credential_pool", None)
         if _existing_pool is not None:
             _pool_provider = (getattr(_existing_pool, "provider", "") or "").strip().lower()
-            if _pool_provider and _pool_provider != fb_provider:
-                logger.info(
-                    "Fallback to %s/%s: clearing primary credential pool "
-                    "(pool_provider=%s) to prevent cross-provider contamination",
-                    fb_provider, fb_model, _pool_provider,
-                )
+            if _pool_provider and _pool_provider != str(fallback_pool_key or "").lower():
                 agent._credential_pool = None
                 agent._credential_pool_entry_id = None
-        if getattr(agent, "_credential_pool", None) is None:
+        runtime_pool = fb_runtime.get("credential_pool")
+        runtime_pool_key = str(getattr(runtime_pool, "provider", "") or "").strip().lower()
+        if (
+            getattr(agent, "_credential_pool", None) is None
+            and runtime_pool is not None
+            and runtime_pool_key == str(fallback_pool_key or "").lower()
+            and runtime_pool.has_credentials()
+        ):
+            agent._credential_pool = runtime_pool
+        if getattr(agent, "_credential_pool", None) is None and fallback_pool_key:
             try:
                 from agent.credential_pool import load_pool
-
-                fallback_pool = load_pool(fb_provider)
+                fallback_pool = load_pool(fallback_pool_key)
                 if fallback_pool and fallback_pool.has_credentials():
                     agent._credential_pool = fallback_pool
-                    logger.info(
-                        "Fallback to %s/%s: attached fallback credential pool",
-                        fb_provider, fb_model,
-                    )
             except Exception as exc:
-                logger.debug(
-                    "Fallback to %s/%s: could not attach credential pool: %s",
-                    fb_provider, fb_model, exc,
-                )
+                logger.debug("Fallback pool load failed for %s: %s", fallback_pool_key, exc)
 
         # Honor per-provider / per-model request_timeout_seconds for the
         # fallback target (same knob the primary client uses).  None = use

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -389,7 +389,10 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
 
 def _normalize_custom_pool_name(name: str) -> str:
     """Normalize a custom provider name for use as a pool key suffix."""
-    return name.strip().lower().replace(" ", "-")
+    normalized = str(name or "").strip().lower().replace(" ", "-")
+    if normalized.startswith(CUSTOM_POOL_PREFIX):
+        normalized = normalized[len(CUSTOM_POOL_PREFIX):]
+    return normalized
 
 
 def _iter_custom_providers(config: Optional[dict] = None):
@@ -419,28 +422,24 @@ def _iter_custom_providers(config: Optional[dict] = None):
 
 
 def get_custom_provider_pool_key(base_url: Optional[str], provider_name: Optional[str] = None) -> Optional[str]:
-    """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching base_url.
+    """Return the configured custom pool key for an endpoint and optional identity.
 
-    When provider_name is given, prefer matching by name first (solving the case where
-    multiple custom providers share the same base_url but have different API keys).
-    Falls back to base_url matching when no name match is found.
-
-    Returns None if no match is found.
+    An explicit provider name is a trust-boundary assertion: it must match both
+    a configured name and that entry's endpoint. URL-only lookup is retained
+    only for callers that have no named identity at all.
     """
     if not base_url:
         return None
     normalized_url = base_url.strip().rstrip("/")
 
-    # When a provider name is given, try to match by name first.
-    # This fixes the P1 bug where two custom providers sharing the same
-    # base_url always resolve to the first one's credentials.
     if provider_name:
         normalized_name = _normalize_custom_pool_name(provider_name)
         for norm_name, entry in _iter_custom_providers():
-            if norm_name == normalized_name:
+            entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
+            if norm_name == normalized_name and entry_url == normalized_url:
                 return f"{CUSTOM_POOL_PREFIX}{norm_name}"
+        return None
 
-    # Fall back to base_url matching (original behavior)
     for norm_name, entry in _iter_custom_providers():
         entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
         if entry_url and entry_url == normalized_url:
@@ -491,14 +490,17 @@ def credential_pool_matches_provider(
     provider: Optional[str],
     *,
     base_url: Optional[str] = None,
+    provider_name: Optional[str] = None,
 ) -> bool:
     """Return whether a pool belongs to the requested runtime provider.
 
     Named custom endpoints intentionally use two identities: the live agent is
     ``custom`` while its pool is keyed ``custom:<name>``. Accept that pair only
-    when the runtime base URL resolves to the exact same custom pool key.
-    Empty string identities fail closed. Legacy pool adapters without a
-    ``provider`` attribute remain compatible; production pools are scoped.
+    when the runtime base URL plus, when available, the original named provider
+    resolve to the exact same custom pool key. This prevents URL-first lookup
+    from accepting a sibling account group that shares the endpoint. Empty
+    string identities fail closed. Legacy pool adapters without a ``provider``
+    attribute remain compatible; production pools are scoped.
     """
     raw_pool_provider = getattr(pool_or_provider, "provider", None)
     if raw_pool_provider is None:
@@ -518,7 +520,10 @@ def credential_pool_matches_provider(
     if provider_norm != "custom" or not pool_provider.startswith(CUSTOM_POOL_PREFIX):
         return False
     try:
-        matched_pool = get_custom_provider_pool_key(base_url or "")
+        matched_pool = get_custom_provider_pool_key(
+            base_url or "",
+            provider_name=provider_name,
+        )
     except Exception:
         return False
     return str(matched_pool or "").strip().lower() == pool_provider
@@ -2728,6 +2733,16 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
     return changed, active_sources
 
 
+def _get_env_prefer_dotenv(key: str, default: str = "") -> str:
+    """Read a profile env key with the pool's established `.env` precedence."""
+    env_file = load_env()
+    raw = env_file.get(key, "").strip()
+    scoped_value = (_get_secret(key, "") or "").strip()
+    if raw.startswith("op://") and scoped_value:
+        return scoped_value
+    return raw or scoped_value or default
+
+
 def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
@@ -2750,23 +2765,6 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     # authoritative source for Hermes credentials. Stale env vars from parent
     # processes (Codex CLI, test scripts, etc.) should not override deliberate
     # changes to the .env file.
-    def _get_env_prefer_dotenv(key: str) -> str:
-        env_file = load_env()
-        raw = env_file.get(key, "").strip()
-        scoped_value = (_get_secret(key, "") or "").strip()
-        # If .env contains an unresolved op:// reference, prefer the
-        # already-resolved value supplied by the active secret scope (or by
-        # os.environ in legacy single-profile mode), set by
-        # load_hermes_dotenv() -> apply_onepassword_secrets()).  The raw
-        # "op://Vault/Item/field" string would otherwise win and every
-        # provider auth attempt would receive a URL instead of a key.  This
-        # happens during a partial migration, or when the user wrote op://
-        # references straight into .env rather than the secrets.onepassword
-        # config block.  For every non-op:// value the original
-        # .env-takes-precedence behaviour is preserved unchanged.
-        if raw.startswith("op://") and scoped_value:
-            return scoped_value
-        return raw or scoped_value
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it
@@ -2919,10 +2917,16 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
         def _is_suppressed(_p, _s):  # type: ignore[misc]
             return False
 
-    # Seed from the custom_providers config entry's api_key field
+    # Reuse the runtime resolver so pool-first selection cannot preserve an
+    # inline key that the named-provider runtime would correctly supersede.
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
-        api_key = str(cp_config.get("api_key") or "").strip()
+        from hermes_cli.runtime_provider import _resolve_named_custom_api_key
+
+        api_key = _resolve_named_custom_api_key(
+            cp_config,
+            getenv=_get_env_prefer_dotenv,
+        )
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
         if api_key:
@@ -2942,22 +2946,30 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                     },
                 )
 
-    # Seed from model.api_key if model.provider=='custom' and model.base_url matches
+    # Seed from model.api_key when model.provider is a custom transport or
+    # already carries a canonical custom:<name> identity and model.base_url matches.
     try:
         config = _load_config_safe()
         model_cfg = config.get("model") if config else None
         if isinstance(model_cfg, dict):
             model_provider = str(model_cfg.get("provider") or "").strip().lower()
             model_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+            model_requested_provider = str(
+                model_cfg.get("requested_provider") or ""
+            ).strip()
+            if model_provider.startswith(CUSTOM_POOL_PREFIX) and not model_requested_provider:
+                model_requested_provider = model_provider
             model_api_key = ""
             for k in ("api_key", "api"):
                 v = model_cfg.get(k)
                 if isinstance(v, str) and v.strip():
                     model_api_key = v.strip()
                     break
-            if model_provider == "custom" and model_base_url and model_api_key:
-                # Check if this model's base_url matches our custom provider
-                matched_key = get_custom_provider_pool_key(model_base_url)
+            if model_provider in {"custom", model_requested_provider} and model_base_url and model_api_key:
+                matched_key = get_custom_provider_pool_key(
+                    model_base_url,
+                    provider_name=model_requested_provider or None,
+                )
                 if matched_key == pool_key:
                     source = "model_config"
                     if not _is_suppressed(pool_key, source):

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1868,6 +1868,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _base_url = None
     _api_mode = None
     _resolved_provider = None
+    _requested_provider = None
     _credential_pool = None
     _request_overrides: Dict[str, Any] = {}
     _max_tokens = None
@@ -1890,6 +1891,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _base_url = _rp.get("base_url")
         _api_mode = _rp.get("api_mode")
         _resolved_provider = _rp.get("provider") or _provider
+        _requested_provider = str(
+            _rp.get("requested_provider") or _provider or ""
+        )
         _credential_pool = _rp.get("credential_pool")
         _request_overrides = _merge_request_overrides(
             _rp.get("request_overrides"),
@@ -1917,6 +1921,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         review_agent = AIAgent(
             model=_model_name,
             provider=_resolved_provider,
+            requested_provider=_requested_provider,
             api_key=_api_key,
             base_url=_base_url,
             api_mode=_api_mode,

--- a/cli.py
+++ b/cli.py
@@ -8192,6 +8192,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 _reset_result = _switch_model(
                     raw_input=_config_model,
                     current_provider=self.provider or "",
+                    current_requested_provider=self.requested_provider or "",
                     current_model=self.model or "",
                     current_base_url=self.base_url or "",
                     current_api_key=self.api_key or "",
@@ -8203,13 +8204,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         self.agent.switch_model(
                             new_model=_reset_result.new_model,
                             new_provider=_reset_result.target_provider,
+                            requested_provider=(
+                                _reset_result.requested_provider
+                                or _reset_result.target_provider
+                            ),
                             api_key=_reset_result.api_key,
                             base_url=_reset_result.base_url,
                             api_mode=_reset_result.api_mode,
                         )
                     self.model = _reset_result.new_model
                     self.provider = _reset_result.target_provider
-                    self.requested_provider = _reset_result.target_provider
+                    self.requested_provider = (
+                        _reset_result.requested_provider
+                        or _reset_result.target_provider
+                    )
                     self._explicit_api_key = _reset_result.api_key
                     self._explicit_base_url = _reset_result.base_url
                     if _reset_result.api_key:
@@ -9032,6 +9040,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 agent.switch_model(
                     new_model=snapshot.get("model", ""),
                     new_provider=snapshot.get("provider", ""),
+                    requested_provider=(
+                        snapshot.get("requested_provider")
+                        or snapshot.get("provider", "")
+                    ),
                     api_key=snapshot.get("api_key", ""),
                     base_url=snapshot.get("base_url", ""),
                     api_mode=snapshot.get("api_mode", ""),
@@ -9135,7 +9147,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         }
         self.model = result.new_model
         self.provider = result.target_provider
-        self.requested_provider = result.target_provider
+        self.requested_provider = result.requested_provider or result.target_provider
         # Always overwrite explicit overrides so stale credentials from the
         # previous provider (e.g. Ollama api_key/base_url) don't leak into
         # the new provider's credential resolution on the next turn.
@@ -9153,6 +9165,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
+                    requested_provider=(
+                        result.requested_provider or result.target_provider
+                    ),
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
@@ -9219,7 +9234,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if persist_global:
             HermesCLI._clear_persisted_context_for_model_switch(self, result)
             save_config_value("model.default", result.new_model)
-            save_config_value("model.provider", result.target_provider)
+            save_config_value(
+                "model.provider",
+                result.requested_provider or result.target_provider,
+            )
             # base_url/api_mode were previously never persisted here, so a
             # global switch left the OLD provider's endpoint/wire-protocol in
             # config.yaml. result.base_url/api_mode are always freshly
@@ -9282,6 +9300,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 result = switch_model(
                     raw_input=chosen_model,
                     current_provider=self.provider or "",
+                    current_requested_provider=self.requested_provider or "",
                     current_model=self.model or "",
                     current_base_url=self.base_url or "",
                     current_api_key=self.api_key or "",
@@ -9425,6 +9444,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         result = switch_model(
             raw_input=model_input,
             current_provider=self.provider or "",
+            current_requested_provider=self.requested_provider or "",
             current_model=self.model or "",
             current_base_url=self.base_url or "",
             current_api_key=self.api_key or "",
@@ -9478,7 +9498,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         }
         self.model = result.new_model
         self.provider = result.target_provider
-        self.requested_provider = result.target_provider
+        self.requested_provider = result.requested_provider or result.target_provider
         # Always overwrite explicit overrides so stale credentials from the
         # previous provider (e.g. Ollama api_key/base_url) don't leak into
         # the new provider's credential resolution on the next turn.
@@ -9497,6 +9517,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
+                    requested_provider=(
+                        result.requested_provider or result.target_provider
+                    ),
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
@@ -9572,7 +9595,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if persist_global:
             HermesCLI._clear_persisted_context_for_model_switch(self, result)
             save_config_value("model.default", result.new_model)
-            save_config_value("model.provider", result.target_provider)
+            save_config_value(
+                "model.provider",
+                result.requested_provider or result.target_provider,
+            )
             # See _apply_model_switch_result above for why base_url/api_mode
             # must be synced on every global switch (#25106).
             save_config_value("model.base_url", result.base_url or None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6846,6 +6846,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             override_model = override.get("model", model)
             override_runtime = {
                 "provider": override.get("provider"),
+                # ``provider`` is the runtime transport.  Keep the original
+                # configured identity separately so a named custom endpoint
+                # does not re-resolve as bare ``custom`` after cache eviction.
+                "requested_provider": (
+                    override.get("requested_provider")
+                    or override.get("provider")
+                ),
                 "api_key": override.get("api_key"),
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
@@ -6855,7 +6862,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if override_runtime.get("api_key"):
                 if override_runtime.get("credential_pool") is None:
                     override_runtime["credential_pool"] = _credential_pool_for_provider(
-                        override.get("provider")
+                        override.get("requested_provider") or override.get("provider")
                     )
                 logger.debug(
                     "Session model override (fast): session=%s config_model=%s -> override_model=%s provider=%s",
@@ -22454,19 +22461,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
         if not persisted:
             return
+        requested_provider = (
+            persisted.get("requested_provider") or persisted.get("provider")
+        )
         override: Dict[str, Any] = {
             "model": persisted.get("model"),
             "provider": persisted.get("provider"),
+            "requested_provider": requested_provider,
             "base_url": persisted.get("base_url"),
         }
-        provider = persisted.get("provider")
-        if provider:
+        if requested_provider:
             # Re-resolve credentials for the persisted provider. On failure
             # (e.g. credentials were removed since the switch) keep the
             # credential-less override — _resolve_session_agent_runtime falls
             # back to env-based resolution and applies model/provider on top.
             try:
-                runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
+                runtime = _resolve_runtime_agent_kwargs_for_provider(
+                    requested_provider
+                )
+                override["provider"] = runtime.get("provider") or override.get(
+                    "provider"
+                )
+                override["requested_provider"] = runtime.get(
+                    "requested_provider"
+                ) or requested_provider
                 override["api_key"] = runtime.get("api_key")
                 override["api_mode"] = runtime.get("api_mode")
                 override["credential_pool"] = runtime.get("credential_pool")
@@ -22476,12 +22494,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug(
                     "Credential re-resolution failed for persisted override "
                     "(provider=%s); using credential-less override",
-                    provider, exc_info=True,
+                    requested_provider, exc_info=True,
                 )
         self._session_state(session_key).conversation.model_override = override
         logger.info(
-            "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
-            session_key, override.get("model"), provider or "",
+            "Rehydrated persisted /model override for session=%s: model=%s "
+            "provider=%s requested_provider=%s",
+            session_key,
+            override.get("model"),
+            override.get("provider") or "",
+            override.get("requested_provider") or "",
         )
 
     def _apply_session_model_override(
@@ -22500,17 +22522,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in ("provider", "api_key", "base_url", "api_mode", "credential_pool"):
+        for key in (
+            "provider",
+            "requested_provider",
+            "api_key",
+            "base_url",
+            "api_mode",
+            "credential_pool",
+        ):
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
+        if not runtime_kwargs.get("requested_provider"):
+            runtime_kwargs["requested_provider"] = override.get("provider")
         if (
             runtime_kwargs.get("api_key")
             and runtime_kwargs.get("credential_pool") is None
             and override.get("provider")
         ):
             runtime_kwargs["credential_pool"] = _credential_pool_for_provider(
-                override.get("provider")
+                override.get("requested_provider") or override.get("provider")
             )
         return model, runtime_kwargs
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -746,11 +746,18 @@ def build_session_context_prompt(
 
 
 # Keys of a /model session override that are safe to persist to disk.
-# ``api_key`` (and anything else, e.g. ``api_mode`` which is re-derived from
-# provider resolution) is intentionally excluded: credentials must NEVER be
-# written to sessions.json.  On rehydration after a gateway restart the
-# runner re-resolves credentials via the normal runtime provider resolution.
-PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "base_url")
+# ``provider`` is the runtime transport while ``requested_provider`` preserves
+# the configured/named identity (for example ``custom:account-b``).  ``api_key``
+# (and anything else, e.g. ``api_mode`` which is re-derived from provider
+# resolution) is intentionally excluded: credentials must NEVER be written to
+# sessions.json. On rehydration after a gateway restart the runner re-resolves
+# credentials via the normal runtime provider resolution.
+PERSISTABLE_MODEL_OVERRIDE_KEYS = (
+    "model",
+    "provider",
+    "requested_provider",
+    "base_url",
+)
 
 
 def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1767,8 +1767,13 @@ class GatewaySlashCommandsMixin:
         if override:
             current_model = override.get("model", current_model)
             current_provider = override.get("provider", current_provider)
+            current_requested_provider = override.get(
+                "requested_provider", current_provider
+            )
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
+        else:
+            current_requested_provider = current_provider
 
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
@@ -1805,6 +1810,7 @@ class GatewaySlashCommandsMixin:
                     _session_key = session_key
                     _cur_model = current_model
                     _cur_provider = current_provider
+                    _cur_requested_provider = current_requested_provider
                     _cur_base_url = current_base_url
                     _cur_api_key = current_api_key
                     _picker_profile_home = _command_profile_home
@@ -1824,6 +1830,7 @@ class GatewaySlashCommandsMixin:
                             _switch_model,
                             raw_input=model_id,
                             current_provider=_cur_provider,
+                            current_requested_provider=_cur_requested_provider,
                             current_model=_cur_model,
                             current_base_url=_cur_base_url,
                             current_api_key=_cur_api_key,
@@ -1867,6 +1874,10 @@ class GatewaySlashCommandsMixin:
                                 cached_entry[0].switch_model(
                                     new_model=result.new_model,
                                     new_provider=result.target_provider,
+                                    requested_provider=(
+                                        result.requested_provider
+                                        or result.target_provider
+                                    ),
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
@@ -1925,6 +1936,9 @@ class GatewaySlashCommandsMixin:
                         _self._session_model_overrides[_session_key] = {
                             "model": result.new_model,
                             "provider": result.target_provider,
+                            "requested_provider": (
+                                result.requested_provider or result.target_provider
+                            ),
                             "api_key": result.api_key,
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
@@ -1983,7 +1997,10 @@ class GatewaySlashCommandsMixin:
                                 except Exception:
                                     _persist_model_cfg.pop("context_length", None)
                                 _persist_model_cfg["default"] = result.new_model
-                                _persist_model_cfg["provider"] = result.target_provider
+                                _persist_model_cfg["provider"] = (
+                                    result.requested_provider
+                                    or result.target_provider
+                                )
                                 # Named providers always resolve base_url/api_mode fresh,
                                 # so any leftover is cleared unconditionally below. Custom
                                 # providers have no registry entry to re-derive from, so
@@ -2132,6 +2149,7 @@ class GatewaySlashCommandsMixin:
             _switch_model,
             raw_input=model_input,
             current_provider=current_provider,
+            current_requested_provider=current_requested_provider,
             current_model=current_model,
             current_base_url=current_base_url,
             current_api_key=current_api_key,
@@ -2179,6 +2197,9 @@ class GatewaySlashCommandsMixin:
                     cached_entry[0].switch_model(
                         new_model=result.new_model,
                         new_provider=result.target_provider,
+                        requested_provider=(
+                            result.requested_provider or result.target_provider
+                        ),
                         api_key=result.api_key,
                         base_url=result.base_url,
                         api_mode=result.api_mode,
@@ -2236,6 +2257,9 @@ class GatewaySlashCommandsMixin:
             self._session_model_overrides[session_key] = {
                 "model": result.new_model,
                 "provider": result.target_provider,
+                "requested_provider": (
+                    result.requested_provider or result.target_provider
+                ),
                 "api_key": result.api_key,
                 "base_url": result.base_url,
                 "api_mode": result.api_mode,
@@ -2313,7 +2337,9 @@ class GatewaySlashCommandsMixin:
                     except Exception:
                         model_cfg.pop("context_length", None)
                     model_cfg["default"] = result.new_model
-                    model_cfg["provider"] = result.target_provider
+                    model_cfg["provider"] = (
+                        result.requested_provider or result.target_provider
+                    )
                     # See the picker handler above for why custom providers need an
                     # explicit set-or-clear instead of the old lone truthy check (#25107).
                     _is_custom_target = str(result.target_provider or "").strip().lower() == "custom"

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1914,6 +1914,7 @@ class CLICommandsMixin:
                     api_key=turn_route["runtime"].get("api_key"),
                     base_url=turn_route["runtime"].get("base_url"),
                     provider=turn_route["runtime"].get("provider"),
+                    requested_provider=turn_route["runtime"].get("requested_provider"),
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -440,6 +440,7 @@ class ModelSwitchResult:
     success: bool
     new_model: str = ""
     target_provider: str = ""
+    requested_provider: str = ""
     provider_changed: bool = False
     api_key: str = ""
     base_url: str = ""
@@ -451,6 +452,29 @@ class ModelSwitchResult:
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+
+
+def _canonical_requested_provider_identity(
+    transport_provider: str,
+    requested_provider: str,
+) -> str:
+    """Return the durable identity paired with a resolved transport provider.
+
+    A named custom endpoint is executed through the ``custom`` transport but
+    must remain addressable as ``custom:<name>`` for config persistence and
+    credential-pool selection.  Other providers retain their existing identity
+    unchanged.  This intentionally canonicalizes from the *requested* name,
+    never from a reverse URL lookup: shared endpoints are not identity-safe.
+    """
+    transport = str(transport_provider or "").strip().lower()
+    requested = str(requested_provider or "").strip()
+    if transport != "custom":
+        return requested or transport
+    if not requested or requested.lower() == "custom":
+        return "custom"
+    if requested.lower().startswith("custom:"):
+        requested = requested.split(":", 1)[1].strip()
+    return custom_provider_slug(requested)
 
 
 @dataclass(frozen=True)
@@ -1214,6 +1238,7 @@ def switch_model(
     explicit_provider: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
+    current_requested_provider: str = "",
 ) -> ModelSwitchResult:
     """Core model-switching pipeline shared between CLI and gateway.
 
@@ -1258,11 +1283,15 @@ def switch_model(
         validate_requested_model,
         opencode_model_api_mode,
     )
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.runtime_provider import (
+        _resolve_named_custom_api_key,
+        resolve_runtime_provider,
+    )
 
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
+    requested_provider = current_provider
     resolved_moa_preset = False
 
     # =================================================================
@@ -1300,6 +1329,7 @@ def switch_model(
             )
 
         target_provider = pdef.id
+        requested_provider = pdef.id
         if target_provider == "moa" and not new_model:
             try:
                 from hermes_cli.config import load_config
@@ -1561,8 +1591,23 @@ def switch_model(
     # COMMON PATH: Resolve credentials, normalize, get metadata
     # =================================================================
 
-    provider_changed = target_provider != current_provider
-    provider_label = get_label(target_provider)
+    # ``target_provider`` starts as the routing identity because aliases,
+    # provider definitions and model validation need the named custom slug.
+    # Runtime transport is finalized from `resolve_runtime_provider()` below.
+    if target_provider == current_provider and not explicit_provider:
+        requested_provider = current_requested_provider or target_provider
+    else:
+        requested_provider = target_provider
+    route_provider = target_provider
+    provider_changed = bool(
+        route_provider != current_provider
+        or (
+            current_provider == "custom"
+            and current_requested_provider
+            and requested_provider != current_requested_provider
+        )
+    )
+    provider_label = get_label(route_provider)
     if target_provider == "custom" and current_base_url:
         provider_label = "Custom endpoint"
     if target_provider.startswith("custom:"):
@@ -1578,6 +1623,8 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    runtime_provider = route_provider
+    runtime_requested_provider = requested_provider
 
     if provider_changed or explicit_provider:
         import os
@@ -1595,13 +1642,7 @@ def switch_model(
         if _user_pdef is not None and _user_pdef.base_url:
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
-            _ukey = str(_ucfg.get("api_key", "") or "").strip()
-            if _ukey.startswith("${") and _ukey.endswith("}"):
-                _ukey = os.environ.get(_ukey[2:-1], "").strip()
-            if not _ukey:
-                _kenv = str(_ucfg.get("key_env", "") or "").strip()
-                if _kenv:
-                    _ukey = os.environ.get(_kenv, "").strip()
+            _ukey = _resolve_named_custom_api_key(_ucfg)
             try:
                 runtime = resolve_runtime_provider(
                     requested=target_provider,
@@ -1612,6 +1653,10 @@ def switch_model(
                 api_key = runtime.get("api_key", "") or _ukey
                 base_url = runtime.get("base_url", "") or _user_pdef.base_url
                 api_mode = runtime.get("api_mode", "")
+                runtime_provider = str(runtime.get("provider") or route_provider)
+                runtime_requested_provider = str(
+                    runtime.get("requested_provider") or requested_provider
+                )
             except Exception:
                 api_key = _ukey
                 base_url = _user_pdef.base_url
@@ -1629,6 +1674,10 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                runtime_provider = str(runtime.get("provider") or route_provider)
+                runtime_requested_provider = str(
+                    runtime.get("requested_provider") or requested_provider
+                )
             except Exception as e:
                 return ModelSwitchResult(
                     success=False,
@@ -1643,7 +1692,7 @@ def switch_model(
     else:
         try:
             runtime = resolve_runtime_provider(
-                requested=current_provider,
+                requested=current_requested_provider or current_provider,
                 target_model=new_model,
             )
             # If resolution fell through to "custom" (e.g. named custom provider like
@@ -1653,6 +1702,10 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            runtime_provider = str(runtime.get("provider") or route_provider)
+            runtime_requested_provider = str(
+                runtime.get("requested_provider") or requested_provider
+            )
         except Exception:
             pass
 
@@ -1811,12 +1864,24 @@ def switch_model(
     if hermes_warn:
         warnings.append(hermes_warn)
 
-    # --- Build result ---
+    # Runtime resolver is authoritative for the transport/identity pair. Keep
+    # the named route provider for validation and metadata, but emit transport
+    # in target_provider and the canonical menu key in requested_provider.
+    result_target_provider = runtime_provider or route_provider
+    result_requested_provider = _canonical_requested_provider_identity(
+        result_target_provider,
+        runtime_requested_provider or requested_provider,
+    )
     return ModelSwitchResult(
         success=True,
         new_model=new_model,
-        target_provider=target_provider,
-        provider_changed=provider_changed,
+        target_provider=result_target_provider,
+        requested_provider=result_requested_provider,
+        provider_changed=bool(
+            result_target_provider != current_provider
+            or result_requested_provider
+            != (current_requested_provider or current_provider)
+        ),
         api_key=api_key,
         base_url=base_url,
         api_mode=api_mode,
@@ -2537,6 +2602,11 @@ def list_authenticated_providers(
         from collections import OrderedDict as _OD3
 
         from hermes_cli.config import is_provider_enabled
+        from hermes_cli.runtime_provider import (
+            _getenv,
+            _named_custom_provider_key_env,
+            _resolve_named_custom_api_key,
+        )
 
         ep_groups: "_OD3[tuple, dict]" = _OD3()
         for ep_name, ep_cfg in user_providers.items():
@@ -2555,17 +2625,18 @@ def list_authenticated_providers(
                 or ep_cfg.get("url", "")
                 or ""
             )
-            key_env = str(ep_cfg.get("key_env", "") or "").strip()
-            inline_api_key = str(ep_cfg.get("api_key", "") or "").strip()
+            key_env = _named_custom_provider_key_env(ep_cfg)
+            resolved_api_key = _resolve_named_custom_api_key(ep_cfg)
+            env_api_key = _getenv(key_env, "").strip() if key_env else ""
             api_mode = str(
                 ep_cfg.get("api_mode")
                 or ep_cfg.get("transport")
                 or ""
             ).strip().lower()
             credential_identity = (
-                inline_api_key
-                if inline_api_key
-                else (f"env:{key_env}" if key_env else "")
+                f"env:{key_env}"
+                if env_api_key or (key_env and not resolved_api_key)
+                else resolved_api_key
             )
             api_url_norm = str(api_url).strip().rstrip("/").lower()
             # Per-provider extra_headers participate in the group identity
@@ -2671,10 +2742,7 @@ def list_authenticated_providers(
             # - Without an api_key AND no explicit models: probe anyway so
             #   bare-endpoint providers (local llama.cpp / Ollama servers)
             #   still show their full model catalog.
-            api_key = str(ep_cfg.get("api_key", "") or "").strip()
-            if not api_key:
-                key_env = str(ep_cfg.get("key_env", "") or "").strip()
-                api_key = os.environ.get(key_env, "").strip() if key_env else ""
+            api_key = _resolve_named_custom_api_key(ep_cfg)
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
@@ -2803,6 +2871,12 @@ def list_authenticated_providers(
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
 
+        from hermes_cli.runtime_provider import (
+            _getenv,
+            _named_custom_provider_key_env,
+            _resolve_named_custom_api_key,
+        )
+
         # Key by endpoint + credential identity + wire protocol + display
         # prefix instead of slug: names frequently differ per model
         # ("Ollama — X") while the endpoint stays the same.  Keep same-host
@@ -2828,20 +2902,18 @@ def list_authenticated_providers(
             ).strip().rstrip("/")
             if not raw_name or not api_url:
                 continue
-            inline_api_key = (entry.get("api_key") or "").strip()
-            key_env = (entry.get("key_env") or "").strip()
-            api_key = inline_api_key or (
-                os.environ.get(key_env, "").strip() if key_env else ""
-            )
+            key_env = _named_custom_provider_key_env(entry)
+            api_key = _resolve_named_custom_api_key(entry)
+            env_api_key = _getenv(key_env, "").strip() if key_env else ""
             api_mode = str(
                 entry.get("api_mode")
                 or entry.get("transport")
                 or ""
             ).strip().lower()
             credential_identity = (
-                inline_api_key
-                if inline_api_key
-                else (f"env:{key_env}" if key_env else "")
+                f"env:{key_env}"
+                if env_api_key or (key_env and not api_key)
+                else api_key
             )
 
             # Read discover_models from the entry (same semantics as

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from urllib.parse import urlparse
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,44 @@ def _getenv(name: str, default: str = "") -> str:
 
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
+
+
+def _named_custom_provider_key_env(entry: Dict[str, Any]) -> str:
+    """Return the environment-variable name for a named custom provider.
+
+    ``key_env`` is Hermes' canonical spelling; ``api_key_env`` is accepted as
+    a compatibility alias used by older/imported provider configurations.
+    """
+    return str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+
+
+def _resolve_named_custom_api_key(
+    entry: Dict[str, Any],
+    *,
+    explicit_api_key: Optional[str] = None,
+    getenv: Callable[[str, str], str] = _getenv,
+) -> str:
+    """Resolve a named custom-provider key with explicit/env/inline precedence.
+
+    ``explicit_api_key`` is a call-local override. For config-backed named
+    providers, an explicitly referenced environment variable is authoritative
+    over a stale inline ``api_key``. ``getenv`` is injectable so credential-pool
+    seeding can preserve its profile ``.env`` precedence.
+    """
+    explicit = str(explicit_api_key or "").strip()
+    if explicit:
+        return explicit
+
+    key_env = _named_custom_provider_key_env(entry)
+    if key_env:
+        env_key = getenv(key_env, "").strip()
+        if env_key:
+            return env_key
+
+    inline = str(entry.get("api_key") or "").strip()
+    if inline.startswith("${") and inline.endswith("}"):
+        inline = getenv(inline[2:-1], "").strip()
+    return inline
 
 
 def _loopback_hostname(host: str) -> bool:
@@ -715,12 +753,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # they're not configured.
             if not is_provider_enabled(entry):
                 continue
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
-            # Fall back to inline api_key when key_env is absent or unresolvable
-            if not resolved_api_key:
-                resolved_api_key = str(entry.get("api_key", "") or "").strip()
+            key_env = _named_custom_provider_key_env(entry)
+            resolved_api_key = _resolve_named_custom_api_key(entry)
 
             display_name = entry.get("name", "")
             if requested_norm in custom_provider_aliases(
@@ -780,9 +814,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
-            "api_key": str(entry.get("api_key", "") or "").strip(),
+            "api_key": _resolve_named_custom_api_key(entry),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        key_env = _named_custom_provider_key_env(entry)
         if key_env:
             result["key_env"] = key_env
         if provider_key:
@@ -1905,6 +1939,7 @@ def resolve_runtime_provider(
                     or getattr(entry, "base_url", None)
                     or ""
                 ),
+                provider_name=requested_provider,
             )
         ):
             return _resolve_runtime_from_pool_entry(

--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -1076,6 +1076,11 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
             base_url=runtime_kwargs.get("base_url"),
             api_key=runtime_kwargs.get("api_key"),
             provider=runtime_kwargs.get("provider"),
+            requested_provider=str(
+                runtime_kwargs.get("requested_provider")
+                or runtime_kwargs.get("provider")
+                or ""
+            ),
             api_mode=runtime_kwargs.get("api_mode"),
             credential_pool=runtime_kwargs.get("credential_pool"),
             quiet_mode=True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -867,10 +867,13 @@ class AIAgent:
             return_load_result=True,
         )
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode='', requested_provider=None):
         """Forwarder — see ``agent.agent_runtime_helpers.switch_model``."""
         from agent.agent_runtime_helpers import switch_model
-        return switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
+        return switch_model(
+            self, new_model, new_provider, api_key, base_url, api_mode,
+            requested_provider=requested_provider,
+        )
 
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.

--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -11,6 +11,7 @@ import ast
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -131,6 +132,69 @@ class TestNoPrviateDBAccess:
 # ---------------------------------------------------------------------------
 # Integration: _persist round-trip via SessionManager
 # ---------------------------------------------------------------------------
+
+class TestNamedCustomProviderIdentityPersistence:
+    def test_restore_uses_requested_provider_not_custom_transport(self, tmp_path, monkeypatch):
+        """ACP restart must retain named custom selection when transports collapse."""
+        resolved_requests = []
+
+        def fake_resolve_runtime_provider(requested=None, **_kwargs):
+            resolved_requests.append(requested)
+            return {
+                "provider": "custom",
+                "requested_provider": "custom:account-b",
+                "api_mode": "chat_completions",
+                "base_url": "https://shared.example/v1",
+                "api_key": "account-b-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                requested_provider=kwargs.get("requested_provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"default": "named-model", "provider": "custom:account-a"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            state = manager.create_session(cwd="/work")
+            state.model = "account-b-model"
+            state.agent = fake_agent(
+                model="account-b-model",
+                provider="custom",
+                requested_provider="custom:account-b",
+                base_url="https://shared.example/v1",
+                api_mode="chat_completions",
+            )
+            manager.save_session(state.session_id)
+            persisted = db.get_session(state.session_id)
+            meta = json.loads(persisted["model_config"])
+            assert meta["provider"] == "custom"
+            assert meta["requested_provider"] == "custom:account-b"
+
+            with manager._lock:
+                del manager._sessions[state.session_id]
+            restored = manager.get_session(state.session_id)
+
+        assert restored is not None
+        assert resolved_requests[-1] == "custom:account-b"
+        assert restored.agent.provider == "custom"
+        assert restored.agent.requested_provider == "custom:account-b"
+
 
 class TestPersistRoundTrip:
     """End-to-end: save a session and verify DB state is correct."""

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -73,6 +73,60 @@ def make_agent_and_state():
     return acp_agent, state, fake, conn
 
 
+def test_acp_make_agent_preserves_requested_identity_for_named_custom_runtime(monkeypatch):
+    """ACP must give AIAgent both custom transport and named selection identity."""
+    captured = {}
+
+    class CapturingAgent(FakeAgent):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+
+    def mod(name, **attrs):
+        module = ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=CapturingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "named-model", "provider": "custom:account-b"}
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "provider": "custom",
+                "requested_provider": "custom:account-b",
+                "api_mode": "chat_completions",
+                "base_url": "https://shared.example/v1",
+                "api_key": "account-b-key",
+                "command": None,
+                "args": [],
+            },
+        ),
+    )
+
+    manager = SessionManager(db=NoopDb())
+    manager._make_agent(
+        session_id="acp-named-custom",
+        cwd=".",
+        requested_provider="custom:account-b",
+    )
+
+    assert captured["provider"] == "custom"
+    assert captured["requested_provider"] == "custom:account-b"
+
+
 def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     """ACP sessions persist to SessionDB; recall must receive the same DB handle."""
     captured = {}
@@ -118,6 +172,37 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+
+
+@pytest.mark.asyncio
+async def test_acp_slash_model_reuses_live_named_custom_identity(monkeypatch):
+    """Slash /model must not turn custom:account-a into bare custom."""
+    acp_agent, state, _fake, _conn = make_agent_and_state()
+    state.agent.provider = "custom"
+    state.agent.requested_provider = "custom:account-a"
+    captured = {}
+
+    def resolve_selection(raw_model, current_provider):
+        captured["selection_current_provider"] = current_provider
+        return current_provider, "account-a-next-model"
+
+    def make_agent(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model=kwargs["model"],
+            provider="custom",
+            requested_provider=kwargs["requested_provider"],
+        )
+
+    monkeypatch.setattr(acp_agent, "_resolve_model_selection", resolve_selection)
+    monkeypatch.setattr(acp_agent.session_manager, "_make_agent", make_agent)
+    monkeypatch.setattr(acp_agent.session_manager, "save_session", lambda _sid: None)
+
+    response = acp_agent._cmd_model("account-a-next-model", state)
+
+    assert "account-a-next-model" in response
+    assert captured["selection_current_provider"] == "custom:account-a"
+    assert captured["requested_provider"] == "custom:account-a"
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1257,6 +1257,111 @@ def test_custom_endpoint_pool_seeds_from_config(tmp_path, monkeypatch):
     assert entries[0].source == "config:Together.ai"
 
 
+def test_custom_endpoint_pool_key_env_overrides_inline_config_key(tmp_path, monkeypatch):
+    """A named provider's env key must win when its pool seed is refreshed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("HERMES_TEST_CUSTOM_POOL_API_KEY", "env-first-pool-key")
+    _write_auth_store(tmp_path, {"version": 1})
+
+    config_path = tmp_path / "hermes" / "config.yaml"
+    import yaml
+
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Env First Pool",
+                "base_url": "https://pool.example/v1",
+                "api_key_env": "HERMES_TEST_CUSTOM_POOL_API_KEY",
+                "api_key": "stale-inline-pool-key",
+            }
+        ]
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:env-first-pool")
+    entries = pool.entries()
+
+    assert len(entries) == 1
+    assert entries[0].source == "config:Env First Pool"
+    assert entries[0].access_token == "env-first-pool-key"
+
+
+def test_custom_endpoint_pool_reads_key_env_from_dotenv(tmp_path, monkeypatch):
+    """Pool seeding must honor profile .env before CLI bootstrap loads it."""
+    home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_TEST_DOTENV_POOL_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+
+    (home / ".env").write_text(
+        "HERMES_TEST_DOTENV_POOL_API_KEY=dotenv-pool-key\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Dotenv Pool",
+                "base_url": "https://dotenv-pool.example/v1",
+                "key_env": "HERMES_TEST_DOTENV_POOL_API_KEY",
+                "api_key": "stale-inline-pool-key",
+            }
+        ]
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:dotenv-pool")
+    entries = pool.entries()
+
+    assert len(entries) == 1
+    assert entries[0].access_token == "dotenv-pool-key"
+
+
+def test_custom_endpoint_pool_uses_profile_scoped_env_key(tmp_path, monkeypatch):
+    """Multiplexed pool seeding must use the active profile's environment."""
+    home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_TEST_SCOPED_POOL_API_KEY", "other-profile-key")
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+
+    (home / ".env").write_text(
+        "HERMES_TEST_SCOPED_POOL_API_KEY=active-profile-key\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Scoped Pool",
+                "base_url": "https://scoped.example/v1",
+                "key_env": "HERMES_TEST_SCOPED_POOL_API_KEY",
+                "api_key": "stale-inline-pool-key",
+            }
+        ]
+    }))
+
+    from agent import secret_scope as secret_scope
+    from agent.credential_pool import load_pool
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope(
+        secret_scope.build_profile_secret_scope(home)
+    )
+    try:
+        pool = load_pool("custom:scoped-pool")
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+    entries = pool.entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == "active-profile-key"
+
+
 def test_custom_endpoint_pool_seeds_from_model_config(tmp_path, monkeypatch):
     """Verify seeding from model.api_key when model.provider=='custom' and base_url matches."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))

--- a/tests/agent/test_credential_pool_provider_boundary.py
+++ b/tests/agent/test_credential_pool_provider_boundary.py
@@ -3,7 +3,10 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from agent.credential_pool import credential_pool_matches_provider
+from agent.credential_pool import (
+    credential_pool_matches_provider,
+    get_custom_provider_pool_key,
+)
 from hermes_cli import runtime_provider as rp
 
 
@@ -24,6 +27,173 @@ def test_custom_pool_match_is_scoped_by_endpoint():
         assert not credential_pool_matches_provider(
             "custom:other", "custom", base_url="https://lab.example/v1"
         )
+
+
+def test_custom_pool_match_is_scoped_by_named_provider_when_urls_collide():
+    calls = []
+
+    def pool_key(base_url, provider_name=None):
+        calls.append(provider_name)
+        return "custom:provider-b" if provider_name == "provider-b" else "custom:provider-a"
+
+    with patch(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        side_effect=pool_key,
+    ):
+        assert credential_pool_matches_provider(
+            "custom:provider-b",
+            "custom",
+            base_url="https://gateway.example/v1",
+            provider_name="provider-b",
+        )
+
+    assert calls == ["provider-b"]
+
+
+def test_agent_init_keeps_matching_named_custom_pool_when_urls_collide():
+    pool = SimpleNamespace(provider="custom:provider-b")
+
+    with patch(
+        "agent.credential_pool.get_custom_provider_pool_key",
+        side_effect=lambda _url, provider_name=None: (
+            "custom:provider-b" if provider_name == "provider-b" else "custom:provider-a"
+        ),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            provider="custom",
+            requested_provider="provider-b",
+            base_url="https://gateway.example/v1",
+            api_key="test-key",
+            model="test-model",
+            credential_pool=pool,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._credential_pool is pool
+
+
+def test_named_pool_key_normalizes_raw_and_prefixed_identity(monkeypatch):
+    config = {
+        "custom_providers": [
+            {
+                "name": "provider-a",
+                "base_url": "https://gateway.example/v1",
+            },
+            {
+                "name": "provider-b",
+                "base_url": "https://gateway.example/v1",
+            },
+        ]
+    }
+    monkeypatch.setattr("agent.credential_pool._load_config_safe", lambda: config)
+
+    assert (
+        get_custom_provider_pool_key(
+            "https://gateway.example/v1/",
+            provider_name="provider-b",
+        )
+        == "custom:provider-b"
+    )
+    assert (
+        get_custom_provider_pool_key(
+            "https://gateway.example/v1/",
+            provider_name="custom:provider-b",
+        )
+        == "custom:provider-b"
+    )
+
+
+def test_explicit_named_pool_identity_fails_closed(monkeypatch):
+    config = {
+        "custom_providers": [
+            {
+                "name": "provider-a",
+                "base_url": "https://gateway.example/v1",
+            },
+            {
+                "name": "provider-b",
+                "base_url": "https://gateway.example/v1",
+            },
+        ]
+    }
+    monkeypatch.setattr("agent.credential_pool._load_config_safe", lambda: config)
+
+    assert (
+        get_custom_provider_pool_key(
+            "https://gateway.example/v1",
+            provider_name="custom:deleted-provider",
+        )
+        is None
+    )
+    assert (
+        get_custom_provider_pool_key(
+            "https://other.example/v1",
+            provider_name="custom:provider-b",
+        )
+        is None
+    )
+
+
+def test_identityless_custom_pool_lookup_keeps_legacy_url_fallback(monkeypatch):
+    config = {
+        "custom_providers": [
+            {
+                "name": "provider-a",
+                "base_url": "https://gateway.example/v1",
+            },
+            {
+                "name": "provider-b",
+                "base_url": "https://gateway.example/v1",
+            },
+        ]
+    }
+    monkeypatch.setattr("agent.credential_pool._load_config_safe", lambda: config)
+
+    assert (
+        get_custom_provider_pool_key("https://gateway.example/v1")
+        == "custom:provider-a"
+    )
+
+
+def test_runtime_provider_pool_match_passes_named_identity(monkeypatch):
+    class _Entry:
+        runtime_api_key = "account-b-key"
+        base_url = "https://gateway.example/v1"
+
+    class _Pool:
+        provider = "custom:provider-b"
+
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    pool = _Pool()
+    seen = {}
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **kwargs: None)
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: pool)
+    monkeypatch.setattr(
+        rp,
+        "credential_pool_matches_provider",
+        lambda *args, **kwargs: seen.update(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        rp,
+        "_resolve_runtime_from_pool_entry",
+        lambda **kwargs: {"provider": "custom", "requested_provider": "custom:provider-b"},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:provider-b")
+
+    assert resolved["provider"] == "custom"
+    assert seen["provider_name"] == "custom:provider-b"
 
 
 def test_runtime_ignores_pool_loaded_for_different_provider(monkeypatch):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -80,6 +80,44 @@ def test_curator_defaults(curator_env):
     assert c.get_archive_after_days() == 90
 
 
+def test_llm_review_passes_named_provider_identity(monkeypatch):
+    import agent.curator as curator
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, **kwargs):
+            return {"final_response": "done"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"model": {"provider": "custom:account-b", "default": "review-model"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "custom",
+            "requested_provider": "custom:account-b",
+            "api_key": "account-b-key",
+            "base_url": "https://shared.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    result = curator._run_llm_review("review")
+
+    assert result["error"] is None
+    assert captured["provider"] == "custom"
+    assert captured["requested_provider"] == "custom:account-b"
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -42,6 +42,7 @@ def _make_background_cli_stub():
             "api_key": "test-key",
             "base_url": "https://example.test/v1",
             "provider": "test",
+            "requested_provider": "custom:account-b",
             "api_mode": "chat_completions",
         },
         "request_overrides": None,
@@ -230,6 +231,30 @@ class TestCliApprovalUi:
         assert seen["sudo"].__self__ is cli
         assert seen["sudo"].__func__ is HermesCLI._sudo_password_callback
         assert not cli._background_tasks
+
+    def test_background_task_passes_named_provider_identity(self):
+        cli = _make_background_cli_stub()
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **kwargs):
+                return {"final_response": "done", "messages": []}
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console:
+            chat_console.return_value.print = MagicMock()
+            cli._handle_background_command("/btw check weather")
+            for thread in list(cli._background_tasks.values()):
+                thread.join(timeout=10)
+
+        assert captured["provider"] == "test"
+        assert captured["requested_provider"] == "custom:account-b"
 
 
 def _make_real_paint_cli_stub():

--- a/tests/gateway/test_feishu_comment.py
+++ b/tests/gateway/test_feishu_comment.py
@@ -12,6 +12,44 @@ from plugins.platforms.feishu.feishu_comment import (
 )
 
 
+def test_comment_agent_preserves_named_provider_identity(monkeypatch):
+    from plugins.platforms.feishu import feishu_comment as module
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, *args, **kwargs):
+            return {"final_response": "ok", "api_calls": 0, "messages": []}
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_model_and_runtime",
+        lambda: (
+            "review-model",
+            {
+                "provider": "custom",
+                "requested_provider": "custom:account-b",
+                "base_url": "https://gateway.example/v1",
+                "api_key": "account-b-key",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setattr(module, "_load_session_history", lambda _key: [])
+    monkeypatch.setattr(module, "_save_session_history", lambda *_args: None)
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    monkeypatch.setattr("tools.feishu_doc_tool.set_client", lambda _client: None)
+    monkeypatch.setattr("tools.feishu_drive_tool.set_client", lambda _client: None)
+
+    assert module._run_comment_agent("prompt", object()) == "ok"
+    assert captured["provider"] == "custom"
+    assert captured["requested_provider"] == "custom:account-b"
+
+
 def _make_event(
     comment_id="c1",
     reply_id="r1",

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -20,6 +20,7 @@ closure the PR changed, against a real temp ``HERMES_HOME``.
 """
 
 import types
+from threading import Lock
 
 import yaml
 import pytest
@@ -53,6 +54,9 @@ def _make_runner(adapter):
     runner._voice_mode = {}
     runner._session_model_overrides = {}
     runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = Lock()
+    runner._session_key_for_source = lambda source: "named-custom-session"
     return runner
 
 
@@ -199,6 +203,99 @@ async def test_picker_tap_global_flag_persists(tmp_path, monkeypatch, seed_model
     assert "api_key" not in written["model"]
     assert "api_mode" not in written["model"]
     assert "context_length" not in written["model"]
+
+
+def _fake_named_custom_switch_result():
+    """A successful switch whose runtime transport differs from its identity."""
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    return ModelSwitchResult(
+        success=True,
+        new_model="account-b-model",
+        target_provider="custom",
+        requested_provider="custom:account-b",
+        provider_changed=True,
+        api_key="account-b-key",
+        base_url="https://shared.example/v1",
+        api_mode="chat_completions",
+        provider_label="Account B",
+        is_global=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_picker_tap_preserves_named_custom_identity_in_live_and_session_state(
+    tmp_path, monkeypatch
+):
+    """Picker tap must keep ``custom`` transport and ``custom:account-b`` identity."""
+    adapter = _FakePickerAdapter()
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "old-model", "provider": "custom:account-a"},
+    )
+    runner = _make_runner(adapter)
+    calls = []
+    switch_calls = []
+
+    class _CachedAgent:
+        def switch_model(self, **kwargs):
+            calls.append(kwargs)
+
+    runner._session_model_overrides["named-custom-session"] = {
+        "model": "account-a-model",
+        "provider": "custom",
+        "requested_provider": "custom:account-a",
+        "base_url": "https://shared.example/v1",
+    }
+    runner._agent_cache = {}
+    runner._agent_cache_lock = Lock()
+
+    def _switch(**kwargs):
+        switch_calls.append(kwargs)
+        return _fake_named_custom_switch_result()
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _switch)
+    monkeypatch.setattr(runner, "_evict_cached_agent", lambda *_args: None)
+    monkeypatch.setattr(
+        runner,
+        "_session_key_for_source",
+        lambda _source: "named-custom-session",
+    )
+    runner._agent_cache["named-custom-session"] = (_CachedAgent(), None)
+
+    confirmation = await _drive_picker(runner, _make_event("/model --session"))
+
+    assert "account-b-model" in confirmation
+    assert switch_calls[-1]["current_provider"] == "custom"
+    assert switch_calls[-1]["current_requested_provider"] == "custom:account-a"
+    assert calls[-1]["new_provider"] == "custom"
+    assert calls[-1]["requested_provider"] == "custom:account-b"
+    override = runner._session_model_overrides["named-custom-session"]
+    assert override["provider"] == "custom"
+    assert override["requested_provider"] == "custom:account-b"
+
+
+@pytest.mark.asyncio
+async def test_picker_tap_global_persists_named_custom_identity(
+    tmp_path, monkeypatch
+):
+    """Gateway config must store the named identity, never bare custom."""
+    adapter = _FakePickerAdapter()
+    cfg_path = _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "old-model", "provider": "custom:account-a"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_kwargs: _fake_named_custom_switch_result(),
+    )
+
+    await _drive_picker(_make_runner(adapter), _make_event("/model --global"))
+
+    written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert written["model"]["provider"] == "custom:account-b"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -108,6 +108,48 @@ class TestApplySessionModelOverride:
         assert rt["base_url"] == "https://openrouter.ai/api/v1"
         assert rt["api_mode"] == "chat_completions"
 
+    def test_named_custom_override_preserves_transport_and_requested_identity(
+        self, monkeypatch
+    ):
+        """A stored named custom identity must not collapse to bare custom."""
+        import gateway.run as gateway_run
+
+        runner = _make_runner()
+        sk = build_session_key(_make_source())
+        pool = object()
+        seen = []
+        monkeypatch.setattr(
+            gateway_run,
+            "_credential_pool_for_provider",
+            lambda provider: seen.append(provider) or pool,
+        )
+        runner._session_model_overrides[sk] = {
+            "model": "named-model",
+            "provider": "custom",
+            "requested_provider": "custom:account-b",
+            "api_key": "account-b-key",
+            "base_url": "https://shared.example/v1",
+            "api_mode": "chat_completions",
+        }
+
+        model, runtime = runner._apply_session_model_override(
+            sk,
+            "global-model",
+            {
+                "provider": "anthropic",
+                "requested_provider": "anthropic",
+                "api_key": "global-key",
+                "base_url": "https://api.anthropic.com",
+                "api_mode": "anthropic_messages",
+            },
+        )
+
+        assert model == "named-model"
+        assert runtime["provider"] == "custom"
+        assert runtime["requested_provider"] == "custom:account-b"
+        assert runtime["credential_pool"] is pool
+        assert seen == ["custom:account-b"]
+
     def test_no_override_returns_originals(self):
         runner = _make_runner()
         sk = build_session_key(_make_source())

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -43,6 +43,18 @@ class _StubCLI:
     _pending_model_switch_note = ""
 
 
+class _SwitchingAgent:
+    """Capture the public live-switch contract without constructing a client."""
+
+    def __init__(self):
+        self.calls = []
+        self._custom_providers = None
+        self._config_context_length = None
+
+    def switch_model(self, **kwargs):
+        self.calls.append(kwargs)
+
+
 def _run_display(monkeypatch, result):
     import cli as cli_mod
 
@@ -52,6 +64,41 @@ def _run_display(monkeypatch, result):
     monkeypatch.setattr(cli_mod, "save_config_value", lambda *a, **k: None)
     cli_mod.HermesCLI._apply_model_switch_result(_StubCLI(), result, False)
     return captured
+
+
+def test_picker_apply_keeps_named_custom_identity_on_cli_and_live_agent(
+    monkeypatch,
+):
+    """The picker consumer must pass both transport and named identity through."""
+    import cli as cli_mod
+
+    captured: list[str] = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda s, *a, **k: captured.append(str(s)))
+    monkeypatch.setattr(cli_mod, "save_config_value", lambda *a, **k: None)
+    agent = _SwitchingAgent()
+    cli = _StubCLI()
+    cli.agent = agent
+    cli.model = "old-model"
+    cli.provider = "custom"
+    cli.requested_provider = "custom:account-a"
+    result = ModelSwitchResult(
+        success=True,
+        new_model="named-model",
+        target_provider="custom",
+        requested_provider="custom:account-b",
+        provider_changed=True,
+        api_key="account-b-key",
+        base_url="https://shared.example/v1",
+        api_mode="chat_completions",
+        provider_label="Account B",
+    )
+
+    cli_mod.HermesCLI._apply_model_switch_result(cli, result, False)
+
+    assert cli.provider == "custom"
+    assert cli.requested_provider == "custom:account-b"
+    assert agent.calls[-1]["new_provider"] == "custom"
+    assert agent.calls[-1]["requested_provider"] == "custom:account-b"
 
 
 def test_picker_path_uses_provider_aware_context_on_codex(monkeypatch):

--- a/tests/hermes_cli/test_cli_model_once.py
+++ b/tests/hermes_cli/test_cli_model_once.py
@@ -78,6 +78,64 @@ def test_cli_model_once_records_restore_and_does_not_persist(monkeypatch):
     assert "next turn only" in printed[-1]
 
 
+def test_cli_model_once_keeps_named_custom_identity_on_live_agent(monkeypatch):
+    """Typed /model --once keeps transport and named identity distinct."""
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.provider = "custom"
+    stub.requested_provider = "custom:account-a"
+    stub.agent = _FakeAgent()
+    stub.agent.provider = "custom"
+    stub._snapshot_model_runtime = cli_mod.HermesCLI._snapshot_model_runtime.__get__(stub)
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "save_config_value",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not persist")),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.inventory.load_picker_context",
+        lambda: SimpleNamespace(
+            user_providers=None,
+            custom_providers=None,
+            with_overrides=lambda **_: SimpleNamespace(
+                user_providers=None, custom_providers=None
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_: ModelSwitchResult(
+            success=True,
+            new_model="account-b-model",
+            target_provider="custom",
+            requested_provider="custom:account-b",
+            provider_changed=True,
+            api_key="account-b-key",
+            base_url="https://shared.example/v1",
+            api_mode="chat_completions",
+            provider_label="Account B",
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_display_context_length",
+        lambda *a, **k: None,
+    )
+
+    cli_mod.HermesCLI._handle_model_switch(
+        stub,
+        "/model account-b-model --provider account-b --once",
+    )
+
+    assert stub.provider == "custom"
+    assert stub.requested_provider == "custom:account-b"
+    assert stub.agent.calls[-1]["new_provider"] == "custom"
+    assert stub.agent.calls[-1]["requested_provider"] == "custom:account-b"
+    assert stub._pending_one_turn_model_restore["requested_provider"] == "custom:account-a"
+
+
 def test_cli_restore_model_runtime_snapshot_restores_agent():
     import cli as cli_mod
 

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -58,7 +58,9 @@ def test_routing_to_different_model_marks_routed_and_resolves_credentials():
         "provider": "openrouter", "model": "google/gemini-3-flash-preview",
     }}}
     fake_rp = {
-        "provider": "openrouter", "api_key": "or-key",
+        "provider": "custom",
+        "requested_provider": "custom:review-provider",
+        "api_key": "or-key",
         "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions",
         "credential_pool": "routed-pool",
         "request_overrides": {"extra_body": {"store": False}},
@@ -68,7 +70,8 @@ def test_routing_to_different_model_marks_routed_and_resolves_credentials():
          patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_rp):
         rt = br._resolve_review_runtime(agent)
     assert rt["routed"] is True
-    assert rt["provider"] == "openrouter"
+    assert rt["provider"] == "custom"
+    assert rt["requested_provider"] == "custom:review-provider"
     assert rt["model"] == "google/gemini-3-flash-preview"
     assert rt["api_key"] == "or-key"
     assert rt["credential_pool"] == "routed-pool"

--- a/tests/run_agent/test_fallback_credential_isolation.py
+++ b/tests/run_agent/test_fallback_credential_isolation.py
@@ -14,6 +14,8 @@ fallback calls, contaminating primary state with fallback-provider errors.
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -166,6 +168,369 @@ class TestFallbackCredentialIsolation:
         assert agent._credential_pool is fallback_pool
         assert agent._credential_pool.provider == "openai-codex"
         assert agent._transport_cache == {}
+
+    def test_fallback_reuses_identity_matching_runtime_pool(self):
+        """Resolver-selected pools must not be loaded again during fallback."""
+        from agent.chat_completion_helpers import try_activate_fallback
+
+        agent = _make_agent(
+            provider="ollama-cloud",
+            model="glm-5.2",
+            base_url="https://ollama.com/v1",
+            api_mode="chat_completions",
+        )
+        agent._fallback_chain = [{"provider": "openai-codex", "model": "gpt-5.5"}]
+        agent._credential_pool = _make_pool("ollama-cloud")
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent.context_compressor = None
+
+        fallback_client = SimpleNamespace(
+            api_key="codex-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            _custom_headers={},
+        )
+        runtime_pool = _make_pool("openai-codex")
+        reloaded_pool = _make_pool("openai-codex")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "gpt-5.5"),
+            ),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "provider": "openai-codex",
+                    "requested_provider": "openai-codex",
+                    "api_mode": "codex_responses",
+                    "credential_pool": runtime_pool,
+                },
+            ),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=reloaded_pool,
+            ) as load_pool,
+        ):
+            assert try_activate_fallback(agent) is True
+
+        load_pool.assert_not_called()
+        assert agent._credential_pool is runtime_pool
+
+    def test_named_custom_fallback_separates_transport_and_pool_identity(self):
+        """A named custom fallback must attach its own pool on a shared URL."""
+        from agent.chat_completion_helpers import try_activate_fallback
+
+        agent = _make_agent(
+            provider="custom",
+            model="fallback-model",
+            base_url="https://gateway.example/v1",
+        )
+        agent.requested_provider = "custom:provider-a"
+        agent._primary_runtime["requested_provider"] = "custom:provider-a"
+        agent._fallback_chain = [{"provider": "provider-b", "model": "fallback-model"}]
+        agent._credential_pool = _make_pool("custom:provider-a")
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent.context_compressor = None
+
+        fallback_client = SimpleNamespace(
+            api_key="provider-b-key",
+            base_url="https://gateway.example/v1",
+            _custom_headers={},
+        )
+        fallback_pool = _make_pool("custom:provider-b")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "fallback-model"),
+            ),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "provider": "custom",
+                    "requested_provider": "provider-b",
+                    "api_mode": "chat_completions",
+                },
+            ) as resolve_runtime,
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:provider-b",
+            ) as pool_key,
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=fallback_pool,
+            ) as load_pool,
+        ):
+            assert try_activate_fallback(agent) is True
+
+        resolve_runtime.assert_called_once_with(
+            requested="provider-b",
+            target_model="fallback-model",
+            explicit_base_url=None,
+            explicit_api_key=None,
+        )
+        pool_key.assert_called_once_with(
+            "https://gateway.example/v1",
+            provider_name="custom:provider-b",
+        )
+        load_pool.assert_called_once_with("custom:provider-b")
+        assert agent.provider == "custom"
+        assert agent.requested_provider == "custom:provider-b"
+        assert agent._credential_pool is fallback_pool
+
+    def test_named_custom_fallback_uses_resolved_api_mode_for_native_client(self):
+        """A named custom fallback must honor resolver protocol metadata."""
+        from agent.chat_completion_helpers import try_activate_fallback
+
+        agent = _make_agent(
+            provider="custom",
+            model="fallback-model",
+            base_url="https://gateway.example/v1",
+        )
+        agent.requested_provider = "custom:provider-a"
+        agent._primary_runtime["requested_provider"] = "custom:provider-a"
+        agent._fallback_chain = [{"provider": "provider-b", "model": "fallback-model"}]
+        agent._credential_pool = _make_pool("custom:provider-a")
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent.context_compressor = None
+
+        fallback_client = SimpleNamespace(
+            api_key="provider-b-key",
+            base_url="https://gateway.example/v1",
+            _custom_headers={},
+        )
+        fallback_pool = _make_pool("custom:provider-b")
+        native_client = MagicMock(name="native_anthropic_client")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fallback_client, "fallback-model"),
+            ),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "provider": "custom",
+                    "requested_provider": "provider-b",
+                    "api_mode": "anthropic_messages",
+                },
+            ),
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:provider-b",
+            ),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=fallback_pool,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=native_client,
+            ) as build_anthropic,
+        ):
+            assert try_activate_fallback(agent) is True
+
+        assert agent.provider == "custom"
+        assert agent.requested_provider == "custom:provider-b"
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._anthropic_client is native_client
+        assert agent.client is None
+        build_anthropic.assert_called_once_with(
+            "provider-b-key", "https://gateway.example/v1", timeout=None,
+        )
+
+    @pytest.mark.parametrize(
+        ("native_provider", "native_api_mode"),
+        [
+            ("bedrock", "bedrock_converse"),
+            ("openai-codex", "codex_app_server"),
+        ],
+    )
+    def test_builtin_native_fallback_skips_unconstructable_runtime(
+        self, native_provider, native_api_mode
+    ):
+        """A built-in native route must not be treated as an endpoint fallback."""
+        from agent.chat_completion_helpers import try_activate_fallback
+
+        agent = _make_agent(
+            provider="custom",
+            model="primary-model",
+            base_url="https://primary.example/v1",
+        )
+        agent.requested_provider = "custom:provider-a"
+        agent._primary_runtime["requested_provider"] = "custom:provider-a"
+        agent._fallback_chain = [
+            {"provider": native_provider, "model": "native-model"},
+            {"provider": "provider-b", "model": "fallback-model"},
+        ]
+        agent._credential_pool = _make_pool("custom:provider-a")
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent.context_compressor = None
+        agent._try_activate_fallback.side_effect = (
+            lambda reason=None: try_activate_fallback(agent, reason)
+        )
+
+        supported_client = SimpleNamespace(
+            api_key="provider-b-key",
+            base_url="https://gateway.example/v1",
+            _custom_headers={},
+        )
+        fallback_pool = _make_pool("custom:provider-b")
+
+        def fake_resolve(provider, model=None, raw_codex=False,
+                         explicit_base_url=None, explicit_api_key=None):
+            if provider == "provider-b":
+                return supported_client, "fallback-model"
+            raise AssertionError(
+                f"native fallback must not construct endpoint client for {provider!r}"
+            )
+
+        def fake_runtime(*, requested=None, target_model=None,
+                         explicit_base_url=None, explicit_api_key=None):
+            if requested == native_provider:
+                return {
+                    "provider": native_provider,
+                    "requested_provider": native_provider,
+                    "api_mode": native_api_mode,
+                }
+            if requested == "provider-b":
+                return {
+                    "provider": "custom",
+                    "requested_provider": requested,
+                    "api_mode": "chat_completions",
+                }
+            raise AssertionError(f"unexpected runtime request: {requested!r}")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=fake_resolve,
+            ) as resolve_client,
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=fake_runtime,
+            ),
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:provider-b",
+            ),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=fallback_pool,
+            ),
+        ):
+            assert try_activate_fallback(agent) is True
+
+        assert [call.args[0] for call in resolve_client.call_args_list] == ["provider-b"]
+        assert agent.provider == "custom"
+        assert agent.requested_provider == "custom:provider-b"
+        assert agent.model == "fallback-model"
+        assert agent.api_mode == "chat_completions"
+
+    @pytest.mark.parametrize("api_mode", ["bedrock_converse", "codex_app_server"])
+    def test_named_custom_fallback_skips_unsupported_native_api_modes(self, api_mode):
+        """Fallback must not publish a native-only mode without its runtime."""
+        from agent.chat_completion_helpers import try_activate_fallback
+
+        agent = _make_agent(
+            provider="custom",
+            model="primary-model",
+            base_url="https://primary.example/v1",
+        )
+        agent.requested_provider = "custom:provider-a"
+        agent._primary_runtime["requested_provider"] = "custom:provider-a"
+        agent._fallback_chain = [
+            {"provider": "unsupported-provider", "model": "unsupported-model"},
+            {"provider": "provider-b", "model": "fallback-model"},
+        ]
+        agent._credential_pool = _make_pool("custom:provider-a")
+        agent._buffer_status = MagicMock()
+        agent._is_azure_openai_url.return_value = False
+        agent._is_direct_openai_url.return_value = False
+        agent._provider_model_requires_responses_api.return_value = False
+        agent._anthropic_prompt_cache_policy.return_value = (False, False)
+        agent._ensure_lmstudio_runtime_loaded = MagicMock()
+        agent.context_compressor = None
+        agent._try_activate_fallback.side_effect = (
+            lambda reason=None: try_activate_fallback(agent, reason)
+        )
+
+        supported_client = SimpleNamespace(
+            api_key="provider-b-key",
+            base_url="https://gateway.example/v1",
+            _custom_headers={},
+        )
+        fallback_pool = _make_pool("custom:provider-b")
+
+        def fake_resolve(provider, model=None, raw_codex=False,
+                         explicit_base_url=None, explicit_api_key=None):
+            if provider == "provider-b":
+                return supported_client, "fallback-model"
+            raise AssertionError(
+                f"unsupported native fallback must not construct {provider!r}"
+            )
+
+        def fake_runtime(*, requested=None, target_model=None,
+                         explicit_base_url=None, explicit_api_key=None):
+            if requested == "unsupported-provider":
+                return {
+                    "provider": "custom",
+                    "requested_provider": requested,
+                    "api_mode": api_mode,
+                }
+            if requested == "provider-b":
+                return {
+                    "provider": "custom",
+                    "requested_provider": requested,
+                    "api_mode": "chat_completions",
+                }
+            raise AssertionError(f"unexpected runtime request: {requested!r}")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=fake_resolve,
+            ) as resolve_client,
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=fake_runtime,
+            ),
+            patch(
+                "agent.credential_pool.get_custom_provider_pool_key",
+                return_value="custom:provider-b",
+            ),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=fallback_pool,
+            ),
+        ):
+            assert try_activate_fallback(agent) is True
+
+        assert [call.args[0] for call in resolve_client.call_args_list] == ["provider-b"]
+        assert agent.provider == "custom"
+        assert agent.requested_provider == "custom:provider-b"
+        assert agent.model == "fallback-model"
+        assert agent.api_mode == "chat_completions"
 
 
 # ── Test: _recover_with_credential_pool rejects mismatched pool ──────

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -49,6 +49,262 @@ def test_init_tries_fallback_when_primary_returns_none():
         assert agent._fallback_activated is True
 
 
+def test_init_named_custom_fallback_separates_transport_identity_and_pool():
+    """Init-time fallback must not store a named custom provider as transport."""
+    fallback_client = _mock_client(
+        api_key="provider-b-key",
+        base_url="https://gateway.example/v1",
+    )
+    fallback_pool = MagicMock(name="provider_b_pool")
+    fallback_pool.provider = "custom:provider-b"
+    fallback_pool.has_credentials.return_value = True
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "provider-b":
+            return fallback_client, "fallback-model"
+        return None, None
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "custom",
+                "requested_provider": "provider-b",
+                "api_mode": "chat_completions",
+                "credential_pool": fallback_pool,
+            },
+        ) as resolve_runtime,
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            provider="primary-unavailable",
+            model="primary-model",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "provider-b", "model": "fallback-model"}],
+        )
+
+    resolve_runtime.assert_called_once_with(
+        requested="provider-b",
+        target_model="fallback-model",
+        explicit_base_url=None,
+        explicit_api_key=None,
+    )
+    assert agent.provider == "custom"
+    assert agent.requested_provider == "custom:provider-b"
+    assert agent._credential_pool is fallback_pool
+    assert agent._primary_runtime["provider"] == "custom"
+    assert agent._primary_runtime["requested_provider"] == "custom:provider-b"
+
+
+def test_init_named_custom_fallback_uses_resolved_api_mode():
+    """Init-time fallback must retain the resolver-selected wire protocol."""
+    fallback_client = _mock_client(
+        api_key="provider-b-key",
+        base_url="https://gateway.example/v1",
+    )
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "provider-b":
+            return fallback_client, "fallback-model"
+        return None, None
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "custom",
+                "requested_provider": "provider-b",
+                "api_mode": "codex_responses",
+            },
+        ),
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            provider="primary-unavailable",
+            model="primary-model",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "provider-b", "model": "fallback-model"}],
+        )
+
+    assert agent.api_mode == "codex_responses"
+    assert agent._primary_runtime["api_mode"] == "codex_responses"
+
+
+def test_init_fallback_does_not_adopt_empty_runtime_pool():
+    """Init fallback must use the same credential-bearing pool standard as runtime fallback."""
+    fallback_client = _mock_client()
+    empty_pool = MagicMock(name="empty_fallback_pool")
+    empty_pool.provider = "custom:provider-b"
+    empty_pool.has_credentials.return_value = False
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "provider-b":
+            return fallback_client, "fallback-model"
+        return None, None
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "custom",
+                "requested_provider": "custom:provider-b",
+                "api_mode": "chat_completions",
+                "credential_pool": empty_pool,
+            },
+        ),
+        patch("agent.credential_pool.load_pool", return_value=None),
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            provider="primary-unavailable",
+            model="primary-model",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "provider-b", "model": "fallback-model"}],
+        )
+
+    assert agent._credential_pool is None
+
+
+def test_init_named_custom_anthropic_fallback_builds_native_client():
+    """Init fallback must dispatch a resolved Anthropic-wire route natively."""
+    fallback_client = _mock_client(
+        api_key="provider-b-key",
+        base_url="https://gateway.example/anthropic",
+    )
+    native_client = MagicMock(name="native_anthropic_client")
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "provider-b":
+            return fallback_client, "fallback-model"
+        return None, None
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "custom",
+                "requested_provider": "provider-b",
+                "api_mode": "anthropic_messages",
+            },
+        ),
+        patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=native_client,
+        ) as build_anthropic,
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()) as openai,
+    ):
+        agent = AIAgent(
+            provider="primary-unavailable",
+            model="primary-model",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "provider-b", "model": "fallback-model"}],
+        )
+
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._anthropic_client is native_client
+    assert agent.client is None
+    assert agent._primary_runtime["api_mode"] == "anthropic_messages"
+    build_anthropic.assert_called_once_with(
+        "provider-b-key", "https://gateway.example/anthropic", timeout=None,
+    )
+    openai.assert_not_called()
+
+
+@pytest.mark.parametrize("api_mode", ["bedrock_converse", "codex_app_server"])
+def test_init_named_custom_fallback_skips_unsupported_native_api_modes(api_mode):
+    """Named custom fallback must not enter a native-only runtime it cannot build."""
+    unsupported_client = _mock_client(
+        api_key="unsupported-key",
+        base_url="https://unsupported.example/v1",
+    )
+    supported_client = _mock_client(
+        api_key="provider-b-key",
+        base_url="https://gateway.example/v1",
+    )
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "unsupported-provider":
+            return unsupported_client, "unsupported-model"
+        if provider == "provider-b":
+            return supported_client, "fallback-model"
+        return None, None
+
+    def fake_runtime(*, requested=None, target_model=None,
+                     explicit_base_url=None, explicit_api_key=None):
+        if requested == "unsupported-provider":
+            return {
+                "provider": "custom",
+                "requested_provider": requested,
+                "api_mode": api_mode,
+            }
+        if requested == "provider-b":
+            return {
+                "provider": "custom",
+                "requested_provider": requested,
+                "api_mode": "chat_completions",
+            }
+        raise AssertionError(f"unexpected runtime request: {requested!r}")
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve) as resolve_client,
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=fake_runtime),
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            provider="primary-unavailable",
+            model="primary-model",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[
+                {"provider": "unsupported-provider", "model": "unsupported-model"},
+                {"provider": "provider-b", "model": "fallback-model"},
+            ],
+        )
+
+    assert agent.provider == "custom"
+    assert agent.requested_provider == "custom:provider-b"
+    assert agent.model == "fallback-model"
+    assert all(call.args[0] != "unsupported-provider" for call in resolve_client.call_args_list)
+
+
 def test_init_raises_when_no_fallback_configured():
     """When primary returns None and no fallback is set, should raise."""
     with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)), \

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -110,6 +110,45 @@ class TestSwitchModelReloadsCredentialPool:
         # load_pool MUST have been called with the new provider.
         load_pool_mock.assert_called_once_with("groq")
 
+    def test_switch_to_named_custom_provider_keeps_transport_and_pool_identity_separate(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.credential_pool._load_config_safe",
+            lambda: {
+                "custom_providers": [
+                    {
+                        "name": "provider-a",
+                        "base_url": "https://gateway.example/v1",
+                    },
+                    {
+                        "name": "provider-b",
+                        "base_url": "https://gateway.example/v1",
+                    },
+                ]
+            },
+        )
+        old_pool = _make_pool("opencode-go")
+        new_pool = _make_pool("custom:provider-b")
+        agent = _make_agent("opencode-go", "qwen-coder", old_pool)
+
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=new_pool,
+        ) as load_pool_mock:
+            switch_model(
+                agent,
+                new_model="provider-b-model",
+                new_provider="custom",
+                requested_provider="custom:provider-b",
+                api_key="provider-b-key",
+                base_url="https://gateway.example/v1",
+                api_mode="chat_completions",
+            )
+
+        assert agent.provider == "custom"
+        assert agent.requested_provider == "custom:provider-b"
+        assert agent._credential_pool is new_pool
+        load_pool_mock.assert_called_once_with("custom:provider-b")
+
     def test_switch_to_same_provider_does_not_reload_pool(self):
         """Re-selecting the current provider must NOT churn the pool reference."""
         existing_pool = _make_pool("opencode-go")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3015,12 +3015,21 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert ov["provider_override"] == "anthropic"
     assert ov["model_override"]["provider"] == "anthropic"
 
-    # An explicit routable provider in model_config wins over the bare billing bucket.
+    # A new-format row preserves the runtime transport separately from the
+    # selected identity, so a shared URL cannot choose the wrong account.
     ov = server._stored_session_runtime_overrides(
-        {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
+        {
+            "model": "m",
+            "billing_provider": "custom",
+            "model_config": {
+                "provider": "custom",
+                "requested_provider": "custom:myendpoint",
+            },
+        }
     )
     assert ov["provider_override"] == "custom:myendpoint"
-    assert ov["model_override"]["provider"] == "custom:myendpoint"
+    assert ov["model_override"]["provider"] == "custom"
+    assert ov["model_override"]["requested_provider"] == "custom:myendpoint"
 
 
 def test_stored_session_runtime_overrides_restores_explicit_normal_tier():
@@ -3374,6 +3383,10 @@ def test_apply_model_switch_persist_override_false_never_persists(monkeypatch):
 
     assert out["value"] == "new/model"
     assert session["model_override"]["model"] == "new/model"
+    # Old duck-typed switch results have no requested_provider. Their transport
+    # remains the only available durable identity, rather than crashing the
+    # TUI switch path.
+    assert session["model_override"]["requested_provider"] == "nous"
 
 
 def test_startup_runtime_uses_tui_provider_env(monkeypatch):
@@ -3502,6 +3515,23 @@ def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     kwargs = server._background_agent_kwargs(agent, "task-id")
 
     assert kwargs["fallback_model"] == chain
+
+
+def test_background_agent_kwargs_preserves_named_provider_identity(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="named-model",
+        provider="custom",
+        requested_provider="custom:account-b",
+        _fallback_chain=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["provider"] == "custom"
+    assert kwargs["requested_provider"] == "custom:account-b"
 
 
 def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -60,6 +60,44 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
 
 
+def test_make_agent_passes_resolved_named_provider_identity():
+    """TUI rebuilds must not collapse named custom identity to bare transport."""
+    fake_runtime = {
+        "provider": "custom",
+        "requested_provider": "custom:account-b",
+        "base_url": "https://shared.example/v1",
+        "api_key": "account-b-key",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "model": {"default": "named-model", "provider": "custom:account-b"},
+        "agent": {"system_prompt": "test"},
+    }
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_tool_progress_mode", return_value="compact"),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-named", "key-named")
+
+    assert mock_agent.call_args.kwargs["provider"] == "custom"
+    assert mock_agent.call_args.kwargs["requested_provider"] == "custom:account-b"
+
+
 def test_probe_config_health_flags_null_sections():
     """Bare YAML keys (`agent:` with no value) parse as None and silently
     drop nested settings; probe must surface them so users can fix."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1202,6 +1202,7 @@ def _build_child_agent(
     parent_agent,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
+    override_requested_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
@@ -1370,6 +1371,11 @@ def _build_child_agent(
     # Resolve effective credentials: config override > parent inherit
     effective_model = model or parent_agent.model
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
+    effective_requested_provider = (
+        override_requested_provider
+        or getattr(parent_agent, "requested_provider", None)
+        or effective_provider
+    )
     effective_base_url = override_base_url or parent_agent.base_url
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
@@ -1508,6 +1514,7 @@ def _build_child_agent(
             api_key=effective_api_key,
             model=effective_model,
             provider=effective_provider,
+            requested_provider=str(effective_requested_provider or effective_provider or ""),
             api_mode=effective_api_mode,
             acp_command=effective_acp_command,
             acp_args=effective_acp_args,
@@ -1570,7 +1577,10 @@ def _build_child_agent(
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
     child_pool = _resolve_child_credential_pool(
-        effective_provider, parent_agent, effective_base_url
+        effective_provider,
+        parent_agent,
+        effective_base_url,
+        effective_requested_provider,
     )
     if child_pool is not None:
         child._credential_pool = child_pool
@@ -2953,6 +2963,14 @@ def delegate_task(
             task_count=n_tasks,
             parent_agent=parent_agent,
             override_provider=creds["provider"],
+            override_requested_provider=(
+                str(
+                    creds.get("requested_provider")
+                    or creds.get("provider")
+                    or ""
+                ).strip()
+                or None
+            ),
             override_base_url=creds["base_url"],
             override_api_key=creds["api_key"],
             override_api_mode=creds["api_mode"],
@@ -3395,6 +3413,7 @@ def _resolve_child_credential_pool(
     effective_provider: Optional[str],
     parent_agent,
     effective_base_url: Optional[str] = None,
+    effective_requested_provider: Optional[str] = None,
 ):
     """Resolve a credential pool for the child agent.
 
@@ -3427,7 +3446,11 @@ def _resolve_child_credential_pool(
         try:
             from agent.credential_pool import get_custom_provider_pool_key, load_pool
 
-            child_key = get_custom_provider_pool_key(effective_base_url)
+            child_identity = str(effective_requested_provider or "").strip()
+            child_key = get_custom_provider_pool_key(
+                effective_base_url,
+                provider_name=child_identity or None,
+            )
             if child_key is None:
                 # Unregistered endpoint (raw delegation.base_url with no
                 # matching custom_providers entry) -> no shared pool exists.
@@ -3437,7 +3460,8 @@ def _resolve_child_credential_pool(
 
             # Reuse the parent's pool only when it is the same custom endpoint.
             parent_key = get_custom_provider_pool_key(
-                getattr(parent_agent, "base_url", None)
+                getattr(parent_agent, "base_url", None),
+                provider_name=getattr(parent_agent, "requested_provider", None),
             )
             if (
                 parent_pool is not None
@@ -3554,6 +3578,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         return {
             "model": configured_model,
             "provider": provider,
+            "requested_provider": provider,
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
@@ -3564,6 +3589,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         return {
             "model": configured_model,
             "provider": None,
+            "requested_provider": None,
             "base_url": None,
             "api_key": None,
             "api_mode": None,
@@ -3594,6 +3620,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     return {
         "model": configured_model or runtime.get("model") or None,
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
+        "requested_provider": runtime.get("requested_provider") or configured_provider,
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
         "api_mode": runtime.get("api_mode"),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3617,6 +3617,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     # the provider override makes ``session.resume`` fail with "No LLM provider configured".
     # Only restore an explicit provider; otherwise leave it unset so resume falls back to
     # the configured default, matching the working CLI path.
+    requested_provider = str(model_config.get("requested_provider") or "").strip()
     explicit_provider = str(model_config.get("provider") or "").strip()
     billing_provider = str(
         model_config.get("billing_provider") or row.get("billing_provider") or ""
@@ -3624,6 +3625,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     provider = explicit_provider
     if not provider and billing_provider.lower() not in _BARE_BILLING_PROVIDERS:
         provider = billing_provider
+    transport_provider = provider
     base_url = str(model_config.get("base_url") or "").strip()
     api_mode = str(model_config.get("api_mode") or "").strip()
     reasoning_config = model_config.get("reasoning_config")
@@ -3653,6 +3655,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
                 "custom provider identity recovery failed", exc_info=True
             )
         provider = healed or ("" if not base_url else provider)
+        transport_provider = explicit_provider if requested_provider else provider
 
     if model:
         # Use the same dict-shaped override that live /model switches use so a
@@ -3660,13 +3663,18 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
         # initial resume and later rebuilds (/new). Deliberately do not persist
         # or restore raw api_key here; endpoint credentials should continue to
         # come from config/env/provider resolution rather than the session DB.
-        overrides["model_override"] = {
+        model_override = {
             "model": model,
-            "provider": provider or None,
+            "provider": transport_provider or None,
             "base_url": base_url or None,
             "api_mode": api_mode or None,
         }
-    if provider:
+        if requested_provider:
+            model_override["requested_provider"] = requested_provider
+        overrides["model_override"] = model_override
+    if requested_provider:
+        overrides["provider_override"] = requested_provider
+    elif provider:
         overrides["provider_override"] = provider
     if isinstance(reasoning_config, dict):
         overrides["reasoning_config_override"] = reasoning_config
@@ -3684,6 +3692,9 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
     config = dict(existing or {})
     model = str(getattr(agent, "model", "") or "").strip()
     provider = str(getattr(agent, "provider", "") or "").strip()
+    requested_provider = str(
+        getattr(agent, "requested_provider", "") or ""
+    ).strip()
     base_url = str(getattr(agent, "base_url", "") or "").strip()
     api_mode = str(getattr(agent, "api_mode", "") or "").strip()
     reasoning_config = getattr(agent, "reasoning_config", None)
@@ -3721,6 +3732,10 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
                     "custom provider identity lookup failed", exc_info=True
                 )
         config["provider"] = provider
+    if requested_provider:
+        config["requested_provider"] = requested_provider
+    else:
+        config.pop("requested_provider", None)
     if base_url:
         config["base_url"] = base_url
     else:
@@ -4277,6 +4292,9 @@ def _snapshot_agent_model_runtime(agent) -> dict:
     return {
         "model": getattr(agent, "model", ""),
         "provider": getattr(agent, "provider", ""),
+        "requested_provider": getattr(
+            agent, "requested_provider", getattr(agent, "provider", "")
+        ),
         "api_key": getattr(agent, "api_key", ""),
         "base_url": getattr(agent, "base_url", ""),
         "api_mode": getattr(agent, "api_mode", ""),
@@ -4302,6 +4320,10 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
         agent.switch_model(
             new_model=snapshot.get("model", ""),
             new_provider=snapshot.get("provider", ""),
+            requested_provider=(
+                snapshot.get("requested_provider")
+                or snapshot.get("provider", "")
+            ),
             api_key=snapshot.get("api_key", ""),
             base_url=snapshot.get("base_url", ""),
             api_mode=snapshot.get("api_mode", ""),
@@ -4361,6 +4383,9 @@ def _apply_model_switch(
         raise ValueError("/model --once requires a live session")
     if agent:
         current_provider = getattr(agent, "provider", "") or ""
+        current_requested_provider = (
+            getattr(agent, "requested_provider", "") or current_provider
+        )
         current_model = getattr(agent, "model", "") or ""
         current_base_url = getattr(agent, "base_url", "") or ""
         current_api_key = getattr(agent, "api_key", "") or ""
@@ -4369,10 +4394,12 @@ def _apply_model_switch(
         current_provider = explicit_provider.strip()
         current_base_url = ""
         current_api_key = ""
+        current_requested_provider = current_provider
         if not explicit_provider:
             runtime = resolve_runtime_provider(requested=None)
             current_provider = str(runtime.get("provider", "") or "")
             current_base_url = str(runtime.get("base_url", "") or "")
+            current_requested_provider = str(runtime.get("requested_provider") or current_provider)
             # Preserve a callable api_key (Azure Foundry Entra ID bearer
             # provider) unchanged — ``str(...)`` would produce
             # ``"<function ...>"`` and poison downstream switch_model
@@ -4408,6 +4435,7 @@ def _apply_model_switch(
         explicit_provider=explicit_provider,
         user_providers=user_provs,
         custom_providers=custom_provs,
+        current_requested_provider=current_requested_provider,
     )
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")
@@ -4462,6 +4490,10 @@ def _apply_model_switch(
             agent.switch_model(
                 new_model=result.new_model,
                 new_provider=result.target_provider,
+                requested_provider=(
+                    getattr(result, "requested_provider", "")
+                    or result.target_provider
+                ),
                 api_key=result.api_key,
                 base_url=result.base_url,
                 api_mode=result.api_mode,
@@ -4508,6 +4540,9 @@ def _apply_model_switch(
         session["model_override"] = {
             "model": result.new_model,
             "provider": result.target_provider,
+            "requested_provider": (
+                getattr(result, "requested_provider", "") or result.target_provider
+            ),
             "base_url": result.base_url,
             "api_key": result.api_key,
             "api_mode": result.api_mode,
@@ -5939,6 +5974,9 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "base_url": getattr(agent, "base_url", None) or None,
         "api_key": getattr(agent, "api_key", None) or None,
         "provider": getattr(agent, "provider", None) or None,
+        "requested_provider": getattr(agent, "requested_provider", None)
+        or getattr(agent, "provider", None)
+        or None,
         "api_mode": getattr(agent, "api_mode", None) or None,
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
@@ -6352,7 +6390,12 @@ def _make_agent(
     # also pass scalar model/provider/runtime knobs from the persisted DB row.
     if isinstance(model_override, dict) and model_override.get("model"):
         model = str(model_override.get("model") or "")
-        requested_provider = model_override.get("provider") or provider_override or None
+        requested_provider = (
+            model_override.get("requested_provider")
+            or model_override.get("provider")
+            or provider_override
+            or None
+        )
         override_base_url = model_override.get("base_url")
         override_api_key = model_override.get("api_key")
         override_api_mode = model_override.get("api_mode")
@@ -6418,6 +6461,12 @@ def _make_agent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
         provider=runtime.get("provider"),
+        requested_provider=(
+            runtime.get("requested_provider")
+            or requested_provider
+            or runtime.get("provider")
+            or ""
+        ),
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),


### PR DESCRIPTION
## Summary

- Preserve the separation between the transport provider (`provider="custom"`) and the durable named provider identity (`requested_provider="custom:<name>"`).
- Propagate the named identity through runtime fallback, primary restore, model switching, session persistence, ACP, gateway, TUI, CLI, delegate, curator, and Feishu comment agent construction.
- Scope credential-pool matching by endpoint and named provider identity to prevent sibling account-group selection when URLs collide.
- Add init-time fallback pool adoption parity and regression coverage for empty pools, named routes, and wire API modes.

## Validation

On a clean worktree rebased from the latest `origin/main`:

- Provider-only isolated replay: `950 passed`
- Compileall: passed
- `git diff --check`: passed
- Targeted post-publish verification: `61 passed`
- Staged/replayed patch SHA-256 matched before publication:
  `903888e515743065bcf720497262c62710a36a38b89ff80e257c5417a5e94247`

## Scope and safety

- Compression and auxiliary retry changes are intentionally excluded.
- No credentials or network capability probes are added.
- No deployment or service restart was performed.
- The original local worktree contains separate uncommitted compression changes that were not included in this PR.

## Known limitation

A full repository pytest run was previously blocked by existing test/environment logging failures involving temporary directories and `FileNotFoundError`; the provider-only closure suite passed independently.
