### PR TITLE
fix(agent): treat max-iteration nudge as synthetic during compaction (#78580)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2107,11 +2107,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             defer_logical_completion=True,
         )
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
-    )
+    # Shared constant so compaction recognizers can identify this runtime nudge
+    # by its stable content after SessionDB projection strips metadata flags
+    # (see MAX_ITERATIONS_SUMMARY_REQUEST / _is_synthetic_compression_user_turn).
+    from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+
+    summary_request = MAX_ITERATIONS_SUMMARY_REQUEST
     messages.append({"role": "user", "content": summary_request})
 
     try:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -160,6 +160,15 @@ _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT = (
     "This marker exists because the compacted transcript contained "
     "no preserved user turn."
 )
+# Runtime nudge appended by ``handle_max_iterations`` as a ``role="user"`` row.
+# SessionDB projection strips underscore-prefixed metadata, so a synthetic flag
+# would not survive persistence; the stable content string is the authoritative
+# marker for compaction recognizers (mirrors the continuation/todo markers).
+MAX_ITERATIONS_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished so far, "
+    "without calling any more tools."
+)
 
 
 def _fresh_compaction_message_copy(msg: Dict[str, Any]) -> Dict[str, Any]:
@@ -4178,6 +4187,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
             _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+            MAX_ITERATIONS_SUMMARY_REQUEST,
         } or text.startswith(
             TODO_INJECTION_HEADER + "\n"
         )

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -11,6 +11,7 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
     COMPRESSED_SUMMARY_METADATA_KEY,
     HISTORICAL_TASK_HEADING,
+    MAX_ITERATIONS_SUMMARY_REQUEST,
     SUMMARY_PREFIX,
     ContextCompressor,
     _NO_USER_TASK_SENTINEL,
@@ -200,6 +201,40 @@ def test_zero_user_provenance_survives_iterative_compaction(compressor):
     ]
     assert len(second_handoffs) == 1
     assert second_handoffs[0][COMPRESSED_SUMMARY_HAS_USER_TURN_KEY] is False
+
+
+def test_max_iterations_nudge_is_synthetic_not_actionable():
+    """#78580: the max-iteration runtime nudge is runtime scaffolding, not a
+    human turn. It is appended as ``role="user"`` and persisted verbatim in
+    state.db (metadata flags do not survive projection), so recognition must be
+    content-based — exactly like the continuation/todo markers."""
+    # The projected form: a bare role/content row with no internal metadata.
+    nudge = {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST}
+
+    assert ContextCompressor._is_synthetic_compression_user_turn(nudge) is True
+    # A real human turn with the same shape stays actionable.
+    human = {"role": "user", "content": "Ship the release notes for v2."}
+    assert ContextCompressor._is_synthetic_compression_user_turn(human) is False
+    assert ContextCompressor._transcript_has_real_user_turn([nudge]) is False
+    assert ContextCompressor._transcript_has_real_user_turn([human, nudge]) is True
+
+
+def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
+    """The tail anchor must resolve to the human task, not the nudge that the
+    runtime appended after it when iterations were exhausted."""
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it.", "tool_calls": [
+            {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+    ]
+
+    idx = compressor._find_last_user_message_idx(messages, head_end=0)
+    assert idx == 0, "nudge was selected as the anchor instead of the human task"
+    assert messages[idx]["content"] == human["content"]
 
 
 def test_compress_context_todo_snapshot_stays_synthetic_across_two_boundaries(


### PR DESCRIPTION
## What

`handle_max_iterations()` appends its runtime summary request as a plain `role="user"` message:

> You've reached the maximum number of tool-calling iterations allowed. Please provide a final response summarizing what you've found and accomplished so far, without calling any more tools.

SessionDB persists that row verbatim. On later context compaction the synthetic-turn filters (`_is_synthetic_compression_user_turn`) only recognized compaction summaries, continuation rows, and todo snapshots — **not** this marker. So the nudge could be selected as the latest actionable user turn: it became the task snapshot / auto-focus input and was summarized as `User asked: ...`, demoting the real human task to historical context (or omitting it). Reported in #78580 against `f5be9236e`.

## Why content-based (not a flag)

Underscore-prefixed metadata does **not** survive SessionDB projection — which is exactly why the existing continuation/todo markers are recognized by stable *content*, not by a flag. A `_synthetic` flag on the appended message would be stripped before compaction ever sees it. So recognition must key off the content string.

## Fix

- Extract the nudge into a shared `MAX_ITERATIONS_SUMMARY_REQUEST` constant in `context_compressor.py` (next to `COMPRESSION_CONTINUATION_USER_CONTENT`), and have `handle_max_iterations()` use it — single source of truth, so the producer can't drift from the recognizer.
- Teach `_is_synthetic_compression_user_turn()` to recognize it, mirroring the continuation/todo markers.

Every `_is_actionable_user_turn` call site already composes `and not _is_synthetic_compression_user_turn(msg)` (anchor selection at `_find_last_user_message_idx`, `_ensure_last_n_user_messages_in_tail`, and `_transcript_has_real_user_turn`), so the single recognizer change covers all selection paths — no behavior change to `_is_actionable_user_turn` itself.

## Tests

`tests/agent/test_context_compressor_zero_user_provenance.py`:
- `test_max_iterations_nudge_is_synthetic_not_actionable` — the projected (metadata-free) nudge row is recognized synthetic; a same-shape human turn is not; `_transcript_has_real_user_turn` skips the nudge but sees a real turn.
- `test_real_task_wins_over_trailing_max_iterations_nudge` — with the nudge as the trailing user row, the tail anchor resolves to the human task, not the nudge.

```
pytest tests/agent/test_context_compressor.py \
       tests/agent/test_context_compressor_zero_user_provenance.py \
       tests/agent/test_turn_finalizer_iteration_limit_exit.py    # 118 passed
```

Fixes #78580