### PR TITLE
fix(tools): background commands

### DIFF
--- a/tests/tools/test_terminal_background_parsing.py
+++ b/tests/tools/test_terminal_background_parsing.py
@@ -46,11 +46,8 @@ class TestHeredocDeclarations:
         assert _heredoc_declarations("echo hello") == []
 
     def test_herestring_not_matched(self):
-        # <<< is a herestring, not a heredoc — content is on the same line
-        # and never spans subsequent lines, so it carries no multi-line & risk.
-        # Known limitation: the parser re-encounters the 2nd < in <<< and
-        # incorrectly matches it as a heredoc opener. Skipping until fixed.
-        pytest.skip("known: _heredoc_declarations matches the 2nd < in <<< as a heredoc")
+        # <<< is a herestring, not a heredoc — must not be parsed as one.
+        assert _heredoc_declarations("cat <<< 'foo'") == []
 
     def test_amp_before_heredoc_not_confused(self):
         # Bit-op or redirect before << must not suppress heredoc detection.

--- a/tests/tools/test_terminal_background_parsing.py
+++ b/tests/tools/test_terminal_background_parsing.py
@@ -1,0 +1,261 @@
+"""Tests for the background-operator parsing helpers in terminal_tool.
+
+Covers:
+  _heredoc_declarations       — parse heredoc openers on a single line
+  _strip_heredoc_bodies       — blank out heredoc content before & scanning
+  _shell_background_operator_positions — locate job-control & in a command
+  _contains_shell_background_operator  — boolean wrapper
+  _is_final_shell_background_operator  — is the & the last real token?
+  _normalize_final_shell_background_operator — strip trailing & cleanly
+"""
+
+import pytest
+
+from tools.terminal_tool import (
+    _contains_shell_background_operator,
+    _heredoc_declarations,
+    _is_final_shell_background_operator,
+    _normalize_final_shell_background_operator,
+    _shell_background_operator_positions,
+    _strip_heredoc_bodies,
+)
+
+
+# ---------------------------------------------------------------------------
+# _heredoc_declarations
+# ---------------------------------------------------------------------------
+
+class TestHeredocDeclarations:
+    def test_basic_heredoc(self):
+        assert _heredoc_declarations("cat << EOF") == [("EOF", False)]
+
+    def test_dash_heredoc_strips_tabs(self):
+        assert _heredoc_declarations("cat <<- EOF") == [("EOF", True)]
+
+    def test_quoted_delimiter_single(self):
+        assert _heredoc_declarations("cat << 'EOF'") == [("EOF", False)]
+
+    def test_quoted_delimiter_double(self):
+        assert _heredoc_declarations('cat << "EOF"') == [("EOF", False)]
+
+    def test_multiple_heredocs_on_one_line(self):
+        result = _heredoc_declarations("cmd <<A && cmd2 <<B")
+        assert result == [("A", False), ("B", False)]
+
+    def test_no_heredoc(self):
+        assert _heredoc_declarations("echo hello") == []
+
+    def test_herestring_not_matched(self):
+        # <<< is a herestring, not a heredoc — content is on the same line
+        # and never spans subsequent lines, so it carries no multi-line & risk.
+        # Known limitation: the parser re-encounters the 2nd < in <<< and
+        # incorrectly matches it as a heredoc opener. Skipping until fixed.
+        pytest.skip("known: _heredoc_declarations matches the 2nd < in <<< as a heredoc")
+
+    def test_amp_before_heredoc_not_confused(self):
+        # Bit-op or redirect before << must not suppress heredoc detection.
+        assert _heredoc_declarations("cmd 2>&1 << EOF") == [("EOF", False)]
+
+    def test_delimiter_in_comment_ignored(self):
+        # After a # comment, << is not a heredoc.
+        assert _heredoc_declarations("echo hi # << EOF") == []
+
+    def test_delimiter_inside_single_quotes_ignored(self):
+        assert _heredoc_declarations("echo '<< EOF'") == []
+
+
+# ---------------------------------------------------------------------------
+# _strip_heredoc_bodies
+# ---------------------------------------------------------------------------
+
+class TestStripHeredocBodies:
+    def test_single_heredoc_body_blanked(self):
+        cmd = "cat << EOF\nhello & world\nEOF"
+        result = _strip_heredoc_bodies(cmd)
+        # Body line should be replaced with same-length whitespace; delimiter
+        # line and opener line must be preserved.
+        assert "hello & world" not in result
+        assert len(result) == len(cmd)
+
+    def test_amp_in_heredoc_body_not_visible(self):
+        # The key regression: C++ bitwise-AND inside a heredoc body was being
+        # picked up as a job-control operator before this fix.
+        cmd = "g++ - << 'EOF'\nint r = a & b;\nEOF"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert "&" not in stripped.split("\n")[1]
+
+    def test_command_after_heredoc_preserved(self):
+        cmd = "cat << EOF\nsome data\nEOF\necho done &"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert "echo done &" in stripped
+
+    def test_no_heredoc_unchanged(self):
+        cmd = "echo hello && sleep 1 &"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_tab_stripped_heredoc(self):
+        cmd = "cat <<- EOF\n\thello & world\n\tEOF"
+        result = _strip_heredoc_bodies(cmd)
+        assert "hello & world" not in result
+
+    def test_length_preserved(self):
+        cmd = "cmd <<EOF\nline one\nline two\nEOF\necho end"
+        assert len(_strip_heredoc_bodies(cmd)) == len(cmd)
+
+
+# ---------------------------------------------------------------------------
+# _shell_background_operator_positions
+# ---------------------------------------------------------------------------
+
+class TestShellBackgroundOperatorPositions:
+    def test_simple_trailing_amp(self):
+        positions = _shell_background_operator_positions("sleep 5 &")
+        assert len(positions) == 1
+
+    def test_no_amp(self):
+        assert _shell_background_operator_positions("echo hello") == []
+
+    def test_double_amp_not_counted(self):
+        assert _shell_background_operator_positions("A && B") == []
+
+    def test_amp_gt_redirect_not_counted(self):
+        assert _shell_background_operator_positions("cmd &>/dev/null") == []
+
+    def test_fd_redirect_2_gt_amp_not_counted(self):
+        assert _shell_background_operator_positions("cmd 2>&1") == []
+
+    def test_amp_inside_single_quotes_not_counted(self):
+        assert _shell_background_operator_positions("echo 'a & b'") == []
+
+    def test_amp_inside_double_quotes_not_counted(self):
+        assert _shell_background_operator_positions('echo "a & b"') == []
+
+    def test_amp_after_backslash_not_counted(self):
+        assert _shell_background_operator_positions(r"echo a \& b") == []
+
+    def test_amp_in_comment_not_counted(self):
+        assert _shell_background_operator_positions("echo hi # start &") == []
+
+    def test_amp_in_heredoc_body_not_counted(self):
+        # The original bug: C++ bitwise-AND inside a heredoc was detected.
+        cmd = "g++ - << 'EOF'\nint r = a & b;\nEOF"
+        assert _shell_background_operator_positions(cmd) == []
+
+    def test_internal_amp_detected(self):
+        # Internal & before more commands — two operators.
+        positions = _shell_background_operator_positions("A & B &")
+        assert len(positions) == 2
+
+    def test_single_final_amp_position_correct(self):
+        cmd = "sleep 5 &"
+        positions = _shell_background_operator_positions(cmd)
+        assert len(positions) == 1
+        assert cmd[positions[0]] == "&"
+
+    def test_amp_with_trailing_comment(self):
+        # `cmd & # comment` — the & is a real background operator.
+        positions = _shell_background_operator_positions("cmd & # comment")
+        assert len(positions) == 1
+
+
+# ---------------------------------------------------------------------------
+# _contains_shell_background_operator
+# ---------------------------------------------------------------------------
+
+class TestContainsShellBackgroundOperator:
+    def test_true_for_trailing_amp(self):
+        assert _contains_shell_background_operator("sleep 5 &") is True
+
+    def test_false_for_double_amp(self):
+        assert _contains_shell_background_operator("A && B") is False
+
+    def test_false_for_redirect(self):
+        assert _contains_shell_background_operator("cmd &>/dev/null") is False
+
+    def test_false_for_no_amp(self):
+        assert _contains_shell_background_operator("echo hello") is False
+
+    def test_false_for_heredoc_body_amp(self):
+        cmd = "cat << EOF\na & b\nEOF"
+        assert _contains_shell_background_operator(cmd) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_final_shell_background_operator
+# ---------------------------------------------------------------------------
+
+class TestIsFinalShellBackgroundOperator:
+    def _pos(self, cmd: str) -> int:
+        """Return first & position from the positions list."""
+        positions = _shell_background_operator_positions(cmd)
+        assert positions, f"No & found in: {cmd!r}"
+        return positions[0]
+
+    def test_trailing_amp_is_final(self):
+        cmd = "sleep 5 &"
+        assert _is_final_shell_background_operator(cmd, self._pos(cmd)) is True
+
+    def test_amp_with_trailing_whitespace_is_final(self):
+        cmd = "sleep 5 &   "
+        assert _is_final_shell_background_operator(cmd, self._pos(cmd)) is True
+
+    def test_amp_with_trailing_comment_is_final(self):
+        cmd = "sleep 5 & # start the server"
+        assert _is_final_shell_background_operator(cmd, self._pos(cmd)) is True
+
+    def test_internal_amp_is_not_final(self):
+        cmd = "A & B"
+        pos = _shell_background_operator_positions(cmd)[0]
+        assert _is_final_shell_background_operator(cmd, pos) is False
+
+    def test_first_of_two_amps_is_not_final(self):
+        cmd = "A & B &"
+        positions = _shell_background_operator_positions(cmd)
+        assert _is_final_shell_background_operator(cmd, positions[0]) is False
+        assert _is_final_shell_background_operator(cmd, positions[1]) is True
+
+
+# ---------------------------------------------------------------------------
+# _normalize_final_shell_background_operator
+# ---------------------------------------------------------------------------
+
+class TestNormalizeFinalShellBackgroundOperator:
+    def _pos(self, cmd: str) -> int:
+        positions = _shell_background_operator_positions(cmd)
+        assert positions
+        return positions[-1]
+
+    def test_simple_trailing_amp_removed(self):
+        cmd = "sleep 5 &"
+        result = _normalize_final_shell_background_operator(cmd, self._pos(cmd))
+        assert result == "sleep 5"
+
+    def test_amp_with_trailing_whitespace(self):
+        cmd = "sleep 5 &   "
+        result = _normalize_final_shell_background_operator(cmd, self._pos(cmd))
+        assert "&" not in result
+        assert result.strip() == "sleep 5"
+
+    def test_amp_with_trailing_comment_preserved(self):
+        cmd = "sleep 5 & # background"
+        result = _normalize_final_shell_background_operator(cmd, self._pos(cmd))
+        assert "&" not in result.split("#")[0]
+        assert "# background" in result
+
+    def test_line_continuation_before_amp_removed(self):
+        # `cmd \\\n&` — the backslash-newline before & should be cleaned up.
+        cmd = "sleep 5 \\\n&"
+        result = _normalize_final_shell_background_operator(cmd, self._pos(cmd))
+        assert "&" not in result
+        assert "\\\n" not in result
+
+    def test_multiline_command_only_last_amp_removed(self):
+        cmd = "cd /app \\\n  && python server.py &"
+        result = _normalize_final_shell_background_operator(cmd, self._pos(cmd))
+        assert result.endswith("python server.py")
+        assert "&&" in result  # the && is preserved
+
+    def test_result_does_not_have_trailing_whitespace(self):
+        cmd = "sleep 5 &"
+        result = _normalize_final_shell_background_operator(cmd, self._pos(cmd))
+        assert result == result.rstrip()

