### PR TITLE
Matrix : accept shared truthy aliases for MATRIX_ENCRYPTION

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -51,6 +51,7 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
+from utils import is_truthy_value
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -5491,7 +5492,9 @@ def _platform_status(platform: dict) -> str:
         password = get_env_value("MATRIX_PASSWORD")
         if (val or password) and homeserver:
             e2ee = get_env_value("MATRIX_ENCRYPTION")
-            suffix = " + E2EE" if e2ee and e2ee.lower() in {"true", "1", "yes"} else ""
+            # Match gateway/config.py runtime enablement (is_truthy_value)
+            # so MATRIX_ENCRYPTION=on is reported as configured + E2EE.
+            suffix = " + E2EE" if is_truthy_value(e2ee) else ""
             return f"configured{suffix}"
         if val or password or homeserver:
             return "partially configured"

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -138,6 +138,7 @@ from gateway.platforms.base import (
     _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -719,10 +720,13 @@ def _resolve_e2ee_mode(extra: Optional[Dict[str, Any]] = None) -> str:
     explicit = extra.get("e2ee_mode") or os.getenv("MATRIX_E2EE_MODE", "")
     if explicit:
         return _normalize_e2ee_mode(explicit)
-    legacy_enabled = extra.get(
-        "encryption",
-        os.getenv("MATRIX_ENCRYPTION", "").lower() in ("true", "1", "yes"),
-    )
+    # Prefer config.extra["encryption"] when present; otherwise honor the
+    # legacy MATRIX_ENCRYPTION env with the shared truthy contract (so
+    # "on" matches gateway/config.py enablement).
+    if "encryption" in extra:
+        legacy_enabled = is_truthy_value(extra.get("encryption"))
+    else:
+        legacy_enabled = is_truthy_value(os.getenv("MATRIX_ENCRYPTION", ""))
     return "required" if legacy_enabled else "off"
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -799,6 +799,22 @@ class TestMatrixRequirements:
              patch("tools.lazy_deps.feature_missing", return_value=()):
             assert matrix_mod.check_matrix_requirements() is False
 
+    @pytest.mark.parametrize("raw", ["on", "ON", "1", "yes", " true "])
+    def test_check_requirements_encryption_truthy_aliases_no_e2ee_deps(
+        self, raw, monkeypatch
+    ):
+        """Shared truthy aliases must enable E2EE requirements like 'true'."""
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_ENCRYPTION", raw)
+        monkeypatch.delenv("MATRIX_E2EE_MODE", raising=False)
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False), \
+             patch("tools.lazy_deps.feature_missing", return_value=()):
+            assert matrix_mod.check_matrix_requirements() is False
+            assert matrix_mod._resolve_e2ee_mode({}) == "required"
+
     def test_check_requirements_e2ee_optional_no_deps_ok(self, monkeypatch):
         """MATRIX_E2EE_MODE=optional should not block startup without python-olm."""
         monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")

--- a/tests/hermes_cli/test_matrix_encryption_truthy_status.py
+++ b/tests/hermes_cli/test_matrix_encryption_truthy_status.py
@@ -1,0 +1,38 @@
+"""MATRIX_ENCRYPTION status must accept shared truthy aliases."""
+
+from __future__ import annotations
+
+from hermes_cli.gateway import _platform_status
+
+
+def _matrix_plat():
+    return {
+        "key": "matrix",
+        "token_var": "MATRIX_ACCESS_TOKEN",
+    }
+
+
+def test_platform_status_matrix_e2ee_on_alias(monkeypatch):
+    values = {
+        "MATRIX_ACCESS_TOKEN": "syt_test",
+        "MATRIX_HOMESERVER": "https://matrix.example.org",
+        "MATRIX_ENCRYPTION": "on",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_env_value",
+        lambda key: values.get(key),
+    )
+    assert _platform_status(_matrix_plat()) == "configured + E2EE"
+
+
+def test_platform_status_matrix_e2ee_off_alias(monkeypatch):
+    values = {
+        "MATRIX_ACCESS_TOKEN": "syt_test",
+        "MATRIX_HOMESERVER": "https://matrix.example.org",
+        "MATRIX_ENCRYPTION": "off",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.gateway.get_env_value",
+        lambda key: values.get(key),
+    )
+    assert _platform_status(_matrix_plat()) == "configured"


### PR DESCRIPTION
## Summary
- Align Matrix CLI status and adapter `_resolve_e2ee_mode` with `is_truthy_value`. Gateway config already treated `MATRIX_ENCRYPTION=on` as enabled, but status omitted ` + E2EE` and requirements checks could skip the olm hard-fail for that alias.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.

