### PR TITLE
fix(kanban): goal completion judge must fail open on transport errors

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2187,13 +2187,14 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                     from hermes_cli.goals import judge_goal
                     verdict = "done"
                     reason = ""
+                    transport_failed = False
                     try:
                         # judge_goal returns (verdict, reason, parse_failed,
                         # wait_directive, transport_failed) — see
                         # hermes_cli/goals.py. Unpacking fewer raises
                         # ValueError into the fail-open handler below,
                         # silently disabling the gate.
-                        verdict, reason, _, _, _ = judge_goal(
+                        verdict, reason, _, _, transport_failed = judge_goal(
                             goal=f"{task.title}\n\n{task.body or ''}".strip(),
                             last_response=(summary or args.result or "").strip(),
                         )
@@ -2204,6 +2205,17 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                             judge_exc,
                             exc_info=True,
                         )
+                    # Fail OPEN on transport failure (401 auth, timeout, DNS):
+                    # a broken judge credential returns verdict="continue" with
+                    # transport_failed=True every call, which would otherwise
+                    # wedge every goal_mode worker from ever completing.
+                    # judge_goal is fail-open by design; the gate must honor it.
+                    if transport_failed:
+                        import logging as _logging
+                        _logging.getLogger(__name__).warning(
+                            "goal judge unreachable (%s), allowing completion", reason
+                        )
+                        verdict = "done"
                     if verdict != "done":
                         print(
                             f"kanban: goal completion of {tid} rejected by judge: {reason}. "

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -215,6 +215,56 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         conn2.close()
 
 
+def test_complete_goal_mode_transport_failure_fails_open(monkeypatch, tmp_path):
+    """A goal judge that cannot reach its API (401 auth, timeout, DNS) must
+    NOT wedge the worker. judge_goal returns transport_failed=True with a
+    "continue" verdict on every call when its credential is broken; the
+    completion gate must fail OPEN and let the task complete.
+    Regression for the broken-completion-judge bug: verdict != "done" was
+    rejecting completion even when the reason was an unreachable judge."""
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        goal_task_id = kb.create_task(
+            conn, title="goal-mode-test", assignee="test-worker",
+            body="Must achieve X with verified evidence.", goal_mode=True
+        )
+        kb.claim_task(conn, goal_task_id)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+
+    # Judge credential is broken: verdict "continue" but transport_failed=True.
+    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
+        return "continue", "judge error: AuthenticationError", False, None, True
+
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    out = kt._handle_complete({"summary": "Work is done, evidence attached"})
+    d = json.loads(out)
+    assert "error" not in d, f"transport failure should fail open, got {d}"
+
+    conn2 = kb.connect()
+    try:
+        task = kb.get_task(conn2, goal_task_id)
+        assert task.status == "done"
+    finally:
+        conn2.close()
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -718,13 +718,14 @@ def _handle_complete(args: dict, **kw) -> str:
             if task and task.goal_mode and _goal_judge_available():
                 verdict = "done"
                 reason = ""
+                transport_failed = False
                 try:
                     # judge_goal returns (verdict, reason, parse_failed,
                     # wait_directive, transport_failed) — see
                     # hermes_cli/goals.py. Unpacking fewer raises ValueError,
                     # which the defensive handler below swallows, leaving
                     # verdict="done" and silently disabling the gate.
-                    verdict, reason, _, _, _ = judge_goal(
+                    verdict, reason, _, _, transport_failed = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )
@@ -736,6 +737,16 @@ def _handle_complete(args: dict, **kw) -> str:
                         judge_exc,
                         exc_info=True,
                     )
+                # Fail OPEN on transport failure (401 auth, timeout, DNS): a
+                # broken judge credential returns verdict="continue" with
+                # transport_failed=True on every call, which would otherwise
+                # wedge every goal_mode worker from ever completing its task.
+                # judge_goal is fail-open by design; the gate must honor that.
+                if transport_failed:
+                    logger.warning(
+                        "goal judge unreachable (%s), allowing completion", reason
+                    )
+                    verdict = "done"
                 if verdict != "done":
                     return tool_error(
                         f"Goal completion rejected by judge: {reason}. "


### PR DESCRIPTION
## Problem

The goal-mode pre-completion judge gate fails **closed** on transport errors, which permanently wedges every `goal_mode` worker whenever the judge's own LLM credential is broken.

`judge_goal` (`hermes_cli/goals.py`) is fail-open by design. When it cannot reach its auxiliary API — 401 `AuthenticationError`, timeout, DNS — it returns:

```python
("continue", "judge error: AuthenticationError", False, None, True)
#   verdict     reason                          parse  wait  transport_failed
```

Both kanban completion gates unpacked this as `verdict, reason, _, _, _ = judge_goal(...)`, **discarding `transport_failed`**, then rejected completion on `verdict != "done"`. So a broken judge credential made every `goal_mode` task impossible to complete regardless of the evidence in the worker's summary — the exact symptom reported (`kanban_complete rejected 3x with "judge error: AuthenticationError"`).

The `/goal` loop already handles this correctly: it reads `transport_failed` and only auto-pauses after N consecutive transport failures. The two kanban gates were the only sites that ignored the flag.

## Fix

Both gates (`tools/kanban_tools.py` and `hermes_cli/kanban.py`) now capture `transport_failed` and fail **open** on it — matching `judge_goal`'s documented contract and the goal-loop's behavior. Genuine `continue`/`wait` verdicts from a *reachable* judge still reject completion as before.

## Test

Adds `test_complete_goal_mode_transport_failure_fails_open`: a judge returning `("continue", "judge error: AuthenticationError", False, None, True)` now lets the task reach `done` instead of being rejected.

```
68 passed  (tests/tools/test_kanban_tools.py, tests/hermes_cli/test_goals.py, tests/hermes_cli/test_kanban_goal_mode.py)
```
