### PR TITLE
feat(gateway): persist structured Discord message origins

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3235,6 +3235,21 @@ def repair_empty_non_final_messages(
     return messages
 
 
+_TRANSCRIPT_ONLY_API_MESSAGE_FIELDS = frozenset({
+    "api_content",
+    "display_kind",
+    "display_metadata",
+    "platform_message_id",
+    "message_id",
+    "timestamp",
+    "observed",
+    "active",
+    "compacted",
+    "_row_id",
+    "_db_persisted",
+})
+
+
 def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
@@ -3252,7 +3267,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 role,
             )
             continue
-        filtered.append(msg)
+        # Session and presentation fields are valuable in state.db but are not
+        # part of any provider message schema. Strip them at the final shared
+        # API boundary so every transport, including callers that bypass the
+        # main conversation-loop copy step, receives a clean payload.
+        if msg.keys() & _TRANSCRIPT_ONLY_API_MESSAGE_FIELDS:
+            filtered.append({
+                key: value
+                for key, value in msg.items()
+                if key not in _TRANSCRIPT_ONLY_API_MESSAGE_FIELDS
+            })
+        else:
+            filtered.append(msg)
     messages = filtered
 
     # --- Heal empty-content non-final messages (self-recovery) ---

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1241,6 +1241,7 @@ def run_conversation(
     persist_user_timestamp: Optional[float] = None,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    persist_user_platform_message_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -1266,7 +1267,8 @@ def run_conversation(
             the message unchanged.
         persist_user_display_metadata: Optional payload for that event
             (e.g. a delegation's task count).
-                or queuing follow-up prefetch work.
+        persist_user_platform_message_id: Optional stable identifier assigned
+            to the triggering message by the gateway platform.
 
     Returns:
         Dict: Complete conversation result with final response and message history
@@ -1310,6 +1312,7 @@ def run_conversation(
         persist_user_timestamp,
         persist_user_display_kind=persist_user_display_kind,
         persist_user_display_metadata=persist_user_display_metadata,
+        persist_user_platform_message_id=persist_user_platform_message_id,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -339,6 +339,7 @@ def build_turn_context(
     *,
     persist_user_display_kind: Optional[str] = None,
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    persist_user_platform_message_id: Optional[str] = None,
     restore_or_build_system_prompt,
     install_safe_stdio,
     sanitize_surrogates,
@@ -551,12 +552,14 @@ def build_turn_context(
     # message so the crash persist below writes the row already typed. Typing
     # it after the turn instead leaves the row untyped for the whole run — and
     # forever if the turn crashes — so the raw system note paints as a user
-    # bubble. The model still receives role/content unchanged; the api_messages
-    # build strips both fields from every outgoing copy.
+    # bubble. The model still receives role/content unchanged; the provider
+    # payload sanitizer strips these transcript-only fields from every copy.
     if persist_user_display_kind:
         user_msg["display_kind"] = persist_user_display_kind
-        if persist_user_display_metadata:
-            user_msg["display_metadata"] = persist_user_display_metadata
+    if persist_user_display_metadata:
+        user_msg["display_metadata"] = persist_user_display_metadata
+    if persist_user_platform_message_id:
+        user_msg["platform_message_id"] = str(persist_user_platform_message_id)
 
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5313,6 +5313,14 @@ class TurnRunner:
                 _conversation_kwargs["moa_config"] = ctx.moa_config
             if _persist_user_timestamp_override is not None:
                 _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+            if ctx.persist_user_display_metadata:
+                _conversation_kwargs["persist_user_display_metadata"] = (
+                    ctx.persist_user_display_metadata
+                )
+            if ctx.persist_user_platform_message_id:
+                _conversation_kwargs["persist_user_platform_message_id"] = (
+                    ctx.persist_user_platform_message_id
+                )
             result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
             unregister_gateway_notify(_approval_session_key)
@@ -16295,6 +16303,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _redact_pii = False
         persist_user_message = None
         persist_user_timestamp = None
+        _origin = source.to_dict()
+        if getattr(source, "is_bot", False):
+            _origin["is_bot"] = True
+        _platform_message_id = getattr(event, "message_id", None) or _origin.get(
+            "message_id"
+        )
+        if _platform_message_id:
+            _platform_message_id = str(_platform_message_id)
+            _origin["message_id"] = _platform_message_id
+        persist_user_display_metadata = {"origin": _origin}
+
+        def _decorate_inbound_user_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+            """Attach the current platform event identity to one user row."""
+            if entry.get("role") != "user":
+                return entry
+            if _platform_message_id and not (
+                entry.get("platform_message_id") or entry.get("message_id")
+            ):
+                entry["platform_message_id"] = _platform_message_id
+            metadata = entry.get("display_metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            if "origin" not in metadata:
+                metadata = {**metadata, "origin": _origin}
+            entry["display_metadata"] = metadata
+            return entry
         try:
             _pcfg = _load_gateway_config()
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
@@ -17311,6 +17345,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if message_text is None:
             return
 
+        # The model-facing text above may include sender attribution, channel
+        # backfill, reply pointers, and attachment guidance. Those are useful
+        # live context, but they are not what the person authored. Persist the
+        # triggering text separately so transcript miners can rely on clean
+        # content plus the structured origin metadata attached below.
+        _trigger_text = getattr(event, "_gateway_pending_stt_text", None)
+        if _trigger_text is None:
+            _trigger_text = getattr(event, "text", "")
+        if _trigger_text is None:
+            _trigger_text = ""
+
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).
         # This runs regardless of the toggle so storage stays clean and the
@@ -17326,13 +17371,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             _evt_tz = _get_evt_tz()
             _evt_ts = getattr(event, "timestamp", None)
-            if message_text and isinstance(message_text, str):
+            if isinstance(message_text, str):
                 _clean_message_text, _embedded_ts = _strip_msg_ts(
                     message_text, tz=_evt_tz)
-                persist_user_message = _clean_message_text
+                _clean_trigger_text, _trigger_embedded_ts = _strip_msg_ts(
+                    str(_trigger_text), tz=_evt_tz
+                )
+                persist_user_message = _clean_trigger_text
                 _event_epoch = _coerce_msg_ts(_evt_ts, tz=_evt_tz)
                 persist_user_timestamp = (
-                    _event_epoch if _event_epoch is not None else _embedded_ts
+                    _event_epoch
+                    if _event_epoch is not None
+                    else (
+                        _trigger_embedded_ts
+                        if _trigger_embedded_ts is not None
+                        else _embedded_ts
+                    )
                 )
                 if _message_timestamps_enabled(_load_gateway_config()):
                     message_text = _render_msg_ts(
@@ -17395,6 +17449,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_display_metadata=persist_user_display_metadata,
+                persist_user_platform_message_id=_platform_message_id,
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
@@ -17839,8 +17895,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         else ts
                     ),
                 }
-                if event.message_id:
-                    _user_entry["message_id"] = str(event.message_id)
+                _decorate_inbound_user_entry(_user_entry)
                 # Dedupe: skip if this platform message_id is already in the
                 # transcript (prevents duplicate user turns on Telegram retries
                 # after transient failures). #47237
@@ -17881,8 +17936,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             else ts
                         ),
                     }
-                    if event.message_id:
-                        _user_entry["message_id"] = str(event.message_id)
+                    _decorate_inbound_user_entry(_user_entry)
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id,
                         _user_entry,
@@ -17909,10 +17963,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if (
                             not _user_msg_id_attached
                             and msg.get("role") == "user"
-                            and event.message_id
-                            and "message_id" not in entry
                         ):
-                            entry["message_id"] = str(event.message_id)
+                            _decorate_inbound_user_entry(entry)
                             _user_msg_id_attached = True
                         await self.async_session_store.append_to_transcript(
                             session_entry.session_id, entry,
@@ -18069,8 +18121,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 else time.time()
                             ),
                         }
-                        if getattr(event, "message_id", None):
-                            _user_entry["message_id"] = str(event.message_id)
+                        _decorate_inbound_user_entry(_user_entry)
                         await self.async_session_store.append_to_transcript(
                             session_entry.session_id,
                             _user_entry,
@@ -23868,6 +23919,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+        persist_user_platform_message_id: Optional[str] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
@@ -23887,6 +23940,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_display_metadata=persist_user_display_metadata,
+                persist_user_platform_message_id=persist_user_platform_message_id,
                 message_type=message_type,
             )
 
@@ -23899,6 +23954,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                persist_user_display_metadata=persist_user_display_metadata,
+                persist_user_platform_message_id=persist_user_platform_message_id,
                 message_type=message_type,
             )
 
@@ -24021,6 +24078,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+        persist_user_platform_message_id: Optional[str] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
@@ -24306,6 +24365,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             moa_config=moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
+            persist_user_display_metadata=persist_user_display_metadata,
+            persist_user_platform_message_id=persist_user_platform_message_id,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3273,6 +3273,8 @@ class SessionStore:
             # any gateway-side persistence path or the next turn's
             # replay diverges at this row.
             api_content=extract_api_content_sidecar(message),
+            display_kind=message.get("display_kind"),
+            display_metadata=message.get("display_metadata"),
         )
 
     # Maximum in-memory pending messages per session before dropping the

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -91,6 +91,8 @@ class TurnContext:
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
+    persist_user_display_metadata: Optional[dict] = None
+    persist_user_platform_message_id: Optional[str] = None
     user_config: Any = None
     enabled_toolsets: Any = None
     disabled_toolsets: Any = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -2234,6 +2234,9 @@ class AIAgent:
                     "codex_message_items": msg.get("codex_message_items"),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
