### PR TITLE
docs(readme): steer-first interrupt guidance + feature high-value quick starts (fixes #78539)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ hermes config set   # Set individual config values
 hermes config get   # Print individual config values
 hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
 hermes setup        # Run the full setup wizard (configures everything at once)
+hermes secrets bitwarden setup  # Wire up Bitwarden Secrets Manager (bws) for secret injection
+hermes security     # Supply-chain audit (OSV.dev) for venv, plugins, and MCP servers
+hermes egress       # Manage the iron-proxy egress credential-injection firewall
+hermes sessions     # Manage session history (list, rename, export, prune, ...)
+hermes insights     # Show usage insights and analytics (tokens, costs, tool patterns)
+hermes backup       # Back up the Hermes home directory to a zip file
 hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
 hermes update       # Update to the latest version
 hermes doctor       # Diagnose any issues
@@ -153,7 +159,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Retry or undo the last turn    | `/retry`, `/undo`                             | `/retry`, `/undo`                                                                |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]`                                        |
 | Browse skills                  | `/skills` or `/<skill-name>`                  | `/<skill-name>`                                                                  |
-| Interrupt current work         | `Ctrl+C` or send a new message                | `/stop` or send a new message                                                    |
+| Steer or interrupt current work | `/busy steer`, `/busy queue`, `/busy interrupt`, or `/stop` | `/stop`, or send a new message (busy-input mode set per gateway via `HERMES_GATEWAY_BUSY_INPUT_MODE`) |
 | Platform-specific status       | `/platforms`                                  | `/status`, `/sethome`                                                            |
 
 For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #78539
## What changed and why

Two stale surfaces in the keystone README, both verified against current `main`:

**1. "Interrupt current work" row contradicted the steer-focused release.**
The row said `Ctrl+C or send a new message` — Ctrl+C is never what users reach for, and "send a new message" is the limiting/disruptive behavior the busy-input model replaced. Now:

| CLI | Messaging |
|---|---|
| `/busy steer`, `/busy queue`, `/busy interrupt`, or `/stop` | `/stop`, or send a new message (busy-input mode set per gateway via `HERMES_GATEWAY_BUSY_INPUT_MODE`) |

Verified against `website/docs/reference/slash-commands.md:89` (`/busy [queue|steer|interrupt|status]` — CLI-only) and `website/docs/user-guide/cli.md:283` (`"steer"` = message injected via `/steer` after the next tool call, no interrupt, no new turn). The messaging column does NOT claim `/busy` because it's CLI-only — gateway steer/queue behavior is configured via `HERMES_GATEWAY_BUSY_INPUT_MODE`.

**2. High-value quick starts existed but weren't featured.**
Added to the Getting Started block, each description taken from the command's actual parser help on `main`:
- `hermes secrets bitwarden setup` — Bitwarden Secrets Manager wizard (install bws, store token, pick project)
- `hermes security` — supply-chain audit (OSV.dev) for venv, plugins, MCP servers
- `hermes egress` — iron-proxy egress credential-injection firewall
- `hermes sessions` — session history management
- `hermes insights` — usage insights and analytics
- `hermes backup` — home directory backup to zip

(`hermes status` was audited and deliberately NOT added — its real help is "Show status of all components," not a narrower command.)

## Why this matters to users

New users see the two most important things the README previously hid: how to steer a running agent instead of killing it with Ctrl+C, and that Hermes has one-command setup for secret management, security auditing, and egress control — capabilities that already shipped but weren't discoverable from the README quick-start block.

## How to test

Docs-only change. Verify:
- `git diff origin/main -- README.md` shows only the two sections above
- The commands referenced exist: `hermes --help` lists `secrets`, `security`, `egress`, `sessions`, `insights`, `backup`; `hermes secrets bitwarden setup --help` shows the wizard

## Platforms tested

N/A — documentation-only (no code, no tests).

Closes #78539

Part of #78568

Closes #78568