--- a/tests/tools/test_terminal_background_parsing.py
+++ b/tests/tools/test_terminal_background_parsing.py
@@ -157,6 +157,41 @@ class TestShellBackgroundOperatorPositions:
         positions = _shell_background_operator_positions("cmd & # comment")
         assert len(positions) == 1
 
+    # --- Regressions flagged in code review ---
+
+    def test_pipe_stderr_operator_not_counted(self):
+        # |& is bash's pipe-stderr operator (pipes stdout+stderr to next cmd).
+        # It is not a background operator and must not be flagged.
+        assert _shell_background_operator_positions("make |& tee build.log") == []
+
+    def test_trailing_pipe_stderr_not_counted(self):
+        # A trailing |& must not be confused with a job-control &.
+        # Normalizing it would produce `cmd |` — invalid syntax.
+        assert _shell_background_operator_positions("cmd |&") == []
+
+    def test_arithmetic_bitwise_and_not_counted(self):
+        # $((5&3)) is arithmetic; the & is not a job-control operator.
+        assert _shell_background_operator_positions("x=$((5&3))") == []
+
+    def test_arithmetic_bitwise_and_in_expression_not_counted(self):
+        assert _shell_background_operator_positions("echo $((a & b))") == []
+
+    def test_case_fallthrough_semicolon_amp_not_counted(self):
+        # ;& is the case-statement fallthrough operator, not backgrounding.
+        cmd = "case $x in\n  a) echo a;&\n  b) echo b;;\nesac"
+        assert _shell_background_operator_positions(cmd) == []
+
+    def test_case_test_next_semicolon_amp_not_counted(self):
+        # ;;& tests the next pattern; also not backgrounding.
+        cmd = "case $x in\n  a) echo a;;&\n  b) echo b;;\nesac"
+        assert _shell_background_operator_positions(cmd) == []
+
+    def test_parallel_jobs_with_wait(self):
+        # `job1 & job2 & wait` is a legitimate parallel pattern.
+        # All three & are real background operators.
+        positions = _shell_background_operator_positions("job1 & job2 & wait")
+        assert len(positions) == 2
+
 
 # ---------------------------------------------------------------------------
 # _contains_shell_background_operator

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -135,14 +135,14 @@ def _check_disk_usage_warning():
                         total_bytes += f.stat().st_size
                     except OSError as e:
                         logger.debug("Could not stat file %s: %s", f, e)
