### PR TITLE
fix(mcp): suppress interactive OAuth in desktop probes

### DIFF
--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -165,7 +165,13 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         # override for .env interpolation + OAuth token resolution, which the
         # contextvar provides (copied into this to_thread worker; and
         # _run_on_mcp_loop re-wraps it onto the MCP event-loop thread).
-        with _config_profile_scope(profile):
+        #
+        # This endpoint is also called automatically when Desktop opens its MCP
+        # page. A status probe must never start an interactive OAuth flow or
+        # open the system browser; only the explicit /auth endpoint may do so.
+        from tools.mcp_oauth import suppress_interactive_oauth
+
+        with _config_profile_scope(profile), suppress_interactive_oauth():
             tools = _probe_single_server(name, servers[name], details=details)
             token_present = _oauth_tokens_present(name) if needs_oauth_token else True
             return tools, token_present

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -125,6 +125,48 @@ class TestProfileScopedMcp:
 
 
 
+    def test_mcp_test_probe_suppresses_interactive_oauth(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Opening the Desktop MCP page auto-probes enabled servers.
+
+        A status probe must never start interactive OAuth or open the system
+        browser. Only the explicit /auth endpoint may do that.
+        """
+        import hermes_cli.mcp_config as mcp_config
+        import tools.mcp_oauth as mcp_oauth
+        import tools.mcp_tool as mcp_tool
+
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "mcp_servers:\n  oauth-srv:\n    url: http://x/sse\n    auth: oauth\n",
+            encoding="utf-8",
+        )
+
+        def probe_without_browser(name, config, connect_timeout=30, details=None):
+            async def oauth_is_interactive():
+                return mcp_oauth._is_interactive()
+
+            mcp_tool._ensure_mcp_loop()
+            try:
+                assert (
+                    mcp_tool._run_on_mcp_loop(oauth_is_interactive(), timeout=10)
+                    is False
+                )
+            finally:
+                mcp_tool._stop_mcp_loop()
+            return [("tool-a", "desc")]
+
+        monkeypatch.setattr(mcp_config, "_probe_single_server", probe_without_browser)
+        monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda name: True)
+
+        with mcp_oauth.force_interactive_oauth():
+            resp = client.post(
+                "/api/mcp/servers/oauth-srv/test", params={"profile": "worker_beta"}
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
     def test_mcp_test_oauth_server_without_token_is_not_ok(
         self, client, isolated_profiles, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- make the Desktop MCP status probe non-interactive
- prevent automatic MCP page probes from opening OAuth browser tabs
- preserve interactive OAuth exclusively for the explicit `/auth` endpoint
- add a regression test for an OAuth server while the surrounding process appears interactive

## Root cause

Opening the Desktop MCP page automatically calls `POST /api/mcp/servers/{name}/test` for enabled servers. That endpoint called `_probe_single_server()` without suppressing interactive OAuth. If an OAuth server needed authorization and the Desktop/backend process was considered interactive, a status probe could enter the authorization flow and open the system browser even though the user never clicked **Authenticate**. Repeated page probes could open repeated tabs.

## Fix

Wrap only the `/test` endpoint's probe with the existing `suppress_interactive_oauth()` context. The explicit `/auth` endpoint remains unchanged and continues to use `force_interactive_oauth()`.

## Test plan

- [x] Added a regression test that enters `force_interactive_oauth()` and verifies the `/test` probe still sees OAuth interactivity suppressed
- [x] Dashboard OAuth + profile/MCP endpoint tests: 21 passed
- [x] MCP OAuth core tests: 43 passed, 1 skipped
- [x] Ruff on both changed files
- [x] `git diff --check`

Related to #60313.

This addresses an additional Desktop auto-probe trigger beyond the config/cache behavior originally reported in that issue.