### PR TITLE
Gateway : accept shared truthy aliases for busy-ack enable flag

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8906,8 +8906,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
-        # never actually delivered.
-        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
+        # never actually delivered. Accept the same truthy aliases as steer-ack /
+        # utils.TRUTHY_STRINGS (1/true/yes/on), not only the literal "true".
+        busy_ack_enabled = is_truthy_value(
+            os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true"),
+        )
         if not busy_ack_enabled:
             logger.debug("Busy ack suppressed for session %s", session_key)
             return True  # input still processed, just no ack sent

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -188,6 +188,70 @@ class TestBusySessionAck:
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw", ["1", "yes", "on", "TRUE", " true "])
+    async def test_busy_ack_enabled_accepts_truthy_aliases(self, raw, monkeypatch):
+        """HERMES_GATEWAY_BUSY_ACK_ENABLED must accept shared truthy aliases.
+
+        The previous ``.lower() == "true"`` check treated ``1`` / ``on`` /
+        ``yes`` (and whitespace-padded ``true``) as disabled and silenced acks
+        while the user thought they were enabling them.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", raw)
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="ping while busy")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 60,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter._send_with_retry.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw", ["0", "false", "no", "off", "FALSE"])
+    async def test_busy_ack_disabled_accepts_falsy_aliases(self, raw, monkeypatch):
+        """Falsy aliases must still suppress the ack bubble."""
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", raw)
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="quiet please")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 60,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter._send_with_retry.assert_not_called()
+        agent.interrupt.assert_called_once_with("quiet please")
+
 
     @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Parse `HERMES_GATEWAY_BUSY_ACK_ENABLED` with `is_truthy_value` instead of `.lower() == "true"`. Values like `1` / `on` / `yes` (and whitespace-padded `true`) previously silently suppressed busy acks while users thought they were enabling them — aligning with the project's shared truthy contract and the sibling steer-ack aliases in the same method.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.