### PR TITLE
fix(gateway): do not suppress final send on payload-less split delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24825,12 +24825,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # A successful finalize call is not proof the *content* was
                 # final: the edit may have carried only the last preview
                 # snapshot while the tail generated between that snapshot and
-                # stream completion never reached any API call (#71643).
-                # Reconcile the recorded turn-final payload against the
-                # completed response; only a demonstrable mismatch (False)
-                # overrides the flag — None (no record / multi-message split
-                # delivery) keeps the legacy trust so overflow splits are not
-                # re-sent.
+                # stream completion never reached any API call (#71643), or a
+                # multi-message split may have claimed delivery without a
+                # matching payload (#78541). Reconcile the recorded
+                # turn-final payload against the completed response; only a
+                # demonstrable mismatch (False) overrides the flag — None
+                # (no record at all) keeps legacy trust so ambiguous-timeout
+                # dedup is not re-sent.
                 matcher = getattr(consumer, "delivered_final_matches", None)
                 if callable(matcher):
                     try:
@@ -25614,17 +25615,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
-            # #71643: a *successful* finalize edit can still carry only the
-            # last preview snapshot — deltas generated between that edit and
-            # stream completion never reach any API call, and both suppression
-            # flags are set from the call's success rather than its content.
-            # Reconcile the consumer's recorded turn-final payload against the
-            # completed response: on a demonstrable mismatch (False) neither
-            # final_response_sent nor final_content_delivered may suppress the
-            # normal final send. None (no record / multi-message split
-            # delivery) keeps legacy trust; the failed-finalize family
-            # (#51828 / #33793) is unaffected because those paths leave the
-            # flags False or record the complete fallback payload.
+            # #71643 / #78541: a *successful* finalize edit can still carry
+            # only the last preview snapshot — deltas generated between that
+            # edit and stream completion never reach any API call, and both
+            # suppression flags are set from the call's success rather than
+            # its content. Reconcile the consumer's recorded turn-final
+            # payload against the completed response: on a demonstrable
+            # mismatch (False) neither final_response_sent nor
+            # final_content_delivered may suppress the normal final send.
+            # That includes payload-less multi-message split delivery, which
+            # previously returned None and kept legacy trust (#78541). None
+            # (no record at all) still keeps legacy trust; the
+            # failed-finalize family (#51828 / #33793) is unaffected because
+            # those paths leave the flags False or record the complete
+            # fallback payload.
             _stale_finalized = False
             if _content_delivered and not _is_empty_sentinel:
                 _matcher = getattr(_sc, "delivered_final_matches", None)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -270,9 +270,9 @@ class GatewayStreamConsumer:
         self._delivered_final_text: Optional[str] = None
         # True when the current turn's answer was delivered across multiple
         # sealed messages (overflow split / adapter continuation adoption).
-        # Payload-equality against a single recorded string is meaningless in
-        # that shape, so delivered_final_matches() falls back to legacy trust
-        # rather than risking a duplicate re-send of a multi-message reply.
+        # The joined delivered payload is still recorded when known so
+        # delivered_final_matches() can detect a stale short flush that
+        # claimed final delivery without the complete answer (#78541).
         self._turn_split_delivery = False
         self._delivered_commentary_texts: list[str] = []
         # Retains the finalized visible text of each streaming segment so
@@ -410,16 +410,17 @@ class GatewayStreamConsumer:
 
         Normalized the same way ``_send_or_edit`` normalizes outgoing text
         (media-directive strip + fence closing) so the gateway can compare it
