### PR TITLE
fix(install): honor the full engines.node floor in the managed-Node staleness checks

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -317,7 +317,34 @@ def _candidate_node_command_names(command: str) -> list[str]:
     return [f"{base}.cmd", f"{base}.exe", base]
 
 
+def _parse_node_version(raw: str) -> tuple[int, int, int]:
+    """Parse a ``node --version`` string into a ``(major, minor, patch)`` tuple.
+
+    Tolerates the ``v`` prefix, a prerelease suffix (``v23.0.0-nightly...``)
+    and short forms (``22`` -> ``(22, 0, 0)``). Raises ``ValueError`` on
+    anything else; callers treat that as "unreadable", never as "outdated".
+    """
+    parts = raw.strip().lstrip("v").split("-", 1)[0].split(".")
+    nums = [int(part) for part in parts[:3]]
+    while len(nums) < 3:
+        nums.append(0)
+    return nums[0], nums[1], nums[2]
+
+
+# Which Node major we download when we install ("latest-v{major}.x").
 _HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22"))
+# The full floor a managed tree must clear. Keep in sync with the root
+# package.json's ``engines.node`` (and the mirror in
+# scripts/lib/node-bootstrap.sh): `.npmrc` sets `engine-strict=true`, so a tree
+# below this floor is rejected by every `npm ci` / `npm install` even though
+# its major looks current.
+_HERMES_NODE_TARGET_MIN_VERSION = os.environ.get(
+    "HERMES_NODE_TARGET_MIN_VERSION", "22.22.0"
+)
+try:
+    _HERMES_NODE_TARGET_MIN = _parse_node_version(_HERMES_NODE_TARGET_MIN_VERSION)
+except ValueError:
+    _HERMES_NODE_TARGET_MIN = (_HERMES_NODE_TARGET_MAJOR, 0, 0)
 _managed_node_heal_attempted = False
 _NODE_BOOTSTRAP_SCRIPT = Path(__file__).resolve().parent / "scripts" / "lib" / "node-bootstrap.sh"
 
@@ -552,13 +579,22 @@ def heal_hermes_managed_node() -> bool:
 
 
 def _managed_node_tree_outdated(home: Path | None = None) -> bool:
-    """Return True when the managed tree's node runs but is below the target major.
+    """Return True when the managed tree's node runs but is below the target.
 
-    An outdated managed Node (e.g. a 22 tree from an older install) heals the
-    same way a broken one does: :func:`find_hermes_node_executable` triggers
-    the once-per-process heal, which redownloads
-    ``latest-v{_HERMES_NODE_TARGET_MAJOR}.x`` — so existing users are upgraded
-    on next launch, not just on the next installer re-run. Mirrors
+    "Below the target" is two conditions, and BOTH matter:
+
+    * below ``_HERMES_NODE_TARGET_MAJOR`` — a tree from an older major.
+    * below ``_HERMES_NODE_TARGET_MIN`` — the full ``engines.node`` floor.
+      A 22.21.x tree has a current-looking major but is rejected by every
+      ``npm ci`` with ``EBADENGINE`` because `.npmrc` sets
+      ``engine-strict=true``. Comparing only the major left those users with
+      a broken ``hermes update`` and a heal that declined to fire.
+
+    An outdated managed Node heals the same way a broken one does:
+    :func:`find_hermes_node_executable` triggers the once-per-process heal,
+    which redownloads ``latest-v{_HERMES_NODE_TARGET_MAJOR}.x`` — the newest
+    release in the major, which clears the floor — so existing users are
+    upgraded on next launch, not just on the next installer re-run. Mirrors
     ``_nb_managed_node_outdated`` in ``scripts/lib/node-bootstrap.sh``.
     """
     import subprocess
@@ -579,18 +615,19 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
                     timeout=10,
                     creationflags=windows_hide_flags(),
                 )
-                major = int(result.stdout.decode().strip().lstrip("v").split(".")[0])
+                version = _parse_node_version(result.stdout.decode())
             except (OSError, subprocess.TimeoutExpired, ValueError, IndexError):
                 return False  # broken, not outdated — the runnable probe handles it
-            return major < _HERMES_NODE_TARGET_MAJOR
+            return version[0] < _HERMES_NODE_TARGET_MAJOR or version < _HERMES_NODE_TARGET_MIN
     return False
 
 
 def find_hermes_node_executable(command: str) -> str | None:
     """Return a Hermes-managed Node/npm executable path, healing broken trees.
 
