### PR TITLE
fix(tools): pass native Windows paths to ripgrep in search_files

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -294,6 +294,30 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_escape_native_tool_arg_uses_windows_form_for_rg(self, monkeypatch, file_ops):
+        """ripgrep is a native Windows binary and cannot resolve the MSYS
+        /c/... form produced by _escape_shell_arg; the rg-targeted escaper must
+        emit the native drive form instead."""
+        import os as os_mod
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(os_mod, "name", "nt")
+        monkeypatch.setattr(
+            local_mod,
+            "_msys_to_windows_path",
+            lambda p: r"D:\workexe\notes.txt",
+        )
+        assert (
+            file_ops._escape_native_tool_arg("/d/workexe/notes.txt")
+            == r"'D:\workexe\notes.txt'"
+        )
+
+    def test_escape_native_tool_arg_noop_off_windows(self, monkeypatch, file_ops):
+        import os as os_mod
+
+        monkeypatch.setattr(os_mod, "name", "posix")
+        assert file_ops._escape_native_tool_arg("/tmp/x") == "'/tmp/x'"
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -996,6 +996,24 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_native_tool_arg(self, arg: str) -> str:
+        """Escape *arg* for a NATIVE Windows binary invoked from Git Bash.
+
+        ripgrep (rg.exe) is a native binary: MSYS2 argument conversion
+        deliberately leaves ``/c/Users/x``-style arguments alone (they look
+        like ``/c`` command-line switches), so the MSYS form produced by
+        ``_escape_shell_arg`` reaches rg verbatim and fails with
+        ``系统找不到指定的路径 (os error 3)``. Convert drive paths back to
+        the native ``C:\\Users\\x`` form — single-quoted, so bash preserves
+        the backslashes and MSYS passes the recognized Windows path through.
+        No-op off Windows.
+        """
+        if os.name == "nt":
+            from tools.environments.local import _msys_to_windows_path
+
+            arg = _msys_to_windows_path(arg)
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2311,7 +2329,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2333,7 +2351,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2353,7 +2371,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2473,9 +2491,11 @@ class ShellFileOperations(FileOperations):
 
         fetch_limit = limit + offset
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
+        # rg is a native Windows binary: the path must use the native drive
+        # form, not the MSYS /c/... form (see _escape_native_tool_arg).
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2486,7 +2506,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._escape_native_tool_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2568,9 +2588,11 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path. The pattern is a regex (goes through
+        # _escape_shell_arg); the path must use the native drive form for
+        # the native rg.exe binary (see _escape_native_tool_arg).
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_native_tool_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,


### PR DESCRIPTION
## Summary

`search_files` fails on Windows whenever it is given an absolute path: the path is shell-escaped via `_escape_shell_arg()`, which rewrites `C:\Users\x` to the Git Bash / MSYS form `/c/Users/x`. That form is correct for MSYS binaries (`bash`, `find`, `grep`) but **ripgrep (`rg.exe`) is a native Windows binary** — it does not link against the MSYS DLLs and cannot resolve `/c/...` paths, so every `rg` invocation with an absolute path fails with `系统找不到指定的路径 (os error 3)`.

Affects both `target="files"` (`rg --files`) and `target="content"` (`rg --line-number ...`), plus the zero-match hint probes (`_zero_match_probe`).

## Root cause

- `tools/file_operations.py` — `_escape_shell_arg()` calls `_bash_safe_path()`, converting drive paths to the MSYS form.
- `tools/environments/local.py` already exposes `_msys_to_windows_path()`, the inverse translator, but it was never used for native binaries.

## Fix

Add `ShellFileOperations._escape_native_tool_arg()` — identical quoting to `_escape_shell_arg()`, but converts the path back to the native Windows drive form (via the existing `_msys_to_windows_path` translator) before quoting. Apply it at every `rg` call site that passes a path:

- `_search_with_rg` (content search, `--line-number`)
- `_search_files_rg` (`rg --files`, sorted + plain)
- `_zero_match_probe` (all 3 probe invocations)

The MSYS form is still used for bash built-ins (`find`, `grep`, `test`, `ls`), which need it. No-op off Windows.

## Tests

- `test_escape_native_tool_arg_uses_windows_form_for_rg` — native drive form for the rg escaper (mocked, portable to CI)
- `test_escape_native_tool_arg_noop_off_windows` — passthrough + quoting on POSIX

Verified on Windows (native `rg` 15.x, absolute `D:\...` paths) — file and content searches both return results; zero-match probes no longer error out.

Fixes #75007
Fixes #77036
