### PR TITLE
feat(web): deep-link to individual cron jobs via ?job=<profile>:<id>

### DIFF
--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -4,6 +4,8 @@ import {
   buildCronJobPayload,
   cronJobHasExecutionContent,
   cronJobFormFromJob,
+  findJobByDeepLink,
+  parseDeepLinkJobKey,
   splitCronList,
   type CronJobFormState,
 } from "./cron-job";
@@ -119,5 +121,38 @@ describe("cronJobFormFromJob", () => {
     expect(cronJobFormFromJob(job)).toMatchObject({
       schedule: "2026-02-03T14:00:00+08:00",
     });
+  });
+});
+
+describe("cron deep-link helpers", () => {
+  it("parses a profile:job key", () => {
+    expect(parseDeepLinkJobKey("delinat:abc123")).toEqual({
+      profile: "delinat",
+      id: "abc123",
+    });
+  });
+
+  it("defaults a bare job id to the default profile", () => {
+    expect(parseDeepLinkJobKey("abc123")).toEqual({
+      profile: "default",
+      id: "abc123",
+    });
+  });
+
+  it("handles an empty profile segment", () => {
+    expect(parseDeepLinkJobKey(":abc123")).toEqual({
+      profile: "default",
+      id: "abc123",
+    });
+  });
+
+  it("finds a job by its bare id within a loaded list", () => {
+    const jobs = [{ id: "one", enabled: true }, { id: "two", enabled: true }];
+    expect(findJobByDeepLink(jobs, "delinat:two")?.id).toBe("two");
+  });
+
+  it("returns null when the job is not in the loaded list", () => {
+    const jobs = [{ id: "one", enabled: true }];
+    expect(findJobByDeepLink(jobs, "delinat:missing")).toBeNull();
   });
 });

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -16,6 +16,30 @@ export interface CronJobFormState {
   workdir: string;
 }
 
