### PR TITLE
fix(cron): catch ValueError on NUL paths in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -255,10 +255,22 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
 
 def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+    # A candidate path that itself contains an embedded NUL byte cannot be a
+    # real script reference — it is either transport corruption or a binary's
+    # decoded token. `os.open` raises `ValueError: embedded null byte` (NOT
+    # OSError) on such paths, so reject it up front instead of crashing the
+    # guard (#76762 follow-up: the prior OSError-only guard let ValueError
+    # escape and fail the command closed).
+    try:
+        path_str = str(path)
+    except (ValueError, TypeError):
+        return None, False
+    if "\x00" in path_str:
+        return None, False
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -268,7 +280,7 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         # chunk tells us if this is a binary (NUL bytes) that should be
         # skipped as "nothing to scan" rather than failing closed (#76762).
         data = os.read(descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1)
-    except OSError:
+    except (OSError, ValueError):
         return None, False
     finally:
         os.close(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -16,6 +16,7 @@ from hermes_cli.cron import (
     _contains_gateway_lifecycle_command,
     cron_command,
 )
+from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
 
 
 # ---------------------------------------------------------------------------
@@ -857,3 +858,27 @@ class TestCronCreateLifecycleBlockExtra:
         assert rc == 1
         out = capsys.readouterr().out
         assert "Blocked" in out
+
+
+# ---------------------------------------------------------------------------
+# Regression: embedded NUL in a referenced-script path must not crash the guard
+# ---------------------------------------------------------------------------
+
+class TestEmbeddedNulPath:
+    """``os.open`` raises ``ValueError`` (not ``OSError``) on NUL paths.
+
+    A prior fix (#76762) only wrapped ``os.open`` in ``except OSError``, so a
+    referenced-script token containing an embedded NUL byte escaped as an
+    unhandled ``ValueError: embedded null byte`` and failed the command closed.
+    """
+
+    def test_nul_in_referenced_script_token_does_not_crash(self):
+        cmd = "source /root/.env\x00bogus"
+        assert contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd="/root") is False
+
+    def test_binary_executable_path_is_not_scanned_as_script(self):
+        cmd = "/usr/bin/ls --help 2>&1 | head -5"
+        assert contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd="/root") is False
+
+    def test_embedded_nul_still_blocks_real_lifecycle_command(self):
+        assert _contains_gateway_lifecycle_command("hermes gateway restart") is True


### PR DESCRIPTION
## Summary
`cron.lifecycle_guard._read_referenced_script` wraps `os.open` in `except OSError`, but `os.open` raises **`ValueError: embedded null byte`** (not `OSError`) when a referenced-script path contains an embedded NUL byte. A prior fix (#76762) only guarded against `OSError`, so a command whose tokenized script path carried a NUL escaped as an unhandled `ValueError` and **failed the command closed** — e.g. terminal commands that reference a binary executable path or carry a NUL token crashed the guard instead of running.

## Changes
- Reject candidate paths containing an embedded NUL byte up front (`str(path)` + membership check) before calling `os.open`.
- Broaden the `os.open` / `os.fstat` / `os.read` guards to `except (OSError, ValueError)`.
- Add regression tests in `tests/hermes_cli/test_gateway_restart_loop.py` covering NUL tokens, binary executable paths, and confirming real lifecycle-command detection still fires.

## Verification
- `contains_gateway_lifecycle_command_or_referenced_script("source /root/.env\x00bogus", cwd="/root")` returns `False` (no crash)
- `contains_gateway_lifecycle_command_or_referenced_script("/usr/bin/ls --help", cwd="/root")` returns `False`
- the gateway lifecycle pattern detector still returns `True` for the canonical restart phrase (protection intact)

Fixes a crash observed in production when running terminal commands that reference native binaries.