-    Outdated trees (node major below ``_HERMES_NODE_TARGET_MAJOR``) heal the
-    same way broken ones do — the once-per-process heal redownloads the target
+    Outdated trees — below ``_HERMES_NODE_TARGET_MAJOR``, or below the full
+    ``_HERMES_NODE_TARGET_MIN`` floor within the target major — heal the same
+    way broken ones do: the once-per-process heal redownloads the target
     major, upgrading existing users on next launch rather than next reinstall.
     When the heal fails (offline, download error), an outdated-but-runnable
     tree is still returned: old Node beats no Node.

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -18,13 +18,19 @@
 #   if [ "$HERMES_NODE_AVAILABLE" = true ]; then ...; fi
 #
 # Env inputs (set before sourcing to override defaults):
-#   HERMES_NODE_MIN_VERSION   (default: 20)   — accepted on PATH
-#   HERMES_NODE_TARGET_MAJOR  (default: 22)   — installed when we install
-#   HERMES_HOME               (default: $HOME/.hermes)
+#   HERMES_NODE_MIN_VERSION        (default: 20)       — accepted on PATH
+#   HERMES_NODE_TARGET_MAJOR       (default: 22)       — installed when we install
+#   HERMES_NODE_TARGET_MIN_VERSION (default: 22.22.0)  — floor a managed tree
+#                                                        must clear; keep in
+#                                                        sync with the root
+#                                                        package.json's
+#                                                        engines.node
+#   HERMES_HOME                    (default: $HOME/.hermes)
 # ============================================================================
 
 HERMES_NODE_MIN_VERSION="${HERMES_NODE_MIN_VERSION:-20}"
 HERMES_NODE_TARGET_MAJOR="${HERMES_NODE_TARGET_MAJOR:-22}"
+HERMES_NODE_TARGET_MIN_VERSION="${HERMES_NODE_TARGET_MIN_VERSION:-22.22.0}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 HERMES_NODE_AVAILABLE=false
 
@@ -42,6 +48,44 @@ _nb_warn() { declare -F log_warn    >/dev/null 2>&1 && log_warn    "$*" || print
 
 _nb_is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
+}
+
+# Echo "<major> <minor> <patch>" for a dotted version ("v22.21.1", "22.22.0",
+# "22"). Drops the `v` prefix and any prerelease suffix, pads missing
+# components with 0. Returns non-zero (and echoes nothing) when a component is
+# not a plain integer.
+_nb_version_triple() {
+    local ver rest major minor patch part
+    ver="${1#v}"
+    ver="${ver%%-*}"
+
+    major="${ver%%.*}"
+    case "$ver"  in *.*) rest="${ver#*.}"  ;; *) rest="" ;; esac
+    minor="${rest%%.*}"
+    case "$rest" in *.*) rest="${rest#*.}" ;; *) rest="" ;; esac
+    patch="${rest%%.*}"
+
+    [ -n "$minor" ] || minor=0
+    [ -n "$patch" ] || patch=0
+    for part in "$major" "$minor" "$patch"; do
+        case "$part" in ''|*[!0-9]*) return 1 ;; esac
+    done
+    printf '%s %s %s\n' "$major" "$minor" "$patch"
+}
+
+# True when version $1 is strictly older than version $2. Fails closed: an
+# unreadable version is never reported as older, so we don't redownload a tree
+# just because we couldn't parse its `--version`.
+_nb_version_lt() {
+    local lhs rhs
+    lhs="$(_nb_version_triple "$1")" || return 1
+    rhs="$(_nb_version_triple "$2")" || return 1
+    # Intentional word splitting: each side is exactly three integer fields.
+    # shellcheck disable=SC2086
+    set -- $lhs $rhs
+    if [ "$1" -ne "$4" ]; then [ "$1" -lt "$4" ]; return; fi
+    if [ "$2" -ne "$5" ]; then [ "$2" -lt "$5" ]; return; fi
+    [ "$3" -lt "$6" ]
 }
 
 # Where to symlink node/npm/npx so they land on PATH.
