### PR TITLE
accept shared truthy aliases for headed mode

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -43,6 +43,29 @@ class TestIsHeadedMode:
         with patch("hermes_cli.config.read_raw_config", return_value=cfg):
             assert _is_headed_mode() is True
 
+    @pytest.mark.parametrize("raw", ["on", "ON", "yes", "1", " true "])
+    def test_config_accepts_truthy_aliases(self, raw):
+        from tools.browser_tool import _is_headed_mode
+        cfg = {"browser": {"headed": raw}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _is_headed_mode() is True
+
+    @pytest.mark.parametrize("raw", ["off", "false", "0", "no"])
+    def test_config_rejects_falsy_aliases(self, raw):
+        from tools.browser_tool import _is_headed_mode
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_BROWSER_HEADED", None)
+            cfg = {"browser": {"headed": raw}}
+            with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+                assert _is_headed_mode() is False
+
+    @pytest.mark.parametrize("raw", ["on", "1", "yes", "TRUE"])
+    def test_env_accepts_truthy_aliases(self, raw):
+        from tools.browser_tool import _is_headed_mode
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            with patch.dict(os.environ, {"AGENT_BROWSER_HEADED": raw}):
+                assert _is_headed_mode() is True
+
 
     def test_caching(self):
         from tools.browser_tool import _is_headed_mode

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -977,13 +977,15 @@ def _is_headed_mode() -> bool:
         cfg = read_raw_config()
         val = cfg.get("browser", {}).get("headed")
         if val is not None:
-            _cached_headed_mode = str(val).strip().lower() in ("true", "1", "yes")
+            # Shared truthy contract (1/true/yes/on) — "on" is common in
+            # config.yaml / docs and was previously treated as headless.
+            _cached_headed_mode = is_truthy_value(val)
     except Exception as e:
         logger.debug("Could not read browser.headed from config: %s", e)
 
     if not _cached_headed_mode:
         env_val = os.environ.get("AGENT_BROWSER_HEADED", "").strip()
-        if env_val and env_val.lower() in ("true", "1", "yes"):
+        if env_val and is_truthy_value(env_val):
             _cached_headed_mode = True
 
     return _cached_headed_mode


### PR DESCRIPTION
## Summary
- Parse `browser.headed` / `AGENT_BROWSER_HEADED` with `is_truthy_value` so values like `on` / `1` / `yes` enable headed Chromium. The previous allowlist omitted `on`, a common config.yaml / docs spelling, and silently kept the browser headless.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.