+                    "platform_message_id": (
+                        msg.get("platform_message_id") or msg.get("message_id")
+                    ),
                     "display_kind": (
                         "hidden"
                         if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
@@ -7585,6 +7588,7 @@ class AIAgent:
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+        persist_user_platform_message_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
@@ -7676,6 +7680,7 @@ class AIAgent:
                     persist_user_timestamp=persist_user_timestamp,
                     persist_user_display_kind=persist_user_display_kind,
                     persist_user_display_metadata=persist_user_display_metadata,
+                    persist_user_platform_message_id=persist_user_platform_message_id,
                     moa_config=moa_config,
                 )
             terminal = result if isinstance(result, dict) else {}

--- a/tests/agent/test_synthetic_turn_display_kind.py
+++ b/tests/agent/test_synthetic_turn_display_kind.py
@@ -104,3 +104,27 @@ def test_a_real_user_turn_stays_untyped(agent_db):
 
     row, = [r for r in db.get_messages_as_conversation(sid) if r["role"] == "user"]
     assert row.get("display_kind") is None
+
+
+def test_real_user_origin_metadata_and_platform_id_persist_without_display_kind(agent_db):
+    agent, db, sid = agent_db
+    origin = {
+        "platform": "discord",
+        "chat_id": "channel-42",
+        "chat_type": "channel",
+        "user_id": "person-7",
+        "user_name": "Alice",
+        "scope_id": "guild-1",
+    }
+
+    _build(
+        agent,
+        user_message="hello from Discord",
+        persist_user_display_metadata={"origin": origin},
+        persist_user_platform_message_id="message-99",
+    )
+
+    row, = [r for r in db.get_messages_as_conversation(sid) if r["role"] == "user"]
+    assert row.get("display_kind") is None
+    assert row["display_metadata"] == {"origin": origin}
+    assert row["message_id"] == "message-99"

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -185,9 +185,76 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
     )
 
 
