### PR TITLE
feat(sessions): add lossless persistence fallback spool

### DIFF
--- a/contributors/emails/stefan@noble-pro.com
+++ b/contributors/emails/stefan@noble-pro.com
@@ -1,0 +1,1 @@
+stefanpieter

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -10,6 +10,7 @@ import subprocess
 import shutil
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 from hermes_cli.config import (
     detect_install_method,
@@ -34,6 +35,7 @@ from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
+from session_fallback_spool import collect_session_fallback_spool_status
 from utils import base_url_host_matches
 
 
@@ -212,6 +214,44 @@ def check_fail(text: str, detail: str = ""):
 
 def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
+
+
+def _doctor_fallback_spool_detail(status) -> str:
+    details = [
+        f"pending={int(getattr(status, 'pending_units', 0))}u/"
+        f"{int(getattr(status, 'pending_frames', 0))}f/"
+        f"{int(getattr(status, 'pending_bytes', 0))}b"
+    ]
+    reasons = getattr(status, "reasons", ()) or ()
+    if reasons:
+        details.append(f"reasons={','.join(str(reason) for reason in reasons)}")
+    inspection_error = getattr(status, "inspection_error_class", None)
+    if inspection_error:
+        details.append(f"inspection_error={inspection_error}")
+    return "; ".join(details)
+
+
+def _doctor_fallback_spool_inspection_error_detail() -> str:
+    return _doctor_fallback_spool_detail(
+        SimpleNamespace(
+            pending_units=0,
+            pending_frames=0,
+            pending_bytes=0,
+            reasons=("inspection_error",),
+            inspection_error_class="inspection_error",
+        )
+    )
+
+
+def _doctor_fallback_spool_manual_issue(detail: str) -> str:
+    return f"Fallback spool degraded ({detail}) — requires manual intervention."
+
+
+def _report_doctor_fallback_spool_issue(detail: str, manual_issues: list[str]) -> None:
+    check_warn("Fallback spool degraded", f"({detail})")
+    issue = _doctor_fallback_spool_manual_issue(detail)
+    if issue not in manual_issues:
+        manual_issues.append(issue)
 
 
 def _section(title: str) -> None:
@@ -1619,6 +1659,19 @@ def run_doctor(args):
                 check_info(f"WAL file is {wal_size // (1024*1024)} MB (normal for active sessions)")
         except Exception:
             pass
+
+    try:
+        spool_status = collect_session_fallback_spool_status()
+        if str(getattr(spool_status, "state", "empty") or "empty") == "degraded":
+            _report_doctor_fallback_spool_issue(
+                _doctor_fallback_spool_detail(spool_status),
+                manual_issues,
+            )
+    except Exception:
+        _report_doctor_fallback_spool_issue(
+            _doctor_fallback_spool_inspection_error_detail(),
+            manual_issues,
+        )
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -25,6 +25,7 @@ from hermes_cli.nous_subscription import get_nous_subscription_features
 from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
+from session_fallback_spool import collect_session_fallback_spool_status
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
 def check_mark(ok: bool) -> str:
@@ -107,6 +108,43 @@ def _effective_provider_label() -> str:
             effective = "custom"
 
     return provider_label(effective)
+
+
+def _format_fallback_spool_age(seconds) -> str:
+    if seconds is None:
+        return ""
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, rem = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m{rem:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m"
+
+
+def _render_fallback_spool_row() -> str:
+    try:
+        status = collect_session_fallback_spool_status()
+    except Exception:
+        return "  Fallback spool: degraded reasons=inspection_error"
+
+    state = str(getattr(status, "state", "empty") or "empty")
+    label = "idle" if state == "empty" else state
+    if state == "degraded":
+        details = [
+            f"pending={int(getattr(status, 'pending_units', 0))}u/"
+            f"{int(getattr(status, 'pending_frames', 0))}f/"
+            f"{int(getattr(status, 'pending_bytes', 0))}b"
+        ]
+        age = _format_fallback_spool_age(getattr(status, "oldest_pending_age_seconds", None))
+        if age:
+            details.append(f"age={age}")
+        reasons = getattr(status, "reasons", ()) or ()
+        if reasons:
+            details.append(f"reasons={','.join(str(reason) for reason in reasons)}")
+        return f"  Fallback spool: {label} {' '.join(details)}".rstrip()
+    return f"  Fallback spool: {label}"
 
 
 from hermes_constants import is_termux as _is_termux
@@ -582,7 +620,7 @@ def show_status(args):
     _gateway_rows = []
     try:
         from hermes_state import SessionDB
-        _db = SessionDB()
+        _db = SessionDB(read_only=True)
         try:
             _lister = getattr(_db, "list_gateway_sessions", None)
             if callable(_lister):
@@ -618,6 +656,8 @@ def show_status(args):
                 print("  Active:       (error reading sessions file)")
         else:
             print(f"  Active:       {_session_count if _session_count is not None else 0}")
+
+    print(_render_fallback_spool_row())
 
     # Slot usage, only when max_concurrent_sessions is set. The cap is shared
     # across CLI, desktop/TUI and the messaging gateway, so the surface that

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,7 @@ import threading
 import time
 from collections import deque
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -43,7 +44,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -1681,6 +1682,38 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
     Subclassing keeps every existing ``except CompressionSessionBusyError``
     handler working unchanged.
     """
+
+
+@dataclass(frozen=True, kw_only=True)
+class SessionDBBatchMessage:
+    persistence_unit_id: str
+    persistence_message_key: str
+    persistence_ordinal: int
+    role: str
+    content: Optional[str]
+    timestamp: float
+    tool_name: Optional[str] = None
+    tool_calls: Optional[List[Dict[str, Any]]] = None
+    tool_call_id: Optional[str] = None
+    finish_reason: Optional[str] = None
+    reasoning: Optional[str] = None
+    reasoning_content: Any = None
+    reasoning_details: Any = None
+    codex_reasoning_items: Any = None
+    codex_message_items: Any = None
+    api_content: Any = None
+    display_kind: Optional[str] = None
+    display_metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class AppendMessagesBatchResult:
+    inserted_count: int
+    duplicate_count: int
+
+
+class AppendMessagesBatchConflictError(RuntimeError):
+    """The requested persistence batch conflicts with stored immutable rows."""
 
 
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
@@ -6140,6 +6173,189 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         return meta
 
+    @staticmethod
+    def _coerce_message_timestamp(timestamp: Any) -> float:
+        message_timestamp = time.time()
+        if timestamp is not None:
+            try:
+                if hasattr(timestamp, "timestamp"):
+                    message_timestamp = float(timestamp.timestamp())
+                else:
+                    message_timestamp = float(timestamp)
+            except (TypeError, ValueError):
+                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
+        return message_timestamp
+
+    @staticmethod
+    def _normalize_tool_calls(tool_calls: Any) -> Tuple[Any, Optional[str], int]:
+        normalized_tool_calls = tool_calls
+        if isinstance(normalized_tool_calls, str):
+            try:
+                normalized_tool_calls = json.loads(normalized_tool_calls)
+            except (json.JSONDecodeError, TypeError):
+                normalized_tool_calls = []
+        tool_calls_json = json.dumps(normalized_tool_calls) if normalized_tool_calls else None
+        tool_call_count = 0
+        if normalized_tool_calls is not None:
+            tool_call_count = (
+                len(normalized_tool_calls)
+                if isinstance(normalized_tool_calls, list)
+                else 1
+            )
+        return normalized_tool_calls, tool_calls_json, tool_call_count
+
+    @classmethod
+    def _prepare_message_storage_values(
+        cls,
+        *,
+        role: str,
+        content: Any = None,
+        tool_name: Optional[str] = None,
+        tool_calls: Any = None,
+        tool_call_id: Optional[str] = None,
+        token_count: Optional[int] = None,
+        finish_reason: Optional[str] = None,
+        reasoning: Any = None,
+        reasoning_content: Any = None,
+        reasoning_details: Any = None,
+        codex_reasoning_items: Any = None,
+        codex_message_items: Any = None,
+        platform_message_id: str = None,
+        observed: bool = False,
+        effect_disposition: Optional[str] = None,
+        timestamp: Any = None,
+        api_content: Optional[str] = None,
+        display_kind: Optional[str] = None,
+        display_metadata: Optional[Dict[str, Any]] = None,
+        persistence_unit_id: Optional[str] = None,
+        persistence_message_key: Optional[str] = None,
+        persistence_ordinal: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        normalized_tool_calls, tool_calls_json, tool_call_count = cls._normalize_tool_calls(tool_calls)
+        return {
+            "role": role,
+            "content": cls._encode_content(content),
+            "tool_call_id": tool_call_id,
+            "tool_calls": tool_calls_json,
+            "tool_name": _scrub_surrogates(tool_name),
+            "effect_disposition": effect_disposition,
+            "timestamp": cls._coerce_message_timestamp(timestamp),
+            "token_count": token_count,
+            "finish_reason": finish_reason,
+            "reasoning": _scrub_surrogates(reasoning) if role == "assistant" else None,
+            "reasoning_content": _scrub_surrogates(reasoning_content) if role == "assistant" else None,
+            "reasoning_details": json.dumps(reasoning_details) if reasoning_details else None,
+            "codex_reasoning_items": json.dumps(codex_reasoning_items) if codex_reasoning_items else None,
+            "codex_message_items": json.dumps(codex_message_items) if codex_message_items else None,
+            "platform_message_id": platform_message_id,
+            "observed": 1 if observed else 0,
+            "active": 1,
+            "api_content": _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
+            "display_kind": _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
+            "display_metadata": cls._encode_display_metadata(display_metadata),
+            "persistence_unit_id": persistence_unit_id,
+            "persistence_message_key": persistence_message_key,
+            "persistence_ordinal": persistence_ordinal,
+            "tool_call_count": tool_call_count,
+            "normalized_tool_calls": normalized_tool_calls,
+        }
+
+    @staticmethod
+    def _insert_prepared_message_row(
+        conn: sqlite3.Connection,
+        session_id: str,
+        prepared: Dict[str, Any],
+    ) -> int:
+        cursor = conn.execute(
+            """INSERT INTO messages (
+                   session_id, role, content, tool_call_id, tool_calls, tool_name,
+                   effect_disposition, timestamp, token_count, finish_reason,
+                   reasoning, reasoning_content, reasoning_details,
+                   codex_reasoning_items, codex_message_items, platform_message_id,
+                   observed, active, api_content, display_kind, display_metadata,
+                   persistence_unit_id, persistence_message_key, persistence_ordinal
+               )
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                prepared["role"],
+                prepared["content"],
+                prepared["tool_call_id"],
+                prepared["tool_calls"],
+                prepared["tool_name"],
+                prepared["effect_disposition"],
+                prepared["timestamp"],
+                prepared["token_count"],
+                prepared["finish_reason"],
+                prepared["reasoning"],
+                prepared["reasoning_content"],
+                prepared["reasoning_details"],
+                prepared["codex_reasoning_items"],
+                prepared["codex_message_items"],
+                prepared["platform_message_id"],
+                prepared["observed"],
+                prepared["active"],
+                prepared["api_content"],
+                prepared["display_kind"],
+                prepared["display_metadata"],
+                prepared["persistence_unit_id"],
+                prepared["persistence_message_key"],
+                prepared["persistence_ordinal"],
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    @staticmethod
+    def _assert_append_allowed(
+        conn: sqlite3.Connection,
+        session_id: str,
+        compression_lock_holder: Optional[str],
+    ) -> None:
+        active_lock = conn.execute(
+            "SELECT holder FROM compression_locks WHERE session_id = ? AND expires_at > ?",
+            (session_id, time.time()),
+        ).fetchone()
+        if active_lock is not None and active_lock["holder"] != compression_lock_holder:
+            raise CompressionSessionBusyError(
+                f"Session {session_id!r} is being compressed by another writer"
+            )
+        session = conn.execute(
+            "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if (
+            session is not None
+            and session["ended_at"] is not None
+            and session["end_reason"] == "compression"
+        ):
+            raise CompressionSessionClosedError(session_id)
+
+    @staticmethod
+    def _batch_row_matches_prepared(row: sqlite3.Row, prepared: Dict[str, Any]) -> bool:
+        for column in (
+            "persistence_unit_id",
+            "persistence_message_key",
+            "persistence_ordinal",
+            "role",
+            "content",
+            "tool_name",
+            "tool_calls",
+            "tool_call_id",
+            "finish_reason",
+            "reasoning",
+            "reasoning_content",
+            "reasoning_details",
+            "codex_reasoning_items",
+            "codex_message_items",
+            "timestamp",
+            "api_content",
+            "display_kind",
+            "display_metadata",
+        ):
+            if row[column] != prepared[column]:
+                return False
+        return True
+
     def append_message(
         self,
         session_id: str,
@@ -6184,92 +6400,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         from every outgoing payload anyway, so the scrubbed form IS the
         wire bytes).
         """
-        # Display metadata is presentation-only and never changes the model
-        # context role/content replayed to providers.
-        display_metadata_json = self._encode_display_metadata(display_metadata)
-        # Serialize structured fields to JSON before entering the write txn
-        reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
+        prepared = self._prepare_message_storage_values(
+            role=role,
+            content=content,
+            tool_name=tool_name,
+            tool_calls=tool_calls,
+            tool_call_id=tool_call_id,
+            token_count=token_count,
+            finish_reason=finish_reason,
+            reasoning=reasoning,
+            reasoning_content=reasoning_content,
+            reasoning_details=reasoning_details,
+            codex_reasoning_items=codex_reasoning_items,
+            codex_message_items=codex_message_items,
+            platform_message_id=platform_message_id,
+            observed=observed,
+            effect_disposition=effect_disposition,
+            timestamp=timestamp,
+            api_content=api_content,
+            display_kind=display_kind,
+            display_metadata=display_metadata,
         )
-        codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
-        )
-        codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
-        )
-        # tool_calls may arrive as a Python list (from the live agent) or
-        # as a JSON string (from import/export). Parse first to avoid
-        # double-encoding.
-        if isinstance(tool_calls, str):
-            try:
-                tool_calls = json.loads(tool_calls)
-            except (json.JSONDecodeError, TypeError):
-                tool_calls = []
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
-        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
-        # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
-
-        message_timestamp = time.time()
-        if timestamp is not None:
-            try:
-                if hasattr(timestamp, "timestamp"):
-                    message_timestamp = float(timestamp.timestamp())
-                else:
-                    message_timestamp = float(timestamp)
-            except (TypeError, ValueError):
-                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
-
-        # Pre-compute tool call count
-        num_tool_calls = 0
-        if tool_calls is not None:
-            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
         def _do(conn):
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
             )
-            cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    role,
-                    stored_content,
-                    tool_call_id,
-                    tool_calls_json,
-                    _scrub_surrogates(tool_name),
-                    effect_disposition,
-                    message_timestamp,
-                    token_count,
-                    finish_reason,
-                    _scrub_surrogates(reasoning),
-                    _scrub_surrogates(reasoning_content),
-                    reasoning_details_json,
-                    codex_items_json,
-                    codex_message_items_json,
-                    platform_message_id,
-                    1 if observed else 0,
-                    1,
-                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                    _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
-                    display_metadata_json,
-                ),
-            )
-            msg_id = cursor.lastrowid
-
-            # Update counters
-            if num_tool_calls > 0:
+            msg_id = self._insert_prepared_message_row(conn, session_id, prepared)
+            if prepared["tool_call_count"] > 0:
                 conn.execute(
                     """UPDATE sessions SET message_count = message_count + 1,
                        tool_call_count = tool_call_count + ? WHERE id = ?""",
-                    (num_tool_calls, session_id),
+                    (prepared["tool_call_count"], session_id),
                 )
             else:
                 conn.execute(
@@ -6290,48 +6452,215 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def append_messages_batch(
         self,
         session_id: str,
-        messages: List[Dict[str, Any]],
+        messages: Sequence[Any],
         compression_lock_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
-    ) -> int:
-        """Append multiple messages atomically in ONE write transaction.
+    ) -> Any:
+        """Append multiple messages in one write transaction.
 
-        ``messages`` is a list of dicts in the same shape
-        :meth:`_insert_message_rows` already consumes for replace/compact/
-        import (role, content, tool_name, tool_calls, tool_call_id,
-        finish_reason, reasoning*, codex_*, timestamp, api_content,
-        display_kind, display_metadata, ...). Reusing that helper keeps ONE
-        row-serialization path for every multi-row writer.
-
-        A turn-boundary flush writes the whole turn (user + assistant + tool
-        rows, typically 3-8 messages) as one BEGIN IMMEDIATE / commit pair
-        instead of one transaction (and, off WAL, one fsync) per row.
-
-        Atomicity contract: all rows land or none do (the caller re-flushes
-        unstamped messages on the next attempt). The same admission guards
-        as :meth:`append_message` run once for the batch — same session,
-        same instant.
-
-        ``chunk_rows`` bounds the transaction size for LARGE copies (branch
-        seeds can be thousands of rows; measured: 10k rows ≈ 2.4s inside one
-        BEGIN IMMEDIATE because the FTS triggers run per row, which would
-        monopolize the write lock and starve concurrent writers). When set,
-        the batch commits in chunks of at most that many rows — same
-        recovery semantics as the old per-row loops (a mid-copy failure
-        leaves a partial seed), just with bounded lock holds. A turn flush
-        never needs it. Returns the inserted row count.
+        Supports both the legacy dict-row batch API used by existing callers
+        and the typed ``SessionDBBatchMessage`` API used for idempotent replay
+        of one persistence unit.
         """
         if not messages:
             return 0
 
-        if chunk_rows is not None and len(messages) > chunk_rows:
+        batch_messages = list(messages)
+        typed_flags = [isinstance(msg, SessionDBBatchMessage) for msg in batch_messages]
+        if any(typed_flags) and not all(typed_flags):
+            raise AppendMessagesBatchConflictError(
+                "append_messages_batch requires either all typed or all legacy messages"
+            )
+
+        if all(typed_flags):
+            typed_messages = [
+                msg for msg in batch_messages if isinstance(msg, SessionDBBatchMessage)
+            ]
+            message_keys = [msg.persistence_message_key for msg in typed_messages]
+            if any(not key for key in message_keys):
+                raise AppendMessagesBatchConflictError(
+                    "append_messages_batch requires non-empty persistence_message_key values"
+                )
+
+            unit_ids = {msg.persistence_unit_id for msg in typed_messages}
+            if any(not unit_id for unit_id in unit_ids) or len(unit_ids) != 1:
+                raise AppendMessagesBatchConflictError(
+                    "append_messages_batch requires one shared non-empty persistence_unit_id"
+                )
+
+            if len(set(message_keys)) != len(message_keys):
+                raise AppendMessagesBatchConflictError(
+                    "append_messages_batch requires unique persistence_message_key values"
+                )
+
+            ordinals: List[int] = []
+            for msg in typed_messages:
+                ordinal = msg.persistence_ordinal
+                if isinstance(ordinal, bool) or not isinstance(ordinal, int):
+                    raise AppendMessagesBatchConflictError(
+                        "append_messages_batch requires integer persistence_ordinal values"
+                    )
+                ordinals.append(ordinal)
+            if sorted(ordinals) != list(range(len(typed_messages))):
+                raise AppendMessagesBatchConflictError(
+                    "append_messages_batch requires contiguous persistence_ordinal values"
+                )
+
+            ordered_messages = [
+                msg
+                for _, msg in sorted(
+                    zip(ordinals, typed_messages), key=lambda item: item[0]
+                )
+            ]
+            unit_id = ordered_messages[0].persistence_unit_id
+            prepared_messages = [
+                self._prepare_message_storage_values(
+                    role=msg.role,
+                    content=msg.content,
+                    tool_name=msg.tool_name,
+                    tool_calls=msg.tool_calls,
+                    tool_call_id=msg.tool_call_id,
+                    finish_reason=msg.finish_reason,
+                    reasoning=msg.reasoning,
+                    reasoning_content=msg.reasoning_content,
+                    reasoning_details=msg.reasoning_details,
+                    codex_reasoning_items=msg.codex_reasoning_items,
+                    codex_message_items=msg.codex_message_items,
+                    timestamp=msg.timestamp,
+                    api_content=msg.api_content,
+                    display_kind=msg.display_kind,
+                    display_metadata=msg.display_metadata,
+                    persistence_unit_id=msg.persistence_unit_id,
+                    persistence_message_key=msg.persistence_message_key,
+                    persistence_ordinal=msg.persistence_ordinal,
+                )
+                for msg in ordered_messages
+            ]
+            ordered_keys = [
+                prepared["persistence_message_key"]
+                for prepared in prepared_messages
+            ]
+            select_columns = (
+                "id, persistence_unit_id, persistence_message_key, persistence_ordinal, "
+                "role, content, tool_name, tool_calls, tool_call_id, finish_reason, "
+                "reasoning, reasoning_content, reasoning_details, codex_reasoning_items, "
+                "codex_message_items, timestamp, api_content, display_kind, display_metadata"
+            )
+
+            def _do(conn):
+                self._check_transcript_write_guards(
+                    conn, session_id, compression_lock_holder
+                )
+                session_row = conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                    (session_id,),
+                ).fetchone()
+                if session_row is None:
+                    raise AppendMessagesBatchConflictError(
+                        "append_messages_batch requires an existing session row"
+                    )
+
+                key_placeholders = ",".join("?" for _ in ordered_keys)
+                key_rows = conn.execute(
+                    f"SELECT {select_columns} FROM messages WHERE session_id = ? "
+                    f"AND persistence_message_key IN ({key_placeholders})",
+                    [session_id, *ordered_keys],
+                ).fetchall()
+                unit_rows = conn.execute(
+                    f"SELECT {select_columns} FROM messages WHERE session_id = ? "
+                    "AND persistence_unit_id = ?",
+                    [session_id, unit_id],
+                ).fetchall()
+
+                rows_by_key: Dict[str, sqlite3.Row] = {}
+                for row in key_rows:
+                    key = row["persistence_message_key"]
+                    if key in rows_by_key and rows_by_key[key]["id"] != row["id"]:
+                        raise AppendMessagesBatchConflictError(
+                            "duplicate persisted rows share one persistence_message_key"
+                        )
+                    rows_by_key[key] = row
+
+                rows_by_ordinal: Dict[int, sqlite3.Row] = {}
+                for row in unit_rows:
+                    ordinal = int(row["persistence_ordinal"])
+                    if (
+                        ordinal in rows_by_ordinal
+                        and rows_by_ordinal[ordinal]["id"] != row["id"]
+                    ):
+                        raise AppendMessagesBatchConflictError(
+                            "duplicate persisted rows share one persistence_unit_id/persistence_ordinal"
+                        )
+                    rows_by_ordinal[ordinal] = row
+
+                if not rows_by_key and not rows_by_ordinal:
+                    tool_call_total = sum(
+                        prepared["tool_call_count"] for prepared in prepared_messages
+                    )
+                    try:
+                        for prepared in prepared_messages:
+                            self._insert_prepared_message_row(
+                                conn, session_id, prepared
+                            )
+                    except sqlite3.IntegrityError as exc:
+                        raise AppendMessagesBatchConflictError(
+                            "append_messages_batch encountered a persistence identity collision"
+                        ) from exc
+                    conn.execute(
+                        "UPDATE sessions SET message_count = message_count + ?, "
+                        "tool_call_count = tool_call_count + ? WHERE id = ?",
+                        (len(prepared_messages), tool_call_total, session_id),
+                    )
+                    return AppendMessagesBatchResult(
+                        inserted_count=len(prepared_messages),
+                        duplicate_count=0,
+                    )
+
+                if (
+                    len(rows_by_key) != len(prepared_messages)
+                    or len(rows_by_ordinal) != len(prepared_messages)
+                ):
+                    raise AppendMessagesBatchConflictError(
+                        "append_messages_batch found a partial existing persistence unit"
+                    )
+
+                for prepared in prepared_messages:
+                    key_row = rows_by_key.get(prepared["persistence_message_key"])
+                    ordinal_row = rows_by_ordinal.get(
+                        int(prepared["persistence_ordinal"])
+                    )
+                    if (
+                        key_row is None
+                        or ordinal_row is None
+                        or key_row["id"] != ordinal_row["id"]
+                    ):
+                        raise AppendMessagesBatchConflictError(
+                            "append_messages_batch detected a persistence identity collision"
+                        )
+                    if not self._batch_row_matches_prepared(key_row, prepared):
+                        raise AppendMessagesBatchConflictError(
+                            "append_messages_batch replay does not match the stored immutable row"
+                        )
+
+                return AppendMessagesBatchResult(
+                    inserted_count=0,
+                    duplicate_count=len(prepared_messages),
+                )
+
+            return self._execute_write(
+                _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+            )
+
+        legacy_messages = [msg for msg in batch_messages if isinstance(msg, dict)]
+        if chunk_rows is not None and len(legacy_messages) > chunk_rows:
             inserted_total = 0
-            for start in range(0, len(messages), chunk_rows):
-                inserted_total += self.append_messages_batch(
+            for start in range(0, len(legacy_messages), chunk_rows):
+                chunk_result = self.append_messages_batch(
                     session_id,
-                    messages[start:start + chunk_rows],
+                    legacy_messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
                 )
+                inserted_total += int(chunk_result)
             return inserted_total
 
         def _do(conn):
@@ -6339,9 +6668,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn, session_id, compression_lock_holder
             )
             inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, messages
+                conn, session_id, legacy_messages
             )
-            # One aggregated counter update for the whole batch.
             if tool_calls_total > 0:
                 conn.execute(
                     """UPDATE sessions SET message_count = message_count + ?,
@@ -6355,7 +6683,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             return inserted
 
-        # Same criticality as append_message: this IS the turn's transcript.
         return self._execute_write(
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )
@@ -6855,6 +7182,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def _public_message_row_dict(
+        self,
+        row: sqlite3.Row,
+        *,
+        decode_content: bool = True,
+        decode_tool_calls: bool = True,
+        decode_display_metadata: bool = True,
+        log_context: str,
+    ) -> Dict[str, Any]:
+        msg = dict(row)
+        for key in (
+            "persistence_unit_id",
+            "persistence_message_key",
+            "persistence_ordinal",
+        ):
+            msg.pop(key, None)
+        if decode_content and "content" in msg:
+            msg["content"] = self._decode_content(msg["content"])
+        if decode_tool_calls and msg.get("tool_calls"):
+            try:
+                msg["tool_calls"] = json.loads(msg["tool_calls"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "Failed to deserialize tool_calls in %s, falling back to []",
+                    log_context,
+                )
+                msg["tool_calls"] = []
+        if decode_display_metadata and msg.get("display_metadata") is not None:
+            msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+        return msg
+
     def get_messages(
         self,
         session_id: str,
@@ -6891,21 +7249,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             cursor = conn.execute(sql, params)
             rows = cursor.fetchall()
-        result = []
-        for row in rows:
-            msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
-            if msg.get("tool_calls"):
-                try:
-                    msg["tool_calls"] = json.loads(msg["tool_calls"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
-                    msg["tool_calls"] = []
-            if msg.get("display_metadata") is not None:
-                msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
-            result.append(msg)
-        return result
+        return [
+            self._public_message_row_dict(row, log_context="get_messages")
+            for row in rows
+        ]
 
     def get_messages_around(
         self,
@@ -6960,22 +7307,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         # before_rows is DESC; reverse so it's ASC, then concatenate after_rows.
         rows = list(reversed(before_rows)) + list(after_rows)
-        result = []
-        for row in rows:
-            msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
-            if msg.get("tool_calls"):
-                try:
-                    msg["tool_calls"] = json.loads(msg["tool_calls"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "Failed to deserialize tool_calls in get_messages_around, falling back to []"
-                    )
-                    msg["tool_calls"] = []
-            if msg.get("display_metadata") is not None:
-                msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
-            result.append(msg)
+        result = [
+            self._public_message_row_dict(row, log_context="get_messages_around")
+            for row in rows
+        ]
 
         # before_rows includes the anchor itself; subtract 1 for the count of
         # messages strictly before the anchor in the returned slice.
@@ -7460,15 +7795,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             raise ValueError(
                 f"message {target_message_id} not found in session {session_id}"
             )
-        target_row = dict(row)
+        target_row = self._public_message_row_dict(
+            row,
+            decode_tool_calls=False,
+            decode_display_metadata=False,
+            log_context="rewind_to_message",
+        )
         if target_row.get("role") != "user":
             raise ValueError(
                 f"rewind target must be a 'user' message (got role="
                 f"{target_row.get('role')!r}, id={target_message_id})"
             )
-
-        # Decode content for callers (prefill the prompt buffer).
-        target_row["content"] = self._decode_content(target_row.get("content"))
 
         rewound: List[int] = []
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -44,7 +44,19 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+)
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -1686,7 +1698,32 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
 
 
 @dataclass(frozen=True, kw_only=True)
-class SessionDBBatchMessage:
+class SessionDBBatchMessage(Mapping[str, Any]):
+    """Typed batch row that retains the historical mapping interface.
+
+    ``append_messages_batch`` has long accepted dictionaries, and lightweight
+    database doubles and integrations inspect rows with ``get()``, ``items()``,
+    subscripting, or ``dict(row)``. The immutable typed row adds persistence
+    identities without withdrawing that established protocol.
+    """
+
+    _FIELD_NAMES: ClassVar[tuple[str, ...]] = (
+        "role",
+        "content",
+        "tool_name",
+        "tool_calls",
+        "tool_call_id",
+        "finish_reason",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+        "api_content",
+        "display_kind",
+        "display_metadata",
+    )
+
     persistence_unit_id: str
     persistence_message_key: str
     persistence_ordinal: int
@@ -1705,6 +1742,17 @@ class SessionDBBatchMessage:
     api_content: Any = None
     display_kind: Optional[str] = None
     display_metadata: Optional[Dict[str, Any]] = None
+
+    def __getitem__(self, key: str) -> Any:
+        if key not in self._FIELD_NAMES:
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._FIELD_NAMES)
+
+    def __len__(self) -> int:
+        return len(self._FIELD_NAMES)
 
 
 @dataclass(frozen=True)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -322,6 +322,7 @@ _wal_fallback_warned_lock = threading.Lock()
 # Dedup WARNING for the WAL-reset vulnerability fallback (issue #69784).
 _wal_reset_bug_warned_paths: set[str] = set()
 _wal_reset_bug_warned_lock = threading.Lock()
+_SESSION_SPOOL_STARTUP_ONCE: set[str] = set()
 
 def _set_last_init_error(msg: Optional[str]) -> None:
     """Record (or clear) the most recent state.db init failure.
@@ -2241,6 +2242,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if not report.get("repaired"):
                     raise
                 _connect_and_init_with_lock_patience()
+
+            if not read_only:
+                try:
+                    canonical_db_path = (get_hermes_home() / "state.db").resolve()
+                    current_db_path = Path(self.db_path).resolve()
+                except Exception:
+                    canonical_db_path = None
+                    current_db_path = None
+                if canonical_db_path is not None and current_db_path == canonical_db_path:
+                    replay_key = str(current_db_path)
+                    if replay_key not in _SESSION_SPOOL_STARTUP_ONCE:
+                        import session_fallback_spool as session_spool
+
+                        replay_result = session_spool.replay_to_session_db(self, trigger="startup")
+                        if replay_result.state in {
+                            session_spool.ReplayRunState.EMPTY,
+                            session_spool.ReplayRunState.REPLAYED,
+                        }:
+                            _SESSION_SPOOL_STARTUP_ONCE.add(replay_key)
 
             # NOTE: the v23 FTS optimization is OPT-IN (`hermes db optimize`),
             # never auto-started on open. Legacy installs keep their working
@@ -6686,6 +6706,284 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return self._execute_write(
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )
+
+    def reconcile_bootstrap_and_append_messages_batch(
+        self,
+        bootstrap,
+        messages: Sequence[SessionDBBatchMessage],
+        *,
+        replay_patience_s: float,
+    ) -> AppendMessagesBatchResult:
+        if not messages:
+            return AppendMessagesBatchResult(inserted_count=0, duplicate_count=0)
+
+        batch_messages = list(messages)
+        message_keys = [msg.persistence_message_key for msg in batch_messages]
+        if any(not key for key in message_keys):
+            raise AppendMessagesBatchConflictError(
+                "append_messages_batch requires non-empty persistence_message_key values"
+            )
+
+        unit_ids = {msg.persistence_unit_id for msg in batch_messages}
+        if any(not unit_id for unit_id in unit_ids) or len(unit_ids) != 1:
+            raise AppendMessagesBatchConflictError(
+                "append_messages_batch requires one shared non-empty persistence_unit_id"
+            )
+
+        if len(set(message_keys)) != len(message_keys):
+            raise AppendMessagesBatchConflictError(
+                "append_messages_batch requires unique persistence_message_key values"
+            )
+
+        ordinals: List[int] = []
+        for msg in batch_messages:
+            ordinal = msg.persistence_ordinal
+            if isinstance(ordinal, bool) or not isinstance(ordinal, int):
+                raise AppendMessagesBatchConflictError(
+                    "append_messages_batch requires integer persistence_ordinal values"
+                )
+            ordinals.append(ordinal)
+        if sorted(ordinals) != list(range(len(batch_messages))):
+            raise AppendMessagesBatchConflictError(
+                "append_messages_batch requires contiguous persistence_ordinal values"
+            )
+
+        ordered_messages = [
+            msg for _, msg in sorted(zip(ordinals, batch_messages), key=lambda item: item[0])
+        ]
+        unit_id = ordered_messages[0].persistence_unit_id
+        prepared_messages = [
+            self._prepare_message_storage_values(
+                role=msg.role,
+                content=msg.content,
+                tool_name=msg.tool_name,
+                tool_calls=msg.tool_calls,
+                tool_call_id=msg.tool_call_id,
+                finish_reason=msg.finish_reason,
+                reasoning=msg.reasoning,
+                reasoning_content=msg.reasoning_content,
+                reasoning_details=msg.reasoning_details,
+                codex_reasoning_items=msg.codex_reasoning_items,
+                codex_message_items=msg.codex_message_items,
+                timestamp=msg.timestamp,
+                api_content=msg.api_content,
+                display_kind=msg.display_kind,
+                display_metadata=msg.display_metadata,
+                persistence_unit_id=msg.persistence_unit_id,
+                persistence_message_key=msg.persistence_message_key,
+                persistence_ordinal=msg.persistence_ordinal,
+            )
+            for msg in ordered_messages
+        ]
+        ordered_keys = [prepared["persistence_message_key"] for prepared in prepared_messages]
+        select_columns = (
+            "id, persistence_unit_id, persistence_message_key, persistence_ordinal, "
+            "role, content, tool_name, tool_calls, tool_call_id, finish_reason, "
+            "reasoning, reasoning_content, reasoning_details, codex_reasoning_items, "
+            "codex_message_items, timestamp, api_content, display_kind, display_metadata"
+        )
+
+        bootstrap_session_id = getattr(bootstrap, "session_id", None)
+        bootstrap_source = getattr(bootstrap, "source", None)
+        bootstrap_parent_session_id = getattr(bootstrap, "parent_session_id", None)
+        bootstrap_model_config = getattr(bootstrap, "model_config", None)
+        bootstrap_model_config_json = (
+            json.dumps(bootstrap_model_config) if bootstrap_model_config is not None else None
+        )
+
+        def _require_matching_session_value(
+            session_row: sqlite3.Row,
+            column: str,
+            bootstrap_value,
+        ) -> None:
+            existing_value = session_row[column]
+            if existing_value is not None and bootstrap_value is not None and existing_value != bootstrap_value:
+                raise AppendMessagesBatchConflictError(
+                    f"replay bootstrap {column} conflicts with the stored session row"
+                )
+
+        def _do(conn):
+            if not isinstance(bootstrap_session_id, str) or not bootstrap_session_id:
+                raise AppendMessagesBatchConflictError(
+                    "replay bootstrap requires a non-empty session_id"
+                )
+            if not isinstance(bootstrap_source, str) or not bootstrap_source:
+                raise AppendMessagesBatchConflictError(
+                    "replay bootstrap requires a non-empty source"
+                )
+            if bootstrap_parent_session_id:
+                parent_row = conn.execute(
+                    "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                    (bootstrap_parent_session_id,),
+                ).fetchone()
+                if parent_row is None:
+                    raise AppendMessagesBatchConflictError(
+                        "replay bootstrap parent session is missing"
+                    )
+
+            session_row = conn.execute(
+                "SELECT source, parent_session_id, model, model_config, system_prompt, "
+                "cwd, profile_name, user_id, session_key, chat_id, chat_type, "
+                "thread_id, started_at, message_count FROM sessions WHERE id = ?",
+                (bootstrap_session_id,),
+            ).fetchone()
+
+            if session_row is None:
+                started_at = getattr(bootstrap, "started_at", None)
+                if started_at is None:
+                    raise AppendMessagesBatchConflictError(
+                        "replay bootstrap requires started_at for a missing session row"
+                    )
+                conn.execute(
+                    """INSERT INTO sessions (
+                       id, source, user_id, session_key, chat_id, chat_type, thread_id,
+                       model, model_config, system_prompt, parent_session_id, cwd,
+                       profile_name, started_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        bootstrap_session_id,
+                        bootstrap_source,
+                        getattr(bootstrap, "user_id", None),
+                        getattr(bootstrap, "session_key", None),
+                        getattr(bootstrap, "chat_id", None),
+                        getattr(bootstrap, "chat_type", None),
+                        getattr(bootstrap, "thread_id", None),
+                        getattr(bootstrap, "model", None),
+                        bootstrap_model_config_json,
+                        getattr(bootstrap, "system_prompt", None),
+                        bootstrap_parent_session_id,
+                        getattr(bootstrap, "cwd", None),
+                        getattr(bootstrap, "profile_name", None),
+                        started_at,
+                    ),
+                )
+            else:
+                existing_row_backfill_values = (
+                    ("source", bootstrap_source),
+                    ("parent_session_id", bootstrap_parent_session_id),
+                    ("profile_name", getattr(bootstrap, "profile_name", None)),
+                    ("user_id", getattr(bootstrap, "user_id", None)),
+                    ("session_key", getattr(bootstrap, "session_key", None)),
+                    ("chat_id", getattr(bootstrap, "chat_id", None)),
+                    ("chat_type", getattr(bootstrap, "chat_type", None)),
+                    ("thread_id", getattr(bootstrap, "thread_id", None)),
+                )
+                for column, value in (
+                    *existing_row_backfill_values,
+                ):
+                    _require_matching_session_value(session_row, column, value)
+
+                updates = []
+                params: List[Any] = []
+                for column, value in existing_row_backfill_values:
+                    existing_value = session_row[column]
+                    if existing_value is None and value is not None:
+                        updates.append(f"{column} = ?")
+                        params.append(value)
+                for column, value in (
+                    ("model", getattr(bootstrap, "model", None)),
+                    ("model_config", bootstrap_model_config_json),
+                    ("system_prompt", getattr(bootstrap, "system_prompt", None)),
+                    ("cwd", getattr(bootstrap, "cwd", None)),
+                ):
+                    existing_value = session_row[column]
+                    if existing_value is None and value is not None:
+                        updates.append(f"{column} = ?")
+                        params.append(value)
+                    elif existing_value is not None and value is not None and existing_value != value:
+                        raise AppendMessagesBatchConflictError(
+                            f"replay bootstrap {column} conflicts with the stored session row"
+                        )
+
+                bootstrap_started_at = getattr(bootstrap, "started_at", None)
+                if session_row["started_at"] != bootstrap_started_at:
+                    if bootstrap_started_at is None or int(session_row["message_count"] or 0) != 0:
+                        raise AppendMessagesBatchConflictError(
+                            "replay bootstrap started_at conflicts with the stored session row"
+                        )
+                    updates.append("started_at = ?")
+                    params.append(bootstrap_started_at)
+
+                if updates:
+                    conn.execute(
+                        f"UPDATE sessions SET {', '.join(updates)} WHERE id = ?",
+                        [*params, bootstrap_session_id],
+                    )
+
+            self._assert_append_allowed(conn, bootstrap_session_id, None)
+
+            key_placeholders = ",".join("?" for _ in ordered_keys)
+            key_rows = conn.execute(
+                f"SELECT {select_columns} FROM messages WHERE session_id = ? "
+                f"AND persistence_message_key IN ({key_placeholders})",
+                [bootstrap_session_id, *ordered_keys],
+            ).fetchall()
+            unit_rows = conn.execute(
+                f"SELECT {select_columns} FROM messages WHERE session_id = ? "
+                "AND persistence_unit_id = ?",
+                [bootstrap_session_id, unit_id],
+            ).fetchall()
+
+            rows_by_key: Dict[str, sqlite3.Row] = {}
+            for row in key_rows:
+                key = row["persistence_message_key"]
+                if key in rows_by_key and rows_by_key[key]["id"] != row["id"]:
+                    raise AppendMessagesBatchConflictError(
+                        "duplicate persisted rows share one persistence_message_key"
+                    )
+                rows_by_key[key] = row
+
+            rows_by_ordinal: Dict[int, sqlite3.Row] = {}
+            for row in unit_rows:
+                ordinal = int(row["persistence_ordinal"])
+                if ordinal in rows_by_ordinal and rows_by_ordinal[ordinal]["id"] != row["id"]:
+                    raise AppendMessagesBatchConflictError(
+                        "duplicate persisted rows share one persistence_unit_id/persistence_ordinal"
+                    )
+                rows_by_ordinal[ordinal] = row
+
+            if not rows_by_key and not rows_by_ordinal:
+                tool_call_total = sum(prepared["tool_call_count"] for prepared in prepared_messages)
+                try:
+                    for prepared in prepared_messages:
+                        self._insert_prepared_message_row(conn, bootstrap_session_id, prepared)
+                except sqlite3.IntegrityError as exc:
+                    raise AppendMessagesBatchConflictError(
+                        "append_messages_batch encountered a persistence identity collision"
+                    ) from exc
+                conn.execute(
+                    "UPDATE sessions SET message_count = message_count + ?, "
+                    "tool_call_count = tool_call_count + ? WHERE id = ?",
+                    (len(prepared_messages), tool_call_total, bootstrap_session_id),
+                )
+                return AppendMessagesBatchResult(
+                    inserted_count=len(prepared_messages),
+                    duplicate_count=0,
+                )
+
+            if len(rows_by_key) != len(prepared_messages) or len(rows_by_ordinal) != len(prepared_messages):
+                raise AppendMessagesBatchConflictError(
+                    "append_messages_batch found a partial existing persistence unit"
+                )
+
+            for prepared in prepared_messages:
+                key_row = rows_by_key.get(prepared["persistence_message_key"])
+                ordinal_row = rows_by_ordinal.get(int(prepared["persistence_ordinal"]))
+                if key_row is None or ordinal_row is None or key_row["id"] != ordinal_row["id"]:
+                    raise AppendMessagesBatchConflictError(
+                        "append_messages_batch detected a persistence identity collision"
+                    )
+                if not self._batch_row_matches_prepared(key_row, prepared):
+                    raise AppendMessagesBatchConflictError(
+                        "append_messages_batch replay does not match the stored immutable row"
+                    )
+
+            return AppendMessagesBatchResult(
+                inserted_count=0,
+                duplicate_count=len(prepared_messages),
+            )
+
+        return self._execute_write(_do, patience_s=replay_patience_s)
 
     def set_latest_matching_message_display_kind(
         self, session_id: str, *, role: str, content: str, display_kind: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,7 +29,7 @@ import threading
 import time
 from collections import deque
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -1710,6 +1710,7 @@ class SessionDBBatchMessage(Mapping[str, Any]):
     _FIELD_NAMES: ClassVar[tuple[str, ...]] = (
         "role",
         "content",
+        "timestamp",
         "tool_name",
         "tool_calls",
         "tool_call_id",
@@ -1742,10 +1743,13 @@ class SessionDBBatchMessage(Mapping[str, Any]):
     api_content: Any = None
     display_kind: Optional[str] = None
     display_metadata: Optional[Dict[str, Any]] = None
+    _legacy_timestamp: Any = field(default=None, repr=False, compare=False)
 
     def __getitem__(self, key: str) -> Any:
         if key not in self._FIELD_NAMES:
             raise KeyError(key)
+        if key == "timestamp":
+            return self._legacy_timestamp
         return getattr(self, key)
 
     def __iter__(self) -> Iterator[str]:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -272,7 +272,10 @@ CREATE TABLE IF NOT EXISTS messages (
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,
     display_kind TEXT,
-    display_metadata TEXT
+    display_metadata TEXT,
+    persistence_unit_id TEXT,
+    persistence_message_key TEXT,
+    persistence_ordinal INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS session_model_usage (
@@ -369,6 +372,12 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_active_null
     ON messages(active) WHERE active IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_messages_session_message_key
+    ON messages(session_id, persistence_message_key)
+    WHERE persistence_message_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_messages_session_unit_ordinal
+    ON messages(session_id, persistence_unit_id, persistence_ordinal)
+    WHERE persistence_unit_id IS NOT NULL AND persistence_ordinal IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_session_key
     ON sessions(session_key, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -990,28 +990,20 @@ class SessionSearchMixin:
                 # End rows came back DESC for the LIMIT cap; flip to ASC.
                 bookend_end_rows = list(reversed(bookend_end_rows))
 
-        def _hydrate(row) -> Dict[str, Any]:
-            msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
-            if msg.get("tool_calls"):
-                try:
-                    msg["tool_calls"] = json.loads(msg["tool_calls"])
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning(
-                        "Failed to deserialize tool_calls in get_anchored_view, falling back to []"
-                    )
-                    msg["tool_calls"] = []
-            if msg.get("display_metadata") is not None:
-                msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
-            return msg
+        hydrate_public_row = getattr(self, "_public_message_row_dict")
 
         return {
             "window": filtered_window,
             "messages_before": primitive["messages_before"],
             "messages_after": primitive["messages_after"],
-            "bookend_start": [_hydrate(r) for r in bookend_start_rows],
-            "bookend_end": [_hydrate(r) for r in bookend_end_rows],
+            "bookend_start": [
+                hydrate_public_row(r, log_context="get_anchored_view")
+                for r in bookend_start_rows
+            ],
+            "bookend_end": [
+                hydrate_public_row(r, log_context="get_anchored_view")
+                for r in bookend_end_rows
+            ],
         }
 
     def list_recent_user_messages(

--- a/run_agent.py
+++ b/run_agent.py
@@ -285,6 +285,7 @@ _DB_PERSISTENCE_UNIT_ID = "_db_persistence_unit_id"
 _DB_PERSISTENCE_MESSAGE_KEY = "_db_persistence_message_key"
 _DB_PERSISTENCE_ORDINAL = "_db_persistence_ordinal"
 _DB_PERSISTENCE_TIMESTAMP = "_db_persistence_timestamp"
+_DB_PERSISTENCE_PAYLOAD_FINGERPRINT = "_db_persistence_payload_fingerprint"
 _DB_CANONICAL_COMMIT_MARKER = "_db_canonical_commit"
 
 
@@ -321,6 +322,36 @@ class _PlannedPersistenceUnit:
 @dataclass(frozen=True)
 class _SessionPersistencePlan:
     pending_units: tuple[_PlannedPersistenceUnit, ...]
+    mutated_spooled_unit_ids: tuple[str, ...] = ()
+
+
+def _batch_message_payload_fingerprint(message: Any) -> str:
+    """Hash only the row payload, excluding retry identity metadata."""
+    payload = {
+        "role": message.role,
+        "content": message.content,
+        "timestamp": message.timestamp,
+        "tool_name": message.tool_name,
+        "tool_calls": message.tool_calls,
+        "tool_call_id": message.tool_call_id,
+        "finish_reason": message.finish_reason,
+        "reasoning": message.reasoning,
+        "reasoning_content": message.reasoning_content,
+        "reasoning_details": message.reasoning_details,
+        "codex_reasoning_items": message.codex_reasoning_items,
+        "codex_message_items": message.codex_message_items,
+        "api_content": message.api_content,
+        "display_kind": message.display_kind,
+        "display_metadata": message.display_metadata,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -2140,6 +2171,7 @@ class AIAgent:
                     _DB_PERSISTENCE_MESSAGE_KEY,
                     _DB_PERSISTENCE_ORDINAL,
                     _DB_PERSISTENCE_TIMESTAMP,
+                    _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
                     _DB_CANONICAL_COMMIT_MARKER,
                 ):
                     msg.pop(private_key, None)
@@ -2149,6 +2181,7 @@ class AIAgent:
             pending_messages.append((msg_idx, msg))
 
         units = []
+        mutated_spooled_unit_ids = []
         while pending_messages:
             keyed_idx = next(
                 (
@@ -2171,6 +2204,66 @@ class AIAgent:
                 ):
                     unit_items.append(pending_messages[cursor])
                     cursor += 1
+            batch_messages = tuple(
+                _build_batch_message(unit_msg, unit_idx)
+                for unit_idx, unit_msg in unit_items
+            )
+            fingerprints = tuple(
+                _batch_message_payload_fingerprint(batch_message)
+                for batch_message in batch_messages
+            )
+            fingerprint_changed = any(
+                (
+                    source_msg.get(_DB_PERSISTENCE_PAYLOAD_FINGERPRINT) is not None
+                    and source_msg.get(_DB_PERSISTENCE_PAYLOAD_FINGERPRINT)
+                    != fingerprint
+                )
+                or (
+                    source_msg.get(_DB_SPOOLED_MARKER)
+                    and source_msg.get(_DB_PERSISTENCE_PAYLOAD_FINGERPRINT) is None
+                )
+                for (_unit_idx, source_msg), fingerprint in zip(
+                    unit_items, fingerprints
+                )
+            )
+            unit_blocked = fingerprint_changed and any(
+                source_msg.get(_DB_SPOOLED_MARKER)
+                for _unit_idx, source_msg in unit_items
+            )
+            if unit_blocked:
+                mutated_spooled_unit_ids.append(
+                    str(
+                        unit_items[0][1].get(_DB_PERSISTENCE_UNIT_ID)
+                        or "unknown"
+                    )
+                )
+            elif fingerprint_changed:
+                for _unit_idx, source_msg in unit_items:
+                    for private_key in (
+                        _DB_SPOOLED_MARKER,
+                        _DB_PERSISTENCE_UNIT_ID,
+                        _DB_PERSISTENCE_MESSAGE_KEY,
+                        _DB_PERSISTENCE_ORDINAL,
+                        _DB_PERSISTENCE_TIMESTAMP,
+                        _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
+                        _DB_CANONICAL_COMMIT_MARKER,
+                    ):
+                        source_msg.pop(private_key, None)
+                _assign_new_unit(unit_items)
+                batch_messages = tuple(
+                    _build_batch_message(unit_msg, unit_idx)
+                    for unit_idx, unit_msg in unit_items
+                )
+                fingerprints = tuple(
+                    _batch_message_payload_fingerprint(batch_message)
+                    for batch_message in batch_messages
+                )
+            if not unit_blocked:
+                for (_unit_idx, source_msg), fingerprint in zip(
+                    unit_items, fingerprints
+                ):
+                    source_msg[_DB_PERSISTENCE_PAYLOAD_FINGERPRINT] = fingerprint
+
             selected_ids = {id(unit_msg) for _unit_idx, unit_msg in unit_items}
             pending_messages = [
                 item for item in pending_messages if id(item[1]) not in selected_ids
@@ -2179,14 +2272,14 @@ class AIAgent:
                 _PlannedPersistenceUnit(
                     message_indices=tuple(unit_idx for unit_idx, _msg in unit_items),
                     source_messages=tuple(unit_msg for _unit_idx, unit_msg in unit_items),
-                    batch_messages=tuple(
-                        _build_batch_message(unit_msg, unit_idx)
-                        for unit_idx, unit_msg in unit_items
-                    ),
+                    batch_messages=batch_messages,
                 )
             )
 
-        return _SessionPersistencePlan(pending_units=tuple(units))
+        return _SessionPersistencePlan(
+            pending_units=tuple(units),
+            mutated_spooled_unit_ids=tuple(dict.fromkeys(mutated_spooled_unit_ids)),
+        )
 
     def _finalize_full_canonical_flush(self, messages: List[Dict]) -> None:
         self._flushed_db_message_ids = set()
@@ -2221,6 +2314,7 @@ class AIAgent:
                         _DB_PERSISTENCE_MESSAGE_KEY,
                         _DB_PERSISTENCE_ORDINAL,
                         _DB_PERSISTENCE_TIMESTAMP,
+                        _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
                     ):
                         source_msg.pop(private_key, None)
                 committed_units.append(unit)
@@ -2376,6 +2470,13 @@ class AIAgent:
             self._session_messages = messages
             self._save_session_log(messages)
 
+            if getattr(self, "_persist_disabled", False):
+                return SessionPersistResult(
+                    state=SessionPersistState.NOT_DURABLE,
+                    error_class="PersistenceDisabled",
+                    error_message="session persistence disabled for this agent",
+                )
+
             # Preserve the established instance-level persistence seam used by
             # lightweight agents and shutdown tests. Real AIAgent instances use
             # the class method and therefore continue through the classified
@@ -2398,6 +2499,19 @@ class AIAgent:
                     ),
                 )
 
+            plan = self._plan_session_persistence_units(
+                messages, conversation_history
+            )
+            if plan.mutated_spooled_unit_ids:
+                self._db_flush_scan_prefix = None
+                return SessionPersistResult(
+                    state=SessionPersistState.NOT_DURABLE,
+                    error_class="SpooledPersistenceUnitMutated",
+                    error_message=(
+                        "a durably spooled persistence unit changed before replay"
+                    ),
+                )
+
             replay_result = self._replay_pending_session_spool(trigger="pre_persist")
             blocked, replay_state_value = self._replay_result_blocks_canonical_persist(
                 replay_result
@@ -2409,14 +2523,6 @@ class AIAgent:
                     error_message="session spool replay blocked canonical persistence",
                 )
 
-            if getattr(self, "_persist_disabled", False):
-                return SessionPersistResult(
-                    state=SessionPersistState.NOT_DURABLE,
-                    error_class="PersistenceDisabled",
-                    error_message="session persistence disabled for this agent",
-                )
-
-            plan = self._plan_session_persistence_units(messages, conversation_history)
             if not plan.pending_units:
                 self._finalize_full_canonical_flush(messages)
                 if self._session_db is not None:
@@ -3378,6 +3484,7 @@ class AIAgent:
                             _DB_PERSISTENCE_MESSAGE_KEY,
                             _DB_PERSISTENCE_ORDINAL,
                             _DB_PERSISTENCE_TIMESTAMP,
+                            _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
                             _DB_CANONICAL_COMMIT_MARKER,
                         }
                     }

--- a/run_agent.py
+++ b/run_agent.py
@@ -2232,6 +2232,28 @@ class AIAgent:
             for index, unit in enumerate(units)
         )
 
+    def _replay_pending_session_spool(self, *, trigger: str):
+        if getattr(self, "_persist_disabled", False):
+            return None
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return None
+        return session_spool.replay_to_session_db(session_db, trigger=trigger)
+
+    @staticmethod
+    def _replay_result_blocks_canonical_persist(replay_result) -> Tuple[bool, Optional[str]]:
+        if replay_result is None:
+            return False, None
+        state = getattr(replay_result, "state", None)
+        state_value = getattr(state, "value", state)
+        if state_value in {
+            session_spool.ReplayRunState.BLOCKED_INTEGRITY.value,
+            session_spool.ReplayRunState.NOT_DURABLE.value,
+            session_spool.ReplayRunState.RETRY_PENDING.value,
+        }:
+            return True, state_value
+        return False, state_value
+
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state, preferring canonical DB writes and falling back to the spool."""
         from agent.agent_runtime_helpers import note_turn_persisted
@@ -2242,6 +2264,17 @@ class AIAgent:
             self._drop_trailing_empty_response_scaffolding(messages)
             self._session_messages = messages
             self._save_session_log(messages)
+
+            replay_result = self._replay_pending_session_spool(trigger="pre_persist")
+            blocked, replay_state_value = self._replay_result_blocks_canonical_persist(
+                replay_result
+            )
+            if blocked:
+                return SessionPersistResult(
+                    state=SessionPersistState.NOT_DURABLE,
+                    error_class=replay_state_value,
+                    error_message="session spool replay blocked canonical persistence",
+                )
 
             if getattr(self, "_persist_disabled", False):
                 return SessionPersistResult(
@@ -2461,6 +2494,12 @@ class AIAgent:
         if not self._session_db:
             return None
         try:
+            replay_result = self._replay_pending_session_spool(trigger="pre_persist")
+            blocked, _replay_state_value = self._replay_result_blocks_canonical_persist(
+                replay_result
+            )
+            if blocked:
+                return False
             plan = self._plan_session_persistence_units(messages, conversation_history)
             if not plan.pending_units:
                 self._finalize_full_canonical_flush(messages)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1887,12 +1887,14 @@ class AIAgent:
 
         Ensures conversations are never lost, even on errors or early returns.
 
-        Trailing empty-response scaffolding is dropped from the live list in
-        place (it is ephemeral junk the real transcript should shed). The
-        persist user-message *override* is NOT applied here — it is resolved
-        inside ``_flush_messages_to_session_db`` and written only to the DB row,
-        never mutating the live message list used by the API call (#48677 is
-        thus closed for every persist caller, not just this one).
+        Returns ``False`` only when the canonical SQLite flush explicitly failed;
+        otherwise returns ``True``. Trailing empty-response scaffolding is
+        dropped from the live list in place (it is ephemeral junk the real
+        transcript should shed). The persist user-message *override* is NOT
+        applied here — it is resolved inside ``_flush_messages_to_session_db``
+        and written only to the DB row, never mutating the live message list
+        used by the API call (#48677 is thus closed for every persist caller,
+        not just this one).
         """
         # Scaffolding removal mutates the live list (desired — ephemeral
         # retry/failure sentinels must not survive into the real transcript).
@@ -1903,24 +1905,26 @@ class AIAgent:
 
         persist_lock = getattr(self, "_session_persist_lock", None)
 
-        def _persist_and_drain() -> None:
+        def _persist_and_drain() -> bool:
             self._drop_trailing_empty_response_scaffolding(messages)
             self._session_messages = messages
             self._save_session_log(messages)
-            self._flush_messages_to_session_db(messages, conversation_history)
+            flush_ok = self._flush_messages_to_session_db(messages, conversation_history)
+            if flush_ok is False:
+                return False
             # Drain async token-accounting deltas at every persist point (turn
             # finalize + error exits) so a crash after this line loses at most
             # the in-flight API call's delta. Cheap no-op when nothing queued.
             if self._session_db is not None:
                 self._session_db.flush_token_counts()
             note_turn_persisted(self)
+            return True
 
         if persist_lock is None:
-            _persist_and_drain()
-            return
+            return _persist_and_drain()
 
         with persist_lock:
-            _persist_and_drain()
+            return _persist_and_drain()
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2192,7 +2192,10 @@ class AIAgent:
             )
         except Exception as exc:
             self._db_flush_scan_prefix = None
-            logger.warning("Session DB append_message failed: %s", exc)
+            logger.debug(
+                "Session DB append_message failed canonical_error_class=%s",
+                exc.__class__.__name__,
+            )
             return _CanonicalAppendOutcome(
                 committed_units=tuple(committed_units),
                 remaining_units=tuple(plan.pending_units[len(committed_units) :]),
@@ -2253,6 +2256,76 @@ class AIAgent:
         }:
             return True, state_value
         return False, state_value
+
+    def _persist_log_signature(
+        self,
+        *,
+        outcome: str,
+        canonical_units_committed: int,
+        spooled_units: int,
+        canonical_error_class: Optional[str],
+        failure_class: Optional[str],
+        receipt_count: int,
+    ) -> Tuple[str, int, int, Optional[str], Optional[str], int]:
+        return (
+            outcome,
+            int(canonical_units_committed),
+            int(spooled_units),
+            canonical_error_class,
+            failure_class,
+            int(receipt_count),
+        )
+
+    def _log_persist_outcome(
+        self,
+        *,
+        outcome: str,
+        canonical_units_committed: int,
+        spooled_units: int,
+        canonical_error_class: Optional[str],
+        failure_class: Optional[str],
+        receipt_count: int,
+    ) -> None:
+        signature = self._persist_log_signature(
+            outcome=outcome,
+            canonical_units_committed=canonical_units_committed,
+            spooled_units=spooled_units,
+            canonical_error_class=canonical_error_class,
+            failure_class=failure_class,
+            receipt_count=receipt_count,
+        )
+        previous = getattr(self, "_persist_degraded_log_state", None)
+        now = time.monotonic()
+        degraded = outcome != "canonical"
+        if degraded:
+            if (
+                previous is not None
+                and previous.get("signature") == signature
+                and (now - float(previous.get("logged_at", 0.0))) < 300.0
+            ):
+                return
+            logger.warning(
+                "Session persistence degraded outcome=%s canonical_units_committed=%d spooled_units=%d canonical_error_class=%s failure_class=%s receipt_count=%d",
+                outcome,
+                canonical_units_committed,
+                spooled_units,
+                canonical_error_class,
+                failure_class,
+                receipt_count,
+            )
+            self._persist_degraded_log_state = {"signature": signature, "logged_at": now}
+            return
+        if previous is not None:
+            logger.info(
+                "Session persistence recovered outcome=%s canonical_units_committed=%d spooled_units=%d canonical_error_class=%s failure_class=%s receipt_count=%d",
+                outcome,
+                canonical_units_committed,
+                spooled_units,
+                canonical_error_class,
+                failure_class,
+                receipt_count,
+            )
+            self._persist_degraded_log_state = None
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state, preferring canonical DB writes and falling back to the spool."""
@@ -2321,6 +2394,14 @@ class AIAgent:
                 if self._session_db is not None:
                     self._session_db.flush_token_counts()
                 note_turn_persisted(self)
+                self._log_persist_outcome(
+                    outcome="canonical",
+                    canonical_units_committed=len(canonical_outcome.committed_units),
+                    spooled_units=0,
+                    canonical_error_class=None,
+                    failure_class=None,
+                    receipt_count=0,
+                )
                 return SessionPersistResult(
                     state=SessionPersistState.CANONICAL,
                     canonical_units_committed=len(canonical_outcome.committed_units),
@@ -2373,12 +2454,13 @@ class AIAgent:
                 and len(durable_spooled_units) == len(canonical_outcome.remaining_units)
             ):
                 note_turn_persisted(self)
-                logger.warning(
-                    "Session persistence outcome=spooled session_id=%s unit_ids=%s canonical_error_class=%s receipt_count=%d",
-                    self.session_id,
-                    [unit.persistence_unit_id for unit in canonical_outcome.remaining_units],
-                    canonical_outcome.error.__class__.__name__,
-                    len(spool_receipts),
+                self._log_persist_outcome(
+                    outcome="spooled",
+                    canonical_units_committed=len(canonical_outcome.committed_units),
+                    spooled_units=len(canonical_outcome.remaining_units),
+                    canonical_error_class=canonical_outcome.error.__class__.__name__,
+                    failure_class=None,
+                    receipt_count=len(spool_receipts),
                 )
                 return SessionPersistResult(
                     state=SessionPersistState.SPOOLED,
@@ -2390,13 +2472,13 @@ class AIAgent:
                 )
 
             failure = spool_error or canonical_outcome.error
-            logger.warning(
-                "Session persistence outcome=not_durable session_id=%s unit_ids=%s canonical_error_class=%s spool_error_class=%s receipt_count=%d",
-                self.session_id,
-                [unit.persistence_unit_id for unit in canonical_outcome.remaining_units],
-                canonical_outcome.error.__class__.__name__,
-                failure.__class__.__name__ if failure is not None else None,
-                len(spool_receipts),
+            self._log_persist_outcome(
+                outcome="not_durable",
+                canonical_units_committed=len(canonical_outcome.committed_units),
+                spooled_units=len(durable_spooled_units),
+                canonical_error_class=canonical_outcome.error.__class__.__name__,
+                failure_class=(failure.__class__.__name__ if failure is not None else None),
+                receipt_count=len(spool_receipts),
             )
             return SessionPersistResult(
                 state=SessionPersistState.NOT_DURABLE,

--- a/run_agent.py
+++ b/run_agent.py
@@ -285,6 +285,7 @@ _DB_PERSISTENCE_UNIT_ID = "_db_persistence_unit_id"
 _DB_PERSISTENCE_MESSAGE_KEY = "_db_persistence_message_key"
 _DB_PERSISTENCE_ORDINAL = "_db_persistence_ordinal"
 _DB_PERSISTENCE_TIMESTAMP = "_db_persistence_timestamp"
+_DB_CANONICAL_COMMIT_MARKER = "_db_canonical_commit"
 
 
 class SessionPersistState(str, Enum):
@@ -1954,7 +1955,7 @@ class AIAgent:
                 started_at = float(session_start.timestamp())
             except Exception:
                 started_at = None
-        source = _session_source_for_agent(self.platform)
+        source = _session_source_for_agent(getattr(self, "platform", None))
         bootstrap = session_spool.SessionSpoolBootstrap(
             session_id=getattr(self, "session_id", None),
             source=source,
@@ -1987,7 +1988,10 @@ class AIAgent:
 
         current_session_id = getattr(self, "session_id", None)
         flushed_session_id = getattr(self, "_flushed_db_message_session_id", None)
-        if flushed_session_id != current_session_id or self._last_flushed_db_idx == 0:
+        if (
+            flushed_session_id != current_session_id
+            or getattr(self, "_last_flushed_db_idx", 0) == 0
+        ):
             seed_ids = set()
         else:
             seed_ids = getattr(self, "_flushed_db_message_ids", None)
@@ -2119,6 +2123,23 @@ class AIAgent:
                 continue
             if msg.get(_DB_PERSISTED_MARKER):
                 continue
+            # A missing persisted marker after a successful canonical commit
+            # means a caller intentionally rewrote the live row in place (for
+            # example turn_finalizer filling an incremental tool-call row).
+            # Failed writes have no canonical receipt and must retain their
+            # identity for idempotent retry; rewritten committed rows must get
+            # a fresh key or SessionDB will deduplicate the updated content as
+            # the already-durable stale row.
+            if msg.get(_DB_CANONICAL_COMMIT_MARKER):
+                for private_key in (
+                    _DB_SPOOLED_MARKER,
+                    _DB_PERSISTENCE_UNIT_ID,
+                    _DB_PERSISTENCE_MESSAGE_KEY,
+                    _DB_PERSISTENCE_ORDINAL,
+                    _DB_PERSISTENCE_TIMESTAMP,
+                    _DB_CANONICAL_COMMIT_MARKER,
+                ):
+                    msg.pop(private_key, None)
             if id(msg) in history_ids or id(msg) in seed_ids:
                 msg[_DB_PERSISTED_MARKER] = True
                 continue
@@ -2178,13 +2199,27 @@ class AIAgent:
             for unit in plan.pending_units:
                 self._session_db.append_messages_batch(
                     self.session_id,
-                    unit.batch_messages,
+                    messages=unit.batch_messages,
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
                 )
                 for source_msg in unit.source_messages:
                     source_msg[_DB_PERSISTED_MARKER] = True
+                    source_msg[_DB_CANONICAL_COMMIT_MARKER] = True
+                    # Identity/timestamp must survive failed canonical writes
+                    # and spool retries, but once this unit is canonical the
+                    # durable marker is sufficient. Removing random retry
+                    # metadata keeps live-message semantics identical to the
+                    # pre-spool path and lets a later marker pop re-key a
+                    # rewritten row cleanly.
+                    for private_key in (
+                        _DB_PERSISTENCE_UNIT_ID,
+                        _DB_PERSISTENCE_MESSAGE_KEY,
+                        _DB_PERSISTENCE_ORDINAL,
+                        _DB_PERSISTENCE_TIMESTAMP,
+                    ):
+                        source_msg.pop(private_key, None)
                 committed_units.append(unit)
             return _CanonicalAppendOutcome(
                 committed_units=tuple(committed_units),
@@ -2337,6 +2372,22 @@ class AIAgent:
             self._drop_trailing_empty_response_scaffolding(messages)
             self._session_messages = messages
             self._save_session_log(messages)
+
+            # Preserve the established instance-level persistence seam used by
+            # lightweight agents and shutdown tests. Real AIAgent instances use
+            # the class method and therefore continue through the classified
+            # canonical/spool path below.
+            flush_override = getattr(self, "__dict__", {}).get(
+                "_flush_messages_to_session_db"
+            )
+            if callable(flush_override):
+                override_result = flush_override(messages, conversation_history)
+                if override_result is False:
+                    return SessionPersistResult(
+                        state=SessionPersistState.NOT_DURABLE,
+                        error_class="PersistenceOverrideFailed",
+                    )
+                return SessionPersistResult(state=SessionPersistState.CANONICAL)
 
             replay_result = self._replay_pending_session_spool(trigger="pre_persist")
             blocked, replay_state_value = self._replay_result_blocks_canonical_persist(
@@ -2575,16 +2626,21 @@ class AIAgent:
             return None
         if not self._session_db:
             return None
+
         try:
-            replay_result = self._replay_pending_session_spool(trigger="pre_persist")
-            blocked, _replay_state_value = self._replay_result_blocks_canonical_persist(
-                replay_result
+            replay_result = AIAgent._replay_pending_session_spool(
+                self, trigger="pre_persist"
+            )
+            blocked, _replay_state_value = (
+                AIAgent._replay_result_blocks_canonical_persist(replay_result)
             )
             if blocked:
                 return False
-            plan = self._plan_session_persistence_units(messages, conversation_history)
+            plan = AIAgent._plan_session_persistence_units(
+                self, messages, conversation_history
+            )
             if not plan.pending_units:
-                self._finalize_full_canonical_flush(messages)
+                AIAgent._finalize_full_canonical_flush(self, messages)
                 return True
             if not self._session_db_created:
                 self._ensure_db_session()
@@ -2594,10 +2650,10 @@ class AIAgent:
                     "Session DB append_message failed: session row not created"
                 )
                 return False
-            outcome = self._append_planned_units_canonically(plan)
+            outcome = AIAgent._append_planned_units_canonically(self, plan)
             if outcome.error is not None:
                 return False
-            self._finalize_full_canonical_flush(messages)
+            AIAgent._finalize_full_canonical_flush(self, messages)
             return True
         except Exception as e:
             self._db_flush_scan_prefix = None
@@ -3313,6 +3369,7 @@ class AIAgent:
                             _DB_PERSISTENCE_MESSAGE_KEY,
                             _DB_PERSISTENCE_ORDINAL,
                             _DB_PERSISTENCE_TIMESTAMP,
+                            _DB_CANONICAL_COMMIT_MARKER,
                         }
                     }
                 cleaned.append(msg)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2026,6 +2026,7 @@ class AIAgent:
             row_api_content = msg.get("api_content")
             if not isinstance(row_api_content, str):
                 row_api_content = None
+            legacy_row_timestamp = msg.get("timestamp")
             row_timestamp = _row_timestamp_for(msg)
             pending_cli_message = getattr(self, "_pending_cli_user_message", None)
             is_current_turn_user = (_ov_idx == msg_idx or msg is pending_cli_message)
@@ -2044,6 +2045,7 @@ class AIAgent:
                     content = _ov_content
                 if _ov_timestamp is not None:
                     row_timestamp = _ov_timestamp
+                    legacy_row_timestamp = _ov_timestamp
             if row_api_content == content:
                 row_api_content = None
             if (
@@ -2083,6 +2085,7 @@ class AIAgent:
                 role=role,
                 content=content,
                 timestamp=row_timestamp,
+                _legacy_timestamp=legacy_row_timestamp,
                 tool_name=msg.get("tool_name"),
                 tool_calls=tool_calls_data,
                 tool_call_id=msg.get("tool_call_id"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -286,6 +286,7 @@ _DB_PERSISTENCE_MESSAGE_KEY = "_db_persistence_message_key"
 _DB_PERSISTENCE_ORDINAL = "_db_persistence_ordinal"
 _DB_PERSISTENCE_TIMESTAMP = "_db_persistence_timestamp"
 _DB_PERSISTENCE_PAYLOAD_FINGERPRINT = "_db_persistence_payload_fingerprint"
+_DB_PERSISTENCE_UNIT_FINGERPRINT = "_db_persistence_unit_fingerprint"
 _DB_CANONICAL_COMMIT_MARKER = "_db_canonical_commit"
 
 
@@ -350,6 +351,16 @@ def _batch_message_payload_fingerprint(message: Any) -> str:
         separators=(",", ":"),
         ensure_ascii=False,
         default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _unit_payload_fingerprint(payload_fingerprints: Sequence[str]) -> str:
+    """Freeze unit membership, order, cardinality, and per-row payloads."""
+    encoded = json.dumps(
+        list(payload_fingerprints),
+        separators=(",", ":"),
+        ensure_ascii=False,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
@@ -2172,6 +2183,7 @@ class AIAgent:
                     _DB_PERSISTENCE_ORDINAL,
                     _DB_PERSISTENCE_TIMESTAMP,
                     _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
+                    _DB_PERSISTENCE_UNIT_FINGERPRINT,
                     _DB_CANONICAL_COMMIT_MARKER,
                 ):
                     msg.pop(private_key, None)
@@ -2212,6 +2224,7 @@ class AIAgent:
                 _batch_message_payload_fingerprint(batch_message)
                 for batch_message in batch_messages
             )
+            unit_fingerprint = _unit_payload_fingerprint(fingerprints)
             fingerprint_changed = any(
                 (
                     source_msg.get(_DB_PERSISTENCE_PAYLOAD_FINGERPRINT) is not None
@@ -2225,6 +2238,18 @@ class AIAgent:
                 for (_unit_idx, source_msg), fingerprint in zip(
                     unit_items, fingerprints
                 )
+            )
+            fingerprint_changed = fingerprint_changed or any(
+                (
+                    source_msg.get(_DB_PERSISTENCE_UNIT_FINGERPRINT) is not None
+                    and source_msg.get(_DB_PERSISTENCE_UNIT_FINGERPRINT)
+                    != unit_fingerprint
+                )
+                or (
+                    source_msg.get(_DB_SPOOLED_MARKER)
+                    and source_msg.get(_DB_PERSISTENCE_UNIT_FINGERPRINT) is None
+                )
+                for _unit_idx, source_msg in unit_items
             )
             unit_blocked = fingerprint_changed and any(
                 source_msg.get(_DB_SPOOLED_MARKER)
@@ -2246,6 +2271,7 @@ class AIAgent:
                         _DB_PERSISTENCE_ORDINAL,
                         _DB_PERSISTENCE_TIMESTAMP,
                         _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
+                        _DB_PERSISTENCE_UNIT_FINGERPRINT,
                         _DB_CANONICAL_COMMIT_MARKER,
                     ):
                         source_msg.pop(private_key, None)
@@ -2258,11 +2284,13 @@ class AIAgent:
                     _batch_message_payload_fingerprint(batch_message)
                     for batch_message in batch_messages
                 )
+                unit_fingerprint = _unit_payload_fingerprint(fingerprints)
             if not unit_blocked:
                 for (_unit_idx, source_msg), fingerprint in zip(
                     unit_items, fingerprints
                 ):
                     source_msg[_DB_PERSISTENCE_PAYLOAD_FINGERPRINT] = fingerprint
+                    source_msg[_DB_PERSISTENCE_UNIT_FINGERPRINT] = unit_fingerprint
 
             selected_ids = {id(unit_msg) for _unit_idx, unit_msg in unit_items}
             pending_messages = [
@@ -2315,6 +2343,7 @@ class AIAgent:
                         _DB_PERSISTENCE_ORDINAL,
                         _DB_PERSISTENCE_TIMESTAMP,
                         _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
+                        _DB_PERSISTENCE_UNIT_FINGERPRINT,
                     ):
                         source_msg.pop(private_key, None)
                 committed_units.append(unit)
@@ -3488,6 +3517,7 @@ class AIAgent:
                             _DB_PERSISTENCE_ORDINAL,
                             _DB_PERSISTENCE_TIMESTAMP,
                             _DB_PERSISTENCE_PAYLOAD_FINGERPRINT,
+                            _DB_PERSISTENCE_UNIT_FINGERPRINT,
                             _DB_CANONICAL_COMMIT_MARKER,
                         }
                     }

--- a/run_agent.py
+++ b/run_agent.py
@@ -2743,6 +2743,12 @@ class AIAgent:
             return None
 
         try:
+            plan = AIAgent._plan_session_persistence_units(
+                self, messages, conversation_history
+            )
+            if plan.mutated_spooled_unit_ids:
+                self._db_flush_scan_prefix = None
+                return False
             replay_result = AIAgent._replay_pending_session_spool(
                 self, trigger="pre_persist"
             )
@@ -2751,9 +2757,6 @@ class AIAgent:
             )
             if blocked:
                 return False
-            plan = AIAgent._plan_session_persistence_units(
-                self, messages, conversation_history
-            )
             if not plan.pending_units:
                 AIAgent._finalize_full_canonical_flush(self, messages)
                 return True

--- a/run_agent.py
+++ b/run_agent.py
@@ -46,7 +46,9 @@ import time
 import threading
 import uuid
 import warnings
-from typing import List, Dict, Any, Optional, Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Dict, Any, Optional, Callable, Sequence, Tuple
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
 # that imports the SDK on first call/isinstance check. This preserves:
@@ -64,6 +66,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from hermes_constants import get_hermes_home
+import session_fallback_spool as session_spool
 
 
 def _launch_cwd_for_session(source: str) -> Optional[str]:
@@ -277,10 +280,53 @@ _MAX_TOOL_WORKERS = 8
 # every top-level ``_``-prefixed key before the request leaves the process, so
 # this never reaches a strict OpenAI-compatible gateway.
 _DB_PERSISTED_MARKER = "_db_persisted"
+_DB_SPOOLED_MARKER = "_db_spooled"
 _DB_PERSISTENCE_UNIT_ID = "_db_persistence_unit_id"
 _DB_PERSISTENCE_MESSAGE_KEY = "_db_persistence_message_key"
 _DB_PERSISTENCE_ORDINAL = "_db_persistence_ordinal"
 _DB_PERSISTENCE_TIMESTAMP = "_db_persistence_timestamp"
+
+
+class SessionPersistState(str, Enum):
+    CANONICAL = "canonical"
+    SPOOLED = "spooled"
+    NOT_DURABLE = "not_durable"
+
+
+@dataclass(frozen=True)
+class SessionPersistResult:
+    state: SessionPersistState
+    canonical_units_committed: int = 0
+    spooled_units: int = 0
+    spool_receipts: tuple[session_spool.SpoolUnitAppendResult, ...] = ()
+    error_class: str | None = None
+    error_message: str | None = None
+
+    def __bool__(self) -> bool:
+        raise TypeError("SessionPersistResult has no truthiness; branch on .state")
+
+
+@dataclass(frozen=True)
+class _PlannedPersistenceUnit:
+    message_indices: tuple[int, ...]
+    source_messages: tuple[Dict[str, Any], ...]
+    batch_messages: tuple[Any, ...]
+
+    @property
+    def persistence_unit_id(self) -> str:
+        return self.batch_messages[0].persistence_unit_id
+
+
+@dataclass(frozen=True)
+class _SessionPersistencePlan:
+    pending_units: tuple[_PlannedPersistenceUnit, ...]
+
+
+@dataclass(frozen=True)
+class _CanonicalAppendOutcome:
+    committed_units: tuple[_PlannedPersistenceUnit, ...]
+    remaining_units: tuple[_PlannedPersistenceUnit, ...]
+    error: Exception | None = None
 
 
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
@@ -1886,49 +1932,453 @@ class AIAgent:
                 if timestamp is not None:
                     msg["timestamp"] = timestamp
 
+    def _session_profile_name_for_persistence(self) -> Optional[str]:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            profile_name = get_active_profile_name()
+            if profile_name == "default":
+                return None
+            return profile_name
+        except Exception:
+            return None
+
+    def _get_session_spool_bootstrap(self) -> session_spool.SessionSpoolBootstrap:
+        cached = getattr(self, "_session_spool_bootstrap", None)
+        if cached is not None:
+            return cached
+        started_at = None
+        session_start = getattr(self, "session_start", None)
+        if session_start is not None and hasattr(session_start, "timestamp"):
+            try:
+                started_at = float(session_start.timestamp())
+            except Exception:
+                started_at = None
+        source = _session_source_for_agent(self.platform)
+        bootstrap = session_spool.SessionSpoolBootstrap(
+            session_id=getattr(self, "session_id", None),
+            source=source,
+            started_at=started_at,
+            model=getattr(self, "model", None),
+            model_config=copy.deepcopy(getattr(self, "_session_init_model_config", None)),
+            system_prompt=getattr(self, "_cached_system_prompt", None),
+            parent_session_id=getattr(self, "_parent_session_id", None),
+            cwd=_launch_cwd_for_session(source),
+            profile_name=self._session_profile_name_for_persistence(),
+            user_id=getattr(self, "_user_id", None),
+            session_key=getattr(self, "_gateway_session_key", None),
+            chat_id=getattr(self, "_chat_id", None),
+            chat_type=getattr(self, "_chat_type", None),
+            thread_id=getattr(self, "_thread_id", None),
+        )
+        self._session_spool_bootstrap = bootstrap
+        return bootstrap
+
+    def _plan_session_persistence_units(
+        self,
+        messages: List[Dict],
+        conversation_history: Optional[List[Dict]] = None,
+    ) -> _SessionPersistencePlan:
+        from hermes_state import SessionDBBatchMessage
+
+        _ov_idx = getattr(self, "_persist_user_message_idx", None)
+        _ov_content = getattr(self, "_persist_user_message_override", None)
+        _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
+
+        current_session_id = getattr(self, "session_id", None)
+        flushed_session_id = getattr(self, "_flushed_db_message_session_id", None)
+        if flushed_session_id != current_session_id or self._last_flushed_db_idx == 0:
+            seed_ids = set()
+        else:
+            seed_ids = getattr(self, "_flushed_db_message_ids", None)
+            if not isinstance(seed_ids, set):
+                seed_ids = set()
+        self._flushed_db_message_session_id = current_session_id
+        history_ids = {
+            id(item) for item in (conversation_history or []) if isinstance(item, dict)
+        }
+
+        scan_start = 0
+        previous_prefix = getattr(self, "_db_flush_scan_prefix", None)
+        if isinstance(previous_prefix, list):
+            limit = min(len(previous_prefix), len(messages))
+            while scan_start < limit and messages[scan_start] is previous_prefix[scan_start]:
+                scan_start += 1
+
+        def _row_timestamp_for(msg: Dict[str, Any]):
+            row_timestamp = msg.get("timestamp")
+            if row_timestamp is not None:
+                return row_timestamp
+            if msg.get(_DB_PERSISTENCE_TIMESTAMP) is None:
+                msg[_DB_PERSISTENCE_TIMESTAMP] = time.time()
+            return msg.get(_DB_PERSISTENCE_TIMESTAMP)
+
+        def _build_batch_message(
+            msg: Dict[str, Any],
+            msg_idx: int,
+        ) -> SessionDBBatchMessage:
+            role = msg.get("role", "unknown")
+            content = msg.get("content")
+            row_api_content = msg.get("api_content")
+            if not isinstance(row_api_content, str):
+                row_api_content = None
+            row_timestamp = _row_timestamp_for(msg)
+            pending_cli_message = getattr(self, "_pending_cli_user_message", None)
+            is_current_turn_user = (_ov_idx == msg_idx or msg is pending_cli_message)
+            if is_current_turn_user and msg.get("role") == "user":
+                if (
+                    _ov_content is not None
+                    and (not isinstance(content, list) or isinstance(_ov_content, list))
+                    and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                ):
+                    if (
+                        row_api_content is None
+                        and isinstance(content, str)
+                        and content != _ov_content
+                    ):
+                        row_api_content = content
+                    content = _ov_content
+                if _ov_timestamp is not None:
+                    row_timestamp = _ov_timestamp
+            if row_api_content == content:
+                row_api_content = None
+            if (
+                row_api_content is None
+                and role in ("user", "assistant")
+                and isinstance(content, str)
+                and content
+                and sanitize_context(content).strip() != content.strip()
+            ):
+                row_api_content = content
+            if _is_multimodal_tool_result(content):
+                content = _multimodal_text_summary(content)
+            elif isinstance(content, list):
+                text_parts = []
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(str(part.get("text", "")))
+                    elif isinstance(part, dict) and part.get("type") in {
+                        "image",
+                        "image_url",
+                        "input_image",
+                    }:
+                        text_parts.append("[screenshot]")
+                content = "\n".join(text_parts) if text_parts else None
+            tool_calls_data = None
+            if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
+                tool_calls_data = [
+                    {"name": tc.function.name, "arguments": tc.function.arguments}
+                    for tc in msg.tool_calls
+                ]
+            elif isinstance(msg.get("tool_calls"), list):
+                tool_calls_data = msg["tool_calls"]
+            return SessionDBBatchMessage(
+                persistence_unit_id=msg[_DB_PERSISTENCE_UNIT_ID],
+                persistence_message_key=msg[_DB_PERSISTENCE_MESSAGE_KEY],
+                persistence_ordinal=msg[_DB_PERSISTENCE_ORDINAL],
+                role=role,
+                content=content,
+                timestamp=row_timestamp,
+                tool_name=msg.get("tool_name"),
+                tool_calls=tool_calls_data,
+                tool_call_id=msg.get("tool_call_id"),
+                finish_reason=msg.get("finish_reason"),
+                reasoning=msg.get("reasoning") if role == "assistant" else None,
+                reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
+                reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                api_content=row_api_content,
+                display_kind=(
+                    "hidden"
+                    if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
+                    and not msg.get("_compressed_summary_has_user_turn")
+                    else msg.get("display_kind")
+                ),
+                display_metadata=msg.get("display_metadata"),
+            )
+
+        def _assign_new_unit(unit_items):
+            unit_id = uuid.uuid4().hex
+            for ordinal, (_msg_idx, unit_msg) in enumerate(unit_items):
+                unit_msg.setdefault(_DB_PERSISTENCE_UNIT_ID, unit_id)
+                unit_msg.setdefault(_DB_PERSISTENCE_MESSAGE_KEY, uuid.uuid4().hex)
+                unit_msg.setdefault(_DB_PERSISTENCE_ORDINAL, ordinal)
+                if (
+                    unit_msg.get("timestamp") is None
+                    and unit_msg.get(_DB_PERSISTENCE_TIMESTAMP) is None
+                ):
+                    unit_msg[_DB_PERSISTENCE_TIMESTAMP] = time.time()
+
+        pending_messages = []
+        for msg_idx in range(scan_start, len(messages)):
+            msg = messages[msg_idx]
+            if not isinstance(msg, dict):
+                continue
+            if _is_ephemeral_scaffolding(msg):
+                continue
+            if msg.get(_DB_PERSISTED_MARKER):
+                continue
+            if id(msg) in history_ids or id(msg) in seed_ids:
+                msg[_DB_PERSISTED_MARKER] = True
+                continue
+            pending_messages.append((msg_idx, msg))
+
+        units = []
+        while pending_messages:
+            keyed_idx = next(
+                (
+                    idx
+                    for idx, (_msg_idx, pending_msg) in enumerate(pending_messages)
+                    if pending_msg.get(_DB_PERSISTENCE_UNIT_ID)
+                ),
+                None,
+            )
+            if keyed_idx is None:
+                unit_items = list(pending_messages)
+                _assign_new_unit(unit_items)
+            else:
+                unit_items = []
+                unit_id = pending_messages[keyed_idx][1].get(_DB_PERSISTENCE_UNIT_ID)
+                cursor = keyed_idx
+                while (
+                    cursor < len(pending_messages)
+                    and pending_messages[cursor][1].get(_DB_PERSISTENCE_UNIT_ID) == unit_id
+                ):
+                    unit_items.append(pending_messages[cursor])
+                    cursor += 1
+            selected_ids = {id(unit_msg) for _unit_idx, unit_msg in unit_items}
+            pending_messages = [
+                item for item in pending_messages if id(item[1]) not in selected_ids
+            ]
+            units.append(
+                _PlannedPersistenceUnit(
+                    message_indices=tuple(unit_idx for unit_idx, _msg in unit_items),
+                    source_messages=tuple(unit_msg for _unit_idx, unit_msg in unit_items),
+                    batch_messages=tuple(
+                        _build_batch_message(unit_msg, unit_idx)
+                        for unit_idx, unit_msg in unit_items
+                    ),
+                )
+            )
+
+        return _SessionPersistencePlan(pending_units=tuple(units))
+
+    def _finalize_full_canonical_flush(self, messages: List[Dict]) -> None:
+        self._flushed_db_message_ids = set()
+        self._last_flushed_db_idx = len(messages)
+        self._db_flush_scan_prefix = messages[:]
+
+    def _append_planned_units_canonically(
+        self,
+        plan: _SessionPersistencePlan,
+    ) -> _CanonicalAppendOutcome:
+        committed_units = []
+        try:
+            for unit in plan.pending_units:
+                self._session_db.append_messages_batch(
+                    self.session_id,
+                    unit.batch_messages,
+                    compression_lock_holder=getattr(
+                        self, "_active_compression_lock_holder", None
+                    ),
+                )
+                for source_msg in unit.source_messages:
+                    source_msg[_DB_PERSISTED_MARKER] = True
+                committed_units.append(unit)
+            return _CanonicalAppendOutcome(
+                committed_units=tuple(committed_units),
+                remaining_units=(),
+            )
+        except Exception as exc:
+            self._db_flush_scan_prefix = None
+            logger.warning("Session DB append_message failed: %s", exc)
+            return _CanonicalAppendOutcome(
+                committed_units=tuple(committed_units),
+                remaining_units=tuple(plan.pending_units[len(committed_units) :]),
+                error=exc,
+            )
+
+    def _build_spool_records_for_units(
+        self,
+        units: Sequence[_PlannedPersistenceUnit],
+        *,
+        stage: str,
+        error: Exception | None,
+        session_row_created: bool,
+    ) -> tuple[session_spool.SessionSpoolRecord, ...]:
+        if not units:
+            return ()
+        error_message = str(error or "")
+        error_message = error_message.splitlines()[0]
+        error_message = error_message.encode("utf-8", errors="ignore")[:512].decode(
+            "utf-8", errors="ignore"
+        )
+        persist_attempt_id = uuid.uuid4().hex
+        bootstrap = self._get_session_spool_bootstrap()
+        return tuple(
+            session_spool.SessionSpoolRecord(
+                bootstrap=bootstrap,
+                persist_attempt_id=persist_attempt_id,
+                persist_attempt_unit_index=index,
+                canonical_failure={
+                    "stage": stage,
+                    "error_class": (error.__class__.__name__ if error is not None else "RuntimeError"),
+                    "error_message": error_message,
+                    "session_row_created": session_row_created,
+                },
+                batch_messages=tuple(unit.batch_messages),
+            )
+            for index, unit in enumerate(units)
+        )
+
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
-        """Save session state to both JSON log and SQLite on any exit path.
-
-        Ensures conversations are never lost, even on errors or early returns.
-
-        Returns ``False`` only when the canonical SQLite flush explicitly failed;
-        otherwise returns ``True``. Trailing empty-response scaffolding is
-        dropped from the live list in place (it is ephemeral junk the real
-        transcript should shed). The persist user-message *override* is NOT
-        applied here — it is resolved inside ``_flush_messages_to_session_db``
-        and written only to the DB row, never mutating the live message list
-        used by the API call (#48677 is thus closed for every persist caller,
-        not just this one).
-        """
-        # Scaffolding removal mutates the live list (desired — ephemeral
-        # retry/failure sentinels must not survive into the real transcript).
-        # Close and turn-start persistence can run on separate CLI threads; the
-        # marker test-and-append below must be one critical section or both can
-        # observe the same unmarked dict and write duplicate durable rows.
+        """Save session state, preferring canonical DB writes and falling back to the spool."""
         from agent.agent_runtime_helpers import note_turn_persisted
 
         persist_lock = getattr(self, "_session_persist_lock", None)
 
-        def _persist_and_drain() -> bool:
+        def _persist_and_classify() -> SessionPersistResult:
             self._drop_trailing_empty_response_scaffolding(messages)
             self._session_messages = messages
             self._save_session_log(messages)
-            flush_ok = self._flush_messages_to_session_db(messages, conversation_history)
-            if flush_ok is False:
-                return False
-            # Drain async token-accounting deltas at every persist point (turn
-            # finalize + error exits) so a crash after this line loses at most
-            # the in-flight API call's delta. Cheap no-op when nothing queued.
-            if self._session_db is not None:
-                self._session_db.flush_token_counts()
-            note_turn_persisted(self)
-            return True
+
+            if getattr(self, "_persist_disabled", False):
+                return SessionPersistResult(
+                    state=SessionPersistState.NOT_DURABLE,
+                    error_class="PersistenceDisabled",
+                    error_message="session persistence disabled for this agent",
+                )
+
+            plan = self._plan_session_persistence_units(messages, conversation_history)
+            if not plan.pending_units:
+                self._finalize_full_canonical_flush(messages)
+                if self._session_db is not None:
+                    self._session_db.flush_token_counts()
+                note_turn_persisted(self)
+                return SessionPersistResult(state=SessionPersistState.CANONICAL)
+
+            canonical_stage = "append_messages_batch"
+            canonical_error = None
+            canonical_outcome = _CanonicalAppendOutcome((), plan.pending_units, None)
+
+            if self._session_db is None:
+                canonical_stage = "session_row_create"
+                canonical_error = RuntimeError("session_db unavailable for canonical persistence")
+                self._db_flush_scan_prefix = None
+                canonical_outcome = _CanonicalAppendOutcome((), plan.pending_units, canonical_error)
+            else:
+                if not self._session_db_created:
+                    self._ensure_db_session()
+                if not self._session_db_created:
+                    canonical_stage = "session_row_create"
+                    canonical_error = RuntimeError(
+                        "session row not available for canonical persistence"
+                    )
+                    self._db_flush_scan_prefix = None
+                    canonical_outcome = _CanonicalAppendOutcome(
+                        (), plan.pending_units, canonical_error
+                    )
+                else:
+                    canonical_outcome = self._append_planned_units_canonically(plan)
+                    canonical_error = canonical_outcome.error
+
+            if canonical_outcome.error is None:
+                self._finalize_full_canonical_flush(messages)
+                if self._session_db is not None:
+                    self._session_db.flush_token_counts()
+                note_turn_persisted(self)
+                return SessionPersistResult(
+                    state=SessionPersistState.CANONICAL,
+                    canonical_units_committed=len(canonical_outcome.committed_units),
+                )
+
+            already_spooled_units = []
+            units_to_spool = []
+            for unit in canonical_outcome.remaining_units:
+                if unit.source_messages and all(
+                    msg.get(_DB_SPOOLED_MARKER) for msg in unit.source_messages
+                ):
+                    already_spooled_units.append(unit)
+                else:
+                    units_to_spool.append(unit)
+
+            spool_receipts: tuple[session_spool.SpoolUnitAppendResult, ...] = ()
+            spool_error = None
+            if units_to_spool:
+                records = self._build_spool_records_for_units(
+                    units_to_spool,
+                    stage=canonical_stage,
+                    error=canonical_outcome.error,
+                    session_row_created=(canonical_stage != "session_row_create"),
+                )
+                try:
+                    append_result = session_spool.append_records(records)
+                    spool_receipts = tuple(append_result.unit_results)
+                except session_spool.SpoolAppendAttemptPartialError as exc:
+                    spool_receipts = tuple(exc.durable_results)
+                    spool_error = exc.cause
+                except Exception as exc:
+                    spool_error = exc
+                if spool_error is None and len(spool_receipts) != len(units_to_spool):
+                    spool_error = RuntimeError(
+                        "missing spool receipts for one or more persistence units"
+                    )
+
+            receipt_unit_ids = {
+                receipt.persistence_unit_id for receipt in spool_receipts
+            }
+            durable_spooled_units = list(already_spooled_units)
+            for unit in units_to_spool:
+                if unit.persistence_unit_id in receipt_unit_ids:
+                    for source_msg in unit.source_messages:
+                        source_msg[_DB_SPOOLED_MARKER] = True
+                    durable_spooled_units.append(unit)
+
+            if (
+                spool_error is None
+                and len(durable_spooled_units) == len(canonical_outcome.remaining_units)
+            ):
+                note_turn_persisted(self)
+                logger.warning(
+                    "Session persistence outcome=spooled session_id=%s unit_ids=%s canonical_error_class=%s receipt_count=%d",
+                    self.session_id,
+                    [unit.persistence_unit_id for unit in canonical_outcome.remaining_units],
+                    canonical_outcome.error.__class__.__name__,
+                    len(spool_receipts),
+                )
+                return SessionPersistResult(
+                    state=SessionPersistState.SPOOLED,
+                    canonical_units_committed=len(canonical_outcome.committed_units),
+                    spooled_units=len(canonical_outcome.remaining_units),
+                    spool_receipts=spool_receipts,
+                    error_class=canonical_outcome.error.__class__.__name__,
+                    error_message=str(canonical_outcome.error),
+                )
+
+            failure = spool_error or canonical_outcome.error
+            logger.warning(
+                "Session persistence outcome=not_durable session_id=%s unit_ids=%s canonical_error_class=%s spool_error_class=%s receipt_count=%d",
+                self.session_id,
+                [unit.persistence_unit_id for unit in canonical_outcome.remaining_units],
+                canonical_outcome.error.__class__.__name__,
+                failure.__class__.__name__ if failure is not None else None,
+                len(spool_receipts),
+            )
+            return SessionPersistResult(
+                state=SessionPersistState.NOT_DURABLE,
+                canonical_units_committed=len(canonical_outcome.committed_units),
+                spooled_units=len(durable_spooled_units),
+                spool_receipts=spool_receipts,
+                error_class=(failure.__class__.__name__ if failure is not None else None),
+                error_message=(str(failure) if failure is not None else None),
+            )
 
         if persist_lock is None:
-            return _persist_and_drain()
+            return _persist_and_classify()
 
         with persist_lock:
-            return _persist_and_drain()
+            return _persist_and_classify()
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
@@ -2005,330 +2455,30 @@ class AIAgent:
         messages: List[Dict],
         conversation_history: Optional[List[Dict]] = None,
     ):
-        """Persist any un-flushed messages to the SQLite session store.
-
-        Deduplicates via an intrinsic ``_DB_PERSISTED_MARKER`` stamped on each
-        written message dict, so repeated calls (from multiple exit paths) only
-        write truly new messages — preventing the duplicate-write bug (#860)
-        without relying on positional slices that can drift after
-        message-sequence repair, and without a retained ``id(msg)`` set that
-        CPython could alias onto a freed-then-reused address (#50372). The
-        ``_flushed_db_message_ids`` attribute is now only a one-shot seed
-        (translated to markers, then cleared each flush), not a persisted set.
-
-        Note: the marker is stamped on the live/shared conversation dict, which
-        correctly makes re-persistence idempotent across turns. No code path
-        edits a persisted message's content/role in place expecting a re-write
-        (in-place compaction resets the seed and re-diffs by identity).
-        """
-        # Persistence-isolated agents (e.g. the background skill/memory review
-        # fork) must NEVER write into the canonical session store. The fork
-        # shares the parent's session_id for prompt-cache warmth, so any write
-        # here would land its harness turn ("Review the conversation above and
-        # update the skill library…") inside the user's real session history,
-        # where the next live turn re-reads it as an instruction and the agent
-        # "becomes" the curator. Hard-stop before any DB touch.
+        """Persist any un-flushed messages to the SQLite session store."""
         if getattr(self, "_persist_disabled", False):
             return None
         if not self._session_db:
             return None
-        # Persist user-message override (#48677 chokepoint): historically this
-        # mutated the live `messages` list in place, which — on the early
-        # crash-resilience persist that runs BEFORE the API call is built —
-        # stripped observed group-chat context off the live user message and
-        # silently dropped it. Instead, resolve the override here and apply it
-        # ONLY to the value written to the DB (see the write loop below); the
-        # live dict is never mutated, so every caller (early persist, mid-loop
-        # flush, /resume, /branch) is protected uniformly. Timestamp override is
-        # metadata and is likewise applied only to the written row.
-        _ov_idx = getattr(self, "_persist_user_message_idx", None)
-        _ov_content = getattr(self, "_persist_user_message_override", None)
-        _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
         try:
-            # Retry row creation if the earlier attempt failed transiently.
+            plan = self._plan_session_persistence_units(messages, conversation_history)
+            if not plan.pending_units:
+                self._finalize_full_canonical_flush(messages)
+                return True
             if not self._session_db_created:
                 self._ensure_db_session()
-            # Positional flushing used to slice at
-            # max(len(conversation_history), _last_flushed_db_idx). That
-            # assumes the live `messages` list is the original history plus a
-            # new tail. repair_message_sequence can shrink/merge the history
-            # copy before the final flush, making len(conversation_history)
-            # larger than len(messages); the slice is then empty and delivered
-            # assistant responses never reach state.db (#46053).
-            #
-            # Track persistence with an intrinsic per-message marker rather than
-            # id(msg). `messages` is a shallow copy of `conversation_history`, so
-            # history dicts are skipped by identity, and new dicts appended
-            # during this turn are written once even if repair compacts the list
-            # around them. Unlike an id()-keyed set, a marker bound to the dict
-            # cannot be aliased onto a freed-then-reused address, so a real turn
-            # can never be silently skipped (see _DB_PERSISTED_MARKER).
-            #
-            # `self._flushed_db_message_ids` is still honoured as a *one-shot*
-            # seed: external callers (gateway shutdown, tests) populate it with
-            # {id(m) for m in already_persisted} immediately before the flush,
-            # while those objects are alive — so the ids are valid at that
-            # instant. We translate the seed into durable markers and then clear
-            # the set, so stale ids can never accumulate across turns and alias a
-            # future message.
-            current_session_id = getattr(self, "session_id", None)
-            flushed_session_id = getattr(self, "_flushed_db_message_session_id", None)
-            if flushed_session_id != current_session_id or self._last_flushed_db_idx == 0:
-                seed_ids = set()
-            else:
-                seed_ids = getattr(self, "_flushed_db_message_ids", None)
-                if not isinstance(seed_ids, set):
-                    seed_ids = set()
-            self._flushed_db_message_session_id = current_session_id
-            history_ids = {
-                id(item) for item in (conversation_history or [])
-                if isinstance(item, dict)
-            }
-
-            # Bounded scan: skip the longest identity-matched prefix of the
-            # list snapshot taken at the end of the previous successful flush.
-            # Every message in that snapshot was already given its final
-            # disposition (written+stamped, stamped as durable history, or
-            # skipped as ephemeral scaffolding / non-dict), and no code path
-            # pops _DB_PERSISTED_MARKER from a live dict in place (compression
-            # strips markers on fresh copies, which breaks identity here and
-            # forces a full re-scan). Identity match ⇒ identical skip decision,
-            # so starting after the matched prefix is behavior-preserving.
-            _scan_start = 0
-            _prev_prefix = getattr(self, "_db_flush_scan_prefix", None)
-            if isinstance(_prev_prefix, list):
-                _limit = min(len(_prev_prefix), len(messages))
-                while (
-                    _scan_start < _limit
-                    and messages[_scan_start] is _prev_prefix[_scan_start]
-                ):
-                    _scan_start += 1
-
-            from hermes_state import SessionDBBatchMessage
-
-            pending_messages = []
-
-            def _row_timestamp_for(msg: Dict[str, Any]):
-                row_timestamp = msg.get("timestamp")
-                if row_timestamp is not None:
-                    return row_timestamp
-                if msg.get(_DB_PERSISTENCE_TIMESTAMP) is None:
-                    msg[_DB_PERSISTENCE_TIMESTAMP] = time.time()
-                return msg.get(_DB_PERSISTENCE_TIMESTAMP)
-
-            def _build_batch_message(msg: Dict[str, Any], msg_idx: int) -> SessionDBBatchMessage:
-                role = msg.get("role", "unknown")
-                content = msg.get("content")
-                # api_content sidecar: the exact bytes sent to the API when
-                # they differ from the clean content (stamped by the turn
-                # prologue for prefetch/plugin injections). Written verbatim
-                # so replay can reproduce the sent prefix byte-for-byte.
-                _row_api_content = msg.get("api_content")
-                if not isinstance(_row_api_content, str):
-                    _row_api_content = None
-                _row_timestamp = _row_timestamp_for(msg)
-                # Apply the persist override to THIS row's written values only
-                # (never to the live dict). A multimodal override is a complete
-                # clean replacement for an API-local noted payload. Preserve the
-                # historical text-only guard for a list payload, though: a plain
-                # text override must not erase its image/audio transcript summary.
-                # The close safety-net may flush a shortened snapshot while
-                # turn setup still owns its staged CLI dict. In that shape the
-                # normal turn index refers to the full history, not this list;
-                # preserve the API-local override by recognizing the same dict.
-                pending_cli_message = getattr(self, "_pending_cli_user_message", None)
-                is_current_turn_user = (
-                    _ov_idx == msg_idx or msg is pending_cli_message
+            if not self._session_db_created:
+                self._db_flush_scan_prefix = None
+                logger.warning(
+                    "Session DB append_message failed: session row not created"
                 )
-                if is_current_turn_user and msg.get("role") == "user":
-                    # Preflight compaction can re-anchor the override index at
-                    # a message whose content was MERGED with the compaction
-                    # summary (merge-summary-into-tail). Overwriting that with
-                    # the clean gateway text would silently drop the summary
-                    # from the durable transcript. The wire is already
-                    # consistent — the merge popped the sidecar and the merged
-                    # content is what gets sent — so keep it.
-                    if (
-                        _ov_content is not None
-                        and (not isinstance(content, list) or isinstance(_ov_content, list))
-                        and not msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
-                    ):
-                        # The live content is what the API call sends; the
-                        # override is the cleaned transcript value. If they
-                        # differ and no injection already stamped the sidecar,
-                        # keep the sent bytes in api_content so replay matches
-                        # the wire (#48677 divergence, closed for the cache
-                        # prefix too).
-                        if (
-                            _row_api_content is None
-                            and isinstance(content, str)
-                            and content != _ov_content
-                        ):
-                            _row_api_content = content
-                        content = _ov_content
-                    if _ov_timestamp is not None:
-                        _row_timestamp = _ov_timestamp
-                # Store the sidecar only when it actually differs.
-                if _row_api_content == content:
-                    _row_api_content = None
-                # Load-time sanitize divergence: get_messages_as_conversation
-                # replays user/assistant rows through
-                # ``sanitize_context(content).strip()``, so content that
-                # sanitize would rewrite (echoed/pasted <memory-context>
-                # fences or system notes) replays different bytes after a
-                # session reload even though THIS turn sent it verbatim.
-                # Capture the sent bytes in the sidecar so a reloaded session
-                # replays what was actually on the wire. Compared in wire form
-                # (both sides .strip()-ed — the api_messages build strips
-                # every outgoing content string) so plain surrounding
-                # whitespace doesn't grow redundant sidecars.
-                if (
-                    _row_api_content is None
-                    and role in ("user", "assistant")
-                    and isinstance(content, str)
-                    and content
-                    and sanitize_context(content).strip() != content.strip()
-                ):
-                    _row_api_content = content
-                # Persist multimodal tool results as their text summary only —
-                # base64 images would bloat the session DB and aren't useful
-                # for cross-session replay.
-                if _is_multimodal_tool_result(content):
-                    content = _multimodal_text_summary(content)
-                elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
-                    _txt = []
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "text":
-                            _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
-                            _txt.append("[screenshot]")
-                    content = "\n".join(_txt) if _txt else None
-                tool_calls_data = None
-                if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
-                    tool_calls_data = [
-                        {"name": tc.function.name, "arguments": tc.function.arguments}
-                        for tc in msg.tool_calls
-                    ]
-                elif isinstance(msg.get("tool_calls"), list):
-                    tool_calls_data = msg["tool_calls"]
-                return SessionDBBatchMessage(
-                    persistence_unit_id=msg[_DB_PERSISTENCE_UNIT_ID],
-                    persistence_message_key=msg[_DB_PERSISTENCE_MESSAGE_KEY],
-                    persistence_ordinal=msg[_DB_PERSISTENCE_ORDINAL],
-                    role=role,
-                    content=content,
-                    timestamp=_row_timestamp,
-                    tool_name=msg.get("tool_name"),
-                    tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
-                    api_content=_row_api_content,
-                    display_kind=(
-                        "hidden"
-                        if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
-                        and not msg.get("_compressed_summary_has_user_turn")
-                        else msg.get("display_kind")
-                    ),
-                    display_metadata=msg.get("display_metadata"),
-                )
-
-            def _assign_new_unit(unit_items):
-                unit_id = uuid.uuid4().hex
-                for ordinal, (_msg_idx, unit_msg) in enumerate(unit_items):
-                    unit_msg.setdefault(_DB_PERSISTENCE_UNIT_ID, unit_id)
-                    unit_msg.setdefault(_DB_PERSISTENCE_MESSAGE_KEY, uuid.uuid4().hex)
-                    unit_msg.setdefault(_DB_PERSISTENCE_ORDINAL, ordinal)
-                    if (
-                        unit_msg.get("timestamp") is None
-                        and unit_msg.get(_DB_PERSISTENCE_TIMESTAMP) is None
-                    ):
-                        unit_msg[_DB_PERSISTENCE_TIMESTAMP] = time.time()
-
-            for _msg_idx in range(_scan_start, len(messages)):
-                msg = messages[_msg_idx]
-                if not isinstance(msg, dict):
-                    continue
-                # Never write ephemeral recovery scaffolding to the session
-                # store. The flush is append-only (it only advances
-                # _last_flushed_db_idx via identity tracking), so a synthetic
-                # message committed by a mid-turn persist cannot be un-written
-                # when the end-of-turn drop removes it from the in-memory list —
-                # the resumed transcript would then replay synthetic
-                # "(empty)"/nudge/thinking-prefill turns as if they were genuine
-                # context. Skip regardless of position: an answered nudge leaves
-                # the synthetic pair buried mid-list, not just at the tail.
-                if _is_ephemeral_scaffolding(msg):
-                    continue
-                if msg.get(_DB_PERSISTED_MARKER):
-                    continue
-                # Already-durable messages: either carried over from the loaded
-                # history copy, or seeded by a caller. Stamp them so future
-                # flushes skip them without consulting any id() set again.
-                if id(msg) in history_ids or id(msg) in seed_ids:
-                    msg[_DB_PERSISTED_MARKER] = True
-                    continue
-                pending_messages.append((_msg_idx, msg))
-
-            # Persist one logical unit at a time: normally the whole new tail,
-            # but after a failed write we must replay an already-keyed unit
-            # before appending any newly-seen unkeyed messages behind it.
-            while pending_messages:
-                _keyed_idx = next(
-                    (
-                        idx
-                        for idx, (_msg_idx, pending_msg) in enumerate(pending_messages)
-                        if pending_msg.get(_DB_PERSISTENCE_UNIT_ID)
-                    ),
-                    None,
-                )
-                if _keyed_idx is None:
-                    unit_items = list(pending_messages)
-                    _assign_new_unit(unit_items)
-                else:
-                    unit_items = []
-                    _unit_id = pending_messages[_keyed_idx][1].get(_DB_PERSISTENCE_UNIT_ID)
-                    _cursor = _keyed_idx
-                    while (
-                        _cursor < len(pending_messages)
-                        and pending_messages[_cursor][1].get(_DB_PERSISTENCE_UNIT_ID) == _unit_id
-                    ):
-                        unit_items.append(pending_messages[_cursor])
-                        _cursor += 1
-                batch_messages = [
-                    _build_batch_message(unit_msg, unit_idx)
-                    for unit_idx, unit_msg in unit_items
-                ]
-                self._session_db.append_messages_batch(
-                    self.session_id,
-                    batch_messages,
-                    compression_lock_holder=getattr(
-                        self, "_active_compression_lock_holder", None
-                    ),
-                )
-                for _unit_idx, unit_msg in unit_items:
-                    unit_msg[_DB_PERSISTED_MARKER] = True
-                pending_messages = [
-                    item for item in pending_messages
-                    if not item[1].get(_DB_PERSISTED_MARKER)
-                ]
-            # The intrinsic markers are now the sole source of truth. Reset the
-            # one-shot seed so no id() outlives this flush to alias a message
-            # allocated next turn at a recycled address.
-            self._flushed_db_message_ids = set()
-            self._last_flushed_db_idx = len(messages)
-            # Snapshot for the bounded scan above — only on full success, so
-            # a partially-processed list can never be treated as settled.
-            self._db_flush_scan_prefix = messages[:]
+                return False
+            outcome = self._append_planned_units_canonically(plan)
+            if outcome.error is not None:
+                return False
+            self._finalize_full_canonical_flush(messages)
             return True
         except Exception as e:
-            # Force a full re-scan on the next flush: an exception mid-loop
-            # leaves messages with mixed dispositions.
             self._db_flush_scan_prefix = None
             logger.warning("Session DB append_message failed: %s", e)
             return False
@@ -3037,6 +3187,7 @@ class AIAgent:
                         for key, value in msg.items()
                         if key not in {
                             _DB_PERSISTED_MARKER,
+                            _DB_SPOOLED_MARKER,
                             _DB_PERSISTENCE_UNIT_ID,
                             _DB_PERSISTENCE_MESSAGE_KEY,
                             _DB_PERSISTENCE_ORDINAL,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2382,12 +2382,18 @@ class AIAgent:
             )
             if callable(flush_override):
                 override_result = flush_override(messages, conversation_history)
-                if override_result is False:
-                    return SessionPersistResult(
-                        state=SessionPersistState.NOT_DURABLE,
-                        error_class="PersistenceOverrideFailed",
-                    )
-                return SessionPersistResult(state=SessionPersistState.CANONICAL)
+                if isinstance(override_result, SessionPersistResult):
+                    return override_result
+                if override_result is True:
+                    return SessionPersistResult(state=SessionPersistState.CANONICAL)
+                return SessionPersistResult(
+                    state=SessionPersistState.NOT_DURABLE,
+                    error_class="PersistenceOverrideUnconfirmed",
+                    error_message=(
+                        "instance-level persistence override did not explicitly "
+                        "confirm durable completion"
+                    ),
+                )
 
             replay_result = self._replay_pending_session_spool(trigger="pre_persist")
             blocked, replay_state_value = self._replay_result_blocks_canonical_persist(

--- a/run_agent.py
+++ b/run_agent.py
@@ -277,6 +277,10 @@ _MAX_TOOL_WORKERS = 8
 # every top-level ``_``-prefixed key before the request leaves the process, so
 # this never reaches a strict OpenAI-compatible gateway.
 _DB_PERSISTED_MARKER = "_db_persisted"
+_DB_PERSISTENCE_UNIT_ID = "_db_persistence_unit_id"
+_DB_PERSISTENCE_MESSAGE_KEY = "_db_persistence_message_key"
+_DB_PERSISTENCE_ORDINAL = "_db_persistence_ordinal"
+_DB_PERSISTENCE_TIMESTAMP = "_db_persistence_timestamp"
 
 
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
@@ -2100,33 +2104,19 @@ class AIAgent:
                 ):
                     _scan_start += 1
 
-            # Collect this flush's new rows and write them in ONE transaction
-            # at the end of the scan (see append_messages_batch).
-            _batch_rows: List[Dict[str, Any]] = []
-            _batch_msgs: List[Dict] = []
-            for _msg_idx in range(_scan_start, len(messages)):
-                msg = messages[_msg_idx]
-                if not isinstance(msg, dict):
-                    continue
-                # Never write ephemeral recovery scaffolding to the session
-                # store. The flush is append-only (it only advances
-                # _last_flushed_db_idx via identity tracking), so a synthetic
-                # message committed by a mid-turn persist cannot be un-written
-                # when the end-of-turn drop removes it from the in-memory list —
-                # the resumed transcript would then replay synthetic
-                # "(empty)"/nudge/thinking-prefill turns as if they were genuine
-                # context. Skip regardless of position: an answered nudge leaves
-                # the synthetic pair buried mid-list, not just at the tail.
-                if _is_ephemeral_scaffolding(msg):
-                    continue
-                if msg.get(_DB_PERSISTED_MARKER):
-                    continue
-                # Already-durable messages: either carried over from the loaded
-                # history copy, or seeded by a caller. Stamp them so future
-                # flushes skip them without consulting any id() set again.
-                if id(msg) in history_ids or id(msg) in seed_ids:
-                    msg[_DB_PERSISTED_MARKER] = True
-                    continue
+            from hermes_state import SessionDBBatchMessage
+
+            pending_messages = []
+
+            def _row_timestamp_for(msg: Dict[str, Any]):
+                row_timestamp = msg.get("timestamp")
+                if row_timestamp is not None:
+                    return row_timestamp
+                if msg.get(_DB_PERSISTENCE_TIMESTAMP) is None:
+                    msg[_DB_PERSISTENCE_TIMESTAMP] = time.time()
+                return msg.get(_DB_PERSISTENCE_TIMESTAMP)
+
+            def _build_batch_message(msg: Dict[str, Any], msg_idx: int) -> SessionDBBatchMessage:
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 # api_content sidecar: the exact bytes sent to the API when
@@ -2136,7 +2126,7 @@ class AIAgent:
                 _row_api_content = msg.get("api_content")
                 if not isinstance(_row_api_content, str):
                     _row_api_content = None
-                _row_timestamp = msg.get("timestamp")
+                _row_timestamp = _row_timestamp_for(msg)
                 # Apply the persist override to THIS row's written values only
                 # (never to the live dict). A multimodal override is a complete
                 # clean replacement for an API-local noted payload. Preserve the
@@ -2148,7 +2138,7 @@ class AIAgent:
                 # preserve the API-local override by recognizing the same dict.
                 pending_cli_message = getattr(self, "_pending_cli_user_message", None)
                 is_current_turn_user = (
-                    _ov_idx == _msg_idx or msg is pending_cli_message
+                    _ov_idx == msg_idx or msg is pending_cli_message
                 )
                 if is_current_turn_user and msg.get("role") == "user":
                     # Preflight compaction can re-anchor the override index at
@@ -2222,48 +2212,111 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
-                _batch_rows.append({
-                    "role": role,
-                    "content": content,
-                    "tool_name": msg.get("tool_name"),
-                    "tool_calls": tool_calls_data,
-                    "tool_call_id": msg.get("tool_call_id"),
-                    "finish_reason": msg.get("finish_reason"),
-                    # Reasoning/codex fields are role-gated (assistant-only)
-                    # inside _insert_message_rows — pass through untouched.
-                    "reasoning": msg.get("reasoning"),
-                    "reasoning_content": msg.get("reasoning_content"),
-                    "reasoning_details": msg.get("reasoning_details"),
-                    "codex_reasoning_items": msg.get("codex_reasoning_items"),
-                    "codex_message_items": msg.get("codex_message_items"),
-                    "timestamp": _row_timestamp,
-                    "api_content": _row_api_content,
-                    "display_kind": (
+                return SessionDBBatchMessage(
+                    persistence_unit_id=msg[_DB_PERSISTENCE_UNIT_ID],
+                    persistence_message_key=msg[_DB_PERSISTENCE_MESSAGE_KEY],
+                    persistence_ordinal=msg[_DB_PERSISTENCE_ORDINAL],
+                    role=role,
+                    content=content,
+                    timestamp=_row_timestamp,
+                    tool_name=msg.get("tool_name"),
+                    tool_calls=tool_calls_data,
+                    tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
+                    reasoning=msg.get("reasoning") if role == "assistant" else None,
+                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
+                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    api_content=_row_api_content,
+                    display_kind=(
                         "hidden"
                         if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
                         and not msg.get("_compressed_summary_has_user_turn")
                         else msg.get("display_kind")
                     ),
-                    "display_metadata": msg.get("display_metadata"),
-                })
-                _batch_msgs.append(msg)
-            # One transaction for the whole turn's new rows (typically 3-8
-            # messages): one BEGIN IMMEDIATE / commit — and, off WAL, one
-            # fsync — instead of one per row. All-or-nothing pairs exactly
-            # with the marker stamping below: on failure NO rows landed and
-            # NO markers were stamped, so the next flush re-scans and
-            # re-writes the whole tail (same recovery contract as before,
-            # minus the partial-prefix case that could double-pay counters).
-            if _batch_rows:
+                    display_metadata=msg.get("display_metadata"),
+                )
+
+            def _assign_new_unit(unit_items):
+                unit_id = uuid.uuid4().hex
+                for ordinal, (_msg_idx, unit_msg) in enumerate(unit_items):
+                    unit_msg.setdefault(_DB_PERSISTENCE_UNIT_ID, unit_id)
+                    unit_msg.setdefault(_DB_PERSISTENCE_MESSAGE_KEY, uuid.uuid4().hex)
+                    unit_msg.setdefault(_DB_PERSISTENCE_ORDINAL, ordinal)
+                    if (
+                        unit_msg.get("timestamp") is None
+                        and unit_msg.get(_DB_PERSISTENCE_TIMESTAMP) is None
+                    ):
+                        unit_msg[_DB_PERSISTENCE_TIMESTAMP] = time.time()
+
+            for _msg_idx in range(_scan_start, len(messages)):
+                msg = messages[_msg_idx]
+                if not isinstance(msg, dict):
+                    continue
+                # Never write ephemeral recovery scaffolding to the session
+                # store. The flush is append-only (it only advances
+                # _last_flushed_db_idx via identity tracking), so a synthetic
+                # message committed by a mid-turn persist cannot be un-written
+                # when the end-of-turn drop removes it from the in-memory list —
+                # the resumed transcript would then replay synthetic
+                # "(empty)"/nudge/thinking-prefill turns as if they were genuine
+                # context. Skip regardless of position: an answered nudge leaves
+                # the synthetic pair buried mid-list, not just at the tail.
+                if _is_ephemeral_scaffolding(msg):
+                    continue
+                if msg.get(_DB_PERSISTED_MARKER):
+                    continue
+                # Already-durable messages: either carried over from the loaded
+                # history copy, or seeded by a caller. Stamp them so future
+                # flushes skip them without consulting any id() set again.
+                if id(msg) in history_ids or id(msg) in seed_ids:
+                    msg[_DB_PERSISTED_MARKER] = True
+                    continue
+                pending_messages.append((_msg_idx, msg))
+
+            # Persist one logical unit at a time: normally the whole new tail,
+            # but after a failed write we must replay an already-keyed unit
+            # before appending any newly-seen unkeyed messages behind it.
+            while pending_messages:
+                _keyed_idx = next(
+                    (
+                        idx
+                        for idx, (_msg_idx, pending_msg) in enumerate(pending_messages)
+                        if pending_msg.get(_DB_PERSISTENCE_UNIT_ID)
+                    ),
+                    None,
+                )
+                if _keyed_idx is None:
+                    unit_items = list(pending_messages)
+                    _assign_new_unit(unit_items)
+                else:
+                    unit_items = []
+                    _unit_id = pending_messages[_keyed_idx][1].get(_DB_PERSISTENCE_UNIT_ID)
+                    _cursor = _keyed_idx
+                    while (
+                        _cursor < len(pending_messages)
+                        and pending_messages[_cursor][1].get(_DB_PERSISTENCE_UNIT_ID) == _unit_id
+                    ):
+                        unit_items.append(pending_messages[_cursor])
+                        _cursor += 1
+                batch_messages = [
+                    _build_batch_message(unit_msg, unit_idx)
+                    for unit_idx, unit_msg in unit_items
+                ]
                 self._session_db.append_messages_batch(
-                    session_id=self.session_id,
-                    messages=_batch_rows,
+                    self.session_id,
+                    batch_messages,
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
                 )
-                for _written in _batch_msgs:
-                    _written[_DB_PERSISTED_MARKER] = True
+                for _unit_idx, unit_msg in unit_items:
+                    unit_msg[_DB_PERSISTED_MARKER] = True
+                pending_messages = [
+                    item for item in pending_messages
+                    if not item[1].get(_DB_PERSISTED_MARKER)
+                ]
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.
@@ -2978,6 +3031,18 @@ class AIAgent:
                 if "content" in msg:
                     msg = dict(msg)
                     msg["content"] = self._redact_message_content(msg.get("content"))
+                if isinstance(msg, dict):
+                    msg = {
+                        key: value
+                        for key, value in msg.items()
+                        if key not in {
+                            _DB_PERSISTED_MARKER,
+                            _DB_PERSISTENCE_UNIT_ID,
+                            _DB_PERSISTENCE_MESSAGE_KEY,
+                            _DB_PERSISTENCE_ORDINAL,
+                            _DB_PERSISTENCE_TIMESTAMP,
+                        }
+                    }
                 cleaned.append(msg)
 
             # Guard: never overwrite a larger session log with fewer messages.

--- a/session_fallback_spool.py
+++ b/session_fallback_spool.py
@@ -4,6 +4,7 @@ import errno
 import json
 import os
 import re
+import sqlite3
 import stat
 import time
 from contextlib import contextmanager
@@ -14,7 +15,12 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from hermes_constants import get_hermes_home
-from hermes_state import SessionDBBatchMessage
+from hermes_state import (
+    AppendMessagesBatchConflictError,
+    CompressionSessionBusyError,
+    CompressionSessionClosedError,
+    SessionDBBatchMessage,
+)
 
 try:  # pragma: no cover - Windows-only import path
     import fcntl  # type: ignore[attr-defined]
@@ -30,7 +36,12 @@ except ImportError:  # pragma: no cover - POSIX-only fallback
 SPOOL_ROOT_NAME = "session_fallback_spool"
 ACTIVE_SPOOL_NAME = "active.spool"
 LOCK_FILE_NAME = "append.lock"
+REPLAY_OWNER_LOCK_NAME = "replay-owner.lock"
 QUARANTINE_DIR_NAME = "quarantine"
+SEALED_DIR_NAME = "sealed"
+ACKS_DIR_NAME = "acks"
+BLOCKERS_DIR_NAME = "blockers"
+HIGHWATER_FILE_NAME = "segment-sequence.highwater.json"
 HEADER_MAGIC = b"HSPL"
 HEADER_SIZE = 32
 FRAME_VERSION = 0x01
@@ -42,12 +53,20 @@ MAX_FRAME_BYTES = MAX_PAYLOAD_BYTES + HEADER_SIZE
 TOTAL_CAP_BYTES = 64 * 1024 * 1024
 LOCK_TIMEOUT_SECONDS = 5.0
 LOCK_RETRY_SECONDS = 0.02
+SEGMENT_SEQUENCE_WIDTH = 20
+MAX_SEGMENT_SEQUENCE = 18446744073709551615
+_REPLAY_RETRYABLE_ERRNOS = {
+    errno.EAGAIN,
+    getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
+    getattr(errno, "EBUSY", errno.EAGAIN),
+}
 _LOCK_CONTENTION_ERRNOS = {
     errno.EACCES,
     errno.EAGAIN,
     getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
 }
 _CURRENT_QUARANTINE_DIR_FD: int | None = None
+_REPLAY_COOLDOWNS: dict[str, dict[str, Any]] = {}
 
 
 class SpoolTailStatus(str, Enum):
@@ -121,6 +140,72 @@ class SpoolScanResult:
 
 
 @dataclass(frozen=True)
+class SessionSpoolFrame:
+    record: SessionSpoolRecord
+    frame_offset: int
+    frame_length: int
+    payload_length: int
+    checksum_hex: str
+
+
+@dataclass(frozen=True)
+class DecodedSegment:
+    prefix_frames: tuple[SessionSpoolFrame, ...]
+    valid_prefix_bytes: int
+    tail_status: SpoolTailStatus
+    tail_offset: int | None
+
+
+class ReplayFrameState(str, Enum):
+    REPLAYED = "replayed"
+    DUPLICATE = "duplicate"
+    RETRY_PENDING = "retry_pending"
+    BLOCKED_INTEGRITY = "blocked_integrity"
+
+
+class ReplayRunState(str, Enum):
+    EMPTY = "empty"
+    OWNER_BUSY = "owner_busy"
+    REPLAYED = "replayed"
+    PARTIALLY_REPLAYED = "partially_replayed"
+    RETRY_PENDING = "retry_pending"
+    BLOCKED_INTEGRITY = "blocked_integrity"
+    CORRUPT_QUARANTINED = "corrupt_quarantined"
+    NOT_DURABLE = "not_durable"
+
+
+@dataclass(frozen=True)
+class ReplayFrameResult:
+    state: ReplayFrameState
+    segment_sequence: int
+    frame_offset: int
+    frame_length: int
+    checksum_hex: str
+    retry_class: str | None = None
+    error_class: str | None = None
+
+
+@dataclass(frozen=True)
+class ReplayRunResult:
+    state: ReplayRunState
+    trigger: str
+    segment_count_seen: int = 0
+    frames_decoded: int = 0
+    frames_committed: int = 0
+    frames_duplicated: int = 0
+    frames_acked: int = 0
+    bytes_decoded: int = 0
+    bytes_acked: int = 0
+    pending_bytes_after: int = 0
+    first_blocked_segment: int | None = None
+    first_blocked_offset: int | None = None
+    retry_class: str | None = None
+    error_class: str | None = None
+    ack_pending: bool = False
+    cooldown_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
 class _AnchoredRuntime:
     home_path: Path
     root_path: Path
@@ -129,6 +214,23 @@ class _AnchoredRuntime:
     home_fd: int
     root_fd: int
     lock_fd: int
+
+
+@dataclass(frozen=True)
+class _BlockerBackedPrefixReplayState:
+    segment_sequence: int
+    blocking_offset: int
+    tail_status: SpoolTailStatus
+    prefix_segment_name: str
+    prefix_segment_path: Path
+    valid_prefix_bytes: int
+    acked_prefix_bytes: int
+
+
+@dataclass(frozen=True)
+class _DurableCapacityInventory:
+    quarantine_bytes: int
+    other_artifact_bytes: int
 
 
 class SessionFallbackSpoolError(RuntimeError):
@@ -158,16 +260,19 @@ class SpoolCapacityError(SessionFallbackSpoolError):
         *,
         active_bytes: int,
         quarantine_bytes: int,
+        other_artifact_bytes: int = 0,
         requested_bytes: int,
         cap_bytes: int,
     ):
         super().__init__(
             "fallback spool capacity exceeded: "
             f"active_bytes={active_bytes} quarantine_bytes={quarantine_bytes} "
+            f"other_artifact_bytes={other_artifact_bytes} "
             f"requested_bytes={requested_bytes} cap_bytes={cap_bytes}"
         )
         self.active_bytes = active_bytes
         self.quarantine_bytes = quarantine_bytes
+        self.other_artifact_bytes = other_artifact_bytes
         self.requested_bytes = requested_bytes
         self.cap_bytes = cap_bytes
 
@@ -187,6 +292,20 @@ class SpoolAppendAttemptPartialError(SessionFallbackSpoolError):
         self.cause = cause
 
 
+class SpoolRetryableReplayError(SessionFallbackSpoolError):
+    def __init__(self, retry_class: str, *, ack_pending: bool = False):
+        super().__init__(retry_class)
+        self.retry_class = retry_class
+        self.ack_pending = ack_pending
+
+
+class SpoolBlockedReplayError(SessionFallbackSpoolError):
+    def __init__(self, error_class: str, *, frame_offset: int):
+        super().__init__(error_class)
+        self.error_class = error_class
+        self.frame_offset = frame_offset
+
+
 def _spool_root() -> Path:
     return get_hermes_home() / SPOOL_ROOT_NAME
 
@@ -201,6 +320,138 @@ def _lock_path() -> Path:
 
 def _quarantine_dir() -> Path:
     return _spool_root() / QUARANTINE_DIR_NAME
+
+
+def _sealed_dir() -> Path:
+    return _spool_root() / SEALED_DIR_NAME
+
+
+def _acks_dir() -> Path:
+    return _sealed_dir() / ACKS_DIR_NAME
+
+
+def _blockers_dir() -> Path:
+    return _sealed_dir() / BLOCKERS_DIR_NAME
+
+
+def _owner_lock_path() -> Path:
+    return _spool_root() / REPLAY_OWNER_LOCK_NAME
+
+
+def _segment_sequence_highwater_path() -> Path:
+    return _spool_root() / HIGHWATER_FILE_NAME
+
+
+def _format_segment_sequence(sequence: int) -> str:
+    return f"{sequence:0{SEGMENT_SEQUENCE_WIDTH}d}"
+
+
+def _replay_root_key(runtime: _AnchoredRuntime) -> str:
+    return str(runtime.root_path)
+
+
+def _trigger_budget(trigger: str) -> tuple[int | None, int | None, float | None]:
+    if trigger == "startup":
+        return 64, 8 * 1024 * 1024, 2.0
+    if trigger == "pre_persist":
+        return 16, 2 * 1024 * 1024, 0.5
+    return None, None, None
+
+
+def _retry_delay_seconds(failures: int) -> float:
+    return min(30.0, 0.5 * (2 ** max(failures - 1, 0)))
+
+
+def _register_replay_cooldown(
+    runtime: _AnchoredRuntime,
+    *,
+    retry_class: str,
+    ack_pending: bool,
+) -> float:
+    key = _replay_root_key(runtime)
+    now = time.monotonic()
+    previous = _REPLAY_COOLDOWNS.get(key)
+    failures = int(previous.get("failures", 0)) + 1 if previous else 1
+    delay = _retry_delay_seconds(failures)
+    _REPLAY_COOLDOWNS[key] = {
+        "failures": failures,
+        "next_eligible": now + delay,
+        "retry_class": retry_class,
+        "ack_pending": ack_pending,
+    }
+    return delay
+
+
+def _clear_replay_cooldown(runtime: _AnchoredRuntime) -> None:
+    _REPLAY_COOLDOWNS.pop(_replay_root_key(runtime), None)
+
+
+def _cooldown_result(runtime: _AnchoredRuntime, *, trigger: str) -> ReplayRunResult | None:
+    state = _REPLAY_COOLDOWNS.get(_replay_root_key(runtime))
+    if not state:
+        return None
+    remaining = float(state["next_eligible"] - time.monotonic())
+    if remaining <= 0:
+        return None
+    return ReplayRunResult(
+        state=ReplayRunState.RETRY_PENDING,
+        trigger=trigger,
+        retry_class=str(state.get("retry_class") or "retry_pending"),
+        ack_pending=bool(state.get("ack_pending", False)),
+        cooldown_seconds=remaining,
+    )
+
+
+def _is_retryable_replay_os_error(exc: OSError) -> bool:
+    return exc.errno in _REPLAY_RETRYABLE_ERRNOS
+
+
+def _remaining_segment_bytes(ordered_segments: Sequence[tuple[int, str, Path]], start_index: int) -> int:
+    total = 0
+    for _sequence, _name, path in ordered_segments[start_index:]:
+        try:
+            total += int(path.stat().st_size)
+        except OSError:
+            continue
+    return total
+
+
+def _replay_db_call(
+    session_db,
+    frame: SessionSpoolFrame,
+):
+    try:
+        return session_db.reconcile_bootstrap_and_append_messages_batch(
+            frame.record.bootstrap,
+            frame.record.batch_messages,
+            replay_patience_s=2.0,
+        )
+    except AppendMessagesBatchConflictError as exc:
+        raise SpoolBlockedReplayError(
+            "AppendMessagesBatchConflictError",
+            frame_offset=frame.frame_offset,
+        ) from exc
+    except CompressionSessionClosedError as exc:
+        raise SpoolBlockedReplayError(
+            "CompressionSessionClosedError",
+            frame_offset=frame.frame_offset,
+        ) from exc
+    except CompressionSessionBusyError as exc:
+        raise SpoolRetryableReplayError("compression_busy", ack_pending=False) from exc
+    except sqlite3.OperationalError as exc:
+        err = str(exc).lower()
+        if "locked" in err or "busy" in err:
+            raise SpoolRetryableReplayError(
+                "sqlite_locked_or_busy",
+                ack_pending=False,
+            ) from exc
+        raise
+
+
+@dataclass(frozen=True)
+class _ReplayOwnerLease:
+    fd: int
+    path: Path
 
 
 def _is_symlink(path: Path) -> bool:
@@ -629,6 +880,62 @@ def _payload_bytes_for_record(record: SessionSpoolRecord) -> bytes:
     if len(payload) > MAX_PAYLOAD_BYTES:
         raise SpoolFrameTooLargeError(len(payload), len(payload) + HEADER_SIZE)
     return payload
+
+
+def _record_from_payload_object(payload_obj: Mapping[str, Any]) -> SessionSpoolRecord:
+    session = payload_obj["session"]
+    canonical_failure = payload_obj["canonical_failure"]
+    unit = payload_obj["unit"]
+    batch_messages = tuple(
+        SessionDBBatchMessage(
+            persistence_unit_id=unit["persistence_unit_id"],
+            persistence_message_key=message["persistence_message_key"],
+            persistence_ordinal=message["persistence_ordinal"],
+            role=message["role"],
+            content=message["content"],
+            timestamp=message["timestamp"],
+            tool_name=message["tool_name"],
+            tool_calls=message["tool_calls"],
+            tool_call_id=message["tool_call_id"],
+            finish_reason=message["finish_reason"],
+            reasoning=message["reasoning"],
+            reasoning_content=message["reasoning_content"],
+            reasoning_details=message["reasoning_details"],
+            codex_reasoning_items=message["codex_reasoning_items"],
+            codex_message_items=message["codex_message_items"],
+            api_content=message["api_content"],
+            display_kind=message["display_kind"],
+            display_metadata=message["display_metadata"],
+        )
+        for message in unit["messages"]
+    )
+    return SessionSpoolRecord(
+        bootstrap=SessionSpoolBootstrap(
+            session_id=session["session_id"],
+            source=session["source"],
+            started_at=session["started_at"],
+            model=session["model"],
+            model_config=session["model_config"],
+            system_prompt=session["system_prompt"],
+            parent_session_id=session["parent_session_id"],
+            cwd=session["cwd"],
+            profile_name=session["profile_name"],
+            user_id=session["user_id"],
+            session_key=session["session_key"],
+            chat_id=session["chat_id"],
+            chat_type=session["chat_type"],
+            thread_id=session["thread_id"],
+        ),
+        persist_attempt_id=payload_obj["persist_attempt_id"],
+        persist_attempt_unit_index=payload_obj["persist_attempt_unit_index"],
+        canonical_failure={
+            "stage": canonical_failure["stage"],
+            "error_class": canonical_failure["error_class"],
+            "error_message": canonical_failure["error_message"],
+            "session_row_created": canonical_failure["session_row_created"],
+        },
+        batch_messages=batch_messages,
+    )
 
 
 def _frame_from_payload_bytes(
@@ -1109,6 +1416,134 @@ def scan_spool(
         os.close(fd)
 
 
+def decode_spool_segment(
+    path: Path,
+    *,
+    start_offset: int = 0,
+    max_file_bytes: int = TOTAL_CAP_BYTES,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
+) -> DecodedSegment:
+    if start_offset < 0:
+        raise SpoolDurabilityError(f"invalid decode offset for fallback spool segment: {start_offset}")
+    if not path.exists():
+        return DecodedSegment(
+            prefix_frames=(),
+            valid_prefix_bytes=0,
+            tail_status=SpoolTailStatus.CLEAN,
+            tail_offset=None,
+        )
+    _require_existing_file(path)
+    fd = os.open(str(path), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        file_size = os.fstat(fd).st_size
+        payload_cap = max_frame_bytes - HEADER_SIZE
+        budget = min(file_size, max_file_bytes if max_file_bytes > 0 else file_size)
+        offset = start_offset
+        frames: list[SessionSpoolFrame] = []
+        while offset < file_size:
+            if offset + HEADER_SIZE > budget:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+                    tail_offset=offset,
+                )
+            header = _read_exact_from_fd(fd, offset=offset, length=HEADER_SIZE)
+            if len(header) < HEADER_SIZE:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.INCOMPLETE_EOF,
+                    tail_offset=offset,
+                )
+            if header[:4] != HEADER_MAGIC:
+                tail_status = SpoolTailStatus.BAD_MAGIC
+            elif header[4] != FRAME_VERSION:
+                tail_status = SpoolTailStatus.BAD_VERSION
+            elif header[5] != RECORD_KIND_SESSION_PERSISTENCE_UNIT:
+                tail_status = SpoolTailStatus.BAD_RECORD_KIND
+            elif header[6:8] != b"\x00\x00":
+                tail_status = SpoolTailStatus.NONZERO_RESERVED
+            else:
+                tail_status = None
+            if tail_status is not None:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=tail_status,
+                    tail_offset=offset,
+                )
+            payload_len = int.from_bytes(header[8:16], "big")
+            if payload_len == 0 or payload_len > payload_cap:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.OVERSIZED_LENGTH,
+                    tail_offset=offset,
+                )
+            frame_length = HEADER_SIZE + payload_len
+            if offset + frame_length > budget:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+                    tail_offset=offset,
+                )
+            payload = _read_exact_from_fd(fd, offset=offset + HEADER_SIZE, length=payload_len)
+            if len(payload) < payload_len:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.INCOMPLETE_EOF,
+                    tail_offset=offset,
+                )
+            expected_digest = blake2s(header[4:16] + payload, digest_size=16).digest()
+            if header[16:32] != expected_digest:
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.CHECKSUM_MISMATCH,
+                    tail_offset=offset,
+                )
+            try:
+                payload_obj = json.loads(
+                    payload.decode("utf-8"),
+                    object_pairs_hook=_reject_duplicate_json_keys,
+                )
+            except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.INVALID_JSON,
+                    tail_offset=offset,
+                )
+            if not _validate_payload_schema(payload_obj):
+                return DecodedSegment(
+                    prefix_frames=tuple(frames),
+                    valid_prefix_bytes=offset,
+                    tail_status=SpoolTailStatus.INVALID_SCHEMA,
+                    tail_offset=offset,
+                )
+            frames.append(
+                SessionSpoolFrame(
+                    record=_record_from_payload_object(payload_obj),
+                    frame_offset=offset,
+                    frame_length=frame_length,
+                    payload_length=payload_len,
+                    checksum_hex=header[16:32].hex(),
+                )
+            )
+            offset += frame_length
+        return DecodedSegment(
+            prefix_frames=tuple(frames),
+            valid_prefix_bytes=offset,
+            tail_status=SpoolTailStatus.CLEAN,
+            tail_offset=None,
+        )
+    finally:
+        os.close(fd)
+
+
 def _iter_quarantine_entries(quarantine_dir: Path):
     if _CURRENT_QUARANTINE_DIR_FD is not None:
         return list(os.scandir(_CURRENT_QUARANTINE_DIR_FD))
@@ -1254,6 +1689,41 @@ def _write_sidecar_json(
     finally:
         if directory_fd is None:
             os.close(dir_fd)
+
+
+def _publish_bytes_file(path: Path, data: bytes, *, directory_fd: int) -> None:
+    temp_name = f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp"
+    fd = -1
+    try:
+        fd = os.open(
+            temp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            FILE_MODE,
+            dir_fd=directory_fd,
+        )
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, FILE_MODE)
+        _write_all(fd, data)
+        _fsync_fd(fd)
+        os.close(fd)
+        fd = -1
+        try:
+            os.link(temp_name, path.name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd, follow_symlinks=False)
+        except FileExistsError as exc:
+            raise SpoolPathSecurityError(
+                f"fallback spool destination already exists or was swapped: {path}"
+            ) from exc
+        _fsync_directory_fd(directory_fd, path.parent)
+        os.unlink(temp_name, dir_fd=directory_fd)
+        _fsync_directory_fd(directory_fd, path.parent)
+    except BaseException:
+        if fd >= 0:
+            _close_fd_quietly(fd)
+        try:
+            os.unlink(temp_name, dir_fd=directory_fd)
+        except OSError:
+            pass
+        raise
 
 
 def _reconcile_missing_sidecars(quarantine_dir: Path, *, quarantine_fd: int) -> None:
@@ -1483,6 +1953,2205 @@ def _open_locked_runtime() -> _AnchoredRuntime:
         raise
 
 
+def _try_lock_fd_nonblocking(fd: int, label: str) -> bool:
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt is not None:  # pragma: no cover - Windows-only branch
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:  # pragma: no cover - unsupported platform
+            raise SpoolDurabilityError("no secure file-locking primitive available")
+        return True
+    except BlockingIOError:
+        return False
+    except OSError as exc:
+        if _is_lock_contention_error(exc):
+            return False
+        raise SpoolDurabilityError(
+            f"unexpected fallback spool lock failure for {label}: {exc}"
+        ) from exc
+
+
+def _try_acquire_replay_owner(runtime: _AnchoredRuntime) -> _ReplayOwnerLease | None:
+    owner_fd = -1
+    try:
+        owner_fd, _ = _open_file_at(
+            runtime.root_fd,
+            REPLAY_OWNER_LOCK_NAME,
+            full_path=_owner_lock_path(),
+            mode=FILE_MODE,
+            create=True,
+            fsync_parent_on_create=True,
+            fsync_file_on_create=False,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        if not _try_lock_fd_nonblocking(owner_fd, str(_owner_lock_path())):
+            os.close(owner_fd)
+            return None
+        return _ReplayOwnerLease(fd=owner_fd, path=_owner_lock_path())
+    except BaseException:
+        if owner_fd >= 0:
+            _close_fd_quietly(owner_fd)
+        raise
+
+
+def _read_segment_highwater(*, runtime: _AnchoredRuntime, root_fd: int) -> int | None:
+    try:
+        highwater_fd, _ = _open_file_at(
+            root_fd,
+            HIGHWATER_FILE_NAME,
+            full_path=_segment_sequence_highwater_path(),
+            mode=FILE_MODE,
+            create=False,
+            fsync_parent_on_create=False,
+            fsync_file_on_create=False,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=False,
+        )
+    except SpoolDurabilityError as exc:
+        if "missing" in str(exc):
+            return None
+        raise
+    try:
+        raw = _read_exact_from_fd(highwater_fd, offset=0, length=os.fstat(highwater_fd).st_size)
+    finally:
+        os.close(highwater_fd)
+    return _parse_highwater_payload_bytes(
+        raw,
+        label=_segment_sequence_highwater_path(),
+    )
+
+
+def _parse_highwater_payload_bytes(raw: bytes, *, label: Path | str) -> int:
+    try:
+        payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError) as exc:
+        raise SpoolDurabilityError(
+            f"invalid fallback spool segment high-water file: {label}"
+        ) from exc
+    if set(payload.keys()) != {"last_reserved_sequence", "schema_version"}:
+        raise SpoolDurabilityError(
+            f"invalid fallback spool segment high-water schema: {label}"
+        )
+    if payload.get("schema_version") != 1:
+        raise SpoolDurabilityError(
+            f"unsupported fallback spool segment high-water version: {label}"
+        )
+    encoded = payload.get("last_reserved_sequence")
+    if not isinstance(encoded, str) or not re.fullmatch(r"\d{20}", encoded):
+        raise SpoolDurabilityError(
+            f"invalid fallback spool segment high-water sequence: {label}"
+        )
+    return int(encoded)
+
+
+def _write_segment_highwater(
+    last_reserved_sequence: int,
+    *,
+    runtime: _AnchoredRuntime,
+    root_fd: int,
+) -> None:
+    if last_reserved_sequence < 0 or last_reserved_sequence > MAX_SEGMENT_SEQUENCE:
+        raise SpoolDurabilityError(
+            f"invalid fallback spool segment sequence reservation: {last_reserved_sequence}"
+        )
+    temp_name = f".{HIGHWATER_FILE_NAME}.{os.getpid()}.{time.time_ns()}.tmp"
+    fd = -1
+    try:
+        fd = os.open(
+            temp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            FILE_MODE,
+            dir_fd=root_fd,
+        )
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, FILE_MODE)
+        data = json.dumps(
+            {
+                "last_reserved_sequence": _format_segment_sequence(last_reserved_sequence),
+                "schema_version": 1,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        _write_all(fd, data)
+        _fsync_fd(fd)
+        os.close(fd)
+        fd = -1
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(
+            runtime.home_fd,
+            SPOOL_ROOT_NAME,
+            root_fd,
+            expect="dir",
+            label=str(runtime.root_path),
+        )
+        os.replace(temp_name, HIGHWATER_FILE_NAME, src_dir_fd=root_fd, dst_dir_fd=root_fd)
+        _fsync_directory_fd(root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+    except BaseException:
+        if fd >= 0:
+            _close_fd_quietly(fd)
+        try:
+            os.unlink(temp_name, dir_fd=root_fd)
+        except OSError:
+            pass
+        raise
+
+
+def _sealed_segment_sequences() -> list[int]:
+    sealed_dir = _sealed_dir()
+    if not sealed_dir.exists():
+        return []
+    _require_existing_dir(sealed_dir)
+    sequences: list[int] = []
+    for path in sealed_dir.iterdir():
+        name = path.name
+        if name in {ACKS_DIR_NAME, BLOCKERS_DIR_NAME}:
+            continue
+        match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool", name)
+        if match:
+            sequences.append(int(match.group(1)))
+            continue
+        if name.startswith("."):
+            continue
+        raise SpoolDurabilityError(f"unrecognized sealed segment artifact: {path}")
+    return sequences
+
+
+def _parse_sealed_segment_sequence(name: str) -> int | None:
+    match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool", name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _parse_ack_sidecar_sequence(name: str) -> int | None:
+    match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool\.ap\d{20}\.json", name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _parse_blocker_sequence(name: str) -> int | None:
+    match = re.fullmatch(r"(\d{20})\.blocker\.json", name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _parse_replay_quarantine_sequence(name: str) -> int | None:
+    match = re.fullmatch(r"seq-(\d{20})-[a-z0-9_]+-vp\d+\.(?:spool|json)", name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _is_legacy_quarantine_name(name: str) -> bool:
+    return bool(re.fullmatch(r"\d{6}-[A-Za-z0-9_]+-vp\d+\.(?:spool|json)", name))
+
+
+def _parse_protocol_temp_sequence(
+    name: str,
+    *,
+    dir_fd: int,
+    label: Path | str,
+) -> int | None:
+    match = re.fullmatch(r"\.(.+)\.\d+\.\d+\.tmp", name)
+    if not match:
+        return None
+    inner_name = match.group(1)
+    if inner_name == HIGHWATER_FILE_NAME:
+        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+        try:
+            raw = _read_exact_from_fd(fd, offset=0, length=os.fstat(fd).st_size)
+        finally:
+            os.close(fd)
+        return _parse_highwater_payload_bytes(raw, label=label)
+    for parser in (
+        _parse_sealed_segment_sequence,
+        _parse_ack_sidecar_sequence,
+        _parse_blocker_sequence,
+        _parse_replay_quarantine_sequence,
+    ):
+        parsed = parser(inner_name)
+        if parsed is not None:
+            return parsed
+    raise SpoolDurabilityError(f"unrecognized protocol temp artifact: {label}")
+
+
+def _open_dir_optional(parent_fd: int, name: str, *, full_path: Path) -> int | None:
+    try:
+        fd = os.open(name, _dir_open_flags(), dir_fd=parent_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise SpoolPathSecurityError(
+                f"symlinked fallback spool directory refused: {full_path}"
+            ) from exc
+        raise SpoolDurabilityError(
+            f"unable to open fallback spool directory {full_path}: {exc}"
+        ) from exc
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISDIR(st.st_mode):
+            raise SpoolPathSecurityError(f"fallback spool path is not a directory: {full_path}")
+        if name != ".":
+            _assert_entry_matches_fd(parent_fd, name, fd, expect="dir", label=str(full_path))
+    except BaseException:
+        _close_fd_quietly(fd)
+        raise
+    return fd
+
+
+def _collect_sequences_from_directory(
+    *,
+    dir_fd: int,
+    dir_path: Path,
+    parsers: tuple,
+    allowed_dirs: set[str],
+    legacy_quarantine_ok: bool = False,
+    sealed_error_label: bool = False,
+    byte_accumulator: list[int] | None = None,
+) -> list[int]:
+    sequences: list[int] = []
+    for entry in os.scandir(dir_fd):
+        if entry.is_symlink():
+            raise SpoolPathSecurityError(f"symlinked fallback spool path refused: {dir_path / entry.name}")
+        entry_stat = entry.stat(follow_symlinks=False)
+        if stat.S_ISDIR(entry_stat.st_mode):
+            if entry.name in allowed_dirs:
+                continue
+            raise SpoolPathSecurityError(
+                f"unexpected fallback spool directory encountered during sequence inventory: {dir_path / entry.name}"
+            )
+        if not stat.S_ISREG(entry_stat.st_mode):
+            raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {dir_path / entry.name}")
+        for parser in parsers:
+            parsed = parser(entry.name)
+            if parsed is not None:
+                sequences.append(parsed)
+                if byte_accumulator is not None:
+                    byte_accumulator[0] += entry_stat.st_size
+                break
+        else:
+            temp_parsed = _parse_protocol_temp_sequence(
+                entry.name,
+                dir_fd=dir_fd,
+                label=dir_path / entry.name,
+            )
+            if temp_parsed is not None:
+                sequences.append(temp_parsed)
+            elif legacy_quarantine_ok and _is_legacy_quarantine_name(entry.name):
+                if byte_accumulator is not None:
+                    byte_accumulator[0] += entry_stat.st_size
+                continue
+            elif sealed_error_label:
+                raise SpoolDurabilityError(f"unrecognized sealed segment artifact: {dir_path / entry.name}")
+            else:
+                raise SpoolDurabilityError(f"unrecognized sequence-bearing artifact: {dir_path / entry.name}")
+    return sequences
+
+
+def _durable_capacity_inventory(
+    runtime: _AnchoredRuntime,
+    root_fd: int,
+) -> _DurableCapacityInventory:
+    quarantine_bytes = [0]
+    other_artifact_bytes = [0]
+    sealed_fd: int | None = None
+    acks_fd: int | None = None
+    blockers_fd: int | None = None
+    quarantine_fd: int | None = None
+    try:
+        for entry in os.scandir(root_fd):
+            label = runtime.root_path / entry.name
+            if entry.is_symlink():
+                raise SpoolPathSecurityError(f"symlinked fallback spool path refused: {label}")
+            entry_stat = entry.stat(follow_symlinks=False)
+            if stat.S_ISDIR(entry_stat.st_mode):
+                if entry.name in {SEALED_DIR_NAME, QUARANTINE_DIR_NAME}:
+                    continue
+                raise SpoolPathSecurityError(
+                    f"unexpected fallback spool directory encountered during sequence inventory: {label}"
+                )
+            if not stat.S_ISREG(entry_stat.st_mode):
+                raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {label}")
+            if entry.name in {ACTIVE_SPOOL_NAME, LOCK_FILE_NAME, REPLAY_OWNER_LOCK_NAME}:
+                continue
+            if entry.name == HIGHWATER_FILE_NAME:
+                other_artifact_bytes[0] += entry_stat.st_size
+                continue
+            if entry.name.startswith("."):
+                temp_parsed = _parse_protocol_temp_sequence(
+                    entry.name,
+                    dir_fd=root_fd,
+                    label=label,
+                )
+                if temp_parsed is not None:
+                    continue
+            raise SpoolDurabilityError(f"unrecognized sequence-bearing artifact: {label}")
+
+        sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+        if sealed_fd is not None:
+            _collect_sequences_from_directory(
+                dir_fd=sealed_fd,
+                dir_path=_sealed_dir(),
+                parsers=(_parse_sealed_segment_sequence,),
+                allowed_dirs={ACKS_DIR_NAME, BLOCKERS_DIR_NAME},
+                sealed_error_label=True,
+                byte_accumulator=other_artifact_bytes,
+            )
+
+            acks_fd = _open_dir_optional(sealed_fd, ACKS_DIR_NAME, full_path=_acks_dir())
+            if acks_fd is not None:
+                _collect_sequences_from_directory(
+                    dir_fd=acks_fd,
+                    dir_path=_acks_dir(),
+                    parsers=(_parse_ack_sidecar_sequence,),
+                    allowed_dirs=set(),
+                    byte_accumulator=other_artifact_bytes,
+                )
+
+            blockers_fd = _open_dir_optional(sealed_fd, BLOCKERS_DIR_NAME, full_path=_blockers_dir())
+            if blockers_fd is not None:
+                _collect_sequences_from_directory(
+                    dir_fd=blockers_fd,
+                    dir_path=_blockers_dir(),
+                    parsers=(_parse_blocker_sequence,),
+                    allowed_dirs=set(),
+                    byte_accumulator=other_artifact_bytes,
+                )
+
+        quarantine_fd = _open_dir_optional(root_fd, QUARANTINE_DIR_NAME, full_path=_quarantine_dir())
+        if quarantine_fd is not None:
+            _collect_sequences_from_directory(
+                dir_fd=quarantine_fd,
+                dir_path=_quarantine_dir(),
+                parsers=(_parse_replay_quarantine_sequence,),
+                allowed_dirs=set(),
+                legacy_quarantine_ok=True,
+                byte_accumulator=quarantine_bytes,
+            )
+
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(
+            runtime.home_fd,
+            SPOOL_ROOT_NAME,
+            root_fd,
+            expect="dir",
+            label=str(runtime.root_path),
+        )
+        if sealed_fd is not None:
+            _assert_entry_matches_fd(root_fd, SEALED_DIR_NAME, sealed_fd, expect="dir", label=str(_sealed_dir()))
+        if acks_fd is not None:
+            assert sealed_fd is not None
+            _assert_entry_matches_fd(sealed_fd, ACKS_DIR_NAME, acks_fd, expect="dir", label=str(_acks_dir()))
+        if blockers_fd is not None:
+            assert sealed_fd is not None
+            _assert_entry_matches_fd(
+                sealed_fd,
+                BLOCKERS_DIR_NAME,
+                blockers_fd,
+                expect="dir",
+                label=str(_blockers_dir()),
+            )
+        if quarantine_fd is not None:
+            _assert_entry_matches_fd(
+                root_fd,
+                QUARANTINE_DIR_NAME,
+                quarantine_fd,
+                expect="dir",
+                label=str(_quarantine_dir()),
+            )
+        return _DurableCapacityInventory(
+            quarantine_bytes=quarantine_bytes[0],
+            other_artifact_bytes=other_artifact_bytes[0],
+        )
+    finally:
+        if quarantine_fd is not None:
+            _close_fd_quietly(quarantine_fd)
+        if blockers_fd is not None:
+            _close_fd_quietly(blockers_fd)
+        if acks_fd is not None:
+            _close_fd_quietly(acks_fd)
+        if sealed_fd is not None:
+            _close_fd_quietly(sealed_fd)
+
+
+def _collect_sequence_inventory(*, runtime: _AnchoredRuntime, root_fd: int) -> list[int]:
+    sequences: list[int] = []
+    highwater = _read_segment_highwater(runtime=runtime, root_fd=root_fd)
+    if highwater is not None:
+        sequences.append(highwater)
+
+    for entry in os.scandir(root_fd):
+        if entry.name in {
+            ACTIVE_SPOOL_NAME,
+            LOCK_FILE_NAME,
+            REPLAY_OWNER_LOCK_NAME,
+            QUARANTINE_DIR_NAME,
+            SEALED_DIR_NAME,
+            HIGHWATER_FILE_NAME,
+        }:
+            continue
+        if entry.name.startswith("."):
+            temp_parsed = _parse_protocol_temp_sequence(
+                entry.name,
+                dir_fd=root_fd,
+                label=runtime.root_path / entry.name,
+            )
+            if temp_parsed is not None:
+                sequences.append(temp_parsed)
+
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return sequences
+    try:
+        sequences.extend(
+            _collect_sequences_from_directory(
+                dir_fd=sealed_fd,
+                dir_path=_sealed_dir(),
+                parsers=(_parse_sealed_segment_sequence,),
+                allowed_dirs={ACKS_DIR_NAME, BLOCKERS_DIR_NAME},
+                sealed_error_label=True,
+            )
+        )
+
+        acks_fd = _open_dir_optional(sealed_fd, ACKS_DIR_NAME, full_path=_acks_dir())
+        if acks_fd is not None:
+            try:
+                sequences.extend(
+                    _collect_sequences_from_directory(
+                        dir_fd=acks_fd,
+                        dir_path=_acks_dir(),
+                        parsers=(_parse_ack_sidecar_sequence,),
+                        allowed_dirs=set(),
+                    )
+                )
+            finally:
+                _close_fd_quietly(acks_fd)
+
+        blockers_fd = _open_dir_optional(sealed_fd, BLOCKERS_DIR_NAME, full_path=_blockers_dir())
+        if blockers_fd is not None:
+            try:
+                sequences.extend(
+                    _collect_sequences_from_directory(
+                        dir_fd=blockers_fd,
+                        dir_path=_blockers_dir(),
+                        parsers=(_parse_blocker_sequence,),
+                        allowed_dirs=set(),
+                    )
+                )
+            finally:
+                _close_fd_quietly(blockers_fd)
+    finally:
+        _close_fd_quietly(sealed_fd)
+
+    quarantine_fd = _open_dir_optional(root_fd, QUARANTINE_DIR_NAME, full_path=_quarantine_dir())
+    if quarantine_fd is not None:
+        try:
+            sequences.extend(
+                _collect_sequences_from_directory(
+                    dir_fd=quarantine_fd,
+                    dir_path=_quarantine_dir(),
+                    parsers=(_parse_replay_quarantine_sequence,),
+                    allowed_dirs=set(),
+                    legacy_quarantine_ok=True,
+                )
+            )
+        finally:
+            _close_fd_quietly(quarantine_fd)
+
+    return sequences
+
+
+def _allocate_next_segment_sequence(*, runtime: _AnchoredRuntime, root_fd: int) -> int:
+    baseline = max(_collect_sequence_inventory(runtime=runtime, root_fd=root_fd), default=0)
+    if baseline >= MAX_SEGMENT_SEQUENCE:
+        raise SpoolDurabilityError("segment_sequence_overflow")
+    candidate = baseline + 1
+    _write_segment_highwater(candidate, runtime=runtime, root_fd=root_fd)
+    return candidate
+
+
+def _ordered_segment_paths() -> list[tuple[int, Path]]:
+    sealed_dir = _sealed_dir()
+    if not sealed_dir.exists():
+        return []
+    _require_existing_dir(sealed_dir)
+    segments: list[tuple[int, Path]] = []
+    for path in sealed_dir.iterdir():
+        match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool", path.name)
+        if not match:
+            continue
+        _require_existing_file(path)
+        segments.append((int(match.group(1)), path))
+    return sorted(segments, key=lambda item: (item[0], item[1].name))
+
+
+def _ack_path_for_segment(segment_path: Path, acked_prefix_bytes: int) -> Path:
+    return _acks_dir() / (
+        f"{segment_path.name}.ap{_format_segment_sequence(acked_prefix_bytes)}.json"
+    )
+
+
+def _canonical_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _parse_ack_sidecar_name(name: str) -> tuple[int, str, int] | None:
+    match = re.fullmatch(r"(\d{20}(?:\.prefix)?\.spool)\.ap(\d{20})\.json", name)
+    if not match:
+        return None
+    segment_name = match.group(1)
+    sequence_match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool", segment_name)
+    if sequence_match is None:
+        return None
+    return int(sequence_match.group(1)), segment_name, int(match.group(2))
+
+
+def _open_acks_dir(runtime: _AnchoredRuntime, *, create: bool) -> tuple[int, int]:
+    sealed_fd = _open_dir_at(
+        runtime.root_fd,
+        SEALED_DIR_NAME,
+        full_path=_sealed_dir(),
+        mode=ROOT_MODE,
+        create=True,
+        parent_label=runtime.root_path,
+        fsync_parent_on_open_existing=True,
+    )[0]
+    try:
+        acks_fd = _open_dir_at(
+            sealed_fd,
+            ACKS_DIR_NAME,
+            full_path=_acks_dir(),
+            mode=ROOT_MODE,
+            create=create,
+            parent_label=_sealed_dir(),
+            fsync_parent_on_open_existing=True,
+        )[0]
+    except BaseException:
+        _close_fd_quietly(sealed_fd)
+        raise
+    return sealed_fd, acks_fd
+
+
+def _load_segment_stat_for_ack(runtime: _AnchoredRuntime, segment_name: str) -> tuple[int, int, int]:
+    sealed_fd = -1
+    segment_fd = -1
+    try:
+        sealed_fd = _open_dir_at(
+            runtime.root_fd,
+            SEALED_DIR_NAME,
+            full_path=_sealed_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )[0]
+        segment_fd = os.open(segment_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=sealed_fd)
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(runtime.home_fd, SPOOL_ROOT_NAME, runtime.root_fd, expect="dir", label=str(runtime.root_path))
+        _assert_entry_matches_fd(runtime.root_fd, SEALED_DIR_NAME, sealed_fd, expect="dir", label=str(_sealed_dir()))
+        _assert_entry_matches_fd(sealed_fd, segment_name, segment_fd, expect="file", label=str(_sealed_dir() / segment_name))
+        st = os.fstat(segment_fd)
+        return sealed_fd, segment_fd, int(st.st_size)
+    except BaseException:
+        if segment_fd >= 0:
+            _close_fd_quietly(segment_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+        raise
+
+
+def _validate_ack_payload(
+    *,
+    raw_bytes: bytes,
+    payload: Mapping[str, Any],
+    ack_name: str,
+    expected_segment_name: str,
+    segment_size_bytes: int,
+) -> Mapping[str, Any]:
+    required_fields = {
+        "schema_version",
+        "segment_sequence",
+        "segment_name",
+        "segment_kind",
+        "segment_size_bytes",
+        "acked_prefix_bytes",
+        "valid_prefix_bytes",
+        "tail_status",
+        "last_frame_offset",
+        "last_frame_length",
+        "last_frame_checksum_hex",
+    }
+    if set(payload.keys()) != required_fields:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    if payload.get("schema_version") != 1:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    parsed_name = _parse_ack_sidecar_name(ack_name)
+    if parsed_name is None:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    sequence, segment_name, acked_prefix_from_name = parsed_name
+    if payload.get("segment_sequence") != _format_segment_sequence(sequence):
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    if payload.get("segment_name") != expected_segment_name or segment_name != expected_segment_name:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    segment_kind = payload.get("segment_kind")
+    expected_kind = "prefix" if expected_segment_name.endswith(".prefix.spool") else "clean"
+    if segment_kind != expected_kind:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    if payload.get("segment_size_bytes") != segment_size_bytes:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    acked_prefix_bytes = payload.get("acked_prefix_bytes")
+    valid_prefix_bytes = payload.get("valid_prefix_bytes")
+    last_frame_offset = payload.get("last_frame_offset")
+    last_frame_length = payload.get("last_frame_length")
+    if not all(isinstance(v, int) and not isinstance(v, bool) for v in (acked_prefix_bytes, valid_prefix_bytes, last_frame_offset, last_frame_length)):
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    if acked_prefix_bytes <= 0 or acked_prefix_bytes != acked_prefix_from_name:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    if valid_prefix_bytes < acked_prefix_bytes or valid_prefix_bytes > segment_size_bytes:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    if last_frame_offset + last_frame_length != acked_prefix_bytes:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    checksum_hex = payload.get("last_frame_checksum_hex")
+    if not isinstance(checksum_hex, str) or not re.fullmatch(r"[0-9a-f]{32}", checksum_hex):
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    canonical_bytes = _canonical_json_bytes(payload)
+    if canonical_bytes != raw_bytes:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {ack_name}")
+    return payload
+
+
+def _load_ack_payload_from_fd(
+    *,
+    dir_fd: int,
+    entry_name: str,
+    expected_segment_name: str,
+    segment_size_bytes: int,
+) -> tuple[int, Mapping[str, Any]]:
+    parsed = _parse_ack_sidecar_name(entry_name)
+    if parsed is None:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    _sequence, entry_segment_name, acked_prefix = parsed
+    if entry_segment_name != expected_segment_name:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    fd = os.open(entry_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    try:
+        raw = _read_exact_from_fd(fd, offset=0, length=os.fstat(fd).st_size)
+    finally:
+        os.close(fd)
+    try:
+        payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    validated = _validate_ack_payload(
+        raw_bytes=raw,
+        payload=payload,
+        ack_name=entry_name,
+        expected_segment_name=expected_segment_name,
+        segment_size_bytes=segment_size_bytes,
+    )
+    return acked_prefix, validated
+
+
+def _cleanup_stale_lower_ack_sidecars(
+    *,
+    acks_fd: int,
+    segment_name: str,
+    keep_acked_prefix: int,
+) -> None:
+    removed_any = False
+    for entry in os.scandir(acks_fd):
+        parsed = _parse_ack_sidecar_name(entry.name)
+        if parsed is None:
+            continue
+        _sequence, entry_segment_name, acked_prefix = parsed
+        if entry_segment_name != segment_name or acked_prefix >= keep_acked_prefix:
+            continue
+        os.unlink(entry.name, dir_fd=acks_fd)
+        removed_any = True
+    if removed_any:
+        _fsync_directory_fd(acks_fd, _acks_dir())
+
+
+def _classify_ack_tombstones(*, runtime: _AnchoredRuntime, root_fd: int) -> tuple[set[int], int | None]:
+    sealed_fd = -1
+    acks_fd = -1
+    try:
+        sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+        existing_segments: set[str] = set()
+        if sealed_fd is not None:
+            for entry in os.scandir(sealed_fd):
+                if entry.is_symlink():
+                    raise SpoolPathSecurityError(
+                        f"symlinked fallback spool path refused: {_sealed_dir() / entry.name}"
+                    )
+                match = re.fullmatch(r"\d{20}(?:\.prefix)?\.spool", entry.name)
+                if match:
+                    st = entry.stat(follow_symlinks=False)
+                    if not stat.S_ISREG(st.st_mode):
+                        raise SpoolPathSecurityError(
+                            f"fallback spool path is not a regular file: {_sealed_dir() / entry.name}"
+                        )
+                    existing_segments.add(entry.name)
+            acks_fd = _open_dir_optional(sealed_fd, ACKS_DIR_NAME, full_path=_acks_dir())
+        if acks_fd is None:
+            return set(), None
+        tombstones: set[int] = set()
+        blocked_seq: int | None = None
+        for entry in os.scandir(acks_fd):
+            if entry.is_symlink():
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            st = entry.stat(follow_symlinks=False)
+            if not stat.S_ISREG(st.st_mode):
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            if st.st_size > 2048:
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            parsed = _parse_ack_sidecar_name(entry.name)
+            if parsed is None:
+                continue
+            sequence, segment_name, _acked = parsed
+            if segment_name in existing_segments:
+                continue
+            fd = os.open(entry.name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=acks_fd)
+            try:
+                raw = _read_exact_from_fd(fd, offset=0, length=os.fstat(fd).st_size)
+            finally:
+                os.close(fd)
+            try:
+                payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
+            except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            segment_size_bytes = payload.get("segment_size_bytes")
+            if isinstance(segment_size_bytes, bool) or not isinstance(segment_size_bytes, int):
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            validated = _validate_ack_payload(
+                raw_bytes=raw,
+                payload=payload,
+                ack_name=entry.name,
+                expected_segment_name=segment_name,
+                segment_size_bytes=segment_size_bytes,
+            )
+            acked_prefix = int(validated["acked_prefix_bytes"])
+            valid_prefix = int(validated["valid_prefix_bytes"])
+            if acked_prefix == valid_prefix:
+                tombstones.add(sequence)
+            else:
+                blocked_seq = sequence if blocked_seq is None else min(blocked_seq, sequence)
+        return tombstones, blocked_seq
+    finally:
+        if acks_fd is not None and acks_fd >= 0:
+            _close_fd_quietly(acks_fd)
+        if sealed_fd is not None and sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+
+
+def _load_ack_sidecar_winner(runtime: _AnchoredRuntime, *, segment_path: Path) -> Mapping[str, Any] | None:
+    sealed_fd = -1
+    segment_fd = -1
+    acks_fd = -1
+    try:
+        sealed_fd, segment_fd, segment_size_bytes = _load_segment_stat_for_ack(runtime, segment_path.name)
+        _, acks_fd = _open_acks_dir(runtime, create=True)
+        matching_entries: list[tuple[int, Mapping[str, Any]]] = []
+        count = 0
+        for entry in os.scandir(acks_fd):
+            if entry.is_symlink():
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            st = entry.stat(follow_symlinks=False)
+            if not stat.S_ISREG(st.st_mode):
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            if st.st_size > 2048:
+                raise SpoolDurabilityError(f"invalid ack sidecar: {entry.name}")
+            parsed = _parse_ack_sidecar_name(entry.name)
+            if parsed is None:
+                continue
+            _sequence, entry_segment_name, acked_prefix = parsed
+            if entry_segment_name != segment_path.name:
+                continue
+            count += 1
+            if count > 64:
+                raise SpoolDurabilityError("too many ack sidecars")
+            _acked_prefix, validated = _load_ack_payload_from_fd(
+                dir_fd=acks_fd,
+                entry_name=entry.name,
+                expected_segment_name=segment_path.name,
+                segment_size_bytes=segment_size_bytes,
+            )
+            matching_entries.append((acked_prefix, validated))
+        if not matching_entries:
+            return None
+        matching_entries.sort(key=lambda item: item[0])
+        return matching_entries[-1][1]
+    finally:
+        if acks_fd >= 0:
+            _close_fd_quietly(acks_fd)
+        if segment_fd >= 0:
+            _close_fd_quietly(segment_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+
+
+def _publish_ack_sidecar_strict(
+    runtime: _AnchoredRuntime,
+    *,
+    segment_sequence: int,
+    segment_path: Path,
+    ack_payload: Mapping[str, Any],
+) -> None:
+    sealed_fd = -1
+    segment_fd = -1
+    acks_fd = -1
+    try:
+        sealed_fd, segment_fd, segment_size_bytes = _load_segment_stat_for_ack(runtime, segment_path.name)
+        _, acks_fd = _open_acks_dir(runtime, create=True)
+        ack_name = f"{segment_path.name}.ap{_format_segment_sequence(int(ack_payload['acked_prefix_bytes']))}.json"
+        raw_bytes = _canonical_json_bytes(ack_payload)
+        _validate_ack_payload(
+            raw_bytes=raw_bytes,
+            payload=ack_payload,
+            ack_name=ack_name,
+            expected_segment_name=segment_path.name,
+            segment_size_bytes=segment_size_bytes,
+        )
+        temp_name = f".{ack_name}.{os.getpid()}.{time.time_ns()}.tmp"
+        fd = -1
+        try:
+            fd = os.open(
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                FILE_MODE,
+                dir_fd=acks_fd,
+            )
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, FILE_MODE)
+            _write_all(fd, raw_bytes)
+            _fsync_fd(fd)
+            os.close(fd)
+            fd = -1
+            try:
+                os.link(temp_name, ack_name, src_dir_fd=acks_fd, dst_dir_fd=acks_fd, follow_symlinks=False)
+            except FileExistsError:
+                existing_fd = os.open(ack_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=acks_fd)
+                try:
+                    existing_bytes = _read_exact_from_fd(existing_fd, offset=0, length=os.fstat(existing_fd).st_size)
+                finally:
+                    os.close(existing_fd)
+                if existing_bytes != raw_bytes:
+                    raise SpoolDurabilityError(f"conflicting ack sidecar already exists: {_acks_dir() / ack_name}")
+                os.unlink(temp_name, dir_fd=acks_fd)
+                try:
+                    _cleanup_stale_lower_ack_sidecars(
+                        acks_fd=acks_fd,
+                        segment_name=segment_path.name,
+                        keep_acked_prefix=int(ack_payload["acked_prefix_bytes"]),
+                    )
+                except OSError as exc:
+                    if _is_retryable_replay_os_error(exc):
+                        raise SpoolRetryableReplayError(
+                            "ack_cleanup_busy",
+                            ack_pending=True,
+                        ) from exc
+                    raise
+                return
+            _fsync_directory_fd(acks_fd, _acks_dir())
+            os.unlink(temp_name, dir_fd=acks_fd)
+            _fsync_directory_fd(acks_fd, _acks_dir())
+            try:
+                _cleanup_stale_lower_ack_sidecars(
+                    acks_fd=acks_fd,
+                    segment_name=segment_path.name,
+                    keep_acked_prefix=int(ack_payload["acked_prefix_bytes"]),
+                )
+            except OSError as exc:
+                if _is_retryable_replay_os_error(exc):
+                    raise SpoolRetryableReplayError(
+                        "ack_cleanup_busy",
+                        ack_pending=True,
+                    ) from exc
+                raise
+        except BaseException:
+            if fd >= 0:
+                _close_fd_quietly(fd)
+            try:
+                os.unlink(temp_name, dir_fd=acks_fd)
+            except OSError:
+                pass
+            raise
+    finally:
+        if acks_fd >= 0:
+            _close_fd_quietly(acks_fd)
+        if segment_fd >= 0:
+            _close_fd_quietly(segment_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+
+
+def _publish_ack_sidecar(
+    runtime: _AnchoredRuntime,
+    *,
+    segment_sequence: int,
+    segment_path: Path,
+    decoded_segment: DecodedSegment,
+    frame: SessionSpoolFrame,
+) -> bool:
+    acked_prefix_bytes = frame.frame_offset + frame.frame_length
+    payload = {
+        "schema_version": 1,
+        "segment_sequence": _format_segment_sequence(segment_sequence),
+        "segment_name": segment_path.name,
+        "segment_kind": "prefix" if segment_path.name.endswith(".prefix.spool") else "clean",
+        "segment_size_bytes": int(decoded_segment.valid_prefix_bytes),
+        "acked_prefix_bytes": acked_prefix_bytes,
+        "valid_prefix_bytes": decoded_segment.valid_prefix_bytes,
+        "tail_status": decoded_segment.tail_status.value,
+        "last_frame_offset": frame.frame_offset,
+        "last_frame_length": frame.frame_length,
+        "last_frame_checksum_hex": frame.checksum_hex,
+    }
+    _publish_ack_sidecar_strict(
+        runtime,
+        segment_sequence=segment_sequence,
+        segment_path=segment_path,
+        ack_payload=payload,
+    )
+    return True
+
+
+def _delete_fully_acked_segment(segment_path: Path) -> None:
+    runtime = _open_locked_runtime()
+    sealed_fd = -1
+    acks_fd = -1
+    try:
+        sealed_fd = _open_dir_at(
+            runtime.root_fd,
+            SEALED_DIR_NAME,
+            full_path=_sealed_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )[0]
+        acks_fd = _open_dir_at(
+            sealed_fd,
+            ACKS_DIR_NAME,
+            full_path=_acks_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=_sealed_dir(),
+            fsync_parent_on_open_existing=True,
+        )[0]
+        try:
+            os.unlink(segment_path.name, dir_fd=sealed_fd)
+        except FileNotFoundError:
+            pass
+        _fsync_directory_fd(sealed_fd, _sealed_dir())
+        removed_any = False
+        for entry in os.scandir(acks_fd):
+            parsed = _parse_ack_sidecar_name(entry.name)
+            if parsed is None:
+                continue
+            _sequence, entry_segment_name, _acked = parsed
+            if entry_segment_name != segment_path.name:
+                continue
+            os.unlink(entry.name, dir_fd=acks_fd)
+            removed_any = True
+        if removed_any:
+            _fsync_directory_fd(acks_fd, _acks_dir())
+    finally:
+        if acks_fd >= 0:
+            _close_fd_quietly(acks_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+        _close_fd_quietly(runtime.lock_fd)
+        _close_fd_quietly(runtime.root_fd)
+        _close_fd_quietly(runtime.home_fd)
+
+
+def _ordered_segment_entries(*, runtime: _AnchoredRuntime, root_fd: int) -> list[tuple[int, str, Path]]:
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return []
+    try:
+        entries: list[tuple[int, str, Path]] = []
+        for entry in os.scandir(sealed_fd):
+            if entry.is_symlink():
+                raise SpoolPathSecurityError(
+                    f"symlinked fallback spool path refused: {_sealed_dir() / entry.name}"
+                )
+            match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool", entry.name)
+            if not match:
+                continue
+            st = entry.stat(follow_symlinks=False)
+            if not stat.S_ISREG(st.st_mode):
+                raise SpoolPathSecurityError(
+                    f"fallback spool path is not a regular file: {_sealed_dir() / entry.name}"
+                )
+            entries.append((int(match.group(1)), entry.name, _sealed_dir() / entry.name))
+        return sorted(entries, key=lambda item: (item[0], item[1]))
+    finally:
+        _close_fd_quietly(sealed_fd)
+
+
+def _first_blocker_sequence(*, runtime: _AnchoredRuntime, root_fd: int) -> int | None:
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return None
+    blockers_fd: int | None = None
+    try:
+        blockers_fd = _open_dir_optional(sealed_fd, BLOCKERS_DIR_NAME, full_path=_blockers_dir())
+        if blockers_fd is None:
+            return None
+        sequences = _collect_sequences_from_directory(
+            dir_fd=blockers_fd,
+            dir_path=_blockers_dir(),
+            parsers=(_parse_blocker_sequence,),
+            allowed_dirs=set(),
+        )
+        return min(sequences) if sequences else None
+    finally:
+        if blockers_fd is not None:
+            _close_fd_quietly(blockers_fd)
+        _close_fd_quietly(sealed_fd)
+
+
+def _load_canonical_json_entry(
+    *,
+    dir_fd: int,
+    entry_name: str,
+    label: Path,
+    invalid_message: str,
+) -> Mapping[str, Any]:
+    fd = os.open(entry_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {label}")
+        raw = _read_exact_from_fd(fd, offset=0, length=st.st_size)
+    finally:
+        os.close(fd)
+    try:
+        payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError) as exc:
+        raise SpoolDurabilityError(invalid_message) from exc
+    if not isinstance(payload, Mapping):
+        raise SpoolDurabilityError(invalid_message)
+    if _canonical_json_bytes(payload) != raw:
+        raise SpoolDurabilityError(invalid_message)
+    return payload
+
+
+def _classify_blocker_crash_state_error(exc: BaseException) -> str:
+    if isinstance(exc, FileNotFoundError):
+        missing_name = Path(getattr(exc, "filename", "") or "").name
+        if missing_name.startswith("seq-") and missing_name.endswith(".json"):
+            return "missing_replay_evidence_sidecar"
+        if missing_name.startswith("seq-") and missing_name.endswith(".spool"):
+            return "missing_replay_evidence_spool"
+        return "invalid_blocker_relationship"
+    if isinstance(exc, SpoolDurabilityError):
+        message = str(exc)
+        if message.startswith("invalid replay evidence sidecar:"):
+            return "invalid_replay_evidence_sidecar"
+        return "invalid_blocker_relationship"
+    if isinstance(exc, SpoolPathSecurityError):
+        return "invalid_blocker_relationship"
+    raise TypeError(f"unsupported blocker crash-state exception: {type(exc).__name__}")
+
+
+def _load_blocker_backed_prefix_replay_state(
+    *,
+    runtime: _AnchoredRuntime,
+    root_fd: int,
+    blocker_sequence: int,
+) -> _BlockerBackedPrefixReplayState | None:
+    sequence_str = _format_segment_sequence(blocker_sequence)
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return None
+    blockers_fd: int | None = None
+    quarantine_fd: int | None = None
+    prefix_segment_fd = -1
+    try:
+        blockers_fd = _open_dir_optional(sealed_fd, BLOCKERS_DIR_NAME, full_path=_blockers_dir())
+        if blockers_fd is None:
+            return None
+        blocker_name = f"{sequence_str}.blocker.json"
+        blocker_path = _blockers_dir() / blocker_name
+        blocker_payload = _load_canonical_json_entry(
+            dir_fd=blockers_fd,
+            entry_name=blocker_name,
+            label=blocker_path,
+            invalid_message=f"invalid corruption blocker: {blocker_path}",
+        )
+        required_fields = {
+            "schema_version",
+            "segment_sequence",
+            "source_kind",
+            "tail_status",
+            "valid_prefix_bytes",
+            "acked_prefix_bytes",
+            "blocking_offset",
+            "prefix_segment_name",
+            "evidence_spool_name",
+            "evidence_sidecar_name",
+            "original_size_bytes",
+        }
+        if set(blocker_payload.keys()) != required_fields:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=0)
+        if blocker_payload.get("schema_version") != 1:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=0)
+        if blocker_payload.get("segment_sequence") != sequence_str:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=0)
+        source_kind = blocker_payload.get("source_kind")
+        if source_kind not in {"active", "sealed"}:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=0)
+        try:
+            tail_status = SpoolTailStatus(str(blocker_payload.get("tail_status")))
+        except ValueError as exc:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=0) from exc
+        valid_prefix_bytes = blocker_payload.get("valid_prefix_bytes")
+        acked_prefix_bytes = blocker_payload.get("acked_prefix_bytes")
+        blocking_offset = blocker_payload.get("blocking_offset")
+        original_size_bytes = blocker_payload.get("original_size_bytes")
+        if not all(
+            isinstance(value, int) and not isinstance(value, bool)
+            for value in (valid_prefix_bytes, acked_prefix_bytes, blocking_offset, original_size_bytes)
+        ):
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=0)
+        assert valid_prefix_bytes is not None
+        assert acked_prefix_bytes is not None
+        assert blocking_offset is not None
+        assert original_size_bytes is not None
+        valid_prefix_bytes = int(valid_prefix_bytes)
+        acked_prefix_bytes = int(acked_prefix_bytes)
+        blocking_offset = int(blocking_offset)
+        original_size_bytes = int(original_size_bytes)
+        if valid_prefix_bytes < 0 or acked_prefix_bytes < 0 or acked_prefix_bytes > valid_prefix_bytes:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+        prefix_segment_name = blocker_payload.get("prefix_segment_name")
+        if prefix_segment_name is None:
+            if valid_prefix_bytes != 0 or acked_prefix_bytes != 0 or blocking_offset != 0:
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+            return None
+        if not isinstance(prefix_segment_name, str):
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+        expected_prefix_name = f"{sequence_str}.prefix.spool"
+        if prefix_segment_name != expected_prefix_name or valid_prefix_bytes <= 0 or blocking_offset != valid_prefix_bytes:
+            raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+        try:
+            prefix_segment_path = _sealed_dir() / prefix_segment_name
+            try:
+                prefix_segment_fd = os.open(prefix_segment_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=sealed_fd)
+            except FileNotFoundError:
+                if acked_prefix_bytes == valid_prefix_bytes:
+                    return None
+                raise
+            prefix_stat = os.fstat(prefix_segment_fd)
+            if not stat.S_ISREG(prefix_stat.st_mode):
+                raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {prefix_segment_path}")
+            if int(prefix_stat.st_size) != valid_prefix_bytes:
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+
+            evidence_spool_name = blocker_payload.get("evidence_spool_name")
+            evidence_sidecar_name = blocker_payload.get("evidence_sidecar_name")
+            if not isinstance(evidence_spool_name, str) or not isinstance(evidence_sidecar_name, str):
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+            expected_evidence_base = f"seq-{sequence_str}-{tail_status.value}-vp{valid_prefix_bytes}"
+            if (
+                evidence_spool_name != f"{expected_evidence_base}.spool"
+                or evidence_sidecar_name != f"{expected_evidence_base}.json"
+            ):
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+
+            quarantine_fd = _open_dir_optional(root_fd, QUARANTINE_DIR_NAME, full_path=_quarantine_dir())
+            if quarantine_fd is None:
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+            evidence_payload = _load_canonical_json_entry(
+                dir_fd=quarantine_fd,
+                entry_name=evidence_sidecar_name,
+                label=_quarantine_dir() / evidence_sidecar_name,
+                invalid_message=f"invalid replay evidence sidecar: {_quarantine_dir() / evidence_sidecar_name}",
+            )
+            expected_evidence_payload = {
+                "schema_version": 1,
+                "segment_sequence": sequence_str,
+                "source_kind": source_kind,
+                "tail_status": tail_status.value,
+                "valid_prefix_bytes": valid_prefix_bytes,
+                "original_size_bytes": original_size_bytes,
+                "evidence_spool_name": evidence_spool_name,
+            }
+            if dict(evidence_payload) != expected_evidence_payload:
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+            evidence_spool_fd = os.open(evidence_spool_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=quarantine_fd)
+            try:
+                evidence_stat = os.fstat(evidence_spool_fd)
+                if not stat.S_ISREG(evidence_stat.st_mode):
+                    raise SpoolPathSecurityError(
+                        f"fallback spool path is not a regular file: {_quarantine_dir() / evidence_spool_name}"
+                    )
+            finally:
+                os.close(evidence_spool_fd)
+            if int(evidence_stat.st_size) != original_size_bytes:
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+
+            os.close(prefix_segment_fd)
+            prefix_segment_fd = -1
+            decoded_prefix = decode_spool_segment(prefix_segment_path)
+            if (
+                decoded_prefix.tail_status is not SpoolTailStatus.CLEAN
+                or decoded_prefix.valid_prefix_bytes != valid_prefix_bytes
+            ):
+                raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+
+            winner = _load_ack_sidecar_winner(runtime, segment_path=prefix_segment_path)
+            effective_acked_prefix = acked_prefix_bytes
+            if winner is not None:
+                if winner.get("tail_status") != tail_status.value:
+                    raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+                if winner.get("valid_prefix_bytes") != valid_prefix_bytes:
+                    raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+                winner_acked_prefix = winner.get("acked_prefix_bytes")
+                if not isinstance(winner_acked_prefix, int) or isinstance(winner_acked_prefix, bool):
+                    raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+                if winner_acked_prefix > valid_prefix_bytes:
+                    raise SpoolBlockedReplayError("invalid_blocker_relationship", frame_offset=blocking_offset)
+                effective_acked_prefix = winner_acked_prefix
+
+            return _BlockerBackedPrefixReplayState(
+                segment_sequence=blocker_sequence,
+                blocking_offset=blocking_offset,
+                tail_status=tail_status,
+                prefix_segment_name=prefix_segment_name,
+                prefix_segment_path=prefix_segment_path,
+                valid_prefix_bytes=valid_prefix_bytes,
+                acked_prefix_bytes=effective_acked_prefix,
+            )
+        except (FileNotFoundError, SpoolDurabilityError, SpoolPathSecurityError) as exc:
+            raise SpoolBlockedReplayError(
+                _classify_blocker_crash_state_error(exc),
+                frame_offset=blocking_offset,
+            ) from exc
+    finally:
+        if prefix_segment_fd >= 0:
+            _close_fd_quietly(prefix_segment_fd)
+        if quarantine_fd is not None:
+            _close_fd_quietly(quarantine_fd)
+        if blockers_fd is not None:
+            _close_fd_quietly(blockers_fd)
+        _close_fd_quietly(sealed_fd)
+
+
+def _publish_corrupt_sealed_segment_state(
+    runtime: _AnchoredRuntime,
+    *,
+    segment_sequence: int,
+    segment_name: str,
+    decoded_segment: DecodedSegment,
+) -> None:
+    sealed_fd = -1
+    blockers_fd = -1
+    quarantine_fd = -1
+    segment_fd = -1
+    try:
+        sealed_fd = _open_dir_at(
+            runtime.root_fd,
+            SEALED_DIR_NAME,
+            full_path=_sealed_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )[0]
+        blockers_fd = _open_dir_at(
+            sealed_fd,
+            BLOCKERS_DIR_NAME,
+            full_path=_blockers_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=_sealed_dir(),
+            fsync_parent_on_open_existing=True,
+        )[0]
+        quarantine_fd = _open_dir_at(
+            runtime.root_fd,
+            QUARANTINE_DIR_NAME,
+            full_path=_quarantine_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )[0]
+        segment_fd = os.open(segment_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=sealed_fd)
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(runtime.home_fd, SPOOL_ROOT_NAME, runtime.root_fd, expect="dir", label=str(runtime.root_path))
+        _assert_entry_matches_fd(runtime.root_fd, SEALED_DIR_NAME, sealed_fd, expect="dir", label=str(_sealed_dir()))
+        _assert_entry_matches_fd(sealed_fd, segment_name, segment_fd, expect="file", label=str(_sealed_dir() / segment_name))
+        _assert_entry_matches_fd(sealed_fd, BLOCKERS_DIR_NAME, blockers_fd, expect="dir", label=str(_blockers_dir()))
+        _assert_entry_matches_fd(runtime.root_fd, QUARANTINE_DIR_NAME, quarantine_fd, expect="dir", label=str(_quarantine_dir()))
+
+        segment_stat = os.fstat(segment_fd)
+        original_bytes = _read_exact_from_fd(segment_fd, offset=0, length=segment_stat.st_size)
+        sequence_str = _format_segment_sequence(segment_sequence)
+        evidence_base = f"seq-{sequence_str}-{decoded_segment.tail_status.value}-vp{decoded_segment.valid_prefix_bytes}"
+        evidence_spool_name = f"{evidence_base}.spool"
+        evidence_sidecar_name = f"{evidence_base}.json"
+        prefix_segment_name = (
+            f"{sequence_str}.prefix.spool" if decoded_segment.valid_prefix_bytes > 0 else None
+        )
+
+        if prefix_segment_name is not None:
+            prefix_bytes = original_bytes[: decoded_segment.valid_prefix_bytes]
+            _publish_bytes_file(_sealed_dir() / prefix_segment_name, prefix_bytes, directory_fd=sealed_fd)
+            _fsync_directory_fd(sealed_fd, _sealed_dir())
+            _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+            _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+
+        try:
+            os.link(
+                segment_name,
+                evidence_spool_name,
+                src_dir_fd=sealed_fd,
+                dst_dir_fd=quarantine_fd,
+                follow_symlinks=False,
+            )
+        except FileExistsError as exc:
+            raise SpoolPathSecurityError(
+                f"fallback spool evidence destination already exists or was swapped: {_quarantine_dir() / evidence_spool_name}"
+            ) from exc
+        _fsync_directory_fd(quarantine_fd, _quarantine_dir())
+        _write_sidecar_json(
+            _quarantine_dir() / evidence_sidecar_name,
+            {
+                "schema_version": 1,
+                "segment_sequence": sequence_str,
+                "source_kind": "sealed",
+                "tail_status": decoded_segment.tail_status.value,
+                "valid_prefix_bytes": decoded_segment.valid_prefix_bytes,
+                "original_size_bytes": int(segment_stat.st_size),
+                "evidence_spool_name": evidence_spool_name,
+            },
+            directory_fd=quarantine_fd,
+        )
+        _fsync_directory_fd(quarantine_fd, _quarantine_dir())
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+        _write_sidecar_json(
+            _blockers_dir() / f"{sequence_str}.blocker.json",
+            {
+                "schema_version": 1,
+                "segment_sequence": sequence_str,
+                "source_kind": "sealed",
+                "tail_status": decoded_segment.tail_status.value,
+                "valid_prefix_bytes": decoded_segment.valid_prefix_bytes,
+                "acked_prefix_bytes": 0,
+                "blocking_offset": decoded_segment.valid_prefix_bytes,
+                "prefix_segment_name": prefix_segment_name,
+                "evidence_spool_name": evidence_spool_name,
+                "evidence_sidecar_name": evidence_sidecar_name,
+                "original_size_bytes": int(segment_stat.st_size),
+            },
+            directory_fd=blockers_fd,
+        )
+        _fsync_directory_fd(blockers_fd, _blockers_dir())
+        _fsync_directory_fd(sealed_fd, _sealed_dir())
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+        os.unlink(segment_name, dir_fd=sealed_fd)
+        _fsync_directory_fd(sealed_fd, _sealed_dir())
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+    finally:
+        if segment_fd >= 0:
+            _close_fd_quietly(segment_fd)
+        if quarantine_fd >= 0:
+            _close_fd_quietly(quarantine_fd)
+        if blockers_fd >= 0:
+            _close_fd_quietly(blockers_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+
+
+def _reconcile_active_spool_for_replay(runtime: _AnchoredRuntime) -> dict[str, Any] | None:
+    sealed_fd = -1
+    blockers_fd = -1
+    quarantine_fd = -1
+    active_fd = -1
+    try:
+        sealed_fd, _ = _open_dir_at(
+            runtime.root_fd,
+            SEALED_DIR_NAME,
+            full_path=_sealed_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        blockers_fd, _ = _open_dir_at(
+            sealed_fd,
+            BLOCKERS_DIR_NAME,
+            full_path=_blockers_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=_sealed_dir(),
+            fsync_parent_on_open_existing=True,
+        )
+        quarantine_fd, _ = _open_dir_at(
+            runtime.root_fd,
+            QUARANTINE_DIR_NAME,
+            full_path=_quarantine_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        active_fd, _ = _open_file_at(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            full_path=runtime.active_path,
+            mode=FILE_MODE,
+            create=True,
+            fsync_parent_on_create=True,
+            fsync_file_on_create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        active_stat = os.fstat(active_fd)
+        if active_stat.st_size <= 0:
+            return None
+        scan = _scan_fd(active_fd)
+        if scan.tail_status is SpoolTailStatus.CLEAN:
+            return None
+
+        sequence = _allocate_next_segment_sequence(runtime=runtime, root_fd=runtime.root_fd)
+        sequence_str = _format_segment_sequence(sequence)
+        evidence_base = f"seq-{sequence_str}-{scan.tail_status.value}-vp{scan.valid_prefix_bytes}"
+        evidence_spool_name = f"{evidence_base}.spool"
+        evidence_sidecar_name = f"{evidence_base}.json"
+        prefix_segment_name = (
+            f"{sequence_str}.prefix.spool" if scan.valid_prefix_bytes > 0 else None
+        )
+
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(runtime.home_fd, SPOOL_ROOT_NAME, runtime.root_fd, expect="dir", label=str(runtime.root_path))
+        _assert_entry_matches_fd(runtime.root_fd, SEALED_DIR_NAME, sealed_fd, expect="dir", label=str(_sealed_dir()))
+        _assert_entry_matches_fd(sealed_fd, BLOCKERS_DIR_NAME, blockers_fd, expect="dir", label=str(_blockers_dir()))
+        _assert_entry_matches_fd(runtime.root_fd, QUARANTINE_DIR_NAME, quarantine_fd, expect="dir", label=str(_quarantine_dir()))
+        _assert_entry_matches_fd(runtime.root_fd, ACTIVE_SPOOL_NAME, active_fd, expect="file", label=str(runtime.active_path))
+
+        if prefix_segment_name is not None:
+            prefix_bytes = _read_exact_from_fd(active_fd, offset=0, length=scan.valid_prefix_bytes)
+            _publish_bytes_file(_sealed_dir() / prefix_segment_name, prefix_bytes, directory_fd=sealed_fd)
+            _fsync_directory_fd(sealed_fd, _sealed_dir())
+            _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+            _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+
+        try:
+            os.link(
+                ACTIVE_SPOOL_NAME,
+                evidence_spool_name,
+                src_dir_fd=runtime.root_fd,
+                dst_dir_fd=quarantine_fd,
+                follow_symlinks=False,
+            )
+        except FileExistsError as exc:
+            raise SpoolPathSecurityError(
+                f"fallback spool evidence destination already exists or was swapped: {_quarantine_dir() / evidence_spool_name}"
+            ) from exc
+        _fsync_directory_fd(quarantine_fd, _quarantine_dir())
+        _write_sidecar_json(
+            _quarantine_dir() / evidence_sidecar_name,
+            {
+                "schema_version": 1,
+                "segment_sequence": sequence_str,
+                "source_kind": "active",
+                "tail_status": scan.tail_status.value,
+                "valid_prefix_bytes": scan.valid_prefix_bytes,
+                "original_size_bytes": int(active_stat.st_size),
+                "evidence_spool_name": evidence_spool_name,
+            },
+            directory_fd=quarantine_fd,
+        )
+        _fsync_directory_fd(quarantine_fd, _quarantine_dir())
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+
+        blocker_payload = {
+            "schema_version": 1,
+            "segment_sequence": sequence_str,
+            "source_kind": "active",
+            "tail_status": scan.tail_status.value,
+            "valid_prefix_bytes": scan.valid_prefix_bytes,
+            "acked_prefix_bytes": 0,
+            "blocking_offset": scan.valid_prefix_bytes,
+            "prefix_segment_name": prefix_segment_name,
+            "evidence_spool_name": evidence_spool_name,
+            "evidence_sidecar_name": evidence_sidecar_name,
+            "original_size_bytes": int(active_stat.st_size),
+        }
+        _write_sidecar_json(
+            _blockers_dir() / f"{sequence_str}.blocker.json",
+            blocker_payload,
+            directory_fd=blockers_fd,
+        )
+        _fsync_directory_fd(blockers_fd, _blockers_dir())
+        _fsync_directory_fd(sealed_fd, _sealed_dir())
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(runtime.home_fd, SPOOL_ROOT_NAME, runtime.root_fd, expect="dir", label=str(runtime.root_path))
+        _assert_entry_matches_fd(runtime.root_fd, ACTIVE_SPOOL_NAME, active_fd, expect="file", label=str(runtime.active_path))
+        os.unlink(ACTIVE_SPOOL_NAME, dir_fd=runtime.root_fd)
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        os.close(active_fd)
+        active_fd = -1
+        active_fd, _ = _open_file_at(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            full_path=runtime.active_path,
+            mode=FILE_MODE,
+            create=True,
+            fsync_parent_on_create=True,
+            fsync_file_on_create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        _fsync_fd(active_fd)
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+
+        return {
+            "tail_status": scan.tail_status,
+            "valid_prefix_bytes": scan.valid_prefix_bytes,
+            "segment_sequence": sequence,
+            "prefix_segment_name": prefix_segment_name,
+            "evidence_spool_name": evidence_spool_name,
+            "evidence_sidecar_name": evidence_sidecar_name,
+        }
+    finally:
+        if active_fd >= 0:
+            _close_fd_quietly(active_fd)
+        if quarantine_fd >= 0:
+            _close_fd_quietly(quarantine_fd)
+        if blockers_fd >= 0:
+            _close_fd_quietly(blockers_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+
+
+def _seal_clean_active_spool_for_replay(runtime: _AnchoredRuntime) -> bool:
+    sealed_fd = -1
+    active_fd = -1
+    try:
+        sealed_fd, _ = _open_dir_at(
+            runtime.root_fd,
+            SEALED_DIR_NAME,
+            full_path=_sealed_dir(),
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        active_fd, _ = _open_file_at(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            full_path=runtime.active_path,
+            mode=FILE_MODE,
+            create=True,
+            fsync_parent_on_create=True,
+            fsync_file_on_create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        active_stat = os.fstat(active_fd)
+        if active_stat.st_size <= 0:
+            return False
+        scan = _scan_fd(active_fd)
+        if scan.tail_status is not SpoolTailStatus.CLEAN:
+            return False
+
+        sequence = _allocate_next_segment_sequence(runtime=runtime, root_fd=runtime.root_fd)
+        segment_name = f"{_format_segment_sequence(sequence)}.spool"
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(
+            runtime.home_fd,
+            SPOOL_ROOT_NAME,
+            runtime.root_fd,
+            expect="dir",
+            label=str(runtime.root_path),
+        )
+        _assert_entry_matches_fd(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            active_fd,
+            expect="file",
+            label=str(runtime.active_path),
+        )
+        os.rename(
+            ACTIVE_SPOOL_NAME,
+            segment_name,
+            src_dir_fd=runtime.root_fd,
+            dst_dir_fd=sealed_fd,
+        )
+        _fsync_directory_fd(sealed_fd, _sealed_dir())
+        os.close(active_fd)
+        active_fd = -1
+
+        active_fd, _ = _open_file_at(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            full_path=runtime.active_path,
+            mode=FILE_MODE,
+            create=True,
+            fsync_parent_on_create=True,
+            fsync_file_on_create=True,
+            parent_label=runtime.root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        _fsync_fd(active_fd)
+        _fsync_directory_fd(sealed_fd, _sealed_dir())
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+        return True
+    finally:
+        if active_fd >= 0:
+            _close_fd_quietly(active_fd)
+        if sealed_fd >= 0:
+            _close_fd_quietly(sealed_fd)
+
+
+def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
+    runtime = _open_locked_runtime()
+    owner = None
+    try:
+        cooldown = _cooldown_result(runtime, trigger=trigger)
+        if cooldown is not None:
+            return cooldown
+        owner = _try_acquire_replay_owner(runtime)
+        if owner is None:
+            return ReplayRunResult(state=ReplayRunState.OWNER_BUSY, trigger=trigger)
+
+        with _append_lock(runtime.lock_fd, str(_lock_path())):
+            _ensure_directory(_sealed_dir(), mode=ROOT_MODE)
+            _ensure_directory(_acks_dir(), mode=ROOT_MODE)
+            _ensure_directory(_blockers_dir(), mode=ROOT_MODE)
+            reconciled_active = _reconcile_active_spool_for_replay(runtime)
+            if reconciled_active is None:
+                _seal_clean_active_spool_for_replay(runtime)
+
+        _tombstones, blocked_orphan_sequence = _classify_ack_tombstones(
+            runtime=runtime,
+            root_fd=runtime.root_fd,
+        )
+        if blocked_orphan_sequence is not None:
+            return ReplayRunResult(
+                state=ReplayRunState.BLOCKED_INTEGRITY,
+                trigger=trigger,
+                first_blocked_segment=blocked_orphan_sequence,
+            )
+
+        blocker_sequence = _first_blocker_sequence(runtime=runtime, root_fd=runtime.root_fd)
+        blocked_prefix_state: _BlockerBackedPrefixReplayState | None = None
+        if blocker_sequence is not None:
+            try:
+                blocked_prefix_state = _load_blocker_backed_prefix_replay_state(
+                    runtime=runtime,
+                    root_fd=runtime.root_fd,
+                    blocker_sequence=blocker_sequence,
+                )
+            except SpoolBlockedReplayError as exc:
+                return ReplayRunResult(
+                    state=ReplayRunState.BLOCKED_INTEGRITY,
+                    trigger=trigger,
+                    first_blocked_segment=blocker_sequence,
+                    first_blocked_offset=exc.frame_offset,
+                    error_class=exc.error_class,
+                )
+
+        ordered_segments = _ordered_segment_entries(runtime=runtime, root_fd=runtime.root_fd)
+        if not ordered_segments:
+            if blocker_sequence is not None:
+                return ReplayRunResult(
+                    state=ReplayRunState.BLOCKED_INTEGRITY,
+                    trigger=trigger,
+                    first_blocked_segment=blocker_sequence,
+                    first_blocked_offset=(
+                        blocked_prefix_state.blocking_offset
+                        if blocked_prefix_state is not None
+                        else None
+                    ),
+                    error_class=(
+                        blocked_prefix_state.tail_status.value
+                        if blocked_prefix_state is not None
+                        else None
+                    ),
+                )
+            _clear_replay_cooldown(runtime)
+            return ReplayRunResult(state=ReplayRunState.EMPTY, trigger=trigger)
+
+        max_frames, max_bytes, max_seconds = _trigger_budget(trigger)
+        start_monotonic = time.monotonic()
+        frames_committed = 0
+        frames_duplicated = 0
+        frames_acked = 0
+        frames_decoded = 0
+        bytes_decoded = 0
+        bytes_acked = 0
+        for segment_index, (segment_sequence, segment_name, segment_path) in enumerate(ordered_segments):
+            if (
+                (max_frames is not None and frames_decoded >= max_frames)
+                or (max_bytes is not None and bytes_decoded >= max_bytes)
+                or (
+                    max_seconds is not None
+                    and (time.monotonic() - start_monotonic) >= max_seconds
+                )
+            ):
+                return ReplayRunResult(
+                    state=ReplayRunState.PARTIALLY_REPLAYED,
+                    trigger=trigger,
+                    segment_count_seen=len(ordered_segments),
+                    frames_decoded=frames_decoded,
+                    frames_committed=frames_committed,
+                    frames_duplicated=frames_duplicated,
+                    frames_acked=frames_acked,
+                    bytes_decoded=bytes_decoded,
+                    bytes_acked=bytes_acked,
+                    pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                )
+            if blocker_sequence is not None and segment_sequence > blocker_sequence:
+                return ReplayRunResult(
+                    state=ReplayRunState.BLOCKED_INTEGRITY,
+                    trigger=trigger,
+                    segment_count_seen=len(ordered_segments),
+                    frames_decoded=frames_decoded,
+                    frames_committed=frames_committed,
+                    frames_duplicated=frames_duplicated,
+                    frames_acked=frames_acked,
+                    bytes_decoded=bytes_decoded,
+                    bytes_acked=bytes_acked,
+                    pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                    first_blocked_segment=blocker_sequence,
+                    first_blocked_offset=(
+                        blocked_prefix_state.blocking_offset
+                        if blocked_prefix_state is not None
+                        else None
+                    ),
+                    error_class=(
+                        blocked_prefix_state.tail_status.value
+                        if blocked_prefix_state is not None
+                        else None
+                    ),
+                )
+            if blocker_sequence is not None and segment_sequence == blocker_sequence:
+                if blocked_prefix_state is None:
+                    return ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                        first_blocked_segment=blocker_sequence,
+                    )
+                if segment_name != blocked_prefix_state.prefix_segment_name:
+                    return ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                        first_blocked_segment=blocker_sequence,
+                        first_blocked_offset=blocked_prefix_state.blocking_offset,
+                        error_class="invalid_blocker_relationship",
+                    )
+                decoded = decode_spool_segment(segment_path)
+                if (
+                    decoded.tail_status is not SpoolTailStatus.CLEAN
+                    or decoded.valid_prefix_bytes != blocked_prefix_state.valid_prefix_bytes
+                ):
+                    return ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                        first_blocked_segment=blocker_sequence,
+                        first_blocked_offset=blocked_prefix_state.blocking_offset,
+                        error_class="invalid_blocker_relationship",
+                    )
+                for frame in decoded.prefix_frames:
+                    frame_end = frame.frame_offset + frame.frame_length
+                    if frame_end <= blocked_prefix_state.acked_prefix_bytes:
+                        continue
+                    if frame.frame_offset < blocked_prefix_state.acked_prefix_bytes:
+                        return ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(
+                                ordered_segments, segment_index
+                            ),
+                            first_blocked_segment=blocker_sequence,
+                            first_blocked_offset=blocked_prefix_state.blocking_offset,
+                            error_class="invalid_blocker_relationship",
+                        )
+                    frames_decoded += 1
+                    bytes_decoded += frame.frame_length
+                    try:
+                        result = _replay_db_call(session_db, frame)
+                    except SpoolBlockedReplayError as exc:
+                        return ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(
+                                ordered_segments, segment_index
+                            ),
+                            first_blocked_segment=segment_sequence,
+                            first_blocked_offset=exc.frame_offset,
+                            error_class=exc.error_class,
+                        )
+                    except SpoolRetryableReplayError as exc:
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                        )
+                        return ReplayRunResult(
+                            state=ReplayRunState.RETRY_PENDING,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(
+                                ordered_segments, segment_index
+                            ),
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                            cooldown_seconds=cooldown_seconds,
+                        )
+                    if result.inserted_count > 0:
+                        frames_committed += 1
+                    else:
+                        frames_duplicated += 1
+                    try:
+                        with _append_lock(runtime.lock_fd, str(_lock_path())):
+                            if _publish_ack_sidecar(
+                                runtime,
+                                segment_sequence=segment_sequence,
+                                segment_path=segment_path,
+                                decoded_segment=decoded,
+                                frame=frame,
+                            ):
+                                frames_acked += 1
+                                bytes_acked += frame.frame_length
+                    except SpoolRetryableReplayError as exc:
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                        )
+                        return ReplayRunResult(
+                            state=ReplayRunState.RETRY_PENDING,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(
+                                ordered_segments, segment_index
+                            ),
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                            cooldown_seconds=cooldown_seconds,
+                        )
+                    except OSError as exc:
+                        if _is_retryable_replay_os_error(exc):
+                            cooldown_seconds = _register_replay_cooldown(
+                                runtime,
+                                retry_class="ack_publish_busy",
+                                ack_pending=True,
+                            )
+                            return ReplayRunResult(
+                                state=ReplayRunState.RETRY_PENDING,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=_remaining_segment_bytes(
+                                    ordered_segments, segment_index
+                                ),
+                                retry_class="ack_publish_busy",
+                                ack_pending=True,
+                                cooldown_seconds=cooldown_seconds,
+                            )
+                        raise
+                return ReplayRunResult(
+                    state=ReplayRunState.BLOCKED_INTEGRITY,
+                    trigger=trigger,
+                    segment_count_seen=len(ordered_segments),
+                    frames_decoded=frames_decoded,
+                    frames_committed=frames_committed,
+                    frames_duplicated=frames_duplicated,
+                    frames_acked=frames_acked,
+                    bytes_decoded=bytes_decoded,
+                    bytes_acked=bytes_acked,
+                    pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                    first_blocked_segment=blocker_sequence,
+                    first_blocked_offset=blocked_prefix_state.blocking_offset,
+                    error_class=blocked_prefix_state.tail_status.value,
+                )
+            decoded = decode_spool_segment(segment_path)
+            if decoded.tail_status is not SpoolTailStatus.CLEAN:
+                for frame in decoded.prefix_frames:
+                    frames_decoded += 1
+                    bytes_decoded += frame.frame_length
+                    try:
+                        result = _replay_db_call(session_db, frame)
+                    except SpoolBlockedReplayError as exc:
+                        return ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(
+                                ordered_segments, segment_index
+                            ),
+                            first_blocked_segment=segment_sequence,
+                            first_blocked_offset=exc.frame_offset,
+                            error_class=exc.error_class,
+                        )
+                    except SpoolRetryableReplayError as exc:
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                        )
+                        return ReplayRunResult(
+                            state=ReplayRunState.RETRY_PENDING,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(
+                                ordered_segments, segment_index
+                            ),
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                            cooldown_seconds=cooldown_seconds,
+                        )
+                    if result.inserted_count > 0:
+                        frames_committed += 1
+                    else:
+                        frames_duplicated += 1
+                with _append_lock(runtime.lock_fd, str(_lock_path())):
+                    _publish_corrupt_sealed_segment_state(
+                        runtime,
+                        segment_sequence=segment_sequence,
+                        segment_name=segment_name,
+                        decoded_segment=decoded,
+                    )
+                return ReplayRunResult(
+                    state=ReplayRunState.BLOCKED_INTEGRITY,
+                    trigger=trigger,
+                    segment_count_seen=len(ordered_segments),
+                    frames_decoded=frames_decoded,
+                    frames_committed=frames_committed,
+                    frames_duplicated=frames_duplicated,
+                    frames_acked=frames_acked,
+                    bytes_decoded=bytes_decoded,
+                    bytes_acked=bytes_acked,
+                    first_blocked_segment=segment_sequence,
+                    first_blocked_offset=decoded.tail_offset,
+                    error_class=decoded.tail_status.value,
+                )
+            for frame in decoded.prefix_frames:
+                frames_decoded += 1
+                bytes_decoded += frame.frame_length
+                try:
+                    result = _replay_db_call(session_db, frame)
+                except SpoolBlockedReplayError as exc:
+                    return ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=_remaining_segment_bytes(
+                            ordered_segments, segment_index
+                        ),
+                        first_blocked_segment=segment_sequence,
+                        first_blocked_offset=exc.frame_offset,
+                        error_class=exc.error_class,
+                    )
+                except SpoolRetryableReplayError as exc:
+                    cooldown_seconds = _register_replay_cooldown(
+                        runtime,
+                        retry_class=exc.retry_class,
+                        ack_pending=exc.ack_pending,
+                    )
+                    return ReplayRunResult(
+                        state=ReplayRunState.RETRY_PENDING,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=_remaining_segment_bytes(
+                            ordered_segments, segment_index
+                        ),
+                        retry_class=exc.retry_class,
+                        ack_pending=exc.ack_pending,
+                        cooldown_seconds=cooldown_seconds,
+                    )
+                if result.inserted_count > 0:
+                    frames_committed += 1
+                else:
+                    frames_duplicated += 1
+                try:
+                    with _append_lock(runtime.lock_fd, str(_lock_path())):
+                        if _publish_ack_sidecar(
+                            runtime,
+                            segment_sequence=segment_sequence,
+                            segment_path=segment_path,
+                            decoded_segment=decoded,
+                            frame=frame,
+                        ):
+                            frames_acked += 1
+                            bytes_acked += frame.frame_length
+                except SpoolRetryableReplayError as exc:
+                    cooldown_seconds = _register_replay_cooldown(
+                        runtime,
+                        retry_class=exc.retry_class,
+                        ack_pending=exc.ack_pending,
+                    )
+                    return ReplayRunResult(
+                        state=ReplayRunState.RETRY_PENDING,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                        retry_class=exc.retry_class,
+                        ack_pending=exc.ack_pending,
+                        cooldown_seconds=cooldown_seconds,
+                    )
+                except OSError as exc:
+                    if _is_retryable_replay_os_error(exc):
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
+                            retry_class="ack_publish_busy",
+                            ack_pending=True,
+                        )
+                        return ReplayRunResult(
+                            state=ReplayRunState.RETRY_PENDING,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                            retry_class="ack_publish_busy",
+                            ack_pending=True,
+                            cooldown_seconds=cooldown_seconds,
+                        )
+                    raise
+            with _append_lock(runtime.lock_fd, str(_lock_path())):
+                _delete_fully_acked_segment(segment_path)
+        _clear_replay_cooldown(runtime)
+        return ReplayRunResult(
+            state=ReplayRunState.REPLAYED,
+            trigger=trigger,
+            segment_count_seen=len(ordered_segments),
+            frames_decoded=frames_decoded,
+            frames_committed=frames_committed,
+            frames_duplicated=frames_duplicated,
+            frames_acked=frames_acked,
+            bytes_decoded=bytes_decoded,
+            bytes_acked=bytes_acked,
+        )
+    finally:
+        if owner is not None:
+            _close_fd_quietly(owner.fd)
+        _close_fd_quietly(runtime.lock_fd)
+        _close_fd_quietly(runtime.root_fd)
+        _close_fd_quietly(runtime.home_fd)
+
+
 def append_records(records: Sequence[SessionSpoolRecord]) -> SpoolAppendAttemptResult:
     if not records:
         return SpoolAppendAttemptResult(unit_results=())
@@ -1560,12 +4229,19 @@ def append_records(records: Sequence[SessionSpoolRecord]) -> SpoolAppendAttemptR
                 )
 
             active_bytes = os.fstat(active_fd).st_size
-            quarantine_bytes = _quarantine_spool_bytes(runtime.quarantine_path)
+            inventory = _durable_capacity_inventory(runtime, runtime.root_fd)
             requested_bytes = sum(len(frame) for _record, frame in frames)
-            if active_bytes + quarantine_bytes + requested_bytes > TOTAL_CAP_BYTES:
+            if (
+                active_bytes
+                + inventory.quarantine_bytes
+                + inventory.other_artifact_bytes
+                + requested_bytes
+                > TOTAL_CAP_BYTES
+            ):
                 raise SpoolCapacityError(
                     active_bytes=active_bytes,
-                    quarantine_bytes=quarantine_bytes,
+                    quarantine_bytes=inventory.quarantine_bytes,
+                    other_artifact_bytes=inventory.other_artifact_bytes,
                     requested_bytes=requested_bytes,
                     cap_bytes=TOTAL_CAP_BYTES,
                 )

--- a/session_fallback_spool.py
+++ b/session_fallback_spool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -21,6 +22,8 @@ from hermes_state import (
     CompressionSessionClosedError,
     SessionDBBatchMessage,
 )
+
+logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - Windows-only import path
     import fcntl  # type: ignore[attr-defined]
@@ -53,6 +56,9 @@ MAX_FRAME_BYTES = MAX_PAYLOAD_BYTES + HEADER_SIZE
 TOTAL_CAP_BYTES = 64 * 1024 * 1024
 LOCK_TIMEOUT_SECONDS = 5.0
 LOCK_RETRY_SECONDS = 0.02
+STATUS_LOCK_TIMEOUT_SECONDS = 0.25
+STATUS_LOCK_RETRY_SECONDS = 0.01
+STATUS_SCAN_ARTIFACT_LIMIT = 4096
 SEGMENT_SEQUENCE_WIDTH = 20
 MAX_SEGMENT_SEQUENCE = 18446744073709551615
 _REPLAY_RETRYABLE_ERRNOS = {
@@ -67,6 +73,17 @@ _LOCK_CONTENTION_ERRNOS = {
 }
 _CURRENT_QUARANTINE_DIR_FD: int | None = None
 _REPLAY_COOLDOWNS: dict[str, dict[str, Any]] = {}
+_REPLAY_LOG_STATE: dict[str, dict[str, Any]] = {}
+_STATUS_REASON_ORDER = (
+    "pending_backlog",
+    "blocker",
+    "retry_cooldown",
+    "ack_pending",
+    "capacity_constrained",
+    "capacity_full",
+    "disk_low",
+    "inspection_error",
+)
 
 
 class SpoolTailStatus(str, Enum):
@@ -197,12 +214,42 @@ class ReplayRunResult:
     bytes_decoded: int = 0
     bytes_acked: int = 0
     pending_bytes_after: int = 0
+    pending_frames_after: int | None = None
     first_blocked_segment: int | None = None
     first_blocked_offset: int | None = None
     retry_class: str | None = None
     error_class: str | None = None
     ack_pending: bool = False
     cooldown_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
+class SessionFallbackSpoolStatus:
+    schema_version: int
+    state: str
+    reasons: tuple[str, ...]
+    pending_units: int
+    pending_frames: int
+    pending_bytes: int
+    oldest_pending_age_seconds: float | None
+    retry_pending: bool
+    retry_class: str | None
+    cooldown_seconds: float
+    ack_pending: bool
+    blocker_present: bool
+    blocker_sequence: int | None
+    blocker_offset: int | None
+    blocker_reason_class: str | None
+    blocker_source_kind: str | None
+    capacity_used_bytes: int
+    capacity_cap_bytes: int
+    capacity_remaining_bytes: int
+    capacity_state: str
+    disk_free_bytes: int | None
+    disk_total_bytes: int | None
+    disk_headroom_threshold_bytes: int
+    disk_state: str
+    inspection_error_class: str | None
 
 
 @dataclass(frozen=True)
@@ -233,8 +280,55 @@ class _DurableCapacityInventory:
     other_artifact_bytes: int
 
 
+@dataclass(frozen=True)
+class _StatusSegmentSnapshot:
+    sequence: int
+    name: str
+    size_bytes: int
+    frame_count: int
+    mtime_ns: int
+    decoded: DecodedSegment
+
+
+@dataclass(frozen=True)
+class _StatusAckDirectorySnapshot:
+    winners_by_segment: Mapping[str, Mapping[str, Any]]
+    orphan_tombstone_sequence: int | None = None
+    orphan_tombstone_mtime_ns: int | None = None
+    blocked_orphan_sequence: int | None = None
+
+
+@dataclass(frozen=True)
+class _StatusBlockerSnapshot:
+    present: bool = False
+    sequence: int | None = None
+    offset: int | None = None
+    reason_class: str | None = None
+    source_kind: str | None = None
+    mtime_ns: int | None = None
+    acked_prefix_bytes: int = 0
+    valid_prefix_bytes: int = 0
+    prefix_segment_name: str | None = None
+    zero_prefix: bool = False
+
+
+@dataclass(frozen=True)
+class _PendingBacklogSnapshot:
+    pending_bytes: int
+    pending_frames: int
+    ack_pending: bool = False
+    first_blocked_segment: int | None = None
+    first_blocked_offset: int | None = None
+
+
 class SessionFallbackSpoolError(RuntimeError):
     pass
+
+
+class _StatusInspectionError(SessionFallbackSpoolError):
+    def __init__(self, error_class: str):
+        super().__init__(error_class)
+        self.error_class = error_class
 
 
 class SpoolPathSecurityError(SessionFallbackSpoolError):
@@ -393,13 +487,124 @@ def _cooldown_result(runtime: _AnchoredRuntime, *, trigger: str) -> ReplayRunRes
     remaining = float(state["next_eligible"] - time.monotonic())
     if remaining <= 0:
         return None
+    pending_snapshot = _capture_replay_terminal_backlog(
+        runtime,
+        ack_pending=bool(state.get("ack_pending", False)),
+    )
     return ReplayRunResult(
         state=ReplayRunState.RETRY_PENDING,
         trigger=trigger,
+        pending_bytes_after=pending_snapshot.pending_bytes,
+        pending_frames_after=pending_snapshot.pending_frames,
+        first_blocked_segment=pending_snapshot.first_blocked_segment,
+        first_blocked_offset=pending_snapshot.first_blocked_offset,
         retry_class=str(state.get("retry_class") or "retry_pending"),
-        ack_pending=bool(state.get("ack_pending", False)),
+        ack_pending=pending_snapshot.ack_pending,
         cooldown_seconds=remaining,
     )
+
+
+def _classify_nonretryable_replay_error(exc: BaseException) -> str:
+    if isinstance(exc, OSError) and exc.errno is not None:
+        errno_name = errno.errorcode.get(exc.errno)
+        if errno_name:
+            return f"errno_{errno_name.lower()}"
+    return exc.__class__.__name__
+
+
+def _pending_frames_for_log(result: ReplayRunResult) -> int:
+    if result.pending_frames_after is not None:
+        return int(result.pending_frames_after)
+    return -1
+
+
+def _pending_backlog_signature_state(result: ReplayRunResult) -> str | None:
+    if result.state is not ReplayRunState.NOT_DURABLE:
+        return None
+    pending_frames = result.pending_frames_after
+    if int(result.pending_bytes_after) < 0:
+        return "pending_bytes_unknown"
+    if pending_frames is not None and int(pending_frames) < 0:
+        return "pending_frames_unknown"
+    return None
+
+
+def _log_replay_run_result(runtime: _AnchoredRuntime, result: ReplayRunResult) -> None:
+    state = getattr(result.state, "value", result.state)
+    state_text = str(state)
+    signature = (
+        state_text,
+        result.retry_class,
+        result.error_class,
+        result.first_blocked_segment,
+        result.first_blocked_offset,
+        result.ack_pending,
+        _pending_backlog_signature_state(result),
+    )
+    key = _replay_root_key(runtime)
+    previous = _REPLAY_LOG_STATE.get(key)
+    now = time.monotonic()
+    if state_text in {
+        ReplayRunState.RETRY_PENDING.value,
+        ReplayRunState.BLOCKED_INTEGRITY.value,
+        ReplayRunState.NOT_DURABLE.value,
+    }:
+        if (
+            previous is not None
+            and previous.get("signature") == signature
+            and (now - float(previous.get("logged_at", 0.0))) < 300.0
+        ):
+            return
+        pending_frames = _pending_frames_for_log(result)
+        pending_bytes = int(result.pending_bytes_after)
+        if state_text == ReplayRunState.RETRY_PENDING.value:
+            logger.warning(
+                "Fallback spool replay degraded state=%s trigger=%s retry_class=%s ack_pending=%s cooldown_seconds=%.3f pending_frames=%d pending_bytes=%d",
+                state_text,
+                result.trigger,
+                result.retry_class,
+                result.ack_pending,
+                result.cooldown_seconds,
+                pending_frames,
+                pending_bytes,
+            )
+        elif state_text == ReplayRunState.BLOCKED_INTEGRITY.value:
+            logger.error(
+                "Fallback spool replay degraded state=%s trigger=%s error_class=%s first_blocked_segment=%s first_blocked_offset=%s pending_frames=%d pending_bytes=%d",
+                state_text,
+                result.trigger,
+                result.error_class,
+                result.first_blocked_segment,
+                result.first_blocked_offset,
+                pending_frames,
+                pending_bytes,
+            )
+        else:
+            logger.error(
+                "Fallback spool replay degraded state=%s trigger=%s error_class=%s pending_frames=%d pending_bytes=%d",
+                state_text,
+                result.trigger,
+                result.error_class,
+                pending_frames,
+                pending_bytes,
+            )
+        _REPLAY_LOG_STATE[key] = {"signature": signature, "logged_at": now}
+        return
+    if (
+        previous is not None
+        and state_text in {ReplayRunState.EMPTY.value, ReplayRunState.REPLAYED.value}
+    ):
+        logger.info(
+            "Fallback spool replay recovered state=%s trigger=%s",
+            state_text,
+            result.trigger,
+        )
+        _REPLAY_LOG_STATE.pop(key, None)
+
+
+def _log_and_return_replay_result(runtime: _AnchoredRuntime, result: ReplayRunResult) -> ReplayRunResult:
+    _log_replay_run_result(runtime, result)
+    return result
 
 
 def _is_retryable_replay_os_error(exc: OSError) -> bool:
@@ -414,6 +619,215 @@ def _remaining_segment_bytes(ordered_segments: Sequence[tuple[int, str, Path]], 
         except OSError:
             continue
     return total
+
+
+def _measure_active_pending_backlog(runtime: _AnchoredRuntime) -> tuple[int, int]:
+    active_fd: int | None = None
+    try:
+        active_fd = _open_file_optional(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            full_path=runtime.active_path,
+        )
+        if active_fd is None:
+            return 0, 0
+        pending_bytes = max(0, int(os.fstat(active_fd).st_size))
+        if pending_bytes == 0:
+            return 0, 0
+        try:
+            return pending_bytes, _scan_fd(active_fd).frame_count
+        except OSError:
+            return pending_bytes, -1
+    except (OSError, SpoolDurabilityError, SpoolPathSecurityError):
+        return -1, -1
+    finally:
+        if active_fd is not None:
+            _close_fd_quietly(active_fd)
+
+
+def _measure_remaining_segment_backlog(
+    runtime: _AnchoredRuntime,
+    *,
+    ordered_segments: Sequence[tuple[int, str, Path]],
+    start_index: int,
+    current_segment_name: str | None = None,
+    current_segment_frame_count: int | None = None,
+    current_segment_pending_bytes: int | None = None,
+) -> tuple[int, int]:
+    if start_index >= len(ordered_segments):
+        return 0, 0
+    sealed_fd: int | None = None
+    pending_bytes = 0
+    pending_frames = 0
+    try:
+        sealed_fd = _open_dir_optional(runtime.root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+        if sealed_fd is None:
+            return -1, -1
+        for index, (_sequence, segment_name, _segment_path) in enumerate(
+            ordered_segments[start_index:], start=start_index
+        ):
+            segment_fd: int | None = None
+            try:
+                segment_fd = os.open(segment_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=sealed_fd)
+                segment_stat = os.fstat(segment_fd)
+                _status_assert_regular_fd_matches_entry(
+                    parent_fd=sealed_fd,
+                    name=segment_name,
+                    entry_stat=segment_stat,
+                    fd=segment_fd,
+                    error_class="entry_replaced",
+                    default_error_class="inspection_error",
+                )
+                if (
+                    index == start_index
+                    and current_segment_name is not None
+                    and current_segment_frame_count is not None
+                    and segment_name == current_segment_name
+                ):
+                    if current_segment_pending_bytes is not None:
+                        pending_bytes += max(0, int(current_segment_pending_bytes))
+                    else:
+                        pending_bytes += max(0, int(segment_stat.st_size))
+                    pending_frames += max(0, int(current_segment_frame_count))
+                    continue
+                pending_bytes += max(0, int(segment_stat.st_size))
+                pending_frames += _scan_fd(segment_fd).frame_count
+            except (
+                _StatusInspectionError,
+                OSError,
+                SpoolDurabilityError,
+                SpoolPathSecurityError,
+            ):
+                return -1, -1
+            finally:
+                if segment_fd is not None:
+                    _close_fd_quietly(segment_fd)
+        return pending_bytes, pending_frames
+    except (OSError, SpoolDurabilityError, SpoolPathSecurityError):
+        return -1, -1
+    finally:
+        if sealed_fd is not None:
+            _close_fd_quietly(sealed_fd)
+
+
+def _unknown_pending_backlog_snapshot(
+    *,
+    ack_pending: bool = False,
+    first_blocked_segment: int | None = None,
+    first_blocked_offset: int | None = None,
+) -> _PendingBacklogSnapshot:
+    return _PendingBacklogSnapshot(
+        pending_bytes=-1,
+        pending_frames=-1,
+        ack_pending=ack_pending,
+        first_blocked_segment=first_blocked_segment,
+        first_blocked_offset=first_blocked_offset,
+    )
+
+
+def _snapshot_pending_backlog(runtime: _AnchoredRuntime) -> _PendingBacklogSnapshot:
+    active_fd: int | None = None
+    lock_held = False
+    try:
+        if not _try_acquire_status_lock(runtime.lock_fd):
+            return _unknown_pending_backlog_snapshot()
+        lock_held = True
+        _status_count_protocol_artifacts(
+            root_fd=runtime.root_fd,
+            limit=STATUS_SCAN_ARTIFACT_LIMIT,
+        )
+        pending_bytes = 0
+        pending_frames = 0
+        active_fd = _open_file_optional(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            full_path=runtime.active_path,
+        )
+        if active_fd is not None:
+            active_stat = os.fstat(active_fd)
+            _status_assert_active_fd_matches_entry(
+                root_fd=runtime.root_fd,
+                entry_stat=active_stat,
+                fd=active_fd,
+            )
+            pending_bytes = max(0, int(active_stat.st_size))
+            if pending_bytes > 0:
+                active_scan = _scan_fd(active_fd)
+                _status_assert_active_fd_matches_entry(
+                    root_fd=runtime.root_fd,
+                    entry_stat=active_stat,
+                    fd=active_fd,
+                )
+                pending_frames = active_scan.frame_count
+
+        blocker = _status_load_blocker_snapshot(root_fd=runtime.root_fd)
+        segments = _status_collect_segment_snapshots(root_fd=runtime.root_fd)
+        ack_snapshot = _status_scan_ack_sidecars(
+            root_fd=runtime.root_fd,
+            segment_sizes={item.name: item.size_bytes for item in segments},
+        )
+        if ack_snapshot.blocked_orphan_sequence is not None:
+            return _unknown_pending_backlog_snapshot(
+                ack_pending=True,
+                first_blocked_segment=ack_snapshot.blocked_orphan_sequence,
+            )
+
+        ack_pending = (
+            blocker.acked_prefix_bytes > 0
+            or ack_snapshot.orphan_tombstone_sequence is not None
+        )
+        for item in segments:
+            acked_prefix_bytes, segment_ack_pending = _status_effective_acked_prefix(
+                segment=item,
+                ack_snapshot=ack_snapshot,
+                blocker=blocker,
+            )
+            segment_pending_frames, segment_pending_bytes = _status_pending_prefix_metrics(
+                item.decoded,
+                acked_prefix_bytes=acked_prefix_bytes,
+                error_class="invalid_ack_json",
+            )
+            pending_frames += segment_pending_frames
+            pending_bytes += segment_pending_bytes
+            ack_pending = ack_pending or segment_ack_pending
+
+        return _PendingBacklogSnapshot(
+            pending_bytes=pending_bytes,
+            pending_frames=pending_frames,
+            ack_pending=ack_pending,
+            first_blocked_segment=blocker.sequence if blocker.present else None,
+            first_blocked_offset=blocker.offset if blocker.present else None,
+        )
+    finally:
+        if active_fd is not None:
+            _close_fd_quietly(active_fd)
+        if lock_held:
+            _release_status_lock(runtime.lock_fd)
+
+
+def _capture_pending_backlog_snapshot(runtime: _AnchoredRuntime) -> _PendingBacklogSnapshot:
+    try:
+        return _snapshot_pending_backlog(runtime)
+    except Exception:
+        return _unknown_pending_backlog_snapshot()
+
+
+def _capture_replay_terminal_backlog(
+    runtime: _AnchoredRuntime,
+    *,
+    ack_pending: bool = False,
+) -> _PendingBacklogSnapshot:
+    snapshot = _capture_pending_backlog_snapshot(runtime)
+    merged_ack_pending = bool(snapshot.ack_pending or ack_pending)
+    if merged_ack_pending == snapshot.ack_pending:
+        return snapshot
+    return _PendingBacklogSnapshot(
+        pending_bytes=snapshot.pending_bytes,
+        pending_frames=snapshot.pending_frames,
+        ack_pending=merged_ack_pending,
+        first_blocked_segment=snapshot.first_blocked_segment,
+        first_blocked_offset=snapshot.first_blocked_offset,
+    )
 
 
 def _replay_db_call(
@@ -1416,8 +1830,8 @@ def scan_spool(
         os.close(fd)
 
 
-def decode_spool_segment(
-    path: Path,
+def _decode_spool_segment_fd(
+    fd: int,
     *,
     start_offset: int = 0,
     max_file_bytes: int = TOTAL_CAP_BYTES,
@@ -1425,6 +1839,120 @@ def decode_spool_segment(
 ) -> DecodedSegment:
     if start_offset < 0:
         raise SpoolDurabilityError(f"invalid decode offset for fallback spool segment: {start_offset}")
+    file_size = os.fstat(fd).st_size
+    payload_cap = max_frame_bytes - HEADER_SIZE
+    budget = min(file_size, max_file_bytes if max_file_bytes > 0 else file_size)
+    offset = start_offset
+    frames: list[SessionSpoolFrame] = []
+    while offset < file_size:
+        if offset + HEADER_SIZE > budget:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+                tail_offset=offset,
+            )
+        header = _read_exact_from_fd(fd, offset=offset, length=HEADER_SIZE)
+        if len(header) < HEADER_SIZE:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.INCOMPLETE_EOF,
+                tail_offset=offset,
+            )
+        if header[:4] != HEADER_MAGIC:
+            tail_status = SpoolTailStatus.BAD_MAGIC
+        elif header[4] != FRAME_VERSION:
+            tail_status = SpoolTailStatus.BAD_VERSION
+        elif header[5] != RECORD_KIND_SESSION_PERSISTENCE_UNIT:
+            tail_status = SpoolTailStatus.BAD_RECORD_KIND
+        elif header[6:8] != b"\x00\x00":
+            tail_status = SpoolTailStatus.NONZERO_RESERVED
+        else:
+            tail_status = None
+        if tail_status is not None:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=tail_status,
+                tail_offset=offset,
+            )
+        payload_len = int.from_bytes(header[8:16], "big")
+        if payload_len == 0 or payload_len > payload_cap:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.OVERSIZED_LENGTH,
+                tail_offset=offset,
+            )
+        frame_length = HEADER_SIZE + payload_len
+        if offset + frame_length > budget:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+                tail_offset=offset,
+            )
+        payload = _read_exact_from_fd(fd, offset=offset + HEADER_SIZE, length=payload_len)
+        if len(payload) < payload_len:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.INCOMPLETE_EOF,
+                tail_offset=offset,
+            )
+        expected_digest = blake2s(header[4:16] + payload, digest_size=16).digest()
+        if header[16:32] != expected_digest:
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.CHECKSUM_MISMATCH,
+                tail_offset=offset,
+            )
+        try:
+            payload_obj = json.loads(
+                payload.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.INVALID_JSON,
+                tail_offset=offset,
+            )
+        if not _validate_payload_schema(payload_obj):
+            return DecodedSegment(
+                prefix_frames=tuple(frames),
+                valid_prefix_bytes=offset,
+                tail_status=SpoolTailStatus.INVALID_SCHEMA,
+                tail_offset=offset,
+            )
+        frames.append(
+            SessionSpoolFrame(
+                record=_record_from_payload_object(payload_obj),
+                frame_offset=offset,
+                frame_length=frame_length,
+                payload_length=payload_len,
+                checksum_hex=header[16:32].hex(),
+            )
+        )
+        offset += frame_length
+    return DecodedSegment(
+        prefix_frames=tuple(frames),
+        valid_prefix_bytes=offset,
+        tail_status=SpoolTailStatus.CLEAN,
+        tail_offset=None,
+    )
+
+
+def decode_spool_segment(
+    path: Path,
+    *,
+    start_offset: int = 0,
+    max_file_bytes: int = TOTAL_CAP_BYTES,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
+) -> DecodedSegment:
     if not path.exists():
         return DecodedSegment(
             prefix_frames=(),
@@ -1435,110 +1963,11 @@ def decode_spool_segment(
     _require_existing_file(path)
     fd = os.open(str(path), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
     try:
-        file_size = os.fstat(fd).st_size
-        payload_cap = max_frame_bytes - HEADER_SIZE
-        budget = min(file_size, max_file_bytes if max_file_bytes > 0 else file_size)
-        offset = start_offset
-        frames: list[SessionSpoolFrame] = []
-        while offset < file_size:
-            if offset + HEADER_SIZE > budget:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
-                    tail_offset=offset,
-                )
-            header = _read_exact_from_fd(fd, offset=offset, length=HEADER_SIZE)
-            if len(header) < HEADER_SIZE:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.INCOMPLETE_EOF,
-                    tail_offset=offset,
-                )
-            if header[:4] != HEADER_MAGIC:
-                tail_status = SpoolTailStatus.BAD_MAGIC
-            elif header[4] != FRAME_VERSION:
-                tail_status = SpoolTailStatus.BAD_VERSION
-            elif header[5] != RECORD_KIND_SESSION_PERSISTENCE_UNIT:
-                tail_status = SpoolTailStatus.BAD_RECORD_KIND
-            elif header[6:8] != b"\x00\x00":
-                tail_status = SpoolTailStatus.NONZERO_RESERVED
-            else:
-                tail_status = None
-            if tail_status is not None:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=tail_status,
-                    tail_offset=offset,
-                )
-            payload_len = int.from_bytes(header[8:16], "big")
-            if payload_len == 0 or payload_len > payload_cap:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.OVERSIZED_LENGTH,
-                    tail_offset=offset,
-                )
-            frame_length = HEADER_SIZE + payload_len
-            if offset + frame_length > budget:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
-                    tail_offset=offset,
-                )
-            payload = _read_exact_from_fd(fd, offset=offset + HEADER_SIZE, length=payload_len)
-            if len(payload) < payload_len:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.INCOMPLETE_EOF,
-                    tail_offset=offset,
-                )
-            expected_digest = blake2s(header[4:16] + payload, digest_size=16).digest()
-            if header[16:32] != expected_digest:
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.CHECKSUM_MISMATCH,
-                    tail_offset=offset,
-                )
-            try:
-                payload_obj = json.loads(
-                    payload.decode("utf-8"),
-                    object_pairs_hook=_reject_duplicate_json_keys,
-                )
-            except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.INVALID_JSON,
-                    tail_offset=offset,
-                )
-            if not _validate_payload_schema(payload_obj):
-                return DecodedSegment(
-                    prefix_frames=tuple(frames),
-                    valid_prefix_bytes=offset,
-                    tail_status=SpoolTailStatus.INVALID_SCHEMA,
-                    tail_offset=offset,
-                )
-            frames.append(
-                SessionSpoolFrame(
-                    record=_record_from_payload_object(payload_obj),
-                    frame_offset=offset,
-                    frame_length=frame_length,
-                    payload_length=payload_len,
-                    checksum_hex=header[16:32].hex(),
-                )
-            )
-            offset += frame_length
-        return DecodedSegment(
-            prefix_frames=tuple(frames),
-            valid_prefix_bytes=offset,
-            tail_status=SpoolTailStatus.CLEAN,
-            tail_offset=None,
+        return _decode_spool_segment_fd(
+            fd,
+            start_offset=start_offset,
+            max_file_bytes=max_file_bytes,
+            max_frame_bytes=max_frame_bytes,
         )
     finally:
         os.close(fd)
@@ -2208,6 +2637,60 @@ def _open_dir_optional(parent_fd: int, name: str, *, full_path: Path) -> int | N
     return fd
 
 
+def _open_file_optional(parent_fd: int, name: str, *, full_path: Path) -> int | None:
+    try:
+        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.EISDIR}:
+            raise SpoolPathSecurityError(f"symlinked fallback spool path refused: {full_path}") from exc
+        raise SpoolDurabilityError(f"unable to open fallback spool file {full_path}: {exc}") from exc
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {full_path}")
+        _assert_entry_matches_fd(parent_fd, name, fd, expect="file", label=str(full_path))
+    except BaseException:
+        _close_fd_quietly(fd)
+        raise
+    return fd
+
+
+def _try_acquire_status_lock(fd: int) -> bool:
+    deadline = time.monotonic() + STATUS_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            elif msvcrt is not None:  # pragma: no cover - Windows-only branch
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            else:  # pragma: no cover - unsupported platform
+                raise _StatusInspectionError("append_lock_unavailable")
+            return True
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(STATUS_LOCK_RETRY_SECONDS)
+        except OSError as exc:
+            if _is_lock_contention_error(exc):
+                if time.monotonic() >= deadline:
+                    return False
+                time.sleep(STATUS_LOCK_RETRY_SECONDS)
+                continue
+            raise _StatusInspectionError("append_lock_error") from exc
+
+
+def _release_status_lock(fd: int) -> None:
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        elif msvcrt is not None:  # pragma: no cover - Windows-only branch
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+
+
 def _collect_sequences_from_directory(
     *,
     dir_fd: int,
@@ -2381,6 +2864,1180 @@ def _durable_capacity_inventory(
             _close_fd_quietly(acks_fd)
         if sealed_fd is not None:
             _close_fd_quietly(sealed_fd)
+
+
+def _ordered_status_reasons(reasons: set[str]) -> tuple[str, ...]:
+    return tuple(reason for reason in _STATUS_REASON_ORDER if reason in reasons)
+
+
+def _probe_disk_from_home_fd(
+    home_fd: int,
+    *,
+    threshold_bytes: int,
+) -> tuple[int | None, int | None, str, str | None]:
+    if not hasattr(os, "fstatvfs"):
+        return None, None, "unknown", "disk_probe_failed"
+    try:
+        statvfs = os.fstatvfs(home_fd)
+    except OSError:
+        return None, None, "unknown", "disk_probe_failed"
+    free_bytes = int(statvfs.f_bavail) * int(statvfs.f_frsize)
+    total_bytes = int(statvfs.f_blocks) * int(statvfs.f_frsize)
+    state = "low" if free_bytes < max(0, int(threshold_bytes)) else "ok"
+    return free_bytes, total_bytes, state, None
+
+
+def _classify_status_os_error(
+    exc: OSError,
+    *,
+    default_error_class: str = "inspection_error",
+) -> str:
+    if isinstance(exc, FileNotFoundError):
+        return "entry_replaced"
+    if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.EISDIR}:
+        return "symlink_refused"
+    return default_error_class
+
+
+def _classify_status_exception(
+    exc: BaseException,
+    *,
+    default_error_class: str = "inspection_error",
+) -> str:
+    if isinstance(exc, _StatusInspectionError):
+        return exc.error_class
+    if isinstance(exc, SpoolPathSecurityError):
+        return "symlink_refused"
+    if isinstance(exc, OSError):
+        return _classify_status_os_error(exc, default_error_class=default_error_class)
+    cause = getattr(exc, "__cause__", None)
+    if isinstance(cause, SpoolPathSecurityError):
+        return "symlink_refused"
+    if isinstance(cause, OSError):
+        return _classify_status_os_error(cause, default_error_class=default_error_class)
+    return default_error_class
+
+
+def _status_iter_dir_entries(
+    dir_fd: int,
+    *,
+    default_error_class: str = "inspection_error",
+):
+    try:
+        entries = os.scandir(dir_fd)
+    except OSError as exc:
+        raise _StatusInspectionError(
+            _classify_status_os_error(exc, default_error_class=default_error_class)
+        ) from exc
+    try:
+        while True:
+            try:
+                entry = next(entries)
+            except StopIteration:
+                break
+            except OSError as exc:
+                raise _StatusInspectionError(
+                    _classify_status_os_error(exc, default_error_class=default_error_class)
+                ) from exc
+            yield entry
+    finally:
+        close = getattr(entries, "close", None)
+        if close is not None:
+            close()
+
+
+def _status_entry_is_symlink(
+    entry,
+    *,
+    default_error_class: str = "inspection_error",
+) -> bool:
+    try:
+        return entry.is_symlink()
+    except OSError as exc:
+        raise _StatusInspectionError(
+            _classify_status_os_error(exc, default_error_class=default_error_class)
+        ) from exc
+
+
+def _status_entry_stat(
+    entry,
+    *,
+    default_error_class: str = "inspection_error",
+) -> os.stat_result:
+    try:
+        return entry.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise _StatusInspectionError(
+            _classify_status_os_error(exc, default_error_class=default_error_class)
+        ) from exc
+
+
+def _status_root_has_entries(root_fd: int) -> bool:
+    for _entry in _status_iter_dir_entries(root_fd):
+        return True
+    return False
+
+
+def _status_pending_prefix_metrics(
+    decoded: DecodedSegment,
+    *,
+    acked_prefix_bytes: int,
+    error_class: str,
+) -> tuple[int, int]:
+    if acked_prefix_bytes < 0 or acked_prefix_bytes > decoded.valid_prefix_bytes:
+        raise _StatusInspectionError(error_class)
+    pending_frames = 0
+    pending_bytes = 0
+    for frame in decoded.prefix_frames:
+        frame_end = frame.frame_offset + frame.frame_length
+        if frame_end <= acked_prefix_bytes:
+            continue
+        if frame.frame_offset < acked_prefix_bytes:
+            raise _StatusInspectionError(error_class)
+        pending_frames += 1
+        pending_bytes += frame.frame_length
+    return pending_frames, pending_bytes
+
+
+def _status_assert_regular_fd_matches_entry(
+    *,
+    parent_fd: int,
+    name: str,
+    entry_stat: os.stat_result,
+    fd: int,
+    error_class: str,
+    default_error_class: str | None = None,
+) -> None:
+    normalized_default_error_class = (
+        error_class if default_error_class is None else default_error_class
+    )
+    try:
+        current_stat = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except (FileNotFoundError, OSError) as exc:
+        raise _StatusInspectionError(
+            _classify_status_os_error(
+                exc,
+                default_error_class=normalized_default_error_class,
+            )
+        ) from exc
+    try:
+        target_stat = os.fstat(fd)
+    except OSError as exc:
+        raise _StatusInspectionError(
+            _classify_status_os_error(
+                exc,
+                default_error_class=normalized_default_error_class,
+            )
+        ) from exc
+    if not stat.S_ISREG(current_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
+        raise _StatusInspectionError(error_class)
+    if not _same_file_stat(entry_stat, target_stat) or not _same_file_stat(
+        current_stat, target_stat
+    ):
+        raise _StatusInspectionError(error_class)
+
+
+def _status_assert_active_fd_matches_entry(
+    *,
+    root_fd: int,
+    entry_stat: os.stat_result,
+    fd: int,
+) -> None:
+    _status_assert_regular_fd_matches_entry(
+        parent_fd=root_fd,
+        name=ACTIVE_SPOOL_NAME,
+        entry_stat=entry_stat,
+        fd=fd,
+        error_class="entry_replaced",
+        default_error_class="inspection_error",
+    )
+
+
+def _status_load_orphan_ack_payload(
+    *,
+    dir_fd: int,
+    entry_name: str,
+    expected_segment_name: str,
+) -> tuple[int, Mapping[str, Any]]:
+    parsed = _parse_ack_sidecar_name(entry_name)
+    if parsed is None:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    _sequence, entry_segment_name, acked_prefix = parsed
+    if entry_segment_name != expected_segment_name:
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    fd = os.open(entry_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    try:
+        raw = _read_exact_from_fd(fd, offset=0, length=os.fstat(fd).st_size)
+    finally:
+        os.close(fd)
+    try:
+        payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    segment_size_bytes = payload.get("segment_size_bytes")
+    if isinstance(segment_size_bytes, bool) or not isinstance(segment_size_bytes, int):
+        raise SpoolDurabilityError(f"invalid ack sidecar: {entry_name}")
+    validated = _validate_ack_payload(
+        raw_bytes=raw,
+        payload=payload,
+        ack_name=entry_name,
+        expected_segment_name=expected_segment_name,
+        segment_size_bytes=int(segment_size_bytes),
+    )
+    return acked_prefix, validated
+
+
+def _classify_status_ack_os_error(exc: OSError) -> str:
+    return _classify_status_os_error(exc, default_error_class="invalid_ack_json")
+
+
+def _status_scan_ack_sidecars(
+    *,
+    root_fd: int,
+    segment_sizes: Mapping[str, int],
+) -> _StatusAckDirectorySnapshot:
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return _StatusAckDirectorySnapshot(winners_by_segment={})
+    acks_fd: int | None = None
+    try:
+        acks_fd = _open_dir_optional(sealed_fd, ACKS_DIR_NAME, full_path=_acks_dir())
+        if acks_fd is None:
+            return _StatusAckDirectorySnapshot(winners_by_segment={})
+        winners: dict[str, Mapping[str, Any]] = {}
+        orphan_winners: dict[str, tuple[int, int, Mapping[str, Any], int]] = {}
+        blocked_orphan_sequence: int | None = None
+        candidate_counts: dict[str, int] = {}
+        for entry in _status_iter_dir_entries(
+            acks_fd,
+            default_error_class="invalid_ack_json",
+        ):
+            if _status_entry_is_symlink(
+                entry,
+                default_error_class="invalid_ack_json",
+            ):
+                raise _StatusInspectionError("symlink_refused")
+            entry_stat = _status_entry_stat(
+                entry,
+                default_error_class="invalid_ack_json",
+            )
+            if stat.S_ISDIR(entry_stat.st_mode):
+                raise _StatusInspectionError("unexpected_artifact")
+            if not stat.S_ISREG(entry_stat.st_mode):
+                raise _StatusInspectionError("unexpected_artifact")
+            if entry.name.startswith("."):
+                try:
+                    temp_parsed = _parse_protocol_temp_sequence(
+                        entry.name,
+                        dir_fd=acks_fd,
+                        label=_acks_dir() / entry.name,
+                    )
+                except OSError as exc:
+                    raise _StatusInspectionError(_classify_status_ack_os_error(exc)) from exc
+                except (SpoolDurabilityError, SpoolPathSecurityError) as exc:
+                    raise _StatusInspectionError("unexpected_artifact") from exc
+                if temp_parsed is not None:
+                    continue
+            parsed = _parse_ack_sidecar_name(entry.name)
+            if parsed is None:
+                raise _StatusInspectionError("unexpected_artifact")
+            sequence, segment_name, acked_prefix = parsed
+            candidate_counts[segment_name] = candidate_counts.get(segment_name, 0) + 1
+            if candidate_counts[segment_name] > 64:
+                raise _StatusInspectionError("invalid_ack_json")
+            try:
+                if segment_name in segment_sizes:
+                    _acked_prefix, validated = _load_ack_payload_from_fd(
+                        dir_fd=acks_fd,
+                        entry_name=entry.name,
+                        expected_segment_name=segment_name,
+                        segment_size_bytes=segment_sizes[segment_name],
+                    )
+                    current_winner = winners.get(segment_name)
+                    if current_winner is None or acked_prefix > int(
+                        current_winner["acked_prefix_bytes"]
+                    ):
+                        winners[segment_name] = validated
+                    continue
+                _acked_prefix, validated = _status_load_orphan_ack_payload(
+                    dir_fd=acks_fd,
+                    entry_name=entry.name,
+                    expected_segment_name=segment_name,
+                )
+            except OSError as exc:
+                raise _StatusInspectionError(_classify_status_ack_os_error(exc)) from exc
+            except SpoolDurabilityError as exc:
+                raise _StatusInspectionError("invalid_ack_json") from exc
+            current_orphan = orphan_winners.get(segment_name)
+            if current_orphan is None or acked_prefix > current_orphan[1]:
+                orphan_winners[segment_name] = (
+                    sequence,
+                    acked_prefix,
+                    validated,
+                    int(entry_stat.st_mtime_ns),
+                )
+
+        orphan_tombstone_sequence: int | None = None
+        orphan_tombstone_mtime_ns: int | None = None
+        for sequence, _acked_prefix, validated, mtime_ns in orphan_winners.values():
+            validated_acked_prefix = int(validated["acked_prefix_bytes"])
+            validated_valid_prefix = int(validated["valid_prefix_bytes"])
+            segment_size_bytes = int(validated["segment_size_bytes"])
+            if (
+                validated_acked_prefix == validated_valid_prefix
+                and validated_valid_prefix == segment_size_bytes
+            ):
+                if (
+                    orphan_tombstone_sequence is None
+                    or sequence < orphan_tombstone_sequence
+                ):
+                    orphan_tombstone_sequence = sequence
+                    orphan_tombstone_mtime_ns = mtime_ns
+                continue
+            blocked_orphan_sequence = (
+                sequence
+                if blocked_orphan_sequence is None
+                else min(blocked_orphan_sequence, sequence)
+            )
+        return _StatusAckDirectorySnapshot(
+            winners_by_segment=winners,
+            orphan_tombstone_sequence=orphan_tombstone_sequence,
+            orphan_tombstone_mtime_ns=orphan_tombstone_mtime_ns,
+            blocked_orphan_sequence=blocked_orphan_sequence,
+        )
+    finally:
+        if acks_fd is not None:
+            _close_fd_quietly(acks_fd)
+        _close_fd_quietly(sealed_fd)
+
+
+def _status_effective_acked_prefix(
+    *,
+    segment: _StatusSegmentSnapshot,
+    ack_snapshot: _StatusAckDirectorySnapshot,
+    blocker: _StatusBlockerSnapshot,
+) -> tuple[int, bool]:
+    winner = ack_snapshot.winners_by_segment.get(segment.name)
+    acked_prefix_bytes = 0
+    ack_pending = False
+    if winner is not None:
+        acked_prefix_bytes = int(winner["acked_prefix_bytes"])
+        ack_pending = True
+    if blocker.present and blocker.prefix_segment_name == segment.name and blocker.acked_prefix_bytes > 0:
+        if blocker.valid_prefix_bytes != segment.size_bytes:
+            raise _StatusInspectionError("invalid_blocker_json")
+        acked_prefix_bytes = max(acked_prefix_bytes, blocker.acked_prefix_bytes)
+        ack_pending = True
+    return acked_prefix_bytes, ack_pending
+
+
+def _status_count_directory_protocol_artifacts(
+    *,
+    dir_fd: int,
+    dir_path: Path,
+    parsers: tuple,
+    allowed_dirs: set[str],
+    limit: int,
+    counted: list[int],
+    legacy_quarantine_ok: bool = False,
+) -> None:
+    for entry in _status_iter_dir_entries(dir_fd):
+        if _status_entry_is_symlink(entry):
+            raise _StatusInspectionError("symlink_refused")
+        entry_stat = _status_entry_stat(entry)
+        if stat.S_ISDIR(entry_stat.st_mode) and entry.name in allowed_dirs:
+            continue
+        matched = False
+        for parser in parsers:
+            if parser(entry.name) is not None:
+                matched = True
+                break
+        if not matched and entry.name.startswith("."):
+            try:
+                temp_parsed = _parse_protocol_temp_sequence(
+                    entry.name,
+                    dir_fd=dir_fd,
+                    label=dir_path / entry.name,
+                )
+            except OSError as exc:
+                raise _StatusInspectionError(
+                    _classify_status_os_error(exc)
+                ) from exc
+            except SpoolPathSecurityError as exc:
+                raise _StatusInspectionError("symlink_refused") from exc
+            except SpoolDurabilityError as exc:
+                raise _StatusInspectionError("unexpected_artifact") from exc
+            if temp_parsed is not None:
+                matched = True
+        if not matched and legacy_quarantine_ok and _is_legacy_quarantine_name(entry.name):
+            matched = True
+        if not matched:
+            raise _StatusInspectionError("unexpected_artifact")
+        counted[0] += 1
+        if counted[0] > limit:
+            raise _StatusInspectionError("artifact_limit_exceeded")
+
+
+def _status_count_protocol_artifacts(*, root_fd: int, limit: int) -> None:
+    counted = [0]
+    for entry in _status_iter_dir_entries(root_fd):
+        label = _spool_root() / entry.name
+        if _status_entry_is_symlink(entry):
+            raise _StatusInspectionError("symlink_refused")
+        entry_stat = _status_entry_stat(entry)
+        if stat.S_ISDIR(entry_stat.st_mode):
+            if entry.name in {SEALED_DIR_NAME, QUARANTINE_DIR_NAME}:
+                continue
+            raise _StatusInspectionError("unexpected_artifact")
+        if not stat.S_ISREG(entry_stat.st_mode):
+            raise _StatusInspectionError("unexpected_artifact")
+        if entry.name in {LOCK_FILE_NAME, REPLAY_OWNER_LOCK_NAME}:
+            continue
+        if entry.name in {ACTIVE_SPOOL_NAME, HIGHWATER_FILE_NAME}:
+            counted[0] += 1
+            if counted[0] > limit:
+                raise _StatusInspectionError("artifact_limit_exceeded")
+            continue
+        if entry.name.startswith("."):
+            try:
+                temp_parsed = _parse_protocol_temp_sequence(
+                    entry.name,
+                    dir_fd=root_fd,
+                    label=label,
+                )
+            except OSError as exc:
+                raise _StatusInspectionError(
+                    _classify_status_os_error(exc)
+                ) from exc
+            except SpoolPathSecurityError as exc:
+                raise _StatusInspectionError("symlink_refused") from exc
+            except SpoolDurabilityError as exc:
+                raise _StatusInspectionError("unexpected_artifact") from exc
+            if temp_parsed is not None:
+                counted[0] += 1
+                if counted[0] > limit:
+                    raise _StatusInspectionError("artifact_limit_exceeded")
+                continue
+        raise _StatusInspectionError("unexpected_artifact")
+
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is not None:
+        try:
+            _status_count_directory_protocol_artifacts(
+                dir_fd=sealed_fd,
+                dir_path=_sealed_dir(),
+                parsers=(_parse_sealed_segment_sequence,),
+                allowed_dirs={ACKS_DIR_NAME, BLOCKERS_DIR_NAME},
+                limit=limit,
+                counted=counted,
+            )
+            acks_fd = _open_dir_optional(sealed_fd, ACKS_DIR_NAME, full_path=_acks_dir())
+            if acks_fd is not None:
+                try:
+                    _status_count_directory_protocol_artifacts(
+                        dir_fd=acks_fd,
+                        dir_path=_acks_dir(),
+                        parsers=(_parse_ack_sidecar_sequence,),
+                        allowed_dirs=set(),
+                        limit=limit,
+                        counted=counted,
+                    )
+                finally:
+                    _close_fd_quietly(acks_fd)
+            blockers_fd = _open_dir_optional(sealed_fd, BLOCKERS_DIR_NAME, full_path=_blockers_dir())
+            if blockers_fd is not None:
+                try:
+                    _status_count_directory_protocol_artifacts(
+                        dir_fd=blockers_fd,
+                        dir_path=_blockers_dir(),
+                        parsers=(_parse_blocker_sequence,),
+                        allowed_dirs=set(),
+                        limit=limit,
+                        counted=counted,
+                    )
+                finally:
+                    _close_fd_quietly(blockers_fd)
+        finally:
+            _close_fd_quietly(sealed_fd)
+
+    quarantine_fd = _open_dir_optional(root_fd, QUARANTINE_DIR_NAME, full_path=_quarantine_dir())
+    if quarantine_fd is not None:
+        try:
+            _status_count_directory_protocol_artifacts(
+                dir_fd=quarantine_fd,
+                dir_path=_quarantine_dir(),
+                parsers=(_parse_replay_quarantine_sequence,),
+                allowed_dirs=set(),
+                limit=limit,
+                counted=counted,
+                legacy_quarantine_ok=True,
+            )
+        finally:
+            _close_fd_quietly(quarantine_fd)
+
+
+def _status_collect_segment_snapshots(*, root_fd: int) -> list[_StatusSegmentSnapshot]:
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return []
+    try:
+        snapshots: list[_StatusSegmentSnapshot] = []
+        for entry in _status_iter_dir_entries(sealed_fd):
+            if _status_entry_is_symlink(entry):
+                raise _StatusInspectionError("symlink_refused")
+            entry_stat = _status_entry_stat(entry)
+            if stat.S_ISDIR(entry_stat.st_mode):
+                if entry.name in {ACKS_DIR_NAME, BLOCKERS_DIR_NAME}:
+                    continue
+                raise _StatusInspectionError("unexpected_artifact")
+            if not stat.S_ISREG(entry_stat.st_mode):
+                raise _StatusInspectionError("unexpected_artifact")
+            if entry.name.startswith("."):
+                try:
+                    temp_parsed = _parse_protocol_temp_sequence(
+                        entry.name,
+                        dir_fd=sealed_fd,
+                        label=_sealed_dir() / entry.name,
+                    )
+                except OSError as exc:
+                    raise _StatusInspectionError(
+                        _classify_status_os_error(exc)
+                    ) from exc
+                except SpoolPathSecurityError as exc:
+                    raise _StatusInspectionError("symlink_refused") from exc
+                except SpoolDurabilityError as exc:
+                    raise _StatusInspectionError("unexpected_artifact") from exc
+                if temp_parsed is not None:
+                    continue
+            match = re.fullmatch(r"(\d{20})(?:\.prefix)?\.spool", entry.name)
+            if not match:
+                raise _StatusInspectionError("unexpected_artifact")
+            try:
+                segment_fd = os.open(entry.name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=sealed_fd)
+            except OSError as exc:
+                raise _StatusInspectionError(_classify_status_os_error(exc)) from exc
+            try:
+                _status_assert_regular_fd_matches_entry(
+                    parent_fd=sealed_fd,
+                    name=entry.name,
+                    entry_stat=entry_stat,
+                    fd=segment_fd,
+                    error_class="entry_replaced",
+                    default_error_class="inspection_error",
+                )
+                decoded = _decode_spool_segment_fd(segment_fd)
+                if decoded.tail_status is not SpoolTailStatus.CLEAN:
+                    raise _StatusInspectionError(decoded.tail_status.value)
+                _status_assert_regular_fd_matches_entry(
+                    parent_fd=sealed_fd,
+                    name=entry.name,
+                    entry_stat=entry_stat,
+                    fd=segment_fd,
+                    error_class="entry_replaced",
+                    default_error_class="inspection_error",
+                )
+                snapshots.append(
+                    _StatusSegmentSnapshot(
+                        sequence=int(match.group(1)),
+                        name=entry.name,
+                        size_bytes=decoded.valid_prefix_bytes,
+                        frame_count=len(decoded.prefix_frames),
+                        mtime_ns=int(entry_stat.st_mtime_ns),
+                        decoded=decoded,
+                    )
+                )
+            finally:
+                _close_fd_quietly(segment_fd)
+        snapshots.sort(key=lambda item: (item.sequence, item.name))
+        return snapshots
+    finally:
+        _close_fd_quietly(sealed_fd)
+
+
+def _status_load_blocker_snapshot(*, root_fd: int) -> _StatusBlockerSnapshot:
+    sealed_fd = _open_dir_optional(root_fd, SEALED_DIR_NAME, full_path=_sealed_dir())
+    if sealed_fd is None:
+        return _StatusBlockerSnapshot()
+    blockers_fd: int | None = None
+    quarantine_fd: int | None = None
+    prefix_fd = -1
+    evidence_spool_fd = -1
+    try:
+        blockers_fd = _open_dir_optional(sealed_fd, BLOCKERS_DIR_NAME, full_path=_blockers_dir())
+        if blockers_fd is None:
+            return _StatusBlockerSnapshot()
+        blocker_entries: list[tuple[int, str, os.stat_result]] = []
+        for entry in _status_iter_dir_entries(blockers_fd):
+            if _status_entry_is_symlink(entry):
+                raise _StatusInspectionError("symlink_refused")
+            entry_stat = _status_entry_stat(entry)
+            if stat.S_ISDIR(entry_stat.st_mode):
+                raise _StatusInspectionError("unexpected_artifact")
+            if not stat.S_ISREG(entry_stat.st_mode):
+                raise _StatusInspectionError("unexpected_artifact")
+            if entry.name.startswith("."):
+                try:
+                    temp_parsed = _parse_protocol_temp_sequence(
+                        entry.name,
+                        dir_fd=blockers_fd,
+                        label=_blockers_dir() / entry.name,
+                    )
+                except OSError as exc:
+                    raise _StatusInspectionError(
+                        _classify_status_os_error(exc)
+                    ) from exc
+                except SpoolPathSecurityError as exc:
+                    raise _StatusInspectionError("symlink_refused") from exc
+                except SpoolDurabilityError as exc:
+                    raise _StatusInspectionError("unexpected_artifact") from exc
+                if temp_parsed is not None:
+                    continue
+            sequence = _parse_blocker_sequence(entry.name)
+            if sequence is None:
+                raise _StatusInspectionError("unexpected_artifact")
+            blocker_entries.append((sequence, entry.name, entry_stat))
+        if not blocker_entries:
+            return _StatusBlockerSnapshot()
+        blocker_entries.sort(key=lambda item: item[0])
+        sequence, entry_name, entry_stat = blocker_entries[0]
+        try:
+            payload = _load_canonical_json_entry(
+                dir_fd=blockers_fd,
+                entry_name=entry_name,
+                label=_blockers_dir() / entry_name,
+                invalid_message=f"invalid corruption blocker: {_blockers_dir() / entry_name}",
+            )
+        except (OSError, SpoolDurabilityError, SpoolPathSecurityError) as exc:
+            raise _StatusInspectionError(
+                _classify_status_exception(
+                    exc,
+                    default_error_class="invalid_blocker_json",
+                )
+            ) from exc
+        required_fields = {
+            "schema_version",
+            "segment_sequence",
+            "source_kind",
+            "tail_status",
+            "valid_prefix_bytes",
+            "acked_prefix_bytes",
+            "blocking_offset",
+            "prefix_segment_name",
+            "evidence_spool_name",
+            "evidence_sidecar_name",
+            "original_size_bytes",
+        }
+        if set(payload.keys()) != required_fields:
+            raise _StatusInspectionError("invalid_blocker_json")
+        if payload.get("schema_version") != 1 or payload.get("segment_sequence") != _format_segment_sequence(sequence):
+            raise _StatusInspectionError("invalid_blocker_json")
+        source_kind = payload.get("source_kind")
+        if source_kind not in {"active", "sealed"}:
+            raise _StatusInspectionError("invalid_blocker_json")
+        try:
+            tail_status = SpoolTailStatus(str(payload.get("tail_status")))
+        except ValueError as exc:
+            raise _StatusInspectionError("invalid_blocker_json") from exc
+        blocking_offset = payload.get("blocking_offset")
+        valid_prefix_bytes = payload.get("valid_prefix_bytes")
+        acked_prefix_bytes = payload.get("acked_prefix_bytes")
+        original_size_bytes = payload.get("original_size_bytes")
+        if not all(
+            isinstance(value, int) and not isinstance(value, bool)
+            for value in (
+                blocking_offset,
+                valid_prefix_bytes,
+                acked_prefix_bytes,
+                original_size_bytes,
+            )
+        ):
+            raise _StatusInspectionError("invalid_blocker_json")
+        assert isinstance(blocking_offset, int) and not isinstance(blocking_offset, bool)
+        assert isinstance(valid_prefix_bytes, int) and not isinstance(valid_prefix_bytes, bool)
+        assert isinstance(acked_prefix_bytes, int) and not isinstance(acked_prefix_bytes, bool)
+        assert isinstance(original_size_bytes, int) and not isinstance(
+            original_size_bytes, bool
+        )
+        blocking_offset = int(blocking_offset)
+        valid_prefix_bytes = int(valid_prefix_bytes)
+        acked_prefix_bytes = int(acked_prefix_bytes)
+        original_size_bytes = int(original_size_bytes)
+        if (
+            blocking_offset < 0
+            or valid_prefix_bytes < 0
+            or acked_prefix_bytes < 0
+            or acked_prefix_bytes > valid_prefix_bytes
+            or original_size_bytes < 0
+        ):
+            raise _StatusInspectionError("invalid_blocker_json")
+        prefix_segment_name = payload.get("prefix_segment_name")
+        if prefix_segment_name is not None and not isinstance(prefix_segment_name, str):
+            raise _StatusInspectionError("invalid_blocker_json")
+        evidence_spool_name = payload.get("evidence_spool_name")
+        evidence_sidecar_name = payload.get("evidence_sidecar_name")
+        if not isinstance(evidence_spool_name, str) or not isinstance(
+            evidence_sidecar_name, str
+        ):
+            raise _StatusInspectionError("invalid_blocker_json")
+        sequence_str = _format_segment_sequence(sequence)
+        expected_evidence_base = (
+            f"seq-{sequence_str}-{tail_status.value}-vp{valid_prefix_bytes}"
+        )
+        if (
+            evidence_spool_name != f"{expected_evidence_base}.spool"
+            or evidence_sidecar_name != f"{expected_evidence_base}.json"
+        ):
+            raise _StatusInspectionError("invalid_blocker_json")
+
+        quarantine_fd = _open_dir_optional(
+            root_fd, QUARANTINE_DIR_NAME, full_path=_quarantine_dir()
+        )
+        if quarantine_fd is None:
+            raise _StatusInspectionError("invalid_blocker_json")
+        try:
+            evidence_payload = _load_canonical_json_entry(
+                dir_fd=quarantine_fd,
+                entry_name=evidence_sidecar_name,
+                label=_quarantine_dir() / evidence_sidecar_name,
+                invalid_message=(
+                    f"invalid replay evidence sidecar: {_quarantine_dir() / evidence_sidecar_name}"
+                ),
+            )
+        except (OSError, SpoolDurabilityError, SpoolPathSecurityError) as exc:
+            raise _StatusInspectionError(
+                _classify_status_exception(
+                    exc,
+                    default_error_class="invalid_blocker_json",
+                )
+            ) from exc
+        expected_evidence_payload = {
+            "schema_version": 1,
+            "segment_sequence": sequence_str,
+            "source_kind": str(source_kind),
+            "tail_status": tail_status.value,
+            "valid_prefix_bytes": valid_prefix_bytes,
+            "original_size_bytes": original_size_bytes,
+            "evidence_spool_name": evidence_spool_name,
+        }
+        if dict(evidence_payload) != expected_evidence_payload:
+            raise _StatusInspectionError("invalid_blocker_json")
+
+        try:
+            evidence_entry_stat = os.stat(
+                evidence_spool_name,
+                dir_fd=quarantine_fd,
+                follow_symlinks=False,
+            )
+            if not stat.S_ISREG(evidence_entry_stat.st_mode):
+                raise _StatusInspectionError("invalid_blocker_json")
+            evidence_spool_fd = os.open(
+                evidence_spool_name,
+                os.O_RDONLY | os.O_NOFOLLOW,
+                dir_fd=quarantine_fd,
+            )
+            _status_assert_regular_fd_matches_entry(
+                parent_fd=quarantine_fd,
+                name=evidence_spool_name,
+                entry_stat=evidence_entry_stat,
+                fd=evidence_spool_fd,
+                error_class="invalid_blocker_json",
+            )
+            if int(os.fstat(evidence_spool_fd).st_size) != original_size_bytes:
+                raise _StatusInspectionError("invalid_blocker_json")
+        except (FileNotFoundError, OSError) as exc:
+            raise _StatusInspectionError(
+                "symlink_refused"
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.EISDIR}
+                else "invalid_blocker_json"
+            ) from exc
+        finally:
+            if evidence_spool_fd >= 0:
+                _close_fd_quietly(evidence_spool_fd)
+                evidence_spool_fd = -1
+
+        if prefix_segment_name is None:
+            if valid_prefix_bytes != 0 or acked_prefix_bytes != 0 or blocking_offset != 0:
+                raise _StatusInspectionError("invalid_blocker_json")
+            return _StatusBlockerSnapshot(
+                present=True,
+                sequence=sequence,
+                offset=blocking_offset,
+                reason_class=tail_status.value,
+                source_kind=str(source_kind),
+                mtime_ns=int(entry_stat.st_mtime_ns),
+                acked_prefix_bytes=acked_prefix_bytes,
+                valid_prefix_bytes=valid_prefix_bytes,
+                prefix_segment_name=None,
+                zero_prefix=True,
+            )
+
+        expected_prefix_name = f"{sequence_str}.prefix.spool"
+        if (
+            prefix_segment_name != expected_prefix_name
+            or valid_prefix_bytes <= 0
+            or blocking_offset != valid_prefix_bytes
+        ):
+            raise _StatusInspectionError("invalid_blocker_json")
+        try:
+            prefix_entry_stat = os.stat(
+                prefix_segment_name,
+                dir_fd=sealed_fd,
+                follow_symlinks=False,
+            )
+            if not stat.S_ISREG(prefix_entry_stat.st_mode):
+                raise _StatusInspectionError("invalid_blocker_json")
+            prefix_fd = os.open(
+                prefix_segment_name,
+                os.O_RDONLY | os.O_NOFOLLOW,
+                dir_fd=sealed_fd,
+            )
+            _status_assert_regular_fd_matches_entry(
+                parent_fd=sealed_fd,
+                name=prefix_segment_name,
+                entry_stat=prefix_entry_stat,
+                fd=prefix_fd,
+                error_class="invalid_blocker_json",
+            )
+            if int(os.fstat(prefix_fd).st_size) != valid_prefix_bytes:
+                raise _StatusInspectionError("invalid_blocker_json")
+            decoded_prefix = _decode_spool_segment_fd(prefix_fd)
+            if (
+                decoded_prefix.tail_status is not SpoolTailStatus.CLEAN
+                or decoded_prefix.valid_prefix_bytes != valid_prefix_bytes
+            ):
+                raise _StatusInspectionError("invalid_blocker_json")
+            _status_assert_regular_fd_matches_entry(
+                parent_fd=sealed_fd,
+                name=prefix_segment_name,
+                entry_stat=prefix_entry_stat,
+                fd=prefix_fd,
+                error_class="invalid_blocker_json",
+            )
+        except (FileNotFoundError, OSError) as exc:
+            raise _StatusInspectionError(
+                "symlink_refused"
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.EISDIR}
+                else "invalid_blocker_json"
+            ) from exc
+        finally:
+            if prefix_fd >= 0:
+                _close_fd_quietly(prefix_fd)
+                prefix_fd = -1
+        return _StatusBlockerSnapshot(
+            present=True,
+            sequence=sequence,
+            offset=blocking_offset,
+            reason_class=tail_status.value,
+            source_kind=str(source_kind),
+            mtime_ns=int(entry_stat.st_mtime_ns),
+            acked_prefix_bytes=acked_prefix_bytes,
+            valid_prefix_bytes=valid_prefix_bytes,
+            prefix_segment_name=prefix_segment_name,
+            zero_prefix=False,
+        )
+    finally:
+        if evidence_spool_fd >= 0:
+            _close_fd_quietly(evidence_spool_fd)
+        if prefix_fd >= 0:
+            _close_fd_quietly(prefix_fd)
+        if quarantine_fd is not None:
+            _close_fd_quietly(quarantine_fd)
+        if blockers_fd is not None:
+            _close_fd_quietly(blockers_fd)
+        _close_fd_quietly(sealed_fd)
+
+
+def collect_session_fallback_spool_status(*, now: float | None = None) -> SessionFallbackSpoolStatus:
+    observed_at = time.time() if now is None else float(now)
+    home_path = Path(get_hermes_home())
+    root_path = _spool_root()
+    active_path = _active_spool_path()
+    runtime: _AnchoredRuntime | None = None
+    home_fd = -1
+    root_fd = -1
+    lock_fd = -1
+    lock_held = False
+    inspection_error_class: str | None = None
+    reasons: set[str] = set()
+    pending_units = 0
+    pending_frames = 0
+    pending_bytes = 0
+    oldest_pending_age_seconds: float | None = None
+    retry_pending = False
+    retry_class = None
+    cooldown_seconds = 0.0
+    ack_pending = False
+    blocker = _StatusBlockerSnapshot()
+    capacity_used_bytes = 0
+    capacity_cap_bytes = max(0, int(TOTAL_CAP_BYTES))
+    capacity_remaining_bytes = capacity_cap_bytes
+    capacity_state = "ok"
+    disk_free_bytes: int | None = None
+    disk_total_bytes: int | None = None
+    disk_state = "unknown"
+    root_missing = False
+
+    try:
+        try:
+            home_fd = _open_home_dir_fd(home_path)
+            runtime = _AnchoredRuntime(
+                home_path=home_path,
+                root_path=root_path,
+                quarantine_path=_quarantine_dir(),
+                active_path=active_path,
+                home_fd=home_fd,
+                root_fd=-1,
+                lock_fd=-1,
+            )
+            maybe_root_fd = _open_dir_optional(home_fd, SPOOL_ROOT_NAME, full_path=root_path)
+            if maybe_root_fd is None:
+                root_missing = True
+            else:
+                root_fd = maybe_root_fd
+
+                runtime = _AnchoredRuntime(
+                    home_path=home_path,
+                    root_path=root_path,
+                    quarantine_path=_quarantine_dir(),
+                    active_path=active_path,
+                    home_fd=home_fd,
+                    root_fd=root_fd,
+                    lock_fd=-1,
+                )
+
+                root_populated = _status_root_has_entries(root_fd)
+                maybe_lock_fd = _open_file_optional(root_fd, LOCK_FILE_NAME, full_path=_lock_path())
+                if maybe_lock_fd is None and root_populated:
+                    inspection_error_class = "missing_append_lock"
+                elif maybe_lock_fd is not None:
+                    lock_fd = maybe_lock_fd
+                    if not _try_acquire_status_lock(lock_fd):
+                        inspection_error_class = "append_lock_busy"
+                    else:
+                        lock_held = True
+
+                if inspection_error_class is None:
+                    _status_count_protocol_artifacts(root_fd=root_fd, limit=STATUS_SCAN_ARTIFACT_LIMIT)
+
+                    active_fd = _open_file_optional(root_fd, ACTIVE_SPOOL_NAME, full_path=active_path)
+                    active_size = 0
+                    active_frames = 0
+                    active_mtime_ns: int | None = None
+                    try:
+                        if active_fd is not None:
+                            active_stat = os.fstat(active_fd)
+                            _status_assert_active_fd_matches_entry(
+                                root_fd=root_fd,
+                                entry_stat=active_stat,
+                                fd=active_fd,
+                            )
+                            active_size = int(active_stat.st_size)
+                            active_mtime_ns = int(active_stat.st_mtime_ns)
+                            active_scan = _scan_fd(active_fd)
+                            _status_assert_active_fd_matches_entry(
+                                root_fd=root_fd,
+                                entry_stat=active_stat,
+                                fd=active_fd,
+                            )
+                            if active_scan.tail_status is not SpoolTailStatus.CLEAN:
+                                raise _StatusInspectionError(active_scan.tail_status.value)
+                            active_frames = active_scan.frame_count
+                    finally:
+                        if active_fd is not None:
+                            _close_fd_quietly(active_fd)
+
+                    blocker = _status_load_blocker_snapshot(root_fd=root_fd)
+                    segments = _status_collect_segment_snapshots(
+                        root_fd=root_fd,
+                    )
+                    ack_snapshot = _status_scan_ack_sidecars(
+                        root_fd=root_fd,
+                        segment_sizes={item.name: item.size_bytes for item in segments},
+                    )
+                    if ack_snapshot.blocked_orphan_sequence is not None:
+                        raise _StatusInspectionError("invalid_ack_json")
+
+                    inventory = _durable_capacity_inventory(runtime, root_fd)
+                    capacity_used_bytes = active_size + inventory.quarantine_bytes + inventory.other_artifact_bytes
+                    capacity_remaining_bytes = max(0, capacity_cap_bytes - capacity_used_bytes)
+                    if capacity_remaining_bytes == 0:
+                        capacity_state = "full"
+                    elif capacity_remaining_bytes < MAX_FRAME_BYTES:
+                        capacity_state = "constrained"
+
+                    ack_pending = (
+                        blocker.acked_prefix_bytes > 0
+                        or ack_snapshot.orphan_tombstone_sequence is not None
+                    )
+                    pending_frames = active_frames
+                    pending_units = active_frames
+                    pending_bytes = active_size
+                    for item in segments:
+                        acked_prefix_bytes, segment_ack_pending = _status_effective_acked_prefix(
+                            segment=item,
+                            ack_snapshot=ack_snapshot,
+                            blocker=blocker,
+                        )
+                        segment_pending_frames, segment_pending_bytes = _status_pending_prefix_metrics(
+                            item.decoded,
+                            acked_prefix_bytes=acked_prefix_bytes,
+                            error_class="invalid_ack_json",
+                        )
+                        pending_frames += segment_pending_frames
+                        pending_units += segment_pending_frames
+                        pending_bytes += segment_pending_bytes
+                        ack_pending = ack_pending or segment_ack_pending
+
+                    oldest_mtime_ns: int | None = None
+                    oldest_sequence: int | None = None
+                    first_segment = segments[0] if segments else None
+                    blocker_uses_prefix_queue_head = (
+                        blocker.present
+                        and not blocker.zero_prefix
+                        and blocker.sequence is not None
+                        and first_segment is not None
+                        and first_segment.sequence == blocker.sequence
+                        and blocker.prefix_segment_name == first_segment.name
+                    )
+                    if (
+                        blocker.present
+                        and blocker.sequence is not None
+                        and blocker.mtime_ns is not None
+                        and not blocker_uses_prefix_queue_head
+                    ):
+                        oldest_sequence = blocker.sequence
+                        oldest_mtime_ns = blocker.mtime_ns
+                    if (
+                        ack_snapshot.orphan_tombstone_sequence is not None
+                        and ack_snapshot.orphan_tombstone_mtime_ns is not None
+                        and (
+                            oldest_sequence is None
+                            or ack_snapshot.orphan_tombstone_sequence < oldest_sequence
+                        )
+                    ):
+                        oldest_sequence = ack_snapshot.orphan_tombstone_sequence
+                        oldest_mtime_ns = ack_snapshot.orphan_tombstone_mtime_ns
+                    if first_segment is not None and (
+                        oldest_sequence is None
+                        or first_segment.sequence < oldest_sequence
+                        or blocker_uses_prefix_queue_head
+                    ):
+                        oldest_sequence = first_segment.sequence
+                        oldest_mtime_ns = first_segment.mtime_ns
+                    if oldest_mtime_ns is None and active_frames > 0 and active_mtime_ns is not None:
+                        oldest_mtime_ns = active_mtime_ns
+                    if oldest_mtime_ns is not None:
+                        oldest_pending_age_seconds = max(0.0, observed_at - (oldest_mtime_ns / 1_000_000_000))
+
+                    cooldown_state = _REPLAY_COOLDOWNS.get(_replay_root_key(runtime))
+                    if cooldown_state is not None:
+                        remaining = float(cooldown_state["next_eligible"] - time.monotonic())
+                        if remaining > 0:
+                            retry_pending = True
+                            retry_class = str(cooldown_state.get("retry_class") or "retry_pending")
+                            cooldown_seconds = remaining
+        except (OSError, SpoolDurabilityError, SpoolPathSecurityError, _StatusInspectionError) as exc:
+            inspection_error_class = _classify_status_exception(exc)
+
+        if root_missing and inspection_error_class is None:
+            disk_free_bytes, disk_total_bytes, disk_state, _disk_error_class = _probe_disk_from_home_fd(
+                home_fd,
+                threshold_bytes=capacity_remaining_bytes,
+            )
+            return SessionFallbackSpoolStatus(
+                schema_version=1,
+                state="empty",
+                reasons=(),
+                pending_units=0,
+                pending_frames=0,
+                pending_bytes=0,
+                oldest_pending_age_seconds=None,
+                retry_pending=False,
+                retry_class=None,
+                cooldown_seconds=0.0,
+                ack_pending=False,
+                blocker_present=False,
+                blocker_sequence=None,
+                blocker_offset=None,
+                blocker_reason_class=None,
+                blocker_source_kind=None,
+                capacity_used_bytes=0,
+                capacity_cap_bytes=capacity_cap_bytes,
+                capacity_remaining_bytes=capacity_remaining_bytes,
+                capacity_state="ok",
+                disk_free_bytes=disk_free_bytes,
+                disk_total_bytes=disk_total_bytes,
+                disk_headroom_threshold_bytes=capacity_remaining_bytes,
+                disk_state=disk_state,
+                inspection_error_class=None,
+            )
+
+        if pending_frames > 0 or pending_bytes > 0:
+            reasons.add("pending_backlog")
+        if blocker.present:
+            reasons.add("blocker")
+        if retry_pending:
+            reasons.add("retry_cooldown")
+        if ack_pending:
+            reasons.add("ack_pending")
+        if capacity_state == "constrained":
+            reasons.add("capacity_constrained")
+        elif capacity_state == "full":
+            reasons.add("capacity_full")
+        if home_fd >= 0:
+            disk_free_bytes, disk_total_bytes, disk_state, disk_error_class = _probe_disk_from_home_fd(
+                home_fd,
+                threshold_bytes=capacity_remaining_bytes,
+            )
+            if disk_state == "low":
+                reasons.add("disk_low")
+            elif disk_error_class is not None and inspection_error_class is None:
+                inspection_error_class = disk_error_class
+        if inspection_error_class is not None:
+            reasons.add("inspection_error")
+
+        state = "degraded" if reasons else "healthy"
+        blocker_present = blocker.present
+        blocker_sequence = blocker.sequence
+        blocker_offset = blocker.offset
+        blocker_reason_class = blocker.reason_class
+        blocker_source_kind = blocker.source_kind
+
+        return SessionFallbackSpoolStatus(
+            schema_version=1,
+            state=state,
+            reasons=_ordered_status_reasons(reasons),
+            pending_units=pending_units,
+            pending_frames=pending_frames,
+            pending_bytes=pending_bytes,
+            oldest_pending_age_seconds=oldest_pending_age_seconds,
+            retry_pending=retry_pending,
+            retry_class=retry_class,
+            cooldown_seconds=cooldown_seconds,
+            ack_pending=ack_pending,
+            blocker_present=blocker_present,
+            blocker_sequence=blocker_sequence,
+            blocker_offset=blocker_offset,
+            blocker_reason_class=blocker_reason_class,
+            blocker_source_kind=blocker_source_kind,
+            capacity_used_bytes=capacity_used_bytes,
+            capacity_cap_bytes=capacity_cap_bytes,
+            capacity_remaining_bytes=capacity_remaining_bytes,
+            capacity_state=capacity_state,
+            disk_free_bytes=disk_free_bytes,
+            disk_total_bytes=disk_total_bytes,
+            disk_headroom_threshold_bytes=capacity_remaining_bytes,
+            disk_state=disk_state,
+            inspection_error_class=inspection_error_class,
+        )
+    finally:
+        if lock_held and lock_fd >= 0:
+            _release_status_lock(lock_fd)
+        if lock_fd >= 0:
+            _close_fd_quietly(lock_fd)
+        if root_fd >= 0:
+            _close_fd_quietly(root_fd)
+        _close_fd_quietly(home_fd)
 
 
 def _collect_sequence_inventory(*, runtime: _AnchoredRuntime, root_fd: int) -> list[int]:
@@ -3640,28 +5297,78 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
     try:
         cooldown = _cooldown_result(runtime, trigger=trigger)
         if cooldown is not None:
+            _log_replay_run_result(runtime, cooldown)
             return cooldown
         owner = _try_acquire_replay_owner(runtime)
         if owner is None:
-            return ReplayRunResult(state=ReplayRunState.OWNER_BUSY, trigger=trigger)
+            pending_snapshot = _capture_replay_terminal_backlog(runtime)
+            return ReplayRunResult(
+                state=ReplayRunState.OWNER_BUSY,
+                trigger=trigger,
+                pending_bytes_after=pending_snapshot.pending_bytes,
+                pending_frames_after=pending_snapshot.pending_frames,
+                first_blocked_segment=pending_snapshot.first_blocked_segment,
+                first_blocked_offset=pending_snapshot.first_blocked_offset,
+                ack_pending=pending_snapshot.ack_pending,
+            )
 
-        with _append_lock(runtime.lock_fd, str(_lock_path())):
-            _ensure_directory(_sealed_dir(), mode=ROOT_MODE)
-            _ensure_directory(_acks_dir(), mode=ROOT_MODE)
-            _ensure_directory(_blockers_dir(), mode=ROOT_MODE)
-            reconciled_active = _reconcile_active_spool_for_replay(runtime)
-            if reconciled_active is None:
-                _seal_clean_active_spool_for_replay(runtime)
+        try:
+            with _append_lock(runtime.lock_fd, str(_lock_path())):
+                _ensure_directory(_sealed_dir(), mode=ROOT_MODE)
+                _ensure_directory(_acks_dir(), mode=ROOT_MODE)
+                _ensure_directory(_blockers_dir(), mode=ROOT_MODE)
+                reconciled_active = _reconcile_active_spool_for_replay(runtime)
+                if reconciled_active is None:
+                    _seal_clean_active_spool_for_replay(runtime)
+        except OSError as exc:
+            if not _is_retryable_replay_os_error(exc):
+                pending_snapshot = _capture_pending_backlog_snapshot(runtime)
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
+                        state=ReplayRunState.NOT_DURABLE,
+                        trigger=trigger,
+                        pending_bytes_after=pending_snapshot.pending_bytes,
+                        pending_frames_after=pending_snapshot.pending_frames,
+                        first_blocked_segment=pending_snapshot.first_blocked_segment,
+                        first_blocked_offset=pending_snapshot.first_blocked_offset,
+                        ack_pending=pending_snapshot.ack_pending,
+                        error_class=_classify_nonretryable_replay_error(exc),
+                    ),
+                )
+            pending_snapshot = _capture_replay_terminal_backlog(runtime)
+            cooldown_seconds = _register_replay_cooldown(
+                runtime,
+                retry_class="spool_prepare_busy",
+                ack_pending=pending_snapshot.ack_pending,
+            )
+            return _log_and_return_replay_result(
+                runtime,
+                ReplayRunResult(
+                    state=ReplayRunState.RETRY_PENDING,
+                    trigger=trigger,
+                    pending_bytes_after=pending_snapshot.pending_bytes,
+                    pending_frames_after=pending_snapshot.pending_frames,
+                    first_blocked_segment=pending_snapshot.first_blocked_segment,
+                    first_blocked_offset=pending_snapshot.first_blocked_offset,
+                    retry_class="spool_prepare_busy",
+                    ack_pending=pending_snapshot.ack_pending,
+                    cooldown_seconds=cooldown_seconds,
+                ),
+            )
 
         _tombstones, blocked_orphan_sequence = _classify_ack_tombstones(
             runtime=runtime,
             root_fd=runtime.root_fd,
         )
         if blocked_orphan_sequence is not None:
-            return ReplayRunResult(
-                state=ReplayRunState.BLOCKED_INTEGRITY,
-                trigger=trigger,
-                first_blocked_segment=blocked_orphan_sequence,
+            return _log_and_return_replay_result(
+                runtime,
+                ReplayRunResult(
+                    state=ReplayRunState.BLOCKED_INTEGRITY,
+                    trigger=trigger,
+                    first_blocked_segment=blocked_orphan_sequence,
+                ),
             )
 
         blocker_sequence = _first_blocker_sequence(runtime=runtime, root_fd=runtime.root_fd)
@@ -3674,34 +5381,43 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                     blocker_sequence=blocker_sequence,
                 )
             except SpoolBlockedReplayError as exc:
-                return ReplayRunResult(
-                    state=ReplayRunState.BLOCKED_INTEGRITY,
-                    trigger=trigger,
-                    first_blocked_segment=blocker_sequence,
-                    first_blocked_offset=exc.frame_offset,
-                    error_class=exc.error_class,
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        first_blocked_segment=blocker_sequence,
+                        first_blocked_offset=exc.frame_offset,
+                        error_class=exc.error_class,
+                    ),
                 )
 
         ordered_segments = _ordered_segment_entries(runtime=runtime, root_fd=runtime.root_fd)
         if not ordered_segments:
             if blocker_sequence is not None:
-                return ReplayRunResult(
-                    state=ReplayRunState.BLOCKED_INTEGRITY,
-                    trigger=trigger,
-                    first_blocked_segment=blocker_sequence,
-                    first_blocked_offset=(
-                        blocked_prefix_state.blocking_offset
-                        if blocked_prefix_state is not None
-                        else None
-                    ),
-                    error_class=(
-                        blocked_prefix_state.tail_status.value
-                        if blocked_prefix_state is not None
-                        else None
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        first_blocked_segment=blocker_sequence,
+                        first_blocked_offset=(
+                            blocked_prefix_state.blocking_offset
+                            if blocked_prefix_state is not None
+                            else None
+                        ),
+                        error_class=(
+                            blocked_prefix_state.tail_status.value
+                            if blocked_prefix_state is not None
+                            else None
+                        ),
                     ),
                 )
             _clear_replay_cooldown(runtime)
-            return ReplayRunResult(state=ReplayRunState.EMPTY, trigger=trigger)
+            return _log_and_return_replay_result(
+                runtime,
+                ReplayRunResult(state=ReplayRunState.EMPTY, trigger=trigger),
+            )
 
         max_frames, max_bytes, max_seconds = _trigger_budget(trigger)
         start_monotonic = time.monotonic()
@@ -3720,6 +5436,7 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                     and (time.monotonic() - start_monotonic) >= max_seconds
                 )
             ):
+                pending_snapshot = _capture_replay_terminal_backlog(runtime)
                 return ReplayRunResult(
                     state=ReplayRunState.PARTIALLY_REPLAYED,
                     trigger=trigger,
@@ -3730,126 +5447,160 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                     frames_acked=frames_acked,
                     bytes_decoded=bytes_decoded,
                     bytes_acked=bytes_acked,
-                    pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                    pending_bytes_after=pending_snapshot.pending_bytes,
+                    pending_frames_after=pending_snapshot.pending_frames,
+                    ack_pending=pending_snapshot.ack_pending,
                 )
             if blocker_sequence is not None and segment_sequence > blocker_sequence:
-                return ReplayRunResult(
-                    state=ReplayRunState.BLOCKED_INTEGRITY,
-                    trigger=trigger,
-                    segment_count_seen=len(ordered_segments),
-                    frames_decoded=frames_decoded,
-                    frames_committed=frames_committed,
-                    frames_duplicated=frames_duplicated,
-                    frames_acked=frames_acked,
-                    bytes_decoded=bytes_decoded,
-                    bytes_acked=bytes_acked,
-                    pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
-                    first_blocked_segment=blocker_sequence,
-                    first_blocked_offset=(
-                        blocked_prefix_state.blocking_offset
-                        if blocked_prefix_state is not None
-                        else None
-                    ),
-                    error_class=(
-                        blocked_prefix_state.tail_status.value
-                        if blocked_prefix_state is not None
-                        else None
+                pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=pending_snapshot.pending_bytes,
+                        pending_frames_after=pending_snapshot.pending_frames,
+                        first_blocked_segment=blocker_sequence,
+                        first_blocked_offset=(
+                            blocked_prefix_state.blocking_offset
+                            if blocked_prefix_state is not None
+                            else None
+                        ),
+                        ack_pending=pending_snapshot.ack_pending,
+                        error_class=(
+                            blocked_prefix_state.tail_status.value
+                            if blocked_prefix_state is not None
+                            else None
+                        ),
                     ),
                 )
             if blocker_sequence is not None and segment_sequence == blocker_sequence:
                 if blocked_prefix_state is None:
-                    return ReplayRunResult(
-                        state=ReplayRunState.BLOCKED_INTEGRITY,
-                        trigger=trigger,
-                        segment_count_seen=len(ordered_segments),
-                        frames_decoded=frames_decoded,
-                        frames_committed=frames_committed,
-                        frames_duplicated=frames_duplicated,
-                        frames_acked=frames_acked,
-                        bytes_decoded=bytes_decoded,
-                        bytes_acked=bytes_acked,
-                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
-                        first_blocked_segment=blocker_sequence,
+                    pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            first_blocked_segment=blocker_sequence,
+                            ack_pending=pending_snapshot.ack_pending,
+                        ),
                     )
                 if segment_name != blocked_prefix_state.prefix_segment_name:
-                    return ReplayRunResult(
-                        state=ReplayRunState.BLOCKED_INTEGRITY,
-                        trigger=trigger,
-                        segment_count_seen=len(ordered_segments),
-                        frames_decoded=frames_decoded,
-                        frames_committed=frames_committed,
-                        frames_duplicated=frames_duplicated,
-                        frames_acked=frames_acked,
-                        bytes_decoded=bytes_decoded,
-                        bytes_acked=bytes_acked,
-                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
-                        first_blocked_segment=blocker_sequence,
-                        first_blocked_offset=blocked_prefix_state.blocking_offset,
-                        error_class="invalid_blocker_relationship",
+                    pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            first_blocked_segment=blocker_sequence,
+                            first_blocked_offset=blocked_prefix_state.blocking_offset,
+                            ack_pending=pending_snapshot.ack_pending,
+                            error_class="invalid_blocker_relationship",
+                        ),
                     )
                 decoded = decode_spool_segment(segment_path)
                 if (
                     decoded.tail_status is not SpoolTailStatus.CLEAN
                     or decoded.valid_prefix_bytes != blocked_prefix_state.valid_prefix_bytes
                 ):
-                    return ReplayRunResult(
-                        state=ReplayRunState.BLOCKED_INTEGRITY,
-                        trigger=trigger,
-                        segment_count_seen=len(ordered_segments),
-                        frames_decoded=frames_decoded,
-                        frames_committed=frames_committed,
-                        frames_duplicated=frames_duplicated,
-                        frames_acked=frames_acked,
-                        bytes_decoded=bytes_decoded,
-                        bytes_acked=bytes_acked,
-                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
-                        first_blocked_segment=blocker_sequence,
-                        first_blocked_offset=blocked_prefix_state.blocking_offset,
-                        error_class="invalid_blocker_relationship",
+                    pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            first_blocked_segment=blocker_sequence,
+                            first_blocked_offset=blocked_prefix_state.blocking_offset,
+                            ack_pending=pending_snapshot.ack_pending,
+                            error_class="invalid_blocker_relationship",
+                        ),
                     )
                 for frame in decoded.prefix_frames:
                     frame_end = frame.frame_offset + frame.frame_length
                     if frame_end <= blocked_prefix_state.acked_prefix_bytes:
                         continue
                     if frame.frame_offset < blocked_prefix_state.acked_prefix_bytes:
-                        return ReplayRunResult(
-                            state=ReplayRunState.BLOCKED_INTEGRITY,
-                            trigger=trigger,
-                            segment_count_seen=len(ordered_segments),
-                            frames_decoded=frames_decoded,
-                            frames_committed=frames_committed,
-                            frames_duplicated=frames_duplicated,
-                            frames_acked=frames_acked,
-                            bytes_decoded=bytes_decoded,
-                            bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(
-                                ordered_segments, segment_index
+                        pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.BLOCKED_INTEGRITY,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_snapshot.pending_bytes,
+                                pending_frames_after=pending_snapshot.pending_frames,
+                                first_blocked_segment=blocker_sequence,
+                                first_blocked_offset=blocked_prefix_state.blocking_offset,
+                                ack_pending=pending_snapshot.ack_pending,
+                                error_class="invalid_blocker_relationship",
                             ),
-                            first_blocked_segment=blocker_sequence,
-                            first_blocked_offset=blocked_prefix_state.blocking_offset,
-                            error_class="invalid_blocker_relationship",
                         )
                     frames_decoded += 1
                     bytes_decoded += frame.frame_length
                     try:
                         result = _replay_db_call(session_db, frame)
                     except SpoolBlockedReplayError as exc:
-                        return ReplayRunResult(
-                            state=ReplayRunState.BLOCKED_INTEGRITY,
-                            trigger=trigger,
-                            segment_count_seen=len(ordered_segments),
-                            frames_decoded=frames_decoded,
-                            frames_committed=frames_committed,
-                            frames_duplicated=frames_duplicated,
-                            frames_acked=frames_acked,
-                            bytes_decoded=bytes_decoded,
-                            bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(
-                                ordered_segments, segment_index
+                        pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.BLOCKED_INTEGRITY,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_snapshot.pending_bytes,
+                                pending_frames_after=pending_snapshot.pending_frames,
+                                first_blocked_segment=segment_sequence,
+                                first_blocked_offset=exc.frame_offset,
+                                ack_pending=pending_snapshot.ack_pending,
+                                error_class=exc.error_class,
                             ),
-                            first_blocked_segment=segment_sequence,
-                            first_blocked_offset=exc.frame_offset,
-                            error_class=exc.error_class,
                         )
                     except SpoolRetryableReplayError as exc:
                         cooldown_seconds = _register_replay_cooldown(
@@ -3857,22 +5608,28 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                             retry_class=exc.retry_class,
                             ack_pending=exc.ack_pending,
                         )
-                        return ReplayRunResult(
-                            state=ReplayRunState.RETRY_PENDING,
-                            trigger=trigger,
-                            segment_count_seen=len(ordered_segments),
-                            frames_decoded=frames_decoded,
-                            frames_committed=frames_committed,
-                            frames_duplicated=frames_duplicated,
-                            frames_acked=frames_acked,
-                            bytes_decoded=bytes_decoded,
-                            bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(
-                                ordered_segments, segment_index
-                            ),
-                            retry_class=exc.retry_class,
+                        pending_snapshot = _capture_replay_terminal_backlog(
+                            runtime,
                             ack_pending=exc.ack_pending,
-                            cooldown_seconds=cooldown_seconds,
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.RETRY_PENDING,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_snapshot.pending_bytes,
+                                pending_frames_after=pending_snapshot.pending_frames,
+                                retry_class=exc.retry_class,
+                                ack_pending=pending_snapshot.ack_pending,
+                                cooldown_seconds=cooldown_seconds,
+                            ),
                         )
                     if result.inserted_count > 0:
                         frames_committed += 1
@@ -3895,22 +5652,28 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                             retry_class=exc.retry_class,
                             ack_pending=exc.ack_pending,
                         )
-                        return ReplayRunResult(
-                            state=ReplayRunState.RETRY_PENDING,
-                            trigger=trigger,
-                            segment_count_seen=len(ordered_segments),
-                            frames_decoded=frames_decoded,
-                            frames_committed=frames_committed,
-                            frames_duplicated=frames_duplicated,
-                            frames_acked=frames_acked,
-                            bytes_decoded=bytes_decoded,
-                            bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(
-                                ordered_segments, segment_index
-                            ),
-                            retry_class=exc.retry_class,
+                        pending_snapshot = _capture_replay_terminal_backlog(
+                            runtime,
                             ack_pending=exc.ack_pending,
-                            cooldown_seconds=cooldown_seconds,
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.RETRY_PENDING,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_snapshot.pending_bytes,
+                                pending_frames_after=pending_snapshot.pending_frames,
+                                retry_class=exc.retry_class,
+                                ack_pending=pending_snapshot.ack_pending,
+                                cooldown_seconds=cooldown_seconds,
+                            ),
                         )
                     except OSError as exc:
                         if _is_retryable_replay_os_error(exc):
@@ -3919,7 +5682,109 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                                 retry_class="ack_publish_busy",
                                 ack_pending=True,
                             )
-                            return ReplayRunResult(
+                            pending_snapshot = _capture_replay_terminal_backlog(
+                                runtime,
+                                ack_pending=True,
+                            )
+                            return _log_and_return_replay_result(
+                                runtime,
+                                ReplayRunResult(
+                                    state=ReplayRunState.RETRY_PENDING,
+                                    trigger=trigger,
+                                    segment_count_seen=len(ordered_segments),
+                                    frames_decoded=frames_decoded,
+                                    frames_committed=frames_committed,
+                                    frames_duplicated=frames_duplicated,
+                                    frames_acked=frames_acked,
+                                    bytes_decoded=bytes_decoded,
+                                    bytes_acked=bytes_acked,
+                                    pending_bytes_after=pending_snapshot.pending_bytes,
+                                    pending_frames_after=pending_snapshot.pending_frames,
+                                    retry_class="ack_publish_busy",
+                                    ack_pending=pending_snapshot.ack_pending,
+                                    cooldown_seconds=cooldown_seconds,
+                                ),
+                            )
+                        pending_snapshot = _capture_replay_terminal_backlog(
+                            runtime,
+                            ack_pending=True,
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.NOT_DURABLE,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_snapshot.pending_bytes,
+                                pending_frames_after=pending_snapshot.pending_frames,
+                                ack_pending=pending_snapshot.ack_pending,
+                                error_class=_classify_nonretryable_replay_error(exc),
+                            ),
+                        )
+                pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
+                        state=ReplayRunState.BLOCKED_INTEGRITY,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=pending_snapshot.pending_bytes,
+                        pending_frames_after=pending_snapshot.pending_frames,
+                        first_blocked_segment=blocker_sequence,
+                        first_blocked_offset=blocked_prefix_state.blocking_offset,
+                        ack_pending=pending_snapshot.ack_pending,
+                        error_class=blocked_prefix_state.tail_status.value,
+                    ),
+                )
+            decoded = decode_spool_segment(segment_path)
+            if decoded.tail_status is not SpoolTailStatus.CLEAN:
+                for frame in decoded.prefix_frames:
+                    frames_decoded += 1
+                    bytes_decoded += frame.frame_length
+                    try:
+                        result = _replay_db_call(session_db, frame)
+                    except SpoolBlockedReplayError as exc:
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.BLOCKED_INTEGRITY,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=_remaining_segment_bytes(
+                                    ordered_segments, segment_index
+                                ),
+                                first_blocked_segment=segment_sequence,
+                                first_blocked_offset=exc.frame_offset,
+                                error_class=exc.error_class,
+                            ),
+                        )
+                    except SpoolRetryableReplayError as exc:
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
+                            retry_class=exc.retry_class,
+                            ack_pending=exc.ack_pending,
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
                                 state=ReplayRunState.RETRY_PENDING,
                                 trigger=trigger,
                                 segment_count_seen=len(ordered_segments),
@@ -3932,106 +5797,89 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                                 pending_bytes_after=_remaining_segment_bytes(
                                     ordered_segments, segment_index
                                 ),
-                                retry_class="ack_publish_busy",
-                                ack_pending=True,
+                                retry_class=exc.retry_class,
+                                ack_pending=exc.ack_pending,
                                 cooldown_seconds=cooldown_seconds,
-                            )
-                        raise
-                return ReplayRunResult(
-                    state=ReplayRunState.BLOCKED_INTEGRITY,
-                    trigger=trigger,
-                    segment_count_seen=len(ordered_segments),
-                    frames_decoded=frames_decoded,
-                    frames_committed=frames_committed,
-                    frames_duplicated=frames_duplicated,
-                    frames_acked=frames_acked,
-                    bytes_decoded=bytes_decoded,
-                    bytes_acked=bytes_acked,
-                    pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
-                    first_blocked_segment=blocker_sequence,
-                    first_blocked_offset=blocked_prefix_state.blocking_offset,
-                    error_class=blocked_prefix_state.tail_status.value,
-                )
-            decoded = decode_spool_segment(segment_path)
-            if decoded.tail_status is not SpoolTailStatus.CLEAN:
-                for frame in decoded.prefix_frames:
-                    frames_decoded += 1
-                    bytes_decoded += frame.frame_length
-                    try:
-                        result = _replay_db_call(session_db, frame)
-                    except SpoolBlockedReplayError as exc:
-                        return ReplayRunResult(
-                            state=ReplayRunState.BLOCKED_INTEGRITY,
-                            trigger=trigger,
-                            segment_count_seen=len(ordered_segments),
-                            frames_decoded=frames_decoded,
-                            frames_committed=frames_committed,
-                            frames_duplicated=frames_duplicated,
-                            frames_acked=frames_acked,
-                            bytes_decoded=bytes_decoded,
-                            bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(
-                                ordered_segments, segment_index
                             ),
-                            first_blocked_segment=segment_sequence,
-                            first_blocked_offset=exc.frame_offset,
-                            error_class=exc.error_class,
-                        )
-                    except SpoolRetryableReplayError as exc:
-                        cooldown_seconds = _register_replay_cooldown(
-                            runtime,
-                            retry_class=exc.retry_class,
-                            ack_pending=exc.ack_pending,
-                        )
-                        return ReplayRunResult(
-                            state=ReplayRunState.RETRY_PENDING,
-                            trigger=trigger,
-                            segment_count_seen=len(ordered_segments),
-                            frames_decoded=frames_decoded,
-                            frames_committed=frames_committed,
-                            frames_duplicated=frames_duplicated,
-                            frames_acked=frames_acked,
-                            bytes_decoded=bytes_decoded,
-                            bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(
-                                ordered_segments, segment_index
-                            ),
-                            retry_class=exc.retry_class,
-                            ack_pending=exc.ack_pending,
-                            cooldown_seconds=cooldown_seconds,
                         )
                     if result.inserted_count > 0:
                         frames_committed += 1
                     else:
                         frames_duplicated += 1
-                with _append_lock(runtime.lock_fd, str(_lock_path())):
-                    _publish_corrupt_sealed_segment_state(
-                        runtime,
-                        segment_sequence=segment_sequence,
-                        segment_name=segment_name,
-                        decoded_segment=decoded,
-                    )
-                return ReplayRunResult(
-                    state=ReplayRunState.BLOCKED_INTEGRITY,
-                    trigger=trigger,
-                    segment_count_seen=len(ordered_segments),
-                    frames_decoded=frames_decoded,
-                    frames_committed=frames_committed,
-                    frames_duplicated=frames_duplicated,
-                    frames_acked=frames_acked,
-                    bytes_decoded=bytes_decoded,
-                    bytes_acked=bytes_acked,
-                    first_blocked_segment=segment_sequence,
-                    first_blocked_offset=decoded.tail_offset,
-                    error_class=decoded.tail_status.value,
-                )
-            for frame in decoded.prefix_frames:
-                frames_decoded += 1
-                bytes_decoded += frame.frame_length
                 try:
-                    result = _replay_db_call(session_db, frame)
-                except SpoolBlockedReplayError as exc:
-                    return ReplayRunResult(
+                    with _append_lock(runtime.lock_fd, str(_lock_path())):
+                        _publish_corrupt_sealed_segment_state(
+                            runtime,
+                            segment_sequence=segment_sequence,
+                            segment_name=segment_name,
+                            decoded_segment=decoded,
+                        )
+                except OSError as exc:
+                    if _is_retryable_replay_os_error(exc):
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
+                            retry_class="corrupt_publish_busy",
+                            ack_pending=False,
+                        )
+                        pending_bytes_after, pending_frames_after = (
+                            _measure_remaining_segment_backlog(
+                                runtime,
+                                ordered_segments=ordered_segments,
+                                start_index=segment_index,
+                                current_segment_name=segment_name,
+                                current_segment_frame_count=len(decoded.prefix_frames),
+                                current_segment_pending_bytes=decoded.valid_prefix_bytes,
+                            )
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.RETRY_PENDING,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_bytes_after,
+                                pending_frames_after=pending_frames_after,
+                                retry_class="corrupt_publish_busy",
+                                ack_pending=False,
+                                cooldown_seconds=cooldown_seconds,
+                            ),
+                        )
+                    if not _is_retryable_replay_os_error(exc):
+                        pending_bytes_after, pending_frames_after = (
+                            _measure_remaining_segment_backlog(
+                                runtime,
+                                ordered_segments=ordered_segments,
+                                start_index=segment_index,
+                                current_segment_name=segment_name,
+                                current_segment_frame_count=len(decoded.prefix_frames),
+                            )
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.NOT_DURABLE,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_bytes_after,
+                                pending_frames_after=pending_frames_after,
+                                error_class=_classify_nonretryable_replay_error(exc),
+                            ),
+                        )
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
                         state=ReplayRunState.BLOCKED_INTEGRITY,
                         trigger=trigger,
                         segment_count_seen=len(ordered_segments),
@@ -4041,12 +5889,37 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                         frames_acked=frames_acked,
                         bytes_decoded=bytes_decoded,
                         bytes_acked=bytes_acked,
-                        pending_bytes_after=_remaining_segment_bytes(
-                            ordered_segments, segment_index
-                        ),
                         first_blocked_segment=segment_sequence,
-                        first_blocked_offset=exc.frame_offset,
-                        error_class=exc.error_class,
+                        first_blocked_offset=decoded.tail_offset,
+                        error_class=decoded.tail_status.value,
+                    ),
+                )
+            for frame in decoded.prefix_frames:
+                frames_decoded += 1
+                bytes_decoded += frame.frame_length
+                try:
+                    result = _replay_db_call(session_db, frame)
+                except SpoolBlockedReplayError as exc:
+                    pending_snapshot = _capture_replay_terminal_backlog(runtime)
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.BLOCKED_INTEGRITY,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            first_blocked_segment=segment_sequence,
+                            first_blocked_offset=exc.frame_offset,
+                            ack_pending=pending_snapshot.ack_pending,
+                            error_class=exc.error_class,
+                        ),
                     )
                 except SpoolRetryableReplayError as exc:
                     cooldown_seconds = _register_replay_cooldown(
@@ -4054,22 +5927,28 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                         retry_class=exc.retry_class,
                         ack_pending=exc.ack_pending,
                     )
-                    return ReplayRunResult(
-                        state=ReplayRunState.RETRY_PENDING,
-                        trigger=trigger,
-                        segment_count_seen=len(ordered_segments),
-                        frames_decoded=frames_decoded,
-                        frames_committed=frames_committed,
-                        frames_duplicated=frames_duplicated,
-                        frames_acked=frames_acked,
-                        bytes_decoded=bytes_decoded,
-                        bytes_acked=bytes_acked,
-                        pending_bytes_after=_remaining_segment_bytes(
-                            ordered_segments, segment_index
-                        ),
-                        retry_class=exc.retry_class,
+                    pending_snapshot = _capture_replay_terminal_backlog(
+                        runtime,
                         ack_pending=exc.ack_pending,
-                        cooldown_seconds=cooldown_seconds,
+                    )
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.RETRY_PENDING,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            retry_class=exc.retry_class,
+                            ack_pending=pending_snapshot.ack_pending,
+                            cooldown_seconds=cooldown_seconds,
+                        ),
                     )
                 if result.inserted_count > 0:
                     frames_committed += 1
@@ -4092,29 +5971,13 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                         retry_class=exc.retry_class,
                         ack_pending=exc.ack_pending,
                     )
-                    return ReplayRunResult(
-                        state=ReplayRunState.RETRY_PENDING,
-                        trigger=trigger,
-                        segment_count_seen=len(ordered_segments),
-                        frames_decoded=frames_decoded,
-                        frames_committed=frames_committed,
-                        frames_duplicated=frames_duplicated,
-                        frames_acked=frames_acked,
-                        bytes_decoded=bytes_decoded,
-                        bytes_acked=bytes_acked,
-                        pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
-                        retry_class=exc.retry_class,
+                    pending_snapshot = _capture_replay_terminal_backlog(
+                        runtime,
                         ack_pending=exc.ack_pending,
-                        cooldown_seconds=cooldown_seconds,
                     )
-                except OSError as exc:
-                    if _is_retryable_replay_os_error(exc):
-                        cooldown_seconds = _register_replay_cooldown(
-                            runtime,
-                            retry_class="ack_publish_busy",
-                            ack_pending=True,
-                        )
-                        return ReplayRunResult(
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
                             state=ReplayRunState.RETRY_PENDING,
                             trigger=trigger,
                             segment_count_seen=len(ordered_segments),
@@ -4124,25 +5987,130 @@ def replay_to_session_db(session_db, *, trigger: str) -> ReplayRunResult:
                             frames_acked=frames_acked,
                             bytes_decoded=bytes_decoded,
                             bytes_acked=bytes_acked,
-                            pending_bytes_after=_remaining_segment_bytes(ordered_segments, segment_index),
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            retry_class=exc.retry_class,
+                            ack_pending=pending_snapshot.ack_pending,
+                            cooldown_seconds=cooldown_seconds,
+                        ),
+                    )
+                except OSError as exc:
+                    if _is_retryable_replay_os_error(exc):
+                        cooldown_seconds = _register_replay_cooldown(
+                            runtime,
                             retry_class="ack_publish_busy",
                             ack_pending=True,
-                            cooldown_seconds=cooldown_seconds,
                         )
-                    raise
-            with _append_lock(runtime.lock_fd, str(_lock_path())):
-                _delete_fully_acked_segment(segment_path)
+                        pending_snapshot = _capture_replay_terminal_backlog(
+                            runtime,
+                            ack_pending=True,
+                        )
+                        return _log_and_return_replay_result(
+                            runtime,
+                            ReplayRunResult(
+                                state=ReplayRunState.RETRY_PENDING,
+                                trigger=trigger,
+                                segment_count_seen=len(ordered_segments),
+                                frames_decoded=frames_decoded,
+                                frames_committed=frames_committed,
+                                frames_duplicated=frames_duplicated,
+                                frames_acked=frames_acked,
+                                bytes_decoded=bytes_decoded,
+                                bytes_acked=bytes_acked,
+                                pending_bytes_after=pending_snapshot.pending_bytes,
+                                pending_frames_after=pending_snapshot.pending_frames,
+                                retry_class="ack_publish_busy",
+                                ack_pending=pending_snapshot.ack_pending,
+                                cooldown_seconds=cooldown_seconds,
+                            ),
+                        )
+                    pending_snapshot = _capture_replay_terminal_backlog(
+                        runtime,
+                        ack_pending=True,
+                    )
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.NOT_DURABLE,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            ack_pending=pending_snapshot.ack_pending,
+                            error_class=_classify_nonretryable_replay_error(exc),
+                        ),
+                    )
+            try:
+                with _append_lock(runtime.lock_fd, str(_lock_path())):
+                    _delete_fully_acked_segment(segment_path)
+            except OSError as exc:
+                pending_snapshot = _capture_replay_terminal_backlog(
+                    runtime,
+                    ack_pending=True,
+                )
+                if _is_retryable_replay_os_error(exc):
+                    cooldown_seconds = _register_replay_cooldown(
+                        runtime,
+                        retry_class="ack_cleanup_busy",
+                        ack_pending=True,
+                    )
+                    return _log_and_return_replay_result(
+                        runtime,
+                        ReplayRunResult(
+                            state=ReplayRunState.RETRY_PENDING,
+                            trigger=trigger,
+                            segment_count_seen=len(ordered_segments),
+                            frames_decoded=frames_decoded,
+                            frames_committed=frames_committed,
+                            frames_duplicated=frames_duplicated,
+                            frames_acked=frames_acked,
+                            bytes_decoded=bytes_decoded,
+                            bytes_acked=bytes_acked,
+                            pending_bytes_after=pending_snapshot.pending_bytes,
+                            pending_frames_after=pending_snapshot.pending_frames,
+                            retry_class="ack_cleanup_busy",
+                            ack_pending=pending_snapshot.ack_pending,
+                            cooldown_seconds=cooldown_seconds,
+                        ),
+                    )
+                return _log_and_return_replay_result(
+                    runtime,
+                    ReplayRunResult(
+                        state=ReplayRunState.NOT_DURABLE,
+                        trigger=trigger,
+                        segment_count_seen=len(ordered_segments),
+                        frames_decoded=frames_decoded,
+                        frames_committed=frames_committed,
+                        frames_duplicated=frames_duplicated,
+                        frames_acked=frames_acked,
+                        bytes_decoded=bytes_decoded,
+                        bytes_acked=bytes_acked,
+                        pending_bytes_after=pending_snapshot.pending_bytes,
+                        pending_frames_after=pending_snapshot.pending_frames,
+                        ack_pending=pending_snapshot.ack_pending,
+                        error_class=_classify_nonretryable_replay_error(exc),
+                    ),
+                )
         _clear_replay_cooldown(runtime)
-        return ReplayRunResult(
-            state=ReplayRunState.REPLAYED,
-            trigger=trigger,
-            segment_count_seen=len(ordered_segments),
-            frames_decoded=frames_decoded,
-            frames_committed=frames_committed,
-            frames_duplicated=frames_duplicated,
-            frames_acked=frames_acked,
-            bytes_decoded=bytes_decoded,
-            bytes_acked=bytes_acked,
+        return _log_and_return_replay_result(
+            runtime,
+            ReplayRunResult(
+                state=ReplayRunState.REPLAYED,
+                trigger=trigger,
+                segment_count_seen=len(ordered_segments),
+                frames_decoded=frames_decoded,
+                frames_committed=frames_committed,
+                frames_duplicated=frames_duplicated,
+                frames_acked=frames_acked,
+                bytes_decoded=bytes_decoded,
+                bytes_acked=bytes_acked,
+            ),
         )
     finally:
         if owner is not None:

--- a/session_fallback_spool.py
+++ b/session_fallback_spool.py
@@ -1,0 +1,1632 @@
+from __future__ import annotations
+
+import errno
+import json
+import os
+import re
+import stat
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from hashlib import blake2s
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from hermes_constants import get_hermes_home
+from hermes_state import SessionDBBatchMessage
+
+try:  # pragma: no cover - Windows-only import path
+    import fcntl  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - Windows-only fallback
+    fcntl = None
+
+try:  # pragma: no cover - POSIX-only import path
+    import msvcrt  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - POSIX-only fallback
+    msvcrt = None
+
+
+SPOOL_ROOT_NAME = "session_fallback_spool"
+ACTIVE_SPOOL_NAME = "active.spool"
+LOCK_FILE_NAME = "append.lock"
+QUARANTINE_DIR_NAME = "quarantine"
+HEADER_MAGIC = b"HSPL"
+HEADER_SIZE = 32
+FRAME_VERSION = 0x01
+RECORD_KIND_SESSION_PERSISTENCE_UNIT = 0x01
+ROOT_MODE = 0o700
+FILE_MODE = 0o600
+MAX_PAYLOAD_BYTES = 8 * 1024 * 1024
+MAX_FRAME_BYTES = MAX_PAYLOAD_BYTES + HEADER_SIZE
+TOTAL_CAP_BYTES = 64 * 1024 * 1024
+LOCK_TIMEOUT_SECONDS = 5.0
+LOCK_RETRY_SECONDS = 0.02
+_LOCK_CONTENTION_ERRNOS = {
+    errno.EACCES,
+    errno.EAGAIN,
+    getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
+}
+_CURRENT_QUARANTINE_DIR_FD: int | None = None
+
+
+class SpoolTailStatus(str, Enum):
+    CLEAN = "clean"
+    INCOMPLETE_EOF = "incomplete_eof"
+    BAD_MAGIC = "bad_magic"
+    BAD_VERSION = "bad_version"
+    BAD_RECORD_KIND = "bad_record_kind"
+    NONZERO_RESERVED = "nonzero_reserved"
+    OVERSIZED_LENGTH = "oversized_length"
+    CHECKSUM_MISMATCH = "checksum_mismatch"
+    INVALID_JSON = "invalid_json"
+    INVALID_SCHEMA = "invalid_schema"
+    SCAN_LIMIT_EXCEEDED = "scan_limit_exceeded"
+
+
+@dataclass(frozen=True)
+class SessionSpoolBootstrap:
+    session_id: str | None
+    source: str | None
+    started_at: float | None
+    model: str | None
+    model_config: Any
+    system_prompt: str | None
+    parent_session_id: str | None
+    cwd: str | None
+    profile_name: str | None
+    user_id: str | None
+    session_key: str | None
+    chat_id: str | None
+    chat_type: str | None
+    thread_id: str | None
+
+
+@dataclass(frozen=True)
+class SessionSpoolRecord:
+    bootstrap: SessionSpoolBootstrap
+    persist_attempt_id: str
+    persist_attempt_unit_index: int
+    canonical_failure: Mapping[str, Any]
+    batch_messages: tuple[SessionDBBatchMessage, ...]
+
+
+@dataclass(frozen=True)
+class SpoolFrameReceipt:
+    path: str
+    offset: int
+    frame_length: int
+    payload_length: int
+    checksum_hex: str
+
+
+@dataclass(frozen=True)
+class SpoolUnitAppendResult:
+    persistence_unit_id: str
+    message_keys: tuple[str, ...]
+    receipt: SpoolFrameReceipt
+
+
+@dataclass(frozen=True)
+class SpoolAppendAttemptResult:
+    unit_results: tuple[SpoolUnitAppendResult, ...]
+
+
+@dataclass(frozen=True)
+class SpoolScanResult:
+    valid_prefix_bytes: int
+    frame_count: int
+    tail_status: SpoolTailStatus
+    tail_offset: int | None
+
+
+@dataclass(frozen=True)
+class _AnchoredRuntime:
+    home_path: Path
+    root_path: Path
+    quarantine_path: Path
+    active_path: Path
+    home_fd: int
+    root_fd: int
+    lock_fd: int
+
+
+class SessionFallbackSpoolError(RuntimeError):
+    pass
+
+
+class SpoolPathSecurityError(SessionFallbackSpoolError):
+    pass
+
+
+class SpoolLockTimeoutError(SessionFallbackSpoolError):
+    pass
+
+
+class SpoolFrameTooLargeError(SessionFallbackSpoolError):
+    def __init__(self, payload_bytes: int, frame_bytes: int):
+        super().__init__(
+            f"fallback spool frame too large: payload={payload_bytes} frame={frame_bytes}"
+        )
+        self.payload_bytes = payload_bytes
+        self.frame_bytes = frame_bytes
+
+
+class SpoolCapacityError(SessionFallbackSpoolError):
+    def __init__(
+        self,
+        *,
+        active_bytes: int,
+        quarantine_bytes: int,
+        requested_bytes: int,
+        cap_bytes: int,
+    ):
+        super().__init__(
+            "fallback spool capacity exceeded: "
+            f"active_bytes={active_bytes} quarantine_bytes={quarantine_bytes} "
+            f"requested_bytes={requested_bytes} cap_bytes={cap_bytes}"
+        )
+        self.active_bytes = active_bytes
+        self.quarantine_bytes = quarantine_bytes
+        self.requested_bytes = requested_bytes
+        self.cap_bytes = cap_bytes
+
+
+class SpoolDurabilityError(SessionFallbackSpoolError):
+    pass
+
+
+class SpoolAppendAttemptPartialError(SessionFallbackSpoolError):
+    def __init__(
+        self,
+        durable_results: Sequence[SpoolUnitAppendResult],
+        cause: BaseException,
+    ):
+        super().__init__(f"fallback spool append partially durable: {cause}")
+        self.durable_results = tuple(durable_results)
+        self.cause = cause
+
+
+def _spool_root() -> Path:
+    return get_hermes_home() / SPOOL_ROOT_NAME
+
+
+def _active_spool_path() -> Path:
+    return _spool_root() / ACTIVE_SPOOL_NAME
+
+
+def _lock_path() -> Path:
+    return _spool_root() / LOCK_FILE_NAME
+
+
+def _quarantine_dir() -> Path:
+    return _spool_root() / QUARANTINE_DIR_NAME
+
+
+def _is_symlink(path: Path) -> bool:
+    try:
+        return stat.S_ISLNK(path.lstat().st_mode)
+    except FileNotFoundError:
+        return False
+
+
+
+def _require_not_symlink(path: Path) -> None:
+    if _is_symlink(path):
+        raise SpoolPathSecurityError(f"symlinked fallback spool path refused: {path}")
+
+
+def _require_existing_dir(path: Path) -> None:
+    _require_not_symlink(path)
+    try:
+        st = path.stat()
+    except FileNotFoundError as exc:
+        raise SpoolDurabilityError(f"required directory missing: {path}") from exc
+    if not stat.S_ISDIR(st.st_mode):
+        raise SpoolPathSecurityError(f"fallback spool path is not a directory: {path}")
+    if os.name == "posix":
+        os.chmod(path, ROOT_MODE)
+
+
+def _require_existing_file(path: Path) -> None:
+    _require_not_symlink(path)
+    try:
+        st = path.stat()
+    except FileNotFoundError as exc:
+        raise SpoolDurabilityError(f"required file missing: {path}") from exc
+    if not stat.S_ISREG(st.st_mode):
+        raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {path}")
+    if os.name == "posix":
+        os.chmod(path, FILE_MODE)
+
+
+def _supports_directory_fsync() -> bool:
+    return os.name == "posix"
+
+
+def _dir_open_flags() -> int:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return flags
+
+
+def _file_open_flags(base: int) -> int:
+    if hasattr(os, "O_NOFOLLOW"):
+        base |= os.O_NOFOLLOW
+    return base
+
+
+def _fsync_fd(fd: int) -> None:
+    os.fsync(fd)
+
+
+def _fsync_directory(path: Path) -> None:
+    if not _supports_directory_fsync():
+        raise SpoolDurabilityError(
+            f"directory fsync unavailable for fallback spool path: {path}"
+        )
+    _require_existing_dir(path)
+    directory_fd = os.open(str(path), _dir_open_flags())
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _ensure_directory(path: Path, *, mode: int = ROOT_MODE) -> bool:
+    _require_not_symlink(path)
+    if path.exists():
+        _require_existing_dir(path)
+        return False
+    parent = path.parent
+    _require_existing_dir(parent)
+    try:
+        os.mkdir(path, mode)
+    except FileExistsError:
+        _require_existing_dir(path)
+        return False
+    try:
+        if os.name == "posix":
+            os.chmod(path, mode)
+        _fsync_directory(parent)
+    except OSError as exc:
+        raise SpoolDurabilityError(
+            f"unable to durably create fallback spool directory {path}: {exc}"
+        ) from exc
+    return True
+
+
+def _same_file_stat(lhs: os.stat_result, rhs: os.stat_result) -> bool:
+    return lhs.st_dev == rhs.st_dev and lhs.st_ino == rhs.st_ino
+
+
+def _optional_str(value: Any) -> bool:
+    return value is None or isinstance(value, str)
+
+
+def _json_compatible(value: Any) -> bool:
+    try:
+        json.dumps(value, ensure_ascii=False, allow_nan=False)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _validate_message_payload(payload: Mapping[str, Any]) -> bool:
+    expected_keys = {
+        "persistence_message_key",
+        "persistence_ordinal",
+        "role",
+        "content",
+        "timestamp",
+        "tool_name",
+        "tool_calls",
+        "tool_call_id",
+        "finish_reason",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+        "api_content",
+        "display_kind",
+        "display_metadata",
+    }
+    if set(payload.keys()) != expected_keys:
+        return False
+    if not isinstance(payload.get("persistence_message_key"), str) or not payload.get(
+        "persistence_message_key"
+    ):
+        return False
+    ordinal = payload.get("persistence_ordinal")
+    if isinstance(ordinal, bool) or not isinstance(ordinal, int) or ordinal < 0:
+        return False
+    if not isinstance(payload.get("role"), str) or not payload.get("role"):
+        return False
+    if payload.get("content") is not None and not isinstance(payload.get("content"), str):
+        return False
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+        return False
+    if not _optional_str(payload.get("tool_name")):
+        return False
+    if payload.get("tool_calls") is not None and not isinstance(payload.get("tool_calls"), list):
+        return False
+    if payload.get("tool_calls") is not None and not _json_compatible(payload.get("tool_calls")):
+        return False
+    if not _optional_str(payload.get("tool_call_id")):
+        return False
+    if not _optional_str(payload.get("finish_reason")):
+        return False
+    if not _optional_str(payload.get("reasoning")):
+        return False
+    if not _json_compatible(payload.get("reasoning_content")):
+        return False
+    if not _json_compatible(payload.get("reasoning_details")):
+        return False
+    if not _json_compatible(payload.get("codex_reasoning_items")):
+        return False
+    if not _json_compatible(payload.get("codex_message_items")):
+        return False
+    if payload.get("api_content") is not None and not _json_compatible(payload.get("api_content")):
+        return False
+    if not _optional_str(payload.get("display_kind")):
+        return False
+    if payload.get("display_metadata") is not None and not isinstance(
+        payload.get("display_metadata"), dict
+    ):
+        return False
+    if payload.get("display_metadata") is not None and not _json_compatible(
+        payload.get("display_metadata")
+    ):
+        return False
+    return True
+
+
+def _validate_payload_schema(payload_obj: Any) -> bool:
+    if not isinstance(payload_obj, dict):
+        return False
+    if set(payload_obj.keys()) != {
+        "schema_version",
+        "record_type",
+        "persist_attempt_id",
+        "persist_attempt_unit_index",
+        "session",
+        "canonical_failure",
+        "unit",
+    }:
+        return False
+    if payload_obj.get("schema_version") != 1:
+        return False
+    if payload_obj.get("record_type") != "session_persistence_unit":
+        return False
+    persist_attempt_id = payload_obj.get("persist_attempt_id")
+    if not isinstance(persist_attempt_id, str) or not re.fullmatch(
+        r"[0-9a-f]{32}", persist_attempt_id
+    ):
+        return False
+    attempt_index = payload_obj.get("persist_attempt_unit_index")
+    if isinstance(attempt_index, bool) or not isinstance(attempt_index, int) or attempt_index < 0:
+        return False
+
+    session = payload_obj.get("session")
+    if not isinstance(session, dict) or set(session.keys()) != {
+        "session_id",
+        "source",
+        "started_at",
+        "model",
+        "model_config",
+        "system_prompt",
+        "parent_session_id",
+        "cwd",
+        "profile_name",
+        "user_id",
+        "session_key",
+        "chat_id",
+        "chat_type",
+        "thread_id",
+    }:
+        return False
+    if not all(
+        _optional_str(session.get(key))
+        for key in (
+            "session_id",
+            "source",
+            "model",
+            "system_prompt",
+            "parent_session_id",
+            "cwd",
+            "profile_name",
+            "user_id",
+            "session_key",
+            "chat_id",
+            "chat_type",
+            "thread_id",
+        )
+    ):
+        return False
+    if session.get("started_at") is not None and not isinstance(
+        session.get("started_at"), (int, float)
+    ):
+        return False
+    if not _json_compatible(session.get("model_config")):
+        return False
+
+    canonical_failure = payload_obj.get("canonical_failure")
+    if not isinstance(canonical_failure, dict) or set(canonical_failure.keys()) != {
+        "stage",
+        "error_class",
+        "error_message",
+        "session_row_created",
+    }:
+        return False
+    if canonical_failure.get("stage") not in {
+        "session_row_create",
+        "append_messages_batch",
+    }:
+        return False
+    if not isinstance(canonical_failure.get("error_class"), str) or not canonical_failure.get(
+        "error_class"
+    ):
+        return False
+    error_message = canonical_failure.get("error_message")
+    if error_message is None or not isinstance(error_message, str):
+        return False
+    if "\n" in error_message or "\r" in error_message:
+        return False
+    if len(error_message.encode("utf-8", errors="ignore")) > 512:
+        return False
+    if not isinstance(canonical_failure.get("session_row_created"), bool):
+        return False
+
+    unit = payload_obj.get("unit")
+    if not isinstance(unit, dict) or set(unit.keys()) != {
+        "persistence_unit_id",
+        "message_count",
+        "messages",
+    }:
+        return False
+    if not isinstance(unit.get("persistence_unit_id"), str) or not unit.get(
+        "persistence_unit_id"
+    ):
+        return False
+    message_count = unit.get("message_count")
+    messages = unit.get("messages")
+    if isinstance(message_count, bool) or not isinstance(message_count, int) or message_count < 1:
+        return False
+    if not isinstance(messages, list) or len(messages) != message_count:
+        return False
+    if not all(isinstance(message, dict) and _validate_message_payload(message) for message in messages):
+        return False
+    ordinals = [message["persistence_ordinal"] for message in messages]
+    if ordinals != list(range(len(messages))):
+        return False
+    keys = [message["persistence_message_key"] for message in messages]
+    if len(set(keys)) != len(keys):
+        return False
+    return True
+
+
+def _message_payload(message: SessionDBBatchMessage) -> dict[str, Any]:
+    return {
+        "persistence_message_key": message.persistence_message_key,
+        "persistence_ordinal": message.persistence_ordinal,
+        "role": message.role,
+        "content": message.content,
+        "timestamp": message.timestamp,
+        "tool_name": message.tool_name,
+        "tool_calls": message.tool_calls,
+        "tool_call_id": message.tool_call_id,
+        "finish_reason": message.finish_reason,
+        "reasoning": message.reasoning,
+        "reasoning_content": message.reasoning_content,
+        "reasoning_details": message.reasoning_details,
+        "codex_reasoning_items": message.codex_reasoning_items,
+        "codex_message_items": message.codex_message_items,
+        "api_content": message.api_content,
+        "display_kind": message.display_kind,
+        "display_metadata": message.display_metadata,
+    }
+
+
+def _payload_dict_for_record(record: SessionSpoolRecord) -> dict[str, Any]:
+    if not isinstance(record.persist_attempt_id, str) or not re.fullmatch(
+        r"[0-9a-f]{32}", record.persist_attempt_id
+    ):
+        raise SpoolDurabilityError("invalid fallback spool persist_attempt_id")
+    if (
+        isinstance(record.persist_attempt_unit_index, bool)
+        or not isinstance(record.persist_attempt_unit_index, int)
+        or record.persist_attempt_unit_index < 0
+    ):
+        raise SpoolDurabilityError("invalid fallback spool persist_attempt_unit_index")
+    if not record.batch_messages:
+        raise SpoolDurabilityError("fallback spool record requires at least one message")
+
+    unit_id = record.batch_messages[0].persistence_unit_id
+    if not isinstance(unit_id, str) or not unit_id:
+        raise SpoolDurabilityError("invalid fallback spool persistence_unit_id")
+    seen_keys: set[str] = set()
+    payload_messages = []
+    for expected_ordinal, message in enumerate(record.batch_messages):
+        if message.persistence_unit_id != unit_id:
+            raise SpoolDurabilityError("mixed persistence_unit_id values are not allowed")
+        if message.persistence_ordinal != expected_ordinal:
+            raise SpoolDurabilityError(
+                "fallback spool messages must be stored in ordinal order 0..n-1"
+            )
+        if not isinstance(message.persistence_message_key, str) or not message.persistence_message_key:
+            raise SpoolDurabilityError("invalid fallback spool persistence_message_key")
+        if message.persistence_message_key in seen_keys:
+            raise SpoolDurabilityError("duplicate fallback spool persistence_message_key")
+        seen_keys.add(message.persistence_message_key)
+        payload_messages.append(_message_payload(message))
+
+    payload = {
+        "schema_version": 1,
+        "record_type": "session_persistence_unit",
+        "persist_attempt_id": record.persist_attempt_id,
+        "persist_attempt_unit_index": record.persist_attempt_unit_index,
+        "session": {
+            "session_id": record.bootstrap.session_id,
+            "source": record.bootstrap.source,
+            "started_at": record.bootstrap.started_at,
+            "model": record.bootstrap.model,
+            "model_config": record.bootstrap.model_config,
+            "system_prompt": record.bootstrap.system_prompt,
+            "parent_session_id": record.bootstrap.parent_session_id,
+            "cwd": record.bootstrap.cwd,
+            "profile_name": record.bootstrap.profile_name,
+            "user_id": record.bootstrap.user_id,
+            "session_key": record.bootstrap.session_key,
+            "chat_id": record.bootstrap.chat_id,
+            "chat_type": record.bootstrap.chat_type,
+            "thread_id": record.bootstrap.thread_id,
+        },
+        "canonical_failure": {
+            "stage": record.canonical_failure.get("stage"),
+            "error_class": record.canonical_failure.get("error_class"),
+            "error_message": record.canonical_failure.get("error_message"),
+            "session_row_created": record.canonical_failure.get(
+                "session_row_created"
+            ),
+        },
+        "unit": {
+            "persistence_unit_id": unit_id,
+            "message_count": len(payload_messages),
+            "messages": payload_messages,
+        },
+    }
+    if not _validate_payload_schema(payload):
+        raise SpoolDurabilityError("invalid fallback spool record payload")
+    return payload
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    obj: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in obj:
+            raise _DuplicateJsonKeyError(key)
+        obj[key] = value
+    return obj
+
+
+def _payload_bytes_for_record(record: SessionSpoolRecord) -> bytes:
+    payload = json.dumps(
+        _payload_dict_for_record(record),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    if len(payload) > MAX_PAYLOAD_BYTES:
+        raise SpoolFrameTooLargeError(len(payload), len(payload) + HEADER_SIZE)
+    return payload
+
+
+def _frame_from_payload_bytes(
+    payload: bytes,
+    *,
+    record_kind: int = RECORD_KIND_SESSION_PERSISTENCE_UNIT,
+    reserved_bytes: bytes = b"\x00\x00",
+) -> bytes:
+    payload_len = len(payload)
+    if payload_len == 0 or payload_len > MAX_PAYLOAD_BYTES:
+        raise SpoolFrameTooLargeError(payload_len, payload_len + HEADER_SIZE)
+    if len(reserved_bytes) != 2:
+        raise SpoolDurabilityError("reserved header field must be exactly two bytes")
+    header_prefix = bytes([FRAME_VERSION, record_kind]) + reserved_bytes + payload_len.to_bytes(
+        8, "big"
+    )
+    digest = blake2s(header_prefix + payload, digest_size=16).digest()
+    frame = HEADER_MAGIC + header_prefix + digest + payload
+    if len(frame) > MAX_FRAME_BYTES:
+        raise SpoolFrameTooLargeError(payload_len, len(frame))
+    return frame
+
+
+def _frame_bytes_for_record(record: SessionSpoolRecord) -> bytes:
+    return _frame_from_payload_bytes(_payload_bytes_for_record(record))
+
+
+def _require_secure_path_primitives() -> None:
+    if os.name != "posix":
+        raise SpoolPathSecurityError(
+            "descriptor-anchored fallback spool path security is unavailable on this platform"
+        )
+    if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+        raise SpoolPathSecurityError(
+            "descriptor-anchored fallback spool path security requires O_NOFOLLOW and O_DIRECTORY"
+        )
+
+
+def _open_home_dir_fd(home_path: Path) -> int:
+    _require_secure_path_primitives()
+    try:
+        fd = os.open(str(home_path), os.O_RDONLY | os.O_DIRECTORY)
+    except OSError as exc:
+        raise SpoolDurabilityError(
+            f"unable to open HERMES_HOME for fallback spool security: {home_path}: {exc}"
+        ) from exc
+    home_stat = os.fstat(fd)
+    if not stat.S_ISDIR(home_stat.st_mode):
+        os.close(fd)
+        raise SpoolPathSecurityError(f"HERMES_HOME is not a directory: {home_path}")
+    return fd
+
+
+def _fsync_directory_fd(fd: int, label: Path | str) -> None:
+    if not _supports_directory_fsync():
+        raise SpoolDurabilityError(
+            f"directory fsync unavailable for fallback spool path: {label}"
+        )
+    try:
+        os.fsync(fd)
+    except OSError as exc:
+        raise SpoolDurabilityError(
+            f"unable to fsync fallback spool directory {label}: {exc}"
+        ) from exc
+
+
+def _close_fd_quietly(fd: int) -> None:
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _open_dir_at(
+    parent_fd: int,
+    name: str,
+    *,
+    full_path: Path,
+    mode: int,
+    create: bool,
+    parent_label: Path | str,
+    fsync_parent_on_open_existing: bool = False,
+) -> tuple[int, bool]:
+    open_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    created = False
+    while True:
+        try:
+            fd = os.open(name, open_flags, dir_fd=parent_fd)
+            break
+        except FileNotFoundError:
+            if not create:
+                raise SpoolDurabilityError(
+                    f"required fallback spool directory missing: {full_path}"
+                )
+            try:
+                os.mkdir(name, mode, dir_fd=parent_fd)
+            except FileExistsError:
+                continue
+            except OSError as exc:
+                raise SpoolDurabilityError(
+                    f"unable to create fallback spool directory {full_path}: {exc}"
+                ) from exc
+            created = True
+            continue
+        except OSError as exc:
+            if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+                raise SpoolPathSecurityError(
+                    f"symlinked fallback spool directory refused: {full_path}"
+                ) from exc
+            raise SpoolDurabilityError(
+                f"unable to open fallback spool directory {full_path}: {exc}"
+            ) from exc
+    try:
+        dir_stat = os.fstat(fd)
+        if not stat.S_ISDIR(dir_stat.st_mode):
+            raise SpoolPathSecurityError(
+                f"fallback spool path is not a directory: {full_path}"
+            )
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, mode)
+        if created:
+            _fsync_directory_fd(parent_fd, parent_label)
+        elif fsync_parent_on_open_existing:
+            _fsync_directory_fd(parent_fd, parent_label)
+        _assert_entry_matches_fd(parent_fd, name, fd, expect="dir", label=str(full_path))
+    except SessionFallbackSpoolError:
+        _close_fd_quietly(fd)
+        raise
+    except OSError as exc:
+        _close_fd_quietly(fd)
+        raise SpoolDurabilityError(
+            f"unable to durably open fallback spool directory {full_path}: {exc}"
+        ) from exc
+    except BaseException:
+        _close_fd_quietly(fd)
+        raise
+    return fd, created
+
+
+def _open_file_at(
+    parent_fd: int,
+    name: str,
+    *,
+    full_path: Path,
+    mode: int,
+    create: bool,
+    fsync_parent_on_create: bool,
+    fsync_file_on_create: bool,
+    parent_label: Path | str,
+    fsync_parent_on_open_existing: bool = False,
+) -> tuple[int, bool]:
+    open_flags = os.O_RDWR | os.O_NOFOLLOW
+    created = False
+    while True:
+        try:
+            fd = os.open(name, open_flags, dir_fd=parent_fd)
+            break
+        except FileNotFoundError:
+            if not create:
+                raise SpoolDurabilityError(
+                    f"required fallback spool file missing: {full_path}"
+                )
+            try:
+                fd = os.open(name, open_flags | os.O_CREAT | os.O_EXCL, mode, dir_fd=parent_fd)
+            except FileExistsError:
+                continue
+            except OSError as exc:
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+                    raise SpoolPathSecurityError(
+                        f"symlinked fallback spool file refused: {full_path}"
+                    ) from exc
+                raise SpoolDurabilityError(
+                    f"unable to create fallback spool file {full_path}: {exc}"
+                ) from exc
+            created = True
+            break
+        except OSError as exc:
+            if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+                raise SpoolPathSecurityError(
+                    f"symlinked fallback spool file refused: {full_path}"
+                ) from exc
+            raise SpoolDurabilityError(
+                f"unable to open fallback spool file {full_path}: {exc}"
+            ) from exc
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise SpoolPathSecurityError(
+                f"fallback spool path is not a regular file: {full_path}"
+            )
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, mode)
+        if created:
+            if fsync_file_on_create:
+                _fsync_fd(fd)
+            if fsync_parent_on_create:
+                _fsync_directory_fd(parent_fd, parent_label)
+        elif fsync_parent_on_open_existing:
+            _fsync_directory_fd(parent_fd, parent_label)
+        _assert_entry_matches_fd(parent_fd, name, fd, expect="file", label=str(full_path))
+    except SessionFallbackSpoolError:
+        _close_fd_quietly(fd)
+        raise
+    except OSError as exc:
+        _close_fd_quietly(fd)
+        action = "create" if created else "open"
+        raise SpoolDurabilityError(
+            f"unable to durably {action} fallback spool file {full_path}: {exc}"
+        ) from exc
+    except BaseException:
+        _close_fd_quietly(fd)
+        raise
+    return fd, created
+
+
+def _assert_home_matches_fd(home_path: Path, home_fd: int) -> None:
+    try:
+        current_stat = home_path.stat()
+    except FileNotFoundError as exc:
+        raise SpoolDurabilityError(
+            f"HERMES_HOME disappeared during fallback spool append: {home_path}"
+        ) from exc
+    if not _same_file_stat(current_stat, os.fstat(home_fd)):
+        raise SpoolPathSecurityError(
+            f"HERMES_HOME changed during fallback spool append: {home_path}"
+        )
+
+
+def _assert_entry_matches_fd(
+    parent_fd: int,
+    name: str,
+    fd: int,
+    *,
+    expect: str,
+    label: str,
+) -> None:
+    try:
+        entry_stat = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError as exc:
+        raise SpoolDurabilityError(
+            f"fallback spool entry disappeared before durability was confirmed: {label}"
+        ) from exc
+    except OSError as exc:
+        raise SpoolDurabilityError(
+            f"unable to restat fallback spool entry {label}: {exc}"
+        ) from exc
+    target_stat = os.fstat(fd)
+    if expect == "dir":
+        if not stat.S_ISDIR(entry_stat.st_mode):
+            raise SpoolPathSecurityError(f"fallback spool path is not a directory: {label}")
+    elif expect == "file":
+        if not stat.S_ISREG(entry_stat.st_mode):
+            raise SpoolPathSecurityError(f"fallback spool path is not a regular file: {label}")
+    else:  # pragma: no cover - internal misuse guard
+        raise ValueError(f"unknown expectation: {expect}")
+    if not _same_file_stat(entry_stat, target_stat):
+        raise SpoolPathSecurityError(
+            f"fallback spool entry was swapped during append: {label}"
+        )
+
+
+def _is_lock_contention_error(exc: OSError) -> bool:
+    return exc.errno in _LOCK_CONTENTION_ERRNOS
+
+
+@contextmanager
+def _append_lock(lock_fd: int, lock_label: str):
+    deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+    locked = False
+    try:
+        while True:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                elif msvcrt is not None:  # pragma: no cover - Windows-only branch
+                    msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
+                else:  # pragma: no cover - unsupported platform
+                    raise SpoolDurabilityError("no secure file-locking primitive available")
+                locked = True
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise SpoolLockTimeoutError(
+                        f"timed out waiting for fallback spool append lock: {lock_label}"
+                    )
+                time.sleep(LOCK_RETRY_SECONDS)
+            except OSError as exc:
+                if _is_lock_contention_error(exc):
+                    if time.monotonic() >= deadline:
+                        raise SpoolLockTimeoutError(
+                            f"timed out waiting for fallback spool append lock: {lock_label}"
+                        ) from exc
+                    time.sleep(LOCK_RETRY_SECONDS)
+                    continue
+                raise SpoolDurabilityError(
+                    f"unexpected fallback spool lock failure for {lock_label}: {exc}"
+                ) from exc
+        yield
+    finally:
+        if locked:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                elif msvcrt is not None:  # pragma: no cover - Windows-only branch
+                    msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+
+
+def _read_exact_from_fd(fd: int, *, offset: int, length: int) -> bytes:
+    if length <= 0:
+        return b""
+    chunks = bytearray()
+    while len(chunks) < length:
+        remaining = length - len(chunks)
+        try:
+            if hasattr(os, "pread"):
+                chunk = os.pread(fd, remaining, offset + len(chunks))
+            else:  # pragma: no cover - fallback for runtimes without pread
+                os.lseek(fd, offset + len(chunks), os.SEEK_SET)
+                chunk = os.read(fd, remaining)
+        except InterruptedError:
+            continue
+        if not chunk:
+            break
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _scan_fd(
+    fd: int,
+    *,
+    max_file_bytes: int = TOTAL_CAP_BYTES,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
+) -> SpoolScanResult:
+    file_size = os.fstat(fd).st_size
+    if file_size <= 0:
+        return SpoolScanResult(
+            valid_prefix_bytes=0,
+            frame_count=0,
+            tail_status=SpoolTailStatus.CLEAN,
+            tail_offset=None,
+        )
+    payload_cap = max_frame_bytes - HEADER_SIZE
+    budget = max_file_bytes if max_file_bytes > 0 else file_size
+    offset = 0
+    frame_count = 0
+    while offset < file_size:
+        if offset + HEADER_SIZE > budget:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+                tail_offset=offset,
+            )
+        header = _read_exact_from_fd(fd, offset=offset, length=HEADER_SIZE)
+        if len(header) < HEADER_SIZE:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.INCOMPLETE_EOF,
+                tail_offset=offset,
+            )
+        if header[:4] != HEADER_MAGIC:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.BAD_MAGIC,
+                tail_offset=offset,
+            )
+        if header[4] != FRAME_VERSION:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.BAD_VERSION,
+                tail_offset=offset,
+            )
+        if header[5] != RECORD_KIND_SESSION_PERSISTENCE_UNIT:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.BAD_RECORD_KIND,
+                tail_offset=offset,
+            )
+        if header[6:8] != b"\x00\x00":
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.NONZERO_RESERVED,
+                tail_offset=offset,
+            )
+        payload_len = int.from_bytes(header[8:16], "big")
+        if payload_len == 0 or payload_len > payload_cap:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.OVERSIZED_LENGTH,
+                tail_offset=offset,
+            )
+        frame_len = HEADER_SIZE + payload_len
+        if offset + frame_len > budget:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+                tail_offset=offset,
+            )
+        payload = _read_exact_from_fd(fd, offset=offset + HEADER_SIZE, length=payload_len)
+        if len(payload) < payload_len:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.INCOMPLETE_EOF,
+                tail_offset=offset,
+            )
+        expected_digest = blake2s(header[4:16] + payload, digest_size=16).digest()
+        if header[16:32] != expected_digest:
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.CHECKSUM_MISMATCH,
+                tail_offset=offset,
+            )
+        try:
+            payload_obj = json.loads(
+                payload.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_json_keys,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateJsonKeyError):
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.INVALID_JSON,
+                tail_offset=offset,
+            )
+        if not _validate_payload_schema(payload_obj):
+            return SpoolScanResult(
+                valid_prefix_bytes=offset,
+                frame_count=frame_count,
+                tail_status=SpoolTailStatus.INVALID_SCHEMA,
+                tail_offset=offset,
+            )
+        frame_count += 1
+        offset += frame_len
+    if offset < file_size:
+        return SpoolScanResult(
+            valid_prefix_bytes=offset,
+            frame_count=frame_count,
+            tail_status=SpoolTailStatus.SCAN_LIMIT_EXCEEDED,
+            tail_offset=offset,
+        )
+    return SpoolScanResult(
+        valid_prefix_bytes=offset,
+        frame_count=frame_count,
+        tail_status=SpoolTailStatus.CLEAN,
+        tail_offset=None,
+    )
+
+
+def scan_spool(
+    path: Path,
+    *,
+    max_file_bytes: int = TOTAL_CAP_BYTES,
+    max_frame_bytes: int = MAX_FRAME_BYTES,
+) -> SpoolScanResult:
+    if not path.exists():
+        return SpoolScanResult(
+            valid_prefix_bytes=0,
+            frame_count=0,
+            tail_status=SpoolTailStatus.CLEAN,
+            tail_offset=None,
+        )
+    _require_existing_file(path)
+    fd = os.open(str(path), os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        return _scan_fd(fd, max_file_bytes=max_file_bytes, max_frame_bytes=max_frame_bytes)
+    finally:
+        os.close(fd)
+
+
+def _iter_quarantine_entries(quarantine_dir: Path):
+    if _CURRENT_QUARANTINE_DIR_FD is not None:
+        return list(os.scandir(_CURRENT_QUARANTINE_DIR_FD))
+    return list(quarantine_dir.iterdir())
+
+
+def _next_quarantine_sequence(quarantine_dir: Path) -> int:
+    max_seq = 0
+    for entry in _iter_quarantine_entries(quarantine_dir):
+        name = entry.name if hasattr(entry, "name") else entry.name
+        match = re.match(r"^(\d{6})-", name)
+        if match:
+            max_seq = max(max_seq, int(match.group(1)))
+    return max_seq + 1
+
+
+def _parse_quarantine_spool_name(name: str) -> tuple[int, str, int] | None:
+    match = re.fullmatch(r"(\d{6})-([a-z0-9_]+)-vp(\d+)\.spool", name)
+    if not match:
+        return None
+    seq = int(match.group(1))
+    status = match.group(2)
+    valid_prefix = int(match.group(3))
+    return seq, status, valid_prefix
+
+
+def _quarantine_sidecar_payload_from_file(
+    quarantine_dir: Path,
+    spool_name: str,
+    *,
+    directory_fd: int,
+) -> dict[str, Any]:
+    parsed = _parse_quarantine_spool_name(spool_name)
+    if parsed is None:
+        raise SpoolDurabilityError(
+            f"invalid quarantine spool filename for reconciliation: {spool_name}"
+        )
+    sequence, expected_status, expected_valid_prefix = parsed
+    spool_fd = os.open(spool_name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory_fd)
+    try:
+        spool_stat = os.fstat(spool_fd)
+        if not stat.S_ISREG(spool_stat.st_mode):
+            raise SpoolPathSecurityError(
+                f"quarantine evidence is not a regular file: {quarantine_dir / spool_name}"
+            )
+        scan = _scan_fd(spool_fd)
+    finally:
+        os.close(spool_fd)
+    if scan.tail_status.value != expected_status or scan.valid_prefix_bytes != expected_valid_prefix:
+        raise SpoolDurabilityError(
+            "quarantine evidence no longer matches its durable filename metadata: "
+            f"{quarantine_dir / spool_name}"
+        )
+    return {
+        "sequence": sequence,
+        "tail_status": expected_status,
+        "valid_prefix_bytes": expected_valid_prefix,
+        "original_size": int(spool_stat.st_size),
+        "quarantined_at": float(spool_stat.st_mtime),
+    }
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    written = 0
+    while written < len(view):
+        try:
+            chunk = os.write(fd, bytes(view[written:]))
+        except InterruptedError:
+            continue
+        if chunk <= 0:
+            raise SpoolDurabilityError("short write while appending fallback spool frame")
+        written += chunk
+
+
+def _write_sidecar_json(
+    path: Path,
+    payload: Mapping[str, Any],
+    *,
+    directory_fd: int | None = None,
+) -> None:
+    temp_name = f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp"
+    fd = -1
+    temp_path = path.parent / temp_name
+    if directory_fd is None:
+        _require_existing_dir(path.parent)
+        fd = os.open(
+            str(temp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            FILE_MODE,
+        )
+        dir_fd = os.open(str(path.parent), _dir_open_flags())
+        cleanup_by_name = False
+    else:
+        dir_fd = directory_fd
+        fd = os.open(
+            temp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            FILE_MODE,
+            dir_fd=dir_fd,
+        )
+        cleanup_by_name = True
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, FILE_MODE)
+        data = json.dumps(
+            dict(payload),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        _write_all(fd, data)
+        _fsync_fd(fd)
+        os.close(fd)
+        fd = -1
+        try:
+            if directory_fd is None:
+                os.link(str(temp_path), str(path), follow_symlinks=False)
+            else:
+                os.link(temp_name, path.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd, follow_symlinks=False)
+        except FileExistsError as exc:
+            raise SpoolPathSecurityError(
+                f"fallback spool sidecar destination already exists or was swapped: {path}"
+            ) from exc
+        _fsync_directory_fd(dir_fd, path.parent)
+        if directory_fd is None:
+            os.unlink(temp_path)
+        else:
+            os.unlink(temp_name, dir_fd=dir_fd)
+        _fsync_directory_fd(dir_fd, path.parent)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            if cleanup_by_name:
+                os.unlink(temp_name, dir_fd=dir_fd)
+            else:
+                temp_path.unlink()
+        except OSError:
+            pass
+        raise
+    finally:
+        if directory_fd is None:
+            os.close(dir_fd)
+
+
+def _reconcile_missing_sidecars(quarantine_dir: Path, *, quarantine_fd: int) -> None:
+    for entry in os.scandir(quarantine_fd):
+        if entry.is_symlink():
+            raise SpoolPathSecurityError(
+                f"symlinked quarantine entry refused: {quarantine_dir / entry.name}"
+            )
+    spool_names = sorted(
+        entry.name
+        for entry in os.scandir(quarantine_fd)
+        if entry.is_file(follow_symlinks=False) and entry.name.endswith(".spool")
+    )
+    for spool_name in spool_names:
+        sidecar_name = f"{spool_name[:-6]}.json"
+        try:
+            sidecar_stat = os.stat(sidecar_name, dir_fd=quarantine_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            sidecar_payload = _quarantine_sidecar_payload_from_file(
+                quarantine_dir,
+                spool_name,
+                directory_fd=quarantine_fd,
+            )
+            _write_sidecar_json(
+                quarantine_dir / sidecar_name,
+                sidecar_payload,
+                directory_fd=quarantine_fd,
+            )
+            continue
+        if not stat.S_ISREG(sidecar_stat.st_mode):
+            raise SpoolPathSecurityError(
+                f"quarantine sidecar path is not a regular file: {quarantine_dir / sidecar_name}"
+            )
+
+
+def _find_quarantine_hardlink(
+    quarantine_fd: int,
+    *,
+    target_stat: os.stat_result,
+) -> str | None:
+    for entry in os.scandir(quarantine_fd):
+        if not entry.name.endswith(".spool") or not entry.is_file(follow_symlinks=False):
+            continue
+        entry_stat = entry.stat(follow_symlinks=False)
+        if _same_file_stat(entry_stat, target_stat):
+            return entry.name
+    return None
+
+
+def _quarantine_spool_bytes(quarantine_dir: Path) -> int:
+    total = 0
+    if _CURRENT_QUARANTINE_DIR_FD is not None:
+        for entry in os.scandir(_CURRENT_QUARANTINE_DIR_FD):
+            if entry.is_symlink():
+                raise SpoolPathSecurityError(
+                    f"symlinked quarantine entry refused: {quarantine_dir / entry.name}"
+                )
+            if entry.is_file(follow_symlinks=False) and entry.name.endswith(".spool"):
+                total += int(entry.stat(follow_symlinks=False).st_size)
+        return total
+    if not quarantine_dir.exists():
+        return 0
+    for path in quarantine_dir.glob("*.spool"):
+        _require_existing_file(path)
+        total += path.stat().st_size
+    return total
+
+
+def _quarantine_active_file(
+    active_path: Path,
+    quarantine_dir: Path,
+    scan_result: SpoolScanResult,
+    *,
+    runtime: _AnchoredRuntime,
+    quarantine_fd: int,
+    active_fd: int,
+) -> None:
+    _assert_entry_matches_fd(
+        runtime.root_fd,
+        QUARANTINE_DIR_NAME,
+        quarantine_fd,
+        expect="dir",
+        label=str(quarantine_dir),
+    )
+    active_stat = os.fstat(active_fd)
+    duplicate_name = _find_quarantine_hardlink(quarantine_fd, target_stat=active_stat)
+    if duplicate_name is not None:
+        sidecar_name = f"{duplicate_name[:-6]}.json"
+        try:
+            os.stat(sidecar_name, dir_fd=quarantine_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            _write_sidecar_json(
+                quarantine_dir / sidecar_name,
+                _quarantine_sidecar_payload_from_file(
+                    quarantine_dir,
+                    duplicate_name,
+                    directory_fd=quarantine_fd,
+                ),
+                directory_fd=quarantine_fd,
+            )
+        _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+        _assert_entry_matches_fd(
+            runtime.home_fd,
+            SPOOL_ROOT_NAME,
+            runtime.root_fd,
+            expect="dir",
+            label=str(runtime.root_path),
+        )
+        _assert_entry_matches_fd(
+            runtime.root_fd,
+            ACTIVE_SPOOL_NAME,
+            active_fd,
+            expect="file",
+            label=str(active_path),
+        )
+        os.unlink(ACTIVE_SPOOL_NAME, dir_fd=runtime.root_fd)
+        _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+        return
+
+    seq = _next_quarantine_sequence(quarantine_dir)
+    _assert_entry_matches_fd(
+        runtime.root_fd,
+        QUARANTINE_DIR_NAME,
+        quarantine_fd,
+        expect="dir",
+        label=str(quarantine_dir),
+    )
+    while True:
+        base = f"{seq:06d}-{scan_result.tail_status.value}-vp{scan_result.valid_prefix_bytes}"
+        spool_name = f"{base}.spool"
+        sidecar_path = quarantine_dir / f"{base}.json"
+        try:
+            os.link(
+                ACTIVE_SPOOL_NAME,
+                spool_name,
+                src_dir_fd=runtime.root_fd,
+                dst_dir_fd=quarantine_fd,
+                follow_symlinks=False,
+            )
+            break
+        except FileExistsError:
+            seq += 1
+            continue
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise SpoolPathSecurityError(
+                    f"symlinked quarantine target refused: {quarantine_dir / spool_name}"
+                ) from exc
+            raise SpoolDurabilityError(
+                f"unable to quarantine fallback spool evidence {quarantine_dir / spool_name}: {exc}"
+            ) from exc
+    _fsync_directory_fd(quarantine_fd, quarantine_dir)
+    _write_sidecar_json(
+        sidecar_path,
+        {
+            "sequence": seq,
+            "tail_status": scan_result.tail_status.value,
+            "valid_prefix_bytes": scan_result.valid_prefix_bytes,
+            "original_size": int(active_stat.st_size),
+            "quarantined_at": time.time(),
+        },
+        directory_fd=quarantine_fd,
+    )
+    _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+    _assert_entry_matches_fd(
+        runtime.home_fd,
+        SPOOL_ROOT_NAME,
+        runtime.root_fd,
+        expect="dir",
+        label=str(runtime.root_path),
+    )
+    _assert_entry_matches_fd(
+        runtime.root_fd,
+        ACTIVE_SPOOL_NAME,
+        active_fd,
+        expect="file",
+        label=str(active_path),
+    )
+    os.unlink(ACTIVE_SPOOL_NAME, dir_fd=runtime.root_fd)
+    _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+
+
+def _open_locked_runtime() -> _AnchoredRuntime:
+    home_path = Path(get_hermes_home())
+    root_path = _spool_root()
+    active_path = _active_spool_path()
+    quarantine_path = _quarantine_dir()
+    home_fd = _open_home_dir_fd(home_path)
+    root_fd = -1
+    lock_fd = -1
+    try:
+        root_fd, _ = _open_dir_at(
+            home_fd,
+            SPOOL_ROOT_NAME,
+            full_path=root_path,
+            mode=ROOT_MODE,
+            create=True,
+            parent_label=home_path,
+            fsync_parent_on_open_existing=True,
+        )
+        lock_fd, _ = _open_file_at(
+            root_fd,
+            LOCK_FILE_NAME,
+            full_path=_lock_path(),
+            mode=FILE_MODE,
+            create=True,
+            fsync_parent_on_create=True,
+            fsync_file_on_create=False,
+            parent_label=root_path,
+            fsync_parent_on_open_existing=True,
+        )
+        return _AnchoredRuntime(
+            home_path=home_path,
+            root_path=root_path,
+            quarantine_path=quarantine_path,
+            active_path=active_path,
+            home_fd=home_fd,
+            root_fd=root_fd,
+            lock_fd=lock_fd,
+        )
+    except BaseException:
+        if lock_fd >= 0:
+            os.close(lock_fd)
+        if root_fd >= 0:
+            os.close(root_fd)
+        os.close(home_fd)
+        raise
+
+
+def append_records(records: Sequence[SessionSpoolRecord]) -> SpoolAppendAttemptResult:
+    if not records:
+        return SpoolAppendAttemptResult(unit_results=())
+
+    frames = []
+    for record in records:
+        frames.append((record, _frame_bytes_for_record(record)))
+
+    runtime = _open_locked_runtime()
+    quarantine_fd = -1
+    active_fd = -1
+    global _CURRENT_QUARANTINE_DIR_FD
+    try:
+        with _append_lock(runtime.lock_fd, str(_lock_path())):
+            _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+            _assert_entry_matches_fd(
+                runtime.home_fd,
+                SPOOL_ROOT_NAME,
+                runtime.root_fd,
+                expect="dir",
+                label=str(runtime.root_path),
+            )
+            quarantine_fd, _ = _open_dir_at(
+                runtime.root_fd,
+                QUARANTINE_DIR_NAME,
+                full_path=runtime.quarantine_path,
+                mode=ROOT_MODE,
+                create=True,
+                parent_label=runtime.root_path,
+                fsync_parent_on_open_existing=True,
+            )
+            _assert_entry_matches_fd(
+                runtime.root_fd,
+                QUARANTINE_DIR_NAME,
+                quarantine_fd,
+                expect="dir",
+                label=str(runtime.quarantine_path),
+            )
+            _CURRENT_QUARANTINE_DIR_FD = quarantine_fd
+            _reconcile_missing_sidecars(runtime.quarantine_path, quarantine_fd=quarantine_fd)
+
+            active_fd, _ = _open_file_at(
+                runtime.root_fd,
+                ACTIVE_SPOOL_NAME,
+                full_path=runtime.active_path,
+                mode=FILE_MODE,
+                create=True,
+                fsync_parent_on_create=True,
+                fsync_file_on_create=True,
+                parent_label=runtime.root_path,
+                fsync_parent_on_open_existing=True,
+            )
+            scan = _scan_fd(active_fd)
+            if scan.tail_status is not SpoolTailStatus.CLEAN:
+                _quarantine_active_file(
+                    runtime.active_path,
+                    runtime.quarantine_path,
+                    scan,
+                    runtime=runtime,
+                    quarantine_fd=quarantine_fd,
+                    active_fd=active_fd,
+                )
+                os.close(active_fd)
+                active_fd = -1
+                active_fd, _ = _open_file_at(
+                    runtime.root_fd,
+                    ACTIVE_SPOOL_NAME,
+                    full_path=runtime.active_path,
+                    mode=FILE_MODE,
+                    create=True,
+                    fsync_parent_on_create=True,
+                    fsync_file_on_create=True,
+                    parent_label=runtime.root_path,
+                    fsync_parent_on_open_existing=True,
+                )
+
+            active_bytes = os.fstat(active_fd).st_size
+            quarantine_bytes = _quarantine_spool_bytes(runtime.quarantine_path)
+            requested_bytes = sum(len(frame) for _record, frame in frames)
+            if active_bytes + quarantine_bytes + requested_bytes > TOTAL_CAP_BYTES:
+                raise SpoolCapacityError(
+                    active_bytes=active_bytes,
+                    quarantine_bytes=quarantine_bytes,
+                    requested_bytes=requested_bytes,
+                    cap_bytes=TOTAL_CAP_BYTES,
+                )
+
+            durable_results: list[SpoolUnitAppendResult] = []
+            for record, frame in frames:
+                offset = os.lseek(active_fd, 0, os.SEEK_END)
+                try:
+                    _write_all(active_fd, frame)
+                    _fsync_fd(active_fd)
+                    _fsync_directory_fd(runtime.root_fd, runtime.root_path)
+                    _fsync_directory_fd(runtime.home_fd, runtime.home_path)
+                    _assert_home_matches_fd(runtime.home_path, runtime.home_fd)
+                    _assert_entry_matches_fd(
+                        runtime.home_fd,
+                        SPOOL_ROOT_NAME,
+                        runtime.root_fd,
+                        expect="dir",
+                        label=str(runtime.root_path),
+                    )
+                    _assert_entry_matches_fd(
+                        runtime.root_fd,
+                        ACTIVE_SPOOL_NAME,
+                        active_fd,
+                        expect="file",
+                        label=str(runtime.active_path),
+                    )
+                except BaseException as exc:
+                    cause = (
+                        exc
+                        if isinstance(exc, SessionFallbackSpoolError)
+                        else SpoolDurabilityError(str(exc))
+                    )
+                    if durable_results:
+                        raise SpoolAppendAttemptPartialError(durable_results, cause) from exc
+                    if isinstance(cause, SessionFallbackSpoolError):
+                        raise cause from exc
+                    raise SpoolDurabilityError(str(exc)) from exc
+                receipt = SpoolFrameReceipt(
+                    path=str(runtime.active_path),
+                    offset=offset,
+                    frame_length=len(frame),
+                    payload_length=len(frame) - HEADER_SIZE,
+                    checksum_hex=frame[16:32].hex(),
+                )
+                durable_results.append(
+                    SpoolUnitAppendResult(
+                        persistence_unit_id=record.batch_messages[0].persistence_unit_id,
+                        message_keys=tuple(
+                            message.persistence_message_key for message in record.batch_messages
+                        ),
+                        receipt=receipt,
+                    )
+                )
+            return SpoolAppendAttemptResult(unit_results=tuple(durable_results))
+    finally:
+        _CURRENT_QUARANTINE_DIR_FD = None
+        if active_fd >= 0:
+            os.close(active_fd)
+        if quarantine_fd >= 0:
+            os.close(quarantine_fd)
+        os.close(runtime.lock_fd)
+        os.close(runtime.root_fd)
+        os.close(runtime.home_fd)

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -133,38 +133,26 @@ def test_cli_close_preflush_resumed_prefix_is_not_duplicated(tmp_path, monkeypat
 
     live_messages = list(loaded) + [{"role": "user", "content": "new prompt"}]
     agent = _real_agent(db, session_id, [])
-    entered_flush = threading.Event()
-    release_flush = threading.Event()
-    flush_calls = 0
+    entered_append = threading.Event()
+    release_append = threading.Event()
+    append_calls = 0
+    real_append_messages_batch = db.append_messages_batch
 
-    def _pause_before_flush(
-        messages: list[dict[str, Any]],
-        conversation_history: list[dict[str, Any]] | None = None,
-    ) -> None:
-        nonlocal flush_calls
-        flush_calls += 1
-        if flush_calls == 1:
-            # The worker has assigned its snapshot and is now paused before its
-            # regular DB write. The concurrent close call must stay live.
-            agent._session_messages = messages
-            entered_flush.set()
-            assert release_flush.wait(timeout=5)
-        from run_agent import AIAgent
+    def _pause_batch_append(*args: Any, **kwargs: Any):
+        nonlocal append_calls
+        append_calls += 1
+        if append_calls == 1:
+            entered_append.set()
+            assert release_append.wait(timeout=5)
+        return real_append_messages_batch(*args, **kwargs)
 
-        # Runtime accepts None; the stub keeps that optional contract explicit.
-        return AIAgent._flush_messages_to_session_db(
-            agent,
-            messages,
-            conversation_history if conversation_history is not None else [],
-        )
-
-    agent._flush_messages_to_session_db = _pause_before_flush
+    db.append_messages_batch = _pause_batch_append
     worker = threading.Thread(
         target=lambda: agent._persist_session(live_messages, loaded),
         daemon=True,
     )
     worker.start()
-    assert entered_flush.wait(timeout=5)
+    assert entered_append.wait(timeout=5)
 
     cli = object.__new__(cli_mod.HermesCLI)
     cli.conversation_history = list(loaded) + [{"role": "user", "content": "ui prompt"}]
@@ -185,13 +173,14 @@ def test_cli_close_preflush_resumed_prefix_is_not_duplicated(tmp_path, monkeypat
     # turn-start write has stamped its durable markers.
     assert not close_finished.wait(timeout=0.1)
 
-    release_flush.set()
+    release_append.set()
     worker.join(timeout=5)
     close_worker.join(timeout=5)
     assert not worker.is_alive()
     assert not close_worker.is_alive()
 
     stored = db.get_messages_as_conversation(session_id)
+    assert append_calls == 1
     assert [m["content"] for m in stored] == [
         "old prompt",
         "old answer",

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -318,3 +318,145 @@ def test_cli_close_builds_prompt_before_creating_first_session_row(tmp_path, mon
     assert [m["content"] for m in db.get_messages_as_conversation(session_id)] == [
         "first prompt"
     ]
+
+
+def test_cli_close_waits_while_turn_start_replay_runs_under_persist_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    import cli as cli_mod
+    import run_agent
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "cli-close-replay-lock"
+    db.create_session(session_id=session_id, source="cli")
+    loaded = [
+        {"role": "user", "content": "old prompt"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    for message in loaded:
+        db.append_message(
+            session_id=session_id,
+            role=message["role"],
+            content=message["content"],
+        )
+
+    live_messages = list(loaded) + [{"role": "user", "content": "new prompt"}]
+    agent = _real_agent(db, session_id, [])
+    entered_replay = threading.Event()
+    release_replay = threading.Event()
+
+    def _pause_replay(*_args: Any, **_kwargs: Any):
+        entered_replay.set()
+        assert release_replay.wait(timeout=5)
+        return types.SimpleNamespace(state="empty")
+
+    monkeypatch.setattr(run_agent.session_spool, "replay_to_session_db", _pause_replay)
+
+    worker = threading.Thread(
+        target=lambda: agent._persist_session(live_messages, loaded),
+        daemon=True,
+    )
+    worker.start()
+    assert entered_replay.wait(timeout=5)
+
+    cli = object.__new__(cli_mod.HermesCLI)
+    cli.conversation_history = list(loaded) + [{"role": "user", "content": "ui prompt"}]
+    cli.session_id = session_id
+    cli.agent = agent
+    close_started = threading.Event()
+    close_finished = threading.Event()
+
+    def _close_while_replay_waits():
+        close_started.set()
+        cli._persist_active_session_before_close()
+        close_finished.set()
+
+    close_worker = threading.Thread(target=_close_while_replay_waits, daemon=True)
+    close_worker.start()
+    assert close_started.wait(timeout=5)
+    assert not close_finished.wait(timeout=0.1)
+
+    release_replay.set()
+    worker.join(timeout=5)
+    close_worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert not close_worker.is_alive()
+
+
+def test_cli_close_waits_while_turn_start_replay_lock_returns_retry_pending(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    import cli as cli_mod
+    import run_agent
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "cli-close-replay-retry-pending"
+    db.create_session(session_id=session_id, source="cli")
+    loaded = [
+        {"role": "user", "content": "old prompt"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    for message in loaded:
+        db.append_message(
+            session_id=session_id,
+            role=message["role"],
+            content=message["content"],
+        )
+
+    live_messages = list(loaded) + [{"role": "user", "content": "new prompt"}]
+    agent = _real_agent(db, session_id, [])
+    entered_replay = threading.Event()
+    release_replay = threading.Event()
+    replay_calls = {"count": 0}
+
+    def _pause_replay(*_args: Any, **_kwargs: Any):
+        replay_calls["count"] += 1
+        if replay_calls["count"] == 1:
+            entered_replay.set()
+            assert release_replay.wait(timeout=5)
+        return types.SimpleNamespace(
+            state="retry_pending",
+            retry_class="ack_cleanup_busy",
+            ack_pending=True,
+            cooldown_seconds=1.0,
+        )
+
+    monkeypatch.setattr(run_agent.session_spool, "replay_to_session_db", _pause_replay)
+
+    worker = threading.Thread(
+        target=lambda: agent._persist_session(live_messages, loaded),
+        daemon=True,
+    )
+    worker.start()
+    assert entered_replay.wait(timeout=5)
+
+    cli = object.__new__(cli_mod.HermesCLI)
+    cli.conversation_history = list(loaded) + [{"role": "user", "content": "ui prompt"}]
+    cli.session_id = session_id
+    cli.agent = agent
+    close_started = threading.Event()
+    close_finished = threading.Event()
+
+    def _close_while_replay_waits():
+        close_started.set()
+        cli._persist_active_session_before_close()
+        close_finished.set()
+
+    close_worker = threading.Thread(target=_close_while_replay_waits, daemon=True)
+    close_worker.start()
+    assert close_started.wait(timeout=5)
+    assert not close_finished.wait(timeout=0.1)
+
+    release_replay.set()
+    worker.join(timeout=5)
+    close_worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert not close_worker.is_alive()
+    assert [m["content"] for m in db.get_messages_as_conversation(session_id)] == [
+        "old prompt",
+        "old answer",
+    ]

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -4,8 +4,10 @@ import os
 import sys
 import types
 import io
+import re
 import contextlib
 from argparse import Namespace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -13,6 +15,7 @@ import pytest
 import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
+from hermes_cli.config_defaults import DEFAULT_CONFIG
 from hermes_cli.doctor import _has_provider_env_config
 
 
@@ -1410,3 +1413,249 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+def _doctor_fallback_spool_snapshot(**overrides):
+    snapshot = SimpleNamespace(
+        schema_version=1,
+        state="empty",
+        reasons=(),
+        pending_units=0,
+        pending_frames=0,
+        pending_bytes=0,
+        oldest_pending_age_seconds=None,
+        retry_pending=False,
+        retry_class=None,
+        cooldown_seconds=0.0,
+        ack_pending=False,
+        blocker_present=False,
+        blocker_sequence=None,
+        blocker_offset=None,
+        blocker_reason_class=None,
+        blocker_source_kind=None,
+        capacity_used_bytes=0,
+        capacity_cap_bytes=64,
+        capacity_remaining_bytes=64,
+        capacity_state="ok",
+        disk_free_bytes=1024,
+        disk_total_bytes=2048,
+        disk_headroom_threshold_bytes=64,
+        disk_state="ok",
+        inspection_error_class=None,
+    )
+    for key, value in overrides.items():
+        setattr(snapshot, key, value)
+    return snapshot
+
+
+def _doctor_spool_tree_snapshot(spool_root):
+    if not spool_root.exists():
+        return {}
+    snapshot = {}
+    for path in sorted(path for path in spool_root.rglob("*") if path.is_file()):
+        snapshot[str(path.relative_to(spool_root))] = path.read_bytes()
+    return snapshot
+
+
+def _doctor_summary_tail(output: str) -> str:
+    summary_positions = [
+        match.start()
+        for match in re.finditer(
+            r"(?:Found \d+ issue\(s\) to address:|Fixed \d+ issue\(s\)\.|All checks passed!)",
+            output,
+        )
+    ]
+    return output[summary_positions[-1]:] if summary_positions else ""
+
+
+def _run_doctor_with_fallback_spool_collector(
+    monkeypatch,
+    tmp_path,
+    collector,
+    *,
+    fix=False,
+    prepare_home=None,
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        f"_config_version: {DEFAULT_CONFIG['_config_version']}\nmemory: {{}}\n",
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    (project / "venv" / "bin").mkdir(parents=True, exist_ok=True)
+    (project / "venv" / "bin" / "hermes").write_text("#!/bin/sh\n", encoding="utf-8")
+    command_link = tmp_path / ".local" / "bin" / "hermes"
+    command_link.parent.mkdir(parents=True, exist_ok=True)
+    command_link.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    if prepare_home is not None:
+        prepare_home(home, project)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    from hermes_cli import auth as _auth_mod
+
+    monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    monkeypatch.setattr(
+        doctor_mod,
+        "collect_session_fallback_spool_status",
+        collector,
+        raising=False,
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=fix))
+    return buf.getvalue(), home
+
+
+def _run_doctor_with_fallback_spool_snapshot(
+    monkeypatch,
+    tmp_path,
+    snapshot,
+    *,
+    fix=False,
+    prepare_home=None,
+):
+    return _run_doctor_with_fallback_spool_collector(
+        monkeypatch,
+        tmp_path,
+        lambda **_kwargs: snapshot,
+        fix=fix,
+        prepare_home=prepare_home,
+    )
+
+
+@pytest.mark.parametrize("fix", [False, True])
+def test_run_doctor_summary_includes_degraded_fallback_spool_manual_issue(
+    monkeypatch,
+    tmp_path,
+    fix,
+):
+    snapshot = _doctor_fallback_spool_snapshot(
+        state="degraded",
+        reasons=("inspection_error", "pending_backlog"),
+        pending_units=1,
+        pending_frames=1,
+        pending_bytes=64,
+        oldest_pending_age_seconds=12.0,
+        inspection_error_class="append_lock_busy",
+        blocker_source_kind="inspection",
+        capacity_state="constrained",
+        capacity_used_bytes=63,
+        capacity_remaining_bytes=1,
+        disk_state="unknown",
+        disk_free_bytes=None,
+        disk_total_bytes=None,
+    )
+    before = {}
+
+    def prepare_home(home, _project):
+        spool_root = home / "session_fallback_spool"
+        spool_root.mkdir(parents=True, exist_ok=True)
+        (spool_root / "sentinel.bin").write_bytes(b"truthful-bytes")
+        (spool_root / "sealed-frame.jsonl").write_bytes(b'{"frame":1}\n')
+        before.update(_doctor_spool_tree_snapshot(spool_root))
+
+    out, home = _run_doctor_with_fallback_spool_snapshot(
+        monkeypatch,
+        tmp_path,
+        snapshot,
+        fix=fix,
+        prepare_home=prepare_home,
+    )
+    detail = doctor_mod._doctor_fallback_spool_detail(snapshot)
+    spool_root = home / "session_fallback_spool"
+    summary_tail = _doctor_summary_tail(out)
+
+    assert f"Fallback spool degraded ({detail})" in out
+    assert "append_lock_busy" in out
+    assert "All checks passed!" not in summary_tail
+    if fix:
+        assert "issue(s) require manual intervention." in summary_tail
+    else:
+        assert "Found 1 issue(s) to address:" in summary_tail
+    assert "requires manual intervention" in summary_tail
+    assert f"Fallback spool degraded ({detail})" in summary_tail
+    assert out.count("Fallback spool degraded") == 2
+    assert summary_tail.count("Fallback spool degraded") == 1
+    assert "session-123" not in out
+    assert _doctor_spool_tree_snapshot(spool_root) == before
+
+
+@pytest.mark.parametrize("fix", [False, True])
+def test_run_doctor_summary_includes_inspection_error_fallback_spool_manual_issue(
+    monkeypatch,
+    tmp_path,
+    fix,
+):
+    before = {}
+
+    def prepare_home(home, _project):
+        spool_root = home / "session_fallback_spool"
+        spool_root.mkdir(parents=True, exist_ok=True)
+        (spool_root / "sentinel.bin").write_bytes(b"truthful-bytes")
+        (spool_root / "sealed-frame.jsonl").write_bytes(b'{"frame":2}\n')
+        before.update(_doctor_spool_tree_snapshot(spool_root))
+
+    raw_error = "unsafe session-123 payload detail"
+
+    def raise_inspection_error(**_kwargs):
+        raise RuntimeError(raw_error)
+
+    out, home = _run_doctor_with_fallback_spool_collector(
+        monkeypatch,
+        tmp_path,
+        raise_inspection_error,
+        fix=fix,
+        prepare_home=prepare_home,
+    )
+    detail = doctor_mod._doctor_fallback_spool_inspection_error_detail()
+    spool_root = home / "session_fallback_spool"
+    summary_tail = _doctor_summary_tail(out)
+
+    assert f"Fallback spool degraded ({detail})" in out
+    assert "All checks passed!" not in summary_tail
+    if fix:
+        assert "issue(s) require manual intervention." in summary_tail
+    else:
+        assert "Found 1 issue(s) to address:" in summary_tail
+    assert "requires manual intervention" in summary_tail
+    assert f"Fallback spool degraded ({detail})" in summary_tail
+    assert "inspection_error=inspection_error" in out
+    assert raw_error not in out
+    assert "session-123" not in out
+    assert out.count("Fallback spool degraded") == 2
+    assert summary_tail.count("Fallback spool degraded") == 1
+    assert _doctor_spool_tree_snapshot(spool_root) == before
+
+
+@pytest.mark.parametrize("state", ["empty", "healthy"])
+def test_run_doctor_does_not_warn_for_healthy_or_empty_fallback_spool(
+    monkeypatch, tmp_path, state
+):
+    snapshot = _doctor_fallback_spool_snapshot(state=state)
+
+    out, _ = _run_doctor_with_fallback_spool_snapshot(
+        monkeypatch,
+        tmp_path,
+        snapshot,
+        fix=False,
+    )
+
+    assert "Fallback spool degraded" not in out

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from hermes_cli.status import show_status
 
 
@@ -197,6 +199,37 @@ class TestShowStatusXaiOAuth:
 
         assert "xAI OAuth" in out
         assert "not logged in (run: hermes auth add xai-oauth)" in out
+def _fallback_spool_snapshot(**overrides):
+    snapshot = SimpleNamespace(
+        schema_version=1,
+        state="empty",
+        reasons=(),
+        pending_units=0,
+        pending_frames=0,
+        pending_bytes=0,
+        oldest_pending_age_seconds=None,
+        retry_pending=False,
+        retry_class=None,
+        cooldown_seconds=0.0,
+        ack_pending=False,
+        blocker_present=False,
+        blocker_sequence=None,
+        blocker_offset=None,
+        blocker_reason_class=None,
+        blocker_source_kind=None,
+        capacity_used_bytes=0,
+        capacity_cap_bytes=64,
+        capacity_remaining_bytes=64,
+        capacity_state="ok",
+        disk_free_bytes=1024,
+        disk_total_bytes=2048,
+        disk_headroom_threshold_bytes=64,
+        disk_state="ok",
+        inspection_error_class=None,
+    )
+    for key, value in overrides.items():
+        setattr(snapshot, key, value)
+    return snapshot
 
 
 def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, tmp_path):
@@ -221,6 +254,9 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
 
     class _FakeDB:
+        def __init__(self, db_path=None, read_only=False):
+            self.read_only = read_only
+
         def list_gateway_sessions(self, active_only=True):
             return [
                 {"id": "gw-old", "last_active": time.time() - 7200},
@@ -237,3 +273,61 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_label"),
+    [
+        ("empty", "idle"),
+        ("healthy", "healthy"),
+        ("degraded", "degraded"),
+    ],
+)
+def test_show_status_renders_fallback_spool_row_and_uses_read_only_session_db(
+    monkeypatch, capsys, tmp_path, state, expected_label
+):
+    import hermes_state
+
+    status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+    opened = []
+
+    class _FakeSessionDB:
+        def __init__(self, db_path=None, read_only=False):
+            opened.append(read_only)
+
+        def list_gateway_sessions(self, active_only=True):
+            return [{"id": "one", "last_active": 0}]
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _FakeSessionDB)
+    monkeypatch.setattr(
+        status_mod,
+        "collect_session_fallback_spool_status",
+        lambda **_kwargs: _fallback_spool_snapshot(
+            state=state,
+            reasons=("pending_backlog", "capacity_full") if state == "degraded" else (),
+            pending_units=2 if state == "degraded" else 0,
+            pending_frames=2 if state == "degraded" else 0,
+            pending_bytes=128 if state == "degraded" else 0,
+            oldest_pending_age_seconds=12.0 if state == "degraded" else None,
+            capacity_state="full" if state == "degraded" else "ok",
+            capacity_used_bytes=64 if state == "degraded" else 0,
+            capacity_cap_bytes=64,
+            capacity_remaining_bytes=0 if state == "degraded" else 64,
+        ),
+        raising=False,
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+    out = capsys.readouterr().out
+
+    assert opened == [True]
+    assert "Fallback spool:" in out
+    assert expected_label in out
+    assert "session-123" not in out
+    assert "hello" not in out
+    if state == "degraded":
+        assert "pending=2u/2f/128b" in out
+        assert "pending_backlog,capacity_full" in out

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -281,6 +281,29 @@ def test_persist_session_canonical_returns_explicit_state_and_forbids_bool_coerc
         bool(result)
 
 
+def test_persist_session_instance_override_requires_explicit_durability(agent):
+    seen = []
+    message = {"role": "user", "content": "override seam"}
+    agent._flush_messages_to_session_db = (
+        lambda messages, history: seen.append((messages, history))
+    )
+
+    result = agent._persist_session([message], [])
+
+    assert seen == [([message], [])]
+    assert result.state is run_agent.SessionPersistState.NOT_DURABLE
+    assert result.error_class == "PersistenceOverrideUnconfirmed"
+
+
+def test_persist_session_instance_override_accepts_explicit_success(agent):
+    message = {"role": "user", "content": "override seam"}
+    agent._flush_messages_to_session_db = lambda _messages, _history: True
+
+    result = agent._persist_session([message], [])
+
+    assert result.state is run_agent.SessionPersistState.CANONICAL
+
+
 def test_persist_session_spools_frozen_units_after_session_row_create_failure(agent, monkeypatch):
     db = MagicMock()
     db.create_session.side_effect = RuntimeError("session row locked")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -88,6 +88,45 @@ def test_persist_user_message_override_rewrites_text_turns(agent):
     assert messages == [{"role": "user", "content": "hello"}]
 
 
+def _prime_batch_flush_agent(agent, session_db):
+    agent._session_db = session_db
+    agent._session_db_created = True
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._persist_disabled = False
+    agent._session_persist_lock = threading.RLock()
+    agent._session_json_enabled = False
+    agent._db_flush_scan_prefix = None
+
+
+class _RecordingBatchDB:
+    def __init__(self, outcomes=None):
+        self.calls = []
+        self._outcomes = list(outcomes or [])
+        self.flush_token_counts = MagicMock()
+
+    def append_messages_batch(self, session_id, messages, *, compression_lock_holder=None):
+        batch = list(messages)
+        self.calls.append(
+            {
+                "session_id": session_id,
+                "messages": batch,
+                "compression_lock_holder": compression_lock_holder,
+            }
+        )
+        if self._outcomes:
+            outcome = self._outcomes.pop(0)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+        return SimpleNamespace(inserted_count=len(batch), duplicate_count=0)
+
+
 
 
 
@@ -103,17 +142,16 @@ def test_flush_persist_override_replaces_api_local_multimodal_note(agent):
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
     ]
     agent._session_db = MagicMock()
-    agent._session_db_created = True
-    agent.session_id = "session-123"
-    agent._last_flushed_db_idx = 0
+    _prime_batch_flush_agent(agent, agent._session_db)
     agent._persist_user_message_idx = 0
     agent._persist_user_message_override = clean_content
     agent._persist_user_message_timestamp = None
 
     agent._flush_messages_to_session_db([{"role": "user", "content": api_content}], [])
 
-    batch = agent._session_db.append_messages_batch.call_args.kwargs["messages"]
-    assert batch[0]["content"] == "Describe this screenshot\n[screenshot]"
+    batch_write = agent._session_db.append_messages_batch.call_args.args[1]
+    assert len(batch_write) == 1
+    assert batch_write[0].content == "Describe this screenshot\n[screenshot]"
     assert api_content[0]["text"] == "[MODEL SWITCH NOTE]\n\nDescribe this screenshot"
 
 
@@ -127,42 +165,21 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
             self.calls = 0
             self._lock = threading.Lock()
 
-        def append_message(self, **kwargs):
+        def append_messages_batch(self, _session_id, messages, *, compression_lock_holder=None):
             with self._lock:
                 self.calls += 1
                 first = self.calls == 1
             if first:
                 self.entered.set()
                 assert self.release.wait(timeout=5)
-            self.rows.append(kwargs["content"])
-
-        def append_messages_batch(self, session_id, messages, **kwargs):
-            with self._lock:
-                self.calls += 1
-                first = self.calls == 1
-            if first:
-                self.entered.set()
-                assert self.release.wait(timeout=5)
-            for m in messages:
-                self.rows.append(m["content"])
-            return list(range(1, len(messages) + 1))
+            self.rows.extend(msg.content for msg in messages)
+            return SimpleNamespace(inserted_count=len(self.rows), duplicate_count=0)
 
         def flush_token_counts(self):
             return None
 
     db = _BarrierDB()
-    agent._session_db = db
-    agent._session_db_created = True
-    agent.session_id = "session-123"
-    agent._last_flushed_db_idx = 0
-    agent._flushed_db_message_ids = set()
-    agent._flushed_db_message_session_id = None
-    agent._persist_user_message_idx = None
-    agent._persist_user_message_override = None
-    agent._persist_user_message_timestamp = None
-    agent._persist_disabled = False
-    agent._session_persist_lock = threading.RLock()
-    agent._session_json_enabled = False
+    _prime_batch_flush_agent(agent, db)
 
     message = {"role": "user", "content": "exactly once"}
     normal = threading.Thread(target=lambda: agent._persist_session([message], []))
@@ -180,6 +197,108 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert not normal.is_alive()
     assert not direct.is_alive()
     assert db.rows == ["exactly once"]
+
+
+def test_flush_messages_to_session_db_batch_marks_only_after_success_and_freezes_private_identity(agent):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "hello batch"}
+
+    result = agent._flush_messages_to_session_db([message], [])
+
+    assert result is True
+    assert message[run_agent._DB_PERSISTED_MARKER] is True
+    assert run_agent._DB_PERSISTENCE_UNIT_ID in message
+    assert run_agent._DB_PERSISTENCE_MESSAGE_KEY in message
+    assert run_agent._DB_PERSISTENCE_TIMESTAMP in message
+    assert "timestamp" not in message
+    assert len(db.calls) == 1
+    assert len(db.calls[0]["messages"]) == 1
+    batch_msg = db.calls[0]["messages"][0]
+    assert batch_msg.persistence_unit_id == message[run_agent._DB_PERSISTENCE_UNIT_ID]
+    assert batch_msg.persistence_message_key == message[run_agent._DB_PERSISTENCE_MESSAGE_KEY]
+    assert batch_msg.persistence_ordinal == 0
+    assert batch_msg.timestamp == message[run_agent._DB_PERSISTENCE_TIMESTAMP]
+
+
+def test_flush_messages_to_session_db_failure_preserves_persistence_message_key_and_suppresses_token_drain(agent):
+    db = _RecordingBatchDB(outcomes=[RuntimeError("db down")])
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "hello failure"}
+
+    result = agent._persist_session([message], [])
+
+    assert result is False
+    assert run_agent._DB_PERSISTED_MARKER not in message
+    assert run_agent._DB_PERSISTENCE_UNIT_ID in message
+    assert run_agent._DB_PERSISTENCE_MESSAGE_KEY in message
+    assert run_agent._DB_PERSISTENCE_TIMESTAMP in message
+    assert agent._db_flush_scan_prefix is None
+    assert agent._last_flushed_db_idx == 0
+    db.flush_token_counts.assert_not_called()
+
+
+def test_flush_messages_to_session_db_retry_reuses_persistence_message_key_and_timestamp(agent):
+    db = _RecordingBatchDB(
+        outcomes=[
+            RuntimeError("first failure"),
+            SimpleNamespace(inserted_count=1, duplicate_count=0),
+        ]
+    )
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "retry me"}
+
+    first = agent._flush_messages_to_session_db([message], [])
+    first_key = message[run_agent._DB_PERSISTENCE_MESSAGE_KEY]
+    first_unit = message[run_agent._DB_PERSISTENCE_UNIT_ID]
+    first_ts = message[run_agent._DB_PERSISTENCE_TIMESTAMP]
+
+    second = agent._flush_messages_to_session_db([message], [])
+
+    assert first is False
+    assert second is True
+    assert len(db.calls) == 2
+    assert db.calls[0]["messages"][0].persistence_message_key == first_key
+    assert db.calls[1]["messages"][0].persistence_message_key == first_key
+    assert db.calls[0]["messages"][0].persistence_unit_id == first_unit
+    assert db.calls[1]["messages"][0].persistence_unit_id == first_unit
+    assert db.calls[0]["messages"][0].timestamp == first_ts
+    assert db.calls[1]["messages"][0].timestamp == first_ts
+    assert message[run_agent._DB_PERSISTED_MARKER] is True
+
+
+def test_flush_messages_to_session_db_retries_old_batch_before_new_unkeyed_messages(agent):
+    db = _RecordingBatchDB(
+        outcomes=[
+            RuntimeError("first failure"),
+            SimpleNamespace(inserted_count=2, duplicate_count=0),
+            SimpleNamespace(inserted_count=1, duplicate_count=0),
+        ]
+    )
+    _prime_batch_flush_agent(agent, db)
+    messages = [
+        {"role": "user", "content": "old user"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+
+    assert agent._flush_messages_to_session_db(messages, []) is False
+    failed_unit = messages[0][run_agent._DB_PERSISTENCE_UNIT_ID]
+    failed_keys = [m[run_agent._DB_PERSISTENCE_MESSAGE_KEY] for m in messages]
+
+    messages.append({"role": "user", "content": "new tail"})
+    assert agent._flush_messages_to_session_db(messages, []) is True
+
+    assert len(db.calls) == 3
+    retried_batch = db.calls[1]["messages"]
+    new_batch = db.calls[2]["messages"]
+    assert [msg.persistence_message_key for msg in retried_batch] == failed_keys
+    assert all(msg.persistence_unit_id == failed_unit for msg in retried_batch)
+    assert len(new_batch) == 1
+    assert new_batch[0].persistence_unit_id != failed_unit
+    assert new_batch[0].persistence_message_key == messages[2][run_agent._DB_PERSISTENCE_MESSAGE_KEY]
+    assert messages[0][run_agent._DB_PERSISTED_MARKER] is True
+    assert messages[1][run_agent._DB_PERSISTED_MARKER] is True
+    assert messages[2][run_agent._DB_PERSISTED_MARKER] is True
 
 
 def test_persist_session_does_not_clear_inflight_marker_when_db_flush_fails(agent):
@@ -5743,8 +5862,7 @@ class TestPersistUserMessageOverride:
 
     def test_persist_session_rewrites_current_turn_user_message(self, agent):
         agent._session_db = MagicMock()
-        agent.session_id = "session-123"
-        agent._last_flushed_db_idx = 0
+        _prime_batch_flush_agent(agent, agent._session_db)
         agent._persist_user_message_idx = 0
         agent._persist_user_message_override = "Hello there"
         messages = [
@@ -5770,10 +5888,8 @@ class TestPersistUserMessageOverride:
             "2-3 sentences max. No code blocks or markdown.] Hello there"
         )
         # But the DB write must get the override.
-        batch = agent._session_db.append_messages_batch.call_args_list[0].kwargs[
-            "messages"
-        ]
-        assert batch[0]["content"] == "Hello there"
+        first_db_write = agent._session_db.append_messages_batch.call_args.args[1][0]
+        assert first_db_write.content == "Hello there"
 
 
 class TestReasoningReplayForStrictProviders:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -147,6 +147,9 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.rows.append(m["content"])
             return list(range(1, len(messages) + 1))
 
+        def flush_token_counts(self):
+            return None
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True
@@ -177,6 +180,48 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert not normal.is_alive()
     assert not direct.is_alive()
     assert db.rows == ["exactly once"]
+
+
+def test_persist_session_does_not_clear_inflight_marker_when_db_flush_fails(agent):
+    """A failed canonical flush must not be reported as a completed persist."""
+    from agent import agent_runtime_helpers as _helpers
+
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._persist_user_message_timestamp = None
+    agent._persist_disabled = False
+    agent._session_persist_lock = threading.RLock()
+    agent._session_json_enabled = False
+    agent._inflight_turn_id = "session-123:t1:aaaa"
+    agent._inflight_turn_session_id = agent.session_id
+
+    with _helpers._INFLIGHT_TURNS_LOCK:
+        _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
+        _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id] = (
+            agent._inflight_turn_id,
+            time.time(),
+        )
+
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+
+    try:
+        result = agent._persist_session([{"role": "user", "content": "hello"}], [])
+
+        assert result is False
+        assert agent._inflight_turn_id == "session-123:t1:aaaa"
+        with _helpers._INFLIGHT_TURNS_LOCK:
+            assert _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id][0] == (
+                "session-123:t1:aaaa"
+            )
+    finally:
+        with _helpers._INFLIGHT_TURNS_LOCK:
+            _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
 
 
 @pytest.fixture()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agent.codex_responses_adapter import _normalize_codex_response
+import session_fallback_spool as spool
 
 import run_agent
 from run_agent import AIAgent
@@ -102,6 +103,47 @@ def _prime_batch_flush_agent(agent, session_db):
     agent._session_persist_lock = threading.RLock()
     agent._session_json_enabled = False
     agent._db_flush_scan_prefix = None
+
+
+def _install_inflight_marker(agent):
+    from agent import agent_runtime_helpers as _helpers
+
+    agent._inflight_turn_id = "session-123:t1:aaaa"
+    agent._inflight_turn_session_id = agent.session_id
+    with _helpers._INFLIGHT_TURNS_LOCK:
+        _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
+        _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id] = (
+            agent._inflight_turn_id,
+            time.time(),
+        )
+
+
+def _clear_inflight_markers():
+    from agent import agent_runtime_helpers as _helpers
+
+    with _helpers._INFLIGHT_TURNS_LOCK:
+        _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
+
+
+def _spool_append_result(*records):
+    return spool.SpoolAppendAttemptResult(
+        unit_results=tuple(
+            spool.SpoolUnitAppendResult(
+                persistence_unit_id=record.batch_messages[0].persistence_unit_id,
+                message_keys=tuple(
+                    message.persistence_message_key for message in record.batch_messages
+                ),
+                receipt=spool.SpoolFrameReceipt(
+                    path="/tmp/active.spool",
+                    offset=index * 100,
+                    frame_length=64,
+                    payload_length=32,
+                    checksum_hex=f"{index + 1:032x}",
+                ),
+            )
+            for index, record in enumerate(records)
+        )
+    )
 
 
 class _RecordingBatchDB:
@@ -221,15 +263,88 @@ def test_flush_messages_to_session_db_batch_marks_only_after_success_and_freezes
     assert batch_msg.timestamp == message[run_agent._DB_PERSISTENCE_TIMESTAMP]
 
 
-def test_flush_messages_to_session_db_failure_preserves_persistence_message_key_and_suppresses_token_drain(agent):
-    db = _RecordingBatchDB(outcomes=[RuntimeError("db down")])
+def test_persist_session_canonical_returns_explicit_state_and_forbids_bool_coercion(agent):
+    db = _RecordingBatchDB()
     _prime_batch_flush_agent(agent, db)
-    message = {"role": "user", "content": "hello failure"}
+    message = {"role": "user", "content": "hello canonical"}
 
     result = agent._persist_session([message], [])
 
-    assert result is False
+    assert result.state is run_agent.SessionPersistState.CANONICAL
+    assert result.canonical_units_committed == 1
+    assert result.spooled_units == 0
+    assert result.spool_receipts == ()
+    assert message[run_agent._DB_PERSISTED_MARKER] is True
+    db.flush_token_counts.assert_called_once()
+    with pytest.raises(TypeError):
+        bool(result)
+
+
+def test_persist_session_spools_frozen_units_after_session_row_create_failure(agent, monkeypatch):
+    db = MagicMock()
+    db.create_session.side_effect = RuntimeError("session row locked")
+    db.append_messages_batch.side_effect = AssertionError(
+        "append should not run when session row creation fails"
+    )
+    db.flush_token_counts = MagicMock()
+    _prime_batch_flush_agent(agent, db)
+    agent._session_db_created = False
+    _install_inflight_marker(agent)
+    message = {"role": "user", "content": "hello spool"}
+    seen = {}
+
+    def _capture(records):
+        seen["records"] = records
+        return _spool_append_result(*records)
+
+    monkeypatch.setattr(run_agent.session_spool, "append_records", _capture)
+
+    try:
+        result = agent._persist_session([message], [])
+
+        assert result.state is run_agent.SessionPersistState.SPOOLED
+        assert result.canonical_units_committed == 0
+        assert result.spooled_units == 1
+        assert len(result.spool_receipts) == 1
+        assert run_agent._DB_PERSISTED_MARKER not in message
+        assert message[run_agent._DB_SPOOLED_MARKER] is True
+        assert agent._db_flush_scan_prefix is None
+        assert agent._last_flushed_db_idx == 0
+        db.flush_token_counts.assert_not_called()
+        assert agent._inflight_turn_id is None
+
+        planned = seen["records"]
+        assert len(planned) == 1
+        assert planned[0].canonical_failure["stage"] == "session_row_create"
+        assert planned[0].canonical_failure["session_row_created"] is False
+        assert planned[0].batch_messages[0].persistence_unit_id == message[
+            run_agent._DB_PERSISTENCE_UNIT_ID
+        ]
+        assert planned[0].batch_messages[0].persistence_message_key == message[
+            run_agent._DB_PERSISTENCE_MESSAGE_KEY
+        ]
+        assert planned[0].batch_messages[0].timestamp == message[
+            run_agent._DB_PERSISTENCE_TIMESTAMP
+        ]
+    finally:
+        _clear_inflight_markers()
+
+
+def test_flush_messages_to_session_db_failure_preserves_persistence_message_key_and_suppresses_token_drain(agent, monkeypatch):
+    db = _RecordingBatchDB(outcomes=[RuntimeError("db down")])
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "hello failure"}
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "append_records",
+        MagicMock(side_effect=spool.SpoolDurabilityError("spool down")),
+    )
+
+    result = agent._persist_session([message], [])
+
+    assert result.state is run_agent.SessionPersistState.NOT_DURABLE
     assert run_agent._DB_PERSISTED_MARKER not in message
+    assert run_agent._DB_SPOOLED_MARKER not in message
     assert run_agent._DB_PERSISTENCE_UNIT_ID in message
     assert run_agent._DB_PERSISTENCE_MESSAGE_KEY in message
     assert run_agent._DB_PERSISTENCE_TIMESTAMP in message
@@ -301,46 +416,92 @@ def test_flush_messages_to_session_db_retries_old_batch_before_new_unkeyed_messa
     assert messages[2][run_agent._DB_PERSISTED_MARKER] is True
 
 
+def test_spooled_marker_skips_duplicate_spool_only_and_never_blocks_canonical_retry(agent, monkeypatch):
+    db = _RecordingBatchDB(
+        outcomes=[
+            RuntimeError("first failure"),
+            SimpleNamespace(inserted_count=1, duplicate_count=0),
+        ]
+    )
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "retry me canonically"}
+    spool_calls = []
+
+    def _capture(records):
+        spool_calls.append(records)
+        return _spool_append_result(*records)
+
+    monkeypatch.setattr(run_agent.session_spool, "append_records", _capture)
+
+    first = agent._persist_session([message], [])
+    second = agent._persist_session([message], [])
+
+    assert first.state is run_agent.SessionPersistState.SPOOLED
+    assert second.state is run_agent.SessionPersistState.CANONICAL
+    assert len(spool_calls) == 1
+    assert len(db.calls) == 2
+    assert message[run_agent._DB_SPOOLED_MARKER] is True
+    assert message[run_agent._DB_PERSISTED_MARKER] is True
+
+
+def test_persist_session_disabled_never_touches_db_or_spool(agent, monkeypatch):
+    db = MagicMock()
+    db.flush_token_counts = MagicMock()
+    _prime_batch_flush_agent(agent, db)
+    agent._persist_disabled = True
+    spool_append = MagicMock()
+    monkeypatch.setattr(run_agent.session_spool, "append_records", spool_append)
+
+    result = agent._persist_session([{"role": "user", "content": "skip me"}], [])
+
+    assert result.state is run_agent.SessionPersistState.NOT_DURABLE
+    db.create_session.assert_not_called()
+    db.append_messages_batch.assert_not_called()
+    db.flush_token_counts.assert_not_called()
+    spool_append.assert_not_called()
+
+
 def test_persist_session_does_not_clear_inflight_marker_when_db_flush_fails(agent):
     """A failed canonical flush must not be reported as a completed persist."""
-    from agent import agent_runtime_helpers as _helpers
-
-    agent._session_db = MagicMock()
-    agent._session_db_created = True
-    agent.session_id = "session-123"
-    agent._last_flushed_db_idx = 0
-    agent._flushed_db_message_ids = set()
-    agent._flushed_db_message_session_id = None
-    agent._persist_user_message_idx = None
-    agent._persist_user_message_override = None
-    agent._persist_user_message_timestamp = None
-    agent._persist_disabled = False
-    agent._session_persist_lock = threading.RLock()
-    agent._session_json_enabled = False
-    agent._inflight_turn_id = "session-123:t1:aaaa"
-    agent._inflight_turn_session_id = agent.session_id
-
-    with _helpers._INFLIGHT_TURNS_LOCK:
-        _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
-        _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id] = (
-            agent._inflight_turn_id,
-            time.time(),
-        )
-
-    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+    db = _RecordingBatchDB(outcomes=[RuntimeError("db down")])
+    _prime_batch_flush_agent(agent, db)
+    _install_inflight_marker(agent)
 
     try:
-        result = agent._persist_session([{"role": "user", "content": "hello"}], [])
+        with patch.object(
+            run_agent.session_spool,
+            "append_records",
+            side_effect=spool.SpoolDurabilityError("spool down"),
+        ):
+            result = agent._persist_session([{"role": "user", "content": "hello"}], [])
 
-        assert result is False
+        assert result.state is run_agent.SessionPersistState.NOT_DURABLE
         assert agent._inflight_turn_id == "session-123:t1:aaaa"
+        from agent import agent_runtime_helpers as _helpers
         with _helpers._INFLIGHT_TURNS_LOCK:
             assert _helpers._INFLIGHT_TURNS_BY_SESSION[agent.session_id][0] == (
                 "session-123:t1:aaaa"
             )
     finally:
-        with _helpers._INFLIGHT_TURNS_LOCK:
-            _helpers._INFLIGHT_TURNS_BY_SESSION.clear()
+        _clear_inflight_markers()
+
+
+def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
+    agent.logs_dir = tmp_path
+    agent.session_id = "session-123"
+    agent._session_json_enabled = True
+    message = {
+        "role": "user",
+        "content": "hello",
+        run_agent._DB_SPOOLED_MARKER: True,
+        run_agent._DB_PERSISTENCE_UNIT_ID: "unit-1",
+    }
+
+    agent._save_session_log([message])
+
+    saved = json.loads((tmp_path / "session_session-123.json").read_text(encoding="utf-8"))
+    assert run_agent._DB_SPOOLED_MARKER not in saved["messages"][0]
+    assert run_agent._DB_PERSISTENCE_UNIT_ID not in saved["messages"][0]
 
 
 @pytest.fixture()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -262,6 +262,21 @@ def test_flush_messages_to_session_db_batch_marks_only_after_success_and_clears_
     assert batch_msg.persistence_message_key
     assert batch_msg.persistence_ordinal == 0
     assert batch_msg.timestamp > 0
+    assert dict(batch_msg)["timestamp"] is None
+
+
+def test_batch_message_mapping_preserves_explicit_legacy_timestamp(agent):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "timestamped", "timestamp": 123.5}
+
+    assert agent._flush_messages_to_session_db([message], []) is True
+
+    batch_msg = db.calls[0]["messages"][0]
+    assert batch_msg.timestamp == 123.5
+    assert batch_msg["timestamp"] == 123.5
+    assert batch_msg.get("timestamp") == 123.5
+    assert dict(batch_msg)["timestamp"] == 123.5
 
 
 def test_persist_session_canonical_returns_explicit_state_and_forbids_bool_coercion(agent):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -593,6 +593,108 @@ def test_flush_messages_to_session_db_stops_when_replay_returns_retry_pending(ag
     assert db.calls == []
 
 
+@pytest.mark.parametrize(
+    "replay_result",
+    [
+        SimpleNamespace(state=spool.ReplayRunState.BLOCKED_INTEGRITY, error_class="CompressionSessionClosedError"),
+        SimpleNamespace(
+            state=spool.ReplayRunState.RETRY_PENDING,
+            retry_class="ack_cleanup_busy",
+            ack_pending=True,
+            cooldown_seconds=1.0,
+        ),
+        SimpleNamespace(state=spool.ReplayRunState.NOT_DURABLE, error_class="errno_enospc"),
+    ],
+)
+def test_persist_session_replay_degraded_does_not_flush_tokens_or_note_turn(
+    agent, monkeypatch, replay_result
+):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+    monkeypatch.setattr(run_agent.session_spool, "replay_to_session_db", lambda *_args, **_kwargs: replay_result)
+
+    with patch("agent.agent_runtime_helpers.note_turn_persisted") as note_turn_persisted:
+        result = agent._persist_session([{"role": "user", "content": "hello"}], [])
+
+    assert result.state is run_agent.SessionPersistState.NOT_DURABLE
+    db.flush_token_counts.assert_not_called()
+    note_turn_persisted.assert_not_called()
+    assert db.calls == []
+
+
+def test_persist_session_historical_replay_does_not_stamp_live_markers(agent, monkeypatch):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+    _install_inflight_marker(agent)
+    live_message = {"role": "user", "content": "hello replay then persist"}
+
+    def _replay(*_args, **_kwargs):
+        assert run_agent._DB_PERSISTED_MARKER not in live_message
+        assert run_agent._DB_SPOOLED_MARKER not in live_message
+        assert agent._inflight_turn_id == "session-123:t1:aaaa"
+        return SimpleNamespace(state=spool.ReplayRunState.REPLAYED)
+
+    monkeypatch.setattr(run_agent.session_spool, "replay_to_session_db", _replay)
+
+    try:
+        with patch("agent.agent_runtime_helpers.note_turn_persisted") as note_turn_persisted:
+            result = agent._persist_session([live_message], [])
+    finally:
+        _clear_inflight_markers()
+
+    assert result.state is run_agent.SessionPersistState.CANONICAL
+    assert live_message[run_agent._DB_PERSISTED_MARKER] is True
+    assert live_message.get(run_agent._DB_SPOOLED_MARKER) is not True
+    note_turn_persisted.assert_called_once()
+
+
+def test_persist_session_degraded_logs_are_redacted_deduped_and_recovery_visible(
+    agent, monkeypatch, caplog
+):
+    db = _RecordingBatchDB(outcomes=[RuntimeError("db down"), RuntimeError("db down"), RuntimeError("db down")])
+    _prime_batch_flush_agent(agent, db)
+    clock = {"now": 100.0}
+    monkeypatch.setattr(run_agent.time, "monotonic", lambda: clock["now"])
+    caplog.set_level(logging.INFO)
+
+    failure_append = MagicMock(side_effect=spool.SpoolDurabilityError("spool down"))
+    monkeypatch.setattr(run_agent.session_spool, "append_records", failure_append)
+
+    with patch("agent.agent_runtime_helpers.note_turn_persisted") as note_turn_persisted:
+        first = agent._persist_session([{"role": "user", "content": "hello one"}], [])
+        second = agent._persist_session([{"role": "user", "content": "hello two"}], [])
+        monkeypatch.setattr(
+            run_agent.session_spool,
+            "append_records",
+            lambda records: _spool_append_result(*records),
+        )
+        third = agent._persist_session([{"role": "user", "content": "hello three"}], [])
+        fourth = agent._persist_session([{"role": "user", "content": "hello four"}], [])
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == run_agent.__name__
+    ]
+    joined = "\n".join(messages)
+
+    assert first.state is run_agent.SessionPersistState.NOT_DURABLE
+    assert second.state is run_agent.SessionPersistState.NOT_DURABLE
+    assert third.state is run_agent.SessionPersistState.SPOOLED
+    assert fourth.state is run_agent.SessionPersistState.CANONICAL
+    assert len(messages) == 3
+    assert "outcome=not_durable" in messages[0]
+    assert "outcome=spooled" in messages[1]
+    assert "outcome=canonical" in messages[2]
+    assert "session-123" not in joined
+    assert "hello one" not in joined
+    assert "db down" not in joined
+    assert "spool down" not in joined
+    assert "unit_ids" not in joined
+    db.flush_token_counts.assert_called_once()
+    assert note_turn_persisted.call_count == 2
+
+
 @pytest.fixture()
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -546,6 +546,35 @@ def test_rewritten_spooled_message_blocks_before_stale_replay(agent, monkeypatch
     assert len(spool_calls) == 1
 
 
+def test_removed_row_from_spooled_unit_blocks_before_stale_replay(agent, monkeypatch):
+    db = _RecordingBatchDB(outcomes=[RuntimeError("first failure")])
+    _prime_batch_flush_agent(agent, db)
+    messages = [
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "call-1"}]},
+        {"role": "tool", "content": "tool result", "tool_call_id": "call-1"},
+    ]
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "append_records",
+        lambda records: _spool_append_result(*records),
+    )
+    replay = MagicMock(return_value=None)
+    agent._replay_pending_session_spool = replay
+
+    first = agent._persist_session(messages, [])
+    assert first.state is run_agent.SessionPersistState.SPOOLED
+    assert messages[0]["_db_persistence_unit_fingerprint"] == messages[1][
+        "_db_persistence_unit_fingerprint"
+    ]
+
+    messages.pop()
+    direct = agent._flush_messages_to_session_db(messages, [])
+
+    assert direct is False
+    assert replay.call_count == 1
+    assert len(db.calls) == 1
+
+
 def test_rewritten_failed_nonspooled_unit_rekeys_before_retry(agent, monkeypatch):
     db = _RecordingBatchDB(
         outcomes=[
@@ -627,15 +656,18 @@ def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
         run_agent._DB_PERSISTENCE_UNIT_ID: "unit-1",
         "_db_canonical_commit": True,
         "_db_persistence_payload_fingerprint": "fingerprint-1",
+        "_db_persistence_unit_fingerprint": "unit-fingerprint-1",
     }
 
     agent._save_session_log([message])
 
     saved = json.loads((tmp_path / "session_session-123.json").read_text(encoding="utf-8"))
-    assert run_agent._DB_SPOOLED_MARKER not in saved["messages"][0]
-    assert run_agent._DB_PERSISTENCE_UNIT_ID not in saved["messages"][0]
-    assert "_db_canonical_commit" not in saved["messages"][0]
-    assert "_db_persistence_payload_fingerprint" not in saved["messages"][0]
+    saved_message = saved["messages"][0]
+    assert run_agent._DB_SPOOLED_MARKER not in saved_message
+    assert run_agent._DB_PERSISTENCE_UNIT_ID not in saved_message
+    assert "_db_canonical_commit" not in saved_message
+    assert "_db_persistence_payload_fingerprint" not in saved_message
+    assert "_db_persistence_unit_fingerprint" not in saved_message
 
 
 def test_persist_session_replays_spool_before_canonical_append_under_persist_lock(agent, monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -532,6 +532,11 @@ def test_rewritten_spooled_message_blocks_before_stale_replay(agent, monkeypatch
     assert "_db_persistence_payload_fingerprint" in message
 
     message["content"] = "rewritten after spool"
+    direct = agent._flush_messages_to_session_db([message], [])
+    assert direct is False
+    assert replay.call_count == 1
+    assert len(db.calls) == 1
+
     second = agent._persist_session([message], [])
 
     assert second.state is run_agent.SessionPersistState.NOT_DURABLE

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -511,6 +511,64 @@ def test_spooled_marker_skips_duplicate_spool_only_and_never_blocks_canonical_re
     assert message[run_agent._DB_PERSISTED_MARKER] is True
 
 
+def test_rewritten_spooled_message_blocks_before_stale_replay(agent, monkeypatch):
+    db = _RecordingBatchDB(outcomes=[RuntimeError("first failure")])
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "spooled snapshot"}
+    spool_calls = []
+
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "append_records",
+        lambda records: (
+            spool_calls.append(records) or _spool_append_result(*records)
+        ),
+    )
+    replay = MagicMock(return_value=None)
+    agent._replay_pending_session_spool = replay
+
+    first = agent._persist_session([message], [])
+    assert first.state is run_agent.SessionPersistState.SPOOLED
+    assert "_db_persistence_payload_fingerprint" in message
+
+    message["content"] = "rewritten after spool"
+    second = agent._persist_session([message], [])
+
+    assert second.state is run_agent.SessionPersistState.NOT_DURABLE
+    assert second.error_class == "SpooledPersistenceUnitMutated"
+    assert replay.call_count == 1
+    assert len(db.calls) == 1
+    assert len(spool_calls) == 1
+
+
+def test_rewritten_failed_nonspooled_unit_rekeys_before_retry(agent, monkeypatch):
+    db = _RecordingBatchDB(
+        outcomes=[
+            RuntimeError("first failure"),
+            SimpleNamespace(inserted_count=1, duplicate_count=0),
+        ]
+    )
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "user", "content": "first payload"}
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "append_records",
+        MagicMock(side_effect=spool.SpoolDurabilityError("spool down")),
+    )
+
+    first = agent._persist_session([message], [])
+    first_key = message[run_agent._DB_PERSISTENCE_MESSAGE_KEY]
+    assert first.state is run_agent.SessionPersistState.NOT_DURABLE
+
+    message["content"] = "replacement payload"
+    second = agent._persist_session([message], [])
+
+    assert second.state is run_agent.SessionPersistState.CANONICAL
+    assert len(db.calls) == 2
+    assert db.calls[1]["messages"][0].content == "replacement payload"
+    assert db.calls[1]["messages"][0].persistence_message_key != first_key
+
+
 def test_persist_session_disabled_never_touches_db_or_spool(agent, monkeypatch):
     db = MagicMock()
     db.flush_token_counts = MagicMock()
@@ -563,6 +621,7 @@ def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
         run_agent._DB_SPOOLED_MARKER: True,
         run_agent._DB_PERSISTENCE_UNIT_ID: "unit-1",
         "_db_canonical_commit": True,
+        "_db_persistence_payload_fingerprint": "fingerprint-1",
     }
 
     agent._save_session_log([message])
@@ -571,6 +630,7 @@ def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
     assert run_agent._DB_SPOOLED_MARKER not in saved["messages"][0]
     assert run_agent._DB_PERSISTENCE_UNIT_ID not in saved["messages"][0]
     assert "_db_canonical_commit" not in saved["messages"][0]
+    assert "_db_persistence_payload_fingerprint" not in saved["messages"][0]
 
 
 def test_persist_session_replays_spool_before_canonical_append_under_persist_lock(agent, monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -504,6 +504,95 @@ def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
     assert run_agent._DB_PERSISTENCE_UNIT_ID not in saved["messages"][0]
 
 
+def test_persist_session_replays_spool_before_canonical_append_under_persist_lock(agent, monkeypatch):
+    order = []
+
+    class _OrderingDB(_RecordingBatchDB):
+        def append_messages_batch(self, session_id, messages, *, compression_lock_holder=None):
+            order.append("append")
+            return super().append_messages_batch(
+                session_id,
+                messages,
+                compression_lock_holder=compression_lock_holder,
+            )
+
+    db = _OrderingDB()
+    _prime_batch_flush_agent(agent, db)
+
+    def _replay(session_db, *, trigger):
+        assert session_db is db
+        assert agent._session_persist_lock._is_owned()
+        order.append(("replay", trigger))
+        return SimpleNamespace(state="empty")
+
+    monkeypatch.setattr(run_agent.session_spool, "replay_to_session_db", _replay)
+
+    result = agent._persist_session([{"role": "user", "content": "hello replay hook"}], [])
+
+    assert result.state is run_agent.SessionPersistState.CANONICAL
+    assert order[0] == ("replay", "pre_persist")
+    assert order[1] == "append"
+
+
+def test_flush_messages_to_session_db_stops_when_replay_returns_blocked(agent, monkeypatch):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "replay_to_session_db",
+        lambda *_args, **_kwargs: SimpleNamespace(state="blocked_integrity"),
+    )
+
+    result = agent._flush_messages_to_session_db([{"role": "user", "content": "hello"}], [])
+
+    assert result is False
+    assert db.calls == []
+
+
+def test_persist_session_stops_when_replay_returns_retry_pending(agent, monkeypatch):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "replay_to_session_db",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            state=spool.ReplayRunState.RETRY_PENDING,
+            retry_class="ack_cleanup_busy",
+            ack_pending=True,
+            cooldown_seconds=1.0,
+        ),
+    )
+
+    result = agent._persist_session([{"role": "user", "content": "hello"}], [])
+
+    assert result.state is run_agent.SessionPersistState.NOT_DURABLE
+    assert result.error_class == "retry_pending"
+    assert db.calls == []
+
+
+def test_flush_messages_to_session_db_stops_when_replay_returns_retry_pending(agent, monkeypatch):
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+
+    monkeypatch.setattr(
+        run_agent.session_spool,
+        "replay_to_session_db",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            state=spool.ReplayRunState.RETRY_PENDING,
+            retry_class="ack_cleanup_busy",
+            ack_pending=True,
+            cooldown_seconds=1.0,
+        ),
+    )
+
+    result = agent._flush_messages_to_session_db([{"role": "user", "content": "hello"}], [])
+
+    assert result is False
+    assert db.calls == []
+
+
 @pytest.fixture()
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -191,7 +191,7 @@ def test_flush_persist_override_replaces_api_local_multimodal_note(agent):
 
     agent._flush_messages_to_session_db([{"role": "user", "content": api_content}], [])
 
-    batch_write = agent._session_db.append_messages_batch.call_args.args[1]
+    batch_write = agent._session_db.append_messages_batch.call_args.kwargs["messages"]
     assert len(batch_write) == 1
     assert batch_write[0].content == "Describe this screenshot\n[screenshot]"
     assert api_content[0]["text"] == "[MODEL SWITCH NOTE]\n\nDescribe this screenshot"
@@ -241,7 +241,7 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert db.rows == ["exactly once"]
 
 
-def test_flush_messages_to_session_db_batch_marks_only_after_success_and_freezes_private_identity(agent):
+def test_flush_messages_to_session_db_batch_marks_only_after_success_and_clears_retry_identity(agent):
     db = _RecordingBatchDB()
     _prime_batch_flush_agent(agent, db)
     message = {"role": "user", "content": "hello batch"}
@@ -250,17 +250,18 @@ def test_flush_messages_to_session_db_batch_marks_only_after_success_and_freezes
 
     assert result is True
     assert message[run_agent._DB_PERSISTED_MARKER] is True
-    assert run_agent._DB_PERSISTENCE_UNIT_ID in message
-    assert run_agent._DB_PERSISTENCE_MESSAGE_KEY in message
-    assert run_agent._DB_PERSISTENCE_TIMESTAMP in message
+    assert message[run_agent._DB_CANONICAL_COMMIT_MARKER] is True
+    assert run_agent._DB_PERSISTENCE_UNIT_ID not in message
+    assert run_agent._DB_PERSISTENCE_MESSAGE_KEY not in message
+    assert run_agent._DB_PERSISTENCE_TIMESTAMP not in message
     assert "timestamp" not in message
     assert len(db.calls) == 1
     assert len(db.calls[0]["messages"]) == 1
     batch_msg = db.calls[0]["messages"][0]
-    assert batch_msg.persistence_unit_id == message[run_agent._DB_PERSISTENCE_UNIT_ID]
-    assert batch_msg.persistence_message_key == message[run_agent._DB_PERSISTENCE_MESSAGE_KEY]
+    assert batch_msg.persistence_unit_id
+    assert batch_msg.persistence_message_key
     assert batch_msg.persistence_ordinal == 0
-    assert batch_msg.timestamp == message[run_agent._DB_PERSISTENCE_TIMESTAMP]
+    assert batch_msg.timestamp > 0
 
 
 def test_persist_session_canonical_returns_explicit_state_and_forbids_bool_coercion(agent):
@@ -382,6 +383,33 @@ def test_flush_messages_to_session_db_retry_reuses_persistence_message_key_and_t
     assert message[run_agent._DB_PERSISTED_MARKER] is True
 
 
+def test_flush_messages_to_session_db_rekeys_after_persisted_message_is_rewritten(agent):
+    """Clearing the durable marker after an in-place rewrite starts a new unit.
+
+    Failed canonical writes must retry the same private identity, but a message
+    that was already committed and then rewritten must not be deduplicated as
+    the stale canonical row.
+    """
+    db = _RecordingBatchDB()
+    _prime_batch_flush_agent(agent, db)
+    message = {"role": "assistant", "content": ""}
+
+    assert agent._flush_messages_to_session_db([message], []) is True
+    first_key = db.calls[0]["messages"][0].persistence_message_key
+    first_unit = db.calls[0]["messages"][0].persistence_unit_id
+
+    message["content"] = "the final answer"
+    message.pop(run_agent._DB_PERSISTED_MARKER)
+    agent._db_flush_scan_prefix = None
+
+    assert agent._flush_messages_to_session_db([message], []) is True
+    assert len(db.calls) == 2
+    second = db.calls[1]["messages"][0]
+    assert second.content == "the final answer"
+    assert second.persistence_message_key != first_key
+    assert second.persistence_unit_id != first_unit
+
+
 def test_flush_messages_to_session_db_retries_old_batch_before_new_unkeyed_messages(agent):
     db = _RecordingBatchDB(
         outcomes=[
@@ -410,7 +438,8 @@ def test_flush_messages_to_session_db_retries_old_batch_before_new_unkeyed_messa
     assert all(msg.persistence_unit_id == failed_unit for msg in retried_batch)
     assert len(new_batch) == 1
     assert new_batch[0].persistence_unit_id != failed_unit
-    assert new_batch[0].persistence_message_key == messages[2][run_agent._DB_PERSISTENCE_MESSAGE_KEY]
+    assert new_batch[0].persistence_message_key
+    assert run_agent._DB_PERSISTENCE_MESSAGE_KEY not in messages[2]
     assert messages[0][run_agent._DB_PERSISTED_MARKER] is True
     assert messages[1][run_agent._DB_PERSISTED_MARKER] is True
     assert messages[2][run_agent._DB_PERSISTED_MARKER] is True
@@ -495,6 +524,7 @@ def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
         "content": "hello",
         run_agent._DB_SPOOLED_MARKER: True,
         run_agent._DB_PERSISTENCE_UNIT_ID: "unit-1",
+        "_db_canonical_commit": True,
     }
 
     agent._save_session_log([message])
@@ -502,6 +532,7 @@ def test_save_session_log_strips_private_spool_marker(agent, tmp_path):
     saved = json.loads((tmp_path / "session_session-123.json").read_text(encoding="utf-8"))
     assert run_agent._DB_SPOOLED_MARKER not in saved["messages"][0]
     assert run_agent._DB_PERSISTENCE_UNIT_ID not in saved["messages"][0]
+    assert "_db_canonical_commit" not in saved["messages"][0]
 
 
 def test_persist_session_replays_spool_before_canonical_append_under_persist_lock(agent, monkeypatch):
@@ -6240,7 +6271,9 @@ class TestPersistUserMessageOverride:
             "2-3 sentences max. No code blocks or markdown.] Hello there"
         )
         # But the DB write must get the override.
-        first_db_write = agent._session_db.append_messages_batch.call_args.args[1][0]
+        first_db_write = agent._session_db.append_messages_batch.call_args.kwargs[
+            "messages"
+        ][0]
         assert first_db_write.content == "Hello there"
 
 

--- a/tests/state/test_session_spool_replay.py
+++ b/tests/state/test_session_spool_replay.py
@@ -1,0 +1,1241 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+import hermes_state
+import session_fallback_spool as spool
+from hermes_state import SessionDB, SessionDBBatchMessage
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    session_db = SessionDB(db_path=home / "state.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+def _bootstrap(
+    *,
+    session_id: str = "replay-session",
+    parent_session_id: str | None = None,
+) -> spool.SessionSpoolBootstrap:
+    return spool.SessionSpoolBootstrap(
+        session_id=session_id,
+        source="cli",
+        started_at=123.456,
+        model="gpt-test",
+        model_config={"mode": "replay"},
+        system_prompt="persist me exactly",
+        parent_session_id=parent_session_id,
+        cwd="/tmp/project",
+        profile_name="profile-a",
+        user_id="user-1",
+        session_key="session-key",
+        chat_id="chat-1",
+        chat_type="group",
+        thread_id="thread-1",
+    )
+
+
+def _batch_messages(
+    unit_id: str = "unit-1",
+    *,
+    content: str = "hello replay",
+) -> list[SessionDBBatchMessage]:
+    return [
+        SessionDBBatchMessage(
+            persistence_unit_id=unit_id,
+            persistence_message_key=f"{unit_id}-key-0",
+            persistence_ordinal=0,
+            role="user",
+            content=content,
+            timestamp=100.0,
+        )
+    ]
+
+
+def _record(
+    unit_id: str = "unit-1",
+    *,
+    session_id: str = "replay-session",
+    content: str = "hello replay",
+) -> spool.SessionSpoolRecord:
+    return spool.SessionSpoolRecord(
+        bootstrap=_bootstrap(session_id=session_id),
+        persist_attempt_id="a" * 32,
+        persist_attempt_unit_index=0,
+        canonical_failure={
+            "stage": "append_messages_batch",
+            "error_class": "RuntimeError",
+            "error_message": "db down",
+            "session_row_created": True,
+        },
+        batch_messages=tuple(_batch_messages(unit_id=unit_id, content=content)),
+    )
+
+
+def _write_sealed_segment(home, sequence: int, *records: spool.SessionSpoolRecord):
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+    segment_path = sealed / f"{sequence:020d}.spool"
+    segment_path.write_bytes(b"".join(spool._frame_bytes_for_record(record) for record in records))
+    return segment_path
+
+
+def _backfill_record(
+    unit_id: str,
+    *,
+    content: str,
+    parent_session_id: str,
+) -> spool.SessionSpoolRecord:
+    return spool.SessionSpoolRecord(
+        bootstrap=_bootstrap(parent_session_id=parent_session_id),
+        persist_attempt_id="b" * 32,
+        persist_attempt_unit_index=0,
+        canonical_failure={
+            "stage": "append_messages_batch",
+            "error_class": "RuntimeError",
+            "error_message": "db down",
+            "session_row_created": True,
+        },
+        batch_messages=tuple(_batch_messages(unit_id=unit_id, content=content)),
+    )
+
+
+def _fts_message_count(db) -> int:
+    with db._lock:
+        return int(db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
+
+
+def _assert_existing_row_backfilled(session, *, parent_session_id: str) -> None:
+    assert session["source"] == "cli"
+    assert session["parent_session_id"] == parent_session_id
+    assert session["profile_name"] == "profile-a"
+    assert session["user_id"] == "user-1"
+    assert session["session_key"] == "session-key"
+    assert session["chat_id"] == "chat-1"
+    assert session["chat_type"] == "group"
+    assert session["thread_id"] == "thread-1"
+
+
+def test_existing_row_bootstrap_backfill_manual_replay_fills_null_fields_and_duplicate_safe(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db.create_session("real-parent", "cli")
+    db.create_session(
+        "replay-session",
+        "cli",
+        chat_type="group",
+        thread_id="thread-1",
+    )
+    record = _backfill_record(
+        "existing-row-bootstrap-backfill-manual",
+        content="backfill manual transcript",
+        parent_session_id="real-parent",
+    )
+    _write_sealed_segment(home, 1, record)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+    session = db.get_session("replay-session")
+
+    assert result.state is spool.ReplayRunState.REPLAYED
+    assert session is not None
+    _assert_existing_row_backfilled(session, parent_session_id="real-parent")
+    assert session["message_count"] == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "backfill manual transcript"
+    ]
+    assert _fts_message_count(db) == 1
+
+    duplicate = db.reconcile_bootstrap_and_append_messages_batch(
+        record.bootstrap,
+        record.batch_messages,
+        replay_patience_s=2.0,
+    )
+
+    session_after = db.get_session("replay-session")
+    assert duplicate.inserted_count == 0
+    assert duplicate.duplicate_count == 1
+    assert session_after is not None
+    _assert_existing_row_backfilled(session_after, parent_session_id="real-parent")
+    assert session_after["message_count"] == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "backfill manual transcript"
+    ]
+    assert _fts_message_count(db) == 1
+
+
+def test_existing_row_bootstrap_backfill_startup_replay_fills_null_fields_after_restart(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    setup_db = SessionDB(db_path=home / "state.db")
+    try:
+        setup_db.create_session("real-parent", "cli")
+        setup_db.create_session("replay-session", "cli")
+    finally:
+        setup_db.close()
+
+    record = _backfill_record(
+        "existing-row-bootstrap-backfill-startup",
+        content="backfill startup transcript",
+        parent_session_id="real-parent",
+    )
+    _write_sealed_segment(home, 1, record)
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+
+    startup_db = SessionDB(db_path=home / "state.db")
+    try:
+        session = startup_db.get_session("replay-session")
+        assert session is not None
+        _assert_existing_row_backfilled(session, parent_session_id="real-parent")
+        assert session["message_count"] == 1
+        assert [row["content"] for row in startup_db.get_messages("replay-session")] == [
+            "backfill startup transcript"
+        ]
+        assert _fts_message_count(startup_db) == 1
+    finally:
+        startup_db.close()
+
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+    restarted = SessionDB(db_path=home / "state.db")
+    try:
+        session = restarted.get_session("replay-session")
+        assert session is not None
+        _assert_existing_row_backfilled(session, parent_session_id="real-parent")
+        assert session["message_count"] == 1
+        assert [row["content"] for row in restarted.get_messages("replay-session")] == [
+            "backfill startup transcript"
+        ]
+        assert _fts_message_count(restarted) == 1
+    finally:
+        restarted.close()
+
+
+def test_existing_row_bootstrap_backfill_conflict_rolls_back_metadata_messages_counters_and_fts(
+    db,
+):
+    db.create_session("real-parent", "cli")
+    db.create_session(
+        "replay-session",
+        "cli",
+        thread_id="wrong-thread",
+    )
+    record = _backfill_record(
+        "existing-row-bootstrap-backfill-conflict",
+        content="backfill conflict transcript",
+        parent_session_id="real-parent",
+    )
+
+    with pytest.raises(hermes_state.AppendMessagesBatchConflictError, match="thread_id"):
+        db.reconcile_bootstrap_and_append_messages_batch(
+            record.bootstrap,
+            record.batch_messages,
+            replay_patience_s=2.0,
+        )
+
+    session = db.get_session("replay-session")
+    assert session is not None
+    assert session["source"] == "cli"
+    assert session["thread_id"] == "wrong-thread"
+    assert session["parent_session_id"] is None
+    assert session["profile_name"] is None
+    assert session["user_id"] is None
+    assert session["session_key"] is None
+    assert session["chat_id"] is None
+    assert session["chat_type"] is None
+    assert session["message_count"] == 0
+    assert db.get_messages("replay-session") == []
+    assert _fts_message_count(db) == 0
+
+
+def test_reconcile_bootstrap_and_append_messages_batch_creates_missing_session_row(db):
+    bootstrap = _bootstrap()
+
+    result = db.reconcile_bootstrap_and_append_messages_batch(
+        bootstrap,
+        _batch_messages(),
+        replay_patience_s=2.0,
+    )
+
+    assert result.inserted_count == 1
+    assert result.duplicate_count == 0
+    session = db.get_session("replay-session")
+    assert session is not None
+    assert session["source"] == "cli"
+    assert session["model"] == "gpt-test"
+    assert session["system_prompt"] == "persist me exactly"
+    assert session["parent_session_id"] is None
+    assert session["cwd"] == "/tmp/project"
+    assert session["profile_name"] == "profile-a"
+    assert session["user_id"] == "user-1"
+    assert session["session_key"] == "session-key"
+    assert session["chat_id"] == "chat-1"
+    assert session["chat_type"] == "group"
+    assert session["thread_id"] == "thread-1"
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["hello replay"]
+
+
+def test_reconcile_bootstrap_and_append_messages_batch_rejects_missing_parent(db):
+    bootstrap = _bootstrap(parent_session_id="missing-parent")
+
+    with pytest.raises(hermes_state.AppendMessagesBatchConflictError, match="parent"):
+        db.reconcile_bootstrap_and_append_messages_batch(
+            bootstrap,
+            _batch_messages(),
+            replay_patience_s=2.0,
+        )
+
+    assert db.get_session("replay-session") is None
+    assert db.get_messages("replay-session") == []
+
+
+def test_missing_parent_manual_replay_blocks_and_preserves_later_fifo_head(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_sealed_segment(
+        home,
+        1,
+        spool.SessionSpoolRecord(
+            bootstrap=_bootstrap(parent_session_id="missing-parent"),
+            persist_attempt_id="b" * 32,
+            persist_attempt_unit_index=0,
+            canonical_failure={
+                "stage": "append_messages_batch",
+                "error_class": "RuntimeError",
+                "error_message": "db down",
+                "session_row_created": True,
+            },
+            batch_messages=tuple(_batch_messages(unit_id="unit-missing", content="alpha")),
+        ),
+    )
+    later = _write_sealed_segment(home, 2, _record(unit_id="unit-later", content="later"))
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert result.first_blocked_segment == 1
+    assert result.first_blocked_offset == 0
+    assert result.error_class == "AppendMessagesBatchConflictError"
+    assert db.get_messages("replay-session") == []
+    assert later.exists()
+
+
+def test_missing_parent_startup_replay_opens_and_preserves_sealed_head(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+    head = _write_sealed_segment(
+        home,
+        1,
+        spool.SessionSpoolRecord(
+            bootstrap=_bootstrap(parent_session_id="missing-parent"),
+            persist_attempt_id="c" * 32,
+            persist_attempt_unit_index=0,
+            canonical_failure={
+                "stage": "append_messages_batch",
+                "error_class": "RuntimeError",
+                "error_message": "db down",
+                "session_row_created": True,
+            },
+            batch_messages=tuple(_batch_messages(unit_id="unit-startup", content="alpha")),
+        ),
+    )
+
+    startup_db = SessionDB(db_path=home / "state.db")
+    try:
+        assert startup_db.get_messages("replay-session") == []
+        assert head.exists()
+    finally:
+        startup_db.close()
+
+
+def test_compression_busy_returns_retry_pending_and_preserves_later_fifo(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_sealed_segment(home, 1, _record(unit_id="unit-a", content="alpha"))
+    later = _write_sealed_segment(home, 2, _record(unit_id="unit-b", content="later"))
+
+    def _busy(*_args, **_kwargs):
+        raise hermes_state.CompressionSessionBusyError("busy")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _busy)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class is not None
+    assert result.cooldown_seconds > 0
+    assert result.frames_acked == 0
+    assert db.get_messages("replay-session") == []
+    assert later.exists()
+
+
+def test_compression_closed_returns_blocked_integrity(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_sealed_segment(home, 1, _record(unit_id="unit-a", content="alpha"))
+
+    def _closed(*_args, **_kwargs):
+        raise hermes_state.CompressionSessionClosedError("replay-session")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _closed)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert result.first_blocked_segment == 1
+    assert result.first_blocked_offset == 0
+    assert result.error_class == "CompressionSessionClosedError"
+
+
+def test_sqlite_locked_returns_retry_pending(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_sealed_segment(home, 1, _record(unit_id="unit-a", content="alpha"))
+
+    def _locked(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _locked)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class is not None
+    assert result.cooldown_seconds > 0
+
+
+def test_sqlite_busy_unrelated_operational_error_propagates(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_sealed_segment(home, 1, _record(unit_id="unit-a", content="alpha"))
+
+    def _busy(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is busy")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _busy)
+    busy_result = spool.replay_to_session_db(db, trigger="manual")
+    assert busy_result.state is spool.ReplayRunState.RETRY_PENDING
+    assert busy_result.retry_class is not None
+
+    other_home = tmp_path / ".hermes-other"
+    monkeypatch.setenv("HERMES_HOME", str(other_home))
+    _write_sealed_segment(other_home, 1, _record(unit_id="unit-b", content="beta"))
+
+    def _other(*_args, **_kwargs):
+        raise sqlite3.OperationalError("syntax error")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _other)
+    with pytest.raises(sqlite3.OperationalError, match="syntax error"):
+        spool.replay_to_session_db(db, trigger="manual")
+
+
+def test_replay_to_session_db_replays_clean_segment_and_compacts_it(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    segment_path = _write_sealed_segment(home, 1, _record())
+
+    result = spool.replay_to_session_db(db, trigger="startup")
+
+    assert result.state is spool.ReplayRunState.REPLAYED
+    assert result.frames_committed == 1
+    assert result.frames_duplicated == 0
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["hello replay"]
+    assert not segment_path.exists()
+
+
+def test_sessiondb_startup_replay_runs_once_only_for_writable_canonical_db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+    calls = []
+
+    def _fake_replay(session_db, *, trigger):
+        calls.append((session_db.db_path, trigger))
+        return spool.ReplayRunResult(state=spool.ReplayRunState.EMPTY, trigger=trigger)
+
+    monkeypatch.setattr(spool, "replay_to_session_db", _fake_replay)
+
+    canonical = SessionDB(db_path=home / "state.db")
+    canonical.close()
+    second = SessionDB(db_path=home / "state.db")
+    second.close()
+    other = SessionDB(db_path=home / "other.db")
+    other.close()
+    readonly = SessionDB(db_path=home / "state.db", read_only=True)
+    readonly.close()
+
+    assert calls == [(home / "state.db", "startup")]
+
+
+def test_corrupt_active_public_replay_publishes_evidence_and_blocker(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    spool.append_records((_record(unit_id="corrupt-active-direct"),))
+
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    corrupted = bytearray(active_path.read_bytes())
+    corrupted[0] = 0
+    active_path.write_bytes(bytes(corrupted))
+
+    result = spool.replay_to_session_db(db, trigger="startup")
+
+    blockers = sorted((home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME).glob("*.blocker.json"))
+    quarantine_spools = sorted((home / spool.SPOOL_ROOT_NAME / spool.QUARANTINE_DIR_NAME).glob("*.spool"))
+    quarantine_sidecars = sorted((home / spool.SPOOL_ROOT_NAME / spool.QUARANTINE_DIR_NAME).glob("*.json"))
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert result.first_blocked_segment == 1
+    assert len(blockers) == 1
+    assert len(quarantine_spools) == 1
+    assert len(quarantine_sidecars) == 1
+    assert active_path.read_bytes() == b""
+
+
+def test_corrupt_active_startup_replay_publishes_evidence_and_keeps_messages_empty(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+
+    spool.append_records((_record(unit_id="corrupt-active-startup"),))
+
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    corrupted = bytearray(active_path.read_bytes())
+    corrupted[0] = 0
+    active_path.write_bytes(bytes(corrupted))
+
+    startup_db = SessionDB(db_path=home / "state.db")
+    try:
+        blockers = sorted((home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME).glob("*.blocker.json"))
+        quarantine_spools = sorted((home / spool.SPOOL_ROOT_NAME / spool.QUARANTINE_DIR_NAME).glob("*.spool"))
+        quarantine_sidecars = sorted((home / spool.SPOOL_ROOT_NAME / spool.QUARANTINE_DIR_NAME).glob("*.json"))
+
+        assert startup_db.get_messages("replay-session") == []
+        assert len(blockers) == 1
+        assert len(quarantine_spools) == 1
+        assert len(quarantine_sidecars) == 1
+        assert active_path.read_bytes() == b""
+    finally:
+        startup_db.close()
+
+
+def _assert_metadata_only_replay_evidence(
+    home,
+    *,
+    sequence: int,
+    expected_source_kind: str,
+    expected_tail_status: str,
+    expected_valid_prefix_bytes: int,
+    expected_original_size_bytes: int,
+):
+    quarantine = home / spool.SPOOL_ROOT_NAME / spool.QUARANTINE_DIR_NAME
+    evidence_spools = sorted(
+        quarantine.glob(f"seq-{sequence:020d}-{expected_tail_status}-vp{expected_valid_prefix_bytes}.spool")
+    )
+    evidence_sidecars = sorted(
+        quarantine.glob(f"seq-{sequence:020d}-{expected_tail_status}-vp{expected_valid_prefix_bytes}.json")
+    )
+    assert len(evidence_spools) == 1
+    assert len(evidence_sidecars) == 1
+
+    payload = json.loads(evidence_sidecars[0].read_text(encoding="utf-8"))
+    assert set(payload.keys()) == {
+        "schema_version",
+        "segment_sequence",
+        "source_kind",
+        "tail_status",
+        "valid_prefix_bytes",
+        "original_size_bytes",
+        "evidence_spool_name",
+    }
+    assert payload == {
+        "schema_version": 1,
+        "segment_sequence": f"{sequence:020d}",
+        "source_kind": expected_source_kind,
+        "tail_status": expected_tail_status,
+        "valid_prefix_bytes": expected_valid_prefix_bytes,
+        "original_size_bytes": expected_original_size_bytes,
+        "evidence_spool_name": evidence_spools[0].name,
+    }
+    return evidence_spools[0], evidence_sidecars[0]
+
+
+def _write_blocker_backed_prefix_state(
+    home,
+    *,
+    sequence: int,
+    source_kind: str,
+    prefix_bytes: bytes,
+    original_bytes: bytes,
+    tail_status: str,
+):
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    blockers = sealed / spool.BLOCKERS_DIR_NAME
+    quarantine = root / spool.QUARANTINE_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+    blockers.mkdir(parents=True, exist_ok=True)
+    quarantine.mkdir(parents=True, exist_ok=True)
+
+    prefix_name = f"{sequence:020d}.prefix.spool"
+    (sealed / prefix_name).write_bytes(prefix_bytes)
+    evidence_base = f"seq-{sequence:020d}-{tail_status}-vp{len(prefix_bytes)}"
+    evidence_spool_name = f"{evidence_base}.spool"
+    evidence_sidecar_name = f"{evidence_base}.json"
+    (quarantine / evidence_spool_name).write_bytes(original_bytes)
+    (quarantine / evidence_sidecar_name).write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": f"{sequence:020d}",
+                "source_kind": source_kind,
+                "tail_status": tail_status,
+                "valid_prefix_bytes": len(prefix_bytes),
+                "original_size_bytes": len(original_bytes),
+                "evidence_spool_name": evidence_spool_name,
+            }
+        )
+    )
+    (blockers / f"{sequence:020d}.blocker.json").write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": f"{sequence:020d}",
+                "source_kind": source_kind,
+                "tail_status": tail_status,
+                "valid_prefix_bytes": len(prefix_bytes),
+                "acked_prefix_bytes": 0,
+                "blocking_offset": len(prefix_bytes),
+                "prefix_segment_name": prefix_name,
+                "evidence_spool_name": evidence_spool_name,
+                "evidence_sidecar_name": evidence_sidecar_name,
+                "original_size_bytes": len(original_bytes),
+            }
+        )
+    )
+    return sealed / prefix_name
+
+
+def _build_blocker_crash_state(home, case_name: str):
+    first = _record(unit_id=f"{case_name}-a", content="alpha")
+    second = _record(unit_id=f"{case_name}-b", content="beta")
+    clean_frame = spool._frame_bytes_for_record(first)
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(second))
+    corrupt_frame[-1] ^= 0x01
+    prefix_path = _write_blocker_backed_prefix_state(
+        home,
+        sequence=1,
+        source_kind="sealed",
+        prefix_bytes=clean_frame,
+        original_bytes=clean_frame + bytes(corrupt_frame),
+        tail_status="checksum_mismatch",
+    )
+    _write_sealed_segment(home, 2, _record(unit_id=f"{case_name}-later", content="gamma"))
+    root = home / spool.SPOOL_ROOT_NAME
+    quarantine = root / spool.QUARANTINE_DIR_NAME
+    evidence_spool = quarantine / f"seq-{1:020d}-checksum_mismatch-vp{len(clean_frame)}.spool"
+    evidence_sidecar = quarantine / f"seq-{1:020d}-checksum_mismatch-vp{len(clean_frame)}.json"
+    blocker_path = root / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME / f"{1:020d}.blocker.json"
+
+    if case_name == "missing_evidence_sidecar":
+        evidence_sidecar.unlink()
+        expected_error_class = "missing_replay_evidence_sidecar"
+    elif case_name == "missing_evidence_spool":
+        evidence_spool.unlink()
+        expected_error_class = "missing_replay_evidence_spool"
+    elif case_name == "malformed_evidence_sidecar":
+        evidence_sidecar.write_text('{"schema_version":1}\n', encoding="utf-8")
+        expected_error_class = "invalid_replay_evidence_sidecar"
+    elif case_name == "mismatched_evidence_relationship":
+        payload = json.loads(evidence_sidecar.read_text(encoding="utf-8"))
+        payload["valid_prefix_bytes"] = payload["valid_prefix_bytes"] + 1
+        evidence_sidecar.write_bytes(spool._canonical_json_bytes(payload))
+        expected_error_class = "invalid_blocker_relationship"
+    elif case_name == "missing_prefix_required":
+        prefix_path.unlink()
+        expected_error_class = "invalid_blocker_relationship"
+    elif case_name == "mismatched_prefix_required":
+        prefix_path.write_bytes(clean_frame[:-1])
+        expected_error_class = "invalid_blocker_relationship"
+    else:
+        raise AssertionError(f"unknown blocker crash-state case: {case_name}")
+
+    return {
+        "blocked_sequence": 1,
+        "blocking_offset": len(clean_frame),
+        "blocker_path": blocker_path,
+        "evidence_spool": evidence_spool,
+        "evidence_sidecar": evidence_sidecar,
+        "expected_error_class": expected_error_class,
+        "prefix_path": prefix_path,
+    }
+
+
+@pytest.mark.parametrize(
+    ("case_name", "expected_error_class"),
+    [
+        ("missing_evidence_sidecar", "missing_replay_evidence_sidecar"),
+        ("missing_evidence_spool", "missing_replay_evidence_spool"),
+        ("malformed_evidence_sidecar", "invalid_replay_evidence_sidecar"),
+        ("mismatched_evidence_relationship", "invalid_blocker_relationship"),
+        ("missing_prefix_required", "invalid_blocker_relationship"),
+        ("mismatched_prefix_required", "invalid_blocker_relationship"),
+    ],
+)
+def test_blocker_crash_state_outcome_manual_replay_returns_blocked_integrity_and_fd_stable(
+    db, tmp_path, monkeypatch, case_name, expected_error_class
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state = _build_blocker_crash_state(home, case_name)
+
+    import psutil
+
+    baseline_fds = psutil.Process().num_fds()
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    second = spool.replay_to_session_db(db, trigger="manual")
+
+    assert first.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert first.first_blocked_segment == state["blocked_sequence"]
+    assert first.first_blocked_offset == state["blocking_offset"]
+    assert first.error_class == expected_error_class
+    assert db.get_messages("replay-session") == []
+    assert [row["content"] for row in db.get_messages("replay-session") if row["content"] == "gamma"] == []
+    assert second.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert second.first_blocked_segment == state["blocked_sequence"]
+    assert second.first_blocked_offset == state["blocking_offset"]
+    assert second.error_class == expected_error_class
+    assert state["blocker_path"].exists()
+    assert psutil.Process().num_fds() == baseline_fds
+
+
+@pytest.mark.parametrize(
+    ("case_name", "expected_error_class"),
+    [
+        ("missing_evidence_sidecar", "missing_replay_evidence_sidecar"),
+        ("missing_evidence_spool", "missing_replay_evidence_spool"),
+        ("malformed_evidence_sidecar", "invalid_replay_evidence_sidecar"),
+        ("mismatched_evidence_relationship", "invalid_blocker_relationship"),
+        ("missing_prefix_required", "invalid_blocker_relationship"),
+        ("mismatched_prefix_required", "invalid_blocker_relationship"),
+    ],
+)
+def test_blocker_crash_state_outcome_startup_remains_available_and_fail_closed(
+    tmp_path, monkeypatch, case_name, expected_error_class
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state = _build_blocker_crash_state(home, case_name)
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+
+    startup_db = SessionDB(db_path=home / "state.db")
+    try:
+        assert startup_db.get_messages("replay-session") == []
+        assert state["blocker_path"].exists()
+    finally:
+        startup_db.close()
+
+    replay_db = SessionDB(db_path=home / "state.db")
+    try:
+        replay_result = spool.replay_to_session_db(replay_db, trigger="startup")
+        assert replay_result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+        assert replay_result.first_blocked_segment == state["blocked_sequence"]
+        assert replay_result.first_blocked_offset == state["blocking_offset"]
+        assert replay_result.error_class == expected_error_class
+        assert replay_db.get_messages("replay-session") == []
+        assert [row["content"] for row in replay_db.get_messages("replay-session") if row["content"] == "gamma"] == []
+    finally:
+        replay_db.close()
+
+
+def test_blocker_backed_valid_prefix_active_manual_replays_prefix_once_then_blocks_restart_duplicate_safe(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    first = _record(unit_id="unit-a", content="alpha")
+    second = _record(unit_id="unit-b", content="beta")
+    clean_frame = spool._frame_bytes_for_record(first)
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(second))
+    corrupt_frame[-1] ^= 0x01
+    expected_sequence = 1
+
+    spool.append_records((first, second))
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    active_path.write_bytes(clean_frame + bytes(corrupt_frame))
+
+    first_result = spool.replay_to_session_db(db, trigger="manual")
+
+    blocker_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.BLOCKERS_DIR_NAME
+        / f"{expected_sequence:020d}.blocker.json"
+    )
+    ack_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.ACKS_DIR_NAME
+        / f"{expected_sequence:020d}.prefix.spool.ap{len(clean_frame):020d}.json"
+    )
+
+    assert first_result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert first_result.first_blocked_segment == expected_sequence
+    assert first_result.first_blocked_offset == len(clean_frame)
+    assert blocker_path.exists()
+    assert ack_path.exists()
+    evidence_spool, _evidence_sidecar = _assert_metadata_only_replay_evidence(
+        home,
+        sequence=expected_sequence,
+        expected_source_kind="active",
+        expected_tail_status="checksum_mismatch",
+        expected_valid_prefix_bytes=len(clean_frame),
+        expected_original_size_bytes=len(clean_frame) + len(corrupt_frame),
+    )
+    assert evidence_spool.read_bytes() == clean_frame + bytes(corrupt_frame)
+
+    restarted = SessionDB(db_path=home / "state.db")
+    try:
+        second_result = spool.replay_to_session_db(restarted, trigger="manual")
+        assert second_result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+        assert [row["content"] for row in restarted.get_messages("replay-session")] == [
+            "alpha"
+        ]
+        assert second_result.first_blocked_segment == expected_sequence
+        assert second_result.first_blocked_offset == len(clean_frame)
+        assert restarted.get_messages("replay-session") == db.get_messages("replay-session")
+        assert blocker_path.exists()
+        assert ack_path.exists()
+    finally:
+        restarted.close()
+
+
+def test_blocker_backed_valid_prefix_sealed_startup_replays_prefix_once_then_blocks_restart_duplicate_safe(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+
+    first = _record(unit_id="unit-a", content="alpha")
+    second = _record(unit_id="unit-b", content="beta")
+    clean_frame = spool._frame_bytes_for_record(first)
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(second))
+    corrupt_frame[-1] ^= 0x01
+    _write_blocker_backed_prefix_state(
+        home,
+        sequence=1,
+        source_kind="sealed",
+        prefix_bytes=clean_frame,
+        original_bytes=clean_frame + bytes(corrupt_frame),
+        tail_status="checksum_mismatch",
+    )
+    _write_sealed_segment(home, 2, _record(unit_id="unit-c", content="gamma"))
+
+    startup_db = SessionDB(db_path=home / "state.db")
+    try:
+        blocker_path = (
+            home
+            / spool.SPOOL_ROOT_NAME
+            / spool.SEALED_DIR_NAME
+            / spool.BLOCKERS_DIR_NAME
+            / "00000000000000000001.blocker.json"
+        )
+        ack_path = (
+            home
+            / spool.SPOOL_ROOT_NAME
+            / spool.SEALED_DIR_NAME
+            / spool.ACKS_DIR_NAME
+            / f"00000000000000000001.prefix.spool.ap{len(clean_frame):020d}.json"
+        )
+        assert [row["content"] for row in startup_db.get_messages("replay-session")] == [
+            "alpha"
+        ]
+        assert [row["content"] for row in startup_db.get_messages("replay-session") if row["content"] == "gamma"] == []
+        assert blocker_path.exists()
+        assert ack_path.exists()
+        evidence_spool, _evidence_sidecar = _assert_metadata_only_replay_evidence(
+            home,
+            sequence=1,
+            expected_source_kind="sealed",
+            expected_tail_status="checksum_mismatch",
+            expected_valid_prefix_bytes=len(clean_frame),
+            expected_original_size_bytes=len(clean_frame) + len(corrupt_frame),
+        )
+        assert evidence_spool.read_bytes() == clean_frame + bytes(corrupt_frame)
+    finally:
+        startup_db.close()
+
+    monkeypatch.setattr(hermes_state, "_SESSION_SPOOL_STARTUP_ONCE", set(), raising=False)
+    restarted = SessionDB(db_path=home / "state.db")
+    try:
+        replay_result = spool.replay_to_session_db(restarted, trigger="startup")
+        assert replay_result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+        assert replay_result.first_blocked_segment == 1
+        assert replay_result.first_blocked_offset == len(clean_frame)
+        assert [row["content"] for row in restarted.get_messages("replay-session")] == [
+            "alpha"
+        ]
+    finally:
+        restarted.close()
+
+
+def test_blocker_backed_valid_prefix_zero_prefix_active_remains_blocked_without_messages(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    spool.append_records((_record(unit_id="zero-prefix-active"),))
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    corrupted = bytearray(active_path.read_bytes())
+    corrupted[0] = 0
+    active_path.write_bytes(bytes(corrupted))
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert db.get_messages("replay-session") == []
+
+
+def test_blocker_backed_valid_prefix_zero_prefix_sealed_remains_blocked_without_messages(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(_record(unit_id="unit-bad", content="beta")))
+    corrupt_frame[0] = 0
+    (sealed / "00000000000000000001.spool").write_bytes(bytes(corrupt_frame))
+    (sealed / "00000000000000000002.spool").write_bytes(
+        spool._frame_bytes_for_record(_record(unit_id="unit-c", content="gamma"))
+    )
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert db.get_messages("replay-session") == []
+    assert [row["content"] for row in db.get_messages("replay-session") if row["content"] == "gamma"] == []
+
+
+def test_replay_stops_at_blocker_and_does_not_advance_later_sequences_after_restart(
+    db, tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    blockers = sealed / spool.BLOCKERS_DIR_NAME
+    quarantine = root / spool.QUARANTINE_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+    blockers.mkdir(parents=True, exist_ok=True)
+    quarantine.mkdir(parents=True, exist_ok=True)
+
+    clean_frame = spool._frame_bytes_for_record(_record(unit_id="unit-a", content="alpha"))
+    corrupt_frame = bytearray(
+        spool._frame_bytes_for_record(_record(unit_id="unit-b", content="beta"))
+    )
+    corrupt_frame[-1] ^= 0x01
+    (sealed / "00000000000000000001.spool").write_bytes(clean_frame + bytes(corrupt_frame))
+    (sealed / "00000000000000000002.spool").write_bytes(
+        spool._frame_bytes_for_record(_record(unit_id="unit-c", content="gamma"))
+    )
+
+    first = spool.replay_to_session_db(db, trigger="startup")
+
+    assert first.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+
+    restarted = SessionDB(db_path=home / "state.db")
+    try:
+        second = spool.replay_to_session_db(restarted, trigger="startup")
+        assert second.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+        assert [row["content"] for row in restarted.get_messages("replay-session")] == [
+            "alpha"
+        ]
+        assert restarted.get_messages("replay-session") == db.get_messages("replay-session")
+    finally:
+        restarted.close()
+
+
+def test_corrupt_sealed_segment_replays_only_prefix_then_blocks_fifo(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+
+    clean_frame = spool._frame_bytes_for_record(_record(unit_id="unit-a", content="alpha"))
+    corrupt_frame = bytearray(
+        spool._frame_bytes_for_record(_record(unit_id="unit-b", content="beta"))
+    )
+    corrupt_frame[-1] ^= 0x01
+    (sealed / "00000000000000000001.spool").write_bytes(clean_frame + bytes(corrupt_frame))
+    (sealed / "00000000000000000002.spool").write_bytes(
+        spool._frame_bytes_for_record(_record(unit_id="unit-c", content="gamma"))
+    )
+
+    result = spool.replay_to_session_db(db, trigger="startup")
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert result.first_blocked_segment == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert [row["content"] for row in db.get_messages("replay-session") if row["content"] == "gamma"] == []
+
+
+def _write_ack_sidecar(home, segment_name: str, acked_prefix_bytes: int, valid_prefix_bytes: int, *, sequence: int = 1):
+    acks = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.ACKS_DIR_NAME
+    acks.mkdir(parents=True, exist_ok=True)
+    ack_name = f"{segment_name}.ap{acked_prefix_bytes:020d}.json"
+    payload = {
+        "schema_version": 1,
+        "segment_sequence": f"{sequence:020d}",
+        "segment_name": segment_name,
+        "segment_kind": "prefix" if segment_name.endswith(".prefix.spool") else "clean",
+        "segment_size_bytes": valid_prefix_bytes,
+        "acked_prefix_bytes": acked_prefix_bytes,
+        "valid_prefix_bytes": valid_prefix_bytes,
+        "tail_status": "clean",
+        "last_frame_offset": 0,
+        "last_frame_length": acked_prefix_bytes,
+        "last_frame_checksum_hex": "1" * 32,
+    }
+    (acks / ack_name).write_bytes(spool._canonical_json_bytes(payload))
+    return acks / ack_name
+
+
+def test_full_ack_tombstone_suppresses_replay_but_partial_ack_tombstone_blocks(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+
+    full = _write_ack_sidecar(home, "00000000000000000001.spool", 5, 5, sequence=1)
+    empty_result = spool.replay_to_session_db(db, trigger="startup")
+
+    assert empty_result.state is spool.ReplayRunState.EMPTY
+    assert db.get_messages("replay-session") == []
+
+    full.unlink()
+    _write_ack_sidecar(home, "00000000000000000001.spool", 3, 5, sequence=1)
+    blocked = spool.replay_to_session_db(db, trigger="startup")
+
+    assert blocked.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert blocked.first_blocked_segment == 1
+
+
+def test_blocker_held_full_ack_tombstone_keeps_fifo_stopped_after_restart(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    blockers = sealed / spool.BLOCKERS_DIR_NAME
+    sealed.mkdir(parents=True, exist_ok=True)
+    blockers.mkdir(parents=True, exist_ok=True)
+    _write_ack_sidecar(home, "00000000000000000001.prefix.spool", 5, 5, sequence=1)
+    (blockers / "00000000000000000001.blocker.json").write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": "00000000000000000001",
+                "source_kind": "sealed",
+                "tail_status": "checksum_mismatch",
+                "valid_prefix_bytes": 5,
+                "acked_prefix_bytes": 5,
+                "blocking_offset": 5,
+                "prefix_segment_name": "00000000000000000001.prefix.spool",
+                "evidence_spool_name": "seq-00000000000000000001-checksum_mismatch-vp5.spool",
+                "evidence_sidecar_name": "seq-00000000000000000001-checksum_mismatch-vp5.json",
+                "original_size_bytes": 10,
+            }
+        )
+    )
+    (sealed / "00000000000000000002.spool").write_bytes(
+        spool._frame_bytes_for_record(_record(unit_id="unit-c", content="gamma"))
+    )
+
+    first = spool.replay_to_session_db(db, trigger="startup")
+    assert first.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert db.get_messages("replay-session") == []
+
+    restarted = SessionDB(db_path=home / "state.db")
+    try:
+        second = spool.replay_to_session_db(restarted, trigger="startup")
+        assert second.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+        assert restarted.get_messages("replay-session") == []
+    finally:
+        restarted.close()
+
+
+def test_replay_respects_startup_pre_persist_and_manual_budgets(tmp_path, monkeypatch):
+    def _run(trigger: str):
+        home = tmp_path / trigger
+        home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db = SessionDB(db_path=home / "state.db")
+        try:
+            for idx in range(20):
+                _write_sealed_segment(
+                    home,
+                    idx + 1,
+                    _record(unit_id=f"unit-{idx}", content=f"msg-{idx}"),
+                )
+            result = spool.replay_to_session_db(db, trigger=trigger)
+            return db, result
+        except Exception:
+            db.close()
+            raise
+
+    startup_db, startup = _run("startup")
+    try:
+        assert startup.state is spool.ReplayRunState.REPLAYED
+        assert startup.frames_committed == 20
+    finally:
+        startup_db.close()
+
+    pre_db, pre = _run("pre_persist")
+    try:
+        assert pre.state is spool.ReplayRunState.PARTIALLY_REPLAYED
+        assert pre.frames_committed == 16
+        assert pre.pending_bytes_after > 0
+        assert len(pre_db.get_messages("replay-session")) == 16
+    finally:
+        pre_db.close()
+
+    manual_db, manual = _run("manual")
+    try:
+        assert manual.state is spool.ReplayRunState.REPLAYED
+        assert manual.frames_committed == 20
+    finally:
+        manual_db.close()
+
+
+def test_retryable_ack_cleanup_returns_retry_pending_with_ack_pending_true(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "ack-cleanup-retry"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        _write_sealed_segment(home, 1, _record(unit_id="unit-a", content="alpha"))
+        _write_ack_sidecar(home, "00000000000000000001.spool", 3, 5, sequence=1)
+
+        def _busy(**_kwargs):
+            raise OSError(16, "busy")
+
+        monkeypatch.setattr(spool, "_cleanup_stale_lower_ack_sidecars", _busy)
+
+        result = spool.replay_to_session_db(db, trigger="manual")
+
+        assert result.state is spool.ReplayRunState.RETRY_PENDING
+        assert result.ack_pending is True
+        assert result.frames_committed == 1
+        assert result.frames_acked == 0
+        assert result.retry_class == "ack_cleanup_busy"
+        assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    finally:
+        db.close()
+
+
+def test_retry_cooldown_skips_early_trigger_and_allows_later_takeover(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "retry-cooldown"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        _write_sealed_segment(home, 1, _record(unit_id="unit-a", content="alpha"))
+        original = spool._publish_ack_sidecar_strict
+        calls = {"count": 0}
+        clock = {"now": 100.0}
+
+        monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+
+        def _flaky(runtime, *, segment_sequence, segment_path, ack_payload):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise OSError(16, "busy")
+            return original(
+                runtime,
+                segment_sequence=segment_sequence,
+                segment_path=segment_path,
+                ack_payload=ack_payload,
+            )
+
+        monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _flaky)
+
+        first = spool.replay_to_session_db(db, trigger="manual")
+        assert first.state is spool.ReplayRunState.RETRY_PENDING
+        assert first.ack_pending is True
+        assert calls["count"] == 1
+
+        second = spool.replay_to_session_db(db, trigger="manual")
+        assert second.state is spool.ReplayRunState.RETRY_PENDING
+        assert second.cooldown_seconds > 0
+        assert calls["count"] == 1
+
+        clock["now"] += second.cooldown_seconds + 0.01
+        third = spool.replay_to_session_db(db, trigger="manual")
+        assert third.state is spool.ReplayRunState.REPLAYED
+        assert calls["count"] == 2
+    finally:
+        db.close()
+
+
+def test_replay_to_session_db_seals_clean_active_spool_before_replaying(db, tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    root = home / spool.SPOOL_ROOT_NAME
+    root.mkdir(parents=True, exist_ok=True)
+    active_path = root / spool.ACTIVE_SPOOL_NAME
+    active_path.write_bytes(spool._frame_bytes_for_record(_record()))
+
+    result = spool.replay_to_session_db(db, trigger="startup")
+
+    assert result.state is spool.ReplayRunState.REPLAYED
+    assert result.frames_committed == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["hello replay"]
+    sealed_entries = sorted((root / spool.SEALED_DIR_NAME).glob("*.spool"))
+    assert sealed_entries == []
+    assert active_path.exists()
+    assert active_path.read_bytes() == b""

--- a/tests/state/test_session_spool_replay.py
+++ b/tests/state/test_session_spool_replay.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import errno
 import json
+import logging
+import multiprocessing as mp
+import os
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -91,6 +96,34 @@ def _write_sealed_segment(home, sequence: int, *records: spool.SessionSpoolRecor
     return segment_path
 
 
+def _close_runtime_fds(runtime) -> None:
+    spool._close_fd_quietly(runtime.lock_fd)
+    spool._close_fd_quietly(runtime.root_fd)
+    spool._close_fd_quietly(runtime.home_fd)
+
+
+def _hold_replay_owner_lock(home_path: str, ready_conn, release_conn) -> None:
+    os.environ["HERMES_HOME"] = home_path
+    runtime = spool._open_locked_runtime()
+    owner = None
+    try:
+        owner = spool._try_acquire_replay_owner(runtime)
+        ready_conn.send(owner is not None)
+        release_conn.recv()
+    finally:
+        if owner is not None:
+            spool._close_fd_quietly(owner.fd)
+        ready_conn.close()
+        release_conn.close()
+        _close_runtime_fds(runtime)
+
+
+def _replay_owner_context():
+    if "fork" in mp.get_all_start_methods():
+        return mp.get_context("fork")
+    return mp.get_context()
+
+
 def _backfill_record(
     unit_id: str,
     *,
@@ -114,6 +147,14 @@ def _backfill_record(
 def _fts_message_count(db) -> int:
     with db._lock:
         return int(db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
+
+
+def _replay_messages_for_state(caplog, state: str) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and f"state={state}" in record.getMessage()
+    ]
 
 
 def _assert_existing_row_backfilled(session, *, parent_session_id: str) -> None:
@@ -1222,6 +1263,270 @@ def test_retry_cooldown_skips_early_trigger_and_allows_later_takeover(
         db.close()
 
 
+def test_owner_busy_returns_truthful_backlog_without_mutating_or_taking_over_owner(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    append = spool.append_records((_record(unit_id="owner-busy", content="alpha"),))
+    active_path = Path(append.unit_results[0].receipt.path)
+    active_bytes = active_path.read_bytes()
+    sealed_dir = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME
+    context = _replay_owner_context()
+    ready_parent, ready_child = context.Pipe()
+    release_parent, release_child = context.Pipe()
+    proc = context.Process(
+        target=_hold_replay_owner_lock,
+        args=(str(home), ready_child, release_child),
+    )
+    proc.start()
+    ready_child.close()
+    release_child.close()
+    assert ready_parent.recv() is True
+    try:
+        result = spool.replay_to_session_db(object(), trigger="manual")
+
+        assert proc.is_alive()
+        assert result.state is spool.ReplayRunState.OWNER_BUSY
+        assert result.pending_bytes_after == len(active_bytes)
+        assert result.pending_frames_after == 1
+        assert result.ack_pending is False
+        assert result.first_blocked_segment is None
+        assert result.first_blocked_offset is None
+        assert active_path.read_bytes() == active_bytes
+        assert not sealed_dir.exists()
+
+        runtime = spool._open_locked_runtime()
+        try:
+            assert spool._try_acquire_replay_owner(runtime) is None
+        finally:
+            _close_runtime_fds(runtime)
+    finally:
+        release_parent.send(True)
+        proc.join(5)
+        ready_parent.close()
+        release_parent.close()
+
+    assert proc.exitcode == 0
+
+
+def test_owner_busy_snapshot_failure_returns_unknown_metrics_without_mutation_or_takeover(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    append = spool.append_records((_record(unit_id="owner-busy-unknown", content="alpha"),))
+    active_path = Path(append.unit_results[0].receipt.path)
+    active_bytes = active_path.read_bytes()
+    sealed_dir = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME
+    context = _replay_owner_context()
+    ready_parent, ready_child = context.Pipe()
+    release_parent, release_child = context.Pipe()
+    proc = context.Process(
+        target=_hold_replay_owner_lock,
+        args=(str(home), ready_child, release_child),
+    )
+    proc.start()
+    ready_child.close()
+    release_child.close()
+    assert ready_parent.recv() is True
+
+    def _snapshot_boom(_runtime):
+        raise OSError(errno.EIO, f"secondary snapshot race {active_path} owner-busy-unknown")
+
+    monkeypatch.setattr(spool, "_snapshot_pending_backlog", _snapshot_boom)
+    try:
+        result = spool.replay_to_session_db(object(), trigger="manual")
+
+        assert proc.is_alive()
+        assert result.state is spool.ReplayRunState.OWNER_BUSY
+        assert result.pending_bytes_after == -1
+        assert result.pending_frames_after == -1
+        assert result.ack_pending is False
+        assert result.first_blocked_segment is None
+        assert result.first_blocked_offset is None
+        assert active_path.read_bytes() == active_bytes
+        assert not sealed_dir.exists()
+
+        runtime = spool._open_locked_runtime()
+        try:
+            assert spool._try_acquire_replay_owner(runtime) is None
+        finally:
+            _close_runtime_fds(runtime)
+    finally:
+        release_parent.send(True)
+        proc.join(5)
+        ready_parent.close()
+        release_parent.close()
+
+    assert proc.exitcode == 0
+
+
+def test_retry_cooldown_returns_truthful_backlog_without_reacquiring_owner(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    db = SessionDB(db_path=home / "state.db")
+    caplog.set_level(logging.INFO)
+    segment_path = _write_sealed_segment(
+        home,
+        1,
+        _record(unit_id="cooldown-truth", content="alpha"),
+    )
+    segment_bytes = segment_path.read_bytes()
+    ack_dir = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.ACKS_DIR_NAME
+    original_publish = spool._publish_ack_sidecar_strict
+    original_try_owner = spool._try_acquire_replay_owner
+    calls = {"ack": 0, "owner": 0}
+
+    def _count_owner(runtime):
+        calls["owner"] += 1
+        return original_try_owner(runtime)
+
+    def _busy_once(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls["ack"] += 1
+        if calls["ack"] == 1:
+            raise OSError(
+                errno.EBUSY,
+                f"busy {segment_path} cooldown-truth-key-0 alpha",
+            )
+        return original_publish(
+            runtime,
+            segment_sequence=segment_sequence,
+            segment_path=segment_path,
+            ack_payload=ack_payload,
+        )
+
+    monkeypatch.setattr(spool, "_try_acquire_replay_owner", _count_owner)
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _busy_once)
+    try:
+        first = spool.replay_to_session_db(db, trigger="manual")
+        second = spool.replay_to_session_db(db, trigger="manual")
+    finally:
+        db.close()
+
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert first.state is spool.ReplayRunState.RETRY_PENDING
+    assert first.retry_class == "ack_publish_busy"
+    assert first.ack_pending is True
+    assert first.cooldown_seconds > 0
+    assert first.pending_bytes_after == len(segment_bytes)
+    assert first.pending_frames_after == 1
+    assert second.state is spool.ReplayRunState.RETRY_PENDING
+    assert second.retry_class == "ack_publish_busy"
+    assert second.ack_pending is True
+    assert second.cooldown_seconds > 0
+    assert second.pending_bytes_after == len(segment_bytes)
+    assert second.pending_frames_after == 1
+    assert segment_path.read_bytes() == segment_bytes
+    assert ack_dir.exists()
+    assert sorted(ack_dir.glob("*.json")) == []
+    assert calls["ack"] == 1
+    assert calls["owner"] == 1
+    assert len(messages) == 1
+    assert "retry_class=ack_publish_busy" in messages[0]
+    assert "ack_pending=True" in messages[0]
+    assert f"pending_bytes={len(segment_bytes)}" in messages[0]
+    assert "pending_frames=1" in messages[0]
+
+
+def test_retry_cooldown_snapshot_failure_returns_unknown_metrics_without_reacquiring_owner(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    db = SessionDB(db_path=home / "state.db")
+    caplog.set_level(logging.INFO)
+    segment_path = _write_sealed_segment(
+        home,
+        1,
+        _record(unit_id="cooldown-unknown", content="alpha"),
+    )
+    segment_bytes = segment_path.read_bytes()
+    ack_dir = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.ACKS_DIR_NAME
+    original_publish = spool._publish_ack_sidecar_strict
+    original_try_owner = spool._try_acquire_replay_owner
+    calls = {"ack": 0, "owner": 0}
+
+    def _count_owner(runtime):
+        calls["owner"] += 1
+        return original_try_owner(runtime)
+
+    def _busy_once(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls["ack"] += 1
+        if calls["ack"] == 1:
+            raise OSError(
+                errno.EBUSY,
+                f"busy {segment_path} cooldown-unknown-key-0 alpha",
+            )
+        return original_publish(
+            runtime,
+            segment_sequence=segment_sequence,
+            segment_path=segment_path,
+            ack_payload=ack_payload,
+        )
+
+    def _snapshot_boom(_runtime):
+        raise OSError(
+            errno.EIO,
+            f"secondary snapshot race {segment_path} cooldown-unknown-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_try_acquire_replay_owner", _count_owner)
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _busy_once)
+    try:
+        first = spool.replay_to_session_db(db, trigger="manual")
+        spool._REPLAY_LOG_STATE.clear()
+        monkeypatch.setattr(spool, "_snapshot_pending_backlog", _snapshot_boom)
+        second = spool.replay_to_session_db(db, trigger="manual")
+    finally:
+        db.close()
+
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+    joined = "\n".join(messages)
+
+    assert first.state is spool.ReplayRunState.RETRY_PENDING
+    assert first.retry_class == "ack_publish_busy"
+    assert first.pending_bytes_after == len(segment_bytes)
+    assert first.pending_frames_after == 1
+    assert second.state is spool.ReplayRunState.RETRY_PENDING
+    assert second.retry_class == "ack_publish_busy"
+    assert second.ack_pending is True
+    assert second.cooldown_seconds > 0
+    assert second.pending_bytes_after == -1
+    assert second.pending_frames_after == -1
+    assert segment_path.read_bytes() == segment_bytes
+    assert ack_dir.exists()
+    assert sorted(ack_dir.glob("*.json")) == []
+    assert calls["ack"] == 1
+    assert calls["owner"] == 1
+    assert len(messages) == 2
+    assert "pending_bytes=-1" in messages[-1]
+    assert "pending_frames=-1" in messages[-1]
+    assert "secondary snapshot race" not in joined
+    assert str(segment_path) not in joined
+    assert "cooldown-unknown-key-0" not in joined
+    assert "alpha" not in joined
+
+
 def test_replay_to_session_db_seals_clean_active_spool_before_replaying(db, tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -1239,3 +1544,1448 @@ def test_replay_to_session_db_seals_clean_active_spool_before_replaying(db, tmp_
     assert sealed_entries == []
     assert active_path.exists()
     assert active_path.read_bytes() == b""
+
+
+def test_ack_publish_enospc_returns_not_durable_and_next_retry_is_duplicate_safe(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    segment_path = _write_sealed_segment(home, 1, _record(unit_id="unit-enospc", content="alpha"))
+    segment_bytes = segment_path.read_bytes()
+    caplog.set_level(logging.INFO)
+
+    def _enospc(*_args, **_kwargs):
+        raise OSError(errno.ENOSPC, f"disk full {segment_path} unit-enospc-key-0 alpha")
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _enospc)
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    first_log = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+
+    assert first.state is spool.ReplayRunState.NOT_DURABLE
+    assert first.error_class == "errno_enospc"
+    assert segment_path.exists()
+    assert first.pending_bytes_after == len(segment_bytes)
+    assert spool._pending_frames_for_log(first) == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert "pending_frames=1" in first_log
+    assert f"pending_bytes={len(segment_bytes)}" in first_log
+    assert "disk full" not in first_log
+    assert str(segment_path) not in first_log
+    assert "unit-enospc-key-0" not in first_log
+    assert "alpha" not in first_log
+
+    monkeypatch.undo()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    second = spool.replay_to_session_db(db, trigger="manual")
+
+    assert second.state is spool.ReplayRunState.REPLAYED
+    assert second.frames_committed == 0
+    assert second.frames_duplicated == 1
+    assert second.frames_acked == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert not segment_path.exists()
+
+
+def test_second_ack_publish_enospc_reports_only_unacked_frame_and_retry_stays_duplicate_safe(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    segment_path = _write_sealed_segment(
+        home,
+        1,
+        _record(unit_id="second-ack-enospc-a", content="alpha"),
+        _record(unit_id="second-ack-enospc-b", content="second-is-longer"),
+    )
+    decoded = spool.decode_spool_segment(segment_path)
+    first_frame, second_frame = decoded.prefix_frames
+    caplog.set_level(logging.INFO)
+    original_publish = spool._publish_ack_sidecar_strict
+    calls = {"count": 0}
+
+    def _fail_second(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise OSError(
+                errno.ENOSPC,
+                f"disk full {segment_path} second-ack-enospc-b-key-0 second-is-longer",
+            )
+        return original_publish(
+            runtime,
+            segment_sequence=segment_sequence,
+            segment_path=segment_path,
+            ack_payload=ack_payload,
+        )
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _fail_second)
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "not_durable")
+    ack_dir = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.ACKS_DIR_NAME
+
+    assert first.state is spool.ReplayRunState.NOT_DURABLE
+    assert first.error_class == "errno_enospc"
+    assert first.frames_acked == 1
+    assert first.pending_frames_after == 1
+    assert first.pending_bytes_after == second_frame.frame_length
+    assert first.ack_pending is True
+    assert sorted(path.name for path in ack_dir.glob("*.json")) == [
+        f"{segment_path.name}.ap{first_frame.frame_length:020d}.json"
+    ]
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "alpha",
+        "second-is-longer",
+    ]
+    assert _fts_message_count(db) == 2
+    assert len(messages) == 1
+    assert "pending_frames=1" in messages[0]
+    assert f"pending_bytes={second_frame.frame_length}" in messages[0]
+    assert "disk full" not in messages[0]
+    assert str(segment_path) not in messages[0]
+    assert "second-ack-enospc-b-key-0" not in messages[0]
+    assert "second-is-longer" not in messages[0]
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", original_publish)
+
+    second = spool.replay_to_session_db(db, trigger="manual")
+
+    assert second.state is spool.ReplayRunState.REPLAYED
+    assert second.frames_committed == 0
+    assert second.frames_duplicated == 2
+    assert second.frames_acked == 2
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "alpha",
+        "second-is-longer",
+    ]
+    assert _fts_message_count(db) == 2
+    assert not segment_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected_retry_class"),
+    [
+        (OSError(errno.EBUSY, "busy"), "ack_publish_busy"),
+        (spool.SpoolRetryableReplayError("ack_cleanup_busy", ack_pending=True), "ack_cleanup_busy"),
+    ],
+)
+def test_second_ack_publish_retry_pending_reports_exact_unacked_frame_metadata(
+    db, tmp_path, monkeypatch, caplog, raised, expected_retry_class
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    segment_path = _write_sealed_segment(
+        home,
+        1,
+        _record(unit_id="second-ack-retry-a", content="alpha"),
+        _record(unit_id="second-ack-retry-b", content="second-is-longer"),
+    )
+    decoded = spool.decode_spool_segment(segment_path)
+    first_frame, second_frame = decoded.prefix_frames
+    caplog.set_level(logging.INFO)
+    original_publish = spool._publish_ack_sidecar_strict
+    calls = {"count": 0}
+
+    def _fail_second(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise raised
+        return original_publish(
+            runtime,
+            segment_sequence=segment_sequence,
+            segment_path=segment_path,
+            ack_payload=ack_payload,
+        )
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _fail_second)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class == expected_retry_class
+    assert result.pending_frames_after == 1
+    assert result.pending_bytes_after == second_frame.frame_length
+    assert result.ack_pending is True
+    assert result.cooldown_seconds > 0
+    assert len(messages) == 1
+    assert f"retry_class={expected_retry_class}" in messages[0]
+    assert "ack_pending=True" in messages[0]
+    assert "pending_frames=1" in messages[0]
+    assert f"pending_bytes={second_frame.frame_length}" in messages[0]
+    assert str(segment_path) not in messages[0]
+    assert "second-is-longer" not in messages[0]
+
+
+def test_blocker_prefix_retry_metrics_exclude_durable_acked_prefix(db, tmp_path, monkeypatch, caplog):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    first = _record(unit_id="blocker-prefix-a", content="alpha")
+    second = _record(unit_id="blocker-prefix-b", content="beta-longer")
+    third = _record(unit_id="blocker-prefix-c", content="gamma")
+    first_frame = spool._frame_bytes_for_record(first)
+    second_frame = spool._frame_bytes_for_record(second)
+    third_frame = bytearray(spool._frame_bytes_for_record(third))
+    third_frame[-1] ^= 0x01
+    prefix_path = _write_blocker_backed_prefix_state(
+        home,
+        sequence=1,
+        source_kind="sealed",
+        prefix_bytes=first_frame + second_frame,
+        original_bytes=first_frame + second_frame + bytes(third_frame),
+        tail_status="checksum_mismatch",
+    )
+    blocker_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.BLOCKERS_DIR_NAME
+        / "00000000000000000001.blocker.json"
+    )
+    blocker_payload = json.loads(blocker_path.read_text(encoding="utf-8"))
+    blocker_payload["acked_prefix_bytes"] = len(first_frame)
+    blocker_path.write_bytes(spool._canonical_json_bytes(blocker_payload))
+    db.reconcile_bootstrap_and_append_messages_batch(
+        first.bootstrap,
+        first.batch_messages,
+        replay_patience_s=2.0,
+    )
+    caplog.set_level(logging.INFO)
+
+    def _blocked(*_args, **_kwargs):
+        raise hermes_state.CompressionSessionClosedError("replay-session")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _blocked)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "blocked_integrity")
+
+    assert result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert result.error_class == "CompressionSessionClosedError"
+    assert result.first_blocked_segment == 1
+    assert result.first_blocked_offset == len(first_frame)
+    assert result.pending_frames_after == 1
+    assert result.pending_bytes_after == len(second_frame)
+    assert result.ack_pending is True
+    assert prefix_path.exists()
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert len(messages) == 1
+    assert "pending_frames=1" in messages[0]
+    assert f"pending_bytes={len(second_frame)}" in messages[0]
+    assert "replay-session" not in messages[0]
+    assert str(prefix_path) not in messages[0]
+    assert "beta-longer" not in messages[0]
+
+
+def test_blocker_prefix_ack_publish_enospc_returns_not_durable_until_repaired(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+
+    first = _record(unit_id="blocker-prefix-ack-enospc-a", content="alpha")
+    second = _record(unit_id="blocker-prefix-ack-enospc-b", content="beta-longer")
+    later = _record(unit_id="blocker-prefix-ack-enospc-c", content="gamma")
+    corrupt_tail = bytearray(
+        spool._frame_bytes_for_record(
+            _record(unit_id="blocker-prefix-ack-enospc-tail", content="corrupt-tail")
+        )
+    )
+    corrupt_tail[-1] ^= 0x01
+    first_frame = spool._frame_bytes_for_record(first)
+    second_frame = spool._frame_bytes_for_record(second)
+    prefix_path = _write_blocker_backed_prefix_state(
+        home,
+        sequence=1,
+        source_kind="sealed",
+        prefix_bytes=first_frame + second_frame,
+        original_bytes=first_frame + second_frame + bytes(corrupt_tail),
+        tail_status="checksum_mismatch",
+    )
+    blocker_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.BLOCKERS_DIR_NAME
+        / "00000000000000000001.blocker.json"
+    )
+    ack_dir = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.ACKS_DIR_NAME
+    full_ack_path = ack_dir / f"00000000000000000001.prefix.spool.ap{len(first_frame) + len(second_frame):020d}.json"
+    evidence_spool, evidence_sidecar = _assert_metadata_only_replay_evidence(
+        home,
+        sequence=1,
+        expected_source_kind="sealed",
+        expected_tail_status="checksum_mismatch",
+        expected_valid_prefix_bytes=len(first_frame) + len(second_frame),
+        expected_original_size_bytes=len(first_frame) + len(second_frame) + len(corrupt_tail),
+    )
+    caplog.set_level(logging.INFO)
+    original_publish = spool._publish_ack_sidecar_strict
+    calls = {"count": 0}
+
+    def _fail_first(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise OSError(
+                errno.ENOSPC,
+                f"injected {prefix_path} blocker-prefix-ack-enospc-a-key-0 alpha",
+            )
+        return original_publish(
+            runtime,
+            segment_sequence=segment_sequence,
+            segment_path=segment_path,
+            ack_payload=ack_payload,
+        )
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _fail_first)
+
+    first_result = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "not_durable")
+
+    assert first_result.state is spool.ReplayRunState.NOT_DURABLE
+    assert first_result.error_class == "errno_enospc"
+    assert first_result.frames_decoded == 1
+    assert first_result.frames_committed == 1
+    assert first_result.frames_duplicated == 0
+    assert first_result.frames_acked == 0
+    assert first_result.bytes_decoded == len(first_frame)
+    assert first_result.bytes_acked == 0
+    assert first_result.pending_frames_after == 2
+    assert first_result.pending_bytes_after == len(first_frame) + len(second_frame)
+    assert first_result.ack_pending is True
+    assert prefix_path.exists()
+    assert blocker_path.exists()
+    assert evidence_spool.exists()
+    assert evidence_sidecar.exists()
+    assert prefix_path.read_bytes() == first_frame + second_frame
+    assert evidence_spool.read_bytes() == first_frame + second_frame + bytes(corrupt_tail)
+    assert sorted(path.name for path in ack_dir.glob("*.json")) == []
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert [row["content"] for row in db.get_messages("replay-session") if row["content"] == "gamma"] == []
+    assert len(messages) == 1
+    assert "error_class=errno_enospc" in messages[0]
+    assert "pending_frames=2" in messages[0]
+    assert f"pending_bytes={len(first_frame) + len(second_frame)}" in messages[0]
+    assert "injected" not in messages[0]
+    assert "OSError" not in messages[0]
+    assert str(prefix_path) not in messages[0]
+    assert str(blocker_path) not in messages[0]
+    assert str(evidence_spool) not in messages[0]
+    assert "blocker-prefix-ack-enospc-a-key-0" not in messages[0]
+    assert "alpha" not in messages[0]
+    assert "beta-longer" not in messages[0]
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", original_publish)
+
+    second_result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert second_result.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert second_result.error_class == "checksum_mismatch"
+    assert second_result.first_blocked_segment == 1
+    assert second_result.first_blocked_offset == len(first_frame) + len(second_frame)
+    assert second_result.frames_committed == 1
+    assert second_result.frames_duplicated == 1
+    assert second_result.frames_acked == 2
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "alpha",
+        "beta-longer",
+    ]
+    assert [row["content"] for row in db.get_messages("replay-session") if row["content"] == "gamma"] == []
+    assert prefix_path.exists()
+    assert blocker_path.exists()
+    assert evidence_spool.exists()
+    assert evidence_sidecar.exists()
+    assert full_ack_path.exists()
+
+    blocker_path.unlink()
+    evidence_spool.unlink()
+    evidence_sidecar.unlink()
+    later_segment = _write_sealed_segment(home, 2, later)
+
+    third_result = spool.replay_to_session_db(db, trigger="manual")
+
+    assert third_result.state is spool.ReplayRunState.REPLAYED
+    assert third_result.frames_committed == 1
+    assert third_result.frames_duplicated == 2
+    assert third_result.frames_acked == 3
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "alpha",
+        "beta-longer",
+        "gamma",
+    ]
+    assert not prefix_path.exists()
+    assert not later_segment.exists()
+
+
+def test_second_ack_publish_snapshot_failure_returns_unknown_metrics_without_leaking_context(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    segment_path = _write_sealed_segment(
+        home,
+        1,
+        _record(unit_id="snapshot-unknown-a", content="alpha"),
+        _record(unit_id="snapshot-unknown-b", content="second-is-longer"),
+    )
+    caplog.set_level(logging.INFO)
+    original_publish = spool._publish_ack_sidecar_strict
+    calls = {"count": 0}
+
+    def _fail_second(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise OSError(errno.EBUSY, f"busy {segment_path} snapshot-unknown-b-key-0 second-is-longer")
+        return original_publish(
+            runtime,
+            segment_sequence=segment_sequence,
+            segment_path=segment_path,
+            ack_payload=ack_payload,
+        )
+
+    def _snapshot_boom(_runtime):
+        raise OSError(errno.EIO, f"snapshot blew up {segment_path} second-is-longer")
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _fail_second)
+    monkeypatch.setattr(spool, "_snapshot_pending_backlog", _snapshot_boom)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class == "ack_publish_busy"
+    assert result.ack_pending is True
+    assert result.cooldown_seconds > 0
+    assert result.pending_bytes_after == -1
+    assert result.pending_frames_after == -1
+    assert len(messages) == 1
+    assert "retry_class=ack_publish_busy" in messages[0]
+    assert "ack_pending=True" in messages[0]
+    assert "pending_bytes=-1" in messages[0]
+    assert "pending_frames=-1" in messages[0]
+    assert "snapshot blew up" not in messages[0]
+    assert str(segment_path) not in messages[0]
+    assert "snapshot-unknown-b-key-0" not in messages[0]
+    assert "second-is-longer" not in messages[0]
+
+
+def test_fully_acked_cleanup_busy_returns_retry_pending_with_zero_backlog_and_duplicate_safe(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    record = _record(unit_id="ack-cleanup-busy", content="alpha")
+    frame = spool._frame_bytes_for_record(record)
+    segment_path = _write_sealed_segment(home, 1, record)
+    ack_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.ACKS_DIR_NAME
+        / f"{segment_path.name}.ap{len(frame):020d}.json"
+    )
+    caplog.set_level(logging.INFO)
+    original_delete = spool._delete_fully_acked_segment
+
+    def _busy(*_args, **_kwargs):
+        raise OSError(
+            errno.EBUSY,
+            f"delete failed {segment_path} ack-cleanup-busy-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_delete_fully_acked_segment", _busy)
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert first.state is spool.ReplayRunState.RETRY_PENDING
+    assert first.retry_class == "ack_cleanup_busy"
+    assert first.ack_pending is True
+    assert first.cooldown_seconds > 0
+    assert first.frames_committed == 1
+    assert first.frames_duplicated == 0
+    assert first.frames_acked == 1
+    assert first.pending_bytes_after == 0
+    assert first.pending_frames_after == 0
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert segment_path.exists()
+    assert ack_path.exists()
+    assert len(messages) == 1
+    assert "retry_class=ack_cleanup_busy" in messages[0]
+    assert "ack_pending=True" in messages[0]
+    assert "pending_bytes=0" in messages[0]
+    assert "pending_frames=0" in messages[0]
+    assert "delete failed" not in messages[0]
+    assert str(segment_path) not in messages[0]
+    assert "ack-cleanup-busy-key-0" not in messages[0]
+    assert "alpha" not in messages[0]
+
+    monkeypatch.setattr(spool, "_delete_fully_acked_segment", original_delete)
+    clock["now"] += first.cooldown_seconds + 0.01
+
+    second = spool.replay_to_session_db(db, trigger="manual")
+
+    assert second.state is spool.ReplayRunState.REPLAYED
+    assert second.frames_committed == 0
+    assert second.frames_duplicated == 1
+    assert second.frames_acked == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert not segment_path.exists()
+    assert not ack_path.exists()
+
+
+def test_fully_acked_cleanup_enospc_returns_not_durable_with_zero_backlog_and_duplicate_safe(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record = _record(unit_id="ack-cleanup-enospc", content="alpha")
+    frame = spool._frame_bytes_for_record(record)
+    segment_path = _write_sealed_segment(home, 1, record)
+    ack_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.ACKS_DIR_NAME
+        / f"{segment_path.name}.ap{len(frame):020d}.json"
+    )
+    caplog.set_level(logging.INFO)
+    original_delete = spool._delete_fully_acked_segment
+
+    def _enospc(*_args, **_kwargs):
+        raise OSError(
+            errno.ENOSPC,
+            f"delete failed {segment_path} ack-cleanup-enospc-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_delete_fully_acked_segment", _enospc)
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "not_durable")
+
+    assert first.state is spool.ReplayRunState.NOT_DURABLE
+    assert first.error_class == "errno_enospc"
+    assert first.ack_pending is True
+    assert first.frames_committed == 1
+    assert first.frames_duplicated == 0
+    assert first.frames_acked == 1
+    assert first.pending_bytes_after == 0
+    assert first.pending_frames_after == 0
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert segment_path.exists()
+    assert ack_path.exists()
+    assert len(messages) == 1
+    assert "error_class=errno_enospc" in messages[0]
+    assert "pending_bytes=0" in messages[0]
+    assert "pending_frames=0" in messages[0]
+    assert "delete failed" not in messages[0]
+    assert str(segment_path) not in messages[0]
+    assert "ack-cleanup-enospc-key-0" not in messages[0]
+    assert "alpha" not in messages[0]
+
+    monkeypatch.setattr(spool, "_delete_fully_acked_segment", original_delete)
+
+    second = spool.replay_to_session_db(db, trigger="manual")
+
+    assert second.state is spool.ReplayRunState.REPLAYED
+    assert second.frames_committed == 0
+    assert second.frames_duplicated == 1
+    assert second.frames_acked == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert not segment_path.exists()
+    assert not ack_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("raised", "expected_state", "expected_retry_class", "expected_error_class"),
+    [
+        (
+            OSError(errno.EBUSY, "busy"),
+            spool.ReplayRunState.RETRY_PENDING,
+            "ack_cleanup_busy",
+            None,
+        ),
+        (
+            OSError(errno.ENOSPC, "disk full"),
+            spool.ReplayRunState.NOT_DURABLE,
+            None,
+            "errno_enospc",
+        ),
+    ],
+)
+def test_fully_acked_cleanup_snapshot_failure_returns_unknown_metrics_without_masking_outcome(
+    db,
+    tmp_path,
+    monkeypatch,
+    caplog,
+    raised,
+    expected_state,
+    expected_retry_class,
+    expected_error_class,
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record = _record(unit_id="ack-cleanup-snapshot", content="alpha")
+    segment_path = _write_sealed_segment(home, 1, record)
+    caplog.set_level(logging.INFO)
+
+    def _fail_delete(*_args, **_kwargs):
+        raise OSError(
+            raised.errno,
+            f"cleanup boom {segment_path} ack-cleanup-snapshot-key-0 alpha",
+        )
+
+    def _snapshot_boom(_runtime):
+        raise OSError(
+            errno.EIO,
+            f"snapshot blew up {segment_path} ack-cleanup-snapshot-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_delete_fully_acked_segment", _fail_delete)
+    monkeypatch.setattr(spool, "_snapshot_pending_backlog", _snapshot_boom)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+    state_messages = _replay_messages_for_state(caplog, expected_state.value)
+    joined = "\n".join(state_messages)
+
+    assert result.state is expected_state
+    assert result.retry_class == expected_retry_class
+    assert result.error_class == expected_error_class
+    assert result.ack_pending is True
+    assert result.pending_bytes_after == -1
+    assert result.pending_frames_after == -1
+    if expected_state is spool.ReplayRunState.RETRY_PENDING:
+        assert result.cooldown_seconds > 0
+    assert len(state_messages) == 1
+    assert "snapshot blew up" not in joined
+    assert "cleanup boom" not in joined
+    assert str(segment_path) not in joined
+    assert "ack-cleanup-snapshot-key-0" not in joined
+    assert "alpha" not in joined
+
+
+def test_reconcile_active_enospc_returns_not_durable_with_truthful_pending_backlog(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record = _record(unit_id="active-not-durable", content="alpha")
+    append = spool.append_records((record,))
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    surviving_bytes = active_path.read_bytes()
+    caplog.set_level(logging.INFO)
+
+    def _enospc(_runtime):
+        raise OSError(
+            errno.ENOSPC,
+            f"disk full {active_path} active-not-durable-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", _enospc)
+
+    result = spool.replay_to_session_db(object(), trigger="startup")
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+
+    assert Path(append.unit_results[0].receipt.path) == active_path
+    assert result.state is spool.ReplayRunState.NOT_DURABLE
+    assert result.error_class == "errno_enospc"
+    assert active_path.read_bytes() == surviving_bytes
+    assert result.pending_bytes_after == len(surviving_bytes)
+    assert spool._pending_frames_for_log(result) == 1
+    assert f"pending_bytes={len(surviving_bytes)}" in message
+    assert "pending_frames=1" in message
+    assert "disk full" not in message
+    assert str(active_path) not in message
+    assert "active-not-durable-key-0" not in message
+    assert "alpha" not in message
+
+
+def test_post_rename_active_recreate_enospc_returns_not_durable_with_truthful_sealed_backlog(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    record = _record(
+        unit_id="post-rename-active-create-failure",
+        content="post-rename-active-create-failure",
+    )
+    append = spool.append_records((record,))
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    caplog.set_level(logging.INFO)
+    original_open_file_at = spool._open_file_at
+
+    def _fail_recreate(parent_fd, name, **kwargs):
+        if (
+            name == spool.ACTIVE_SPOOL_NAME
+            and kwargs.get("create")
+            and not active_path.exists()
+        ):
+            raise OSError(
+                errno.ENOSPC,
+                f"disk full {active_path} post-rename-active-create-failure-key-0 post-rename-active-create-failure",
+            )
+        return original_open_file_at(parent_fd, name, **kwargs)
+
+    monkeypatch.setattr(spool, "_open_file_at", _fail_recreate)
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    first_log = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+    sealed = sorted((home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME).glob("*.spool"))
+    surviving_bytes = sum(path.stat().st_size for path in sealed)
+
+    assert Path(append.unit_results[0].receipt.path) == active_path
+    assert first.state is spool.ReplayRunState.NOT_DURABLE
+    assert first.error_class == "errno_enospc"
+    assert not active_path.exists()
+    assert len(sealed) == 1
+    assert surviving_bytes > 0
+    assert first.pending_bytes_after == surviving_bytes
+    assert spool._pending_frames_for_log(first) == 1
+    assert db.get_messages("replay-session") == []
+    assert f"pending_bytes={surviving_bytes}" in first_log
+    assert "pending_frames=1" in first_log
+    assert "disk full" not in first_log
+    assert str(active_path) not in first_log
+    assert "post-rename-active-create-failure-key-0" not in first_log
+    assert "post-rename-active-create-failure" not in first_log
+
+    monkeypatch.setattr(spool, "_open_file_at", original_open_file_at)
+    second = spool.replay_to_session_db(db, trigger="manual")
+    third = spool.replay_to_session_db(db, trigger="manual")
+
+    assert second.state is spool.ReplayRunState.REPLAYED
+    assert second.frames_committed == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == [
+        "post-rename-active-create-failure"
+    ]
+    assert third.state is spool.ReplayRunState.EMPTY
+
+
+def test_early_setup_not_durable_snapshot_counts_preexisting_sealed_partial_ack_backlog(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    first_record = _record(unit_id="sealed-partial-a", content="alpha")
+    second_record = _record(unit_id="sealed-partial-b", content="beta")
+    segment_path = _write_sealed_segment(home, 1, first_record, second_record)
+    first_frame = spool._frame_bytes_for_record(first_record)
+    second_frame = spool._frame_bytes_for_record(second_record)
+    _write_ack_sidecar(
+        home,
+        segment_path.name,
+        len(first_frame),
+        segment_path.stat().st_size,
+        sequence=1,
+    )
+    (home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME).write_bytes(b"")
+    caplog.set_level(logging.INFO)
+
+    def _enospc(_runtime):
+        raise OSError(
+            errno.ENOSPC,
+            f"disk full {segment_path} sealed-partial-a-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", _enospc)
+
+    result = spool.replay_to_session_db(object(), trigger="startup")
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+
+    assert result.state is spool.ReplayRunState.NOT_DURABLE
+    assert result.error_class == "errno_enospc"
+    assert result.pending_bytes_after == len(second_frame)
+    assert spool._pending_frames_for_log(result) == 1
+    assert result.ack_pending is True
+    assert f"pending_bytes={len(second_frame)}" in message
+    assert "pending_frames=1" in message
+    assert "disk full" not in message
+    assert str(segment_path) not in message
+    assert "sealed-partial-a-key-0" not in message
+    assert "alpha" not in message
+
+
+def test_not_durable_pending_snapshot_unknown_preserves_original_error_and_logs_known_unknown_transitions(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    monkeypatch.setattr(spool.time, "monotonic", lambda: 100.0)
+    record = _record(unit_id="snapshot-unknown", content="alpha")
+    append = spool.append_records((record,))
+    active_path = Path(append.unit_results[0].receipt.path)
+    caplog.set_level(logging.INFO)
+
+    def _enospc(_runtime):
+        raise OSError(
+            errno.ENOSPC,
+            f"disk full {active_path} snapshot-unknown-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", _enospc)
+    original_snapshot = getattr(spool, "_snapshot_pending_backlog", None)
+
+    first = spool.replay_to_session_db(object(), trigger="startup")
+
+    def _snapshot_boom(_runtime):
+        raise OSError(errno.EIO, f"secondary snapshot race {active_path} alpha")
+
+    monkeypatch.setattr(spool, "_snapshot_pending_backlog", _snapshot_boom)
+    second = spool.replay_to_session_db(object(), trigger="startup")
+    monkeypatch.setattr(spool, "_snapshot_pending_backlog", original_snapshot)
+    third = spool.replay_to_session_db(object(), trigger="startup")
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    ]
+    joined = "\n".join(messages)
+
+    assert first.state is spool.ReplayRunState.NOT_DURABLE
+    assert first.error_class == "errno_enospc"
+    assert first.pending_bytes_after == active_path.stat().st_size
+    assert first.pending_frames_after == 1
+
+    assert second.state is spool.ReplayRunState.NOT_DURABLE
+    assert second.error_class == "errno_enospc"
+    assert second.pending_bytes_after == -1
+    assert second.pending_frames_after == -1
+
+    assert third.state is spool.ReplayRunState.NOT_DURABLE
+    assert third.error_class == "errno_enospc"
+    assert third.pending_bytes_after == active_path.stat().st_size
+    assert third.pending_frames_after == 1
+
+    assert len(messages) == 3
+    assert f"pending_bytes={active_path.stat().st_size}" in messages[0]
+    assert "pending_frames=1" in messages[0]
+    assert "pending_bytes=-1" in messages[1]
+    assert "pending_frames=-1" in messages[1]
+    assert f"pending_bytes={active_path.stat().st_size}" in messages[2]
+    assert "pending_frames=1" in messages[2]
+    assert "secondary snapshot race" not in joined
+    assert str(active_path) not in joined
+    assert "snapshot-unknown-key-0" not in joined
+    assert "alpha" not in joined
+
+
+def test_not_durable_active_replacement_during_snapshot_returns_unknown_backlog(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    record = _record(unit_id="snapshot-race", content="alpha")
+    append = spool.append_records((record,))
+    active_path = Path(append.unit_results[0].receipt.path)
+    replacement_frame = spool._frame_bytes_for_record(
+        _record(
+            unit_id="snapshot-race-replacement",
+            content="replacement-is-longer",
+        )
+    )
+    parked_path = active_path.with_name("held-active.spool")
+    caplog.set_level(logging.INFO)
+
+    def _enospc(_runtime):
+        raise OSError(
+            errno.ENOSPC,
+            f"disk full {active_path} snapshot-race-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", _enospc)
+    original_scan = spool._scan_fd
+    swapped = {"done": False}
+
+    def _swap(fd: int):
+        if not swapped["done"]:
+            swapped["done"] = True
+            os.replace(active_path, parked_path)
+            active_path.write_bytes(replacement_frame)
+        return original_scan(fd)
+
+    monkeypatch.setattr(spool, "_scan_fd", _swap)
+
+    result = spool.replay_to_session_db(object(), trigger="startup")
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+
+    assert result.state is spool.ReplayRunState.NOT_DURABLE
+    assert result.error_class == "errno_enospc"
+    assert result.pending_bytes_after == -1
+    assert result.pending_frames_after == -1
+    assert active_path.read_bytes() == replacement_frame
+    assert "error_class=errno_enospc" in message
+    assert "pending_bytes=-1" in message
+    assert "pending_frames=-1" in message
+    assert "disk full" not in message
+    assert str(active_path) not in message
+    assert "snapshot-race-key-0" not in message
+    assert "alpha" not in message
+
+
+def test_prepare_busy_returns_retry_pending_with_truthful_active_backlog_and_duplicate_safe(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    record = _record(unit_id="prepare-busy", content="alpha")
+    append = spool.append_records((record,))
+    active_path = Path(append.unit_results[0].receipt.path)
+    active_bytes = active_path.read_bytes()
+    caplog.set_level(logging.INFO)
+    original_reconcile = spool._reconcile_active_spool_for_replay
+    calls = {"count": 0}
+
+    def _busy(_runtime):
+        calls["count"] += 1
+        raise OSError(errno.EBUSY, f"busy {active_path} prepare-busy-key-0 alpha")
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", _busy)
+
+    first = spool.replay_to_session_db(db, trigger="startup")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert first.state is spool.ReplayRunState.RETRY_PENDING
+    assert first.retry_class == "spool_prepare_busy"
+    assert first.ack_pending is False
+    assert first.cooldown_seconds > 0
+    assert first.pending_bytes_after == len(active_bytes)
+    assert first.pending_frames_after == 1
+    assert first.first_blocked_segment is None
+    assert first.first_blocked_offset is None
+    assert active_path.read_bytes() == active_bytes
+    assert calls["count"] == 1
+    assert len(messages) == 1
+    assert "retry_class=spool_prepare_busy" in messages[0]
+    assert "ack_pending=False" in messages[0]
+    assert f"pending_bytes={len(active_bytes)}" in messages[0]
+    assert "pending_frames=1" in messages[0]
+    assert f"busy {active_path}" not in messages[0]
+    assert str(active_path) not in messages[0]
+    assert "prepare-busy-key-0" not in messages[0]
+    assert "alpha" not in messages[0]
+
+    second = spool.replay_to_session_db(db, trigger="startup")
+
+    assert second.state is spool.ReplayRunState.RETRY_PENDING
+    assert second.retry_class == "spool_prepare_busy"
+    assert second.ack_pending is False
+    assert second.cooldown_seconds > 0
+    assert calls["count"] == 1
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", original_reconcile)
+    clock["now"] += first.cooldown_seconds + 0.01
+
+    third = spool.replay_to_session_db(db, trigger="startup")
+    fourth = spool.replay_to_session_db(db, trigger="startup")
+
+    assert third.state is spool.ReplayRunState.REPLAYED
+    assert third.frames_committed == 1
+    assert third.frames_duplicated == 0
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert active_path.exists()
+    assert active_path.read_bytes() == b""
+    assert fourth.state is spool.ReplayRunState.EMPTY
+
+
+def test_prepare_busy_snapshot_failure_returns_unknown_metrics_without_masking_retry_class(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    monkeypatch.setattr(spool.time, "monotonic", lambda: 100.0)
+    record = _record(unit_id="prepare-busy-unknown", content="alpha")
+    append = spool.append_records((record,))
+    active_path = Path(append.unit_results[0].receipt.path)
+    active_bytes = active_path.read_bytes()
+    caplog.set_level(logging.INFO)
+
+    def _busy(_runtime):
+        raise OSError(
+            errno.EBUSY,
+            f"busy {active_path} prepare-busy-unknown-key-0 alpha",
+        )
+
+    def _snapshot_boom(_runtime):
+        raise OSError(
+            errno.EIO,
+            f"secondary snapshot race {active_path} prepare-busy-unknown-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_reconcile_active_spool_for_replay", _busy)
+    monkeypatch.setattr(spool, "_snapshot_pending_backlog", _snapshot_boom)
+
+    result = spool.replay_to_session_db(object(), trigger="startup")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+    joined = "\n".join(messages)
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class == "spool_prepare_busy"
+    assert result.ack_pending is False
+    assert result.cooldown_seconds > 0
+    assert result.pending_bytes_after == -1
+    assert result.pending_frames_after == -1
+    assert result.first_blocked_segment is None
+    assert result.first_blocked_offset is None
+    assert active_path.read_bytes() == active_bytes
+    assert len(messages) == 1
+    assert "retry_class=spool_prepare_busy" in messages[0]
+    assert "ack_pending=False" in messages[0]
+    assert "pending_bytes=-1" in messages[0]
+    assert "pending_frames=-1" in messages[0]
+    assert f"busy {active_path}" not in joined
+    assert "secondary snapshot race" not in joined
+    assert str(active_path) not in joined
+    assert "prepare-busy-unknown-key-0" not in joined
+    assert "alpha" not in joined
+
+
+def test_corrupt_active_evidence_enospc_returns_not_durable_and_leaves_active_bytes_truthful(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool.append_records((_record(unit_id="corrupt-active-enospc"),))
+
+    active_path = home / spool.SPOOL_ROOT_NAME / spool.ACTIVE_SPOOL_NAME
+    corrupted = bytearray(active_path.read_bytes())
+    corrupted[0] = 0
+    active_path.write_bytes(bytes(corrupted))
+    caplog.set_level(logging.INFO)
+
+    def _enospc(*_args, **_kwargs):
+        raise OSError(
+            errno.ENOSPC,
+            f"disk full {active_path} corrupt-active-enospc-key-0 hello replay",
+        )
+
+    monkeypatch.setattr(spool, "_write_sidecar_json", _enospc)
+
+    result = spool.replay_to_session_db(db, trigger="startup")
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+
+    assert result.state is spool.ReplayRunState.NOT_DURABLE
+    assert result.error_class == "errno_enospc"
+    assert active_path.read_bytes() == bytes(corrupted)
+    assert result.pending_bytes_after == len(corrupted)
+    assert spool._pending_frames_for_log(result) == 0
+    blockers = sorted((home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME).glob("*.blocker.json"))
+    assert blockers == []
+    assert f"pending_bytes={len(corrupted)}" in message
+    assert "pending_frames=0" in message
+    assert "disk full" not in message
+    assert str(active_path) not in message
+    assert "corrupt-active-enospc-key-0" not in message
+    assert "hello replay" not in message
+
+
+def test_corrupt_sealed_publish_enospc_returns_not_durable_with_truthful_backlog(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    first_segment = _write_sealed_segment(home, 1, _record(unit_id="corrupt-sealed-a", content="alpha"))
+    corrupted = bytearray(first_segment.read_bytes())
+    corrupted[0] = 0
+    first_segment.write_bytes(bytes(corrupted))
+    later_segment = _write_sealed_segment(
+        home,
+        2,
+        _record(unit_id="corrupt-sealed-b", content="beta"),
+    )
+    caplog.set_level(logging.INFO)
+
+    def _enospc(*_args, **_kwargs):
+        raise OSError(
+            errno.ENOSPC,
+            f"disk full {first_segment} corrupt-sealed-a-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_publish_corrupt_sealed_segment_state", _enospc)
+
+    result = spool.replay_to_session_db(object(), trigger="manual")
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__ and "state=not_durable" in record.getMessage()
+    )
+    expected_bytes = first_segment.stat().st_size + later_segment.stat().st_size
+
+    assert result.state is spool.ReplayRunState.NOT_DURABLE
+    assert result.error_class == "errno_enospc"
+    assert first_segment.read_bytes() == bytes(corrupted)
+    assert later_segment.exists()
+    assert result.pending_bytes_after == expected_bytes
+    assert spool._pending_frames_for_log(result) == 1
+    assert f"pending_bytes={expected_bytes}" in message
+    assert "pending_frames=1" in message
+    assert "disk full" not in message
+    assert str(first_segment) not in message
+    assert "corrupt-sealed-a-key-0" not in message
+    assert "alpha" not in message
+
+
+def test_corrupt_sealed_publish_busy_returns_retry_pending_with_truthful_prefix_backlog_and_duplicate_safe(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    clean_frame = spool._frame_bytes_for_record(
+        _record(unit_id="corrupt-publish-busy", content="alpha")
+    )
+    corrupt_frame = bytearray(
+        spool._frame_bytes_for_record(_record(unit_id="corrupt-publish-busy-tail", content="beta"))
+    )
+    corrupt_frame[-1] ^= 0x01
+    segment_path = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / "00000000000000000001.spool"
+    segment_path.parent.mkdir(parents=True, exist_ok=True)
+    segment_bytes = clean_frame + bytes(corrupt_frame)
+    segment_path.write_bytes(segment_bytes)
+    caplog.set_level(logging.INFO)
+    original_publish = spool._publish_corrupt_sealed_segment_state
+
+    def _busy(*_args, **_kwargs):
+        raise OSError(
+            errno.EBUSY,
+            f"busy {segment_path} corrupt-publish-busy-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_publish_corrupt_sealed_segment_state", _busy)
+
+    first = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert first.state is spool.ReplayRunState.RETRY_PENDING
+    assert first.retry_class == "corrupt_publish_busy"
+    assert first.ack_pending is False
+    assert first.cooldown_seconds > 0
+    assert first.frames_committed == 1
+    assert first.frames_duplicated == 0
+    assert first.frames_acked == 0
+    assert first.pending_bytes_after == len(clean_frame)
+    assert first.pending_frames_after == 1
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert segment_path.read_bytes() == segment_bytes
+    assert len(messages) == 1
+    assert "retry_class=corrupt_publish_busy" in messages[0]
+    assert "ack_pending=False" in messages[0]
+    assert f"pending_bytes={len(clean_frame)}" in messages[0]
+    assert "pending_frames=1" in messages[0]
+    assert f"busy {segment_path}" not in messages[0]
+    assert str(segment_path) not in messages[0]
+    assert "corrupt-publish-busy-key-0" not in messages[0]
+    assert "alpha" not in messages[0]
+
+    monkeypatch.setattr(spool, "_publish_corrupt_sealed_segment_state", original_publish)
+    clock["now"] += first.cooldown_seconds + 0.01
+
+    second = spool.replay_to_session_db(db, trigger="manual")
+    blocker_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / spool.BLOCKERS_DIR_NAME
+        / "00000000000000000001.blocker.json"
+    )
+    prefix_path = (
+        home
+        / spool.SPOOL_ROOT_NAME
+        / spool.SEALED_DIR_NAME
+        / "00000000000000000001.prefix.spool"
+    )
+    evidence_spool, evidence_sidecar = _assert_metadata_only_replay_evidence(
+        home,
+        sequence=1,
+        expected_source_kind="sealed",
+        expected_tail_status="checksum_mismatch",
+        expected_valid_prefix_bytes=len(clean_frame),
+        expected_original_size_bytes=len(segment_bytes),
+    )
+
+    assert second.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert second.error_class == "checksum_mismatch"
+    assert second.first_blocked_segment == 1
+    assert second.first_blocked_offset == len(clean_frame)
+    assert second.frames_committed == 0
+    assert second.frames_duplicated == 1
+    assert second.frames_acked == 0
+    assert [row["content"] for row in db.get_messages("replay-session")] == ["alpha"]
+    assert _fts_message_count(db) == 1
+    assert not segment_path.exists()
+    assert prefix_path.exists()
+    assert blocker_path.exists()
+    assert evidence_spool.read_bytes() == segment_bytes
+    assert evidence_sidecar.exists()
+
+
+def test_corrupt_sealed_publish_busy_snapshot_failure_returns_unknown_metrics_without_masking_retry_class(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    spool._REPLAY_COOLDOWNS.clear()
+    spool._REPLAY_LOG_STATE.clear()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    clean_frame = spool._frame_bytes_for_record(
+        _record(unit_id="corrupt-publish-unknown-a", content="alpha")
+    )
+    corrupt_frame = bytearray(
+        spool._frame_bytes_for_record(_record(unit_id="corrupt-publish-unknown-b", content="beta"))
+    )
+    corrupt_frame[-1] ^= 0x01
+    first_segment = home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME / "00000000000000000001.spool"
+    first_segment.parent.mkdir(parents=True, exist_ok=True)
+    first_segment.write_bytes(clean_frame + bytes(corrupt_frame))
+    _write_sealed_segment(home, 2, _record(unit_id="corrupt-publish-unknown-c", content="gamma"))
+    caplog.set_level(logging.INFO)
+
+    def _busy(*_args, **_kwargs):
+        raise OSError(
+            errno.EBUSY,
+            f"busy {first_segment} corrupt-publish-unknown-a-key-0 alpha",
+        )
+
+    def _snapshot_boom(_fd, **_kwargs):
+        raise OSError(
+            errno.EIO,
+            f"secondary snapshot race {first_segment} corrupt-publish-unknown-a-key-0 alpha",
+        )
+
+    monkeypatch.setattr(spool, "_publish_corrupt_sealed_segment_state", _busy)
+    monkeypatch.setattr(spool, "_scan_fd", _snapshot_boom)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+    messages = _replay_messages_for_state(caplog, "retry_pending")
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class == "corrupt_publish_busy"
+    assert result.ack_pending is False
+    assert result.cooldown_seconds > 0
+    assert result.pending_bytes_after == -1
+    assert result.pending_frames_after == -1
+    assert len(messages) == 1
+    assert "retry_class=corrupt_publish_busy" in messages[0]
+    assert "pending_bytes=-1" in messages[0]
+    assert "pending_frames=-1" in messages[0]
+    assert "secondary snapshot race" not in messages[0]
+    assert str(first_segment) not in messages[0]
+    assert "corrupt-publish-unknown-a-key-0" not in messages[0]
+    assert "alpha" not in messages[0]
+
+
+def test_replay_degraded_logs_are_deduped_and_recovery_logs_once(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_sealed_segment(home, 1, _record(unit_id="unit-log", content="alpha"))
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    caplog.set_level(logging.INFO)
+
+    def _busy(*_args, **_kwargs):
+        raise hermes_state.CompressionSessionBusyError("busy")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _busy)
+    first = spool.replay_to_session_db(db, trigger="manual")
+    second = spool.replay_to_session_db(db, trigger="manual")
+
+    clock["now"] += second.cooldown_seconds + 0.01
+
+    def _closed(*_args, **_kwargs):
+        raise hermes_state.CompressionSessionClosedError("replay-session")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _closed)
+    third = spool.replay_to_session_db(db, trigger="manual")
+
+    monkeypatch.setattr(
+        db,
+        "reconcile_bootstrap_and_append_messages_batch",
+        lambda *_args, **_kwargs: hermes_state.AppendMessagesBatchResult(inserted_count=1, duplicate_count=0),
+    )
+    fourth = spool.replay_to_session_db(db, trigger="manual")
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == spool.__name__
+    ]
+    joined = "\n".join(messages)
+
+    assert first.state is spool.ReplayRunState.RETRY_PENDING
+    assert first.retry_class == "compression_busy"
+    assert second.state is spool.ReplayRunState.RETRY_PENDING
+    assert third.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert third.error_class == "CompressionSessionClosedError"
+    assert fourth.state is spool.ReplayRunState.REPLAYED
+    assert len(messages) == 3
+    assert "state=retry_pending" in messages[0]
+    assert "retry_class=compression_busy" in messages[0]
+    assert "state=blocked_integrity" in messages[1]
+    assert "error_class=CompressionSessionClosedError" in messages[1]
+    assert "state=replayed" in messages[2]
+    assert "alpha" not in joined
+    assert "replay-session" not in joined
+
+
+def test_replay_silent_blocked_branch_logs_and_empty_recovery_clears_state(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    caplog.set_level(logging.INFO)
+
+    saved = {
+        name: getattr(spool, name)
+        for name in (
+            "_reconcile_active_spool_for_replay",
+            "_seal_clean_active_spool_for_replay",
+            "_first_blocker_sequence",
+            "_load_blocker_backed_prefix_replay_state",
+            "_ordered_segment_entries",
+        )
+    }
+    spool._reconcile_active_spool_for_replay = lambda _runtime: None
+    spool._seal_clean_active_spool_for_replay = lambda _runtime: None
+    spool._first_blocker_sequence = lambda **_kwargs: 1
+
+    def _blocked(**_kwargs):
+        raise spool.SpoolBlockedReplayError("compression_closed", frame_offset=0)
+
+    spool._load_blocker_backed_prefix_replay_state = _blocked
+    spool._ordered_segment_entries = lambda **_kwargs: []
+
+    try:
+        first = spool.replay_to_session_db(object(), trigger="manual")
+        spool._first_blocker_sequence = lambda **_kwargs: None
+        second = spool.replay_to_session_db(object(), trigger="manual")
+    finally:
+        for name, value in saved.items():
+            setattr(spool, name, value)
+
+    messages = [record.getMessage() for record in caplog.records if record.name == spool.__name__]
+    joined = "\n".join(messages)
+
+    assert first.state is spool.ReplayRunState.BLOCKED_INTEGRITY
+    assert first.error_class == "compression_closed"
+    assert second.state is spool.ReplayRunState.EMPTY
+    assert len(messages) == 2
+    assert "state=blocked_integrity" in messages[0]
+    assert "error_class=compression_closed" in messages[0]
+    assert "state=empty" in messages[1]
+    assert "replay-session" not in joined
+    assert "unit-" not in joined
+
+
+def test_replay_silent_retry_branch_logs_truthful_pending_metadata(
+    db, tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    first = _record(unit_id="blocked-prefix-a", content="alpha")
+    second = _record(unit_id="blocked-prefix-b", content="beta")
+    clean_frame = spool._frame_bytes_for_record(first)
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(second))
+    corrupt_frame[-1] ^= 0x01
+    _write_blocker_backed_prefix_state(
+        home,
+        sequence=1,
+        source_kind="sealed",
+        prefix_bytes=clean_frame,
+        original_bytes=clean_frame + bytes(corrupt_frame),
+        tail_status="checksum_mismatch",
+    )
+    clock = {"now": 100.0}
+    monkeypatch.setattr(spool.time, "monotonic", lambda: clock["now"])
+    caplog.set_level(logging.INFO)
+
+    def _busy(*_args, **_kwargs):
+        raise hermes_state.CompressionSessionBusyError("busy")
+
+    monkeypatch.setattr(db, "reconcile_bootstrap_and_append_messages_batch", _busy)
+
+    result = spool.replay_to_session_db(db, trigger="manual")
+
+    messages = [record.getMessage() for record in caplog.records if record.name == spool.__name__]
+    joined = "\n".join(messages)
+
+    assert result.state is spool.ReplayRunState.RETRY_PENDING
+    assert result.retry_class == "compression_busy"
+    assert len(messages) == 1
+    assert "state=retry_pending" in messages[0]
+    assert "retry_class=compression_busy" in messages[0]
+    assert "pending_frames=1" in messages[0]
+    assert f"pending_bytes={len(clean_frame)}" in messages[0]
+    assert "alpha" not in joined
+    assert "replay-session" not in joined

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -625,6 +625,550 @@ class TestTimestampPreservation:
 
 
 # =========================================================================
+# append_messages_batch
+# =========================================================================
+
+
+class TestAppendMessagesBatch:
+    @staticmethod
+    def _batch_message(
+        *,
+        unit: str,
+        key: str,
+        ordinal: int,
+        role: str,
+        content=None,
+        timestamp: float,
+        tool_calls=None,
+        tool_name=None,
+        tool_call_id=None,
+        finish_reason=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+        codex_reasoning_items=None,
+        codex_message_items=None,
+        api_content=None,
+        display_kind=None,
+        display_metadata=None,
+    ):
+        batch_cls = hermes_state.SessionDBBatchMessage
+        return batch_cls(
+            persistence_unit_id=unit,
+            persistence_message_key=key,
+            persistence_ordinal=ordinal,
+            role=role,
+            content=content,
+            timestamp=timestamp,
+            tool_name=tool_name,
+            tool_calls=tool_calls,
+            tool_call_id=tool_call_id,
+            finish_reason=finish_reason,
+            reasoning=reasoning,
+            reasoning_content=reasoning_content,
+            reasoning_details=reasoning_details,
+            codex_reasoning_items=codex_reasoning_items,
+            codex_message_items=codex_message_items,
+            api_content=api_content,
+            display_kind=display_kind,
+            display_metadata=display_metadata,
+        )
+
+    @staticmethod
+    def _index_sql(db, name):
+        row = db._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (name,),
+        ).fetchone()
+        return row[0] if row else None
+
+    @staticmethod
+    def _stored_identity_rows(db, session_id="s1"):
+        return db._conn.execute(
+            "SELECT content, persistence_unit_id, persistence_message_key, persistence_ordinal "
+            "FROM messages WHERE session_id = ? ORDER BY id",
+            (session_id,),
+        ).fetchall()
+
+    def test_persistence_unit_columns_and_indexes_exist_on_fresh_db(self, db):
+        columns = {
+            row[1]
+            for row in db._conn.execute('PRAGMA table_info("messages")').fetchall()
+        }
+
+        assert "persistence_unit_id" in columns
+        assert "persistence_message_key" in columns
+        assert "persistence_ordinal" in columns
+
+        key_sql = self._index_sql(db, "ux_messages_session_message_key")
+        ordinal_sql = self._index_sql(db, "ux_messages_session_unit_ordinal")
+        assert key_sql is not None and "persistence_message_key IS NOT NULL" in key_sql
+        assert ordinal_sql is not None and "persistence_unit_id IS NOT NULL" in ordinal_sql
+
+    def test_persistence_unit_columns_and_indexes_reconcile_on_legacy_db(self, tmp_path):
+        db_path = tmp_path / "legacy_state.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE schema_version (version INTEGER NOT NULL);
+                INSERT INTO schema_version(version) VALUES (1);
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    parent_session_id TEXT,
+                    started_at REAL NOT NULL,
+                    message_count INTEGER DEFAULT 0,
+                    tool_call_count INTEGER DEFAULT 0
+                );
+                CREATE TABLE messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL REFERENCES sessions(id),
+                    role TEXT NOT NULL,
+                    content TEXT,
+                    tool_call_id TEXT,
+                    tool_calls TEXT,
+                    tool_name TEXT,
+                    timestamp REAL NOT NULL,
+                    finish_reason TEXT,
+                    reasoning TEXT,
+                    reasoning_content TEXT,
+                    reasoning_details TEXT,
+                    codex_reasoning_items TEXT,
+                    codex_message_items TEXT,
+                    api_content TEXT,
+                    display_kind TEXT,
+                    display_metadata TEXT
+                );
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        legacy = SessionDB(db_path=db_path)
+        try:
+            columns = {
+                row[1]
+                for row in legacy._conn.execute('PRAGMA table_info("messages")').fetchall()
+            }
+            assert "persistence_unit_id" in columns
+            assert "persistence_message_key" in columns
+            assert "persistence_ordinal" in columns
+            assert self._index_sql(legacy, "ux_messages_session_message_key") is not None
+            assert self._index_sql(legacy, "ux_messages_session_unit_ordinal") is not None
+        finally:
+            legacy.close()
+
+    def test_append_messages_batch_insert_and_exact_replay_are_idempotent(self, db):
+        db.create_session(session_id="s1", source="cli")
+        messages = [
+            self._batch_message(
+                unit="unit-a",
+                key="msg-a",
+                ordinal=0,
+                role="user",
+                content="alpha user",
+                timestamp=101.0,
+                display_metadata={"source": "test"},
+            ),
+            self._batch_message(
+                unit="unit-a",
+                key="msg-b",
+                ordinal=1,
+                role="assistant",
+                content="beta assistant",
+                timestamp=102.0,
+                tool_calls=[{"name": "terminal", "arguments": "{}"}],
+                reasoning="thinking",
+                reasoning_details={"depth": 1},
+                api_content="beta assistant",
+            ),
+        ]
+
+        result = db.append_messages_batch("s1", messages)
+        assert result.inserted_count == 2
+        assert result.duplicate_count == 0
+
+        session = db.get_session("s1")
+        assert session["message_count"] == 2
+        assert session["tool_call_count"] == 1
+        rows = db.get_messages("s1")
+        assert [row["content"] for row in rows] == ["alpha user", "beta assistant"]
+        assert [tuple(row) for row in self._stored_identity_rows(db)] == [
+            ("alpha user", "unit-a", "msg-a", 0),
+            ("beta assistant", "unit-a", "msg-b", 1),
+        ]
+        assert len(db.search_messages("alpha")) == 1
+
+        replay = db.append_messages_batch("s1", messages)
+        assert replay.inserted_count == 0
+        assert replay.duplicate_count == 2
+        session_after = db.get_session("s1")
+        assert session_after["message_count"] == 2
+        assert session_after["tool_call_count"] == 1
+        assert len(db.get_messages("s1")) == 2
+        assert len(db.search_messages("alpha")) == 1
+
+    def test_append_messages_batch_rejects_missing_session_without_mutation(self, db):
+        missing_session_id = "missing-session"
+        messages = [
+            self._batch_message(
+                unit="unit-a",
+                key="msg-a",
+                ordinal=0,
+                role="user",
+                content="must not persist",
+                timestamp=151.0,
+            )
+        ]
+
+        assert db.get_session(missing_session_id) is None
+        assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
+        assert db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+
+        with pytest.raises(
+            hermes_state.AppendMessagesBatchConflictError,
+            match="existing session",
+        ):
+            db.append_messages_batch(missing_session_id, messages)
+
+        assert db.get_session(missing_session_id) is None
+        assert (
+            db._conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE id = ?",
+                (missing_session_id,),
+            ).fetchone()[0]
+            == 0
+        )
+        assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+        assert (
+            db._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?",
+                (missing_session_id,),
+            ).fetchone()[0]
+            == 0
+        )
+        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
+        assert db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+            db.append_message(missing_session_id, role="user", content="legacy orphan")
+
+        assert db.get_session(missing_session_id) is None
+        assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
+        assert db._conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+
+    def test_append_messages_batch_rejects_duplicate_persistence_message_key_in_input(self, db):
+        db.create_session(session_id="s1", source="cli")
+        conflict_error = hermes_state.AppendMessagesBatchConflictError
+        messages = [
+            self._batch_message(
+                unit="unit-a",
+                key="dup-key",
+                ordinal=0,
+                role="user",
+                content="first",
+                timestamp=201.0,
+            ),
+            self._batch_message(
+                unit="unit-a",
+                key="dup-key",
+                ordinal=1,
+                role="assistant",
+                content="second",
+                timestamp=202.0,
+            ),
+        ]
+
+        with pytest.raises(conflict_error):
+            db.append_messages_batch("s1", messages)
+        assert db.get_messages("s1") == []
+
+    @pytest.mark.parametrize(
+        ("ordinals", "expected_rows"),
+        [
+            ([0.5], [("float-msg", "unit-a", "msg-a", 0.5)]),
+            (["0"], [("string-msg", "unit-a", "msg-a", "0")]),
+            (
+                [False, True],
+                [
+                    ("bool-false", "unit-a", "msg-a", False),
+                    ("bool-true", "unit-a", "msg-b", True),
+                ],
+            ),
+        ],
+    )
+    def test_append_messages_batch_rejects_non_integer_ordinals(self, db, ordinals, expected_rows):
+        db.create_session(session_id="s1", source="cli")
+        contents = [row[0] for row in expected_rows]
+        messages = [
+            self._batch_message(
+                unit="unit-a",
+                key=f"msg-{chr(ord('a') + idx)}",
+                ordinal=ordinal,
+                role="user" if idx % 2 == 0 else "assistant",
+                content=contents[idx],
+                timestamp=210.0 + idx,
+            )
+            for idx, ordinal in enumerate(ordinals)
+        ]
+
+        with pytest.raises(hermes_state.AppendMessagesBatchConflictError):
+            db.append_messages_batch("s1", messages)
+
+        assert db.get_messages("s1") == []
+        assert list(self._stored_identity_rows(db)) == []
+        assert db.get_session("s1")["message_count"] == 0
+        assert db.get_session("s1")["tool_call_count"] == 0
+
+    def test_append_messages_batch_rejects_partial_persistence_unit_and_rolls_back(self, db):
+        db.create_session(session_id="s1", source="cli")
+        first = self._batch_message(
+            unit="unit-a",
+            key="msg-a",
+            ordinal=0,
+            role="user",
+            content="first",
+            timestamp=301.0,
+        )
+        db.append_messages_batch("s1", [first])
+
+        full_batch = [
+            first,
+            self._batch_message(
+                unit="unit-a",
+                key="msg-b",
+                ordinal=1,
+                role="assistant",
+                content="second",
+                timestamp=302.0,
+            ),
+        ]
+
+        with pytest.raises(hermes_state.AppendMessagesBatchConflictError):
+            db.append_messages_batch("s1", full_batch)
+
+        rows = db.get_messages("s1")
+        assert len(rows) == 1
+        assert rows[0]["content"] == "first"
+        assert db.get_session("s1")["message_count"] == 1
+
+    def test_append_messages_batch_rejects_subset_replay_of_existing_persistence_unit(self, db):
+        db.create_session(session_id="s1", source="cli")
+        full_batch = [
+            self._batch_message(
+                unit="unit-a",
+                key="msg-a",
+                ordinal=0,
+                role="user",
+                content="alpha first",
+                timestamp=351.0,
+            ),
+            self._batch_message(
+                unit="unit-a",
+                key="msg-b",
+                ordinal=1,
+                role="assistant",
+                content="beta second",
+                timestamp=352.0,
+                tool_calls=[{"name": "terminal", "arguments": "{}"}],
+            ),
+            self._batch_message(
+                unit="unit-a",
+                key="msg-c",
+                ordinal=2,
+                role="assistant",
+                content="gamma third",
+                timestamp=353.0,
+            ),
+        ]
+        db.append_messages_batch("s1", full_batch)
+
+        session_before = db.get_session("s1")
+        rows_before = db.get_messages("s1")
+        alpha_before = db.search_messages("alpha")
+        gamma_before = db.search_messages("gamma")
+
+        with pytest.raises(hermes_state.AppendMessagesBatchConflictError):
+            db.append_messages_batch("s1", full_batch[:2])
+
+        session_after = db.get_session("s1")
+        assert session_after["message_count"] == session_before["message_count"] == 3
+        assert session_after["tool_call_count"] == session_before["tool_call_count"] == 1
+        assert db.get_messages("s1") == rows_before
+        assert db.search_messages("alpha") == alpha_before
+        assert db.search_messages("gamma") == gamma_before
+
+    def test_append_messages_batch_rejects_changed_timestamp_for_existing_persistence_message_key(self, db):
+        db.create_session(session_id="s1", source="cli")
+        original = self._batch_message(
+            unit="unit-a",
+            key="msg-a",
+            ordinal=0,
+            role="user",
+            content="stable",
+            timestamp=401.0,
+        )
+        db.append_messages_batch("s1", [original])
+
+        changed = self._batch_message(
+            unit="unit-a",
+            key="msg-a",
+            ordinal=0,
+            role="user",
+            content="stable",
+            timestamp=999.0,
+        )
+
+        with pytest.raises(hermes_state.AppendMessagesBatchConflictError):
+            db.append_messages_batch("s1", [changed])
+
+        rows = db.get_messages("s1")
+        assert len(rows) == 1
+        assert rows[0]["timestamp"] == 401.0
+
+    def test_append_messages_batch_rejects_persistence_unit_ordinal_collision(self, db):
+        db.create_session(session_id="s1", source="cli")
+        original = self._batch_message(
+            unit="unit-a",
+            key="msg-a",
+            ordinal=0,
+            role="user",
+            content="stable",
+            timestamp=501.0,
+        )
+        db.append_messages_batch("s1", [original])
+
+        colliding = self._batch_message(
+            unit="unit-a",
+            key="msg-b",
+            ordinal=0,
+            role="user",
+            content="changed",
+            timestamp=502.0,
+        )
+
+        with pytest.raises(hermes_state.AppendMessagesBatchConflictError):
+            db.append_messages_batch("s1", [colliding])
+
+        rows = db.get_messages("s1")
+        assert len(rows) == 1
+        assert [tuple(row) for row in self._stored_identity_rows(db)] == [
+            ("stable", "unit-a", "msg-a", 0)
+        ]
+
+    def test_append_message_still_writes_null_persistence_message_key(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="legacy row")
+
+        row = db._conn.execute(
+            "SELECT persistence_unit_id, persistence_message_key, persistence_ordinal "
+            "FROM messages WHERE session_id = ?",
+            ("s1",),
+        ).fetchone()
+        assert tuple(row) == (None, None, None)
+
+
+class TestPrivatePersistenceIdentityReadSurfaces:
+    PRIVATE_KEYS = {
+        "persistence_unit_id",
+        "persistence_message_key",
+        "persistence_ordinal",
+    }
+
+    @staticmethod
+    def _seed(db):
+        db.create_session(session_id="s1", source="cli")
+        messages = [
+            TestAppendMessagesBatch._batch_message(
+                unit="unit-a",
+                key=f"msg-{chr(ord('a') + idx)}",
+                ordinal=idx,
+                role="user" if idx % 2 == 0 else "assistant",
+                content=content,
+                timestamp=610.0 + idx,
+            )
+            for idx, content in enumerate(
+                [
+                    "alpha first",
+                    "beta second",
+                    "gamma third",
+                    "delta fourth",
+                    "epsilon fifth",
+                ]
+            )
+        ]
+        db.append_messages_batch("s1", messages)
+        return db._conn.execute(
+            "SELECT id, role, content, persistence_unit_id, persistence_message_key, persistence_ordinal "
+            "FROM messages WHERE session_id = ? ORDER BY id",
+            ("s1",),
+        ).fetchall()
+
+    @classmethod
+    def _assert_private_keys_absent(cls, message):
+        assert cls.PRIVATE_KEYS.isdisjoint(message.keys())
+
+    def test_public_read_surfaces_strip_private_persistence_identity(self, db):
+        stored_rows = self._seed(db)
+        anchor_id = stored_rows[2]["id"]
+
+        messages = db.get_messages("s1")
+        assert [row["content"] for row in messages] == [
+            "alpha first",
+            "beta second",
+            "gamma third",
+            "delta fourth",
+            "epsilon fifth",
+        ]
+        for row in messages:
+            self._assert_private_keys_absent(row)
+
+        around = db.get_messages_around("s1", anchor_id, window=1)
+        assert [row["content"] for row in around["window"]] == [
+            "beta second",
+            "gamma third",
+            "delta fourth",
+        ]
+        for row in around["window"]:
+            self._assert_private_keys_absent(row)
+
+        anchored = db.get_anchored_view("s1", anchor_id, window=0, bookend=1)
+        assert [row["content"] for row in anchored["window"]] == ["gamma third"]
+        assert [row["content"] for row in anchored["bookend_start"]] == ["alpha first"]
+        assert [row["content"] for row in anchored["bookend_end"]] == ["epsilon fifth"]
+        for row in (
+            anchored["window"]
+            + anchored["bookend_start"]
+            + anchored["bookend_end"]
+        ):
+            self._assert_private_keys_absent(row)
+
+        rewind = db.rewind_to_message("s1", anchor_id)
+        assert rewind["target_message"]["content"] == "gamma third"
+        self._assert_private_keys_absent(rewind["target_message"])
+
+    def test_direct_sql_still_exposes_exact_private_persistence_identity(self, db):
+        self._seed(db)
+
+        rows = db._conn.execute(
+            "SELECT persistence_unit_id, persistence_message_key, persistence_ordinal "
+            "FROM messages WHERE session_id = ? ORDER BY id",
+            ("s1",),
+        ).fetchall()
+        assert [tuple(row) for row in rows] == [
+            ("unit-a", "msg-a", 0),
+            ("unit-a", "msg-b", 1),
+            ("unit-a", "msg-c", 2),
+            ("unit-a", "msg-d", 3),
+            ("unit-a", "msg-e", 4),
+        ]
+
+
+# =========================================================================
 # FTS5 search
 # =========================================================================
 

--- a/tests/test_session_fallback_spool.py
+++ b/tests/test_session_fallback_spool.py
@@ -1,0 +1,728 @@
+import hashlib
+import json
+import errno
+import os
+import stat
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDBBatchMessage
+import session_fallback_spool as spool
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows-only fallback
+    fcntl = None
+
+
+@pytest.fixture()
+def spool_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _bootstrap() -> spool.SessionSpoolBootstrap:
+    return spool.SessionSpoolBootstrap(
+        session_id="session-123",
+        source="cli",
+        started_at=123.456,
+        model="gpt-test",
+        model_config={"max_iterations": 2},
+        system_prompt="system prompt",
+        parent_session_id=None,
+        cwd="/tmp/project",
+        profile_name=None,
+        user_id="user-1",
+        session_key="session-key",
+        chat_id="chat-1",
+        chat_type="group",
+        thread_id="thread-1",
+    )
+
+
+def _batch_messages(
+    unit_id: str = "unit-1",
+    *,
+    contents: tuple[str, ...] = ("hello",),
+    timestamp: float = 100.0,
+) -> tuple[SessionDBBatchMessage, ...]:
+    return tuple(
+        SessionDBBatchMessage(
+            persistence_unit_id=unit_id,
+            persistence_message_key=f"{unit_id}-key-{idx}",
+            persistence_ordinal=idx,
+            role="assistant" if idx else "user",
+            content=content,
+            timestamp=timestamp + idx,
+        )
+        for idx, content in enumerate(contents)
+    )
+
+
+def _record(
+    unit_id: str = "unit-1",
+    *,
+    attempt_index: int = 0,
+    contents: tuple[str, ...] = ("hello",),
+) -> spool.SessionSpoolRecord:
+    return spool.SessionSpoolRecord(
+        bootstrap=_bootstrap(),
+        persist_attempt_id="a" * 32,
+        persist_attempt_unit_index=attempt_index,
+        canonical_failure={
+            "stage": "append_messages_batch",
+            "error_class": "RuntimeError",
+            "error_message": "db down",
+            "session_row_created": True,
+        },
+        batch_messages=_batch_messages(unit_id, contents=contents),
+    )
+
+
+def _paths(home: Path) -> tuple[Path, Path, Path, Path]:
+    root = home / "session_fallback_spool"
+    return root, root / "active.spool", root / "append.lock", root / "quarantine"
+
+
+def _fd_count() -> int:
+    import psutil
+
+    return psutil.Process().num_fds()
+
+
+def test_frame_bytes_are_deterministic_and_schema_validation_is_strict(spool_home):
+    record = _record()
+    frame_one = spool._frame_bytes_for_record(record)
+    frame_two = spool._frame_bytes_for_record(record)
+
+    assert frame_one == frame_two
+    assert frame_one[:4] == b"HSPL"
+    assert int.from_bytes(frame_one[8:16], "big") == len(frame_one) - 32
+    assert frame_one[16:32].hex() == hashlib.blake2s(
+        frame_one[4:16] + frame_one[32:], digest_size=16
+    ).hexdigest()
+
+    _, active_path, _, _ = _paths(spool_home)
+    active_path.parent.mkdir(parents=True, exist_ok=True)
+    active_path.write_bytes(spool._frame_from_payload_bytes(b'{"schema_version":1}'))
+
+    scan = spool.scan_spool(active_path)
+    assert scan.tail_status is spool.SpoolTailStatus.INVALID_SCHEMA
+    assert scan.valid_prefix_bytes == 0
+    assert scan.frame_count == 0
+
+
+def test_append_creates_private_profile_local_layout_and_modes(spool_home):
+    result = spool.append_records((_record(),))
+    receipt = result.unit_results[0].receipt
+    root, active_path, lock_path, quarantine_path = _paths(spool_home)
+
+    assert root == spool_home / "session_fallback_spool"
+    assert receipt.path == str(active_path)
+    assert active_path.exists()
+    assert lock_path.exists()
+    assert quarantine_path.exists()
+    assert str(root).startswith(str(spool_home))
+
+    if os.name == "posix":
+        assert (root.stat().st_mode & 0o777) == 0o700
+        assert (quarantine_path.stat().st_mode & 0o777) == 0o700
+        assert (active_path.stat().st_mode & 0o777) == 0o600
+        assert (lock_path.stat().st_mode & 0o777) == 0o600
+
+    scan = spool.scan_spool(active_path)
+    assert scan.tail_status is spool.SpoolTailStatus.CLEAN
+    assert scan.frame_count == 1
+    assert receipt.offset == 0
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink security is POSIX-only")
+def test_symlinked_root_is_refused(spool_home):
+    root, _, _, _ = _paths(spool_home)
+    target = spool_home / "other-root"
+    target.mkdir()
+    root.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(spool.SpoolPathSecurityError):
+        spool.append_records((_record(),))
+
+    assert list(target.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink race schedule is POSIX-only")
+def test_root_swap_after_preflight_is_rejected(spool_home, monkeypatch):
+    external = spool_home / "external-root"
+    external.mkdir()
+    sentinel = external / "sentinel.txt"
+    sentinel.write_text("outside", encoding="utf-8")
+    real_assert = spool._assert_entry_matches_fd
+    swapped = {"done": False}
+
+    def _swap(parent_fd, name, fd, *, expect, label):
+        if (
+            not swapped["done"]
+            and name == spool.SPOOL_ROOT_NAME
+            and label == str(spool._spool_root())
+        ):
+            swapped["done"] = True
+            root = spool._spool_root()
+            parked = root.with_name(root.name + ".real")
+            os.replace(root, parked)
+            os.mkdir(root, mode=0o755)
+        return real_assert(parent_fd, name, fd, expect=expect, label=label)
+
+    monkeypatch.setattr(spool, "_assert_entry_matches_fd", _swap)
+
+    with pytest.raises(spool.SessionFallbackSpoolError):
+        spool.append_records((_record(),))
+
+    replacement_root = spool._spool_root()
+    assert replacement_root.is_dir()
+    if os.name == "posix":
+        assert (replacement_root.stat().st_mode & 0o777) == 0o755
+    assert not (replacement_root / "quarantine").exists()
+    assert not (replacement_root / "active.spool").exists()
+    assert sentinel.read_text(encoding="utf-8") == "outside"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="quarantine race schedule is POSIX-only")
+def test_quarantine_dir_swap_after_preflight_is_rejected(spool_home, monkeypatch):
+    root, active_path, _, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    clean_frame = spool._frame_bytes_for_record(_record("unit-clean"))
+    active_path.write_bytes(clean_frame[:-1])
+    external = spool_home / "external-quarantine"
+    external.mkdir()
+
+    real_next = spool._next_quarantine_sequence
+    swapped = {"done": False}
+
+    def _swap(path: Path) -> int:
+        seq = real_next(path)
+        if not swapped["done"]:
+            swapped["done"] = True
+            parked = path.with_name(path.name + ".real")
+            os.replace(path, parked)
+            os.symlink(external, path, target_is_directory=True)
+        return seq
+
+    monkeypatch.setattr(spool, "_next_quarantine_sequence", _swap)
+
+    with pytest.raises(spool.SessionFallbackSpoolError):
+        spool.append_records((_record("unit-fresh"),))
+
+    assert list(external.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="active rename race schedule is POSIX-only")
+def test_active_name_swap_before_receipt_is_rejected(spool_home, monkeypatch):
+    root, active_path, _, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    active_path.write_bytes(b"")
+    external_target = spool_home / "external-active"
+    external_target.write_bytes(b"")
+
+    real_fsync = spool._fsync_fd
+    seen = {"count": 0}
+
+    def _swap(fd: int) -> None:
+        seen["count"] += 1
+        if seen["count"] == 1:
+            parked = active_path.with_name(active_path.name + ".real")
+            os.replace(active_path, parked)
+            os.symlink(external_target, active_path)
+        real_fsync(fd)
+
+    monkeypatch.setattr(spool, "_fsync_fd", _swap)
+
+    with pytest.raises(spool.SessionFallbackSpoolError):
+        spool.append_records((_record("unit-live"),))
+
+    assert external_target.read_bytes() == b""
+
+
+@pytest.mark.skipif(os.name != "posix", reason="sidecar race schedule is POSIX-only")
+def test_sidecar_destination_swap_is_rejected(spool_home, monkeypatch):
+    root, active_path, _, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    clean_frame = spool._frame_bytes_for_record(_record("unit-clean"))
+    active_path.write_bytes(clean_frame[:-1])
+    external_target = spool_home / "external-sidecar"
+    external_target.write_text("outside", encoding="utf-8")
+
+    real_fsync = spool._fsync_fd
+    final_sidecar = quarantine_path / "000001-incomplete_eof-vp0.json"
+    injected = {"done": False}
+
+    def _swap(fd: int) -> None:
+        if not injected["done"]:
+            temp_files = list(quarantine_path.glob("*.tmp"))
+            if temp_files:
+                injected["done"] = True
+                os.symlink(external_target, final_sidecar)
+        real_fsync(fd)
+
+    monkeypatch.setattr(spool, "_fsync_fd", _swap)
+
+    with pytest.raises(spool.SessionFallbackSpoolError):
+        spool.append_records((_record("unit-fresh"),))
+
+    assert external_target.read_text(encoding="utf-8") == "outside"
+
+
+def test_unknown_record_kind_is_rejected_by_scan(spool_home):
+    payload = spool._payload_bytes_for_record(_record())
+    _, active_path, _, _ = _paths(spool_home)
+    active_path.parent.mkdir(parents=True, exist_ok=True)
+    active_path.write_bytes(spool._frame_from_payload_bytes(payload, record_kind=0x02))
+
+    scan = spool.scan_spool(active_path)
+    assert scan.tail_status is spool.SpoolTailStatus.BAD_RECORD_KIND
+
+
+def test_nonzero_reserved_header_bytes_are_rejected_by_scan(spool_home):
+    payload = spool._payload_bytes_for_record(_record())
+    payload_len = len(payload)
+    header_prefix = bytes(
+        [spool.FRAME_VERSION, spool.RECORD_KIND_SESSION_PERSISTENCE_UNIT, 0x12, 0x34]
+    ) + payload_len.to_bytes(8, "big")
+    digest = hashlib.blake2s(header_prefix + payload, digest_size=16).digest()
+    frame = spool.HEADER_MAGIC + header_prefix + digest + payload
+    _, active_path, _, _ = _paths(spool_home)
+    active_path.parent.mkdir(parents=True, exist_ok=True)
+    active_path.write_bytes(frame)
+
+    scan = spool.scan_spool(active_path)
+    assert scan.tail_status is spool.SpoolTailStatus.NONZERO_RESERVED
+
+
+@pytest.mark.skipif(fcntl is None, reason="POSIX flock required")
+def test_non_contention_lock_errors_fail_immediately(spool_home, monkeypatch):
+    monkeypatch.setattr(spool, "LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(spool, "LOCK_RETRY_SECONDS", 0.01)
+
+    def _boom(_fd: int, _op: int) -> None:
+        raise OSError(errno.EBADF, "bad fd")
+
+    monkeypatch.setattr(spool.fcntl, "flock", _boom)
+
+    with pytest.raises(spool.SpoolDurabilityError):
+        spool.append_records((_record(),))
+
+
+def test_invalid_ordinal_record_is_rejected_before_receipt(spool_home):
+    invalid = spool.SessionSpoolRecord(
+        bootstrap=_bootstrap(),
+        persist_attempt_id="b" * 32,
+        persist_attempt_unit_index=0,
+        canonical_failure={
+            "stage": "append_messages_batch",
+            "error_class": "RuntimeError",
+            "error_message": "db down",
+            "session_row_created": True,
+        },
+        batch_messages=(
+            SessionDBBatchMessage(
+                persistence_unit_id="unit-invalid",
+                persistence_message_key="key-invalid",
+                persistence_ordinal=7,
+                role="user",
+                content="bad order",
+                timestamp=1.0,
+            ),
+        ),
+    )
+
+    with pytest.raises(spool.SessionFallbackSpoolError):
+        spool.append_records((invalid,))
+
+    _, active_path, _, _ = _paths(spool_home)
+    assert not active_path.exists() or active_path.stat().st_size == 0
+
+
+def test_scan_budget_exceeded_is_not_reported_clean(spool_home):
+    frame_one = spool._frame_bytes_for_record(_record("unit-a"))
+    frame_two = spool._frame_bytes_for_record(_record("unit-b"))
+    _, active_path, _, _ = _paths(spool_home)
+    active_path.parent.mkdir(parents=True, exist_ok=True)
+    active_path.write_bytes(frame_one + frame_two)
+
+    scan = spool.scan_spool(active_path, max_file_bytes=len(frame_one))
+
+    assert scan.tail_status is not spool.SpoolTailStatus.CLEAN
+    assert scan.valid_prefix_bytes == len(frame_one)
+    assert scan.tail_offset == len(frame_one)
+
+
+def test_missing_sidecar_is_reconciled_before_new_receipt(spool_home, monkeypatch):
+    root, active_path, _, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    clean_frame = spool._frame_bytes_for_record(_record("unit-clean"))
+    active_path.write_bytes(clean_frame[:-1])
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("sidecar write failed")
+
+    real_write_sidecar_json = spool._write_sidecar_json
+    monkeypatch.setattr(spool, "_write_sidecar_json", _boom)
+    with pytest.raises(OSError):
+        spool.append_records((_record("unit-first"),))
+
+    monkeypatch.setattr(spool, "_write_sidecar_json", real_write_sidecar_json)
+    result = spool.append_records((_record("unit-second"),))
+
+    assert len(result.unit_results) == 1
+    assert sorted(quarantine_path.glob("*.spool"))
+    assert sorted(quarantine_path.glob("*.json"))
+
+
+def test_parent_fsync_failure_on_created_active_must_be_reestablished_before_receipt(
+    spool_home, monkeypatch
+):
+    root, active_path, lock_path, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path.write_bytes(b"")
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(quarantine_path, 0o700)
+        os.chmod(lock_path, 0o600)
+
+    real_dir_fsync = spool._fsync_directory_fd
+    fail_parent = {"enabled": True}
+    root_fsync_calls = {"count": 0}
+
+    def _fail_root(fd: int, label):
+        if str(label) == str(root):
+            root_fsync_calls["count"] += 1
+        if (
+            fail_parent["enabled"]
+            and str(label) == str(root)
+            and root_fsync_calls["count"] >= 3
+        ):
+            raise OSError("simulated parent fsync failure")
+        return real_dir_fsync(fd, label)
+
+    monkeypatch.setattr(spool, "_fsync_directory_fd", _fail_root)
+
+    with pytest.raises(spool.SpoolDurabilityError):
+        spool.append_records((_record("unit-first"),))
+
+    assert active_path.exists()
+    assert active_path.stat().st_size == 0
+
+    with pytest.raises(spool.SpoolDurabilityError):
+        spool.append_records((_record("unit-second"),))
+
+    fail_parent["enabled"] = False
+    result = spool.append_records((_record("unit-third"),))
+    assert len(result.unit_results) == 1
+    assert result.unit_results[0].receipt.offset == 0
+
+
+@pytest.mark.skipif(os.name != "posix", reason="fd-count regression is POSIX-only")
+def test_repeated_parent_fsync_failures_do_not_leak_fds_on_lock_open(spool_home, monkeypatch):
+    root, _, lock_path, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path.write_bytes(b"")
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(quarantine_path, 0o700)
+        os.chmod(lock_path, 0o600)
+
+    baseline = _fd_count()
+    root_stat = root.stat()
+    real_fsync = spool.os.fsync
+
+    def _boom(fd: int):
+        fd_stat = os.fstat(fd)
+        if stat.S_ISDIR(fd_stat.st_mode) and (
+            fd_stat.st_dev == root_stat.st_dev and fd_stat.st_ino == root_stat.st_ino
+        ):
+            raise OSError("simulated root-directory fsync failure")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(spool.os, "fsync", _boom)
+
+    for attempt in range(25):
+        with pytest.raises(spool.SpoolDurabilityError):
+            spool.append_records((_record(f"unit-lock-{attempt}"),))
+        assert _fd_count() == baseline
+
+
+@pytest.mark.skipif(os.name != "posix", reason="fd-count regression is POSIX-only")
+def test_repeated_parent_fsync_failures_do_not_leak_fds_on_quarantine_open(
+    spool_home, monkeypatch
+):
+    root, active_path, lock_path, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path.write_bytes(b"")
+    active_path.write_bytes(b"")
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(quarantine_path, 0o700)
+        os.chmod(lock_path, 0o600)
+        os.chmod(active_path, 0o600)
+
+    baseline = _fd_count()
+    root_stat = root.stat()
+    real_fsync = spool.os.fsync
+
+    for attempt in range(25):
+        root_fsync_calls = {"count": 0}
+
+        def _boom(fd: int):
+            fd_stat = os.fstat(fd)
+            if stat.S_ISDIR(fd_stat.st_mode) and (
+                fd_stat.st_dev == root_stat.st_dev and fd_stat.st_ino == root_stat.st_ino
+            ):
+                root_fsync_calls["count"] += 1
+                if root_fsync_calls["count"] >= 2:
+                    raise OSError("simulated quarantine-parent fsync failure")
+            return real_fsync(fd)
+
+        monkeypatch.setattr(spool.os, "fsync", _boom)
+        with pytest.raises(spool.SpoolDurabilityError):
+            spool.append_records((_record(f"unit-dir-{attempt}"),))
+        assert _fd_count() == baseline
+
+
+def test_file_fsync_failure_produces_no_receipt(spool_home, monkeypatch):
+    real_fsync = spool._fsync_fd
+    seen = {"file": 0}
+
+    def _boom(fd: int) -> None:
+        seen["file"] += 1
+        if seen["file"] >= 2:
+            raise OSError("fsync failed")
+        real_fsync(fd)
+
+    monkeypatch.setattr(spool, "_fsync_fd", _boom)
+
+    with pytest.raises(spool.SpoolDurabilityError):
+        spool.append_records((_record(),))
+
+    _, active_path, _, _ = _paths(spool_home)
+    assert active_path.exists()
+    assert active_path.stat().st_size > 0
+
+
+def test_directory_fsync_failure_on_create_produces_no_receipt(spool_home, monkeypatch):
+    def _boom(_fd: int, _label) -> None:
+        raise OSError("dir fsync failed")
+
+    monkeypatch.setattr(spool, "_fsync_directory_fd", _boom)
+
+    with pytest.raises(spool.SpoolDurabilityError):
+        spool.append_records((_record(),))
+
+    root, _, _, _ = _paths(spool_home)
+    assert root.exists()
+
+
+@pytest.mark.skipif(fcntl is None, reason="POSIX flock required")
+def test_lock_timeout_is_bounded(spool_home, monkeypatch):
+    root, _, lock_path, _ = _paths(spool_home)
+    root.mkdir(mode=0o700)
+    lock_path.touch(mode=0o600)
+
+    with lock_path.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        monkeypatch.setattr(spool, "LOCK_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(spool, "LOCK_RETRY_SECONDS", 0.01)
+        with pytest.raises(spool.SpoolLockTimeoutError):
+            spool.append_records((_record(),))
+
+
+@pytest.mark.skipif(fcntl is None, reason="POSIX flock required")
+def test_concurrent_writers_serialize_and_do_not_overlap_offsets(spool_home):
+    records = [_record("unit-a"), _record("unit-b")]
+    results = []
+    errors = []
+
+    def _worker(item):
+        try:
+            results.append(spool.append_records((item,)).unit_results[0].receipt)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(item,)) for item in records]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert errors == []
+    assert len(results) == 2
+    ordered = sorted(results, key=lambda receipt: receipt.offset)
+    assert ordered[0].offset == 0
+    assert ordered[1].offset == ordered[0].frame_length
+
+    _, active_path, _, _ = _paths(spool_home)
+    scan = spool.scan_spool(active_path)
+    assert scan.tail_status is spool.SpoolTailStatus.CLEAN
+    assert scan.frame_count == 2
+
+
+def test_capacity_includes_quarantine_bytes_and_refuses_before_append(spool_home, monkeypatch):
+    first = spool.append_records((_record("unit-a"),)).unit_results[0].receipt
+    root, active_path, _, quarantine_path = _paths(spool_home)
+    quarantine_spool = quarantine_path / "000001-clean-vp0.spool"
+    quarantine_bytes = spool._frame_bytes_for_record(_record("unit-q"))
+    quarantine_spool.write_bytes(quarantine_bytes)
+    (quarantine_path / "000001-clean-vp0.json").write_text(
+        json.dumps(
+            {
+                "sequence": 1,
+                "tail_status": "clean",
+                "valid_prefix_bytes": len(quarantine_bytes),
+                "original_size": len(quarantine_bytes),
+                "quarantined_at": 1.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    if os.name == "posix":
+        os.chmod(quarantine_spool, 0o600)
+
+    second_frame = spool._frame_bytes_for_record(_record("unit-b"))
+    monkeypatch.setattr(
+        spool,
+        "TOTAL_CAP_BYTES",
+        active_path.stat().st_size + quarantine_spool.stat().st_size + len(second_frame) - 1,
+    )
+    before = active_path.read_bytes()
+
+    with pytest.raises(spool.SpoolCapacityError):
+        spool.append_records((_record("unit-b"),))
+
+    assert active_path.read_bytes() == before
+    assert first.frame_length == len(before)
+
+
+_CORRUPT_TAIL_CASES = (
+    (
+        spool.SpoolTailStatus.INCOMPLETE_EOF,
+        lambda frame: frame[:-1],
+    ),
+    (
+        spool.SpoolTailStatus.BAD_MAGIC,
+        lambda frame: b"NOPE" + frame[4:],
+    ),
+    (
+        spool.SpoolTailStatus.BAD_VERSION,
+        lambda frame: frame[:4] + b"\x02" + frame[5:],
+    ),
+    (
+        spool.SpoolTailStatus.OVERSIZED_LENGTH,
+        lambda frame: frame[:8]
+        + (spool.MAX_PAYLOAD_BYTES + 1).to_bytes(8, "big")
+        + frame[16:],
+    ),
+    (
+        spool.SpoolTailStatus.CHECKSUM_MISMATCH,
+        lambda frame: frame[:20] + bytes([frame[20] ^ 0xFF]) + frame[21:],
+    ),
+    (
+        spool.SpoolTailStatus.INVALID_JSON,
+        lambda _frame: spool._frame_from_payload_bytes(b"{"),
+    ),
+    (
+        spool.SpoolTailStatus.INVALID_SCHEMA,
+        lambda _frame: spool._frame_from_payload_bytes(b'{"schema_version":1}'),
+    ),
+)
+
+
+@pytest.mark.parametrize(("status", "corrupt"), _CORRUPT_TAIL_CASES)
+def test_corrupt_tails_are_quarantined_with_valid_prefix(
+    spool_home,
+    status,
+    corrupt,
+):
+    root, active_path, _, quarantine_path = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    quarantine_path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(quarantine_path, 0o700)
+
+    clean_frame = spool._frame_bytes_for_record(_record("unit-clean"))
+    corrupt_frame = corrupt(spool._frame_bytes_for_record(_record("unit-bad")))
+    original_bytes = clean_frame + corrupt_frame
+    active_path.write_bytes(original_bytes)
+    if os.name == "posix":
+        os.chmod(active_path, 0o600)
+
+    result = spool.append_records((_record("unit-fresh"),))
+    receipt = result.unit_results[0].receipt
+
+    quarantine_spools = sorted(quarantine_path.glob("*.spool"))
+    quarantine_sidecars = sorted(quarantine_path.glob("*.json"))
+    assert len(quarantine_spools) == 1
+    assert len(quarantine_sidecars) == 1
+    assert quarantine_spools[0].read_bytes() == original_bytes
+    assert f"vp{len(clean_frame)}" in quarantine_spools[0].name
+
+    meta = json.loads(quarantine_sidecars[0].read_text(encoding="utf-8"))
+    assert meta["sequence"] == 1
+    assert meta["tail_status"] == status.value
+    assert meta["valid_prefix_bytes"] == len(clean_frame)
+    assert meta["original_size"] == len(original_bytes)
+    assert "quarantined_at" in meta
+
+    scan = spool.scan_spool(active_path)
+    assert scan.tail_status is spool.SpoolTailStatus.CLEAN
+    assert scan.frame_count == 1
+    assert receipt.offset == 0
+
+
+def test_existing_active_append_does_not_require_directory_fsync(spool_home, monkeypatch):
+    first = spool.append_records((_record("unit-a"),)).unit_results[0].receipt
+
+    def _boom(_path: Path) -> None:  # pragma: no cover - should never fire
+        raise AssertionError("directory fsync should not run for an existing active append")
+
+    monkeypatch.setattr(spool, "_fsync_directory", _boom)
+    second = spool.append_records((_record("unit-b"),)).unit_results[0].receipt
+
+    assert second.offset == first.frame_length
+
+
+def test_multi_unit_partial_append_returns_durable_prefix_only(spool_home, monkeypatch):
+    real_write = spool.os.write
+    second_unit = {"active": False, "started": False}
+
+    def _flaky_write(fd: int, data: bytes) -> int:
+        if not second_unit["started"]:
+            if data.startswith(b"HSPL") and second_unit["active"]:
+                second_unit["started"] = True
+                wrote = real_write(fd, data[:7])
+                raise OSError("interrupted write")
+            if data.startswith(b"HSPL"):
+                second_unit["active"] = True
+        return real_write(fd, data)
+
+    monkeypatch.setattr(spool.os, "write", _flaky_write)
+
+    with pytest.raises(spool.SpoolAppendAttemptPartialError) as excinfo:
+        spool.append_records((_record("unit-a"), _record("unit-b", attempt_index=1)))
+
+    err = excinfo.value
+    assert len(err.durable_results) == 1
+    assert err.durable_results[0].persistence_unit_id == "unit-a"
+
+    _, active_path, _, _ = _paths(spool_home)
+    scan = spool.scan_spool(active_path)
+    assert scan.valid_prefix_bytes == err.durable_results[0].receipt.frame_length
+    assert scan.tail_status is spool.SpoolTailStatus.INCOMPLETE_EOF

--- a/tests/test_session_fallback_spool.py
+++ b/tests/test_session_fallback_spool.py
@@ -4,7 +4,9 @@ import errno
 import os
 import stat
 import threading
+import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1594,3 +1596,1276 @@ def test_corrupt_active_with_zero_prefix_publishes_evidence_and_blocker(spool_ho
         assert active_path.read_bytes() == b""
     finally:
         _close_runtime(runtime)
+
+
+def _write_status_blocker_state(home: Path) -> dict[str, object]:
+    root = home / spool.SPOOL_ROOT_NAME
+    sealed = root / spool.SEALED_DIR_NAME
+    blockers = sealed / spool.BLOCKERS_DIR_NAME
+    quarantine = root / spool.QUARANTINE_DIR_NAME
+    lock_path = root / spool.LOCK_FILE_NAME
+    root.mkdir(parents=True, exist_ok=True)
+    sealed.mkdir(parents=True, exist_ok=True)
+    blockers.mkdir(parents=True, exist_ok=True)
+    quarantine.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+
+    clean_frame = spool._frame_bytes_for_record(_record("status-blocked"))
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(_record("status-bad", attempt_index=1)))
+    corrupt_frame[-1] ^= 0x01
+    prefix_path = sealed / "00000000000000000001.prefix.spool"
+    prefix_path.write_bytes(clean_frame)
+
+    evidence_base = f"seq-{1:020d}-checksum_mismatch-vp{len(clean_frame)}"
+    evidence_spool = quarantine / f"{evidence_base}.spool"
+    evidence_sidecar = quarantine / f"{evidence_base}.json"
+    evidence_spool.write_bytes(clean_frame + bytes(corrupt_frame))
+    evidence_sidecar.write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": f"{1:020d}",
+                "source_kind": "sealed",
+                "tail_status": "checksum_mismatch",
+                "valid_prefix_bytes": len(clean_frame),
+                "original_size_bytes": len(clean_frame) + len(corrupt_frame),
+                "evidence_spool_name": evidence_spool.name,
+            }
+        )
+    )
+    blocker_path = blockers / "00000000000000000001.blocker.json"
+    blocker_path.write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": f"{1:020d}",
+                "source_kind": "sealed",
+                "tail_status": "checksum_mismatch",
+                "valid_prefix_bytes": len(clean_frame),
+                "acked_prefix_bytes": 0,
+                "blocking_offset": len(clean_frame),
+                "prefix_segment_name": prefix_path.name,
+                "evidence_spool_name": evidence_spool.name,
+                "evidence_sidecar_name": evidence_sidecar.name,
+                "original_size_bytes": len(clean_frame) + len(corrupt_frame),
+            }
+        )
+    )
+    return {
+        "prefix_path": prefix_path,
+        "blocker_path": blocker_path,
+        "evidence_spool": evidence_spool,
+        "evidence_sidecar": evidence_sidecar,
+        "blocking_offset": len(clean_frame),
+    }
+
+
+def _status_scandir_matches(target: object, expected_path: Path) -> bool:
+    return isinstance(target, int) and spool._same_file_stat(os.fstat(target), expected_path.stat())
+
+
+class _StatusFaultingDirEntry:
+    def __init__(
+        self,
+        wrapped,
+        *,
+        stat_exc=None,
+        symlink_exc=None,
+    ):
+        self._wrapped = wrapped
+        self._stat_exc = stat_exc
+        self._symlink_exc = symlink_exc
+        self.name = wrapped.name
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+    def is_symlink(self):
+        if self._symlink_exc is not None:
+            raise self._symlink_exc
+        return self._wrapped.is_symlink()
+
+    def stat(self, *, follow_symlinks=True):
+        if self._stat_exc is not None:
+            raise self._stat_exc
+        return self._wrapped.stat(follow_symlinks=follow_symlinks)
+
+
+class _StatusFaultingScandir:
+    def __init__(
+        self,
+        entries,
+        *,
+        iteration_exc=None,
+        raise_after: int = 0,
+    ):
+        self._entries = iter(entries)
+        self._iteration_exc = iteration_exc
+        self._raise_after = raise_after
+        self._yielded = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._iteration_exc is not None and self._yielded >= self._raise_after:
+            raise self._iteration_exc
+        entry = next(self._entries)
+        self._yielded += 1
+        return entry
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+
+    def close(self):
+        return None
+
+
+def test_collect_session_fallback_spool_status_missing_root_is_empty_and_non_creating(
+    spool_home, monkeypatch
+):
+    before = sorted(path.relative_to(spool_home) for path in spool_home.rglob("*"))
+
+    monkeypatch.setattr(
+        spool.os,
+        "fstatvfs",
+        lambda _fd: SimpleNamespace(f_bavail=0, f_blocks=10, f_frsize=1),
+    )
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.schema_version == 1
+    assert status.state == "empty"
+    assert status.reasons == ()
+    assert status.pending_units == 0
+    assert status.pending_frames == 0
+    assert status.pending_bytes == 0
+    assert status.oldest_pending_age_seconds is None
+    assert status.retry_pending is False
+    assert status.ack_pending is False
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_offset is None
+    assert status.blocker_reason_class is None
+    assert status.blocker_source_kind is None
+    assert status.inspection_error_class is None
+    assert not (spool_home / spool.SPOOL_ROOT_NAME).exists()
+    after = sorted(path.relative_to(spool_home) for path in spool_home.rglob("*"))
+    assert after == before
+
+
+def test_collect_session_fallback_spool_status_counts_clean_backlog_age_and_capacity(spool_home):
+    root, active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    root.mkdir(parents=True, exist_ok=True)
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+
+    first = spool._frame_bytes_for_record(_record("status-unit-a"))
+    second = spool._frame_bytes_for_record(_record("status-unit-b", attempt_index=1))
+    active = spool._frame_bytes_for_record(_record("status-unit-c", attempt_index=2))
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    segment_path.write_bytes(first + second)
+    active_path.write_bytes(active)
+
+    os.utime(segment_path, (75.0, 75.0))
+    os.utime(active_path, (90.0, 90.0))
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.reasons == ("pending_backlog",)
+    assert status.pending_units == 3
+    assert status.pending_frames == 3
+    assert status.pending_bytes == len(first + second) + len(active)
+    assert status.oldest_pending_age_seconds == pytest.approx(25.0)
+    assert status.capacity_used_bytes == len(first + second) + len(active)
+    assert status.capacity_cap_bytes == spool.TOTAL_CAP_BYTES
+    assert status.capacity_remaining_bytes == spool.TOTAL_CAP_BYTES - (len(first + second) + len(active))
+    assert status.capacity_state == "ok"
+    assert status.blocker_present is False
+    assert status.retry_pending is False
+    assert status.ack_pending is False
+
+
+def test_collect_session_fallback_spool_status_reports_blocker_metadata_without_mutation(spool_home):
+    paths = _write_status_blocker_state(spool_home)
+    before = {
+        name: hashlib.sha256(Path(path).read_bytes()).hexdigest()
+        for name, path in paths.items()
+        if isinstance(path, Path)
+    }
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.blocker_present is True
+    assert status.blocker_sequence == 1
+    assert status.blocker_offset == paths["blocking_offset"]
+    assert status.blocker_reason_class == "checksum_mismatch"
+    assert status.blocker_source_kind == "sealed"
+    assert "blocker" in status.reasons
+    assert "pending_backlog" in status.reasons
+
+    after = {
+        name: hashlib.sha256(Path(path).read_bytes()).hexdigest()
+        for name, path in paths.items()
+        if isinstance(path, Path)
+    }
+    assert after == before
+
+
+def test_collect_session_fallback_spool_status_missing_append_lock_is_inspection_only(
+    spool_home,
+):
+    root, active_path, _lock_path, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True)
+    active_path.write_bytes(spool._frame_bytes_for_record(_record("missing-lock")))
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "missing_append_lock"
+    assert "inspection_error" in status.reasons
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_offset is None
+    assert status.blocker_reason_class is None
+    assert status.blocker_source_kind is None
+
+
+def test_collect_session_fallback_spool_status_fails_closed_for_invalid_blocker_json(spool_home):
+    paths = _write_status_blocker_state(spool_home)
+    blocker_path = Path(str(paths["blocker_path"]))
+    blocker_path.write_text('{"schema_version":1}\n', encoding="utf-8")
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert "inspection_error" in status.reasons
+    assert status.inspection_error_class == "invalid_blocker_json"
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_offset is None
+    assert status.blocker_reason_class is None
+    assert status.blocker_source_kind is None
+
+
+def test_collect_session_fallback_spool_status_reports_capacity_and_disk_from_home_descriptor(
+    spool_home, monkeypatch
+):
+    root, active_path, lock_path, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    active = spool._frame_bytes_for_record(_record("status-capacity"))
+    active_path.write_bytes(active)
+    captured = {}
+
+    def _fake_fstatvfs(fd):
+        captured["fd"] = fd
+        return SimpleNamespace(f_bavail=0, f_blocks=10, f_frsize=8)
+
+    monkeypatch.setattr(spool.os, "fstatvfs", _fake_fstatvfs)
+    monkeypatch.setattr(spool, "TOTAL_CAP_BYTES", len(active) + 1)
+
+    constrained = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert isinstance(captured["fd"], int)
+    assert constrained.capacity_remaining_bytes == 1
+    assert constrained.capacity_state == "constrained"
+    assert constrained.disk_free_bytes == 0
+    assert constrained.disk_total_bytes == 80
+    assert constrained.disk_headroom_threshold_bytes == 1
+    assert constrained.disk_state == "low"
+
+    monkeypatch.setattr(spool, "TOTAL_CAP_BYTES", len(active))
+    full = spool.collect_session_fallback_spool_status(now=100.0)
+    assert full.capacity_remaining_bytes == 0
+    assert full.capacity_state == "full"
+
+
+def test_collect_session_fallback_spool_status_degrades_when_disk_probe_fails(spool_home, monkeypatch):
+    root, active_path, lock_path, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    active_path.write_bytes(spool._frame_bytes_for_record(_record("status-disk-fail")))
+
+    def _boom(_fd):
+        raise OSError(errno.EIO, "boom disk path should stay hidden")
+
+    monkeypatch.setattr(spool.os, "fstatvfs", _boom)
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert "inspection_error" in status.reasons
+    assert status.inspection_error_class == "disk_probe_failed"
+    assert status.disk_state == "unknown"
+    assert status.disk_free_bytes is None
+    assert status.disk_total_bytes is None
+    assert "boom disk path should stay hidden" not in repr(status)
+
+
+def test_collect_session_fallback_spool_status_valid_blocker_survives_later_disk_probe_failure(
+    spool_home, monkeypatch
+):
+    _write_status_blocker_state(spool_home)
+
+    def _boom(_fd):
+        raise OSError(errno.EIO, "later disk probe failure")
+
+    monkeypatch.setattr(spool.os, "fstatvfs", _boom)
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "disk_probe_failed"
+    assert status.blocker_present is True
+    assert status.blocker_sequence == 1
+    assert status.blocker_reason_class == "checksum_mismatch"
+    assert status.blocker_source_kind == "sealed"
+
+
+def test_collect_session_fallback_spool_status_artifact_bound_exhaustion_is_degraded(spool_home, monkeypatch):
+    root, active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    root.mkdir(parents=True, exist_ok=True)
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    (root / spool.HIGHWATER_FILE_NAME).write_text(
+        '{"last_reserved_sequence":"00000000000000000001","schema_version":1}',
+        encoding="utf-8",
+    )
+    (sealed_dir / "00000000000000000001.spool").write_bytes(
+        spool._frame_bytes_for_record(_record("status-bound-sealed", attempt_index=1))
+    )
+
+    monkeypatch.setattr(spool, "STATUS_SCAN_ARTIFACT_LIMIT", 1)
+    monkeypatch.setattr(
+        spool,
+        "_durable_capacity_inventory",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("status bound should preflight before capacity inventory")),
+    )
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "artifact_limit_exceeded"
+    assert "inspection_error" in status.reasons
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_offset is None
+    assert status.blocker_reason_class is None
+    assert status.blocker_source_kind is None
+
+
+def test_collect_session_fallback_spool_status_fully_acked_segment_reports_ack_pending_without_backlog(
+    spool_home,
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    frame_bytes = spool._frame_bytes_for_record(_record("ack-only"))
+    segment_path.write_bytes(frame_bytes)
+    os.utime(segment_path, (75.0, 75.0))
+    decoded = spool.decode_spool_segment(segment_path)
+    frame = decoded.prefix_frames[0]
+    acks_dir = sealed_dir / spool.ACKS_DIR_NAME
+    acks_dir.mkdir(parents=True, exist_ok=True)
+    ack_name = f"{segment_path.name}.ap{decoded.valid_prefix_bytes:020d}.json"
+    (acks_dir / ack_name).write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": "00000000000000000001",
+                "segment_name": segment_path.name,
+                "segment_kind": "clean",
+                "segment_size_bytes": decoded.valid_prefix_bytes,
+                "acked_prefix_bytes": decoded.valid_prefix_bytes,
+                "valid_prefix_bytes": decoded.valid_prefix_bytes,
+                "tail_status": decoded.tail_status.value,
+                "last_frame_offset": frame.frame_offset,
+                "last_frame_length": frame.frame_length,
+                "last_frame_checksum_hex": frame.checksum_hex,
+            }
+        )
+    )
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.pending_units == 0
+    assert status.pending_frames == 0
+    assert status.pending_bytes == 0
+    assert "pending_backlog" not in status.reasons
+    assert status.ack_pending is True
+    assert status.oldest_pending_age_seconds == pytest.approx(25.0)
+
+
+def test_collect_session_fallback_spool_status_partial_ack_subtracts_exact_prefix(
+    spool_home,
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    first = spool._frame_bytes_for_record(_record("partial-a"))
+    second = spool._frame_bytes_for_record(_record("partial-b", attempt_index=1))
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    segment_path.write_bytes(first + second)
+    os.utime(segment_path, (75.0, 75.0))
+    acks_dir = sealed_dir / spool.ACKS_DIR_NAME
+    acks_dir.mkdir(parents=True, exist_ok=True)
+    ack_name = f"{segment_path.name}.ap{len(first):020d}.json"
+    (acks_dir / ack_name).write_bytes(
+        spool._canonical_json_bytes(
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=len(first),
+                valid_prefix_bytes=len(first + second),
+            )
+        )
+    )
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.pending_units == 1
+    assert status.pending_frames == 1
+    assert status.pending_bytes == len(second)
+    assert status.ack_pending is True
+    assert status.oldest_pending_age_seconds == pytest.approx(25.0)
+
+
+def test_collect_session_fallback_spool_status_blocker_prefix_subtracts_acked_prefix_once(
+    spool_home,
+):
+    first = spool._frame_bytes_for_record(_record("blocker-a"))
+    second = spool._frame_bytes_for_record(_record("blocker-b", attempt_index=1))
+    corrupt_tail = bytearray(spool._frame_bytes_for_record(_record("blocker-c", attempt_index=2)))
+    corrupt_tail[-1] ^= 0x01
+    state = _write_status_blocker_state(spool_home)
+    prefix_path = Path(str(state["prefix_path"]))
+    evidence_spool = Path(str(state["evidence_spool"]))
+    evidence_sidecar = Path(str(state["evidence_sidecar"]))
+    prefix_path.write_bytes(first + second)
+    blocker_path = Path(str(state["blocker_path"]))
+    payload = json.loads(blocker_path.read_text(encoding="utf-8"))
+    evidence_base = f"seq-{1:020d}-checksum_mismatch-vp{len(first + second)}"
+    new_evidence_spool = evidence_spool.with_name(f"{evidence_base}.spool")
+    new_evidence_sidecar = evidence_sidecar.with_name(f"{evidence_base}.json")
+    evidence_spool.unlink()
+    evidence_sidecar.unlink()
+    new_evidence_spool.write_bytes(first + second + bytes(corrupt_tail))
+    new_evidence_sidecar.write_bytes(
+        spool._canonical_json_bytes(
+            {
+                "schema_version": 1,
+                "segment_sequence": f"{1:020d}",
+                "source_kind": "sealed",
+                "tail_status": "checksum_mismatch",
+                "valid_prefix_bytes": len(first + second),
+                "original_size_bytes": len(first + second + bytes(corrupt_tail)),
+                "evidence_spool_name": new_evidence_spool.name,
+            }
+        )
+    )
+    payload["valid_prefix_bytes"] = len(first + second)
+    payload["acked_prefix_bytes"] = len(first)
+    payload["blocking_offset"] = len(first + second)
+    payload["evidence_spool_name"] = new_evidence_spool.name
+    payload["evidence_sidecar_name"] = new_evidence_sidecar.name
+    payload["original_size_bytes"] = len(first + second + bytes(corrupt_tail))
+    blocker_path.write_bytes(spool._canonical_json_bytes(payload))
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.blocker_present is True
+    assert status.pending_units == 1
+    assert status.pending_frames == 1
+    assert status.pending_bytes == len(second)
+    assert status.capacity_used_bytes >= len(first + second)
+
+
+def test_collect_session_fallback_spool_status_invalid_ack_is_inspection_degradation(
+    spool_home,
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    frame_bytes = spool._frame_bytes_for_record(_record("invalid-ack"))
+    segment_path.write_bytes(frame_bytes)
+    acks_dir = sealed_dir / spool.ACKS_DIR_NAME
+    acks_dir.mkdir(parents=True, exist_ok=True)
+    (acks_dir / f"{segment_path.name}.ap{len(frame_bytes):020d}.json").write_text(
+        '{"schema_version":1}\n',
+        encoding="utf-8",
+    )
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "invalid_ack_json"
+    assert "inspection_error" in status.reasons
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_source_kind is None
+
+
+@pytest.mark.skipif(fcntl is None, reason="POSIX flock required")
+def test_collect_session_fallback_spool_status_lock_contention_is_bounded_and_non_mutating(spool_home):
+    assert fcntl is not None
+    root, active_path, lock_path, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    active_path.write_bytes(spool._frame_bytes_for_record(_record("status-lock")))
+    before = active_path.read_bytes()
+
+    with lock_path.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "append_lock_busy"
+    assert "inspection_error" in status.reasons
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_offset is None
+    assert status.blocker_reason_class is None
+    assert status.blocker_source_kind is None
+    assert active_path.read_bytes() == before
+
+
+def _status_write_ack_sidecar(segment_path: Path, *, acked_prefix_bytes: int) -> None:
+    acks_dir = segment_path.parent / spool.ACKS_DIR_NAME
+    acks_dir.mkdir(parents=True, exist_ok=True)
+    ack_name = f"{segment_path.name}.ap{acked_prefix_bytes:020d}.json"
+    (acks_dir / ack_name).write_bytes(
+        spool._canonical_json_bytes(
+            _ack_payload(
+                segment_sequence=int(segment_path.name[:20]),
+                segment_name=segment_path.name,
+                acked_prefix_bytes=acked_prefix_bytes,
+                valid_prefix_bytes=segment_path.stat().st_size,
+                segment_kind=(
+                    "prefix" if segment_path.name.endswith(".prefix.spool") else "clean"
+                ),
+            )
+        )
+    )
+
+
+def _mutate_status_blocker_case(paths: dict[str, object], case_name: str) -> None:
+    blocker_path = Path(str(paths["blocker_path"]))
+    prefix_path = Path(str(paths["prefix_path"]))
+    evidence_spool = Path(str(paths["evidence_spool"]))
+    evidence_sidecar = Path(str(paths["evidence_sidecar"]))
+    payload = json.loads(blocker_path.read_text(encoding="utf-8"))
+
+    if case_name == "negative_acked_prefix":
+        payload["acked_prefix_bytes"] = -1
+        blocker_path.write_bytes(spool._canonical_json_bytes(payload))
+        return
+    if case_name == "acked_prefix_gt_valid_prefix":
+        payload["acked_prefix_bytes"] = payload["valid_prefix_bytes"] + 1
+        blocker_path.write_bytes(spool._canonical_json_bytes(payload))
+        return
+    if case_name == "prefix_name_none_with_nonzero_offsets":
+        payload["prefix_segment_name"] = None
+        blocker_path.write_bytes(spool._canonical_json_bytes(payload))
+        return
+    if case_name == "wrong_expected_prefix_name":
+        payload["prefix_segment_name"] = f"{1:020d}.spool"
+        blocker_path.write_bytes(spool._canonical_json_bytes(payload))
+        return
+    if case_name == "wrong_expected_evidence_names":
+        payload["evidence_spool_name"] = "wrong-evidence.spool"
+        payload["evidence_sidecar_name"] = "wrong-evidence.json"
+        blocker_path.write_bytes(spool._canonical_json_bytes(payload))
+        return
+    if case_name == "wrong_evidence_metadata":
+        evidence_payload = json.loads(evidence_sidecar.read_text(encoding="utf-8"))
+        evidence_payload["valid_prefix_bytes"] = evidence_payload["valid_prefix_bytes"] + 1
+        evidence_sidecar.write_bytes(spool._canonical_json_bytes(evidence_payload))
+        return
+    if case_name == "missing_prefix_artifact":
+        prefix_path.unlink()
+        return
+    if case_name == "nonregular_evidence_artifact":
+        evidence_spool.unlink()
+        evidence_spool.mkdir()
+        return
+    raise AssertionError(f"unknown blocker case: {case_name}")
+
+
+def test_collect_session_fallback_spool_status_decodes_sealed_segments_from_fds_only(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    segment_path.write_bytes(spool._frame_bytes_for_record(_record("status-fd-only")))
+
+    called = []
+
+    def _forbidden(path, **_kwargs):
+        called.append(str(path))
+        raise AssertionError("status path re-resolution")
+
+    monkeypatch.setattr(spool, "decode_spool_segment", _forbidden)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert called == []
+    assert status.inspection_error_class is None
+    assert status.pending_units == 1
+    assert status.pending_frames == 1
+    assert status.pending_bytes == segment_path.stat().st_size
+
+
+def test_collect_session_fallback_spool_status_ack_directory_scan_count_is_constant(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    acks_dir = sealed_dir / spool.ACKS_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    acks_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+
+    for sequence in range(1, 4):
+        segment_path = sealed_dir / f"{sequence:020d}.spool"
+        segment_path.write_bytes(
+            spool._frame_bytes_for_record(
+                _record(f"status-ack-scan-{sequence}", attempt_index=sequence - 1)
+            )
+        )
+        _status_write_ack_sidecar(
+            segment_path,
+            acked_prefix_bytes=segment_path.stat().st_size,
+        )
+
+    ack_dir_stat = acks_dir.stat()
+    counts = {"scans": 0, "entries": 0}
+    original_scandir = spool.os.scandir
+
+    class _CountingScandir:
+        def __init__(self, iterator, *, count_entries: bool):
+            self._iterator = iterator
+            self._count_entries = count_entries
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            entry = next(self._iterator)
+            if self._count_entries:
+                counts["entries"] += 1
+            return entry
+
+        def __enter__(self):
+            self._iterator.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return self._iterator.__exit__(exc_type, exc, tb)
+
+        def close(self):
+            return self._iterator.close()
+
+    def _counting_scandir(target):
+        iterator = original_scandir(target)
+        count_entries = False
+        if isinstance(target, int) and spool._same_file_stat(os.fstat(target), ack_dir_stat):
+            counts["scans"] += 1
+            count_entries = True
+        return _CountingScandir(iterator, count_entries=count_entries)
+
+    monkeypatch.setattr(spool.os, "scandir", _counting_scandir)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.ack_pending is True
+    assert counts["scans"] == 3
+    assert counts["entries"] == 9
+
+
+def test_collect_session_fallback_spool_status_oldest_age_uses_zero_prefix_blocker_queue_head(
+    spool_home,
+):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        corrupt_frame = bytearray(spool._frame_bytes_for_record(_record("zero-prefix-head")))
+        corrupt_frame[0] = 0x00
+        spool._active_spool_path().write_bytes(bytes(corrupt_frame))
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            published = spool._reconcile_active_spool_for_replay(runtime)
+    finally:
+        _close_runtime(runtime)
+
+    assert published is not None
+    assert published["valid_prefix_bytes"] == 0
+
+    blocker_path = spool._blockers_dir() / "00000000000000000001.blocker.json"
+    segment_path = sealed_dir / "00000000000000000002.spool"
+    segment_path.write_bytes(spool._frame_bytes_for_record(_record("later-segment")))
+    now = time.time()
+    os.utime(blocker_path, (now - 3600, now - 3600))
+    os.utime(segment_path, (now - 10, now - 10))
+
+    status = spool.collect_session_fallback_spool_status(now=now)
+
+    assert status.blocker_present is True
+    assert status.pending_frames == 1
+    assert status.oldest_pending_age_seconds == pytest.approx(3600.0, abs=1.0)
+
+
+def test_collect_session_fallback_spool_status_oldest_age_uses_nonzero_prefix_queue_head(
+    spool_home,
+):
+    paths = _write_status_blocker_state(spool_home)
+    blocker_path = Path(str(paths["blocker_path"]))
+    prefix_path = Path(str(paths["prefix_path"]))
+    now = time.time()
+    os.utime(blocker_path, (now - 3600, now - 3600))
+    os.utime(prefix_path, (now - 10, now - 10))
+
+    status = spool.collect_session_fallback_spool_status(now=now)
+
+    assert status.blocker_present is True
+    assert status.pending_frames == 1
+    assert status.oldest_pending_age_seconds == pytest.approx(10.0, abs=1.0)
+
+
+def test_collect_session_fallback_spool_status_blocker_preflight_direntry_stat_race_is_exception_safe(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    blockers_dir = root / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME
+    blockers_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    (blockers_dir / "00000000000000000001.blocker.json").write_bytes(b"not-json\n")
+
+    original_scandir = spool.os.scandir
+    injected = {"done": False}
+
+    def _racing_scandir(target):
+        iterator = original_scandir(target)
+        if not injected["done"] and _status_scandir_matches(target, blockers_dir):
+            entries = list(iterator)
+            iterator.close()
+            injected["done"] = True
+            return _StatusFaultingScandir(
+                [
+                    _StatusFaultingDirEntry(
+                        entries[0],
+                        stat_exc=FileNotFoundError("raced away"),
+                    ),
+                    *entries[1:],
+                ]
+            )
+        return iterator
+
+    monkeypatch.setattr(spool.os, "scandir", _racing_scandir)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "entry_replaced"
+    assert "inspection_error" in status.reasons
+    assert "raced away" not in repr(status)
+
+
+def test_collect_session_fallback_spool_status_segment_direntry_stat_race_after_preflight_is_exception_safe(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    (sealed_dir / "00000000000000000001.spool").write_bytes(
+        spool._frame_bytes_for_record(_record("segment-stat-race"))
+    )
+
+    original_scandir = spool.os.scandir
+    sealed_scans = {"count": 0}
+
+    def _racing_scandir(target):
+        iterator = original_scandir(target)
+        if _status_scandir_matches(target, sealed_dir):
+            sealed_scans["count"] += 1
+            if sealed_scans["count"] == 2:
+                entries = list(iterator)
+                iterator.close()
+                return _StatusFaultingScandir(
+                    [
+                        _StatusFaultingDirEntry(
+                            entry,
+                            stat_exc=(
+                                FileNotFoundError("segment replaced")
+                                if entry.name.endswith(".spool")
+                                else None
+                            ),
+                        )
+                        for entry in entries
+                    ]
+                )
+        return iterator
+
+    monkeypatch.setattr(spool.os, "scandir", _racing_scandir)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "entry_replaced"
+    assert "inspection_error" in status.reasons
+    assert "segment replaced" not in repr(status)
+
+
+def test_collect_session_fallback_spool_status_nested_scandir_iteration_oserror_is_exception_safe(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    blockers_dir = root / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME
+    blockers_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    (blockers_dir / "00000000000000000001.blocker.json").write_bytes(b"not-json\n")
+
+    original_scandir = spool.os.scandir
+    injected = {"done": False}
+
+    def _racing_scandir(target):
+        iterator = original_scandir(target)
+        if not injected["done"] and _status_scandir_matches(target, blockers_dir):
+            iterator.close()
+            injected["done"] = True
+            return _StatusFaultingScandir(
+                [],
+                iteration_exc=OSError(errno.EIO, "nested iteration boom"),
+            )
+        return iterator
+
+    monkeypatch.setattr(spool.os, "scandir", _racing_scandir)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "inspection_error"
+    assert "inspection_error" in status.reasons
+    assert "nested iteration boom" not in repr(status)
+
+
+def test_collect_session_fallback_spool_status_symlink_shaped_metadata_race_maps_to_symlink_refused(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    (sealed_dir / "00000000000000000001.spool").write_bytes(
+        spool._frame_bytes_for_record(_record("segment-eloop-race"))
+    )
+
+    original_scandir = spool.os.scandir
+    sealed_scans = {"count": 0}
+
+    def _racing_scandir(target):
+        iterator = original_scandir(target)
+        if _status_scandir_matches(target, sealed_dir):
+            sealed_scans["count"] += 1
+            if sealed_scans["count"] == 2:
+                entries = list(iterator)
+                iterator.close()
+                return _StatusFaultingScandir(
+                    [
+                        _StatusFaultingDirEntry(
+                            entry,
+                            stat_exc=(
+                                OSError(errno.ELOOP, "symlink loop should stay hidden")
+                                if entry.name.endswith(".spool")
+                                else None
+                            ),
+                        )
+                        for entry in entries
+                    ]
+                )
+        return iterator
+
+    monkeypatch.setattr(spool.os, "scandir", _racing_scandir)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "symlink_refused"
+    assert "inspection_error" in status.reasons
+    assert "symlink loop should stay hidden" not in repr(status)
+
+
+def test_collect_session_fallback_spool_status_home_open_race_is_exception_safe(
+    spool_home, monkeypatch
+):
+    monkeypatch.setattr(
+        spool,
+        "_open_home_dir_fd",
+        lambda _home_path: (_ for _ in ()).throw(FileNotFoundError("home vanished")),
+    )
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.reasons == ("inspection_error",)
+    assert status.inspection_error_class == "entry_replaced"
+    assert "home vanished" not in repr(status)
+
+
+def test_collect_session_fallback_spool_status_segment_replacement_after_open_fails_closed(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    segment_path.write_bytes(spool._frame_bytes_for_record(_record("status-swap-a")))
+    replacement_frame = spool._frame_bytes_for_record(
+        _record("status-swap-b", attempt_index=1)
+    )
+    original_read_exact = spool._read_exact_from_fd
+    swapped = {"done": False}
+
+    def _swap(fd: int, *, offset: int, length: int) -> bytes:
+        if not swapped["done"] and length == spool.HEADER_SIZE:
+            swapped["done"] = True
+            parked = segment_path.with_name(segment_path.name + ".parked")
+            os.replace(segment_path, parked)
+            segment_path.write_bytes(replacement_frame)
+        return original_read_exact(fd, offset=offset, length=length)
+
+    monkeypatch.setattr(spool, "_read_exact_from_fd", _swap)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "entry_replaced"
+
+
+def test_collect_session_fallback_spool_status_active_replacement_during_scan_fails_closed(
+    spool_home, monkeypatch
+):
+    root, active_path, lock_path, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    active_path.write_bytes(spool._frame_bytes_for_record(_record("status-active-swap-old")))
+    replacement_frame = spool._frame_bytes_for_record(
+        _record(
+            "status-active-swap-new",
+            attempt_index=1,
+            contents=("replacement-is-longer",),
+        )
+    )
+    parked_path = root / "held-active.spool"
+    original_scan = spool._scan_fd
+    swapped = {"done": False}
+
+    def _swap(fd: int):
+        if not swapped["done"]:
+            swapped["done"] = True
+            os.replace(active_path, parked_path)
+            active_path.write_bytes(replacement_frame)
+        return original_scan(fd)
+
+    monkeypatch.setattr(spool, "_scan_fd", _swap)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "entry_replaced"
+    assert "inspection_error" in status.reasons
+    assert status.pending_units == 0
+    assert status.pending_frames == 0
+    assert status.pending_bytes == 0
+    assert active_path.read_bytes() == replacement_frame
+
+
+def test_collect_session_fallback_spool_status_active_file_stat_oserror_is_exception_safe(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    corrupt_frame = bytearray(spool._frame_bytes_for_record(_record("status-bad-tail")))
+    corrupt_frame[0] = 0x00
+    segment_path.write_bytes(bytes(corrupt_frame))
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == spool.SpoolTailStatus.BAD_MAGIC.value
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink security is POSIX-only")
+def test_collect_session_fallback_spool_status_segment_symlink_fails_closed(spool_home):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    target = spool_home / "symlink-target.spool"
+    target.write_bytes(spool._frame_bytes_for_record(_record("status-symlink-target")))
+    (sealed_dir / "00000000000000000001.spool").symlink_to(target)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "symlink_refused"
+
+
+def test_collect_session_fallback_spool_status_segment_nonregular_artifact_fails_closed(
+    spool_home,
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    (sealed_dir / "00000000000000000001.spool").mkdir()
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "unexpected_artifact"
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    [
+        "negative_acked_prefix",
+        "acked_prefix_gt_valid_prefix",
+        "prefix_name_none_with_nonzero_offsets",
+        "wrong_expected_prefix_name",
+        "wrong_expected_evidence_names",
+        "wrong_evidence_metadata",
+        "missing_prefix_artifact",
+        "nonregular_evidence_artifact",
+    ],
+)
+def test_collect_session_fallback_spool_status_invalid_blocker_relationships_fail_closed(
+    spool_home, case_name
+):
+    paths = _write_status_blocker_state(spool_home)
+    _mutate_status_blocker_case(paths, case_name)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "invalid_blocker_json"
+    assert "inspection_error" in status.reasons
+    assert status.blocker_present is False
+    assert status.blocker_sequence is None
+    assert status.blocker_offset is None
+    assert status.blocker_reason_class is None
+    assert status.blocker_source_kind is None
+
+
+def _publish_status_ack_tombstone(
+    *,
+    sequence: int,
+    unit_id: str,
+    attempt_index: int = 0,
+) -> tuple[Path, Path, bytes]:
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / f"{sequence:020d}.spool"
+        frame_bytes = spool._frame_bytes_for_record(
+            _record(unit_id, attempt_index=attempt_index)
+        )
+        segment_path.write_bytes(frame_bytes)
+        decoded = spool.decode_spool_segment(segment_path)
+        frame = decoded.prefix_frames[0]
+        spool._publish_ack_sidecar_strict(
+            runtime,
+            segment_sequence=sequence,
+            segment_path=segment_path,
+            ack_payload={
+                "schema_version": 1,
+                "segment_sequence": f"{sequence:020d}",
+                "segment_name": segment_path.name,
+                "segment_kind": "clean",
+                "segment_size_bytes": decoded.valid_prefix_bytes,
+                "acked_prefix_bytes": decoded.valid_prefix_bytes,
+                "valid_prefix_bytes": decoded.valid_prefix_bytes,
+                "tail_status": decoded.tail_status.value,
+                "last_frame_offset": frame.frame_offset,
+                "last_frame_length": frame.frame_length,
+                "last_frame_checksum_hex": frame.checksum_hex,
+            },
+        )
+        segment_path.unlink()
+    finally:
+        _close_runtime(runtime)
+    ack_path = next(spool._acks_dir().glob(f"{sequence:020d}.spool.ap*.json"))
+    return segment_path, ack_path, frame_bytes
+
+
+def test_collect_session_fallback_spool_status_preflight_beats_blocker_parse(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    blockers_dir = root / spool.SEALED_DIR_NAME / spool.BLOCKERS_DIR_NAME
+    blockers_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    for sequence in (1, 2):
+        (blockers_dir / f"{sequence:020d}.blocker.json").write_bytes(b"not-json\n")
+
+    parsed = {"count": 0}
+    real_load = spool._load_canonical_json_entry
+
+    def _counting_load(**kwargs):
+        parsed["count"] += 1
+        return real_load(**kwargs)
+
+    monkeypatch.setattr(spool, "STATUS_SCAN_ARTIFACT_LIMIT", 1)
+    monkeypatch.setattr(spool, "_load_canonical_json_entry", _counting_load)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "artifact_limit_exceeded"
+    assert parsed["count"] == 0
+
+
+def test_collect_session_fallback_spool_status_orphan_ack_tombstone_reports_ack_cleanup(
+    spool_home,
+):
+    _segment_path, ack_path, _frame_bytes = _publish_status_ack_tombstone(
+        sequence=1,
+        unit_id="ack-tombstone-cleanup",
+    )
+    now = time.time()
+    os.utime(ack_path, (now - 1200, now - 1200))
+
+    status = spool.collect_session_fallback_spool_status(now=now)
+
+    assert status.state == "degraded"
+    assert status.reasons == ("ack_pending",)
+    assert status.pending_units == 0
+    assert status.pending_frames == 0
+    assert status.pending_bytes == 0
+    assert status.ack_pending is True
+    assert status.oldest_pending_age_seconds == pytest.approx(1200.0, abs=1.0)
+    assert status.inspection_error_class is None
+
+
+def test_collect_session_fallback_spool_status_orphan_tombstone_keeps_fifo_age_over_later_segment(
+    spool_home,
+):
+    _segment_path, ack_path, _frame_bytes = _publish_status_ack_tombstone(
+        sequence=1,
+        unit_id="ack-tombstone-fifo",
+    )
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    lock_path.write_bytes(b"")
+    later_segment = sealed_dir / "00000000000000000002.spool"
+    later_bytes = spool._frame_bytes_for_record(
+        _record("later-clean-segment", attempt_index=1)
+    )
+    later_segment.write_bytes(later_bytes)
+    now = time.time()
+    os.utime(ack_path, (now - 1200, now - 1200))
+    os.utime(later_segment, (now - 10, now - 10))
+
+    status = spool.collect_session_fallback_spool_status(now=now)
+
+    assert status.ack_pending is True
+    assert status.pending_units == 1
+    assert status.pending_frames == 1
+    assert status.pending_bytes == len(later_bytes)
+    assert status.oldest_pending_age_seconds == pytest.approx(1200.0, abs=1.0)
+
+
+def test_collect_session_fallback_spool_status_orphan_ack_winner_beats_lower_partial_candidate(
+    spool_home,
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    acks_dir = sealed_dir / spool.ACKS_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    acks_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    first = spool._frame_bytes_for_record(_record("orphan-ack-a"))
+    second = spool._frame_bytes_for_record(_record("orphan-ack-b", attempt_index=1))
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    segment_path.write_bytes(first + second)
+    partial_name = f"{segment_path.name}.ap{len(first):020d}.json"
+    full_name = f"{segment_path.name}.ap{len(first + second):020d}.json"
+    (acks_dir / partial_name).write_bytes(
+        spool._canonical_json_bytes(
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=len(first),
+                valid_prefix_bytes=len(first + second),
+            )
+        )
+    )
+    (acks_dir / full_name).write_bytes(
+        spool._canonical_json_bytes(
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=len(first + second),
+                valid_prefix_bytes=len(first + second),
+            )
+        )
+    )
+    segment_path.unlink()
+    now = time.time()
+    os.utime(acks_dir / full_name, (now - 1200, now - 1200))
+
+    status = spool.collect_session_fallback_spool_status(now=now)
+
+    assert status.state == "degraded"
+    assert status.reasons == ("ack_pending",)
+    assert status.pending_units == 0
+    assert status.pending_frames == 0
+    assert status.pending_bytes == 0
+    assert status.ack_pending is True
+    assert status.inspection_error_class is None
+    assert status.oldest_pending_age_seconds == pytest.approx(1200.0, abs=1.0)
+
+
+def test_collect_session_fallback_spool_status_ack_open_race_is_exception_safe(
+    spool_home, monkeypatch
+):
+    root, _active_path, lock_path, _ = _paths(spool_home)
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_bytes(b"")
+    segment_path = sealed_dir / "00000000000000000001.spool"
+    frame_bytes = spool._frame_bytes_for_record(_record("ack-race"))
+    segment_path.write_bytes(frame_bytes)
+    _status_write_ack_sidecar(segment_path, acked_prefix_bytes=len(frame_bytes))
+
+    def _boom(**_kwargs):
+        raise FileNotFoundError("ack vanished")
+
+    monkeypatch.setattr(spool, "_load_ack_payload_from_fd", _boom)
+
+    status = spool.collect_session_fallback_spool_status(now=100.0)
+
+    assert status.state == "degraded"
+    assert status.inspection_error_class == "entry_replaced"
+    assert "inspection_error" in status.reasons

--- a/tests/test_session_fallback_spool.py
+++ b/tests/test_session_fallback_spool.py
@@ -610,6 +610,293 @@ def test_capacity_includes_quarantine_bytes_and_refuses_before_append(spool_home
     assert first.frame_length == len(before)
 
 
+def _capacity_artifact_payload(*, family: str) -> bytes:
+    if family in {"clean_sealed_spool", "prefix_sealed_spool"}:
+        return b"X" * 257
+    if family == "ack_json":
+        return json.dumps(
+            {
+                "acked_prefix_bytes": 5,
+                "last_frame_checksum_hex": "1" * 32,
+                "last_frame_length": 5,
+                "last_frame_offset": 0,
+                "schema_version": 1,
+                "segment_kind": "clean",
+                "segment_name": "00000000000000000001.spool",
+                "segment_sequence": "00000000000000000001",
+                "segment_size_bytes": 5,
+                "tail_status": "clean",
+                "valid_prefix_bytes": 5,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    if family == "blocker_json":
+        return json.dumps(
+            {
+                "acked_prefix_bytes": 0,
+                "blocking_offset": 0,
+                "evidence_sidecar_name": "seq-00000000000000000001-invalid_json-vp0.json",
+                "evidence_spool_name": "seq-00000000000000000001-invalid_json-vp0.spool",
+                "original_size_bytes": 5,
+                "prefix_segment_name": None,
+                "schema_version": 1,
+                "segment_sequence": "00000000000000000001",
+                "source_kind": "sealed",
+                "tail_status": "invalid_json",
+                "valid_prefix_bytes": 0,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    if family == "highwater_json":
+        return json.dumps(
+            {
+                "last_reserved_sequence": "00000000000000000001",
+                "schema_version": 1,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    if family in {"replay_quarantine_json", "legacy_quarantine_json"}:
+        return json.dumps(
+            {
+                "original_size": 5,
+                "quarantined_at": 1.0,
+                "sequence": 1,
+                "tail_status": "clean",
+                "valid_prefix_bytes": 0,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    if family in {"replay_quarantine_spool", "legacy_quarantine_spool"}:
+        return b"Q" * 257
+    raise AssertionError(f"unknown capacity artifact family: {family}")
+
+
+@pytest.mark.parametrize(
+    ("family", "artifact_parts"),
+    [
+        pytest.param(
+            "clean_sealed_spool",
+            (spool.SEALED_DIR_NAME, "00000000000000000001.spool"),
+            id="clean_sealed_spool",
+        ),
+        pytest.param(
+            "prefix_sealed_spool",
+            (spool.SEALED_DIR_NAME, "00000000000000000001.prefix.spool"),
+            id="prefix_sealed_spool",
+        ),
+        pytest.param(
+            "ack_json",
+            (
+                spool.SEALED_DIR_NAME,
+                spool.ACKS_DIR_NAME,
+                "00000000000000000001.spool.ap00000000000000000005.json",
+            ),
+            id="ack_json",
+        ),
+        pytest.param(
+            "blocker_json",
+            (
+                spool.SEALED_DIR_NAME,
+                spool.BLOCKERS_DIR_NAME,
+                "00000000000000000001.blocker.json",
+            ),
+            id="blocker_json",
+        ),
+        pytest.param(
+            "highwater_json",
+            (spool.HIGHWATER_FILE_NAME,),
+            id="highwater_json",
+        ),
+        pytest.param(
+            "replay_quarantine_spool",
+            (spool.QUARANTINE_DIR_NAME, "seq-00000000000000000001-clean-vp0.spool"),
+            id="replay_quarantine_spool",
+        ),
+        pytest.param(
+            "replay_quarantine_json",
+            (spool.QUARANTINE_DIR_NAME, "seq-00000000000000000001-clean-vp0.json"),
+            id="replay_quarantine_json",
+        ),
+        pytest.param(
+            "legacy_quarantine_spool",
+            (spool.QUARANTINE_DIR_NAME, "000001-clean-vp0.spool"),
+            id="legacy_quarantine_spool",
+        ),
+        pytest.param(
+            "legacy_quarantine_json",
+            (spool.QUARANTINE_DIR_NAME, "000001-clean-vp0.json"),
+            id="legacy_quarantine_json",
+        ),
+    ],
+)
+def test_capacity_artifact_family_is_counted(
+    spool_home,
+    monkeypatch,
+    family,
+    artifact_parts,
+):
+    root, active_path, _, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    active_path.write_bytes(b"")
+
+    artifact_path = root.joinpath(*artifact_parts)
+    artifact_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    artifact_bytes = _capacity_artifact_payload(family=family)
+    artifact_path.write_bytes(artifact_bytes)
+    if family in {"replay_quarantine_spool", "legacy_quarantine_spool"}:
+        artifact_path.with_suffix(".json").write_bytes(b"")
+
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(active_path, 0o600)
+        current = artifact_path.parent
+        while current != root:
+            os.chmod(current, 0o700)
+            current = current.parent
+        os.chmod(artifact_path, 0o600)
+        if family in {"replay_quarantine_spool", "legacy_quarantine_spool"}:
+            os.chmod(artifact_path.with_suffix(".json"), 0o600)
+
+    requested_frame = spool._frame_bytes_for_record(_record(f"unit-{family}"))
+    monkeypatch.setattr(
+        spool,
+        "TOTAL_CAP_BYTES",
+        len(artifact_bytes) + len(requested_frame) - 1,
+    )
+    before = active_path.read_bytes()
+
+    with pytest.raises(spool.SpoolCapacityError):
+        spool.append_records((_record(f"unit-{family}"),))
+
+    assert before == b""
+    assert active_path.read_bytes() == b""
+
+
+def test_capacity_inventory_excludes_lock_and_protocol_temp(spool_home, monkeypatch):
+    root, active_path, lock_path, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    active_path.write_bytes(b"")
+    lock_path.write_bytes(b"L" * 4096)
+    owner_lock_path = root / spool.REPLAY_OWNER_LOCK_NAME
+    owner_lock_path.write_bytes(b"O" * 4096)
+    protocol_temp = root / ".segment-sequence.highwater.json.123.456.tmp"
+    highwater_payload = json.dumps(
+        {
+            "last_reserved_sequence": "00000000000000000001",
+            "schema_version": 1,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    protocol_temp.write_bytes(highwater_payload + (b" " * 5000))
+
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(active_path, 0o600)
+        os.chmod(lock_path, 0o600)
+        os.chmod(owner_lock_path, 0o600)
+        os.chmod(protocol_temp, 0o600)
+
+    requested_frame = spool._frame_bytes_for_record(_record("unit-capacity-exclude"))
+    monkeypatch.setattr(spool, "TOTAL_CAP_BYTES", len(requested_frame))
+
+    result = spool.append_records((_record("unit-capacity-exclude"),))
+
+    assert len(result.unit_results) == 1
+    assert result.unit_results[0].receipt.offset == 0
+    assert result.unit_results[0].receipt.frame_length == len(requested_frame)
+    assert active_path.read_bytes() == requested_frame
+
+
+@pytest.mark.parametrize(
+    ("anomaly", "expected_exc", "match"),
+    [
+        pytest.param(
+            "sealed_symlink",
+            spool.SpoolPathSecurityError,
+            "symlinked fallback spool path refused",
+            id="sealed_symlink",
+        ),
+        pytest.param(
+            "sealed_fifo",
+            spool.SpoolPathSecurityError,
+            "not a regular file",
+            id="sealed_fifo",
+            marks=pytest.mark.skipif(os.name != "posix", reason="FIFO anomaly is POSIX-only"),
+        ),
+        pytest.param(
+            "sealed_unexpected_dir",
+            spool.SpoolPathSecurityError,
+            "unexpected fallback spool directory encountered during sequence inventory",
+            id="sealed_unexpected_dir",
+        ),
+        pytest.param(
+            "sealed_unrecognized_file",
+            spool.SpoolDurabilityError,
+            "unrecognized sealed segment artifact",
+            id="sealed_unrecognized_file",
+        ),
+        pytest.param(
+            "root_unrecognized_file",
+            spool.SpoolDurabilityError,
+            "unrecognized sequence-bearing artifact",
+            id="root_unrecognized_file",
+        ),
+    ],
+)
+def test_capacity_inventory_fails_closed(spool_home, anomaly, expected_exc, match):
+    root, active_path, _, _ = _paths(spool_home)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    active_path.write_bytes(b"")
+
+    sealed_dir = root / spool.SEALED_DIR_NAME
+    sealed_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    anomaly_path = (
+        root / "unexpected.bin"
+        if anomaly == "root_unrecognized_file"
+        else sealed_dir
+        / (
+            "unexpected"
+            if anomaly == "sealed_unexpected_dir"
+            else "unexpected.bin"
+            if anomaly == "sealed_unrecognized_file"
+            else "00000000000000000001.spool"
+        )
+    )
+
+    if anomaly == "sealed_symlink":
+        outside = spool_home / "outside-target.spool"
+        outside.write_bytes(b"outside")
+        anomaly_path.symlink_to(outside)
+    elif anomaly == "sealed_fifo":
+        os.mkfifo(anomaly_path)
+    elif anomaly == "sealed_unexpected_dir":
+        anomaly_path.mkdir(mode=0o700)
+    else:
+        anomaly_path.write_bytes(b"unexpected")
+
+    if os.name == "posix":
+        os.chmod(root, 0o700)
+        os.chmod(active_path, 0o600)
+        os.chmod(sealed_dir, 0o700)
+        if anomaly in {"sealed_unexpected_dir"}:
+            os.chmod(anomaly_path, 0o700)
+        elif anomaly not in {"sealed_symlink", "sealed_fifo"}:
+            os.chmod(anomaly_path, 0o600)
+
+    before = active_path.read_bytes()
+
+    with pytest.raises(expected_exc, match=match):
+        spool.append_records((_record(f"unit-{anomaly}"),))
+
+    assert before == b""
+    assert active_path.read_bytes() == b""
+
+
 _CORRUPT_TAIL_CASES = (
     (
         spool.SpoolTailStatus.INCOMPLETE_EOF,
@@ -726,3 +1013,584 @@ def test_multi_unit_partial_append_returns_durable_prefix_only(spool_home, monke
     scan = spool.scan_spool(active_path)
     assert scan.valid_prefix_bytes == err.durable_results[0].receipt.frame_length
     assert scan.tail_status is spool.SpoolTailStatus.INCOMPLETE_EOF
+
+
+def _close_runtime(runtime) -> None:
+    spool._close_fd_quietly(runtime.lock_fd)
+    spool._close_fd_quietly(runtime.root_fd)
+    spool._close_fd_quietly(runtime.home_fd)
+
+
+def test_replay_owner_lock_is_exclusive_and_supports_takeover_after_release(spool_home):
+    first_runtime = spool._open_locked_runtime()
+    second_runtime = spool._open_locked_runtime()
+    try:
+        owner = spool._try_acquire_replay_owner(first_runtime)
+        assert owner is not None
+        assert spool._try_acquire_replay_owner(second_runtime) is None
+
+        spool._close_fd_quietly(owner.fd)
+        takeover = spool._try_acquire_replay_owner(second_runtime)
+        assert takeover is not None
+        spool._close_fd_quietly(takeover.fd)
+    finally:
+        _close_runtime(second_runtime)
+        _close_runtime(first_runtime)
+
+
+def test_segment_sequence_highwater_never_reuses_reserved_values(spool_home):
+    runtime = spool._open_locked_runtime()
+    sealed_fd = -1
+    try:
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            sealed_fd, _ = spool._open_dir_at(
+                runtime.root_fd,
+                spool.SEALED_DIR_NAME,
+                full_path=spool._sealed_dir(),
+                mode=spool.ROOT_MODE,
+                create=True,
+                parent_label=runtime.root_path,
+                fsync_parent_on_open_existing=True,
+            )
+            first = spool._allocate_next_segment_sequence(
+                runtime=runtime,
+                root_fd=runtime.root_fd,
+            )
+            assert first == 1
+            (spool._sealed_dir() / f"{first:020d}.spool").write_bytes(b"reserved-gap")
+
+            second = spool._allocate_next_segment_sequence(
+                runtime=runtime,
+                root_fd=runtime.root_fd,
+            )
+            assert second == 2
+
+        highwater = json.loads(
+            spool._segment_sequence_highwater_path().read_text(encoding="utf-8")
+        )
+        assert highwater == {
+            "last_reserved_sequence": "00000000000000000002",
+            "schema_version": 1,
+        }
+    finally:
+        if sealed_fd >= 0:
+            spool._close_fd_quietly(sealed_fd)
+        _close_runtime(runtime)
+
+
+def test_decode_spool_segment_returns_full_record_and_frame_metadata(spool_home):
+    record = _record("unit-decode", contents=("hello", "world"))
+    frame = spool._frame_bytes_for_record(record)
+    segment_path = spool_home / "segment.spool"
+    segment_path.write_bytes(frame)
+
+    decoded = spool.decode_spool_segment(segment_path)
+
+    assert decoded.valid_prefix_bytes == len(frame)
+    assert decoded.tail_status is spool.SpoolTailStatus.CLEAN
+    assert decoded.tail_offset is None
+    assert len(decoded.prefix_frames) == 1
+
+    decoded_frame = decoded.prefix_frames[0]
+    assert decoded_frame.record == record
+    assert decoded_frame.frame_offset == 0
+    assert decoded_frame.frame_length == len(frame)
+    assert decoded_frame.payload_length == len(frame) - spool.HEADER_SIZE
+    assert decoded_frame.checksum_hex == frame[16:32].hex()
+
+
+def test_allocate_next_segment_sequence_reconstructs_from_all_artifact_families(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        root = spool._spool_root()
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        blockers_dir = spool._blockers_dir()
+        quarantine_dir = spool._quarantine_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        blockers_dir.mkdir(parents=True, exist_ok=True)
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+
+        (sealed_dir / "00000000000000000003.spool").write_bytes(b"clean")
+        (sealed_dir / "00000000000000000004.prefix.spool").write_bytes(b"prefix")
+        (acks_dir / "00000000000000000007.spool.ap00000000000000000099.json").write_text(
+            "{}",
+            encoding="utf-8",
+        )
+        (blockers_dir / "00000000000000000008.blocker.json").write_text("{}", encoding="utf-8")
+        (quarantine_dir / "seq-00000000000000000009-checksum_mismatch-vp10.spool").write_bytes(
+            b"evidence"
+        )
+        (quarantine_dir / "seq-00000000000000000010-invalid_json-vp0.json").write_text(
+            "{}",
+            encoding="utf-8",
+        )
+        (root / ".segment-sequence.highwater.json.123.456.tmp").write_text(
+            json.dumps(
+                {
+                    "last_reserved_sequence": "00000000000000000011",
+                    "schema_version": 1,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        spool._segment_sequence_highwater_path().write_text(
+            json.dumps(
+                {
+                    "last_reserved_sequence": "00000000000000000002",
+                    "schema_version": 1,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            next_sequence = spool._allocate_next_segment_sequence(
+                runtime=runtime,
+                root_fd=runtime.root_fd,
+            )
+
+        assert next_sequence == 12
+    finally:
+        _close_runtime(runtime)
+
+
+def test_malformed_sequence_bearing_name_blocks_replay(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        (sealed_dir / "not-a-sequence.spool").write_bytes(b"bad")
+
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            with pytest.raises(spool.SpoolDurabilityError, match="unrecognized sealed segment artifact"):
+                spool._allocate_next_segment_sequence(
+                    runtime=runtime,
+                    root_fd=runtime.root_fd,
+                )
+    finally:
+        _close_runtime(runtime)
+
+
+def test_malformed_sequence_bearing_protocol_temp_blocks_replay(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        root = spool._spool_root()
+        root.mkdir(parents=True, exist_ok=True)
+        (root / ".mystery-sequence-00000000000000000012.123.456.tmp").write_text(
+            "bad-temp",
+            encoding="utf-8",
+        )
+
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            with pytest.raises(spool.SpoolDurabilityError, match="unrecognized protocol temp artifact"):
+                spool._allocate_next_segment_sequence(
+                    runtime=runtime,
+                    root_fd=runtime.root_fd,
+                )
+    finally:
+        _close_runtime(runtime)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="directory-swap security checks are POSIX-only")
+@pytest.mark.parametrize(
+    ("target", "target_parts"),
+    [
+        ("root_swap", ()),
+        ("sealed_swap", (spool.SEALED_DIR_NAME,)),
+        ("acks_swap", (spool.SEALED_DIR_NAME, spool.ACKS_DIR_NAME)),
+        ("blockers_swap", (spool.SEALED_DIR_NAME, spool.BLOCKERS_DIR_NAME)),
+        ("quarantine_swap", (spool.QUARANTINE_DIR_NAME,)),
+    ],
+)
+def test_replay_security_checks_reject_root_swap_for_sealed_acks_blockers_and_quarantine(
+    spool_home,
+    target,
+    target_parts,
+):
+    runtime = spool._open_locked_runtime()
+    try:
+        root = spool._spool_root()
+        sealed = spool._sealed_dir()
+        acks = spool._acks_dir()
+        blockers = spool._blockers_dir()
+        quarantine = spool._quarantine_dir()
+        sealed.mkdir(parents=True, exist_ok=True)
+        acks.mkdir(parents=True, exist_ok=True)
+        blockers.mkdir(parents=True, exist_ok=True)
+        quarantine.mkdir(parents=True, exist_ok=True)
+
+        external = spool_home / f"{target}-external"
+        external.mkdir()
+        target_path = root.joinpath(*target_parts) if target_parts else root
+        parked = target_path.with_name(target_path.name + ".real")
+        os.replace(target_path, parked)
+        os.symlink(external, target_path, target_is_directory=True)
+
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            with pytest.raises(spool.SpoolPathSecurityError):
+                spool._allocate_next_segment_sequence(
+                    runtime=runtime,
+                    root_fd=runtime.root_fd,
+                )
+
+        assert not (external / spool.HIGHWATER_FILE_NAME).exists()
+    finally:
+        _close_runtime(runtime)
+
+
+def test_inventory_fd_repeated_exceptions_return_to_baseline(spool_home):
+    baseline = _fd_count()
+    root = spool._spool_root()
+    root.mkdir(parents=True, exist_ok=True)
+    for attempt in range(10):
+        runtime = spool._open_locked_runtime()
+        temp_path = root / f".mystery-sequence-0000000000000000{attempt:04d}.123.456.tmp"
+        temp_path.write_text("bad-temp", encoding="utf-8")
+        try:
+            with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+                with pytest.raises(spool.SpoolDurabilityError, match="unrecognized protocol temp artifact"):
+                    spool._allocate_next_segment_sequence(
+                        runtime=runtime,
+                        root_fd=runtime.root_fd,
+                    )
+        finally:
+            _close_runtime(runtime)
+            temp_path.unlink(missing_ok=True)
+    assert _fd_count() == baseline
+
+
+def _ack_payload(*, segment_sequence: int, segment_name: str, acked_prefix_bytes: int, valid_prefix_bytes: int, tail_status: str = "clean", segment_kind: str = "clean"):
+    return {
+        "schema_version": 1,
+        "segment_sequence": f"{segment_sequence:020d}",
+        "segment_name": segment_name,
+        "segment_kind": segment_kind,
+        "segment_size_bytes": valid_prefix_bytes,
+        "acked_prefix_bytes": acked_prefix_bytes,
+        "valid_prefix_bytes": valid_prefix_bytes,
+        "tail_status": tail_status,
+        "last_frame_offset": 0,
+        "last_frame_length": acked_prefix_bytes,
+        "last_frame_checksum_hex": "1" * 32,
+    }
+
+
+def test_publish_ack_same_prefix_same_content_is_idempotent_success(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(b"alpha")
+        payload = _ack_payload(
+            segment_sequence=1,
+            segment_name=segment_path.name,
+            acked_prefix_bytes=5,
+            valid_prefix_bytes=5,
+        )
+
+        spool._publish_ack_sidecar_strict(
+            runtime,
+            segment_sequence=1,
+            segment_path=segment_path,
+            ack_payload=payload,
+        )
+        spool._publish_ack_sidecar_strict(
+            runtime,
+            segment_sequence=1,
+            segment_path=segment_path,
+            ack_payload=payload,
+        )
+
+        assert sorted(acks_dir.glob("*.json")) == [acks_dir / "00000000000000000001.spool.ap00000000000000000005.json"]
+    finally:
+        _close_runtime(runtime)
+
+
+def test_publish_ack_same_prefix_different_content_blocks_integrity(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(b"alpha")
+        spool._write_sidecar_json(
+            acks_dir / "00000000000000000001.spool.ap00000000000000000005.json",
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=5,
+                valid_prefix_bytes=5,
+            ),
+        )
+
+        with pytest.raises(spool.SpoolDurabilityError, match="conflicting ack sidecar"):
+            spool._publish_ack_sidecar_strict(
+                runtime,
+                segment_sequence=1,
+                segment_path=segment_path,
+                ack_payload=_ack_payload(
+                    segment_sequence=1,
+                    segment_name=segment_path.name,
+                    acked_prefix_bytes=5,
+                    valid_prefix_bytes=5,
+                    tail_status="checksum_mismatch",
+                ),
+            )
+    finally:
+        _close_runtime(runtime)
+
+
+def test_malformed_or_oversized_ack_sidecar_blocks_integrity(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(b"alpha")
+        malformed = acks_dir / "00000000000000000001.spool.ap00000000000000000005.json"
+        malformed.write_text("{}", encoding="utf-8")
+
+        with pytest.raises(spool.SpoolDurabilityError, match="invalid ack sidecar"):
+            spool._load_ack_sidecar_winner(runtime=runtime, segment_path=segment_path)
+
+        malformed.unlink()
+        oversized = acks_dir / "00000000000000000001.spool.ap00000000000000000005.json"
+        oversized.write_text("x" * 3000, encoding="utf-8")
+        with pytest.raises(spool.SpoolDurabilityError, match="invalid ack sidecar"):
+            spool._load_ack_sidecar_winner(runtime=runtime, segment_path=segment_path)
+    finally:
+        _close_runtime(runtime)
+
+
+def test_highest_valid_ack_winner_ignores_lower_or_mismatched_sidecars(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(b"alpha")
+        spool._write_sidecar_json(
+            acks_dir / "00000000000000000001.spool.ap00000000000000000003.json",
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=3,
+                valid_prefix_bytes=5,
+            ),
+        )
+        spool._write_sidecar_json(
+            acks_dir / "00000000000000000001.spool.ap00000000000000000005.json",
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=5,
+                valid_prefix_bytes=5,
+            ),
+        )
+        spool._write_sidecar_json(
+            acks_dir / "00000000000000000009.spool.ap00000000000000000099.json",
+            _ack_payload(
+                segment_sequence=9,
+                segment_name="00000000000000000009.spool",
+                acked_prefix_bytes=99,
+                valid_prefix_bytes=99,
+            ),
+        )
+
+        winner = spool._load_ack_sidecar_winner(runtime=runtime, segment_path=segment_path)
+
+        assert winner is not None
+        assert winner["acked_prefix_bytes"] == 5
+    finally:
+        _close_runtime(runtime)
+
+
+def test_ack_sidecar_count_above_64_blocks_integrity(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(b"a" * 65)
+        for idx in range(1, 66):
+            spool._write_sidecar_json(
+                acks_dir / f"00000000000000000001.spool.ap{idx:020d}.json",
+                _ack_payload(
+                    segment_sequence=1,
+                    segment_name=segment_path.name,
+                    acked_prefix_bytes=idx,
+                    valid_prefix_bytes=65,
+                ),
+            )
+
+        with pytest.raises(spool.SpoolDurabilityError, match="too many ack sidecars"):
+            spool._load_ack_sidecar_winner(runtime=runtime, segment_path=segment_path)
+    finally:
+        _close_runtime(runtime)
+
+
+def test_replay_to_session_db_uses_strict_ack_publication(spool_home, monkeypatch):
+    calls = []
+
+    def _strict(runtime, *, segment_sequence, segment_path, ack_payload):
+        calls.append(
+            {
+                "runtime": runtime,
+                "segment_sequence": segment_sequence,
+                "segment_path": segment_path,
+                "ack_payload": ack_payload,
+            }
+        )
+
+    monkeypatch.setattr(spool, "_publish_ack_sidecar_strict", _strict)
+    monkeypatch.setattr(spool, "_delete_fully_acked_segment", lambda *_args, **_kwargs: None)
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=spool_home / "state.db")
+    try:
+        monkeypatch.setenv("HERMES_HOME", str(spool_home / ".hermes"))
+        hermes_home = spool_home / ".hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        sealed_dir = hermes_home / spool.SPOOL_ROOT_NAME / spool.SEALED_DIR_NAME
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(spool._frame_bytes_for_record(_record()))
+
+        result = spool.replay_to_session_db(db, trigger="startup")
+
+        assert result.state is spool.ReplayRunState.REPLAYED
+        assert len(calls) == 1
+        assert calls[0]["segment_sequence"] == 1
+        assert calls[0]["segment_path"].name == "00000000000000000001.spool"
+    finally:
+        db.close()
+
+
+def test_stale_lower_ack_sidecars_cleanup_only_after_durable_higher_winner(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        sealed_dir = spool._sealed_dir()
+        acks_dir = spool._acks_dir()
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        acks_dir.mkdir(parents=True, exist_ok=True)
+        segment_path = sealed_dir / "00000000000000000001.spool"
+        segment_path.write_bytes(b"alpha")
+        spool._write_sidecar_json(
+            acks_dir / "00000000000000000001.spool.ap00000000000000000003.json",
+            _ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=3,
+                valid_prefix_bytes=5,
+            ),
+        )
+
+        spool._publish_ack_sidecar_strict(
+            runtime,
+            segment_sequence=1,
+            segment_path=segment_path,
+            ack_payload=_ack_payload(
+                segment_sequence=1,
+                segment_name=segment_path.name,
+                acked_prefix_bytes=5,
+                valid_prefix_bytes=5,
+            ),
+        )
+
+        assert sorted(path.name for path in acks_dir.glob("*.json")) == [
+            "00000000000000000001.spool.ap00000000000000000005.json"
+        ]
+    finally:
+        _close_runtime(runtime)
+
+
+def test_corrupt_active_with_valid_prefix_publishes_prefix_evidence_and_blocker(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        root = spool._spool_root()
+        sealed_dir = spool._sealed_dir()
+        blockers_dir = spool._blockers_dir()
+        quarantine_dir = spool._quarantine_dir()
+        root.mkdir(parents=True, exist_ok=True)
+        sealed_dir.mkdir(parents=True, exist_ok=True)
+        blockers_dir.mkdir(parents=True, exist_ok=True)
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+
+        clean_frame = spool._frame_bytes_for_record(_record("unit-clean"))
+        corrupt_frame = bytearray(spool._frame_bytes_for_record(_record("unit-bad", attempt_index=1)))
+        corrupt_frame[-1] ^= 0x01
+        active_path = root / spool.ACTIVE_SPOOL_NAME
+        active_path.write_bytes(clean_frame + bytes(corrupt_frame))
+
+        runtime = spool._open_locked_runtime()
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            result = spool._reconcile_active_spool_for_replay(runtime)
+
+        assert result["tail_status"] is spool.SpoolTailStatus.CHECKSUM_MISMATCH
+        assert result["valid_prefix_bytes"] == len(clean_frame)
+        assert result["segment_sequence"] == 1
+        assert result["prefix_segment_name"] == "00000000000000000001.prefix.spool"
+        assert (sealed_dir / "00000000000000000001.prefix.spool").read_bytes() == clean_frame
+        evidence_spools = sorted(quarantine_dir.glob("seq-00000000000000000001-*.spool"))
+        assert len(evidence_spools) == 1
+        assert evidence_spools[0].read_bytes() == clean_frame + bytes(corrupt_frame)
+        blocker = json.loads((blockers_dir / "00000000000000000001.blocker.json").read_text(encoding="utf-8"))
+        assert blocker["prefix_segment_name"] == "00000000000000000001.prefix.spool"
+        assert blocker["blocking_offset"] == len(clean_frame)
+        assert active_path.exists()
+        assert active_path.read_bytes() == b""
+    finally:
+        _close_runtime(runtime)
+
+
+def test_corrupt_active_with_zero_prefix_publishes_evidence_and_blocker(spool_home):
+    runtime = spool._open_locked_runtime()
+    try:
+        root = spool._spool_root()
+        blockers_dir = spool._blockers_dir()
+        quarantine_dir = spool._quarantine_dir()
+        root.mkdir(parents=True, exist_ok=True)
+        blockers_dir.mkdir(parents=True, exist_ok=True)
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+
+        corrupt_frame = bytearray(spool._frame_bytes_for_record(_record("unit-bad")))
+        corrupt_frame[0] = 0x00
+        active_path = root / spool.ACTIVE_SPOOL_NAME
+        active_path.write_bytes(bytes(corrupt_frame))
+
+        runtime = spool._open_locked_runtime()
+        with spool._append_lock(runtime.lock_fd, str(spool._lock_path())):
+            result = spool._reconcile_active_spool_for_replay(runtime)
+
+        assert result["tail_status"] is spool.SpoolTailStatus.BAD_MAGIC
+        assert result["valid_prefix_bytes"] == 0
+        assert result["segment_sequence"] == 1
+        assert result["prefix_segment_name"] is None
+        evidence_spools = sorted(quarantine_dir.glob("seq-00000000000000000001-*.spool"))
+        assert len(evidence_spools) == 1
+        assert evidence_spools[0].read_bytes() == bytes(corrupt_frame)
+        blocker = json.loads((blockers_dir / "00000000000000000001.blocker.json").read_text(encoding="utf-8"))
+        assert blocker["prefix_segment_name"] is None
+        assert blocker["blocking_offset"] == 0
+        assert active_path.exists()
+        assert active_path.read_bytes() == b""
+    finally:
+        _close_runtime(runtime)


### PR DESCRIPTION
## What does this PR do?

Implements the lossless persistence fallback proposed in #74619.

When canonical `SessionDB` persistence cannot durably accept a completed turn, Hermes now has a second fail-closed durability boundary: a restrictive per-profile append-only spool with checksummed framing, explicit acknowledgement state, bounded capacity checks, and idempotent ordered replay into SQLite.

A turn may continue only when it is either canonically committed or durably spooled. If neither succeeds, existing fail-closed behavior is preserved.

## Related Issue

Fixes #74619

Related: #74284, #57921, #73411, #54189, #23717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add typed, idempotent canonical persistence units and transactional replay/backfill in `hermes_state.py`.
- Add `session_fallback_spool.py` with:
  - append-only framed/checksummed records;
  - restrictive local permissions and fsync boundaries;
  - cross-process append and replay ownership locks;
  - bounded capacity/disk preflight;
  - deterministic per-session replay and duplicate-safe acknowledgement publication;
  - crash-safe active/sealed recovery, corrupt-tail evidence, and explicit quarantine/blocker handling;
  - fail-closed exact/lower-bound/unknown backlog telemetry.
- Integrate canonical/spooled/not-durable outcomes into `run_agent.py` without clearing the only recoverable in-flight evidence.
- Add read-only fallback-spool visibility to `hermes status`.
- Make `hermes doctor` report degraded or uninspectable spool state as manual intervention rather than a false `All checks passed!` result.
- Preserve upstream session-recency/compression behavior and the historical batch-row mapping seam while reconciling the durability stack with current `main`.

## How to Test

1. Run the affected hermetic suite:

   ```bash
   PYTHONDONTWRITEBYTECODE=1 scripts/run_tests.sh \
     tests/test_session_fallback_spool.py \
     tests/state/test_session_spool_replay.py \
     tests/run_agent/test_run_agent.py \
     tests/cli/test_cli_shutdown_memory_messages.py \
     tests/hermes_cli/test_status.py \
     tests/hermes_cli/test_status_model_provider.py \
     tests/hermes_cli/test_doctor.py \
     tests/test_hermes_state.py -q
   ```

   Original implementation result: `700 passed, 0 failed`.

   Exact current-main merge result: `667 passed, 0 failed` across 11 affected feature/integration files; the two previously observed baseline TUI threading-race selectors also passed (`2 passed, 0 failed`) in focused execution.

2. Compile and lint the changed files. Current submitted tree: Ruff blocking check `All checks passed!`; `git diff --check` clean.
3. Exercise fault cases covered by the tests: SQLite lock/failure, spool append failure, process interruption, duplicate replay, partial/corrupt tails, acknowledgement publication failure, disk/capacity pressure, active-file replacement races, replay-owner contention, cooldown shortcuts, and degraded doctor output.

## Verification Summary

Submitted head: `e038c197294f0f01bb25ab1588144cad597be4c3`

- Original implementation head: `146eaa022646f458b19b344dd682efc6e12af105`
- Attribution commit `0065053ed` adds the repository-required `stefan@noble-pro.com -> stefanpieter` mapping
- Compatibility remediation `00496d92a` restores current-main flush seams, retry-marker behavior, and mapping compatibility exposed by the CI mirror
- Fail-closed follow-up `04ad5637f` requires an explicit durable result from instance-level persistence overrides
- Mapping follow-up `4b5c3db24` preserves the legacy batch-row timestamp interface without changing typed DB insertion
- Mutation follow-up `c180e1299` fingerprints frozen units, rekeys changed non-spooled failures, and rejects changed spooled units before replay
- Direct-flush follow-up `fe12ca3c3` applies the same pre-replay mutation gate to direct persistence entry points
- Membership follow-up `e038c1972` freezes unit order/cardinality so partial row removal also fails closed before replay

- Feature base: `f5be9236e00ddf2f2a412697f267078fc4ee068e`; clean merge-tree verified against current upstream main snapshot `6564f319a647b47de391cab2f608660323804a2b`
- Twelve commits; exactly 15 changed files (implementation/tests plus contributor mapping)
- Exact submitted patch SHA-256: `b995d4cdd2d451bc30cc9b793ab3357c2fbccc32fdf31f410d4074c6dff83ee9`
- Compatibility-remediation patch SHA-256: `4e572d70022d4e537fc807418b6caca39ec90a9a21052a40085cdb085807cf27`
- 14 deterministic replay/status/doctor probes passed
- Two fresh independent exact-candidate reviewers passed submitted head `e038c197294f0f01bb25ab1588144cad597be4c3` against base `6564f319a647b47de391cab2f608660323804a2b`; no blockers remained
- Worktree/index clean; no untracked candidate files

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the complete repository suite was not run; the original 700-test feature suite passed, and the exact current-main remediation run passed 667 affected tests plus both focused TUI race selectors
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; behavior is covered by CLI output and code/test contracts
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; contributor workflow unchanged
- [x] I've considered cross-platform impact; platform-specific locking/fsync behavior is guarded and tested where supported
- [x] I've updated tool descriptions/schemas — N/A; no tool schema changed

## Screenshots / Logs

No UI screenshots are applicable. All spool/log diagnostics are metadata-only and tests assert that paths, transcript text, persistence keys, and raw exception context are not emitted.
