### PR TITLE
fix(cron): add require_tool_use so a tool-less run is never delivered

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3658,6 +3658,16 @@ def run_job(
                 f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
             )
 
+        # Stashed on the job (same in-band convention as `_resolved_model`) so
+        # process_job can enforce `require_tool_use` without widening run_job's
+        # return signature. Counts assistant turns that actually issued tool
+        # calls -- the same expression the turn finalizer logs as `tool_turns`.
+        job["_tool_call_count"] = sum(
+            1
+            for m in (result.get("messages") or [])
+            if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+        )
+
         # If the agent itself reported failure (e.g. all retries exhausted on
         # API errors, model abort, mid-run interrupt), do not silently mark the
         # job as successful. run_agent populates `failed=True`/`completed=False`
@@ -3995,6 +4005,30 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 error = (
                     "Interrupted by gateway shutdown before the run finished "
                     "(tool subprocess was killed mid-flight)."
+                )
+
+            # A job that declares it must consult its sources cannot have done so
+            # if it never called a tool. Seen in practice when a provider outage
+            # pushed a scheduled report onto a much weaker fallback model: it made
+            # zero tool calls, emitted "I will read the required files from ..."
+            # and stopped. That planning preamble was delivered as the report and
+            # the run recorded last_status=ok.
+            #
+            # Opt-in per job, because a job that only asks the model to write
+            # something legitimately calls no tools. Like the interrupt guard
+            # above, this runs BEFORE deliver_content is computed -- the
+            # empty-response guard further down only relabels last_status after
+            # delivery has already happened.
+            if success and job.get("require_tool_use") and not job.get("_tool_call_count"):
+                success = False
+                error = (
+                    "Agent produced a response without calling any tool, but this job "
+                    "declares require_tool_use -- it cannot have consulted its sources. "
+                    "Response withheld as unverified."
+                )
+                logger.error(
+                    "Job '%s': withholding response -- require_tool_use set but 0 tool calls made",
+                    job.get("name", job["id"]),
                 )
 
             # Deliver the final response to the origin/target chat.

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1901,3 +1901,59 @@ class TestSetCronSessionTitle:
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
 
 
+
+
+class TestRequireToolUse:
+    """A job that declares it must consult its sources cannot answer without a tool call.
+
+    Observed in production: a provider outage pushed a scheduled report onto a much
+    weaker fallback model, which made zero tool calls, emitted "I will read the
+    required files from ..." and stopped. That planning preamble was delivered as the
+    report and the run recorded last_status=ok.
+    """
+
+    def _make_job(self, **extra):
+        job = {
+            "id": "report-job",
+            "name": "scheduled-report",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+        job.update(extra)
+        return job
+
+    def _run(self, job, tool_calls, response="I will read the required files from outbox/."):
+        def fake_run_job(j, **_kwargs):
+            j["_tool_call_count"] = tool_calls
+            return (True, "# output", response, None)
+
+        with patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.run_job", side_effect=fake_run_job), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run") as mark_mock:
+            from cron.scheduler import tick
+            tick(verbose=False)
+        return deliver_mock, mark_mock
+
+    def test_zero_tool_calls_withholds_the_response(self):
+        deliver_mock, mark_mock = self._run(self._make_job(require_tool_use=True), tool_calls=0)
+        assert "I will read the required files" not in deliver_mock.call_args[0][1]
+        assert mark_mock.call_args[0][1] is False
+
+    def test_zero_tool_calls_is_recorded_as_error_not_ok(self):
+        _deliver, mark_mock = self._run(self._make_job(require_tool_use=True), tool_calls=0)
+        assert "without calling any tool" in mark_mock.call_args[0][2]
+
+    def test_a_run_that_used_its_tools_is_delivered(self):
+        deliver_mock, mark_mock = self._run(
+            self._make_job(require_tool_use=True), tool_calls=9, response="Report body."
+        )
+        assert "Report body." in deliver_mock.call_args[0][1]
+        assert mark_mock.call_args[0][1] is True
+
+    def test_jobs_without_the_flag_may_legitimately_call_no_tools(self):
+        """Opt-in only -- a write-something job calls no tools and is still fine."""
+        deliver_mock, mark_mock = self._run(self._make_job(), tool_calls=0, response="a haiku")
+        assert "a haiku" in deliver_mock.call_args[0][1]
+        assert mark_mock.call_args[0][1] is True


### PR DESCRIPTION
## Problem

A cron job whose prompt instructs it to read files before answering cannot have
answered if it never called a tool. Nothing currently checks that. `run_job`
returning a non-empty string is treated as success, so a model that emits only a
plan and stops has that preamble delivered as the report, and the run records
`last_status=ok`.

I hit this when a provider outage walked the fallback chain down to a much weaker
model. The turn ended `api_calls=1 tool_turns=0` — it had read nothing — and its
`"I will read the required files from …"` was published as the finished report.
It happened to emit a preamble; it could as easily have emitted plausible numbers,
and nothing downstream would have known the difference.

The existing `#8585` empty-response guard does not catch this: the response is not
empty, and that guard runs *after* delivery, so it only relabels `last_status`.

## Change

- `run_job` stashes the number of assistant turns that issued tool calls onto the
  job dict, following the existing `_resolved_model` convention so the return
  signature is unchanged. Same expression the turn finalizer already logs as
  `tool_turns`.
- `process_job` forces the failure path when a job sets `require_tool_use` and made
  zero tool calls, so the delivered message is the failure summary rather than the
  model's text. Placed next to the existing `_is_interrupted` guard and, like it,
  **before** `deliver_content` is computed.
- **Opt-in per job.** A job that only asks the model to write something legitimately
  calls no tools and is unaffected; jobs without the flag behave exactly as before.

## Tests

`TestRequireToolUse` covers four paths: response withheld, run recorded as error,
a genuine tool-using run still delivered, and a job without the flag unaffected.
`tests/cron/` is green (394 passed).

## Notes

No schema or config migration — `require_tool_use` is read with `job.get(...)`, so
existing job records are unaffected until the flag is set explicitly.