+@pytest.mark.asyncio
+async def test_shared_channel_context_is_model_only_and_fallback_keeps_origin_once(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner.config.group_sessions_per_user = False
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-42",
+        chat_name="general",
+        chat_type="channel",
+        user_id="person-7",
+        user_name="Alice",
+        scope_id="guild-1",
+    )
+    event = MessageEvent(
+        text="hello world",
+        source=source,
+        message_id="message-99",
+        channel_context="[Recent channel messages]\n[Bob] earlier",
+    )
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:discord:channel:channel-42",
+        session_id="sess-origin",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.DISCORD,
+        chat_type="channel",
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": None,
+            "error": "429 Too Many Requests",
+            "messages": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        event, source, "agent:main:discord:channel:channel-42", 1
+    )
+
+    run_kwargs = runner._run_agent.await_args.kwargs
+    assert run_kwargs["message"] == (
+        "[Recent channel messages]\n[Bob] earlier\n\n"
+        "[New message]\n[Alice] hello world"
+    )
+    assert run_kwargs["persist_user_message"] == "hello world"
+    assert run_kwargs["persist_user_platform_message_id"] == "message-99"
+    assert run_kwargs["persist_user_display_metadata"]["origin"] == {
+        **source.to_dict(),
+        "message_id": "message-99",
+    }
+
+    user_entries = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "user"
+    ]
+    assert len(user_entries) == 1
+    assert user_entries[0]["content"] == "hello world"
+    assert user_entries[0]["platform_message_id"] == "message-99"
+    assert user_entries[0]["display_metadata"] == (
+        run_kwargs["persist_user_display_metadata"]
+    )
+
+
 # ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────
 
 
 # ── Test 4: normal path (new_messages found) uses skip_db=True ────────