-        against the completed ``final_response`` (#71643). No-op when the turn
-        was delivered across multiple sealed messages — payload equality is
-        undefined there and ``delivered_final_matches`` returns ``None``.
+        against the completed ``final_response`` (#71643).
+
+        Multi-message split deliveries still record the joined payload when
+        the caller provides it (sealed heads + tail). A payload-less split
+        must not leave a stale flag that suppresses a later complete final
+        (#78541).
         """
-        if self._turn_split_delivery:
-            self._delivered_final_text = None
-            return
-        self._delivered_final_text = ensure_closed_code_fences(
+        cleaned = ensure_closed_code_fences(
             self._clean_for_display(text or "")
         ).strip()
+        self._delivered_final_text = cleaned or None
 
     def delivered_final_matches(self, final_text: str) -> Optional[bool]:
         """Reconcile the recorded turn-final payload against ``final_text``.
@@ -432,29 +433,40 @@ class GatewayStreamConsumer:
           delivered segment/commentary) matches ``final_text``; suppressing
           the normal final send is safe.
         - ``False`` — a turn-final delivery was recorded but its payload
-          demonstrably differs from ``final_text``; the user has NOT seen the
-          complete response and the normal final send must run.
-        - ``None``  — no payload comparison is possible (multi-message split
-          delivery, or a legacy/uncertain path that recorded nothing). The
-          caller keeps the pre-existing flag-trusting behavior so overflow
-          splits and ambiguous-timeout dedup are not regressed.
+          demonstrably differs from ``final_text``, **or** a multi-message
+          split claimed delivery without a matching payload (#78541); the
+          user has NOT seen the complete response and the normal final send
+          must run.
+        - ``None``  — no delivery record exists at all (legacy / uncertain
+          path). The caller keeps pre-existing flag-trusting behavior so
+          ambiguous-timeout dedup is not regressed.
         """
-        if self._turn_split_delivery:
-            return None
-        if self._delivered_final_text is None:
-            return None
         target = ensure_closed_code_fences(
             self._clean_for_display(final_text or "")
         ).strip()
         if not target:
             return None
-        if self._delivered_final_text.strip() == target:
-            return True
-        # A segment break / commentary may have delivered the final text
-        # earlier in the turn under a different record.
+
+        # Segment / commentary ledger can prove full delivery regardless of
+        # split vs single-message shape.
         if self.has_delivered_text(final_text):
             return True
-        return False
+
+        if self._delivered_final_text is not None:
+            if self._delivered_final_text.strip() == target:
+                return True
+            # Recorded payload differs from the complete final — stale
+            # preview or incomplete multi-message delivery.
+            return False
+
+        if self._turn_split_delivery:
+            # Split path claimed final delivery but left no payload and no
+            # segment ledger match.  Trusting the flag here is what swallows
+            # complete group replies after an early short flush (#78541).
+            return False
+
+        # No record at all — legacy trust for pre-record paths.
+        return None
 
     def has_delivered_text(self, text: str) -> bool:
         """Return True if *text* was already delivered as visible chat content."""
@@ -939,11 +951,16 @@ class GatewayStreamConsumer:
                             self._final_response_sent = chunks_delivered and tail_delivered
                             if self._final_response_sent:
                                 self._final_content_delivered = True
-                                # Multi-message split delivery — payload
-                                # equality against a single record is
-                                # undefined (#71643).
+                                # Multi-message split delivery. Record the
+                                # joined sealed heads + tail so the gateway
+                                # can reconcile against final_response and
+                                # refuse to suppress a longer complete
+                                # answer after a short early flush (#78541).
                                 self._turn_split_delivery = True
-                                self._delivered_final_text = None
+                                joined = "".join(chunks[:-1]) + (
+                                    self._accumulated or ""
+                                )
+                                self._record_turn_final_payload(joined)
                             return
                         if got_segment_break:
                             self._message_id = None

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -257,6 +257,68 @@ async def test_equal_text_control_still_suppresses_duplicate_send(
     assert len(full_sends) <= 1, f"duplicate final delivery: {full_sends!r}"
 
 
+@pytest.mark.asyncio
+async def test_payloadless_split_does_not_suppress_complete_response(
+    monkeypatch, tmp_path
+):
+    """#78541: payload-less multi-message split must not suppress a longer final.
+
+    Simulates the group/forum failure mode: an early short flush sets
+    final_content_delivered + turn_split_delivery with no recorded payload,
+    then the completed response is much longer. The complete text must still
+    reach the platform.
+    """
+    stream_consumer_mod = importlib.import_module("gateway.stream_consumer")
+
+    class PayloadlessSplitAgent:
+        def __init__(self, **kwargs):
+            self.stream_delta_callback = kwargs.get("stream_delta_callback")
+            self.tools = []
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            if self.stream_delta_callback:
+                self.stream_delta_callback(STREAMED_PREFIX)
+            return {
+                "final_response": FULL_RESPONSE,
+                "response_previewed": False,
+                "messages": [],
+                "api_calls": 2,
+            }
+
+    # Patch the consumer class used by the local import inside _run_agent so
+    # finalize claims multi-message delivery without a payload — the #78541
+    # log signature (streamed=True, content_delivered=True, no record).
+    real_consumer_cls = stream_consumer_mod.GatewayStreamConsumer
+
+    class PayloadlessSplitConsumer(real_consumer_cls):
+        async def run(self):  # type: ignore[override]
+            await super().run()
+            self._final_response_sent = True
+            self._final_content_delivered = True
+            self._turn_split_delivery = True
+            self._delivered_final_text = None
+
+    monkeypatch.setattr(
+        stream_consumer_mod, "GatewayStreamConsumer", PayloadlessSplitConsumer
+    )
+
+    adapter, result = await _run_streaming_turn(
+        monkeypatch,
+        tmp_path,
+        PayloadlessSplitAgent,
+        "sess-78541-payloadless-split",
+    )
+
+    assert result["final_response"] == FULL_RESPONSE
+    all_payloads = [c["content"] for c in adapter.sent] + [
+        e["content"] for e in adapter.edits
+    ]
+    assert any(FULL_RESPONSE in payload for payload in all_payloads), (
+        f"complete response never reached the platform after payload-less "
+        f"split; payloads: {all_payloads!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Consumer unit coverage: delivered_final_matches tri-state
 # ---------------------------------------------------------------------------
@@ -284,11 +346,29 @@ class TestDeliveredFinalMatches:
         consumer._record_turn_final_payload(STREAMED_PREFIX)
         assert consumer.delivered_final_matches(FULL_RESPONSE) is False
 
-    def test_split_delivery_returns_none(self):
+    def test_split_delivery_with_stale_payload_returns_false(self):
+        """#78541: multi-message split that only recorded a short prefix must
+        not trust the flag against a longer complete final_response."""
         consumer = _consumer()
         consumer._turn_split_delivery = True
+        consumer._final_content_delivered = True
         consumer._record_turn_final_payload(STREAMED_PREFIX)
-        assert consumer.delivered_final_matches(FULL_RESPONSE) is None
+        assert consumer.delivered_final_matches(FULL_RESPONSE) is False
+
+    def test_payloadless_split_delivery_returns_false(self):
+        """#78541: split flag with no payload must not legacy-trust."""
+        consumer = _consumer()
+        consumer._turn_split_delivery = True
+        consumer._final_content_delivered = True
+        consumer._delivered_final_text = None
+        assert consumer.delivered_final_matches(FULL_RESPONSE) is False
+
+    def test_split_delivery_with_matching_joined_payload_returns_true(self):
+        """Joined multi-message payload equal to final_response still suppresses."""
+        consumer = _consumer()
+        consumer._turn_split_delivery = True
+        consumer._record_turn_final_payload(FULL_RESPONSE)
+        assert consumer.delivered_final_matches(FULL_RESPONSE) is True
 
     def test_empty_final_text_returns_none(self):
         consumer = _consumer()


### PR DESCRIPTION
## Summary

Fixes #78541: Telegram group/forum sessions could produce a complete response and then never send it. Logs showed `Suppressing normal final send ... content_delivered=True` with a multi-message **payload-less** split delivery record, so a short early flush claimed final delivery while the real 100–3000 char answer was dropped.

### Root cause

`GatewayStreamConsumer` multi-message finalize set `final_content_delivered=True` + `_turn_split_delivery=True` with `_delivered_final_text=None`. `delivered_final_matches()` returned `None` for that shape, and `gateway/run.py` treated `None` as legacy trust of the flag.

### Fix

1. Record the **joined** sealed heads + tail payload on multi-message finalize.
2. Treat payload-less or mismatched split delivery as `False` (do not suppress).
3. Keep `None` only when there is no delivery record at all (true legacy paths).

## Test plan

- [x] `pytest tests/gateway/test_stale_finalize_suppression.py` (12 passed)
  - unit: payload-less split → False
  - unit: stale split payload vs longer final → False
  - unit: matching joined payload → True
  - gateway boundary: complete final still reaches platform after payload-less split claim
- [ ] CI green on this PR