### PR TITLE
fix(anthropic): honor custom CA bundles and ssl_verify on the Anthropic client

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -694,6 +694,59 @@ def _common_betas_for_base_url(
     return betas
 
 
+def _build_tls_http_client(
+    *,
+    ssl_ca_cert=None,
+    ssl_verify=None,
+    base_url: str = "",
+    read_timeout: float = 900.0,
+):
+    """Return an ``httpx.Client`` carrying the resolved TLS verify, or ``None``.
+
+    The Anthropic SDK builds its own httpx client with httpx's default
+    ``verify=True``, which pins certifi's bundle and therefore ignores
+    ``HERMES_CA_BUNDLE`` / ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` /
+    ``CURL_CA_BUNDLE`` and the per-provider ``ssl_ca_cert`` / ``ssl_verify``
+    config. ``agent.ssl_verify.resolve_httpx_verify`` exists precisely because
+    those settings must be passed explicitly — ``create_openai_client`` and the
+    auxiliary clients already route through it, the Anthropic path never did.
+    Behind a corporate TLS-inspecting proxy every OpenAI-wire provider worked
+    while Anthropic-native failed verification with no way to configure it.
+
+    Returns ``None`` when verification resolves to the default (``True``) so the
+    SDK keeps building its own client exactly as before — no new transport, no
+    behaviour change, for the overwhelming majority of installs.
+    """
+    verify = None
+    try:
+        from agent.ssl_verify import resolve_httpx_verify
+
+        verify = resolve_httpx_verify(
+            ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify, base_url=base_url or "",
+        )
+    except Exception:
+        logger.debug("TLS verify resolution failed; using SDK defaults", exc_info=True)
+        return None
+
+    if verify is True:
+        return None
+
+    try:
+        import httpx
+
+        return httpx.Client(
+            verify=verify,
+            timeout=httpx.Timeout(timeout=float(read_timeout), connect=10.0),
+        )
+    except Exception:
+        logger.warning(
+            "Could not build a TLS-configured HTTP client for the Anthropic "
+            "endpoint; falling back to SDK defaults (custom CA bundle / "
+            "ssl_verify will NOT apply)", exc_info=True,
+        )
+        return None
+
+
 def _build_anthropic_client_with_bearer_hook(
     token_provider,
     base_url: str = None,
@@ -780,6 +833,8 @@ def build_anthropic_client(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    ssl_ca_cert=None,
+    ssl_verify=None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -822,6 +877,9 @@ def build_anthropic_client(
             api_key, base_url, timeout,
             drop_context_1m_beta=drop_context_1m_beta,
         )
+    # Resolved before the auth branches below so every one of them — API key,
+    # OAuth, Kimi /coding, bearer-auth and third-party proxies — gets the same
+    # TLS treatment.
 
     normalize_proxy_env_vars()
 
@@ -832,6 +890,12 @@ def build_anthropic_client(
         import re as _re
         normalized_base_url = _re.sub(r"/v1/?$", "", normalized_base_url.rstrip("/"))
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    _tls_http_client = _build_tls_http_client(
+        ssl_ca_cert=ssl_ca_cert,
+        ssl_verify=ssl_verify,
+        base_url=normalized_base_url,
+        read_timeout=_read_timeout,
+    )
     kwargs = {
         "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),
         # Delegate all rate-limit / 5xx retry to hermes's outer conversation
@@ -899,6 +963,9 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    if _tls_http_client is not None:
+        kwargs["http_client"] = _tls_http_client
 
     client = _anthropic_sdk.Anthropic(**kwargs)
     # Bearer-only construction leaves ``api_key`` unset, so the SDK fills it

--- a/tests/agent/test_anthropic_client_tls_verify.py
+++ b/tests/agent/test_anthropic_client_tls_verify.py
@@ -1,0 +1,125 @@
+"""The Anthropic client must honour Hermes' TLS verify resolution.
+
+``agent.ssl_verify.resolve_httpx_verify`` exists because httpx pins certifi's
+bundle and will not pick up ``HERMES_CA_BUNDLE`` / ``SSL_CERT_FILE`` /
+``REQUESTS_CA_BUNDLE`` / ``CURL_CA_BUNDLE`` or the per-provider
+``ssl_ca_cert`` / ``ssl_verify`` config on its own — the settings have to be
+passed explicitly. ``create_openai_client`` and the auxiliary clients already
+route through it; ``build_anthropic_client`` never did, so it always used
+certifi and there was no way to configure it.
+
+Asserts the observable contract: the CA certificates the constructed client
+would actually trust. No network.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import ssl
+
+import certifi
+import pytest
+
+from agent.anthropic_adapter import build_anthropic_client
+from agent.ssl_verify import resolve_httpx_verify
+
+_CA_ENV_VARS = (
+    "HERMES_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ca_env(monkeypatch):
+    for name in _CA_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def tiny_ca(tmp_path):
+    """A one-certificate CA bundle — the count makes the assertion unambiguous."""
+    first = pathlib.Path(certifi.where()).read_text(encoding="utf-8").split(
+        "-----END CERTIFICATE-----"
+    )[0]
+    path = tmp_path / "corp-ca.pem"
+    path.write_text(first + "-----END CERTIFICATE-----\n", encoding="utf-8")
+    return path
+
+
+def _ssl_context(client):
+    """The SSL context the built client's transport would actually use."""
+    return client._client._transport._pool._ssl_context
+
+
+def _trusted_count(client) -> int:
+    return len(_ssl_context(client).get_ca_certs())
+
+
+class TestCaBundleIsHonoured:
+    @pytest.mark.parametrize("env_var", _CA_ENV_VARS)
+    def test_every_documented_ca_env_var_reaches_the_client(
+        self, tiny_ca, env_var, monkeypatch
+    ):
+        monkeypatch.setenv(env_var, str(tiny_ca))
+        client = build_anthropic_client("sk-ant-test", base_url="https://api.anthropic.com")
+        assert _trusted_count(client) == 1
+
+    def test_per_provider_ssl_ca_cert_reaches_the_client(self, tiny_ca):
+        client = build_anthropic_client(
+            "sk-ant-test", base_url="https://proxy.example", ssl_ca_cert=str(tiny_ca)
+        )
+        assert _trusted_count(client) == 1
+
+    def test_matches_what_the_shared_resolver_returns(self, tiny_ca, monkeypatch):
+        """Same answer as the OpenAI path gets — that is the whole point."""
+        monkeypatch.setenv("HERMES_CA_BUNDLE", str(tiny_ca))
+        expected = resolve_httpx_verify()
+        assert isinstance(expected, ssl.SSLContext)
+        client = build_anthropic_client("sk-ant-test", base_url="https://api.anthropic.com")
+        assert _trusted_count(client) == len(expected.get_ca_certs())
+
+    def test_oauth_token_path_is_covered_too(self, tiny_ca, monkeypatch):
+        """OAuth/Bearer auth takes a different kwargs branch; TLS must still apply."""
+        monkeypatch.setenv("HERMES_CA_BUNDLE", str(tiny_ca))
+        client = build_anthropic_client(
+            "sk-ant-oat01-testtoken", base_url="https://api.anthropic.com"
+        )
+        assert _trusted_count(client) == 1
+
+
+class TestSslVerifyFalse:
+    def test_verification_can_be_disabled(self):
+        client = build_anthropic_client(
+            "sk-ant-test", base_url="https://local.example", ssl_verify=False
+        )
+        assert _ssl_context(client).verify_mode == ssl.CERT_NONE
+
+    def test_string_false_is_accepted(self):
+        client = build_anthropic_client(
+            "sk-ant-test", base_url="https://local.example", ssl_verify="false"
+        )
+        assert _ssl_context(client).verify_mode == ssl.CERT_NONE
+
+
+class TestDefaultPathUnchanged:
+    def test_no_tls_config_keeps_the_sdk_default_bundle(self):
+        client = build_anthropic_client("sk-ant-test", base_url="https://api.anthropic.com")
+        assert _trusted_count(client) > 1        # certifi's full bundle
+        assert _ssl_context(client).verify_mode == ssl.CERT_REQUIRED
+
+    def test_missing_ca_file_falls_back_to_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_CA_BUNDLE", str(tmp_path / "nope.pem"))
+        client = build_anthropic_client("sk-ant-test", base_url="https://api.anthropic.com")
+        assert _trusted_count(client) > 1
+        assert _ssl_context(client).verify_mode == ssl.CERT_REQUIRED
+
+    def test_client_still_builds_and_keeps_its_settings(self, tiny_ca, monkeypatch):
+        monkeypatch.setenv("HERMES_CA_BUNDLE", str(tiny_ca))
+        client = build_anthropic_client(
+            "sk-ant-test", base_url="https://api.anthropic.com", timeout=42.0
+        )
+        assert client.max_retries == 0
+        assert client.timeout.read == 42.0
+        assert client.timeout.connect == 10.0


### PR DESCRIPTION
## What does this PR do?

`agent/ssl_verify.resolve_httpx_verify` exists because httpx pins certifi's
bundle and will **not** pick up `HERMES_CA_BUNDLE`, `SSL_CERT_FILE`,
`REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE` or the per-provider `ssl_ca_cert` /
`ssl_verify` config on its own — those have to be passed explicitly.

`create_openai_client` routes through it. The auxiliary clients route through
it. `build_anthropic_client` never did, so it always used certifi and there was
no setting that could change it.

Behind a TLS-inspecting corporate proxy that means **every OpenAI-wire provider
works while Anthropic-native fails certificate verification**, with nothing the
user can configure to fix it. `ssl_verify: false` is ignored on this path too,
so a self-signed Anthropic-compatible endpoint stays unreachable even when the
user explicitly opts out of verification.

### Where the gap came from

| commit | date | what it did |
|---|---|---|
| 7e957cbd0 | 2026-07-01 | *feat(agent): add resolve_httpx_verify for custom CA bundle TLS* — created the shared resolver |
| 676236bb1 | 2026-07-02 | *fix(agent): honor custom CA certs on aux client + harden TLS resolution* — adopted it for the auxiliary clients |
| 9fa2906c1 | 2026-07-22 | named the remaining hole and left it: *"C1 (anthropic path TLS re-application): **pre-existing gap** — the Anthropic adapter (build_anthropic_client) has **no TLS customization support at all**, so this is out of scope for this salvage."* |

The Anthropic path was the one consumer that never adopted the resolver. This is
also the failure mode `docs/rca-ssl-cacert-post-git-pull.md` documents —
"opaque provider/client failures until the user repairs deps or CA
configuration".

### Reproduction on main

Point `HERMES_CA_BUNDLE` at a bundle containing exactly one certificate, then
compare what the shared resolver returns against what the built client actually
trusts:

```text
resolve_httpx_verify()      ->  SSLContext,   1 trusted cert
anthropic client ssl ctx    ->  SSLContext, 119 trusted certs   <- bundle ignored
```

No network needed — the constructed client's transport already carries the SSL
context it would use.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/anthropic_adapter.py`** — new `_build_tls_http_client()` resolves TLS
  through the shared `resolve_httpx_verify` and returns an `httpx.Client`
  carrying it.
- **`agent/anthropic_adapter.py`** — `build_anthropic_client()` resolves once,
  **before** the auth branches, so API-key, OAuth, Kimi `/coding`, bearer-auth
  and third-party-proxy endpoints all get the same treatment rather than only
  whichever branch happened to be patched.
- **`agent/anthropic_adapter.py`** — optional `ssl_ca_cert` / `ssl_verify`
  keyword arguments, matching the fields `hermes_cli/config.py` already accepts
  for custom providers.
- **`tests/agent/test_anthropic_client_tls_verify.py`** — 12 tests.

### Two deliberate choices

1. **No custom client when verification resolves to the default.**
   `_build_tls_http_client` returns `None` for the plain `verify=True` case, so
   the SDK keeps building its own client exactly as before — no new transport,
   no behaviour change, for installs with no TLS configuration. Only a
   non-default verify attaches an `http_client`.
2. **Env-var resolution needs no call-site changes.** There are 18 call sites of
   `build_anthropic_client`; resolving inside the builder fixes the CA-bundle
   env vars for all of them at once. The per-provider `ssl_ca_cert` /
   `ssl_verify` config fields now have a parameter to flow into, but threading
   them from each call site is left out of this change — it is a separate,
   wider plumbing edit and the env vars are the case users actually hit.

## How to Test

```python
import os, pathlib, certifi
from agent.ssl_verify import resolve_httpx_verify
from agent.anthropic_adapter import build_anthropic_client

# a one-certificate bundle, so the count is unambiguous
first = pathlib.Path(certifi.where()).read_text().split("-----END CERTIFICATE-----")[0]
pathlib.Path("corp-ca.pem").write_text(first + "-----END CERTIFICATE-----\n")
os.environ["HERMES_CA_BUNDLE"] = "corp-ca.pem"

c = build_anthropic_client("sk-ant-test", base_url="https://api.anthropic.com")
ctx = c._client._transport._pool._ssl_context
print(len(ctx.get_ca_certs()), len(resolve_httpx_verify().get_ca_certs()))
```

**Before:** `119 1` — the client ignores the bundle.
**After:** `1 1` — the client trusts what Hermes resolved.

Then unset the variable and confirm the count returns to certifi's full bundle,
i.e. the default path is untouched.

## Test Results

New file `tests/agent/test_anthropic_client_tls_verify.py` — 12 tests. They
assert the observable contract, the CA certificates the constructed client would
actually trust:

| Group | Covers |
|---|---|
| `TestCaBundleIsHonoured` | all four documented CA env vars reach the client (parametrised); the per-provider `ssl_ca_cert` argument; the result matches what the shared resolver returns, i.e. the same answer the OpenAI path gets; the OAuth/Bearer branch is covered too |
| `TestSslVerifyFalse` | verification can be disabled, via boolean and via the string form the config accepts |
| `TestDefaultPathUnchanged` | no TLS config keeps certifi's full bundle and `CERT_REQUIRED`; a missing CA file falls back to defaults; the client still carries `max_retries=0` and its read/connect timeouts |

Red-without-fix, with only `agent/anthropic_adapter.py` reverted:

```text
8 failed, 4 passed
```

With the fix:

```text
12 passed in 0.73s
```

**Regression sweep** — 38 related suites (every `*anthropic*`, `*ssl*` and
`*credential_pool*` suite under `tests/agent/` and `tests/run_agent/`), both
sides on the same `main`:

```text
baseline (change stashed):  339 passed, 1 skipped, 0 failed
with this fix:              351 passed, 1 skipped, 0 failed
```

The +12 is exactly this PR's tests; no existing test changes behaviour.

```text
ruff check agent/anthropic_adapter.py:  All checks passed
```