-
+        
         total_gb = total_bytes / (1024 ** 3)
-
+        
         if total_gb > DISK_USAGE_WARNING_THRESHOLD_GB:
             logger.warning("Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
                            total_gb, DISK_USAGE_WARNING_THRESHOLD_GB)
             return True
-
+        
         return False
     except Exception as e:
         logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
@@ -318,26 +318,26 @@ def _validate_workdir(workdir: str) -> str | None:
 def _handle_sudo_failure(output: str, env_type: str) -> str:
     """
     Check for sudo failure and add helpful message for messaging contexts.
-
+    
     Returns enhanced output if sudo failed in messaging context, else original.
     """
     is_gateway = env_var_enabled("HERMES_GATEWAY_SESSION")
-
+    
     if not is_gateway:
         return output
-
+    
     # Check for sudo failure indicators
     sudo_failures = [
         "sudo: a password is required",
         "sudo: no tty present",
         "sudo: a terminal is required",
     ]
-
+    
     for failure in sudo_failures:
         if failure in output:
             from hermes_constants import display_hermes_home as _dhh
             return output + f"\n\n💡 Tip: To enable sudo over messaging, add SUDO_PASSWORD to {_dhh()}/.env on the agent machine."
-
+    
     return output
 
 
@@ -381,19 +381,19 @@ def _invalidate_cached_sudo_on_auth_failure(
 def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     """
     Prompt user for sudo password with timeout.
-
+    
     Returns the password if entered, or empty string if:
     - User presses Enter without input (skip)
     - Timeout expires (45s default)
     - Any error occurs
-
+    
     Only works in interactive mode (HERMES_INTERACTIVE=1).
     If a _sudo_password_callback is registered (by the CLI), delegates to it
     so the prompt integrates with prompt_toolkit's UI.  Otherwise reads
     directly from /dev/tty with echo disabled.
     """
     import sys
-
+    
     # Use the registered callback when available (prompt_toolkit-compatible)
     _sudo_cb = _get_sudo_password_callback()
     if _sudo_cb is not None:
@@ -403,7 +403,7 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             return ""
 
     result = {"password": None, "done": False}
-
+    
     def read_password_thread():
         """Read password with echo disabled. Uses msvcrt on Windows, /dev/tty on Unix."""
         tty_fd = None
@@ -451,11 +451,11 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
                 except Exception as e:
                     logger.debug("Failed to close tty fd: %s", e)
             result["done"] = True
-
+    
     try:
         os.environ["HERMES_SPINNER_PAUSE"] = "1"
         time.sleep(0.2)
-
+        
         print()
         print("┌" + "─" * 58 + "┐")
         print("│  🔐 SUDO PASSWORD REQUIRED" + " " * 30 + "│")
@@ -466,11 +466,11 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
         print("└" + "─" * 58 + "┘")
         print()
         print("  Password (hidden): ", end="", flush=True)
-
+        
         password_thread = threading.Thread(target=read_password_thread, daemon=True)
         password_thread.start()
         password_thread.join(timeout=timeout_seconds)
-
+        
         if result["done"]:
             password = result["password"] or ""
             print()  # newline after hidden input
@@ -487,7 +487,7 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             print()
             sys.stdout.flush()
             return ""
-
+            
     except (EOFError, KeyboardInterrupt):
         print()
         print("  ⏭ Cancelled - continuing without sudo")
@@ -1258,7 +1258,7 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
-
+    
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}
     docker_backend = env_type == "docker"
@@ -1394,7 +1394,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                         host_cwd: str = None):
     """
     Create an execution environment for sandboxed command execution.
-
+    
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
             "daytona", "ssh"
@@ -1405,7 +1405,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         container_config: Resource config for container backends (cpu, memory, disk, persistent)
         task_id: Task identifier for environment reuse and snapshot keying
         host_cwd: Optional host working directory to bind into Docker when explicitly enabled
-
+        
     Returns:
         Environment instance with execute() method
     """
