### PR TITLE
fix(gateway): /rollback now undoes the conversation turn it reverts

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2791,6 +2791,35 @@ class GatewaySlashCommandsMixin:
         idx = len(mgr.state.subgoals) if mgr.state else 0
         return f"✓ Added subgoal {idx}: {text}"
 
+    async def _rewind_last_turns(
+        self, source: SessionSource, n: int = 1,
+    ) -> Optional[dict]:
+        """Back up ``n`` user turns and re-arm the session for a rebuild.
+
+        Shared by /undo and /rollback — both have to truncate the persisted
+        transcript, reset the stored prompt-token count, and evict the cached
+        agent so the next message rebuilds context from the active-only rows.
+        Returns ``rewind_session``'s result, or ``None`` when there was
+        nothing to rewind.
+        """
+        session_entry = await self.async_session_store.get_or_create_session(source)
+        result = await self.async_session_store.rewind_session(session_entry.session_id, n)
+
+        if result is None:
+            return None
+
+        # Reset stored token count — transcript was truncated.
+        session_entry.last_prompt_tokens = 0
+        # Evict the cached agent so the next turn rebuilds from the active-only
+        # transcript and memory providers refresh their per-session caches.
+        try:
+            session_key = build_session_key(source)
+            self._evict_cached_agent(session_key)
+        except Exception as e:
+            logger.debug("rewind: cached-agent eviction skipped: %s", e)
+
+        return result
+
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo [N] — back up N user turns (default 1), soft-deleting
         the truncated rows on disk and echoing the backed-up message text so
@@ -2815,21 +2844,10 @@ class GatewaySlashCommandsMixin:
             if n < 1:
                 n = 1
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
-        result = await self.async_session_store.rewind_session(session_entry.session_id, n)
+        result = await self._rewind_last_turns(source, n)
 
         if result is None:
             return t("gateway.undo.nothing")
-
-        # Reset stored token count — transcript was truncated.
-        session_entry.last_prompt_tokens = 0
-        # Evict the cached agent so the next turn rebuilds from the active-only
-        # transcript and memory providers refresh their per-session caches.
-        try:
-            session_key = build_session_key(source)
-            self._evict_cached_agent(session_key)
-        except Exception as e:
-            logger.debug("undo: cached-agent eviction skipped: %s", e)
 
         target_text = result["target_text"]
         preview = target_text[:200] + "..." if len(target_text) > 200 else target_text
@@ -3033,6 +3051,16 @@ class GatewaySlashCommandsMixin:
 
         result = mgr.restore(cwd, target_hash)
         if result["success"]:
