### PR TITLE
fix(computer_use): disable overlay for embedded daemons

### DIFF
--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -11,7 +11,7 @@ probe), not specific config snapshots.
 
 import os
 import sys
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from tools.computer_use import cua_backend
 
@@ -159,3 +159,30 @@ class TestMcpArgsOverlayFlag:
             result = cua_backend._mcp_args_with_overlay_flag(original)
             assert "--no-overlay" in result
             assert "--no-overlay" not in original
+
+
+class TestEmbeddedDaemonOverlayFlag:
+    def test_serve_process_disables_overlay_when_policy_requires_it(self):
+        daemon = cua_backend._EmbeddedCuaDaemon("/usr/bin/cua-driver", "unrestricted")
+        process = MagicMock()
+        process.poll.return_value = None
+        status = MagicMock(returncode=0)
+
+        with patch.object(
+            cua_backend,
+            "_resolve_mcp_invocation",
+            return_value=("/usr/bin/cua-driver", ["mcp"]),
+        ), patch.object(
+            cua_backend, "_cua_no_overlay", return_value=True,
+        ), patch.object(
+            cua_backend, "_cua_driver_supports_no_overlay", return_value=True,
+        ), patch.object(
+            cua_backend.subprocess, "Popen", return_value=process,
+        ) as popen, patch.object(
+            cua_backend.subprocess, "run", return_value=status,
+        ), patch.object(cua_backend.threading, "Thread"):
+            daemon.start()
+
+        command = popen.call_args.args[0]
+        assert command[:2] == ["/usr/bin/cua-driver", "serve"]
+        assert "--no-overlay" in command

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -450,6 +450,10 @@ class _EmbeddedCuaDaemon:
             "unrestricted",
             "--dangerously-bypass-approvals",
         ]
+        # The private daemon owns the platform cursor overlay. Applying the
+        # policy only to its MCP proxy leaves this long-lived serve process
+        # free to create a full-screen overlay before session tuning runs.
+        command = _mcp_args_with_overlay_flag(command, driver_cmd=self._command)
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## What does this PR do?

Ensures private unrestricted Computer Use daemons honor the existing `computer_use.no_overlay` policy at process startup.

Hermes already applies `--no-overlay` to the cua-driver MCP proxy and later disables the session cursor through the API. However, unrestricted/approval-bypass sessions launch a separate embedded `cua-driver serve` process, which owns the platform overlay and previously did not receive the flag. On Linux this allowed a full-screen XWayland `Cua.AgentCursorOverlay.default` window to remain active even while the machine-wide daemon was correctly running with `--no-overlay`.

The embedded daemon now reuses the existing policy and driver-capability helper before `Popen`. Drivers that do not advertise `--no-overlay` support remain unchanged.

## Related Issue

Fixes #78599

Related upstream reports: trycua/cua#1819, trycua/cua#2350.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/cua_backend.py`: apply the existing no-overlay policy/capability helper to the embedded `serve` command.
- `tests/computer_use/test_cua_no_overlay.py`: add a regression test asserting the command passed to `Popen` contains `--no-overlay` when policy and support are enabled.

## How to Test

1. Set `computer_use.no_overlay: true` and use unrestricted Computer Use (`approvals.mode: off` or explicit YOLO mode).
2. Inspect the private daemon's `/proc/<pid>/cmdline`; verify it contains `serve --embedded … --no-overlay`.
3. Verify no `Cua.AgentCursorOverlay.default` window appears and daemon shutdown still removes the process/socket.

Validation performed:

- `scripts/run_tests.sh tests/computer_use/ -j 4` — 45 passed
- `uv run --extra dev ruff check tools/computer_use/cua_backend.py tests/computer_use/test_cua_no_overlay.py` — passed
- Real Linux/Hyprland process probe — actual embedded command contained `--no-overlay`; overlay set stayed empty before/during/after; shutdown succeeded
- `ty` reports three pre-existing diagnostics at `cua_backend.py:941-942` and `cua_backend.py:1351`, outside this diff
- The full canonical runner was also attempted from the dev-only environment; unrelated optional-feature/import failures remained (134 failed tests and 37 files with no collection). The complete affected `tests/computer_use/` area is green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Hyprland/Wayland with XWayland overlay path, cua-driver 0.17.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; existing config behavior is unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); unsupported drivers do not receive the flag
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Candidate-fix process probe:

```json
{"no_overlay_flag": true, "overlay_before": [], "overlay_during": []}
{"stopped": true, "overlay_after": []}
```
