### PR TITLE
feat(kanban): add HITL blocker language policy

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1434,9 +1434,15 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
+    from agent.prompt_builder import KANBAN_GUIDANCE, build_kanban_hitl_policy_prompt
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        (
+            KANBAN_GUIDANCE
+            + "\n\n"
+            + build_kanban_hitl_policy_prompt()
+        ).rstrip()
+        if "kanban_show" in agent.valid_tool_names
+        else ""
     )
 
     # Check tool requirements

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
@@ -247,8 +247,8 @@ KANBAN_GUIDANCE = (
     "before counting as merged/done (most coding tasks), drop the "
     "structured metadata (changed_files / tests_run / diff_path) into a "
     "`kanban_comment` first, then end with "
-    "`kanban_block(reason=\"review-required: <one-line summary>\")` so a "
-    "reviewer can approve+unblock or request changes. Reviewing-then-"
+    "`kanban_block(reason=\"Please review <one-line summary>.\")` so a "
+    "reviewer can approve and unblock or request changes. Reviewing-then-"
     "completing is more honest than auto-completing work that still needs "
     "eyes on it.\n"
     "6. **If follow-up work appears, create it; don't do it.** Use "
@@ -305,6 +305,245 @@ KANBAN_GUIDANCE = (
     "for short reasoning subtasks inside your own run; board tasks are for "
     "cross-agent handoffs that outlive one API loop."
 )
+
+
+def _default_kanban_hitl_policy() -> dict[str, Any]:
+    """Return a copy of the built-in Kanban HITL policy defaults."""
+    try:
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        policy = (
+            DEFAULT_CONFIG.get("kanban", {})
+            .get("hitl_policy", {})
+        )
+        if isinstance(policy, dict):
+            return json.loads(json.dumps(policy))
+    except Exception:
+        logger.debug("failed to load built-in kanban HITL defaults", exc_info=True)
+    return {
+        "enabled": True,
+        "all_blocked_tasks_are_human_facing": True,
+        "max_notification_chars": 240,
+        "reject_machine_shaped_reasons": True,
+        "require_action_first": True,
+        "default_audience": {
+            "name": "the human reviewer",
+            "role": "human decision-maker",
+            "style": "plain English, action-first, no dev-speak, under 240 chars",
+        },
+        "text": (
+            "When blocking for human input, write like a short business chat message.\n"
+            "Use everyday words. Prefer 'what we can say', 'what we should not say', "
+            "'what you need to choose', 'what approval lets us do next', and "
+            "'what to change if you disagree'.\n"
+            "Use this shape by default:\n"
+            "1. Ask: say exactly what the human must decide or provide.\n"
+            "2. Proposal: say the recommended path in plain words.\n"
+            "3. Limit: say what should not happen, if relevant.\n"
+            "4. Next step: say what approval or the chosen option allows.\n"
+            "5. Change path: say what to ask for if the human disagrees.\n"
+            "Keep the first sentence useful on its own and normally under 240 characters.\n"
+            "If there are choices, label them OPTION A, OPTION B, etc., and recommend one.\n"
+            "Do not use abstract labels such as 'risk posture', 'risk boundary', "
+            "'validation state', 'commercial logic', or 'review status' unless you "
+            "immediately translate them into everyday words.\n"
+            "Do not use JSON, metadata dumps, stack traces, raw file lists, or internal shorthand."
+        ),
+        "profile_overrides": {},
+    }
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    if value is None:
+        return default
+    return default
+
+
+def _as_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _merged_hitl_audience(
+    base: Mapping[str, Any],
+    override: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    audience = {
+        "name": str(base.get("name") or "the human reviewer").strip(),
+        "role": str(base.get("role") or "human decision-maker").strip(),
+        "style": str(base.get("style") or "plain English, action-first").strip(),
+    }
+    if not isinstance(override, Mapping):
+        return audience
+    raw_override = override.get("audience")
+    if isinstance(raw_override, Mapping):
+        for key in ("name", "role", "style"):
+            value = raw_override.get(key)
+            if value:
+                audience[key] = str(value).strip()
+    elif raw_override:
+        audience["name"] = str(raw_override).strip()
+    if override.get("style"):
+        audience["style"] = str(override["style"]).strip()
+    return audience
+
+
+def resolve_kanban_hitl_policy(
+    config: Optional[Mapping[str, Any]] = None,
+    profile: Optional[str] = None,
+) -> dict[str, Any]:
+    """Resolve the Kanban human-in-the-loop language policy.
+
+    Invalid or missing config fails open to the built-in safe policy. An
+    explicit ``enabled: false`` is honored and returns a disabled policy.
+    """
+    defaults = _default_kanban_hitl_policy()
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        except Exception:
+            logger.debug("failed to load config for kanban HITL policy", exc_info=True)
+            config = {}
+
+    raw_policy: Any = None
+    if isinstance(config, Mapping):
+        kanban = config.get("kanban")
+        if isinstance(kanban, Mapping):
+            raw_policy = kanban.get("hitl_policy")
+    if raw_policy is None:
+        raw_policy = defaults
+
+    if not isinstance(raw_policy, Mapping):
+        raw_policy = defaults
+
+    enabled = _as_bool(raw_policy.get("enabled"), _as_bool(defaults.get("enabled"), True))
+    if not enabled:
+        return {
+            "enabled": False,
+            "profile": profile or os.environ.get("HERMES_PROFILE") or "",
+            "max_notification_chars": _as_positive_int(
+                raw_policy.get("max_notification_chars"),
+                _as_positive_int(defaults.get("max_notification_chars"), 240),
+            ),
+        }
+
+    merged = dict(defaults)
+    merged.update(dict(raw_policy))
+    default_audience = defaults.get("default_audience", {})
+    if not isinstance(default_audience, Mapping):
+        default_audience = {}
+    raw_audience = raw_policy.get("default_audience")
+    if not isinstance(raw_audience, Mapping):
+        raw_audience = default_audience
+    else:
+        audience_base = dict(default_audience)
+        audience_base.update(dict(raw_audience))
+        raw_audience = audience_base
+
+    active_profile = (
+        str(profile or os.environ.get("HERMES_PROFILE") or "").strip()
+    )
+    overrides = merged.get("profile_overrides")
+    profile_override: Mapping[str, Any] | None = None
+    if isinstance(overrides, Mapping) and active_profile:
+        candidate = overrides.get(active_profile)
+        if isinstance(candidate, Mapping):
+            profile_override = candidate
+
+    audience = _merged_hitl_audience(raw_audience, profile_override)
+    max_chars = _as_positive_int(
+        merged.get("max_notification_chars"),
+        _as_positive_int(defaults.get("max_notification_chars"), 240),
+    )
+
+    return {
+        "enabled": True,
+        "profile": active_profile,
+        "audience": audience,
+        "all_blocked_tasks_are_human_facing": _as_bool(
+            merged.get("all_blocked_tasks_are_human_facing"),
+            True,
+        ),
+        "max_notification_chars": max_chars,
+        "reject_machine_shaped_reasons": _as_bool(
+            merged.get("reject_machine_shaped_reasons"),
+            True,
+        ),
+        "require_action_first": _as_bool(
+            merged.get("require_action_first"),
+            True,
+        ),
+        "strict": _as_bool(merged.get("strict"), False),
+        "text": str(merged.get("text") or defaults.get("text") or "").strip(),
+        "profile_override": dict(profile_override or {}),
+    }
+
+
+def build_kanban_hitl_policy_prompt(
+    config: Optional[Mapping[str, Any]] = None,
+    profile: Optional[str] = None,
+) -> str:
+    """Build the compact Kanban HITL guidance block for worker prompts."""
+    policy = resolve_kanban_hitl_policy(config=config, profile=profile)
+    if not policy.get("enabled"):
+        return ""
+
+    audience = policy.get("audience") or {}
+    name = str(audience.get("name") or "the human reviewer").strip()
+    role = str(audience.get("role") or "human decision-maker").strip()
+    style = str(audience.get("style") or "plain English, action-first").strip().rstrip(".")
+    max_chars = policy.get("max_notification_chars") or 240
+    text = str(policy.get("text") or "").strip()
+
+    parts = [
+        "# Kanban HITL language policy",
+        (
+            f"When `kanban_block` needs human input, write for {name} "
+            f"({role}). Style: {style}."
+        ),
+        (
+            "All true blocked tasks are human-facing by default. "
+            '`kind="dependency"` is not human-facing; use it only when waiting '
+            "on another board task so it can resume automatically."
+        ),
+        (
+            "Lead with the action the human must take. Keep the first visible "
+            f"notification sentence concise, normally under {max_chars} characters. "
+            "Put machine detail in metadata, artifacts, or internal comments."
+        ),
+        (
+            "If the human must choose, label choices `OPTION A`, `OPTION B`, "
+            "etc., and include a recommendation."
+        ),
+    ]
+    if text:
+        parts.append(text)
+    override = policy.get("profile_override")
+    if isinstance(override, Mapping) and override:
+        override_style = str(override.get("style") or "").strip()
+        human_surface = override.get("human_surface")
+        suffix = []
+        if human_surface:
+            suffix.append(f"human_surface={human_surface}")
+        if override_style:
+            suffix.append(override_style)
+        if suffix:
+            profile_name = policy.get("profile") or "active profile"
+            parts.append(f"Profile override for {profile_name}: {'; '.join(suffix)}")
+    return "\n".join(parts)
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -240,7 +240,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(_kanban_guidance)
     elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
         # Fallback for code paths that bypass agent_init (rare).
-        tool_guidance.append(KANBAN_GUIDANCE)
+        from agent.prompt_builder import build_kanban_hitl_policy_prompt
+
+        tool_guidance.append(
+            (KANBAN_GUIDANCE + "\n\n" + build_kanban_hitl_policy_prompt()).rstrip()
+        )
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -23,6 +24,33 @@ from agent.i18n import t
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+
+def _kanban_hitl_notification_cap() -> int:
+    try:
+        from agent.prompt_builder import resolve_kanban_hitl_policy
+
+        policy = resolve_kanban_hitl_policy()
+        return int(policy.get("max_notification_chars") or 240)
+    except Exception:
+        logger.debug("kanban HITL notification cap resolution failed", exc_info=True)
+        return 240
+
+
+def _kanban_first_action_sentence(reason: Any, *, cap: Optional[int] = None) -> str:
+    """Return the first concise blocker sentence without rewriting meaning."""
+    text = str(reason or "").strip()
+    if not text:
+        return ""
+    limit = cap if isinstance(cap, int) and cap > 0 else _kanban_hitl_notification_cap()
+    first_line = next((line.strip() for line in text.splitlines() if line.strip()), text)
+    match = re.search(r"(?<=[.!?])\s+", first_line)
+    sentence = first_line[: match.start()].strip() if match else first_line
+    if len(sentence) <= limit:
+        return sentence
+    if limit <= 1:
+        return sentence[:limit]
+    return sentence[: limit - 1].rstrip() + "…"
 
 
 def _resolve_auto_decompose_settings(
@@ -435,7 +463,11 @@ class GatewayKanbanWatchersMixin:
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
+                                excerpt = _kanban_first_action_sentence(
+                                    ev.payload["reason"]
+                                )
+                                if excerpt:
+                                    reason = f": {excerpt}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
@@ -475,7 +507,11 @@ class GatewayKanbanWatchersMixin:
                             recurrences = None
                             if ev.payload:
                                 if ev.payload.get("reason"):
-                                    reason = f": {str(ev.payload['reason'])[:160]}"
+                                    excerpt = _kanban_first_action_sentence(
+                                        ev.payload["reason"]
+                                    )
+                                    if excerpt:
+                                        reason = f": {excerpt}"
                                 recurrences = ev.payload.get("recurrences")
                             rc = f" (blocked {recurrences}x for the same cause)" if recurrences else ""
                             msg = (

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2262,6 +2262,41 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Human-in-the-loop language policy. True blockers interrupt a human,
+        # so workers must phrase kanban_block(reason=...) for the configured
+        # audience rather than as agent-to-agent metadata. Dependency waits are
+        # not human-facing and route through todo until their parents finish.
+        "hitl_policy": {
+            "enabled": True,
+            "all_blocked_tasks_are_human_facing": True,
+            "max_notification_chars": 240,
+            "reject_machine_shaped_reasons": True,
+            "require_action_first": True,
+            "default_audience": {
+                "name": "the human reviewer",
+                "role": "human decision-maker",
+                "style": "plain English, action-first, no dev-speak, under 240 chars",
+            },
+            "text": (
+                "When blocking for human input, write like a short business chat message.\n"
+                "Use everyday words. Prefer 'what we can say', 'what we should not say', "
+                "'what you need to choose', 'what approval lets us do next', and "
+                "'what to change if you disagree'.\n"
+                "Use this shape by default:\n"
+                "1. Ask: say exactly what the human must decide or provide.\n"
+                "2. Proposal: say the recommended path in plain words.\n"
+                "3. Limit: say what should not happen, if relevant.\n"
+                "4. Next step: say what approval or the chosen option allows.\n"
+                "5. Change path: say what to ask for if the human disagrees.\n"
+                "Keep the first sentence useful on its own and normally under 240 characters.\n"
+                "If there are choices, label them OPTION A, OPTION B, etc., and recommend one.\n"
+                "Do not use abstract labels such as 'risk posture', 'risk boundary', "
+                "'validation state', 'commercial logic', or 'review status' unless you "
+                "immediately translate them into everyday words.\n"
+                "Do not use JSON, metadata dumps, stack traces, raw file lists, or internal shorthand."
+            ),
+            "profile_overrides": {},
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/tests/agent/test_prompt_builder_kanban_hitl_policy.py
+++ b/tests/agent/test_prompt_builder_kanban_hitl_policy.py
@@ -1,0 +1,67 @@
+from agent.prompt_builder import (
+    build_kanban_hitl_policy_prompt,
+    resolve_kanban_hitl_policy,
+)
+
+
+def test_default_kanban_hitl_policy_names_default_audience():
+    policy = resolve_kanban_hitl_policy({"kanban": {}}, profile="worker")
+    assert policy["enabled"] is True
+    assert policy["audience"]["name"] == "the human reviewer"
+    assert policy["audience"]["role"] == "human decision-maker"
+
+    prompt = build_kanban_hitl_policy_prompt({"kanban": {}}, profile="worker")
+    assert "Kanban HITL language policy" in prompt
+    assert "the human reviewer" in prompt
+    assert "All true blocked tasks are human-facing" in prompt
+    assert 'kind="dependency"` is not human-facing' in prompt
+
+
+def test_disabled_kanban_hitl_policy_returns_empty_prompt():
+    cfg = {"kanban": {"hitl_policy": {"enabled": False}}}
+    assert resolve_kanban_hitl_policy(cfg)["enabled"] is False
+    assert build_kanban_hitl_policy_prompt(cfg) == ""
+
+
+def test_profile_override_updates_audience_style():
+    cfg = {
+        "kanban": {
+            "hitl_policy": {
+                "default_audience": {
+                    "name": "Alex",
+                    "role": "Ops reviewer",
+                    "style": "plain English",
+                },
+                "profile_overrides": {
+                    "platform-ops": {
+                        "human_surface": "blockers_only",
+                        "audience": "Casey",
+                        "style": (
+                            "Translate platform terms. Say whether anything "
+                            "live will change."
+                        ),
+                    }
+                },
+            }
+        }
+    }
+
+    policy = resolve_kanban_hitl_policy(cfg, profile="platform-ops")
+    assert policy["audience"]["name"] == "Casey"
+    assert policy["audience"]["role"] == "Ops reviewer"
+    assert "live will change" in policy["audience"]["style"]
+
+    prompt = build_kanban_hitl_policy_prompt(cfg, profile="platform-ops")
+    assert "Profile override for platform-ops" in prompt
+    assert "human_surface=blockers_only" in prompt
+    assert "live will change" in prompt
+
+
+def test_invalid_kanban_hitl_policy_fails_open_to_safe_default():
+    policy = resolve_kanban_hitl_policy(
+        {"kanban": {"hitl_policy": "not-a-dict"}},
+        profile="worker",
+    )
+    assert policy["enabled"] is True
+    assert policy["audience"]["name"] == "the human reviewer"
+    assert policy["reject_machine_shaped_reasons"] is True

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -35,6 +35,31 @@ def _assert_inherited_notify_sub(subs: list[dict]) -> None:
     assert subs[0]["notifier_profile"] == "default"
 
 
+def test_blocked_notification_prefers_first_action_sentence():
+    from gateway.kanban_watchers import _kanban_first_action_sentence
+
+    reason = (
+        "Please approve the test-only change. Nothing live will change. "
+        "Ask for changes if the test purpose is unclear."
+    )
+
+    assert (
+        _kanban_first_action_sentence(reason, cap=180)
+        == "Please approve the test-only change."
+    )
+
+
+def test_blocked_notification_respects_configured_cap():
+    from gateway.kanban_watchers import _kanban_first_action_sentence
+
+    reason = "Please approve the generated customer migration briefing for Monday."
+
+    excerpt = _kanban_first_action_sentence(reason, cap=32)
+    assert excerpt.startswith("Please approve")
+    assert excerpt.endswith("…")
+    assert len(excerpt) <= 32
+
+
 
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -217,13 +217,94 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
 
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
-    out = kt._handle_block({"reason": "need clarification"})
+    out = kt._handle_block({"reason": "Please clarify the acceptance criteria."})
     d = json.loads(out)
     assert d["ok"] is True
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
         assert kb.get_task(conn, worker_env).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_block_rejects_json_reason_before_db_write(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_block({
+        "reason": '{"status": "review-required", "tests": ["ready"]}',
+        "kind": "needs_input",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "Rewrite this blocker" in d["error"]
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+
+def test_block_rejects_stack_trace_reason_before_db_write(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_block({
+        "reason": (
+            "Traceback (most recent call last):\n"
+            '  File "worker.py", line 12, in <module>\n'
+            "RuntimeError: no token"
+        ),
+        "kind": "capability",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "Rewrite this blocker" in d["error"]
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+
+def test_block_rejects_technical_phrase_without_action(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_block({
+        "reason": "metadata-shape regression tests are ready",
+        "kind": "needs_input",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "Rewrite this blocker" in d["error"]
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+
+def test_dependency_block_is_exempt_from_human_facing_validator(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_block({
+        "reason": '{"waiting_on": "parent task output"}',
+        "kind": "dependency",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["status"] == "todo"
+    assert d["block_kind"] == "dependency"
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "todo"
     finally:
         conn.close()
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -213,6 +214,21 @@ def _connect(board: Optional[str] = None):
 
 
 _GOAL_MODE_BLOCK_ALLOWED_KINDS = frozenset({"dependency", "needs_input"})
+_HITL_ACTION_START_RE = re.compile(
+    r"^\s*(please|choose|approve|reject|decide|tell|provide|grant|confirm|"
+    r"review|pick|select|share|upload|open|reconnect|authorize|sign in|"
+    r"connect|set|move|create|reply|answer|allow|deny)\b",
+    re.IGNORECASE,
+)
+_HITL_INTERNAL_LABEL_RE = re.compile(r"^\s*[a-z][a-z0-9_.-]{2,}\s*:\s+", re.IGNORECASE)
+_HITL_OPTION_RE = re.compile(r"\boption\s+[a-z]\b", re.IGNORECASE)
+_HITL_UNLABELED_CHOICE_RE = re.compile(r"(^|\s)([ab])[\).]\s+\S", re.IGNORECASE)
+_HITL_TECH_OBJECT_RE = re.compile(
+    r"\b(metadata|regression|stack trace|traceback|exception|token|msal|"
+    r"api|json|yaml|sqlite|db|schema|diff|patch|worktree|cron|gateway|"
+    r"artifact|stdout|stderr|pytest|importerror|attributeerror)\b",
+    re.IGNORECASE,
+)
 
 
 def _goal_judge_available() -> bool:
@@ -234,6 +250,92 @@ def _goal_judge_available() -> bool:
     except Exception:
         return False
     return client is not None and bool(model)
+
+
+def _kanban_hitl_rewrite_error(policy: dict[str, Any]) -> str:
+    audience = policy.get("audience") or {}
+    name = str(audience.get("name") or "the human").strip()
+    style = str(audience.get("style") or "plain English").strip()
+    return tool_error(
+        f"Rewrite this blocker for {name} as a short business message. "
+        f"Use {style}. Use this shape: 'Please [decide/provide/approve] ____. "
+        f"Approval means ____. Ask for changes if ____.' If there are choices, "
+        f"write: 'Please choose ____. OPTION A: ____. OPTION B: ____. "
+        f"Recommendation: ____.' Do not use JSON, metadata, stack traces, or "
+        f"agent shorthand."
+    )
+
+
+def _validate_human_facing_block_reason(
+    reason: str,
+    *,
+    kind: Optional[str],
+) -> Optional[str]:
+    """Return a rewrite error for obvious machine-shaped human blockers.
+
+    This is intentionally a coarse pre-write guardrail, not a prose judge.
+    Dependency waits are internal board coordination and bypass HITL wording.
+    """
+    if kind == "dependency":
+        return None
+    try:
+        from agent.prompt_builder import resolve_kanban_hitl_policy
+
+        policy = resolve_kanban_hitl_policy()
+    except Exception:
+        logger.debug("kanban HITL policy resolution failed", exc_info=True)
+        policy = {
+            "enabled": True,
+            "reject_machine_shaped_reasons": True,
+            "require_action_first": True,
+            "max_notification_chars": 240,
+            "strict": False,
+            "audience": {
+                "name": "the human reviewer",
+                "style": "plain English, action-first, no dev-speak, under 240 chars",
+            },
+        }
+    if not policy.get("enabled"):
+        return None
+
+    text = reason.strip()
+    if not text:
+        return _kanban_hitl_rewrite_error(policy)
+
+    reject_machine = bool(policy.get("reject_machine_shaped_reasons", True))
+    if reject_machine:
+        if text.startswith(("{", "[", "```json", "```python")):
+            return _kanban_hitl_rewrite_error(policy)
+        if re.search(
+            r"Traceback \(most recent call last\)|^\s*File \".+\", line \d+",
+            text,
+            re.MULTILINE,
+        ):
+            return _kanban_hitl_rewrite_error(policy)
+        if _HITL_INTERNAL_LABEL_RE.match(text) and not _HITL_ACTION_START_RE.match(text):
+            return _kanban_hitl_rewrite_error(policy)
+        if _HITL_UNLABELED_CHOICE_RE.search(text) and not _HITL_OPTION_RE.search(text):
+            return _kanban_hitl_rewrite_error(policy)
+
+    if policy.get("require_action_first", True):
+        first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+        if (
+            first_line
+            and not _HITL_ACTION_START_RE.match(first_line)
+            and _HITL_TECH_OBJECT_RE.search(first_line)
+        ):
+            return _kanban_hitl_rewrite_error(policy)
+
+    if policy.get("strict"):
+        max_chars = policy.get("max_notification_chars") or 240
+        try:
+            limit = int(max_chars)
+        except (TypeError, ValueError):
+            limit = 240
+        if limit > 0 and len(text) > limit:
+            return _kanban_hitl_rewrite_error(policy)
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -844,6 +946,10 @@ def _handle_block(args: dict, **kw) -> str:
                 f"another reason, call kanban_complete instead — the "
                 f"completion judge will evaluate it."
             )
+        hitl_err = _validate_human_facing_block_reason(reason, kind=kind)
+        if hitl_err:
+            conn.close()
+            return hitl_err
         try:
             ok = kb.block_task(
                 conn, tid,
@@ -1715,7 +1821,9 @@ KANBAN_BLOCK_SCHEMA = {
         "needed), 'needs_input' (you need a human decision/answer), "
         "'capability' (a hard wall: no access, missing credentials, an action "
         "no agent can do), or 'transient' (a flaky failure that may clear). "
-        "``reason`` is shown to the human on the board. If a task keeps "
+        "``reason`` is shown to the human on the board for every non-dependency "
+        "blocker, so lead with the action they need to take in plain English. "
+        "If a task keeps "
         "getting unblocked and re-blocked for the same reason, it is "
         "auto-escalated to triage. Use for genuine blockers only — don't "
         "block on things you can resolve yourself."
@@ -1730,9 +1838,12 @@ KANBAN_BLOCK_SCHEMA = {
             "reason": {
                 "type": "string",
                 "description": (
-                    "What you need answered or what stopped you, in one or "
-                    "two sentences. Don't paste the whole conversation; the "
-                    "human has the board and can ask follow-ups via comments."
+                    "What the human needs to do, in one or two plain-English "
+                    "sentences. Lead with the action. If there are choices, "
+                    "label them OPTION A, OPTION B, etc., and recommend one. "
+                    "Don't paste JSON, stack traces, metadata dumps, or the "
+                    "whole conversation; use comments/artifacts for technical "
+                    "detail."
                 ),
             },
             "kind": {

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -352,6 +352,75 @@ Three reasons:
 
 The auto-injected kanban guidance teaches the model which tool to call when and in what order.
 
+### Human-facing blockers
+
+Every true Kanban blocker is treated as human-facing by default. When a worker
+calls `kanban_block(reason=...)` for `needs_input`, `capability`, `transient`,
+or an omitted kind, the reason is visible on the board and can be sent through
+gateway notifications. Workers therefore get extra prompt guidance naming the
+configured human audience and telling them to lead with the action that person
+must take.
+
+`kind="dependency"` is different: it means the worker is waiting on another
+board task. Dependency waits route through `todo` and resume automatically when
+their parents finish; they are not forced through the human-facing wording
+validator.
+
+The `kanban_block` tool has a lightweight guardrail for obvious machine-shaped
+reasons. It rejects JSON/dict dumps, stack traces, internal-label starts like
+`review-required:` without a plain-English action, unlabeled choices, and
+strict-mode overlong reasons before the DB write happens. It is not a writing
+judge: short actionable text passes even if it is not stylistically perfect.
+
+Configure the audience and profile-specific wording under `kanban.hitl_policy`:
+
+```yaml
+kanban:
+  hitl_policy:
+    enabled: true
+    all_blocked_tasks_are_human_facing: true
+    max_notification_chars: 240
+    reject_machine_shaped_reasons: true
+    require_action_first: true
+
+    default_audience:
+      name: the human reviewer
+      role: human decision-maker
+      style: plain English, action-first, no dev-speak, under 240 chars
+
+    text: |
+      When blocking for human input, write like a short business chat message.
+      Use everyday words. Prefer "what we can say", "what we should not say",
+      "what you need to choose", "what approval lets us do next", and
+      "what to change if you disagree".
+      Use this shape by default:
+      1. Ask: say exactly what the human must decide or provide.
+      2. Proposal: say the recommended path in plain words.
+      3. Limit: say what should not happen, if relevant.
+      4. Next step: say what approval or the chosen option allows.
+      5. Change path: say what to ask for if the human disagrees.
+      Keep the first sentence useful on its own and normally under 240 characters.
+      If there are choices, label them OPTION A, OPTION B, etc., and recommend one.
+      Do not use abstract labels such as "risk posture", "risk boundary",
+      "validation state", "commercial logic", or "review status" unless you
+      immediately translate them into everyday words.
+      Do not use JSON, metadata dumps, stack traces, raw file lists, or internal shorthand.
+
+    profile_overrides:
+      platform-ops:
+        human_surface: blockers_only
+        audience: the operations reviewer
+        style: Translate platform terms. Say whether anything live will change.
+      red-team:
+        human_surface: blockers_only
+        audience: the security reviewer
+        style: Use everyday words for risk. Say what is okay, what is not okay, and what the reviewer should approve or change.
+```
+
+Gateway notifications do not rewrite blocker meaning. They deliver the worker's
+first plain-English action sentence and cap it to `max_notification_chars`; the
+full reason remains on the task for follow-up context.
+
 ### Recommended handoff evidence
 
 `kanban_complete(summary=..., metadata={...})` is intentionally flexible:
@@ -580,6 +649,10 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `hitl_policy.enabled` | `true` | Inject human-facing blocker guidance into Kanban worker prompts and validate obvious machine-shaped blocker reasons. |
+| `hitl_policy.default_audience` | human reviewer / human decision-maker | The explicit human audience workers should write blocker reasons for. Set `name`, `role`, and `style` for your install. |
+| `hitl_policy.profile_overrides` | `{}` | Optional per-profile audience/style overrides. These customize wording; they do not make true blockers non-human-facing. |
+| `hitl_policy.max_notification_chars` | `240` | Cap for the first blocker sentence delivered by gateway notifications. |
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
## Summary

- Add a configurable `kanban.hitl_policy` for human-facing Kanban blockers.
- Inject HITL language guidance into Kanban worker prompts when Kanban tools are available.
- Treat true blockers as human-facing by default while keeping `kind="dependency"` as internal coordination.
- Reject obvious machine-shaped blocker reasons, including JSON dumps, stack traces, empty reasons, internal labels, and unlabeled choices, before writing a blocked event.
- Use the first action sentence for gateway blocked-task previews, capped by `max_notification_chars` with a default of 240.
- Document YAML configuration for default audience, notification cap, policy text, and per-profile overrides.

## Why

Kanban blockers are often surfaced directly to humans through gateway notifications or dashboards. Without explicit guidance, agents can write blocker reasons as internal metadata or terse machine notes. This makes human review slower and less reliable.

This PR adds a small language and guardrail layer. It does not implement a full approval-routing or multi-recipient HITL system.

## Configuration

The policy is install-configurable under:

```yaml
kanban:
  hitl_policy:
    enabled: true
    default_audience:
      name: the human reviewer
      role: human decision-maker
      style: plain English, action-first, no dev-speak, under 240 chars
    max_notification_chars: 240
    profile_overrides: {}
```

## Validation

- `uv run --with pytest --with pytest-asyncio python -m pytest -q tests/tools/test_kanban_tools.py tests/agent/test_prompt_builder_kanban_hitl_policy.py tests/hermes_cli/test_kanban_notify.py`
  - `39 passed`
- `python -m py_compile tools/kanban_tools.py agent/prompt_builder.py hermes_cli/config_defaults.py gateway/kanban_watchers.py agent/agent_init.py agent/system_prompt.py`
  - passed
- `git diff --check`
  - passed

## Manual UAT performed locally

Using an isolated test board/worktree harness:

- Chief-of-staff-style triage decomposition produced legible child cards.
- Human approval blocker used action-first plain language.
- OPTION A / OPTION B blocker included a recommendation.
- `kind="dependency"` did not become a human-facing blocked card.
- Long full blocker reason remained preserved while notification preview stayed concise.
- JSON-style blocker was rejected before DB write.
- Empty blocker was rejected before DB write.

## Notes

- Draft PR for maintainer review.
- This is intentionally scoped to language policy, blocker guardrails, and notification excerpts. It does not add multi-human routing or approval ownership semantics.
