### PR TITLE
fix(config): guard against null extra in platform config merge

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1437,8 +1437,11 @@ def load_gateway_config() -> GatewayConfig:
                     existing = platforms_data.get(plat_name, {})
                     if not isinstance(existing, dict):
                         existing = {}
-                    # Deep-merge extra dicts so gateway.json defaults survive
-                    merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
+                    # Deep-merge extra dicts so gateway.json defaults survive.
+                    # Guard against ``extra:`` being explicitly null in YAML
+                    # (parses to None) — ``**None`` raises TypeError and aborts
+                    # the whole platform registration (api_server silently lost).
+                    merged_extra = {**(existing.get("extra") or {}), **(plat_block.get("extra") or {})}
                     if "enabled" in plat_block:
                         merged_extra["_enabled_explicit"] = True
                     merged = {**existing, **plat_block}
@@ -1608,11 +1611,13 @@ def load_gateway_config() -> GatewayConfig:
                 # ``extra:`` sub-key, not from the top level.
                 if plat in {Platform.WEBHOOK, Platform.MSGRAPH_WEBHOOK}:
                     for _bridge_key in ("port", "host", "secret"):
-                        if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
+                        _extra_ref = platform_cfg.get("extra") or {}
+                        if _bridge_key in platform_cfg and _bridge_key not in _extra_ref:
                             bridged[_bridge_key] = platform_cfg[_bridge_key]
                 if plat == Platform.API_SERVER:
                     for _bridge_key in ("port", "host"):
-                        if _bridge_key in platform_cfg and _bridge_key not in platform_cfg.get("extra", {}):
+                        _extra_ref = platform_cfg.get("extra") or {}
+                        if _bridge_key in platform_cfg and _bridge_key not in _extra_ref:
                             bridged[_bridge_key] = platform_cfg[_bridge_key]
                 has_channel_overrides = "channel_overrides" in platform_cfg
                 if has_channel_overrides:

--- a/tests/gateway/test_config_extra_none_guard.py
+++ b/tests/gateway/test_config_extra_none_guard.py
@@ -1,0 +1,90 @@
+"""Regression test for config parser crash on null ``extra`` field.
+
+YAML ``extra:`` with no value parses to ``None`` in Python. The dict-unpacking
+``**plat_block.get('extra', {})`` returns ``None`` (key exists, default unused)
+and raises ``TypeError: argument of type 'NoneType' is not iterable``. The
+exception is caught by the outer try/except, silently dropping the platform
+registration — api_server never starts after unclean shutdown.
+
+This suite locks the fix: ``or {}`` coerces None before unpacking.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gateway.config import Platform, load_gateway_config
+
+
+def _write_config(tmp_path: Path, yaml_body: str) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(textwrap.dedent(yaml_body), encoding="utf-8")
+    return cfg
+
+
+class TestNullExtraDoesNotCrash:
+    """``extra:`` (null) must not abort platform registration."""
+
+    def test_api_server_extra_null(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(
+            tmp_path,
+            """\
+            platforms:
+              api_server:
+                enabled: true
+                extra:
+                key: test-key-1234
+                host: 0.0.0.0
+                port: 8642
+            """,
+        )
+
+        # Must not raise TypeError.
+        cfg = load_gateway_config()
+
+        # api_server platform must be registered with the bridged key.
+        ps = cfg.platforms
+        assert Platform.API_SERVER in ps, "api_server platform silently dropped"
+        assert ps[Platform.API_SERVER].enabled is True
+
+    def test_webhook_extra_null(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(
+            tmp_path,
+            """\
+            platforms:
+              webhook:
+                enabled: true
+                extra:
+                port: 8649
+            """,
+        )
+
+        cfg = load_gateway_config()
+        assert Platform.WEBHOOK in cfg.platforms
+
+    def test_extra_dict_still_merges(self, tmp_path, monkeypatch):
+        """When extra is a real dict, merge must still work."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(
+            tmp_path,
+            """\
+            platforms:
+              api_server:
+                enabled: true
+                extra:
+                  key: my-key
+                  custom_field: custom_value
+            """,
+        )
+
+        cfg = load_gateway_config()
+        ps = cfg.platforms
+        assert Platform.API_SERVER in ps
+        extra = ps[Platform.API_SERVER].extra
+        assert extra is not None
+        assert extra.get("key") == "my-key"
+        assert extra.get("custom_field") == "custom_value"


### PR DESCRIPTION
## Problem

YAML `extra:` with no value parses to `None` in Python. The dict-unpacking `**plat_block.get('extra', {})` then raises `TypeError` because `.get()` returns `None` (key exists, default not used). The exception is caught by the outer `try/except`, silently dropping the platform registration — api_server never starts after unclean shutdown.

This caused a 3-day silent outage of the WeChat notification channel (iLink) on a self-hosted deployment: the gateway process restarted after SIGKILL, but the api_server platform registration was silently lost, so port 8642 never bound. No alerts were generated because the alert-bridge itself depended on the gateway.

## Fix

Use `or {}` to coerce `None` to empty dict before unpacking. Applied to:
1. `_merge_platform_map` (line 1441) — the main crash site
2. Webhook/msgraph bridge loop (line 1614)
3. api_server bridge loop (line 1618)

## Tests

`tests/gateway/test_config_extra_none_guard.py` — 3 test cases:
- `test_api_server_extra_null` — null extra does not crash, platform registered
- `test_webhook_extra_null` — null extra for webhook
- `test_extra_dict_still_merges` — normal dict extra still merges correctly

Bug-injection verified: tests fail without fix, pass with fix.

## Scope

Single-file change (`gateway/config.py`) + test file. No behavioral change for configs where `extra` is a normal dict or absent — only guards the explicit `null` case.