### PR TITLE
fix: enforce LF line endings for text files via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,21 @@ web/package-lock.json linguist-generated=true
 Dockerfile  text eol=lf
 *.dockerfile text eol=lf
 docker/entrypoint.sh text eol=lf
+
+# Enforce LF for all text content. On Windows (`core.autocrlf=true`) checkouts
+# otherwise convert these to CRLF, producing spurious whole-file diffs across
+# worktrees and breaking `git apply` / GottZ review diffs for no real reason.
+*           text=auto eol=lf
+*.md        text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.toml      text eol=lf
+*.json      text eol=lf
+*.py        text eol=lf
+*.ts        text eol=lf
+*.tsx       text eol=lf
+*.js        text eol=lf
+*.jsx       text eol=lf
+*.html      text eol=lf
+*.css       text eol=lf
+*.rst       text eol=lf


### PR DESCRIPTION
## What
On Windows hosts with `core.autocrlf=true`, Git checkouts convert text files
to CRLF while other worktrees keep LF. This produces spurious **whole-file
diffs** across worktrees and breaks `git apply` / review diffs for no real
change — observed across the 16 fleet worktrees all showing "DIFF" on
`creative-ideation/SKILL.md` that was actually content-identical.

## Change
- Force `eol=lf` for all text via `text=auto`.
- Pin the common source formats: `.md`, `.yml/.yaml`, `.toml`, `.json`,
  `.py`, `.ts/.tsx`, `.js/.jsx`, `.html`, `.css`, `.rst`.
- Preserve existing `*.sh` / `Dockerfile` LF rules.

## Why low-risk
Declarative attributes only; no code, no content change. Repos already LF
stay LF; CRLF worktrees normalize on next `git add`/`checkout`. May surface a
one-time normalization diff the first time Git re-touches files — expected.

## Test
`git diff` between the 16 fleet worktrees on `optional-skills/creative/creative-ideation/SKILL.md`
is now content-identical after normalization; this makes such comparisons
identical by default.