### PR TITLE
docs(readme): steer-first interrupt guidance + five-stream README accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 Use any model you want — [Nous Portal](https://portal.nousresearch.com), OpenRouter, OpenAI, your own endpoint, and [many others](https://hermes-agent.nousresearch.com/docs/integrations/providers). Switch with `hermes model` — no code changes, no lock-in.
 
 <table>
-<tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, steer-or-interrupt mid-turn (press Enter to redirect, or `/busy queue|steer|interrupt` to pick the behavior; `/steer` injects a message after the next tool call without interrupting), and streaming tool output.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, Email, and CLI — with 15+ more platforms (Matrix, Mattermost, Teams, iMessage, WeChat, QQ, Yuanbao, Home Assistant…) all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -50,9 +50,9 @@ Run this in PowerShell:
 iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ```
 
-The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). Hermes uses this bundled Git Bash to run shell commands.
+The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (PortableGit — the full Git for Windows without the installer, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). Hermes uses this bundled Git Bash (bash.exe + POSIX utilities) to run shell commands.
 
-If you already have Git installed, the installer detects it and uses that instead. Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
+If you already have Git installed (with a working Git Bash), the installer detects it and uses that instead. Otherwise it downloads PortableGit (one-time, several hundred MB) — it won't touch or interfere with any system Git. (MinGit is used only as a 32-bit fallback, with bash-based features unavailable.)
 
 > **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
 >
@@ -123,10 +123,10 @@ hermes doctor       # Diagnose any issues
 
 ## Skip the API-key collection — Nous Portal
 
-Hermes works with whatever provider you want — that's not changing. But if you'd rather not collect five separate API keys for the model, web search, image generation, TTS, and a cloud browser, **[Nous Portal](https://portal.nousresearch.com)** covers all of them under one subscription:
+Hermes works with whatever provider you want — that's not changing. But if you'd rather not collect separate API keys for the model, web search, image generation, TTS, speech-to-text, and a cloud browser, **[Nous Portal](https://portal.nousresearch.com)** covers all of them under one subscription:
 
 - **300+ models** — pick any of them with `/model <name>`
-- **Tool Gateway** — web search (Firecrawl), image generation (FAL), text-to-speech (OpenAI), cloud browser (Browser Use), all routed through your sub. No extra accounts.
+- **Tool Gateway** — web search (Firecrawl), image generation and video (FAL), text-to-speech (OpenAI), speech-to-text (OpenAI Whisper), cloud browser (Browser Use), all routed through your sub. No extra accounts.
 
 One command from a fresh install:
 
@@ -134,7 +134,7 @@ One command from a fresh install:
 hermes setup --portal
 ```
 
-That logs you in via OAuth, sets Nous as your provider, and turns on the Tool Gateway. Check what's wired up any time with `hermes portal info`. Full details on the [Tool Gateway docs page](https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-gateway).
+That logs you in via OAuth, sets Nous as your provider, and offers to route your tools through the Tool Gateway (per-tool opt-in — your own API keys are left alone). Check what's wired up any time with `hermes portal info`, or run bare `hermes portal` to redo this setup. Full details on the [Tool Gateway docs page](https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-gateway).
 
 You can still bring your own keys per-tool whenever you want — the gateway is per-backend, not all-or-nothing.
 
@@ -148,12 +148,12 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | ------------------------------ | --------------------------------------------- | -------------------------------------------------------------------------------- |
 | Start chatting                 | `hermes`                                      | Run `hermes gateway setup` + `hermes gateway start`, then send the bot a message |
 | Start fresh conversation       | `/new` or `/reset`                            | `/new` or `/reset`                                                               |
-| Change model                   | `/model [provider:model]`                     | `/model [provider:model]`                                                        |
+| Change model                   | `/model [model] [--provider <name>] [--global]` | `/model [model] [--provider <name>]`                                            |
 | Set a personality              | `/personality [name]`                         | `/personality [name]`                                                            |
 | Retry or undo the last turn    | `/retry`, `/undo`                             | `/retry`, `/undo`                                                                |
-| Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]`                                        |
+| Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [--days N]`                                    |
 | Browse skills                  | `/skills` or `/<skill-name>`                  | `/<skill-name>`                                                                  |
-| Interrupt current work         | `Ctrl+C` or send a new message                | `/stop` or send a new message                                                    |
+| Interrupt or steer current work | `Ctrl+C` (interrupt the run); `/busy [queue\|steer\|interrupt]` sets what Enter does; `/steer <text>` injects mid-run; `/stop` kills background processes | `/stop` (hard stop: interrupt + unlock the session), or send a new message (interrupts by default); `/steer <text>` injects mid-run, `/queue <text>` waits for the next turn |
 | Platform-specific status       | `/platforms`                                  | `/status`, `/sethome`                                                            |
 
 For the full command lists, see the [CLI guide](https://hermes-agent.nousresearch.com/docs/user-guide/cli) and the [Messaging Gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
@@ -166,12 +166,12 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 
 | Section                                                                                             | What's Covered                                             |
 | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart)                 | Install → setup → first conversation in 2 minutes          |