@@ -1422,7 +1422,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
-
+    
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
         # prior Hermes processes that hit SIGKILL / OOM / a closed terminal
@@ -1445,14 +1445,14 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
         )
-
+    
     elif env_type == "singularity":
         return _SingularityEnvironment(
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
             persistent_filesystem=persistent, task_id=task_id,
         )
-
+    
     elif env_type == "modal":
         sandbox_kwargs = {}
         if cpu > 0:
@@ -1510,7 +1510,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             modal_sandbox_kwargs=sandbox_kwargs,
             persistent_filesystem=persistent, task_id=task_id,
         )
-
+    
     elif env_type == "daytona":
         # Lazy import so daytona SDK is only required when backend is selected.
         from tools.environments.daytona import DaytonaEnvironment as _DaytonaEnvironment
@@ -1668,14 +1668,14 @@ def cleanup_all_environments():
     """Clean up ALL active environments. Use with caution."""
     task_ids = list(_active_environments.keys())
     cleaned = 0
-
+    
     for task_id in task_ids:
         try:
             cleanup_vm(task_id)
             cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
-
+    
     # Also clean any orphaned directories
     scratch_dir = _get_scratch_dir()
     import glob
@@ -1685,7 +1685,7 @@ def cleanup_all_environments():
             logger.info("Removed orphaned: %s", path)
         except OSError as e:
             logger.debug("Failed to remove orphaned path %s: %s", path, e)
-
+    
     if cleaned > 0:
         logger.info("Cleaned %d environments", cleaned)
     return cleaned
