### PR TITLE
fix(model-switch): stop Ollama models dict from hiding live models (salvage #72331)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -102,6 +102,30 @@ def _declared_model_ids(value: Any) -> list[str]:
     return ids
 
 
+def _models_config_is_allowlist(value: Any) -> bool:
+    """Return True when ``models:`` is an intentional ID allowlist.
+
+    A mapping like ``{model_id: {context_length: N}}`` is per-model *metadata*
+    written by ``_save_custom_provider`` / the ``hermes model`` wizard — not a
+    catalog narrow. Treating that shape as an allowlist made Desktop/Telegram
+    pickers show only the saved default for local Ollama (no ``api_key``),
+    while ``hermes model`` still live-probed the full ``/v1/models`` list.
+    Refresh could not help because the same gate skipped probing.
+
+    List/string shapes remain allowlists for no-key endpoints. To pin a
+    dict-shaped catalog, set ``discover_models: false``.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, dict):
+        return False
+    if isinstance(value, (list, tuple)):
+        return bool(_declared_model_ids(value))
+    return False
+
+
 def _save_discovered_models_to_config(
     api_url: str, model_ids: list[str]
 ) -> None:
@@ -2631,12 +2655,13 @@ def list_authenticated_providers(
             for _m in entry_models:
                 if _m and _m not in ep_groups[group_key]["models"]:
                     ep_groups[group_key]["models"].append(_m)
-            # Track explicit ``models:`` declarations separately from the
-            # merged list: a singular ``default_model``/``model`` is only the
-            # active selection and must not be mistaken for the user narrowing
-            # the endpoint to a curated subset (mirrors section 4's
-            # declaration-tracking; see #40542 / PR #61928).
-            if entry_declared_models:
+            # Track allowlist-shaped ``models:`` separately from the merged
+            # list: a singular ``default_model``/``model`` is only the active
+            # selection and must not suppress discovery (see #40542 / PR
+            # #61928). Dict-shaped ``models:`` is context_length metadata from
+            # ``hermes model``, not an allowlist — see
+            # ``_models_config_is_allowlist``.
+            if _models_config_is_allowlist(ep_cfg.get("models")):
                 ep_groups[group_key]["has_explicit_models"] = True
             ep_groups[group_key]["raw_names"].append(display_name)
             ep_groups[group_key]["aliases"].update(
@@ -2663,14 +2688,16 @@ def list_authenticated_providers(
             # unless the provider explicitly opts out via discover_models: false.
             # Policy mirrors Section 4's should_probe logic:
             # - With an api_key: always probe (user opted into the endpoint).
-            # - Without an api_key but with an explicit ``models:`` list:
-            #   skip — the user is narrowing a public endpoint to a specific
-            #   subset. A singular ``default_model``/``model`` does NOT count
-            #   as narrowing (it's just the active selection) and must not
-            #   suppress discovery — mirrors section 4 / #40542.
-            # - Without an api_key AND no explicit models: probe anyway so
-            #   bare-endpoint providers (local llama.cpp / Ollama servers)
-            #   still show their full model catalog.
+            # - Without an api_key but with an allowlist-shaped ``models:``
+            #   (list/string): skip — the user narrowed a public endpoint.
+            #   A singular ``default_model``/``model`` does NOT count as
+            #   narrowing (mirrors section 4 / #40542).
+            # - A dict-shaped ``models:`` is per-model metadata
+            #   (context_length), not an allowlist — still probe so local
+            #   Ollama/llama.cpp match ``hermes model``. Pin with
+            #   ``discover_models: false`` instead.
+            # - Without an api_key AND no allowlist: probe anyway so bare
+            #   local endpoints still show their full model catalog.
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
@@ -2911,8 +2938,12 @@ def list_authenticated_providers(
             if default_model and default_model not in groups[group_key]["models"]:
                 groups[group_key]["models"].append(default_model)
 
-            declared_models = _declared_model_ids(entry.get("models", {}))
-            if declared_models:
+            models_field = entry.get("models", {})
+            declared_models = _declared_model_ids(models_field)
+            # Dict-shaped models: is context_length metadata from
+            # ``_save_custom_provider``, not an allowlist — see
+            # ``_models_config_is_allowlist``.
+            if _models_config_is_allowlist(models_field):
                 groups[group_key]["has_explicit_models"] = True
             for model_id in declared_models:
                 if model_id not in groups[group_key]["models"]:
@@ -2974,24 +3005,20 @@ def list_authenticated_providers(
             # Live-discovery policy:
             # - With an api_key, the user has explicitly opted into the
             #   endpoint and live /models is the source of truth — replace
-            #   the (possibly partial) ``models:`` subset configured for
-            #   context-length overrides with the full live catalog.
-            #   This is the Bifrost / aggregator-gateway case.
-            # - Without an api_key but with an explicit ``models:`` list,
-            #   the user is narrowing a public endpoint to a specific subset
-            #   (e.g. ollama.com /v1/models returns 35 models but the user
-            #   only wants 4). Preserve the explicit list and skip live
-            #   discovery. The singular ``model:`` field is only the current
-            #   active selection and must not suppress discovery on local
-            #   no-key endpoints.
-            # - Without an api_key AND no explicit models, fall through to
-            #   live discovery so bare-endpoint custom providers (local
-            #   llama.cpp / Ollama servers) still appear populated.
+            #   the (possibly partial) ``models:`` subset with the full
+            #   live catalog (Bifrost / aggregator-gateway case).
+            # - Without an api_key but with an allowlist-shaped ``models:``
+            #   (list/string), the user narrowed a public endpoint (e.g.
+            #   ollama.com). Preserve that list and skip live discovery.
+            # - A dict-shaped ``models:`` is per-model metadata written by
+            #   ``_save_custom_provider`` for context_length — not an
+            #   allowlist. Still probe so Desktop/Telegram match
+            #   ``hermes model``. Pin a dict catalog with
+            #   ``discover_models: false``.
+            # - The singular ``model:`` field is only the current active
+            #   selection and must not suppress discovery.
             # - When discover_models: false is set, skip live discovery and
-            #   keep the explicit ``models:`` list regardless of whether an
-            #   api_key is present. This supports endpoints that expose a
-            #   full aggregator catalog via /models but only serve a subset
-            #   (parity with section 3's user ``providers:`` behaviour).
+            #   keep the configured ``models:`` list regardless of api_key.
             _grp_is_current = (
                 slug.lower() == _current_provider_norm
                 or _current_provider_norm in {

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -897,3 +897,74 @@ def test_excluded_providers_hides_builtin_row(monkeypatch):
     )
 
 
+def test_custom_provider_context_length_models_dict_still_probes(monkeypatch):
+    """Dict-shaped ``models:`` from ``_save_custom_provider`` is metadata.
+
+    ``hermes model`` writes ``models: {default: {context_length: N}}`` for
+    local Ollama. That must not suppress live /v1/models discovery — otherwise
+    Desktop/Telegram only show the saved default and Refresh does nothing.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
+
+    def fetch(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["qwen3.6:35b-mlx", "gemma4:31b", "llama3"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:local-ollama",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "model": "qwen3.6:35b-mlx",
+                "models": {"qwen3.6:35b-mlx": {"context_length": 32768}},
+            }
+        ],
+        # GUI picker path: probe current custom provider only.
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+        current_base_url="http://localhost:11434/v1",
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == ""
+    assert calls[0][1] == "http://localhost:11434/v1"
+    row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert row["models"] == ["qwen3.6:35b-mlx", "gemma4:31b", "llama3"]
+    assert row["total_models"] == 3
+
+
+def test_custom_provider_dict_models_pin_requires_discover_false(monkeypatch):
+    """Dict-shaped catalogs pin only when ``discover_models: false``."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
+
+    def fetch(*args, **kwargs):
+        calls.append((args, kwargs))
+        return ["unexpected-live-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:local-ollama",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "model": "llama3",
+                "models": {"llama3": {}},
+                "discover_models": False,
+            }
+        ],
+    )
+
+    row = next(p for p in providers if p["name"] == "Local Ollama")
+    assert calls == []
+    assert row["models"] == ["llama3"]


### PR DESCRIPTION
## Summary
Local no-key endpoints (Ollama / llama.cpp) show their full live model catalog again in the Desktop and Telegram `/model` pickers. `hermes model` saves custom endpoints with `models: {<default>: {context_length: N}}` — pure per-model metadata — but the picker treated any non-empty `models:` as a user allowlist and skipped the live `/v1/models` probe on no-key endpoints, so only the saved default appeared and Refresh did nothing.

Salvage of #72331 by @HexLab98, cherry-picked onto current main with authorship preserved.

## Changes
- `hermes_cli/model_switch.py`: new `_models_config_is_allowlist()` — dict-shaped `models:` counts as metadata (probe still fires); list/string shapes remain allowlists; `discover_models: false` pins dict catalogs. Applied at both `has_explicit_models` sites (endpoint groups + custom_providers section).
- `tests/hermes_cli/test_model_switch_custom_providers.py`: 2 regression tests (dict still probes; dict + `discover_models: false` pins).

## Validation
| | Before | After |
|---|---|---|
| No-key Ollama w/ saved default (picker) | 1 model, Refresh no-op | full live catalog (E2E: 8/8 via real local HTTP server) |
| `models: [a, b]` no key | allowlist honored | allowlist honored (unchanged) |
| dict + `discover_models: false` | pinned | pinned (unchanged) |

Targeted suites green (37 + user_providers + custom_provider + list_picker files, 0 failed). Sabotage run confirmed the new regression test fails without the fix.

Fixes the Discord report from sd_mtb (Ollama on M1 Studio, Desktop 0.19.0 via remote gateway — only default `qwen3.6:35b-mlx` visible out of 8+ installed models).

## Infographic

![models dict vs allowlist fix](https://v3b.fal.media/files/b/0aa50030/g0e7oExp8Z5JROjNywo-S_s026vQeE.png)