+| [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart)                 | Install → setup → first conversation in under 5 minutes    |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli)                              | Commands, keybindings, personalities, sessions             |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration)                | Config file, providers, models, all options                |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Slack, WhatsApp, Signal, Email, and 15+ more platforms |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security)                          | Command approval, DM pairing, container isolation          |
-| [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools)            | 40+ tools, toolset system, terminal backends               |
+| [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools)            | 80+ tools, toolset system, terminal backends               |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)              | Procedural memory, Skills Hub, creating skills             |
 | [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory)                     | Persistent memory, user profiles, best practices           |
 | [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)               | Connect any MCP server for extended capabilities           |
@@ -206,7 +206,7 @@ What gets imported:
 - **Skills** — user-created skills → `~/.hermes/skills/openclaw-imports/`
 - **Command allowlist** — approval patterns
 - **Messaging settings** — platform configs, allowed users, working directory
-- **API keys** — allowlisted secrets (Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs)
+- **API keys** — allowlisted secrets (Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs, voice-tools OpenAI)
 - **TTS assets** — workspace audio files
 - **Workspace instructions** — AGENTS.md (with `--workspace-target`)
 
@@ -252,8 +252,8 @@ scripts/run_tests.sh
 - 💬 [Discord](https://discord.gg/NousResearch)
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
-- 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
-- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [computer-use-linux](https://github.com/agent-sh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
+- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent, OpenClaw, and OpenCode on the same WeChat account.
 
 ---
 


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #78540
## What changed and why

The keystone README's "Interrupt current work" guidance was stuck in the pre-steering world (`Ctrl+C or send a new message`), contradicting the release focus on smooth mid-turn steering. Five parallel audit streams reconciled the README against current `main` (every command, flag, path, and platform verified against code).

## Changes

**Steer-first interrupt guidance (implements #78540 scope; issue closed not_planned):**
- Quick-reference row now documents `/busy [queue|steer|interrupt]` (what Enter does while Hermes works), `/steer <text>` (inject mid-run), `/queue <text>`, and the hard-stop semantics of `/stop` — on both CLI and messaging columns
- Feature table: "interrupt-and-redirect" → "steer-or-interrupt mid-turn" with the `/busy` surface named

**Accuracy fixes (from the five-stream audit):**
- `/model` row: `[provider:model]` syntax is explicitly rejected by `model_switch.py`; corrected to `/model [model] [--provider <name>] [--global]`
- Windows installer: MinGit → **PortableGit** (install.ps1 explicitly rejects MinGit for bash-based features; the ~45MB figure was wrong — it's a several-hundred-MB download)
- Tool Gateway: + speech-to-text (OpenAI Whisper), + video (FAL); "turns on the Tool Gateway" → "offers to route" (per-tool opt-in, BYOK keys left alone)
- Platform lists aligned across all three lists in the README (Email + 15+ more platforms)
- Docs table: 40+ → 80+ tools; 2 minutes → under 5 minutes
- Community: computer-use-linux link → agent-sh org; HermesClaw + OpenCode
- OpenClaw migration list: + VOICE_TOOLS_OPENAI_KEY

## Verification

- Every command/flags/path verified against current main by the audit streams (grep evidence in each stream's report)
- `git diff --check` clean; single-file docs change (README.md only)

## Why this matters to users

Users hitting Ctrl+C to "interrupt" were missing the flagship steering feature — `/busy steer` and `/steer` let you redirect a running agent mid-turn without killing it. The README now teaches the actual command surface instead of the old disrupt-first model, and the accuracy fixes (PortableGit, 80+ tools, platform list) stop users from being misled during install and evaluation.

## Audit trail

Five parallel audit streams, each scoped to a README section and verified against `origin/main` @ f5be9236:
- stream 1: CLI-vs-Messaging table (interrupt row, /model row, insights row)
- stream 2: header/feature bullets (/busy absent from README; platform list inconsistency)
- stream 3: Quickstart/Portal (Tool Gateway list, opt-in wording, hermes portal alias)
- stream 4: docs table + community (80+ tools, 5 min, moved repo link, HermesClaw)
- stream 5: installer + migrate list (PortableGit, VOICE_TOOLS_OPENAI_KEY, Windows note)

Related #78568

Part of #78568

Part of #78539
Part of #78567

Closes #78568
