### PR TITLE
fix(whatsapp): empty response UX, session key persistence, and batch merge

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17459,11 +17459,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # prefill, empty-retry, fallback).  Sending the raw sentinel
             # looks like a bug; a short explanation is more helpful.
             if response == "(empty)" and not _intentional_silence:
-                response = (
-                    "⚠️ The model returned no response after processing tool "
-                    "results. This can happen with some models — try again or "
-                    "rephrase your question."
-                )
+                if _platform_name == "whatsapp":
+                    response = "Desculpa, tive um probleminha aqui. Pode repetir sua pergunta? 😊"
+                else:
+                    response = (
+                        "⚠️ The model returned no response after processing tool "
+                        "results. This can happen with some models — try again or "
+                        "rephrase your question."
+                    )
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2632,6 +2632,16 @@ class SessionStore:
                 )
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
+        elif self._db and entry and not db_create_kwargs and session_key and source:
+            # Existing session loaded from routing index — ensure session_key is
+            # written to state.db in case it was missing (e.g. sessions.json
+            # imported at startup before state.db was populated).
+            self._record_gateway_session_peer(
+                entry.session_id,
+                session_key,
+                source,
+                display_name=entry.display_name,
+            )
 
         return entry
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -479,10 +479,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # ``gateway.platforms.whatsapp.extra.text_batch_delay_seconds`` /
         # ``text_batch_split_delay_seconds``.
         self._text_batch_delay_seconds = self._coerce_float_extra(
-            "text_batch_delay_seconds", 5.0
+            "text_batch_delay_seconds", 35.0
         )
         self._text_batch_split_delay_seconds = self._coerce_float_extra(
-            "text_batch_split_delay_seconds", 10.0
+            "text_batch_split_delay_seconds", 40.0
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
@@ -979,8 +979,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 continuation_message_ids=tuple(sent_message_ids[:-1]),
                 raw_response={"message_ids": sent_message_ids},
             )
+        except asyncio.TimeoutError:
+            # asyncio.TimeoutError stringifies to "" which bypasses _is_timeout_error()
+            # and wrongly triggers plain-text fallback, causing duplicate messages.
+            return SendResult(success=False, error="bridge-timed-out: HTTP call exceeded 30s — message may have already been delivered")
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=str(e) or repr(e))
 
     async def edit_message(
         self,
@@ -1341,6 +1345,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 if event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
                                 else:
+                                    # Se há texto pendente no batch para esta sessão, funde com a mídia
+                                    # para que texto + mídia gerem UMA ÚNICA resposta da Sofia.
+                                    key = self._text_batch_key(event)
+                                    prior_task = self._pending_text_batch_tasks.pop(key, None)
+                                    if prior_task and not prior_task.done():
+                                        prior_task.cancel()
+                                    pending_text = self._pending_text_batches.pop(key, None)
+                                    if pending_text and pending_text.text:
+                                        event.text = f"{pending_text.text}\n{event.text}" if event.text else pending_text.text
                                     await self.handle_message(event)
             except asyncio.CancelledError:
                 break


### PR DESCRIPTION
## Summary

Three WhatsApp platform improvements for the gateway:

### 1. Friendly empty-response message on WhatsApp
`gateway/run.py` — When the model returns an empty response after tool processing, show a Portuguese-friendly message on WhatsApp instead of the English technical error. This is essential for bots like Sofia that operate in pt-BR.

### 2. Session key backfill into state.db
`gateway/session.py` — When an existing session is loaded from `sessions.json` routing index but the `session_key` field is missing from `state.db`, backfill it automatically. Prevents sessions from being orphaned after import.

### 3. WhatsApp adapter fixes
`plugins/platforms/whatsapp/adapter.py`:
- **Text batch timing**: increase delays from 5s/10s to 35s/40s for multi-message bot flows where messages arrive slowly
- **TimeoutError handling**: `asyncio.TimeoutError` stringifies to `""` which bypasses `_is_timeout_error()` and triggers a plain-text fallback, causing duplicate messages. Catch it explicitly with a descriptive error string.
- **Text + media merge**: when a media event arrives and there's pending text for the same session, merge them so the agent generates a single response instead of two separate ones

## Test Plan
- [x] Tested in production (Sofia agent) — verified no duplicate messages, timeout errors handled correctly, text+media merged properly