-
-

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -452,6 +452,36 @@ class TestLoadTranscriptDBOnly:
         assert result[0]["content"] == "db-q"
         assert result[1]["content"] == "db-a"
 
+    def test_fallback_append_preserves_origin_and_platform_message_id(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        sid = "db_origin_session"
+        store._db.create_session(session_id=sid, source="discord", model="m")
+        origin = {
+            "platform": "discord",
+            "chat_id": "channel-42",
+            "chat_type": "channel",
+            "user_id": "person-7",
+        }
+
+        store.append_to_transcript(
+            sid,
+            {
+                "role": "user",
+                "content": "hello",
+                "platform_message_id": "message-99",
+                "display_metadata": {"origin": origin},
+            },
+        )
+
+        result = store.load_transcript(sid)
+        assert len(result) == 1
+        assert result[0]["content"] == "hello"
+        assert result[0]["message_id"] == "message-99"
+        assert result[0]["display_metadata"] == {"origin": origin}
+
 
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""
@@ -1528,5 +1558,4 @@ class TestGatewayRoutingTable:
         recovered = restarted.get_or_create_session(self._source())
         assert recovered.session_id == entry.session_id
         restarted._db.close()
-
 

--- a/tests/gateway/test_streaming_tts_gateway_regression.py
+++ b/tests/gateway/test_streaming_tts_gateway_regression.py
@@ -41,7 +41,15 @@ class _NoopAgent:
 
     def run_conversation(self, user_message, conversation_history=None,
                          task_id=None, persist_user_message=None,
-                         persist_user_timestamp=None):
+                         persist_user_timestamp=None,
+                         persist_user_display_metadata=None,
+                         persist_user_platform_message_id=None):
+        type(self).last_run = {
+            "user_message": user_message,
+            "persist_user_message": persist_user_message,
+            "persist_user_display_metadata": persist_user_display_metadata,
+            "persist_user_platform_message_id": persist_user_platform_message_id,
+        }
         return {
             "final_response": "Hello from the agent.",
             "messages": [],
@@ -154,4 +162,42 @@ def test_run_agent_voice_turn_no_name_error(monkeypatch, tmp_path):
     result = asyncio.new_event_loop().run_until_complete(_run())
     assert result["final_response"] == "Hello from the agent."
 
+
+def test_local_run_propagates_clean_text_origin_and_platform_message_id(monkeypatch, tmp_path):
+    _setup_monkeypatches(monkeypatch, tmp_path)
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-42",
+        chat_name="general",
+        chat_type="channel",
+        user_id="person-7",
+        user_name="Alice",
+        scope_id="guild-1",
+    )
+    origin = {"origin": source.to_dict()}
+
+    async def _run():
+        return await runner._run_agent(
+            message="[Recent channel messages]\n[Bob] earlier\n\n[New message]\n[Alice] hello",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key="agent:main:discord:channel:channel-42",
+            event_message_id="message-99",
+            persist_user_message="hello",
+            persist_user_display_metadata=origin,
+            persist_user_platform_message_id="message-99",
+        )
+
+    result = asyncio.new_event_loop().run_until_complete(_run())
+
+    assert result["final_response"] == "Hello from the agent."
+    assert _NoopAgent.last_run == {
+        "user_message": "[Recent channel messages]\n[Bob] earlier\n\n[New message]\n[Alice] hello",
+        "persist_user_message": "hello",
+        "persist_user_display_metadata": origin,
+        "persist_user_platform_message_id": "message-99",
+    }
 

