### PR TITLE
fix(simplex): send DMs by numeric contactId via /_send, not bare @<id>

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -838,7 +838,14 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                # Structured form: addresses by numeric contactId, and
+                # json.dumps escapes newlines + special chars correctly.
+                # The bare @<id> shorthand resolves <id> as a display-name
+                # lookup, which fails with chatCmdError on v6.5.6+ and v7.
+                composed = json.dumps(
+                    [{"msgContent": {"type": "text", "text": content}}]
+                )
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
@@ -1267,8 +1274,12 @@ async def _standalone_send(
             )
             cmd_str = f"/_send #{group_id} json {composed}"
         else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
+            # Structured form: addresses by numeric contactId, and
+            # json.dumps escapes newlines + special chars correctly.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": message}}]
+            )
+            cmd_str = f"/_send @{chat_id} json {composed}"
 
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -237,6 +237,90 @@ async def test_list_channels_returns_none_on_contacts_timeout():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
+async def test_send_dm():
+    """DMs use the structured ``/_send @<id> json [...]`` form.
+
+    The bare ``@<id> text`` shorthand resolves ``<id>`` as a display-name
+    lookup in the daemon, so numeric contact IDs fail with
+    ``chatCmdError { contactNotFound }``. The structured ``/_send`` form
+    addresses by numeric contact ID and survives newlines/quoting through
+    ``json.dumps``.
+    """
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    result = await adapter.send("42", "Hello, DM!")
+    payload = json.loads(mock_ws.send.call_args[0][0])
+    assert payload["cmd"].startswith("/_send @42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "Hello, DM!"}
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_dm_multiline():
+    """Multiline DM content is preserved through json.dumps escaping."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    text = "Line one\nLine two\n\"quoted\""
+    result = await adapter.send("6", text)
+    payload = json.loads(mock_ws.send.call_args[0][0])
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": text}
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_dm_uses_structured_form(monkeypatch):
+    """Standalone send (cron path) uses /_send @<id> json, not bare @<id>."""
+    try:
+        import websockets  # noqa: F401
+    except ImportError:
+        pytest.skip("websockets not installed")
+
+    sent_payload = {}
+
+    class FakeWS:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def send(self, data):
+            sent_payload["data"] = data
+
+    # The standalone send path does ``import websockets as _wsclient``
+    # inside the function body, so patch the connect on the real module.
+    monkeypatch.setattr(websockets, "connect", lambda *a, **kw: FakeWS())
+
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    result = await _standalone_send(pconfig, "42", "hello from cron")
+
+    assert result["success"] is True
+    payload = json.loads(sent_payload["data"])
+    assert payload["cmd"].startswith("/_send @42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "hello from cron"}
+
+
+@pytest.mark.asyncio
 async def test_standalone_send_missing_websockets(monkeypatch):
     """When websockets is unimportable, return a clean error dict.
 


### PR DESCRIPTION
## What does this PR do?

Fixes silent loss of outbound SimpleX direct messages. Both the in-process `send()` and standalone `_standalone_send()` paths addressed DM recipients with the bare chat-command form `@<id> text`. The SimpleX daemon parses `@<n>` as a display-name lookup — since `chat_id` is a numeric `contactId` (e.g. `6`), the daemon returns `chatCmdError { contactNotFound, contactName: "6" }`. Chat commands return no `corrId`, so the adapter never observes the error and logs success while the message silently drops.

This PR mirrors the group/media/voice branches: address by numeric ID and escape via `json.dumps` using the structured `/_send @<id> json [...]` form.

## Related Issue

Fixes #66951

Refs #66969 and #76569 — two earlier PRs for the same bug. #66969 patches only the in-process `send()` path and has merge conflicts. #76569 covers both paths but has no issue reference. This PR covers both send paths, is rebased on latest `main`, and includes regression tests for DM text, multiline content, and the standalone (cron) path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py` line ~841 (`send()` DM path): `@{chat_id} {content}` to `/_send @{chat_id} json {composed}` with `json.dumps` payload
- `plugins/platforms/simplex/adapter.py` line ~1271 (`_standalone_send()` DM path): same fix for the cron/out-of-process send path
- `tests/gateway/test_simplex_plugin.py`: added `test_send_dm`, `test_send_dm_multiline`, `test_standalone_send_dm_uses_structured_form`

## How to Test

1. `python3 -m pytest tests/gateway/test_simplex_plugin.py -v` -> 16 passed
2. Confirm DM payloads use `/_send @<id> json ...` (not bare `@<id>`)
3. Confirm multiline text round-trips through JSON payload
4. Confirm standalone (cron) path uses the same structured form

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (found #66969 and #76569 — same fix, this PR covers both send paths and is rebased)
- [x] My PR contains only changes related to this fix
- [x] I have run pytest and all tests pass (16/16 in SimpleX suite)
- [x] I have added tests for my changes (3 new tests)
- [x] I have tested on my platform: Ubuntu 24.04, SimpleX daemon v7.0.0
- [x] Cross-platform impact: N/A (daemon-version-specific, not OS-specific)

## Notes for Reviewers

Two earlier PRs address the same bug:
- **#66969** (dsitmilis, Jul 18) — patches `send()` only, has merge conflicts
- **#76569** (FerMPY, Aug 2) — covers both paths, no issue reference, fewer tests

This PR aims to be the canonical version: both send paths patched, rebased on latest main, 3 regression tests. Happy to collaborate if the maintainers prefer to merge one of the earlier PRs instead.