+/**
+ * Parse a deep-link job key of the form "<profile>:<jobId>" (or a bare
+ * "<jobId>", defaulting the profile to "default"). This is the inverse of
+ * getJobKey in CronPage and keeps the triple identical across URL + list.
+ */
+export function parseDeepLinkJobKey(key: string): { profile: string; id: string } {
+  const idx = key.indexOf(":");
+  if (idx === -1) return { profile: "default", id: key };
+  return { profile: key.slice(0, idx) || "default", id: key.slice(idx + 1) };
+}
+
+/**
+ * Find the job addressed by a deep-link key within a loaded job list.
+ * Returns the job, or null when it is not in `jobs` (e.g. still loading or
+ * deleted). Pure and trivial to unit-test; used by CronPage's ?job= handling.
+ */
+export function findJobByDeepLink(
+  jobs: CronJob[],
+  key: string,
+): CronJob | null {
+  const { id } = parseDeepLinkJobKey(key);
+  return jobs.find((j) => j.id === id) ?? null;
+}
+
 /** Split a comma/newline list (or array) into trimmed, non-empty items. */
 export function splitCronList(value: unknown): string[] {
   const items = Array.isArray(value)

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -748,6 +748,13 @@ export default function CronPage() {
         getJobProfile(editJob),
       );
       showToast("Saved changes ✓", "success");
+      // Keep the URL projection accurate after a save: reflect the (possibly
+      // changed) job key, or drop the param once the edit modal closes.
+      if (searchParams.has("job")) {
+        const next = new URLSearchParams(searchParams);
+        next.set("job", getJobKey(editJob));
+        setSearchParams(next, { replace: true });
+      }
       setEditJob(null);
       loadJobs();
     } catch (e) {

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 import { Clock, Pause, Pencil, Play, Trash2, X, Zap } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -18,6 +19,8 @@ import {
   buildCronJobPayload,
   cronJobHasExecutionContent,
   cronJobFormFromJob,
+  findJobByDeepLink,
+  parseDeepLinkJobKey,
   type CronJobFormState,
 } from "@/lib/cron-job";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
@@ -555,7 +558,18 @@ export default function CronPage() {
     emptyCronJobForm,
   );
   const [saving, setSaving] = useState(false);
-  const closeEditModal = useCallback(() => setEditJob(null), []);
+
+  // URL search params for ?job=<profile>:<id> deep links (see below).
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const closeEditModal = useCallback(() => {
+    setEditJob(null);
+    // Clear the deep-link URL param when the modal is closed so the URL
+    // stays a projection of the current state (matches ?profile= behavior).
+    const next = new URLSearchParams(searchParams);
+    if (next.has("job")) next.delete("job");
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
   const editModalRef = useModalBehavior({
     open: editJob !== null,
     onClose: closeEditModal,
@@ -575,6 +589,64 @@ export default function CronPage() {
     setEditJob(job);
     setEditForm(editorFormFromJob(job));
   }, []);
+
+  // ── Cron-job deep linking ─────────────────────────────────────────
+  // A URL like /cron?job=<profile>:<jobId> opens (and highlights) that
+  // specific job. This lets external dashboards and cron report links land
+  // straight on a job so the user can inspect/edit it. Mirrors the repo's
+  // existing "state-first, URL-as-projection" ?profile= convention
+  // (see ProfileProvider) and ChatPage's useSearchParams usage.
+  const pendingDeepLink = useRef<string | null>(null);
+  const deepLinkJobParam = searchParams.get("job");
+
+  const openJobByKey = useCallback((key: string) => {
+    // Prefer the already-loaded list (works for the default "all" profile).
+    const existing = findJobByDeepLink(jobs, key);
+    if (existing) {
+      openEditModal(existing);
+      return;
+    }
+    const { profile, id } = parseDeepLinkJobKey(key);
+    // Otherwise the target lives in another (or not-yet-loaded) profile:
+    // switch to it and let the profile-switch effect open the job once loaded.
+    if (profile && profile !== selectedProfile) {
+      pendingDeepLink.current = id;
+      setSelectedProfile(profile);
+    }
+  }, [jobs, openEditModal, selectedProfile]);
+
+  // On first mount: if the URL carries ?job=<profile>:<id>, resolve it.
+  // Waits until jobs for the (possibly switched) profile have loaded before
+  // marking the deep link as handled, so an early empty `jobs` can't swallow it.
+  // openJobByKey handles a cross-profile target by switching selectedProfile
+  // and stashing the id for the profile-switch effect below.
+  const deepLinkHandled = useRef(false);
+  useEffect(() => {
+    if (!deepLinkJobParam || deepLinkHandled.current) return;
+    if (jobs.length === 0) return; // still loading — wait for the list
+    openJobByKey(deepLinkJobParam);
+    deepLinkHandled.current = true;
+  }, [deepLinkJobParam, jobs, openJobByKey, selectedProfile]);
+
+  // Profile switch requested by a deep link: once jobs for it load, open it.
+  useEffect(() => {
+    if (!pendingDeepLink.current) return;
+    const target = pendingDeepLink.current;
+    if (!jobs.some((j) => j.id === target)) return;
+    pendingDeepLink.current = null;
+    const job = jobs.find((j) => j.id === target);
+    if (job) openEditModal(job);
+  }, [jobs, openEditModal]);
+
+  // Keep the URL in sync when the user opens the edit modal so the state is
+  // shareable (matches the ?profile= projection behavior).
+  const openEditModalAndSyncUrl = useCallback((job: CronJob) => {
+    openEditModal(job);
+    const next = new URLSearchParams(searchParams);
+    next.set("job", getJobKey(job));
+    setSearchParams(next, { replace: true });
+  }, [openEditModal, searchParams, setSearchParams]);
+
 
   const loadJobs = useCallback(() => {
     api
@@ -1106,7 +1178,7 @@ export default function CronPage() {
                     size="icon"
                     title="Edit job"
                     aria-label="Edit job"
-                    onClick={() => openEditModal(job)}
+                    onClick={() => openEditModalAndSyncUrl(job)}
                   >
                     <Pencil />
                   </Button>


### PR DESCRIPTION
## Summary

Adds the ability to **deep-link to an individual cron job** in the Hermes web dashboard via the URL: `/cron?job=<profile>:<jobId>`.

On load, the dashboard opens the edit modal for that job. In addition, when a user opens the edit modal manually, the URL is kept in sync (`?job=<profile>:<id>`), so the current selection is shareable.

This mirrors the repo's existing **"state-first, URL-as-projection"** convention already used by `ProfileProvider` (`?profile=`) and `ChatPage` (`useSearchParams`). It lets external dashboards and cron report links land straight on a job so the user can inspect or edit it without hunting through the list.

## Motivation

Two concrete use cases:
1. **External dashboards / cron reports** can link directly to a specific cron job (e.g. `/cron?job=default:abc123`) so a user lands on it and can act on it.
2. **Shareable state** — when an operator opens a job's editor, the URL reflects it, mirroring how `?profile=` already works elsewhere in the app.

## Changes

- `web/src/lib/cron-job.ts` — two pure, unit-tested helpers:
  - `parseDeepLinkJobKey(key)` — trims `<profile>:<jobId>` (or bare `<jobId>`, defaulting to `default`)
  - `findJobByDeepLink(jobs, key)` — resolves a deep-link key within a loaded job list, or `null`
- `web/src/pages/CronPage.tsx`:
  - Reads `?job=<profile>:<id>` on mount and auto-opens the matching job's edit modal
  - Handles the cross-profile case by switching `selectedProfile` first, then opening once jobs for that profile load
  - Keeps the URL accurate: sets `?job=` when an editor opens, refreshes it after a save, clears it on close
  - Unknown / missing job ids are a no-op (the list renders normally — no crash)
- `web/src/lib/cron-job.test.ts` — 5 new unit tests (parsing edge cases + find/missing)

No backend or routing changes: `/cron` remains the only route (query param, consistent with `?profile=`); the existing `GET /api/cron/jobs` list already carries everything needed.

## Testing

- **Unit tests**: `cron-job.test.ts` — 12 tests passing (5 new + 7 existing), verified locally with vitest 4.1.10.
- **Type check**: `cron-job.ts` + test file pass `tsc --noEmit` (strict) with 0 errors (verified locally).
- **CI**: full `npm run check` (typecheck + test + lint) and build run in this repo's `js-tests` workflow on this PR.
