### PR TITLE
test(stt): de-flake command-STT idle-timeout stderr-progress test

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1159,7 +1159,7 @@ class TestTranscribeCredentialReadGuard:
         from agent.file_safety import get_read_block_error
 
         env_file = tmp_path / ".env"
-        env_file.write_text("OPENAI_API_KEY=sk-secret\n")
+        env_file.write_text("OPENAI_API_KEY=sk-secret\n", encoding="utf-8")
 
         expected = get_read_block_error(str(env_file))
         assert expected, "test setup: a .env file should be read-blocked"

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1187,13 +1187,20 @@ class TestRunCommandSttIdleTimeout:
         idle timeout shorter than its total runtime."""
         from tools.transcription_tools import _run_command_stt
 
+        # Margins are deliberately generous relative to the idle timeout: the
+        # per-tick gap (0.05s) is an order of magnitude under the 0.5s idle
+        # window, and the initial window comfortably exceeds interpreter
+        # cold-start. A tighter budget (e.g. 0.04s ticks under a 0.1s timeout)
+        # spuriously trips the idle deadline when a loaded CI host starves the
+        # reader thread between two ticks. The invariant under test is only
+        # that total runtime (~0.75s) outlasts the idle timeout (0.5s).
         script = tmp_path / "progress_then_exit.py"
         script.write_text(
             "\n".join([
                 "import sys, time",
-                "for idx in range(4):",
+                "for idx in range(15):",
                 "    print(f'tick {idx}', file=sys.stderr, flush=True)",
-                "    time.sleep(0.04)",
+                "    time.sleep(0.05)",
                 "print('done', flush=True)",
             ]),
             encoding="utf-8",
@@ -1201,11 +1208,11 @@ class TestRunCommandSttIdleTimeout:
 
         result = _run_command_stt(
             self._shell_command(sys.executable, "-u", str(script)),
-            timeout=0.1,
+            timeout=0.5,
         )
 
         assert result.returncode == 0
-        assert "tick 3" in result.stderr
+        assert "tick 14" in result.stderr
         assert "done" in result.stdout
 
     def test_silent_stall_still_times_out(self, tmp_path):


### PR DESCRIPTION
## What

`tests/tools/test_transcription_tools.py::TestRunCommandSttIdleTimeout::test_stderr_progress_extends_beyond_timeout` is flaky. It drives `_run_command_stt` with a **0.1s idle timeout** and **0.04s** inter-tick sleeps.

The idle deadline in `_run_command_stt` is reset on the *runner thread's read* of each output chunk (`deadline = time.monotonic() + timeout`), not on the child's emit time. On a loaded CI host the reader/main loop can be starved between two ticks — or the interpreter cold-start can exceed the initial window before the first tick — so the 0.1s deadline elapses with no *observed* progress and the runner spuriously tears the process down. The product code is correct; the test's budget is just too tight to survive scheduling jitter.

Reproduced locally at ~1/6 failures; the failure surfaced on CI slice 6/8 for an unrelated PR.

## Fix

Widen the margins while preserving the exact invariant under test (**total runtime outlasts the idle timeout**, and continuous progress keeps the process alive):

- 15 ticks at 0.05s (~0.75s total runtime) under a **0.5s** idle timeout.
- Per-tick gap is now ~10× under the idle window; the initial window comfortably exceeds interpreter start.

No production code changes — the STT idle runner is exercised exactly as before. 8/8 local passes after the change.

A second commit adds `encoding="utf-8"` to a pre-existing bare `Path.write_text()` in the same file (the `windows-footguns` gate scans the whole changed file; aligns with the repo-wide read_text/write_text encoding campaign, #71014).

## Testing

```
pytest tests/tools/test_transcription_tools.py::TestRunCommandSttIdleTimeout  # 2 passed
# de-flake target run 8× in a row: 8/8 passed
```

The unrelated `TestTranscribeLocalExtended::test_config_device_and_compute_type_passed_to_whisper` fails only on local macOS (faster-whisper resolves `compute_type=int8` on this CPU); it passes in CI and is untouched by this change.