--- a/tests/run_agent/test_session_meta_filtering.py
+++ b/tests/run_agent/test_session_meta_filtering.py
@@ -63,43 +63,36 @@ class TestDisplayFieldsStrippedFromApiPayload:
     provider-bound API payload — strict OpenAI-compatible backends reject
     unknown fields."""
 
-    def test_sanitizer_does_not_remove_display_fields(self):
-        """sanitize_api_messages is NOT the chokepoint for display fields —
-        they are popped earlier in conversation_loop. But this test documents
-        that the sanitizer alone does NOT strip them, proving the pop in
-        conversation_loop is load-bearing."""
+    def test_sanitizer_removes_all_transcript_only_fields(self):
         msgs = [
-            {"role": "user", "content": "hello", "display_kind": "model_switch"},
+            {
+                "role": "user",
+                "content": "hello",
+                "display_kind": "model_switch",
+                "display_metadata": {"origin": {"platform": "discord"}},
+                "api_content": "hello with injected context",
+                "platform_message_id": "message-99",
+                "message_id": "legacy-message-99",
+                "timestamp": 123.0,
+                "observed": True,
+                "active": True,
+                "compacted": False,
+                "_row_id": 7,
+                "_db_persisted": True,
+            },
             {"role": "assistant", "content": "hi", "display_metadata": {"model": "m"}},
         ]
         out = AIAgent._sanitize_api_messages(msgs)
-        # The sanitizer preserves them — the conversation_loop pop is the fix.
-        assert "display_kind" in out[0]
-        assert "display_metadata" in out[1]
-
-    def test_conversation_loop_strips_display_fields(self):
-        """The per-request api_msg copy in conversation_loop strips
-        display_kind and display_metadata before the message reaches the
-        provider. This simulates that pop."""
-        msg = {
-            "role": "user",
-            "content": "switch event",
-            "display_kind": "model_switch",
-            "display_metadata": {"model": "test"},
-            "api_content": "sidecar",
+        local_only = {
+            "api_content", "display_kind", "display_metadata", "platform_message_id",
+            "message_id", "timestamp", "observed", "active", "compacted",
+            "_row_id", "_db_persisted",
         }
-        # Reproduce the pop sequence from conversation_loop.py
-        api_msg = msg.copy()
-        api_msg.pop("api_content", None)
-        api_msg.pop("display_kind", None)
-        api_msg.pop("display_metadata", None)
-        assert "display_kind" not in api_msg
-        assert "display_metadata" not in api_msg
-        assert "api_content" not in api_msg
-        assert api_msg["content"] == "switch event"
-        # Original message dict is untouched.
-        assert msg.get("display_kind") == "model_switch"
-
+        assert not (local_only & out[0].keys())
+        assert "display_metadata" not in out[1]
+        assert out[0]["content"] == "hello"
+        # Sanitization operates on provider-bound copies, not durable history.
+        assert msgs[0]["platform_message_id"] == "message-99"
 
 # ---------------------------------------------------------------------------
 # Layer 2 — CLI session-restore filters session_meta before loading


### PR DESCRIPTION
## What does this PR do?

Discord gateway turns currently persist the model-facing shared-channel sender prefix as part of the authored message, but do not retain a structured record of who sent the trigger or which platform message produced the turn. That makes downstream archival and community-memory projections depend on parsing presentation text.

This PR keeps the current sender label visible to the model while persisting clean authored content plus a structured Discord origin in `display_metadata.origin` and the stable platform message ID in `platform_message_id`. Provider-bound copies strip those transcript-only fields without mutating durable history.

The same persistence contract is threaded through normal gateway execution, voice/STT, batch, and fallback writes so the result does not depend on which gateway path completed the turn.

## Related Issue

This is related work and does not close an existing issue:

- #69961 defines the broader shared-session sender-attribution contract. This PR addresses durable Discord provenance, not its proposed cross-platform model-visible UID envelope.
- #42039 and #47237 document duplicate user-turn failure modes in `state.db`; #42049 is the earlier fallback-path fix this change preserves.
- #71904 overlaps the `platform_message_id` write path. This PR carries that identifier together with structured origin metadata and can be rebased to reuse #71904 if it lands first.
- #73399 proposes a broader platform metadata schema. This PR intentionally reuses the existing `display_metadata` sidecar for the narrower Discord-origin contract.
- #67886 preserves model-visible sender prefixes in shared sessions. This PR separates that presentation concern from clean durable authored content.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`, `gateway/session.py`, `gateway/turn_context.py`: derive origin data from the inbound adapter event and carry it through gateway, voice/STT, batch, and fallback persistence paths.
- `agent/turn_context.py`, `agent/conversation_loop.py`, `run_agent.py`: stamp the real user turn with optional durable origin metadata and platform message ID.
- `agent/agent_runtime_helpers.py`: remove transcript-only provenance fields from provider payload copies while leaving stored history intact.
- `tests/agent/`, `tests/gateway/`, `tests/run_agent/`: cover clean authored content, exactly-once origin persistence, fallback behavior, platform ID propagation, and provider sanitation.

## How to Test

1. Run the focused regression suite:
   ```bash
   PYTHONPATH="$PWD" python -m pytest -q \
     tests/agent/test_synthetic_turn_display_kind.py \
     tests/gateway/test_42039_duplicate_user_message.py \
     tests/gateway/test_session.py \
     tests/gateway/test_streaming_tts_gateway_regression.py \
     tests/run_agent/test_session_meta_filtering.py
   ```
2. Send a Discord message in a shared channel and inspect the resulting user row in `state.db`. Confirm `content` is the clean authored text, `display_metadata.origin` identifies the Discord sender/channel/thread, and `platform_message_id` matches the inbound event.
3. Resume the session and inspect the provider request. Confirm the existing shared-channel sender label remains model-visible while `display_metadata` and `platform_message_id` are absent from the provider payload.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed [issues](https://github.com/NousResearch/hermes-agent/issues) and open and merged [PRs](https://github.com/NousResearch/hermes-agent/pulls) for duplicate and overlapping work
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.15

Full-suite note: `scripts/run_tests.sh` was attempted, but this worktree's `.venv` does not contain pytest. The runner fell back to the installed Hermes venv and imported `agent` modules from `~/.hermes/hermes-agent` rather than this branch, so that run was stopped as invalid. The branch-local focused suite passes 75 tests.

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A, no user-facing configuration or command changes
- [x] `cli-config.yaml.example` update: N/A, no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A, no contribution workflow or architecture contract changed
- [x] Cross-platform impact considered: optional string/dict persistence only; `scripts/check-windows-footguns.py --diff origin/main` passes
- [x] Tool descriptions/schemas update: N/A, no tool behavior changed

## Security and Provider Boundary

Origin metadata is derived from the gateway's adapter event, not parsed from user-authored text. It is durable transcript metadata, not a new authorization primitive. Provider payload sanitation removes `display_metadata` and `platform_message_id` from copied messages before API calls and does not mutate the stored transcript.

## Screenshots / Logs

```text
75 passed in 4.16s
All checks passed!  # Ruff
✓ No Windows footguns found (12 file(s) scanned).
Good "git" signature for offendingcommit@gmail.com
```
