### PR TITLE
fix(auxiliary): release stream permits when closed before iteration

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8565,15 +8565,50 @@ def _release_sync_semaphore_after_stream(
     stream: Any, semaphore: threading.BoundedSemaphore,
 ):
     """Release a permit only after a streaming response is consumed or closed."""
-    try:
-        yield from stream
-    finally:
+    return _SemaphoreOwnedStream(stream, semaphore)
+
+
+class _SemaphoreOwnedStream:
+    """Iterator that releases its permit even when closed before iteration."""
+
+    def __init__(self, stream: Any, semaphore: threading.BoundedSemaphore):
+        self._stream = stream
+        self._iterator = iter(stream)
+        self._semaphore = semaphore
+        self._closed = False
+        self._close_lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
         try:
-            close = getattr(stream, "close", None)
+            return next(self._iterator)
+        except BaseException:
+            self.close()
+            raise
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def close(self) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        try:
+            close = getattr(self._stream, "close", None)
             if callable(close):
                 close()
         finally:
-            semaphore.release()
+            self._semaphore.release()
 
 
 def _call_llm_impl(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9139,15 +9139,50 @@ def _release_sync_semaphore_after_stream(
     stream: Any, semaphore: threading.BoundedSemaphore,
 ):
     """Release a permit only after a streaming response is consumed or closed."""
-    try:
-        yield from stream
-    finally:
+    return _SemaphoreOwnedStream(stream, semaphore)
+
+
+class _SemaphoreOwnedStream:
+    """Iterator that releases its permit even when closed before iteration."""
+
+    def __init__(self, stream: Any, semaphore: threading.BoundedSemaphore):
+        self._stream = stream
+        self._iterator = iter(stream)
+        self._semaphore = semaphore
+        self._closed = False
+        self._close_lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
         try:
-            close = getattr(stream, "close", None)
+            return next(self._iterator)
+        except BaseException:
+            self.close()
+            raise
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def close(self) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        try:
+            close = getattr(self._stream, "close", None)
             if callable(close):
                 close()
         finally:
-            semaphore.release()
+            self._semaphore.release()
 
 
 def _call_llm_impl(

--- a/tests/agent/test_auxiliary_concurrency.py
+++ b/tests/agent/test_auxiliary_concurrency.py
@@ -13,6 +13,7 @@ from agent.auxiliary_client import (
     _acquire_sync_aux_semaphore,
     _acquire_async_aux_semaphore,
     _get_task_max_concurrency,
+    _release_sync_semaphore_after_stream,
     _reset_aux_semaphores,
 )
 
@@ -116,6 +117,33 @@ class TestSemaphoreCache:
 
 
 class TestSyncCallEnforcesLimit:
+    def test_stream_close_before_iteration_releases_permit(self):
+        semaphore = threading.BoundedSemaphore(1)
+        semaphore.acquire()
+        stream = _release_sync_semaphore_after_stream(iter(["chunk"]), semaphore)
+
+        stream.close()
+        stream.close()
+
+        assert semaphore.acquire(blocking=False) is True
+        semaphore.release()
+
+    def test_stream_iteration_error_releases_permit(self):
+        semaphore = threading.BoundedSemaphore(1)
+        semaphore.acquire()
+
+        def broken_stream():
+            raise RuntimeError("provider stream failed")
+            yield
+
+        stream = _release_sync_semaphore_after_stream(broken_stream(), semaphore)
+
+        with pytest.raises(RuntimeError, match="provider stream failed"):
+            next(stream)
+
+        assert semaphore.acquire(blocking=False) is True
+        semaphore.release()
+
     def test_call_llm_caps_concurrent_inflight(self):
         limit = 2
         n_callers = 6


### PR DESCRIPTION
## What does this PR do?

Fixes a leaked auxiliary concurrency permit when a streamed response is closed before its first iteration.

The existing `_release_sync_semaphore_after_stream()` is a generator. Python does not execute a generator body or its `finally` block when `close()` is called before the first `next()`, so `auxiliary.<task>.max_concurrency: 1` remains permanently occupied and later calls block.

The wrapper is now an iterator object that owns the stream and semaphore from construction time. Exhaustion, provider errors, explicit close, and close-before-iteration all close the provider stream and release the permit exactly once.

## Related Issue

Follow-up hardening for the per-task stream concurrency lifecycle introduced by #77878.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Replace the lazy generator finalizer with `_SemaphoreOwnedStream`.
- Delegate stream attributes and context-manager behavior.
- Make close idempotent and thread-safe.
- Cover close before iteration, repeated close, and provider iteration failure.

## How to Test

1. `python -m pytest tests/agent/test_auxiliary_concurrency.py -q`
2. `python -m pytest tests/agent/test_auxiliary*.py -q`
3. `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_concurrency.py`

Result: 316 passed, 1 skipped across all auxiliary suites.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs for duplicates
- [x] This PR contains only related changes
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I added tests for the bug
- [x] Tested on macOS (Apple Silicon, Python 3.12)

### Documentation & Housekeeping

- [x] Documentation N/A; no user-facing behavior or config changed
- [x] Config example N/A
- [x] Architecture/workflow docs N/A
- [x] Cross-platform impact considered; uses Python locks and existing semaphore primitives
- [x] Tool schemas N/A
