### PR TITLE
 clamp sessions browse --limit before SQLite fetch

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -31,6 +31,22 @@ def _m():
     return main
 
 
+def clamp_sessions_browse_limit(raw, *, default: int = 500, maximum: int = 2000) -> int:
+    """Bound ``hermes sessions browse --limit`` before ``list_sessions_rich``.
+
+    Negative SQL ``LIMIT`` is unbounded in SQLite; oversized positives force
+    expensive compression-chain CTE work before the picker opens.
+    """
+    try:
+        if raw is None or raw == "":
+            value = default
+        else:
+            value = int(raw)
+    except (TypeError, ValueError):
+        value = default
+    return max(1, min(value, maximum))
+
+
 def get_hermes_home():
     return _m().get_hermes_home()
 
@@ -981,7 +997,7 @@ def cmd_sessions(args, sessions_parser=None):
             print(f"✓ Re-titled {changed} session(s).")
 
     elif action == "browse":
-        limit = getattr(args, "limit", 500) or 500
+        limit = clamp_sessions_browse_limit(getattr(args, "limit", 500))
         source = getattr(args, "source", None)
         _browse_exclude = None if source else ["tool"]
         sessions = db.list_sessions_rich(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_sessions_browse_limit_clamp.py
+++ b/tests/hermes_cli/test_sessions_browse_limit_clamp.py
@@ -1,0 +1,20 @@
+"""Clamp hermes sessions browse --limit before SQLite fetch."""
+
+from hermes_cli.sessions_cmd import clamp_sessions_browse_limit
+
+
+def test_clamp_sessions_browse_limit_default():
+    assert clamp_sessions_browse_limit(None) == 500
+    assert clamp_sessions_browse_limit("") == 500
+    assert clamp_sessions_browse_limit("nope") == 500
+
+
+def test_clamp_sessions_browse_limit_floors_zero_and_negative():
+    assert clamp_sessions_browse_limit(0) == 1
+    assert clamp_sessions_browse_limit(-5) == 1
+
+
+def test_clamp_sessions_browse_limit_caps_excessive():
+    assert clamp_sessions_browse_limit(10_000_000) == 2000
+    assert clamp_sessions_browse_limit(42) == 42
+    assert clamp_sessions_browse_limit(500) == 500


### PR DESCRIPTION
## Summary
- Clamp `hermes sessions browse --limit` to 1–2000 (default 500) before `list_sessions_rich`. Negative SQL `LIMIT` is unbounded in SQLite; oversized positives force expensive compression-chain CTE work before the picker opens.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.