+            # Step 4 of the documented /rollback flow: undo the conversation
+            # turn that produced the now-reverted edits, so the agent's
+            # context matches the restored filesystem state.  Without this the
+            # cached agent keeps a transcript describing files that no longer
+            # look that way on disk.  Best-effort: the files are already
+            # restored, so a rewind failure must not report the restore failed.
+            try:
+                await self._rewind_last_turns(event.source, 1)
+            except Exception as e:
+                logger.warning("rollback: transcript rewind failed: %s", e)
             return t(
                 "gateway.rollback.restored",
                 hash=result["restored_to"],

--- a/tests/gateway/test_rollback_rewinds_transcript.py
+++ b/tests/gateway/test_rollback_rewinds_transcript.py
@@ -1,0 +1,222 @@
+"""Gateway ``/rollback`` must undo the conversation turn it just reverted.
+
+``website/docs/user-guide/checkpoints-and-rollback.md`` documents ``/rollback
+<N>`` as a four-step flow, ending with:
+
+    4. **Undoes the last conversation turn** so the agent's context matches
+       the restored filesystem state.
+
+The CLI handler honours step 4 (``hermes_cli/cli_commands_mixin.py`` calls
+``undo_last(prefill=False)`` after a successful restore).  The gateway handler
+restored the files and stopped there, so on every messaging platform the
+cached agent kept a transcript describing edits that no longer existed on
+disk.  These tests drive the real handler against a real checkpoint store.
+"""
+
+import shutil
+
+import pytest
+
+import gateway.run as gateway_run
+import tools.checkpoint_manager as cpm
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git required for /rollback"
+)
+
+BASELINE = "VERSION = 1\n"
+EDITED = "VERSION = 2  # written by the agent\n"
+
+
+class _SessionEntry:
+    def __init__(self):
+        self.session_id = "sess-1"
+        self.last_prompt_tokens = 4321
+
+
+class _SessionStore:
+    """Records what the handler asks of the session store."""
+
+    def __init__(self, rewind_result=None, rewind_error=None):
+        self.entry = _SessionEntry()
+        self.rewind_calls = []
+        self._rewind_result = rewind_result
+        self._rewind_error = rewind_error
+
+    async def get_or_create_session(self, source):
+        return self.entry
+
+    async def rewind_session(self, session_id, n):
+        self.rewind_calls.append((session_id, n))
+        if self._rewind_error is not None:
+            raise self._rewind_error
+        return self._rewind_result
+
+
+def _rewind_payload(turns=1):
+    return {
+        "target_text": "bump the version",
+        "turns_undone": turns,
+        "rewound_count": turns * 2,
+    }
+
+
+class _Runner(gateway_run.GatewayRunner):
+    """A real runner with only the session-store facade swapped out.
+
+    ``GatewayRunner.async_session_store`` is a read-only property, so the
+    recorder is injected by overriding it rather than by assignment.
+    """
+
+    @property
+    def async_session_store(self):
+        return self._store_stub
+
+
+def _runner(store):
+    runner = object.__new__(_Runner)
+    runner.config = None
+    runner.session_store = None
+    runner._store_stub = store
+    runner.evicted = []
+    runner._evict_cached_agent = runner.evicted.append
+    return runner
+
+
+def _event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+@pytest.fixture()
+def project(tmp_path, monkeypatch):
+    """A checkpointed working directory with one restorable baseline."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "checkpoints:\n  enabled: true\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", home, raising=False)
+    monkeypatch.setattr(cpm, "CHECKPOINT_BASE", tmp_path / "checkpoints")
+
+    d = tmp_path / "project"
+    d.mkdir()
+    app = d / "app.py"
+    app.write_text(BASELINE, encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(d))
+
+    mgr = cpm.CheckpointManager(enabled=True, max_snapshots=50)
+    assert mgr.ensure_checkpoint(str(d), "before the agent edited app.py") is True
+
+    # The agent's turn: it edits the file and the transcript now says so.
+    app.write_text(EDITED, encoding="utf-8")
+    return app
+
+
+@pytest.mark.asyncio
+async def test_rollback_restores_files_and_rewinds_transcript(project):
+    store = _SessionStore(rewind_result=_rewind_payload())
+    runner = _runner(store)
+
+    reply = await runner._handle_rollback_command(_event("/rollback 1"))
+
+    assert "Restored to checkpoint" in reply
+    assert project.read_text(encoding="utf-8") == BASELINE
+    # Step 4: exactly one turn dropped, for this session.
+    assert store.rewind_calls == [("sess-1", 1)]
+    # …and the session re-armed so the next message rebuilds from the
+    # truncated transcript instead of the stale cached agent.
+    assert store.entry.last_prompt_tokens == 0
+    assert len(runner.evicted) == 1
+
+
+@pytest.mark.asyncio
+async def test_listing_checkpoints_leaves_the_session_untouched(project):
+    store = _SessionStore(rewind_result=_rewind_payload())
+    runner = _runner(store)
+
+    await runner._handle_rollback_command(_event("/rollback"))
+
+    assert store.rewind_calls == []
+    assert store.entry.last_prompt_tokens == 4321
+    assert runner.evicted == []
+    assert project.read_text(encoding="utf-8") == EDITED
+
+
+@pytest.mark.asyncio
+async def test_failed_restore_does_not_drop_a_turn(project):
+    store = _SessionStore(rewind_result=_rewind_payload())
+    runner = _runner(store)
+
+    reply = await runner._handle_rollback_command(
+        _event("/rollback 0123456789abcdef0123456789abcdef01234567")
+    )
+
+    assert "Restored to checkpoint" not in reply
+    # Nothing was reverted, so the transcript still matches the filesystem.
+    assert store.rewind_calls == []
+    assert project.read_text(encoding="utf-8") == EDITED
+
+
+@pytest.mark.asyncio
+async def test_restore_still_reported_when_the_rewind_blows_up(project):
+    store = _SessionStore(rewind_error=RuntimeError("state.db is locked"))
+    runner = _runner(store)
+
+    reply = await runner._handle_rollback_command(_event("/rollback 1"))
+
+    # The files really were restored; a bookkeeping failure afterwards must
+    # not tell the user the rollback failed.
+    assert "Restored to checkpoint" in reply
+    assert project.read_text(encoding="utf-8") == BASELINE
+
+
+@pytest.mark.asyncio
+async def test_rollback_succeeds_when_there_is_no_turn_to_rewind(project):
+    store = _SessionStore(rewind_result=None)
+    runner = _runner(store)
+
+    reply = await runner._handle_rollback_command(_event("/rollback 1"))
+
+    assert "Restored to checkpoint" in reply
+    assert project.read_text(encoding="utf-8") == BASELINE
+    assert store.rewind_calls == [("sess-1", 1)]
+    # Nothing was truncated, so the cached token count stays as it was.
+    assert store.entry.last_prompt_tokens == 4321
+    assert runner.evicted == []
+
+
+@pytest.mark.asyncio
+async def test_undo_still_rewinds_the_requested_number_of_turns():
+    """/undo shares the rewind primitive with /rollback — keep it working."""
+    store = _SessionStore(rewind_result=_rewind_payload(turns=3))
+    runner = _runner(store)
+
+    reply = await runner._handle_undo_command(_event("/undo 3"))
+
+    assert store.rewind_calls == [("sess-1", 3)]
+    assert store.entry.last_prompt_tokens == 0
+    assert len(runner.evicted) == 1
+    assert "bump the version" in reply
+
+
+@pytest.mark.asyncio
+async def test_undo_reports_nothing_to_rewind():
+    store = _SessionStore(rewind_result=None)
+    runner = _runner(store)
+
+    reply = await runner._handle_undo_command(_event("/undo"))
+
+    assert store.rewind_calls == [("sess-1", 1)]
+    assert store.entry.last_prompt_tokens == 4321
+    assert runner.evicted == []
+    assert reply


### PR DESCRIPTION
## What

`website/docs/user-guide/checkpoints-and-rollback.md` documents `/rollback <N>` as a four-step flow:

> 1. Verifies the target commit exists in the shadow store.
> 2. Takes a **pre-rollback snapshot** of the current state so you can "undo the undo" later.
> 3. Restores tracked files in your working directory.
> 4. **Undoes the last conversation turn** so the agent's context matches the restored filesystem state.

The Quick Reference table says the same thing — `/rollback <N>` → "Restore to checkpoint N (also undoes last chat turn)" — and neither is scoped to a single entry point; they describe the in-session slash command.

The CLI handler implements step 4. The gateway handler does not: it restores the files and returns. It never touches the session store at all, so on every messaging platform the transcript keeps describing edits that no longer exist on disk, and the **cached** agent object keeps serving them. The next turn then reasons against a filesystem it no longer matches — re-patching content that was reverted, or skipping work it believes is already done.

Both handlers, driven against the same real checkpoint store — same file restored, opposite session state:

```
gateway reply: '✅ Restored to checkpoint c95d1922: before the agent edited app.py'
gateway: file after rollback: 'VERSION = 1\n'
gateway: attributes touched on the runner: []      <-- nothing; no rewind, no eviction

cli: file after rollback: 'VERSION = 1\n'
cli: undo_last calls: [False]
cli: transcript left: []
```

The two handlers were split into separate modules by 619bd7827 (2026-06-07, refactor(gateway): extract 42 slash-command handlers into GatewaySlashCommandsMixin) and 0904bc7ea (2026-06-08, refactor(cli): extract 32 slash-command handlers into CLICommandsMixin), which is where the divergence stopped being visible in one screen. The gateway wasn't missing the capability — `_handle_undo_command`'s own docstring already states the parity intent ("Mirrors the CLI/TUI /undo … the gateway's equivalent of the CLI's in-place history surgery + memory-cache invalidation"). `/rollback` simply never called it.

Checkpoints are live in gateway mode — `_checkpoint_agent_kwargs` is spread into every gateway-created agent (`gateway/run.py`, `gateway/platforms/api_server.py`), so this path is reachable on all messaging platforms whenever `checkpoints.enabled` is set.

## The fix

`/undo` already had the exact primitive, inline. Extracted it to `_rewind_last_turns()` and called it from both handlers rather than adding a second copy:

- truncate the persisted transcript via `rewind_session`
- reset the stored prompt-token count
- evict the cached agent, so the next message rebuilds context from the active-only rows

`/undo` keeps its own messaging and passes its parsed `N`; `/rollback` passes 1, matching the documented "last conversation turn" and the CLI's `undo_last(prefill=False)`.

The rollback call is deliberately best-effort. The files are already restored by that point, so a bookkeeping failure must not report the restore as failed — it logs and still returns the success reply.

Scope I did not take: `/rollback diff <N>` and `/rollback <N> <file>` are documented but also unimplemented on the gateway — the argument falls through to `except ValueError` and is passed to `restore()` as a raw hash. Those fail safely today (`_validate_commit_hash` rejects them before anything is touched), and adding them needs new user-facing strings, which `tests/agent/test_i18n.py` requires across every locale. Separate change. This one adds no new keys.

## Tests

New: `tests/gateway/test_rollback_rewinds_transcript.py` — 7 tests driving the real handler against a real checkpoint store, following the harness in `tests/gateway/test_diff_command.py`.

- restore drops exactly one turn, for the right session, resets the token count, evicts the cached agent
- listing (`/rollback` with no argument) leaves the session completely untouched
- a failed restore drops no turn — nothing was reverted, so the transcript still matches
- a rewind that raises still reports the restore as succeeded, with the files really restored
- a restore with nothing to rewind returns success and leaves the token count alone
- `/undo N` still rewinds N turns and evicts, and still reports "nothing to rewind" — covering the extracted primitive from the other caller

Results:

```
7 passed
```

Red without the source change (tests kept, `gateway/slash_commands.py` reverted):

```
FAILED test_rollback_restores_files_and_rewinds_transcript
FAILED test_rollback_succeeds_when_there_is_no_turn_to_rewind
E       AssertionError: assert [] == [('sess-1', 1)]
2 failed, 5 passed
```

The 5 that stay green are the guard tests — they assert `/rollback` does *not* rewind when it shouldn't, which must hold on both sides.

Regression run over the blast radius (every test file touching `_handle_undo_command`, `_handle_rollback_command`, `rewind_session`, `_evict_cached_agent` or `async_session_store`, plus the checkpoint-manager, `/diff` and i18n suites), compared against the same files on main:

```
main:      3 failed, 193 passed
with fix:  3 failed, 200 passed
new failures introduced: (none)
```

The 3 failures are identical before and after and pre-exist in the checkpoint-clear, git-env-isolation and zombie-process-reproduction tests, none of which this change touches. `scripts/check-windows-footguns.py` passes on both changed files.