@@ -345,11 +389,15 @@ _nb_managed_tool_broken() {
     return 1
 }
 
-# The managed node runs but is below HERMES_NODE_TARGET_MAJOR — an old tree
-# from a previous install (e.g. 22). Outdated heals the same way broken does,
-# so existing users get upgraded on the next heal probe, not just on a full
-# installer re-run. Mirrors _managed_node_tree_outdated() in
-# hermes_constants.py.
+# The managed node runs but is below the target — either below
+# HERMES_NODE_TARGET_MAJOR (an old tree from a previous major) or below the
+# full HERMES_NODE_TARGET_MIN_VERSION floor within the current major. The
+# second case is the one that bites: a 22.21.x tree looks current by major but
+# `.npmrc`'s engine-strict=true makes every `npm ci` reject it with
+# EBADENGINE, so `hermes update` dies while the heal declines to fire.
+# Outdated heals the same way broken does, so existing users get upgraded on
+# the next heal probe, not just on a full installer re-run. Mirrors
+# _managed_node_tree_outdated() in hermes_constants.py.
 _nb_managed_node_outdated() {
     local probe ver major
     for probe in "$HERMES_HOME/node/bin/node" "$HERMES_HOME/node/node"; do
@@ -358,6 +406,7 @@ _nb_managed_node_outdated() {
         major="${ver#v}"; major="${major%%.*}"
         case "$major" in ''|*[!0-9]*) return 1 ;; esac
         [ "$major" -lt "$HERMES_NODE_TARGET_MAJOR" ] && return 0
+        _nb_version_lt "$ver" "$HERMES_NODE_TARGET_MIN_VERSION" && return 0
         return 1
     done
     return 1

--- a/tests/test_engines_satisfiable.py
+++ b/tests/test_engines_satisfiable.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import pytest
 
+import hermes_constants
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # npm releases bundled with a Node major, newest-per-major. Not a catalog
@@ -183,3 +185,69 @@ class TestManifestMirrors:
         manifest = _root_manifest()["engines"]
         lock = json.loads((REPO_ROOT / "package-lock.json").read_text())
         assert lock["packages"][""]["engines"] == manifest
+
+
+def _manifest_node_floor() -> tuple[int, int, int]:
+    """The loosest `>=` floor `engines.node` declares."""
+    node_range = _root_manifest()["engines"]["node"]
+    floors = [
+        _parse_major_minor_patch(m.group(1))
+        for m in re.finditer(r">=\s*v?(\d+(?:\.\d+){0,2})", node_range)
+    ]
+    assert floors, f"cannot read a floor out of {node_range!r}"
+    return min(floors)
+
+
+class TestRuntimeStalenessGatesCoverTheManifest:
+    """No tree `engines.node` rejects may be judged "current" by the runtime.
+
+    The installers gate on the full floor, but the two *runtime* staleness
+    mirrors — `_managed_node_tree_outdated()` and `_nb_managed_node_outdated()`
+    — compared only the major. A Hermes-managed 22.21.x tree therefore looked
+    current, so `find_hermes_node_executable`'s self-heal declined to fire,
+    while `npm ci` rejected that same tree with EBADENGINE and `hermes update`
+    aborted with no recovery path (`required_npm_range()` returns None for a
+    node-side mismatch by design).
+
+    Behavioral, like the rest of this file: these assert the *relationship*
+    between the declared floor and the gates that have to enforce it, so the
+    next `engines.node` bump fails CI here instead of in users' installs.
+    """
+
+    def test_python_staleness_floor_covers_engines_node(self):
+        assert hermes_constants._HERMES_NODE_TARGET_MIN >= _manifest_node_floor(), (
+            f"hermes_constants._HERMES_NODE_TARGET_MIN is "
+            f"{hermes_constants._HERMES_NODE_TARGET_MIN}, below engines.node "
+            f"{_root_manifest()['engines']['node']!r}. Managed trees in the gap "
+            "are judged current but rejected by every `npm ci`."
+        )
+
+    def test_shell_mirror_declares_a_floor_covering_engines_node(self):
+        bootstrap = (REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh").read_text()
+        match = re.search(
+            r'HERMES_NODE_TARGET_MIN_VERSION="\$\{HERMES_NODE_TARGET_MIN_VERSION:-'
+            r'([^}"]+)\}"',
+            bootstrap,
+        )
+        assert match, (
+            "scripts/lib/node-bootstrap.sh does not declare a default "
+            "HERMES_NODE_TARGET_MIN_VERSION"
+        )
+        assert _parse_major_minor_patch(match.group(1)) >= _manifest_node_floor()
+
+    def test_the_two_runtime_mirrors_agree(self):
+        """Drift between the mirrors is the bug this class exists to catch."""
+        bootstrap = (REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh").read_text()
+        match = re.search(
+            r'HERMES_NODE_TARGET_MIN_VERSION="\$\{HERMES_NODE_TARGET_MIN_VERSION:-'
+            r'([^}"]+)\}"',
+            bootstrap,
+        )
+        assert match, "node-bootstrap.sh does not declare the floor"
+        assert (
+            _parse_major_minor_patch(match.group(1))
+            == hermes_constants._HERMES_NODE_TARGET_MIN
+        ), (
+            "node-bootstrap.sh and hermes_constants.py declare different Node "
+            "floors; they gate the same managed tree and must stay mirrored."
+        )

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -30,6 +30,17 @@ from hermes_constants import (
 )
 
 
+def _current_node_version() -> str:
+    """A ``node --version`` string that clears every managed-tree staleness gate.
+
+    Derived from the constants rather than pinned, so raising the target major
+    or the ``engines.node`` floor does not silently turn these fixtures into
+    "outdated" trees.
+    """
+    major, minor, patch = hermes_constants._HERMES_NODE_TARGET_MIN
+    return f"v{max(major, hermes_constants._HERMES_NODE_TARGET_MAJOR)}.{minor}.{patch}"
+
+
 class TestGetDefaultHermesRoot:
     """Tests for get_default_hermes_root() — Docker/custom deployment awareness."""
 
@@ -230,7 +241,7 @@ class TestNodeToolRunnable:
 
         def _heal():
             heal_called["value"] = True
-            old_node.write_text(f"#!/bin/sh\necho 'v{target}.5.1'\nexit 0\n")
+            old_node.write_text(f"#!/bin/sh\necho '{_current_node_version()}'\nexit 0\n")
             old_node.chmod(0o755)
             return True
 
@@ -257,14 +268,17 @@ class TestNodeToolRunnable:
 
         assert hermes_constants.find_hermes_node_executable("node") == str(old_node)
 
-    def test_target_major_managed_node_does_not_heal(self, tmp_path, monkeypatch):
-        """A tree already at the target major never triggers the heal."""
-        target = hermes_constants._HERMES_NODE_TARGET_MAJOR
+    def test_up_to_date_managed_node_does_not_heal(self, tmp_path, monkeypatch):
+        """A tree clearing the full floor never triggers the heal.
+
+        Being at the target *major* is not sufficient — see
+        :meth:`test_managed_tree_outdated_honors_the_full_floor`.
+        """
         profile_home = tmp_path / "profiles" / "assistant"
         managed_bin = profile_home / "node" / "bin"
         managed_bin.mkdir(parents=True)
         node = self._stub(
-            managed_bin, "node", f"#!/bin/sh\necho 'v{target}.5.1'\nexit 0\n"
+            managed_bin, "node", f"#!/bin/sh\necho '{_current_node_version()}'\nexit 0\n"
         )
 
         monkeypatch.setenv("HERMES_HOME", str(profile_home))
@@ -277,6 +291,52 @@ class TestNodeToolRunnable:
         monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
 
         assert hermes_constants.find_hermes_node_executable("node") == str(node)
+
+    @pytest.mark.parametrize(
+        ("version", "outdated"),
+        [
+            # The regression: a current-looking major, below engines.node.
+            ("v22.21.1", True),
+            ("v22.0.0", True),
+            # The pre-existing major gate must keep working.
+            ("v21.99.99", True),
+            # Exactly the floor, and above it, are current.
+            ("v22.22.0", False),
+            ("v22.23.4", False),
+            ("v24.1.0", False),
+            # A prerelease suffix must not make the probe unreadable.
+            ("v22.23.0-nightly20240101abcdef", False),
+            # An unreadable probe is broken, not outdated — node_tool_runnable
+            # owns that case, and redownloading on a parse failure would be a
+            # surprise network fetch.
+            ("not-a-version", False),
+        ],
+    )
+    def test_managed_tree_outdated_honors_the_full_floor(
+        self, tmp_path, monkeypatch, version, outdated
+    ):
+        """A tree `engines.node` rejects must not be judged current.
+
+        `.npmrc` sets `engine-strict=true`, so a 22.21.x managed tree fails
+        every `npm ci` with EBADENGINE. Comparing only the major called that
+        tree current, so the self-heal built to replace it never fired and
+        `hermes update` had no recovery path.
+
+        Constants are pinned here so the comparator is tested directly; that
+        they stay in sync with `package.json` is asserted separately in
+        `tests/test_engines_satisfiable.py`.
+        """
+        monkeypatch.setattr(hermes_constants, "_HERMES_NODE_TARGET_MAJOR", 22)
+        monkeypatch.setattr(hermes_constants, "_HERMES_NODE_TARGET_MIN", (22, 22, 0))
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        self._stub(managed_bin, "node", f"#!/bin/sh\necho '{version}'\nexit 0\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", "")
+
+        assert hermes_constants._managed_node_tree_outdated() is outdated
 
 
 


### PR DESCRIPTION
## What does this PR do?

**Symptom.** `hermes update` dies on a fresh, untouched install:

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error notsup Required: {"node":">=22.22.0"}
npm error notsup Actual:   {"node":"v22.21.1","npm":"10.9.8"}
```

**Who is affected.** Every Linux/macOS user running on a Hermes-managed Node
tree provisioned before `engines.node` was raised on 2026-08-01 — i.e. anyone
who ran the installer without a system Node and got `latest-v22.x` at the time,
which is the default outcome. Their tree is Node 22.0.0–22.21.x. `.npmrc` sets
`engine-strict=true`, so this is a hard gate on every `npm ci` / `npm install`:
the installer's workspace step and `hermes update`'s dependency refresh alike.

**Why nothing rescues them.** Hermes already has a self-heal for exactly this
situation — `find_hermes_node_executable()` redownloads the tree when it is
stale. It does not fire, because the staleness check compares only the major:

```python
# hermes_constants.py — _managed_node_tree_outdated()
return major < _HERMES_NODE_TARGET_MAJOR
```
```sh
# scripts/lib/node-bootstrap.sh — _nb_managed_node_outdated()
[ "$major" -lt "$HERMES_NODE_TARGET_MAJOR" ] && return 0
```

`22 < 22` is false, so a 22.21.1 tree is judged *current* — while npm rejects
that same tree outright. And there is no other rung to fall back to:

- `hermes_cli/npm_engine.py::required_npm_range()` returns `None` for a
  node-side `EBADENGINE` **by design** ("upgrading npm cannot fix a Node
  version mismatch").
- `with_hermes_node_path()` — used by `update_cmd.py` to build the npm
  environment — only prepends `iter_hermes_node_dirs()` to `PATH`. It never
  calls `find_hermes_node_executable`, so it does not trigger the heal either.

So the comparator is the only thing standing between these users and a working
update. The heal itself is already correct: it resolves
`https://nodejs.org/dist/latest-v${HERMES_NODE_TARGET_MAJOR}.x/`, the newest
release in the major, which today satisfies `>=22.22.0`.

**Sibling relationship.** This completes the sweep started by `63ff4b87b`
*(fix(install): sync the lockfile engines mirrors with the manifests,* merged
2026-08-01), which raised the floor and moved the two **installer** gates to
match, but not the two **runtime** mirrors. See `8e08a4a16` for the context in
which the floor was set.

### All five Node gates, and what this PR does to each

| # | Gate | Location | Compares | This PR |
|---|------|----------|----------|---------|
| 1 | `node_satisfies_build` | `scripts/install.sh:790` | full floor | already correct (`63ff4b87b`) |
| 2 | `Test-NodeVersionOk` | `scripts/install.ps1:1198` | full floor | already correct (`63ff4b87b`) |
| 3 | `_managed_node_tree_outdated` | `hermes_constants.py:585` | **major only** | **fixed** |
| 4 | `_nb_managed_node_outdated` | `scripts/lib/node-bootstrap.sh:360` | **major only** | **fixed** |
| 5 | `_nb_have_modern_node` / `HERMES_NODE_MIN_VERSION` | `scripts/lib/node-bootstrap.sh:26` | major only (`20`) | **deliberately left alone** — see below |

Gates 3 and 4 are explicitly documented as mirrors of one another
(`node-bootstrap.sh:348-352`: *"Mirrors `_managed_node_tree_outdated()` in
hermes_constants.py"*), so they are fixed together and a test now asserts they
cannot drift apart again.

**Gate 5 is out of scope on purpose.** `HERMES_NODE_MIN_VERSION="${...:-20}"`
is the PATH-acceptance gate, and it is also stale relative to the floor. It is
a direct line collision with two open PRs that rewrite that declaration block —
**#74250** (@DeliciousHouse) and **#25043** (@EvanYao826) — so touching it here
would guarantee a conflict for no benefit. Flagging rather than silently
omitting it; it is a separate, smaller change once those land.

**Overlap check.** No open PR touches either comparator.
- **#70725** is the only open PR that edits `_managed_node_tree_outdated` at
  all — a one-line `candidate.is_file()` -> `_safe_path_is_file(candidate)`
  swap near the top of the function, plus new functions appended after it. It
  never touches the comparator. Hunk-disjoint, different bug.
- **#74250** touches `hermes_constants.py @@ -308` (the
  `_HERMES_NODE_TARGET_MAJOR` declaration) and `node-bootstrap.sh @@ -18` (the
  env header). Also disjoint, and orthogonal: it raises the target *major*,
  while the within-major staleness gap survives any major.
- Other `hermes_constants.py` PRs in the managed-Node neighbourhood (#61351,
  #72621, #75419, #75357) are all in different functions.

## Related Issue

No linked issue — this was found by auditing the runtime mirrors of
`63ff4b87b` after that commit moved the installer gates only.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_constants.py`
  - New `_parse_node_version()` — parses `node --version` into
    `(major, minor, patch)`, tolerating the `v` prefix, a prerelease suffix and
    short forms. Raises `ValueError` on anything else, which the existing
    `except` clause already maps to "broken, not outdated".
  - New `_HERMES_NODE_TARGET_MIN_VERSION` env input (default `22.22.0`) and its
    parsed `_HERMES_NODE_TARGET_MIN` tuple. A malformed override degrades to
    `(_HERMES_NODE_TARGET_MAJOR, 0, 0)` rather than raising at import — this
    module is imported from 30+ sites at load time.
  - `_managed_node_tree_outdated()` now returns True when the probed version is
    below the target major **or** below the full floor.
- `scripts/lib/node-bootstrap.sh`
  - New `HERMES_NODE_TARGET_MIN_VERSION` (default `22.22.0`), documented in the
    "Env inputs" header block.
  - New `_nb_version_triple()` / `_nb_version_lt()` — POSIX parameter expansion
    only, no `sort -V`, no arrays, since this file is sourced by the installer.
    Both fail closed: an unparseable version is never reported as older, so we
    never trigger a surprise redownload on a probe we could not read.
  - `_nb_managed_node_outdated()` gains the full-floor comparison alongside the
    existing major check.
- `tests/test_hermes_constants.py`
  - New parametrized `test_managed_tree_outdated_honors_the_full_floor`
    covering the regression (`v22.21.1`, `v22.0.0` -> outdated), the preserved
    major gate (`v21.99.99`), the current cases (`v22.22.0`, `v22.23.4`,
    `v24.1.0`), a prerelease suffix, and an unreadable probe.
  - `test_target_major_managed_node_does_not_heal` renamed to
    `test_up_to_date_managed_node_does_not_heal` and its fixture derived from
    the constants — it previously stubbed `v22.5.1`, which encoded exactly the
    behavior this PR corrects.
- `tests/test_engines_satisfiable.py`
  - New `TestRuntimeStalenessGatesCoverTheManifest`: the Python floor and the
    shell mirror must each cover `engines.node`, and must equal each other.
    Behavioral, matching the file's existing style — nothing pins a version.

**Backward compatibility.** The change is strictly widening: every tree
previously reported outdated still is. `_HERMES_NODE_TARGET_MAJOR` keeps its
job of selecting which major to download, so an operator who raises only that
variable gets exactly the old behavior.

## How to Test

Reproduce the bug on `main`, then confirm the fix:

```sh
# Stand up a managed tree at a version engines.node rejects.
HH=$(mktemp -d); mkdir -p "$HH/node/bin"
printf '#!/bin/sh\necho v22.21.1\n' > "$HH/node/bin/node"; chmod +x "$HH/node/bin/node"

# Shell mirror — on main this prints "current"; with this PR, "OUTDATED".
HERMES_HOME="$HH" bash -c 'source scripts/lib/node-bootstrap.sh
    _nb_managed_node_outdated && echo OUTDATED || echo current'
```

Python mirror, same tree:

```sh
HERMES_HOME="$HH" python3 -c '
import hermes_constants
print(hermes_constants._managed_node_tree_outdated())'   # main: False -> this PR: True
```

Test suite:

```sh
pytest tests/test_engines_satisfiable.py tests/test_hermes_constants.py -q
```

**Fails-before / passes-after, verified in both directions.** Reverting only
the comparator line while leaving the new constants and tests in place gives
the precise failure:

```
FAILED tests/test_hermes_constants.py::TestNodeToolRunnable::
       test_managed_tree_outdated_honors_the_full_floor[v22.21.1-True]
  assert False is True
FAILED ... test_managed_tree_outdated_honors_the_full_floor[v22.0.0-True]
2 failed, 6 passed
```

With the fix restored: `77 passed`
(`test_engines_satisfiable.py`, `test_hermes_constants.py`,
`test_install_sh_node_global_prefix.py`, `test_install_ps1_node_path_for_npm.py`).
Adjacent node-resolution suites — adding `test_managed_runtime_resolution.py`,
`tests/hermes_cli/test_gui_command.py`, `tests/hermes_cli/test_nous_subscription.py`
— `92 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused + adjacent suites listed above and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4). The PowerShell gate is untouched; the shell helpers use POSIX parameter expansion only.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the
  "Env inputs" header in `node-bootstrap.sh` and the docstrings on both
  comparators
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the Python mirror covers Windows (`node.exe` via `_candidate_node_command_names`); `node-bootstrap.sh` is POSIX-only by design and its Windows counterpart, `Test-NodeVersionOk`, was already correct
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