@@ -2274,7 +2274,7 @@ def terminal_tool(
 
         # With custom timeout
         >>> result = terminal_tool(command="long_task.sh", timeout=300)
-
+        
         # Force run after user confirmation
         # Note: force parameter is internal only, not exposed to model API
     """
@@ -2308,7 +2308,7 @@ def terminal_tool(
         # ``"default"``) is still found under its originating session id while
         # isolation-keyed RL/benchmark overrides keep resolving as before.
         overrides = resolve_task_overrides(task_id)
-
+        
         # Select image based on env type, with per-task override support
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -2954,7 +2954,7 @@ def terminal_tool(
                             "exit_code": 124,
                             "error": f"Command timed out after {effective_timeout} seconds"
                         }, ensure_ascii=False)
-
+                    
                     # Retry on transient errors
                     if retry_count < max_retries:
                         retry_count += 1
@@ -2963,7 +2963,7 @@ def terminal_tool(
                                        wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                         time.sleep(wait_time)
                         continue
-
+                    
                     logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
                                  max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                     return json.dumps({
@@ -2971,7 +2971,7 @@ def terminal_tool(
                         "exit_code": -1,
                         "error": f"Command execution failed: {type(e).__name__}: {str(e)}"
                     }, ensure_ascii=False)
-
+                
                 # Got a result
                 break
             
@@ -3016,7 +3016,7 @@ def terminal_tool(
                         break
             except Exception:
                 pass
-
+            
             # Truncate output if too long, keeping both head and tail
             from tools.tool_output_limits import get_max_bytes
             MAX_OUTPUT_CHARS = get_max_bytes()
@@ -3225,7 +3225,7 @@ if __name__ == "__main__":
     # Simple test when run directly
     print("Terminal Tool Module")
     print("=" * 50)
-
+    
     config = _get_env_config()
     print("\nCurrent Configuration:")
     print(f"  Environment type: {config['env_type']}")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1876,8 +1876,215 @@ def _command_requires_pipe_stdin(command: str) -> bool:
 _SHELL_LEVEL_BACKGROUND_RE = re.compile(
     r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b", re.IGNORECASE | re.MULTILINE
 )
-_INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
-_TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
+
+
+def _heredoc_declarations(line: str) -> list[tuple[str, bool]]:
+    """Return ``(delimiter, strip_tabs)`` declarations outside quotes/comments.
+
+    This intentionally recognizes the common shell heredoc forms without
+    attempting to parse the full shell grammar.  Keeping it lexical is enough
+    for the terminal guard: heredoc bodies are data, so shell-looking ``&``
+    characters in them must not be treated as job-control operators.
+    """
+    declarations: list[tuple[str, bool]] = []
+    i = 0
+    n = len(line)
+
+    while i < n:
+        ch = line[i]
+
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
+
+        if ch in {"'", '"', "`"}:
+            quote = ch
+            i += 1
+            while i < n:
+                if line[i] == "\\" and quote != "'" and i + 1 < n:
+                    i += 2
+                    continue
+                if line[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+
+        # A shell comment begins at the start of a word, not in ``foo#bar``.
+        if ch == "#" and (i == 0 or line[i - 1].isspace() or line[i - 1] in ";|&()"):
+            break
+
+        if line.startswith("<<", i) and not line.startswith("<<<", i):
+            i += 2
+            strip_tabs = i < n and line[i] == "-"
+            if strip_tabs:
+                i += 1
+            while i < n and line[i] in " \t":
+                i += 1
+            if i >= n:
+                break
+
+            if line[i] in {"'", '"'}:
+                quote = line[i]
+                i += 1
+                start = i
+                while i < n and line[i] != quote:
+                    if line[i] == "\\" and quote == '"' and i + 1 < n:
+                        i += 2
+                        continue
+                    i += 1
+                delimiter = line[start:i]
+                if i < n:
+                    i += 1
+            else:
+                start = i
+                while i < n and not line[i].isspace() and line[i] not in ";|&()<>":
+                    i += 1
+                delimiter = line[start:i]
+
+            if delimiter:
+                declarations.append((delimiter, strip_tabs))
+            continue
+
+        i += 1
+
+    return declarations
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Replace heredoc bodies and terminators with same-length whitespace.
+
+    Length and newlines are preserved so operator positions still index the
+    original command and commands following a heredoc retain their statement
+    boundaries. Multiple heredocs declared on one command line are consumed
+    in declaration order, as the shell does.
+    """
+    pending: list[tuple[str, bool]] = []
+    result: list[str] = []
+
+    for line in command.splitlines(keepends=True):
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = line.rstrip("\r\n")
+            if strip_tabs:
+                candidate = candidate.lstrip("\t")
+            if candidate == delimiter:
+                pending.pop(0)
+            if line.endswith("\r\n"):
+                result.append(" " * (len(line) - 2) + "\r\n")
+            elif line.endswith(("\n", "\r")):
+                result.append(" " * (len(line) - 1) + line[-1])
+            else:
+                result.append(" " * len(line))
+            continue
+
+        result.append(line)
+        pending.extend(_heredoc_declarations(line))
+
+    return "".join(result)
+
+
+def _shell_background_operator_positions(command: str) -> list[int]:
+    """Return positions of real unquoted shell ``&`` operators in *command*.
+
+    Distinguishes job-control ``&`` from ``&&``, ``&>`` and fd redirects, and
+    ignores escaped operators, quoted strings, comments, and heredoc bodies.
+    """
+    sanitized = _strip_heredoc_bodies(command)
+    positions: list[int] = []
+    i = 0
+    n = len(sanitized)
+
+    while i < n:
+        ch = sanitized[i]
+
+        if ch.isspace():
+            i += 1
+            continue
+
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
+
+        if ch == "#" and (i == 0 or sanitized[i - 1].isspace() or sanitized[i - 1] in ";|&()"):
+            newline = sanitized.find("\n", i)
+            if newline == -1:
+                break
+            i = newline + 1
+            continue
+
+        if ch in {"'", '"', "`"}:
+            quote = ch
+            i += 1
+            while i < n:
+                if sanitized[i] == "\\" and quote != "'" and i + 1 < n:
+                    i += 2
+                    continue
+                if sanitized[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+
+        if ch == "&":
+            if sanitized.startswith("&&", i) or sanitized.startswith("&>", i):
+                i += 2
+                continue
+            if i > 0 and sanitized[i - 1] in "<>":
+                i += 1
+                continue
+            positions.append(i)
+            i += 1
+            continue
+
+        # Skip a whole token so quoted fragments within it cannot be mistaken
+        # for operators (for example: ``printf prefix" & "suffix``).
+        _, next_i = _read_shell_token(sanitized, i)
+        i = max(next_i, i + 1)
+
+    return positions
+
+
+def _contains_shell_background_operator(command: str) -> bool:
+    """Return whether *command* contains a real unquoted shell ``&`` operator."""
+    return bool(_shell_background_operator_positions(command))
+
+
+def _is_final_shell_background_operator(command: str, position: int) -> bool:
+    """Return whether only whitespace/comments follow the operator."""
+    i = position + 1
+    n = len(command)
+
+    while i < n:
+        if command[i].isspace():
+            i += 1
+            continue
+        if command[i] == "#" and (
+            i == 0 or command[i - 1].isspace() or command[i - 1] in ";|&()"
+        ):
+            newline = command.find("\n", i)
+            if newline == -1:
+                return True
+            i = newline + 1
+            continue
+        return False
+
+    return True
+
+
+def _normalize_final_shell_background_operator(command: str, position: int) -> str:
+    """Remove one final ``&`` and any now-dangling line continuation."""
+    prefix = command[:position]
+    suffix = command[position + 1:]
+
+    # Models often format a multiline command with ``\`` on every line,
+    # including the line immediately before a standalone final ``&``.
+    prefix = re.sub(r"\\[ \t]*\r?\n[ \t]*$", "", prefix)
+    prefix = prefix.rstrip()
+
+    if suffix.lstrip().startswith("#"):
+        return f"{prefix} {suffix.lstrip()}".rstrip()
+    return prefix
 
 
 def _strip_quotes(command: str) -> str:
@@ -1888,14 +2095,8 @@ def _strip_quotes(command: str) -> str:
     Also strips backtick-quoted content and heredoc bodies.
     """
     # Remove heredoc bodies first — before quote stripping, which would mangle
-    # the delimiter name (e.g. << 'EOF' → << '' losing the delimiter).
-    # Matches << [-] ['"]? WORD ['"]? ... \n <body> \n WORD at start of line.
-    result = re.sub(
-        r"<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n.*?\n\1(?=\n|$)",
-        "",
-        command,
-        flags=re.DOTALL,
-    )
+    # quoted delimiter names (e.g. << 'EOF' → << '' losing the delimiter).
+    result = _strip_heredoc_bodies(command)
     # Remove single-quoted strings (no escaping inside single quotes in shell)
     result = re.sub(r"'[^']*'", "''", result)
     # Remove double-quoted strings (handle escaped quotes)
@@ -1948,7 +2149,7 @@ def _foreground_background_guidance(command: str) -> str | None:
             "readiness checks and tests in separate commands."
         )
 
-    if _INLINE_BACKGROUND_AMP_RE.search(unquoted) or _TRAILING_BACKGROUND_AMP_RE.search(unquoted):
+    if _contains_shell_background_operator(command):
         return (
             "Foreground command uses '&' backgrounding. Use terminal(background=true) for long-lived "
             "processes, then run health checks and tests in follow-up terminal calls."
@@ -2142,6 +2343,54 @@ def terminal_tool(
             cwd = config["cwd"]
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
+        background_normalization_warning = None
+
+        # Normalize the standard shell spelling ``command &`` into Hermes'
+        # managed background mode. Only one final top-level operator is
+        # unambiguous; internal job control is rejected below.
+        background_positions = _shell_background_operator_positions(command)
+        shell_wrappers = _SHELL_LEVEL_BACKGROUND_RE.search(_strip_quotes(command))
+        has_single_final_background = (
+            len(background_positions) == 1
+            and _is_final_shell_background_operator(command, background_positions[0])
+        )
+        if (
+            has_single_final_background
+            and not shell_wrappers
+        ):
+            requested_background = background
+            command = _normalize_final_shell_background_operator(
+                command,
+                background_positions[0],
+            )
+            background = True
+            if requested_background:
+                background_normalization_warning = (
+                    "Command set background=true and also used a final shell '&'. "
+                    "Only background=true is needed. Hermes removed the redundant "
+                    f"'&' and ran this managed command: {command}"
+                )
+            else:
+                background_normalization_warning = (
+                    "Command used a final shell '&' without background=true. "
+                    "Use terminal(background=true) for managed background processes. "
+                    "Hermes removed the final '&', set background=true, and ran this "
+                    f"managed command: {command}"
+                )
+            background_positions = []
+
+        if background_positions and not has_single_final_background:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    "Command contains internal '&' backgrounding, which Hermes cannot "
+                    "safely track. Only a single final '&' can be normalized. Use "
+                    "separate terminal(background=true) calls or a foreground "
+                    "concurrency mechanism such as xargs -P, make -j, or GNU parallel."
+                ),
+                "status": "error",
+            }, ensure_ascii=False)
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
@@ -2166,10 +2415,10 @@ def terminal_tool(
                     "status": "error",
                 }, ensure_ascii=False)
 
-        # Guardrail: background=True but command still has a trailing '&'.
-        # The shell double-backgrounds the process so Hermes tracks the wrong
-        # pid and cannot poll, wait, or stream output correctly.
-        if background and (_INLINE_BACKGROUND_AMP_RE.search(command) or _TRAILING_BACKGROUND_AMP_RE.search(command)):
+        # Guardrail: background=True but the command still uses shell-level
+        # backgrounding. The shell double-backgrounds the process so Hermes
+        # tracks the wrong pid and cannot poll, wait, or stream output.
+        if background and _contains_shell_background_operator(command):
             return json.dumps({
                 "output": "",
                 "exit_code": -1,
@@ -2451,6 +2700,8 @@ def terminal_tool(
                     result_data["approval"] = approval_note
                 if pty_disabled_reason:
                     result_data["pty_note"] = pty_disabled_reason
+                if background_normalization_warning:
+                    result_data["warning"] = background_normalization_warning
 
                 # Nudge: background=True without notify_on_complete=True OR
                 # watch_patterns is a silent process. The agent has NO way to

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2157,6 +2157,22 @@ def terminal_tool(
                     "status": "error",
                 }, ensure_ascii=False)
 
+        # Guardrail: background=True but command still has a trailing '&'.
+        # The shell double-backgrounds the process so Hermes tracks the wrong
+        # pid and cannot poll, wait, or stream output correctly.
+        if background and (_INLINE_BACKGROUND_AMP_RE.search(command) or _TRAILING_BACKGROUND_AMP_RE.search(command)):
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    "Command contains '&' backgrounding but background=true is already set — "
+                    "remove the '&' from the command string and re-submit. "
+                    "Use background=true alone; adding '&' causes the shell to double-background "
+                    "the process so Hermes tracks the wrong pid."
+                ),
+                "status": "error",
+            }, ensure_ascii=False)
+
         # Start cleanup thread
         _start_cleanup_thread()
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1885,10 +1885,19 @@ def _strip_quotes(command: str) -> str:
 
     This prevents false positives when keywords like 'nohup' or 'setsid' appear
     in commit messages, Python -c code, echo arguments, or PR body text.
-    Also strips backtick-quoted content and heredoc-style inline text.
+    Also strips backtick-quoted content and heredoc bodies.
     """
+    # Remove heredoc bodies first — before quote stripping, which would mangle
+    # the delimiter name (e.g. << 'EOF' → << '' losing the delimiter).
+    # Matches << [-] ['"]? WORD ['"]? ... \n <body> \n WORD at start of line.
+    result = re.sub(
+        r"<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n.*?\n\1(?=\n|$)",
+        "",
+        command,
+        flags=re.DOTALL,
+    )
     # Remove single-quoted strings (no escaping inside single quotes in shell)
-    result = re.sub(r"'[^']*'", "''", command)
+    result = re.sub(r"'[^']*'", "''", result)
     # Remove double-quoted strings (handle escaped quotes)
     result = re.sub(r'"(?:[^"\\]|\\.)*"', '""', result)
     # Remove backtick-quoted strings

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -135,14 +135,14 @@ def _check_disk_usage_warning():
                         total_bytes += f.stat().st_size
                     except OSError as e:
                         logger.debug("Could not stat file %s: %s", f, e)
-        
+
         total_gb = total_bytes / (1024 ** 3)
-        
+
         if total_gb > DISK_USAGE_WARNING_THRESHOLD_GB:
             logger.warning("Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
                            total_gb, DISK_USAGE_WARNING_THRESHOLD_GB)
             return True
-        
+
         return False
     except Exception as e:
         logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
@@ -318,26 +318,26 @@ def _validate_workdir(workdir: str) -> str | None:
 def _handle_sudo_failure(output: str, env_type: str) -> str:
     """
     Check for sudo failure and add helpful message for messaging contexts.
-    
+
     Returns enhanced output if sudo failed in messaging context, else original.
     """
     is_gateway = env_var_enabled("HERMES_GATEWAY_SESSION")
-    
+
     if not is_gateway:
         return output
-    
+
     # Check for sudo failure indicators
     sudo_failures = [
         "sudo: a password is required",
         "sudo: no tty present",
         "sudo: a terminal is required",
     ]
-    
+
     for failure in sudo_failures:
         if failure in output:
             from hermes_constants import display_hermes_home as _dhh
             return output + f"\n\n💡 Tip: To enable sudo over messaging, add SUDO_PASSWORD to {_dhh()}/.env on the agent machine."
-    
+
     return output
 
 
@@ -381,19 +381,19 @@ def _invalidate_cached_sudo_on_auth_failure(
 def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     """
     Prompt user for sudo password with timeout.
-    
+
     Returns the password if entered, or empty string if:
     - User presses Enter without input (skip)
     - Timeout expires (45s default)
     - Any error occurs
-    
+
     Only works in interactive mode (HERMES_INTERACTIVE=1).
     If a _sudo_password_callback is registered (by the CLI), delegates to it
     so the prompt integrates with prompt_toolkit's UI.  Otherwise reads
     directly from /dev/tty with echo disabled.
     """
     import sys
-    
+
     # Use the registered callback when available (prompt_toolkit-compatible)
     _sudo_cb = _get_sudo_password_callback()
     if _sudo_cb is not None:
@@ -403,7 +403,7 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             return ""
 
     result = {"password": None, "done": False}
-    
+
     def read_password_thread():
         """Read password with echo disabled. Uses msvcrt on Windows, /dev/tty on Unix."""
         tty_fd = None
@@ -451,11 +451,11 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
                 except Exception as e:
                     logger.debug("Failed to close tty fd: %s", e)
             result["done"] = True
-    
+
     try:
         os.environ["HERMES_SPINNER_PAUSE"] = "1"
         time.sleep(0.2)
-        
+
         print()
         print("┌" + "─" * 58 + "┐")
         print("│  🔐 SUDO PASSWORD REQUIRED" + " " * 30 + "│")
@@ -466,11 +466,11 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
         print("└" + "─" * 58 + "┘")
         print()
         print("  Password (hidden): ", end="", flush=True)
-        
+
         password_thread = threading.Thread(target=read_password_thread, daemon=True)
         password_thread.start()
         password_thread.join(timeout=timeout_seconds)
-        
+
         if result["done"]:
             password = result["password"] or ""
             print()  # newline after hidden input
@@ -487,7 +487,7 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             print()
             sys.stdout.flush()
             return ""
-            
+
     except (EOFError, KeyboardInterrupt):
         print()
         print("  ⏭ Cancelled - continuing without sudo")
@@ -1258,7 +1258,7 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     env_type = os.getenv("TERMINAL_ENV", "local")
-    
+
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona"}
     docker_backend = env_type == "docker"
@@ -1394,7 +1394,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                         host_cwd: str = None):
     """
     Create an execution environment for sandboxed command execution.
-    
+
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
             "daytona", "ssh"
@@ -1405,7 +1405,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         container_config: Resource config for container backends (cpu, memory, disk, persistent)
         task_id: Task identifier for environment reuse and snapshot keying
         host_cwd: Optional host working directory to bind into Docker when explicitly enabled
-        
+
     Returns:
         Environment instance with execute() method
     """
@@ -1422,7 +1422,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
-    
+
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
         # prior Hermes processes that hit SIGKILL / OOM / a closed terminal
@@ -1445,14 +1445,14 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
         )
-    
+
     elif env_type == "singularity":
         return _SingularityEnvironment(
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
             persistent_filesystem=persistent, task_id=task_id,
         )
-    
+
     elif env_type == "modal":
         sandbox_kwargs = {}
         if cpu > 0:
@@ -1510,7 +1510,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             modal_sandbox_kwargs=sandbox_kwargs,
             persistent_filesystem=persistent, task_id=task_id,
         )
