### PR TITLE
Whatsapp : accept shared truthy aliases for WHATSAPP_ENABLED status/setup

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -51,6 +51,7 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
+from utils import is_truthy_value
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -5464,7 +5465,9 @@ def _platform_status(platform: dict) -> str:
         return "not configured"
     val = get_env_value(token_var)
     if token_var == "WHATSAPP_ENABLED":
-        if val and val.lower() == "true":
+        # Match gateway/config.py runtime enablement (is_truthy_value) so
+        # WHATSAPP_ENABLED=1|on|yes is not reported as "not configured".
+        if is_truthy_value(val):
             session_file = get_hermes_home() / "whatsapp" / "session" / "creds.json"
             if session_file.exists():
                 return "configured + paired"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2763,6 +2763,7 @@ def cmd_whatsapp(args):
     _require_tty("whatsapp")
     from hermes_cli.config import get_env_value, save_env_value
     from hermes_constants import find_node_executable, with_hermes_node_path
+    from utils import is_truthy_value
 
     print()
     print("⚕ WhatsApp Setup")
@@ -2828,7 +2829,7 @@ def cmd_whatsapp(args):
     # Re-runs that already have WHATSAPP_ENABLED=true (from a prior
     # successful pairing) stay enabled — we just don't write it pre-emptively.
     print()
-    if (get_env_value("WHATSAPP_ENABLED") or "").lower() == "true":
+    if is_truthy_value(get_env_value("WHATSAPP_ENABLED")):
         print("✓ WhatsApp is already enabled")
 
     # ── Step 3: Allowed users ────────────────────────────────────────────
@@ -2926,7 +2927,7 @@ def cmd_whatsapp(args):
             # (Older installs may have lost the env var; covers re-runs
             # where the user picked "no, keep my session" but the var
             # was never set or got removed.)
-            if (get_env_value("WHATSAPP_ENABLED") or "").lower() != "true":
+            if not is_truthy_value(get_env_value("WHATSAPP_ENABLED")):
                 save_env_value("WHATSAPP_ENABLED", "true")
             print("\n✓ WhatsApp is configured and paired!")
             print("  Start the gateway with: hermes gateway")

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_whatsapp_enabled_truthy_status.py
+++ b/tests/hermes_cli/test_whatsapp_enabled_truthy_status.py
@@ -1,0 +1,44 @@
+"""WHATSAPP_ENABLED status/setup must accept shared truthy aliases."""
+
+from __future__ import annotations
+
+from hermes_cli.gateway import _platform_status
+
+
+def test_platform_status_whatsapp_accepts_truthy_aliases(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.gateway.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_env_value",
+        lambda key: "on" if key == "WHATSAPP_ENABLED" else None,
+    )
+
+    status = _platform_status({"token_var": "WHATSAPP_ENABLED", "key": "whatsapp"})
+    assert status == "enabled, not paired"
+
+
+def test_platform_status_whatsapp_paired_when_creds_exist(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.gateway.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_env_value",
+        lambda key: "1" if key == "WHATSAPP_ENABLED" else None,
+    )
+    creds = tmp_path / "whatsapp" / "session" / "creds.json"
+    creds.parent.mkdir(parents=True)
+    creds.write_text("{}", encoding="utf-8")
+
+    status = _platform_status({"token_var": "WHATSAPP_ENABLED", "key": "whatsapp"})
+    assert status == "configured + paired"
+
+
+def test_platform_status_whatsapp_rejects_falsy(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.gateway.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_env_value",
+        lambda key: "off" if key == "WHATSAPP_ENABLED" else None,
+    )
+
+    status = _platform_status({"token_var": "WHATSAPP_ENABLED", "key": "whatsapp"})
+    assert status == "not configured"


### PR DESCRIPTION
## Summary
- Align WhatsApp CLI status (`_platform_status`) and setup wizard enablement checks with `is_truthy_value`. Gateway runtime already treated `1` / `on` / `yes` as enabled, but status reported "not configured" and setup missed the already-enabled path for those aliases.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.
