### PR TITLE
fix(agent): stop degenerate output repetition during streaming

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -41,6 +41,11 @@ from agent.message_sanitization import (
 )
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.stream_output_repetition_guard import (
+    StreamOutputRepetitionError,
+    StreamOutputRepetitionGuard,
+    truncate_repeated_tail,
+)
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
@@ -3237,6 +3242,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         content_parts: list = []
         tool_calls_acc: dict = {}
         tool_gen_notified: set = set()
+        repetition_guard = StreamOutputRepetitionGuard()
+        reasoning_repetition_guard = StreamOutputRepetitionGuard()
         # Ollama-compatible endpoints reuse index 0 for every tool call
         # in a parallel batch, distinguishing them only by id.  Track
         # the last seen id per raw index so we can detect a new tool
@@ -3439,12 +3446,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     reasoning_parts[-1] if reasoning_parts else "",
                     reasoning_text,
                 )
+                # Feed the guard the separated text, not the raw delta: the
+                # guard measures what actually accumulates into the stream.
+                reasoning_repetition_guard.feed(reasoning_text)
                 reasoning_parts.append(reasoning_text)
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
+                repetition_guard.feed(delta.content)
                 content_parts.append(delta.content)
                 if not tool_calls_acc:
                     _fire_first_delta()
@@ -3751,6 +3762,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         stream's socket without closing the shared client mid-flight (#67142).
         """
         has_tool_use = False
+        repetition_guard = StreamOutputRepetitionGuard()
+        reasoning_repetition_guard = StreamOutputRepetitionGuard()
         # Zero-event guard parity with the chat_completions path: track
         # whether the provider delivered ANY stream event. On an eventless
         # stream the real Anthropic SDK's get_final_message() raises
@@ -3866,6 +3879,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         delta_type = getattr(delta, "type", None)
                         if delta_type == "text_delta":
                             text = getattr(delta, "text", "")
+                            repetition_guard.feed(text)
                             if text and not has_tool_use:
                                 _fire_first_delta()
                                 agent._fire_stream_delta(text)
@@ -3873,6 +3887,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         elif delta_type == "thinking_delta":
                             thinking_text = getattr(delta, "thinking", "")
                             if thinking_text:
+                                reasoning_repetition_guard.feed(thinking_text)
                                 _fire_first_delta()
                                 agent._fire_reasoning_delta(thinking_text)
             if not agent._interrupt_requested:
@@ -3993,6 +4008,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     return  # success
                 except Exception as e:
                     _close_managed_stream()
+                    if isinstance(e, StreamOutputRepetitionError):
+                        logger.warning(
+                            "Stopping a degenerate streaming response before "
+                            "continuation (model=%s provider=%s): %s",
+                            getattr(agent, "model", None),
+                            getattr(agent, "provider", None),
+                            e,
+                        )
+                        result["error"] = e
+                        return
                     # If the main poll loop force-closed this request because
                     # of an interrupt, the resulting transport error is the
                     # expected consequence of our own close — NOT a transient
@@ -4479,7 +4504,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
-        if deltas_were_sent["yes"]:
+        _repetition_terminated = isinstance(
+            result["error"], StreamOutputRepetitionError
+        )
+        if deltas_were_sent["yes"] or _repetition_terminated:
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make
             # Return a partial response stub with finish_reason="length"
@@ -4488,6 +4516,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _partial_text = (
                 getattr(agent, "_current_streamed_assistant_text", "") or ""
             ).strip() or None
+
+            if _repetition_terminated:
+                _partial_text = truncate_repeated_tail(
+                    _partial_text or "",
+                    result["error"].normalized_line,
+                )
+                try:
+                    agent._fire_stream_delta(
+                        "\n\n[Output stopped: repetitive generation detected.]"
+                    )
+                except Exception:
+                    pass
 
             # Append a user-visible warning if tool calls were dropped so
             # the user and model both know what was attempted.
@@ -4572,6 +4612,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             )
             if _content_filter_terminated:
                 _stub._content_filter_terminated = True
+            if _repetition_terminated:
+                _stub._repetition_loop_terminated = True
+                _stub._repetition_loop_detail = str(result["error"])
             # Partial-stream stub: chunks WERE received (deltas fired), so
             # the provider is demonstrably responsive — clear the circuit
             # breaker (#58962) just like the full-success return below.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -85,6 +85,7 @@ from agent.retry_utils import (
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
 )
+from agent.stream_output_repetition_guard import FAILED_REPETITION_LOOP
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -3094,6 +3095,42 @@ def run_conversation(
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
                     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+
+                    if getattr(response, "_repetition_loop_terminated", False):
+                        partial_response = agent._strip_think_blocks(
+                            _trunc_content or ""
+                        ).strip()
+                        if _trunc_msg is not None:
+                            guarded_message = agent._build_assistant_message(
+                                _trunc_msg, finish_reason
+                            )
+                            guarded_message.pop("tool_calls", None)
+                            guarded_message.pop("reasoning", None)
+                            guarded_message.pop("reasoning_content", None)
+                            guarded_message.pop("reasoning_details", None)
+                            if guarded_message.get("content"):
+                                messages.append(guarded_message)
+                        detail = getattr(
+                            response,
+                            "_repetition_loop_detail",
+                            FAILED_REPETITION_LOOP,
+                        )
+                        final_response = partial_response or (
+                            "[Output stopped: repetitive generation detected.]"
+                        )
+                        agent._cleanup_task_resources(effective_task_id)
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": final_response,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "partial": True,
+                            "error": detail,
+                            "failure_reason": FAILED_REPETITION_LOOP,
+                            "guardrail_code": FAILED_REPETITION_LOOP,
+                        }
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning

--- a/agent/stream_output_repetition_guard.py
+++ b/agent/stream_output_repetition_guard.py
@@ -1,0 +1,179 @@
+"""Bound degenerate repetition while an assistant response is streaming."""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+import re
+
+
+FAILED_REPETITION_LOOP = "FAILED_REPETITION_LOOP"
+REPETITION_CUT_MARKER = "[Output stopped: repetitive generation detected.]"
+
+
+def _normalize_line(line: str, min_chars: int) -> str:
+    normalized = re.sub(r"\s+", " ", (line or "").strip())
+    if len(normalized) < min_chars:
+        return ""
+    if normalized in {"```", "---", "***"}:
+        return ""
+    if set(normalized) <= {"-", "|", ":", " "}:
+        return ""
+    return normalized
+
+
+class StreamOutputRepetitionError(RuntimeError):
+    """Raised when the tail of one streamed response stops making progress."""
+
+    def __init__(
+        self,
+        repeated_unit: str,
+        repeat_count: int,
+        *,
+        normalized_line: str | None = None,
+    ) -> None:
+        self.repeated_unit = repeated_unit
+        self.repeat_count = repeat_count
+        self.normalized_line = normalized_line
+        super().__init__(
+            f"{FAILED_REPETITION_LOOP}: {repeated_unit[:160]!r} "
+            f"repeated {repeat_count} times"
+        )
+
+
+class StreamOutputRepetitionGuard:
+    """Detect a repeated line block or an exact periodic character tail.
+
+    A repeated line only trips the guard when a small set of lines dominates a
+    trailing window. This excludes reports and logs where a recurring status is
+    separated by varied content. The periodic check covers streams that never
+    emit newlines.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_total_chars: int = 1200,
+        min_line_chars: int = 40,
+        repeat_threshold: int = 8,
+        line_window: int | None = None,
+        max_distinct_lines: int = 6,
+        periodic_max_chars: int = 80,
+        periodic_min_repeats: int = 5,
+        periodic_check_every_chars: int = 256,
+    ) -> None:
+        self.min_total_chars = max(0, int(min_total_chars))
+        self.min_line_chars = max(1, int(min_line_chars))
+        self.repeat_threshold = max(2, int(repeat_threshold))
+        self.line_window = max(
+            self.repeat_threshold,
+            int(line_window or self.repeat_threshold * 6),
+        )
+        self.max_distinct_lines = max(1, int(max_distinct_lines))
+        self.periodic_max_chars = max(2, int(periodic_max_chars))
+        self.periodic_min_repeats = max(3, int(periodic_min_repeats))
+        self.periodic_check_every_chars = max(64, int(periodic_check_every_chars))
+
+        self._lines: deque[str] = deque()
+        self._line_counts: Counter[str] = Counter()
+        self._pending_line = ""
+        self._total_chars = 0
+        self._chars_since_periodic_check = 0
+        periodic_window = self.periodic_max_chars * self.periodic_min_repeats
+        self._character_tail: deque[str] = deque(maxlen=periodic_window)
+
+    def feed(self, text: str) -> None:
+        if not isinstance(text, str) or not text:
+            return
+
+        self._total_chars += len(text)
+        self._chars_since_periodic_check += len(text)
+        self._character_tail.extend(text)
+        self._pending_line += text
+        parts = self._pending_line.splitlines(keepends=True)
+        if parts and not parts[-1].endswith(("\n", "\r")):
+            self._pending_line = parts.pop()
+        else:
+            self._pending_line = ""
+
+        for part in parts:
+            self._record_line(part)
+        if (
+            self._pending_line
+            and self._chars_since_periodic_check >= self.periodic_check_every_chars
+        ):
+            self._chars_since_periodic_check = 0
+            self._check_periodic_tail()
+
+    def flush(self) -> None:
+        pending, self._pending_line = self._pending_line, ""
+        if pending:
+            self._record_line(pending)
+
+    def _record_line(self, line: str) -> None:
+        normalized = _normalize_line(line, self.min_line_chars)
+        if not normalized:
+            return
+
+        self._lines.append(normalized)
+        self._line_counts[normalized] += 1
+        if len(self._lines) > self.line_window:
+            evicted = self._lines.popleft()
+            if self._line_counts[evicted] == 1:
+                del self._line_counts[evicted]
+            else:
+                self._line_counts[evicted] -= 1
+
+        if self._total_chars < self.min_total_chars:
+            return
+        repeated_line, repeat_count = self._line_counts.most_common(1)[0]
+        if (
+            repeat_count >= self.repeat_threshold
+            and len(self._line_counts) <= self.max_distinct_lines
+        ):
+            raise StreamOutputRepetitionError(
+                repeated_line,
+                repeat_count,
+                normalized_line=repeated_line,
+            )
+
+    def _check_periodic_tail(self) -> None:
+        if self._total_chars < self.min_total_chars:
+            return
+        tail = "".join(self._character_tail)
+        for period in range(2, self.periodic_max_chars + 1):
+            sample_length = period * self.periodic_min_repeats
+            if len(tail) < sample_length:
+                break
+            unit = tail[-period:]
+            if unit.strip() and tail[-sample_length:] == unit * self.periodic_min_repeats:
+                raise StreamOutputRepetitionError(
+                    f"periodic tail: {unit!r}",
+                    self.periodic_min_repeats,
+                )
+
+
+def truncate_repeated_tail(text: str, repeated_line: str | None) -> str:
+    """Keep one repeated line, remove its repeated tail, and mark the cut."""
+    if not isinstance(text, str) or not text:
+        return REPETITION_CUT_MARKER
+    if not repeated_line:
+        return text.rstrip() + "\n\n" + REPETITION_CUT_MARKER
+
+    seen = 0
+    kept_chars = 0
+    for line in text.splitlines(keepends=True):
+        if _normalize_line(line, 1) == repeated_line:
+            seen += 1
+            if seen == 2:
+                return text[:kept_chars].rstrip() + "\n\n" + REPETITION_CUT_MARKER
+        kept_chars += len(line)
+    return text.rstrip() + "\n\n" + REPETITION_CUT_MARKER
+
+
+__all__ = [
+    "FAILED_REPETITION_LOOP",
+    "REPETITION_CUT_MARKER",
+    "StreamOutputRepetitionError",
+    "StreamOutputRepetitionGuard",
+    "truncate_repeated_tail",
+]