-    
+
     elif env_type == "daytona":
         # Lazy import so daytona SDK is only required when backend is selected.
         from tools.environments.daytona import DaytonaEnvironment as _DaytonaEnvironment
@@ -1668,14 +1668,14 @@ def cleanup_all_environments():
     """Clean up ALL active environments. Use with caution."""
     task_ids = list(_active_environments.keys())
     cleaned = 0
-    
+
     for task_id in task_ids:
         try:
             cleanup_vm(task_id)
             cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
-    
+
     # Also clean any orphaned directories
     scratch_dir = _get_scratch_dir()
     import glob
@@ -1685,7 +1685,7 @@ def cleanup_all_environments():
             logger.info("Removed orphaned: %s", path)
         except OSError as e:
             logger.debug("Failed to remove orphaned path %s: %s", path, e)
-    
+
     if cleaned > 0:
         logger.info("Cleaned %d environments", cleaned)
     return cleaned
@@ -2274,7 +2274,7 @@ def terminal_tool(
 
         # With custom timeout
         >>> result = terminal_tool(command="long_task.sh", timeout=300)
-        
+
         # Force run after user confirmation
         # Note: force parameter is internal only, not exposed to model API
     """
@@ -2308,7 +2308,7 @@ def terminal_tool(
         # ``"default"``) is still found under its originating session id while
         # isolation-keyed RL/benchmark overrides keep resolving as before.
         overrides = resolve_task_overrides(task_id)
-        
+
         # Select image based on env type, with per-task override support
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -2384,10 +2384,15 @@ def terminal_tool(
                 "output": "",
                 "exit_code": -1,
                 "error": (
-                    "Command contains internal '&' backgrounding, which Hermes cannot "
-                    "safely track. Only a single final '&' can be normalized. Use "
-                    "separate terminal(background=true) calls or a foreground "
-                    "concurrency mechanism such as xargs -P, make -j, or GNU parallel."
+                    "Command contains internal shell '&' backgrounding before "
+                    "additional commands. Hermes cannot safely track a background "
+                    "process inside a compound command. Start the background process "
+                    "in its own terminal call with background=true and no '&', then "
+                    "run the remaining commands in a separate terminal call. Hermes "
+                    "returns the managed PID and session ID; do not use '$!'. For "
+                    "example, first use terminal(command=\"<long-running command>\", "
+                    "background=true), then use terminal(command=\"<follow-up "
+                    "commands>\")."
                 ),
                 "status": "error",
             }, ensure_ascii=False)
@@ -2949,7 +2954,7 @@ def terminal_tool(
                             "exit_code": 124,
                             "error": f"Command timed out after {effective_timeout} seconds"
                         }, ensure_ascii=False)
-                    
+
                     # Retry on transient errors
                     if retry_count < max_retries:
                         retry_count += 1
@@ -2958,7 +2963,7 @@ def terminal_tool(
                                        wait_time, retry_count, max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                         time.sleep(wait_time)
                         continue
-                    
+
                     logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
                                  max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
                     return json.dumps({
@@ -2966,7 +2971,7 @@ def terminal_tool(
                         "exit_code": -1,
                         "error": f"Command execution failed: {type(e).__name__}: {str(e)}"
                     }, ensure_ascii=False)
-                
+
                 # Got a result
                 break
             
@@ -3011,7 +3016,7 @@ def terminal_tool(
                         break
             except Exception:
                 pass
-            
+
             # Truncate output if too long, keeping both head and tail
             from tools.tool_output_limits import get_max_bytes
             MAX_OUTPUT_CHARS = get_max_bytes()
@@ -3220,7 +3225,7 @@ if __name__ == "__main__":
     # Simple test when run directly
     print("Terminal Tool Module")
     print("=" * 50)
-    
+
     config = _get_env_config()
     print("\nCurrent Configuration:")
     print(f"  Environment type: {config['env_type']}")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1914,7 +1914,12 @@ def _heredoc_declarations(line: str) -> list[tuple[str, bool]]:
         if ch == "#" and (i == 0 or line[i - 1].isspace() or line[i - 1] in ";|&()"):
             break
 
-        if line.startswith("<<", i) and not line.startswith("<<<", i):
+        if line.startswith("<<<", i):
+            # Herestring — not a heredoc; skip all three characters and move on.
+            i += 3
+            continue
+
+        if line.startswith("<<", i):
             i += 2
             strip_tabs = i < n and line[i] == "-"
             if strip_tabs:
@@ -1987,8 +1992,10 @@ def _strip_heredoc_bodies(command: str) -> str:
 def _shell_background_operator_positions(command: str) -> list[int]:
     """Return positions of real unquoted shell ``&`` operators in *command*.
 
-    Distinguishes job-control ``&`` from ``&&``, ``&>`` and fd redirects, and
-    ignores escaped operators, quoted strings, comments, and heredoc bodies.
+    Distinguishes job-control ``&`` from ``&&``, ``&>``, ``|&``, fd redirects,
+    ``;&``/``;;&`` case-fallthrough operators, and arithmetic/subshell
+    expansions, and ignores escaped operators, quoted strings, comments, and
+    heredoc bodies.
     """
     sanitized = _strip_heredoc_bodies(command)
     positions: list[int] = []
@@ -2026,11 +2033,36 @@ def _shell_background_operator_positions(command: str) -> list[int]:
                 i += 1
             continue
 
+        # Skip parenthesised groups — subshells $(…), arithmetic $((…)),
+        # and plain (…) — so that & inside them is never counted.
+        if ch == "(":
+            depth = 1
+            i += 1
+            while i < n and depth:
+                if sanitized[i] == "(":
+                    depth += 1
+                elif sanitized[i] == ")":
+                    depth -= 1
+                elif sanitized[i] in {"'", '"'}:
+                    quote = sanitized[i]
+                    i += 1
+                    while i < n:
+                        if sanitized[i] == "\\" and quote != "'" and i + 1 < n:
+                            i += 2
+                            continue
+                        if sanitized[i] == quote:
+                            break
+                        i += 1
+                i += 1
+            continue
+
         if ch == "&":
             if sanitized.startswith("&&", i) or sanitized.startswith("&>", i):
+                # && (logical-and) and &> (redirect) — not job-control.
                 i += 2
                 continue
-            if i > 0 and sanitized[i - 1] in "<>":
+            if i > 0 and sanitized[i - 1] in "<>|;":
+                # fd redirect (2>&1), pipe-stderr (|&), case fallthrough (;&, ;;&).
                 i += 1
                 continue
             positions.append(i)
@@ -2051,7 +2083,12 @@ def _contains_shell_background_operator(command: str) -> bool:
 
 
 def _is_final_shell_background_operator(command: str, position: int) -> bool:
-    """Return whether only whitespace/comments follow the operator."""
+    """Return whether only whitespace/comments follow the operator.
+
+    *position* comes from :func:`_shell_background_operator_positions`, which
+    scans the sanitized command.  Because :func:`_strip_heredoc_bodies`
+    preserves total length, positions are valid indices into *command* too.
+    """
     i = position + 1
     n = len(command)
 


### PR DESCRIPTION
## What does this PR do?

Makes terminal background-command handling safe and predictable. Shell-level `&` backgrounding can cause Hermes to track the shell rather than the actual child process, preventing reliable polling, waiting, and output streaming.

The terminal tool now recognizes real, unquoted shell background operators while ignoring quoted text, comments, redirects, and heredoc bodies. A single trailing `&` is normalized into Hermes-managed `background=true` execution with a warning. Internal backgrounding in compound commands, or an `&` used together with `background=true`, is rejected with instructions to split the work into managed terminal calls.

## Related Issue

Related PRs:

- [#63788](https://github.com/NousResearch/hermes-agent/pull/63788) fixes false positives from `&` inside heredoc bodies. This PR includes the same class of heredoc-aware detection, but also normalizes one final top-level `&` into Hermes-managed `background=true` execution and rejects unsafe internal or double backgrounding.
- [#68948](https://github.com/NousResearch/hermes-agent/pull/68948) removes the existing compound-background command rewriter after finding it corrupts valid shell input. This PR does not rewrite compound commands; it rejects internal shell `&` backgrounding and asks the model to split the work into separately managed terminal calls.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added lexical parsing helpers in `tools/terminal_tool.py` for heredoc declarations and top-level shell `&` operators.
- Excluded quoted values, comments, file-descriptor redirects, `&&`, `&>`, and heredoc bodies from backgrounding detection.
- Converted one unambiguous final `&` into managed `background=true` execution and returned a warning explaining the normalization.
- Rejected internal shell backgrounding and `background=true` plus shell `&`, where Hermes cannot safely track the process.

## How to Test

1. Run the focused terminal-tool regression tests once added (this branch currently does **not** add automated coverage for the new parser).
2. Call `terminal(command="sleep 1 &")` and verify it is started as a managed background command with a normalization warning.
3. Call `terminal(command="sleep 1 & echo done")` and verify it is rejected with guidance to split it into separate calls.
4. Verify commands containing `&` in quotes, comments, redirects, or heredoc content are not mistaken for backgrounding.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (benchmark sandbox/container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
