### PR TITLE
docs(secrets): macOS Keychain recipe for the command source

### DIFF
--- a/website/docs/user-guide/secrets/command.md
+++ b/website/docs/user-guide/secrets/command.md
@@ -35,6 +35,69 @@ secrets:
 - Whitespace-only values are treated as "no value" — a placeholder entry never flows into an Authorization header.
 - POSIX-only (needs `/bin/sh`). On Windows the source reports itself unconfigured and startup continues.
 
+## Recipe: macOS Keychain
+
+macOS ships `security`, so a Mac needs no extra vault software. Store each
+credential as a generic-password item and have the helper print them:
+
+```yaml
+secrets:
+  command:
+    enabled: true
+    command: "security find-generic-password -s hermes-env -w"
+```
+
+That works when one item holds a whole dotenv blob. To store credentials
+individually, keep a small helper script and point `command` at it:
+
+```bash
+#!/bin/sh
+# ~/.hermes/scripts/keychain-env.sh — one Keychain item per credential.
+for key in ANTHROPIC_API_KEY OPENAI_API_KEY; do
+  value=$(security find-generic-password -a "$USER" -s "hermes-$key" -w 2>/dev/null)
+  [ -n "$value" ] && printf '%s=%s\n' "$key" "$value"
+done
+```
+
+Add items with `security add-generic-password`. The `-w` flag reads the value
+from a prompt rather than `argv`, so it stays out of your shell history:
+
+```bash
+security add-generic-password -a "$USER" -s hermes-ANTHROPIC_API_KEY -w
+```
+
+On Apple Silicon the login Keychain is hardware-protected and unlocked by your
+login password, so this gives you at-rest encryption with no daemon to run and
+nothing to install.
+
+:::warning The SSH session boundary
+**Keychain reads and writes fail from an SSH session**, even as the same user
+who is logged into the GUI. Keychain items are scoped to the aqua login session:
+
+```console
+$ ssh mac 'security add-generic-password -a u -s test -w secret'
+security: SecKeychainItemCreateFromContent (<default>): User interaction is not allowed.
+```
+
+So a Hermes process started over SSH — or from a LaunchDaemon outside the user
+session — gets nothing, while the identical command works in `Terminal.app`.
+
+Note the two failures look different: a *blocked* read says `User interaction is
+not allowed`, while a *missing* item says `The specified item could not be
+found`. If you see the former over SSH, the item is fine and you are hitting the
+session boundary.
+
+If Hermes must run outside your GUI session, use a
+[LaunchAgent](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+(runs in the login session) rather than a LaunchDaemon, or materialize the
+secrets to a `0600` file during login and `cat` that file instead.
+:::
+
+Timing is not a concern here: `security` resolves an item in well under
+100 ms against an unlocked Keychain, comfortably inside the 3-second budget. A
+*locked* Keychain is the problem — it raises a GUI unlock prompt, which the
+helper cannot answer, so it hits the timeout and yields nothing.
+
 ## Failure modes
 
 Startup is never blocked. Errors print one line plus a `→` remediation hint:
@@ -44,6 +107,7 @@ Startup is never blocked. Errors print one line plus a `→` remediation hint:
 | `secrets.command.command is empty` | Enabled without a command | Set `secrets.command.command` in config.yaml |
 | `helper command failed` | Non-zero exit, timeout, spawn failure | Run the helper manually in a shell to see its real error (Hermes discards its stderr on purpose) |
 | `helper output was not a KEY=VALUE map` | Helper printed a bare value or garbage | Make the helper emit dotenv-shaped lines |
+| Helper works in `Terminal.app`, returns nothing under Hermes (macOS) | Keychain reads are blocked outside the GUI login session | See [the SSH session boundary](#recipe-macos-keychain) |
 
 ## When to use this vs a plugin
 


### PR DESCRIPTION
## What does this PR do?

Adds a **macOS Keychain recipe** to the `command` secret source page.

The page's examples are all Linux — `cat`, `pass show`, `secret-tool` — and it never mentions macOS, Keychain, or Darwin. Mac users have no documented path to a source that works fine for them, and macOS ships `security` in the base system, so it needs no extra vault software at all.

Documentation only. **No code, no new config keys, no new backend** — the recipe rides the existing bundled `command` source.

## Related Issue

No issue — noticed while setting up a Mac node against the `command` source.

## Type of Change

- [x] 📝 Documentation

## Changes Made

**`website/docs/user-guide/secrets/command.md`** (+64)

New `## Recipe: macOS Keychain` section between "Security model" and "Failure modes":

- Both storage shapes — one item holding a whole dotenv blob (a one-line `command:`), or one item per credential via a short helper script.
- `security add-generic-password -w`, which reads the value from a prompt instead of `argv` so it stays out of shell history.
- A note that the login Keychain is hardware-protected on Apple Silicon: at-rest encryption with no daemon and nothing to install.
- **The platform trap** (below), in a `:::warning` admonition.
- Timing against the 3-second budget, and why a *locked* Keychain is the real risk.

One row added to the existing failure-modes table, linking to the section.

## The trap this documents

**Keychain reads and writes fail from an SSH session**, even as the same user who is logged into the GUI, because items are scoped to the aqua login session:

```console
$ ssh mac 'security add-generic-password -a u -s test -w secret'
security: SecKeychainItemCreateFromContent (<default>): User interaction is not allowed.
```

So a helper that works perfectly in `Terminal.app` returns nothing under a Hermes started over SSH or from a LaunchDaemon — and since the source discards helper stderr by design, the user sees no explanation.

The section also distinguishes the two failure strings, which is what makes this diagnosable: a **blocked** read says `User interaction is not allowed`, a **missing** item says `The specified item could not be found`. Seeing the former over SSH means the item is fine and you are hitting the session boundary — worth knowing before you go re-adding items that already exist.

Remedy given: a LaunchAgent (runs inside the login session) rather than a LaunchDaemon, or materialize to a `0600` file at login and `cat` that.

## How to Test

Verified on **macOS 26.5.1, Apple Silicon**:

1. **The SSH refusal reproduces verbatim** — `security add-generic-password` over SSH returns `User interaction is not allowed` (exit 36), while `security` itself resolves fine in a GUI session.

2. **Latency is inside the budget** — an unlocked-Keychain lookup measured **~29 ms** against the 3-second `helper_timeout_seconds`.

3. **The published helper produces valid dotenv**, exercised against a `security` stub so the loop, quoting, and skip logic run for real:

   ```
   PASS simple value
   PASS spaces + = preserved      # "val with spaces and = sign"
   PASS empty skipped             # empty item never emitted
   PASS missing skipped           # missing item never emitted
   PASS stderr suppressed         # CLI error never reaches stdout
   ```

4. **The output round-trips through the real parser** — fed to `agent.secret_sources.command._parse_dotenv_map`, values containing spaces and `=` survive intact:

   ```
   parsed: ['DOCTEST_ALPHA', 'DOCTEST_BETA']
   PASS CommandSource parses the helper output
   ```

Markdown checks: 10 code fences balanced, the `:::warning` admonition opens and closes, and the one internal anchor link resolves.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(secrets):`)
- [x] I searched existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this documentation (1 file, +64/-0)
- [x] No tests needed — documentation only, no code paths touched
- [x] I've tested the documented commands on the target platform: macOS 26.5.1 (Apple Silicon)

### Documentation & Housekeeping
- [x] No new config keys — nothing to add to `cli-config.yaml.example`
- [x] Follows the page's existing structure, voice, and admonition style
- [x] Every command in the section was executed, not assumed

## Note on scope

Deliberately **not** a new backend under `agent/secret_sources/`. Per `website/docs/developer-guide/secret-source-plugin.md`, the bundled set is closed and other backends ship as standalone plugins — this is a usage recipe for the already-bundled `command` source, in the same spirit as the existing `pass` and `secret-tool` examples on the page.

Kept as prose with inline snippets rather than adding a script file to the tree, so there's nothing new to maintain.