--- a/tests/agent/test_stream_output_repetition_guard.py
+++ b/tests/agent/test_stream_output_repetition_guard.py
@@ -1,0 +1,65 @@
+import pytest
+
+from agent.stream_output_repetition_guard import (
+    StreamOutputRepetitionError,
+    StreamOutputRepetitionGuard,
+    truncate_repeated_tail,
+)
+
+
+INCIDENT_LINE = (
+    "- **Texture**: `TEXTURE_LOCAL.md` (creative trace, emergence). "
+    "This line should not repeat indefinitely.\n"
+)
+
+
+def test_guard_detects_dominated_multiline_tail() -> None:
+    guard = StreamOutputRepetitionGuard(
+        min_total_chars=200,
+        repeat_threshold=4,
+    )
+
+    with pytest.raises(StreamOutputRepetitionError) as exc:
+        for _ in range(4):
+            guard.feed(INCIDENT_LINE)
+
+    assert exc.value.repeat_count == 4
+    assert "TEXTURE_LOCAL.md" in exc.value.repeated_unit
+
+
+def test_guard_spares_repeated_status_interleaved_with_unique_content() -> None:
+    guard = StreamOutputRepetitionGuard(
+        min_total_chars=200,
+        repeat_threshold=4,
+        max_distinct_lines=3,
+    )
+
+    for index in range(20):
+        guard.feed(
+            f"Unique report section {index} with enough detail to count as a line.\n"
+        )
+        guard.feed(
+            "No changes detected for this source since the previous scan.\n"
+        )
+
+
+def test_guard_detects_periodic_tail_without_newlines() -> None:
+    guard = StreamOutputRepetitionGuard(
+        min_total_chars=120,
+        periodic_min_repeats=5,
+    )
+
+    with pytest.raises(StreamOutputRepetitionError) as exc:
+        guard.feed("I will check the same thing again. " * 12)
+
+    assert "periodic tail" in str(exc.value)
+
+
+def test_truncate_repeated_tail_keeps_one_copy_and_marks_cut() -> None:
+    text = "Healthy preamble.\n" + INCIDENT_LINE * 12
+
+    truncated = truncate_repeated_tail(text, INCIDENT_LINE.strip())
+
+    assert truncated.count("TEXTURE_LOCAL.md") == 1
+    assert truncated.startswith("Healthy preamble.")
+    assert truncated.endswith("[Output stopped: repetitive generation detected.]")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3817,6 +3817,41 @@ class TestRunConversation:
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
+    def test_repetition_terminated_stream_does_not_request_continuation(self, agent):
+        """A stream guard termination is final, not an output-cap retry."""
+        from agent.stream_output_repetition_guard import FAILED_REPETITION_LOOP
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        self._setup_agent(agent)
+        response = _mock_response(
+            content=(
+                "Useful beginning.\n\n"
+                "[Output stopped: repetitive generation detected.]"
+            ),
+            finish_reason="length",
+        )
+        response.id = PARTIAL_STREAM_STUB_ID
+        response._repetition_loop_terminated = True
+        response._repetition_loop_detail = "repeated line 8 times"
+        agent.client.chat.completions.create.return_value = response
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert agent.client.chat.completions.create.call_count == 1
+        assert result["completed"] is False
+        assert result["failed"] is True
+        assert result["failure_reason"] == FAILED_REPETITION_LOOP
+        assert "Useful beginning." in result["final_response"]
+        assert not any(
+            "truncated by the output length limit" in str(message.get("content", ""))
+            for message in result["messages"]
+        )
+
     def test_length_continuation_preserves_large_provider_default_output_cap(self, agent):
         """Continuation retries must not shrink a higher provider default cap."""
         self._setup_agent(agent)

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -98,6 +98,134 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_repetitive_text_stream_is_stopped_and_tagged(
+        self, mock_close, mock_create,
+    ):
+        """A degenerate token stream must stop before exhausting its budget."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        repeated = (
+            "This non-trivial generated line is repeating without progress.\n"
+        )
+
+        def _repetitive_stream():
+            for _ in range(100):
+                yield _make_stream_chunk(content=repeated)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _repetitive_stream()
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=lambda _text: None,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response._repetition_loop_terminated is True
+        assert "repetitive generation detected" in (
+            response.choices[0].message.content or ""
+        )
+        assert response.choices[0].message.content.count(repeated.strip()) == 1
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_repetitive_reasoning_stream_without_visible_text_is_stopped(
+        self, mock_close, mock_create,
+    ):
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        repeated = (
+            "I need to inspect the same state again before I can proceed.\n"
+        )
+
+        def _repetitive_stream():
+            for _ in range(100):
+                yield _make_stream_chunk(reasoning_content=repeated)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _repetitive_stream()
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            reasoning_callback=lambda _text: None,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response._repetition_loop_terminated is True
+        assert response.choices[0].message.content == (
+            "[Output stopped: repetitive generation detected.]"
+        )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_long_diverse_stream_with_spaced_status_is_not_stopped(
+        self, mock_close, mock_create,
+    ):
+        from run_agent import AIAgent
+
+        chunks = []
+        for index in range(30):
+            chunks.append(
+                _make_stream_chunk(
+                    content=(
+                        f"Unique section {index} contains enough changing detail "
+                        "to demonstrate continuing progress.\n"
+                    )
+                )
+            )
+            chunks.append(
+                _make_stream_chunk(
+                    content=(
+                        "No changes detected for this source since the previous scan.\n"
+                    )
+                )
+            )
+        chunks.append(_make_stream_chunk(content="Done.", finish_reason="stop"))
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content.endswith("Done.")
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_chat_stream_closes_original_provider_resource(
         self,
         mock_close,
@@ -731,6 +859,50 @@ class TestAnthropicStreamCallbacks:
         agent._interruptible_streaming_api_call({})
 
         assert touch_calls.count("receiving stream response") == len(events)
+        mock_stream.close.assert_called_once()
+
+    def test_anthropic_repetitive_text_stream_is_stopped(self):
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+        from run_agent import AIAgent
+
+        repeated = (
+            "This native Anthropic stream is repeating without making progress.\n"
+        )
+        events = [
+            SimpleNamespace(
+                type="content_block_delta",
+                delta=SimpleNamespace(type="text_delta", text=repeated),
+            )
+            for _ in range(100)
+        ]
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=iter(events))
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            stream_delta_callback=lambda _text: None,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = mock_stream
+        agent._create_request_anthropic_client = (
+            lambda *args, **kwargs: agent._anthropic_client
+        )
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response._repetition_loop_terminated is True
+        assert response.choices[0].message.content.count(repeated.strip()) == 1
         mock_stream.close.assert_called_once()
 
     @patch("run_agent.AIAgent._rebuild_anthropic_client")
@@ -1634,4 +1806,3 @@ class TestBedrockReasoningStaleFloor:
         from agent.chat_completion_helpers import _bedrock_reasoning_stale_floor
 
         assert _bedrock_reasoning_stale_floor(model_id) == expected
-


### PR DESCRIPTION
## What does this PR do?

Stops a single assistant response when its token stream degenerates into a repeated tail, before the provider spends the full output budget and Hermes requests up to four continuations on the poisoned partial response.

This is distinct from #67538 (identical assistant turns) and #60087 (repeated tool results): both operate between completed turns or tool calls. This guard acts inside one in-flight model response.

A real unattended local-provider incident produced the same three-line block until the output cap, then repeated that behavior across automatic length continuations. Current `main` has no stream-level content guard: an OpenAI-compatible stream with 100 repeated chunks is fully consumed, classified as a partial stream, and routed toward continuation.

## Design

- `StreamOutputRepetitionGuard` is provider/model neutral and has no MLX-specific wiring.
- A sliding line window fires only when one of at most six distinct lines repeats at least eight times after 1,200 characters. Recurring status lines interleaved with varied report/log content remain below the density gate.
- An exact periodic-tail check covers streams that never emit newlines. It runs only on unterminated text and at 256-character intervals.
- Content and reasoning channels use independent guard instances.
- The guard is wired into both Chat Completions and native Anthropic Messages streaming paths.
- A guard termination reuses the existing partial-stream response shape, tags the response, truncates the repeated tail before persistence, removes reasoning/tool calls, and ends the turn without a synthetic continuation request.
- No new environment variables or user-facing configuration surface.

## Why the default is conservative

The guard does not compare semantic similarity and does not count global occurrences. It requires a locally dominated tail or an exact repeated character period, after a minimum output size. Long diverse output with a recurring status line is covered as a no-fire regression case.

## Tests

Red on current `main` before implementation:

- the 100-chunk stream was consumed and returned as an ordinary partial-stream stub;
- no repetition module or terminal continuation branch existed.

Green after implementation:

- repeated line-block detection;
- split/periodic no-newline detection;
- spaced legitimate repetition no-fire;
- tail truncation keeps one copy and a visible cut marker;
- Chat Completions content loop termination;
- Chat Completions reasoning-only loop termination;
- native Anthropic content loop termination;
- conversation-loop proof that the tagged partial response makes exactly one API call and does not append a length-continuation prompt;
- normal length continuation remains unchanged.

`280 passed` across:

```text
tests/agent/test_stream_output_repetition_guard.py
tests/run_agent/test_streaming.py
tests/run_agent/test_run_agent.py
```

Ruff, `py_compile`, and `git diff --check` pass.

The repository test runner selected an older shared environment without the optional `anthropic` package and exposed three Anthropic test failures. The same three failures reproduce unchanged on a detached `origin/main` worktree. Running with the repository `.venv` (which includes `anthropic`) gives the 280/280 result above.

Hot-path microbenchmark on 10,000 diverse newline-terminated chunks: approximately 5-8 microseconds per chunk on Apple Silicon.

## Checklist

- [x] Current-main premise reproduced before implementation
- [x] Existing sibling guards and open PRs audited
- [x] Behavior tests cover detection, false positives, persistence, and retry suppression
- [x] No model-specific code or new environment configuration
- [x] Tested on macOS Apple Silicon
