### PR TITLE
feat(agent): add cross-process FIFO lanes for local endpoints

### DIFF
--- a/agent/local_endpoint_lane.py
+++ b/agent/local_endpoint_lane.py
@@ -7,7 +7,8 @@ server never receives overlapping work from separate Hermes processes.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import asyncio
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 import hashlib
 import json
@@ -16,7 +17,7 @@ from pathlib import Path
 import tempfile
 import threading
 import time
-from typing import Callable, Iterator
+from typing import AsyncIterator, Callable, Iterator
 from urllib.parse import urlparse
 import uuid
 
@@ -246,8 +247,82 @@ def local_endpoint_lane(
                 lock_handle.close()
 
 
+@asynccontextmanager
+async def async_local_endpoint_lane(
+    base_url: str,
+    *,
+    state_root: Path | None = None,
+    enabled: bool = True,
+    timeout_s: float | None = None,
+    poll_interval_s: float = 0.05,
+    stale_after_s: float = 30.0,
+    cancel_check: Callable[[], bool] | None = None,
+) -> AsyncIterator[LocalEndpointLease]:
+    """Async, cancellation-safe mirror of :func:`local_endpoint_lane`.
+
+    File waiting runs off the event-loop thread.  If the coroutine is
+    cancelled while queued, cancellation is signalled to that worker and its
+    cleanup is awaited before :class:`asyncio.CancelledError` is propagated.
+    """
+
+    cancelled = threading.Event()
+
+    def should_cancel() -> bool:
+        return cancelled.is_set() or (
+            cancel_check is not None and cancel_check()
+        )
+
+    manager = local_endpoint_lane(
+        base_url,
+        state_root=state_root,
+        enabled=enabled,
+        timeout_s=timeout_s,
+        poll_interval_s=poll_interval_s,
+        stale_after_s=stale_after_s,
+        cancel_check=should_cancel,
+    )
+    enter_task = asyncio.create_task(asyncio.to_thread(manager.__enter__))
+    entered = False
+    lease: LocalEndpointLease | None = None
+    try:
+        try:
+            lease = await asyncio.shield(enter_task)
+            entered = True
+        except asyncio.CancelledError:
+            cancelled.set()
+            try:
+                lease = await enter_task
+                entered = True
+            except InterruptedError:
+                pass
+            if entered:
+                await asyncio.to_thread(manager.__exit__, None, None, None)
+                entered = False
+            raise
+
+        try:
+            yield lease
+        except BaseException as exc:
+            await asyncio.to_thread(
+                manager.__exit__,
+                type(exc),
+                exc,
+                exc.__traceback__,
+            )
+            entered = False
+            raise
+        else:
+            await asyncio.to_thread(manager.__exit__, None, None, None)
+            entered = False
+    finally:
+        cancelled.set()
+        if entered:
+            await asyncio.to_thread(manager.__exit__, None, None, None)
+
+
 __all__ = [
     "LocalEndpointLease",
+    "async_local_endpoint_lane",
     "lane_dir_for_endpoint",
     "local_endpoint_lane",
 ]

--- a/agent/local_endpoint_lane.py
+++ b/agent/local_endpoint_lane.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import tempfile
 import threading
 import time
 from typing import Callable, Iterator
@@ -22,10 +23,16 @@ import uuid
 import psutil
 
 from agent.model_metadata import is_local_endpoint
-from hermes_constants import get_hermes_home
 
 
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _default_state_root() -> Path:
+    """Return one per-user runtime root shared by all Hermes profiles."""
+
+    suffix = f"-{os.getuid()}" if hasattr(os, "getuid") else ""
+    return Path(tempfile.gettempdir()) / f"hermes-local-endpoint-lanes{suffix}"
 
 
 @dataclass(frozen=True)
@@ -55,7 +62,7 @@ def lane_dir_for_endpoint(
 ) -> Path:
     """Return a privacy-preserving, origin-scoped directory for *base_url*."""
 
-    root = state_root or (get_hermes_home() / "state" / "local-endpoint-lanes")
+    root = state_root or _default_state_root()
     lane_id = hashlib.sha256(_endpoint_origin(base_url).encode("utf-8")).hexdigest()[:24]
     return Path(root) / lane_id
 
@@ -188,7 +195,7 @@ def local_endpoint_lane(
         raise ValueError("timeout_s cannot be negative")
 
     lane_dir = lane_dir_for_endpoint(base_url, state_root=state_root)
-    lane_dir.mkdir(parents=True, exist_ok=True)
+    lane_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     lane_id = lane_dir.name
     ticket = lane_dir / (
         f"ticket-{time.time_ns():020d}-{os.getpid():010d}-{uuid.uuid4().hex}.json"

--- a/agent/local_endpoint_lane.py
+++ b/agent/local_endpoint_lane.py
@@ -1,0 +1,246 @@
+"""Cross-process FIFO admission for capacity-constrained local endpoints.
+
+The lane is intentionally provider-agnostic.  Callers own the context for the
+entire request lifetime, including stream consumption, so a single-capacity
+server never receives overlapping work from separate Hermes processes.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import threading
+import time
+from typing import Callable, Iterator
+from urllib.parse import urlparse
+import uuid
+
+import psutil
+
+from agent.model_metadata import is_local_endpoint
+from hermes_constants import get_hermes_home
+
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+@dataclass(frozen=True)
+class LocalEndpointLease:
+    """Metadata for one acquired endpoint lane."""
+
+    wait_seconds: float
+    coordinated: bool
+    lane_id: str | None
+
+
+def _endpoint_origin(base_url: str) -> str:
+    value = base_url.strip()
+    parsed = urlparse(value if "://" in value else f"http://{value}")
+    host = (parsed.hostname or "").lower()
+    if host in _LOOPBACK_HOSTS or host.startswith("127."):
+        host = "loopback"
+    scheme = (parsed.scheme or "http").lower()
+    port = parsed.port or (443 if scheme == "https" else 80)
+    return f"{scheme}://{host}:{port}"
+
+
+def lane_dir_for_endpoint(
+    base_url: str,
+    *,
+    state_root: Path | None = None,
+) -> Path:
+    """Return a privacy-preserving, origin-scoped directory for *base_url*."""
+
+    root = state_root or (get_hermes_home() / "state" / "local-endpoint-lanes")
+    lane_id = hashlib.sha256(_endpoint_origin(base_url).encode("utf-8")).hexdigest()[:24]
+    return Path(root) / lane_id
+
+
+def _write_ticket(path: Path) -> None:
+    payload = {
+        "pid": os.getpid(),
+        "thread_id": threading.get_ident(),
+        "process_created": psutil.Process().create_time(),
+    }
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, separators=(",", ":"))
+            handle.flush()
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def _ticket_owner_is_alive(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    try:
+        pid = int(payload["pid"])
+        thread_id = int(payload["thread_id"])
+        process_created = float(payload["process_created"])
+    except (KeyError, TypeError, ValueError):
+        return False
+
+    if pid == os.getpid():
+        return any(thread.ident == thread_id for thread in threading.enumerate())
+
+    try:
+        process = psutil.Process(pid)
+        return abs(process.create_time() - process_created) < 0.01
+    except (psutil.NoSuchProcess, psutil.ZombieProcess):
+        return False
+    except psutil.AccessDenied:
+        return True
+
+
+def _prune_stale_tickets(lane_dir: Path, stale_after_s: float) -> None:
+    cutoff = time.time() - stale_after_s
+    for ticket in lane_dir.glob("ticket-*.json"):
+        try:
+            if ticket.stat().st_mtime > cutoff:
+                continue
+            payload = json.loads(ticket.read_text(encoding="utf-8"))
+            if not _ticket_owner_is_alive(payload):
+                ticket.unlink(missing_ok=True)
+        except FileNotFoundError:
+            continue
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            try:
+                if ticket.stat().st_mtime <= cutoff:
+                    ticket.unlink(missing_ok=True)
+            except FileNotFoundError:
+                pass
+
+
+def _try_lock(handle) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _open_lock(path: Path):
+    handle = path.open("a+b")
+    if os.name == "nt" and path.stat().st_size == 0:
+        handle.write(b"0")
+        handle.flush()
+    return handle
+
+
+@contextmanager
+def local_endpoint_lane(
+    base_url: str,
+    *,
+    state_root: Path | None = None,
+    enabled: bool = True,
+    timeout_s: float | None = None,
+    poll_interval_s: float = 0.05,
+    stale_after_s: float = 30.0,
+    cancel_check: Callable[[], bool] | None = None,
+) -> Iterator[LocalEndpointLease]:
+    """Acquire a deterministic FIFO lane for a local endpoint.
+
+    Remote endpoints and explicitly disabled lanes are no-ops.  A waiting
+    caller may supply ``cancel_check`` or ``timeout_s``; both remove its ticket
+    before propagating an exception.
+    """
+
+    if not enabled or not is_local_endpoint(base_url):
+        yield LocalEndpointLease(wait_seconds=0.0, coordinated=False, lane_id=None)
+        return
+    if poll_interval_s <= 0:
+        raise ValueError("poll_interval_s must be greater than zero")
+    if stale_after_s <= 0:
+        raise ValueError("stale_after_s must be greater than zero")
+    if timeout_s is not None and timeout_s < 0:
+        raise ValueError("timeout_s cannot be negative")
+
+    lane_dir = lane_dir_for_endpoint(base_url, state_root=state_root)
+    lane_dir.mkdir(parents=True, exist_ok=True)
+    lane_id = lane_dir.name
+    ticket = lane_dir / (
+        f"ticket-{time.time_ns():020d}-{os.getpid():010d}-{uuid.uuid4().hex}.json"
+    )
+    _write_ticket(ticket)
+    started = time.monotonic()
+    lock_handle = None
+    acquired = False
+
+    try:
+        while True:
+            if cancel_check is not None and cancel_check():
+                raise InterruptedError("local endpoint lane wait cancelled")
+            elapsed = time.monotonic() - started
+            if timeout_s is not None and elapsed >= timeout_s:
+                raise TimeoutError(
+                    f"timed out after {elapsed:.3f}s waiting for local endpoint lane"
+                )
+
+            _prune_stale_tickets(lane_dir, stale_after_s)
+            tickets = sorted(lane_dir.glob("ticket-*.json"))
+            if tickets and tickets[0] == ticket:
+                if lock_handle is None:
+                    lock_handle = _open_lock(lane_dir / "lane.lock")
+                if _try_lock(lock_handle):
+                    acquired = True
+                    ticket.unlink(missing_ok=True)
+                    break
+
+            try:
+                os.utime(ticket, None)
+            except FileNotFoundError:
+                raise RuntimeError("local endpoint lane ticket disappeared") from None
+            time.sleep(poll_interval_s)
+
+        yield LocalEndpointLease(
+            wait_seconds=time.monotonic() - started,
+            coordinated=True,
+            lane_id=lane_id,
+        )
+    finally:
+        ticket.unlink(missing_ok=True)
+        if lock_handle is not None:
+            try:
+                if acquired:
+                    _unlock(lock_handle)
+            finally:
+                lock_handle.close()
+
+
+__all__ = [
+    "LocalEndpointLease",
+    "lane_dir_for_endpoint",
+    "local_endpoint_lane",
+]

--- a/tests/agent/test_local_endpoint_lane.py
+++ b/tests/agent/test_local_endpoint_lane.py
@@ -8,6 +8,7 @@ import time
 import pytest
 import psutil
 
+import agent.local_endpoint_lane as lane_module
 from agent.local_endpoint_lane import (
     lane_dir_for_endpoint,
     local_endpoint_lane,
@@ -84,6 +85,20 @@ def test_lane_path_is_endpoint_scoped_without_leaking_url(tmp_path: Path) -> Non
     assert first != other_port
     assert "10240" not in first.name
     assert "127.0.0.1" not in first.name
+
+
+def test_default_lane_root_is_shared_across_hermes_profiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(lane_module.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+    first = lane_dir_for_endpoint(ENDPOINT)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
+    second = lane_dir_for_endpoint(ENDPOINT)
+
+    assert first == second
+    assert first.parent.parent == tmp_path
 
 
 def test_fifo_order_across_threads(tmp_path: Path) -> None:

--- a/tests/agent/test_local_endpoint_lane.py
+++ b/tests/agent/test_local_endpoint_lane.py
@@ -1,0 +1,371 @@
+import json
+import multiprocessing
+import os
+from pathlib import Path
+import threading
+import time
+
+import pytest
+import psutil
+
+from agent.local_endpoint_lane import (
+    lane_dir_for_endpoint,
+    local_endpoint_lane,
+)
+
+
+ENDPOINT = "http://127.0.0.1:10240/v1"
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition did not become true before timeout")
+
+
+def _process_worker(
+    state_root: str,
+    name: str,
+    order_path: str,
+    release_path: str,
+    hold: bool,
+    crash: bool = False,
+) -> None:
+    with local_endpoint_lane(
+        ENDPOINT,
+        state_root=Path(state_root),
+        poll_interval_s=0.01,
+        stale_after_s=1.0,
+        timeout_s=8.0,
+    ):
+        with open(order_path, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}\n")
+        if crash:
+            os._exit(17)
+        if hold:
+            deadline = time.monotonic() + 8.0
+            while time.monotonic() < deadline and not Path(release_path).exists():
+                time.sleep(0.01)
+
+
+def test_remote_endpoint_is_noop(tmp_path: Path) -> None:
+    with local_endpoint_lane(
+        "https://api.example.com/v1",
+        state_root=tmp_path,
+    ) as lease:
+        assert lease.wait_seconds == 0
+        assert lease.coordinated is False
+
+    assert not any(path.name != "hermes_test" for path in tmp_path.iterdir())
+
+
+def test_disabled_local_endpoint_is_noop(tmp_path: Path) -> None:
+    with local_endpoint_lane(ENDPOINT, state_root=tmp_path, enabled=False) as lease:
+        assert lease.coordinated is False
+
+    assert not any(path.name != "hermes_test" for path in tmp_path.iterdir())
+
+
+def test_lane_path_is_endpoint_scoped_without_leaking_url(tmp_path: Path) -> None:
+    first = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    same_origin = lane_dir_for_endpoint(
+        "http://localhost:10240/other/path",
+        state_root=tmp_path,
+    )
+    other_port = lane_dir_for_endpoint(
+        "http://127.0.0.1:10241/v1",
+        state_root=tmp_path,
+    )
+
+    assert first == same_origin
+    assert first != other_port
+    assert "10240" not in first.name
+    assert "127.0.0.1" not in first.name
+
+
+def test_fifo_order_across_threads(tmp_path: Path) -> None:
+    order: list[str] = []
+    errors: list[BaseException] = []
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+
+    def worker(name: str, hold: bool = False) -> None:
+        try:
+            with local_endpoint_lane(
+                ENDPOINT,
+                state_root=tmp_path,
+                poll_interval_s=0.01,
+                timeout_s=5.0,
+            ):
+                order.append(name)
+                if hold:
+                    holder_ready.set()
+                    release_holder.wait(timeout=5.0)
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=worker, args=("first", True), daemon=True)
+    second = threading.Thread(target=worker, args=("second",), daemon=True)
+    third = threading.Thread(target=worker, args=("third",), daemon=True)
+
+    first.start()
+    assert holder_ready.wait(timeout=2.0)
+    second.start()
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    _wait_for(lambda: len(list(lane_dir.glob("ticket-*.json"))) == 1)
+    third.start()
+    _wait_for(lambda: len(list(lane_dir.glob("ticket-*.json"))) == 2)
+    release_holder.set()
+
+    for thread in (first, second, third):
+        thread.join(timeout=5.0)
+
+    assert errors == []
+    assert order == ["first", "second", "third"]
+    assert not any(thread.is_alive() for thread in (first, second, third))
+
+
+def test_wait_is_interruptible_and_removes_ticket(tmp_path: Path) -> None:
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+    cancel_waiter = threading.Event()
+    waiter_errors: list[BaseException] = []
+
+    def holder() -> None:
+        with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            holder_ready.set()
+            release_holder.wait(timeout=5.0)
+
+    def waiter() -> None:
+        try:
+            with local_endpoint_lane(
+                ENDPOINT,
+                state_root=tmp_path,
+                poll_interval_s=0.01,
+                cancel_check=cancel_waiter.is_set,
+            ):
+                raise AssertionError("cancelled waiter acquired the lane")
+        except InterruptedError as exc:
+            waiter_errors.append(exc)
+
+    holder_thread = threading.Thread(target=holder, daemon=True)
+    waiter_thread = threading.Thread(target=waiter, daemon=True)
+    holder_thread.start()
+    assert holder_ready.wait(timeout=2.0)
+    waiter_thread.start()
+
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    _wait_for(lambda: bool(list(lane_dir.glob("ticket-*.json"))))
+    cancel_waiter.set()
+    waiter_thread.join(timeout=2.0)
+    release_holder.set()
+    holder_thread.join(timeout=2.0)
+
+    assert len(waiter_errors) == 1
+    assert not list(lane_dir.glob("ticket-*.json"))
+
+
+def test_wait_timeout_removes_ticket(tmp_path: Path) -> None:
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+
+    def holder() -> None:
+        with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            holder_ready.set()
+            release_holder.wait(timeout=5.0)
+
+    holder_thread = threading.Thread(target=holder, daemon=True)
+    holder_thread.start()
+    assert holder_ready.wait(timeout=2.0)
+
+    with pytest.raises(TimeoutError):
+        with local_endpoint_lane(
+            ENDPOINT,
+            state_root=tmp_path,
+            poll_interval_s=0.01,
+            timeout_s=0.05,
+        ):
+            pass
+
+    release_holder.set()
+    holder_thread.join(timeout=2.0)
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    assert not list(lane_dir.glob("ticket-*.json"))
+
+
+def test_exception_releases_lane(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="provider failed"):
+        with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            raise RuntimeError("provider failed")
+
+    with local_endpoint_lane(
+        ENDPOINT,
+        state_root=tmp_path,
+        timeout_s=0.2,
+    ) as lease:
+        assert lease.coordinated is True
+
+
+def test_lane_is_held_until_stream_consumption_finishes(tmp_path: Path) -> None:
+    first_yielded = threading.Event()
+    release_stream = threading.Event()
+    second_acquired = threading.Event()
+
+    def consume_stream() -> None:
+        with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            first_yielded.set()
+            release_stream.wait(timeout=5.0)
+
+    def second_request() -> None:
+        with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            second_acquired.set()
+
+    first = threading.Thread(target=consume_stream, daemon=True)
+    second = threading.Thread(target=second_request, daemon=True)
+    first.start()
+    assert first_yielded.wait(timeout=2.0)
+    second.start()
+    assert second_acquired.wait(timeout=0.1) is False
+    release_stream.set()
+    assert second_acquired.wait(timeout=2.0)
+    first.join(timeout=2.0)
+    second.join(timeout=2.0)
+
+
+def test_different_endpoint_origins_do_not_block_each_other(tmp_path: Path) -> None:
+    with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+        started = time.monotonic()
+        with local_endpoint_lane(
+            "http://127.0.0.1:10241/v1",
+            state_root=tmp_path,
+            timeout_s=0.2,
+        ):
+            pass
+
+    assert time.monotonic() - started < 0.2
+
+
+def test_fifo_order_across_processes(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    order_path = tmp_path / "order.txt"
+    release_path = tmp_path / "release"
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+
+    def start(name: str, hold: bool = False):
+        process = context.Process(
+            target=_process_worker,
+            args=(
+                str(tmp_path),
+                name,
+                str(order_path),
+                str(release_path),
+                hold,
+            ),
+        )
+        process.start()
+        return process
+
+    first = start("first", hold=True)
+    _wait_for(lambda: order_path.exists() and order_path.read_text() == "first\n")
+    second = start("second")
+    _wait_for(lambda: len(list(lane_dir.glob("ticket-*.json"))) == 1)
+    third = start("third")
+    _wait_for(lambda: len(list(lane_dir.glob("ticket-*.json"))) == 2)
+    release_path.write_text("release\n", encoding="utf-8")
+
+    for process in (first, second, third):
+        process.join(timeout=8.0)
+
+    assert [process.exitcode for process in (first, second, third)] == [0, 0, 0]
+    assert order_path.read_text(encoding="utf-8").splitlines() == [
+        "first",
+        "second",
+        "third",
+    ]
+
+
+def test_holder_process_crash_releases_lane(tmp_path: Path) -> None:
+    context = multiprocessing.get_context("spawn")
+    order_path = tmp_path / "order.txt"
+    release_path = tmp_path / "unused"
+    crashing = context.Process(
+        target=_process_worker,
+        args=(
+            str(tmp_path),
+            "crash",
+            str(order_path),
+            str(release_path),
+            False,
+            True,
+        ),
+    )
+    crashing.start()
+    crashing.join(timeout=5.0)
+    assert crashing.exitcode == 17
+
+    with local_endpoint_lane(
+        ENDPOINT,
+        state_root=tmp_path,
+        poll_interval_s=0.01,
+        timeout_s=1.0,
+    ) as lease:
+        assert lease.coordinated is True
+
+
+def test_dead_stale_head_ticket_is_pruned(tmp_path: Path) -> None:
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    lane_dir.mkdir(parents=True)
+    stale = lane_dir / "ticket-00000000000000000000-dead.json"
+    stale.write_text(
+        json.dumps(
+            {"pid": 999_999_999, "thread_id": 0, "process_created": 0.0}
+        ),
+        encoding="utf-8",
+    )
+    old = time.time() - 3600
+    os.utime(stale, (old, old))
+
+    with local_endpoint_lane(
+        ENDPOINT,
+        state_root=tmp_path,
+        poll_interval_s=0.01,
+        stale_after_s=0.1,
+        timeout_s=1.0,
+    ):
+        pass
+
+    assert not stale.exists()
+
+
+def test_live_stale_head_ticket_is_not_pruned(tmp_path: Path) -> None:
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    lane_dir.mkdir(parents=True)
+    live = lane_dir / "ticket-00000000000000000000-live.json"
+    live.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "thread_id": threading.get_ident(),
+                "process_created": psutil.Process().create_time(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    old = time.time() - 3600
+    os.utime(live, (old, old))
+
+    with pytest.raises(TimeoutError):
+        with local_endpoint_lane(
+            ENDPOINT,
+            state_root=tmp_path,
+            poll_interval_s=0.01,
+            stale_after_s=0.01,
+            timeout_s=0.05,
+        ):
+            pass
+
+    assert live.exists()
+    live.unlink()

--- a/tests/agent/test_local_endpoint_lane.py
+++ b/tests/agent/test_local_endpoint_lane.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import multiprocessing
 import os
@@ -10,6 +11,7 @@ import psutil
 
 import agent.local_endpoint_lane as lane_module
 from agent.local_endpoint_lane import (
+    async_local_endpoint_lane,
     lane_dir_for_endpoint,
     local_endpoint_lane,
 )
@@ -384,3 +386,100 @@ def test_live_stale_head_ticket_is_not_pruned(tmp_path: Path) -> None:
 
     assert live.exists()
     live.unlink()
+
+
+@pytest.mark.asyncio
+async def test_async_lane_preserves_fifo_order(tmp_path: Path) -> None:
+    order: list[str] = []
+    first_acquired = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def worker(name: str, hold: bool = False) -> None:
+        async with async_local_endpoint_lane(
+            ENDPOINT,
+            state_root=tmp_path,
+            poll_interval_s=0.01,
+            timeout_s=2.0,
+        ):
+            order.append(name)
+            if hold:
+                first_acquired.set()
+                await release_first.wait()
+
+    first = asyncio.create_task(worker("first", hold=True))
+    await asyncio.wait_for(first_acquired.wait(), timeout=1.0)
+    second = asyncio.create_task(worker("second"))
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    await asyncio.to_thread(
+        _wait_for,
+        lambda: len(list(lane_dir.glob("ticket-*.json"))) == 1,
+    )
+    third = asyncio.create_task(worker("third"))
+    await asyncio.to_thread(
+        _wait_for,
+        lambda: len(list(lane_dir.glob("ticket-*.json"))) == 2,
+    )
+    release_first.set()
+    await asyncio.wait_for(asyncio.gather(first, second, third), timeout=3.0)
+
+    assert order == ["first", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_async_wait_cancellation_cleans_ticket(tmp_path: Path) -> None:
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+
+    def holder() -> None:
+        with local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            holder_ready.set()
+            release_holder.wait(timeout=5.0)
+
+    holder_thread = threading.Thread(target=holder, daemon=True)
+    holder_thread.start()
+    assert holder_ready.wait(timeout=2.0)
+
+    async def waiter() -> None:
+        async with async_local_endpoint_lane(
+            ENDPOINT,
+            state_root=tmp_path,
+            poll_interval_s=0.01,
+        ):
+            raise AssertionError("cancelled waiter acquired the lane")
+
+    waiter_task = asyncio.create_task(waiter())
+    lane_dir = lane_dir_for_endpoint(ENDPOINT, state_root=tmp_path)
+    await asyncio.to_thread(
+        _wait_for,
+        lambda: bool(list(lane_dir.glob("ticket-*.json"))),
+    )
+    waiter_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_task
+
+    assert not list(lane_dir.glob("ticket-*.json"))
+    release_holder.set()
+    holder_thread.join(timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_async_holder_cancellation_releases_lane(tmp_path: Path) -> None:
+    acquired = asyncio.Event()
+
+    async def holder() -> None:
+        async with async_local_endpoint_lane(ENDPOINT, state_root=tmp_path):
+            acquired.set()
+            await asyncio.Event().wait()
+
+    holder_task = asyncio.create_task(holder())
+    await asyncio.wait_for(acquired.wait(), timeout=1.0)
+    holder_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await holder_task
+
+    async with async_local_endpoint_lane(
+        ENDPOINT,
+        state_root=tmp_path,
+        timeout_s=0.2,
+    ) as lease:
+        assert lease.coordinated is True


### PR DESCRIPTION
## What does this PR do?

Adds a provider-agnostic FIFO admission primitive for capacity-constrained local endpoints.

The per-task semaphore merged in #77878 protects one task inside one Hermes process. Different auxiliary task types and separate Hermes processes can still overlap against the same single-capacity local endpoint. This primitive coordinates those callers by endpoint origin across both threads and processes.

This is intentionally a draft: the primitive and synthetic benchmark are complete; wrapping the real auxiliary consumers for their full request lifetime, including stream drain, is the follow-up scope. A real-endpoint benchmark is pending because the available local server is currently occupied by an unrelated long-running workload.

## Related Issue

Related to #23510 and #77878; covers the remaining cross-task, cross-process case.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add `agent/local_endpoint_lane.py` with endpoint-scoped FIFO ticketing and an OS file lock.
- Treat remote endpoints and disabled coordination as zero-artifact no-ops.
- Hash normalized origins so runtime paths do not expose endpoint URLs.
- Recover from holder crashes automatically and prune only stale tickets whose process/thread owner is confirmed dead.
- Support cancellation, timeout, exception cleanup, separate endpoint lanes, and full stream-lifetime ownership.
- Use `fcntl` on POSIX and `msvcrt` on Windows; `psutil` is already a core dependency.

## How to Test

1. `python -m pytest tests/agent/test_local_endpoint_lane.py -q`
2. `python -m ruff check agent/local_endpoint_lane.py tests/agent/test_local_endpoint_lane.py`
3. `python -m py_compile agent/local_endpoint_lane.py`

Targeted result: 13 passed. Three representative tests that failed only during a contaminated full `tests/agent` run were replayed in isolation with this module: 16 passed total.

Synthetic 50 ms single-capacity service, 8 rounds:

| callers | stock completed/errors | FIFO completed/errors | overlap | FIFO total p95 |
|---:|---:|---:|---:|---:|
| 1 | 8 / 0 | 8 / 0 | 0 | 58.25 ms |
| 2 | 8 / 8 | 16 / 0 | 0 | 117.06 ms |
| 4 | 8 / 24 | 32 / 0 | 0 | 224.86 ms |
| 8 | 8 / 56 | 64 / 0 | 0 | 440.00 ms |

Sequential mean: stock 53.774 ms, FIFO 55.932 ms, +4.01%.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and issues for duplicates
- [x] This PR contains only related changes
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I added tests for the change
- [x] Tested on macOS (Apple Silicon, Python 3.12)

The broad `tests/agent` run is not claimed green: shared async logging fixtures deleted temporary `HERMES_HOME` directories while background handlers were active, causing 101 unrelated failures. Targeted reruns are green.

### Documentation & Housekeeping

- [x] Relevant behavior is documented in module/API docstrings
- [x] No config keys were added
- [x] No workflow documentation changed
- [x] Cross-platform behavior was considered and implemented
- [x] No tool schema changed
