### PR TITLE
fix(tools): edit tool no operation

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -501,6 +501,7 @@ class TestPatchSchemaShape:
         for name in ("path", "old_string", "new_string"):
             assert "REQUIRED when mode='replace'" in props[name]["description"]
         assert "REQUIRED when mode='patch'" in props["patch"]["description"]
+        assert "must differ from old_string" in props["new_string"]["description"]
 
     def test_no_anyof_required_stays_mode_only(self):
         # anyOf/oneOf at parameters level break Anthropic, Fireworks, and the

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -179,6 +179,19 @@ class TestPatchReplace:
         assert Path(path).read_text() == "hello earth\n"
 
 
+    def test_identical_replacement_explains_no_change(self, ops, tmp_path):
+        path = str(tmp_path / "unchanged.txt")
+        Path(path).write_text("hello world\n")
+
+        result = ops.patch_replace(path, "world", "world")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "No edit was applied" in result.error
+        assert "existing text to replace in old_string" in result.error
+        assert "replacement text in new_string" in result.error
+        assert Path(path).read_text() == "hello world\n"
+
     def test_multiline_patch(self, ops, tmp_path):
         path = str(tmp_path / "multi.txt")
         Path(path).write_text("line1\nline2\nline3\n")

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -25,6 +25,15 @@ class TestExactMatch:
         assert count == 0
         assert err is not None
 
+    def test_identical_strings(self):
+        new, count, _, err = fuzzy_find_and_replace("abc", "abc", "abc")
+        assert count == 0
+        assert new == "abc"
+        assert err == (
+            "No edit was applied because old_string and new_string are identical. "
+            "Provide the existing text to replace in old_string and the changed "
+            "replacement text in new_string."
+        )
 
     def test_multiline_exact(self):
         content = "line1\nline2\nline3"
@@ -431,6 +440,28 @@ class TestFormatNoMatchHint:
         )
         assert result == ""
 
+    def test_silent_on_identical_strings(self):
+        """old_string == new_string — hint irrelevant."""
+        result = self.fmt(
+            "No edit was applied because old_string and new_string are identical. "
+            "Provide the existing text to replace in old_string and the changed "
+            "replacement text in new_string.",
+            0, "foo", "foo bar\n",
+        )
+        assert result == ""
+
+    def test_silent_when_match_count_nonzero(self):
+        """If match succeeded, we shouldn't be in the error path — defense in depth."""
+        result = self.fmt(
+            "Could not find a match for old_string in the file",
+            1, "foo", "foo bar\n",
+        )
+        assert result == ""
+
+    def test_silent_on_none_error(self):
+        """No error at all — no hint."""
+        result = self.fmt(None, 0, "foo", "bar\n")
+        assert result == ""
 
     def test_silent_when_no_similar_content(self):
         """Even for a valid no-match error, skip hint when nothing similar exists."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2218,7 +2218,7 @@ PATCH_SCHEMA = {
             },
             "new_string": {
                 "type": "string",
-                "description": "REQUIRED when mode='replace'. Replacement text. Pass empty string '' to delete the matched text.",
+                "description": "REQUIRED when mode='replace'. Changed replacement text; it must differ from old_string. Pass empty string '' to delete the matched text.",
             },
             "replace_all": {
                 "type": "boolean",

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -143,7 +143,11 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         return content, 0, None, "old_string is only whitespace — provide non-blank text to match"
 
     if old_string == new_string:
-        return content, 0, None, "old_string and new_string are identical"
+        return content, 0, None, (
+            "No edit was applied because old_string and new_string are identical. "
+            "Provide the existing text to replace in old_string and the changed "
+            "replacement text in new_string."
+        )
 
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [


### PR DESCRIPTION
## What does this PR do?

Clarifies failed patch replacements where `old_string` and `new_string` are identical. The existing behavior correctly performed no edit, but its terse error did not explain how to form a valid replacement.

The patch schema now states that `new_string` must differ from `old_string`, and the runtime error explicitly asks for the existing text in `old_string` and the changed replacement in `new_string`. This prevents repeated no-op edits without changing replacement semantics, including intentional deletion with an empty `new_string`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated the `new_string` parameter description in `tools/file_tools.py` to prohibit identical replacements while preserving empty-string deletion.
- Improved the identical-string error in `tools/fuzzy_match.py` with concrete corrective guidance.
- Added schema, live patch-replacement, and fuzzy-match regression assertions in `tests/tools/test_file_tools.py`, `tests/tools/test_file_tools_live.py`, and `tests/tools/test_fuzzy_match.py`.

## How to Test

1. Run `pytest tests/tools/test_file_tools.py tests/tools/test_file_tools_live.py tests/tools/test_fuzzy_match.py -q`.
2. Use patch replace mode with identical `old_string` and `new_string`.
3. Verify that no file change is made and the error explains which argument must contain the changed text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (benchmark sandbox/container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this change improves a structured patch-tool validation error.
