### PR TITLE
feat(docs): add pt-BR locale with Getting Started translations

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,7 +24,7 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans'],
+    locales: ['en', 'zh-Hans', 'pt-BR'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -32,6 +32,10 @@ const config: Config = {
       'zh-Hans': {
         label: '简体中文',
         htmlLang: 'zh-Hans',
+      },
+      'pt-BR': {
+        label: 'Português (Brasil)',
+        htmlLang: 'pt-BR',
       },
     },
   },

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 2
+title: "Instalação"
+description: "Instale o Hermes Agent no Linux, macOS, WSL2, Windows nativo ou Android via Termux"
+---
+
+# Instalação
+
+Coloque o Hermes Agent em funcionamento em menos de dois minutos!
+
+:::tip Suporte de Plataforma
+Para a matriz completa de suporte de plataforma (quais SOs, métodos de distribuição e recursos por plataforma são suportados), veja **[Suporte de Plataforma](./platform-support.md)**.
+:::
+
+## Instalação Rápida
+### Com o instalador do Hermes Desktop no macOS ou Windows (recomendado)
+Para instalar facilmente os aplicativos de linha de comando e desktop, [baixe o instalador do Hermes Desktop](https://hermes-agent.nousresearch.com/) em nosso site e execute-o.
+
+### Sem o Hermes Desktop:
+Para uma instalação apenas de linha de comando sem o Hermes Desktop, execute:
+
+#### Linux / macOS / WSL2 / Android (Termux)
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+#### Windows (nativo)
+
+Execute no PowerShell:
+```powershell
+iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+```
+
+Se quiser instalar e executar o Hermes Desktop após uma instalação apenas de linha de comando, basta executar
+```bash
+hermes desktop
+```
+
+### O que o instalador faz
+
+O instalador cuida de tudo automaticamente — todas as dependências (Python, Node.js, ripgrep, ffmpeg), o clone do repositório, o ambiente virtual, o comando global `hermes` e a configuração do provedor de LLM. Ao final, você está pronto para conversar.
+
+#### Layout de instalação
+
+Onde o instalador coloca as coisas depende se você está instalando como usuário normal ou como root:
+
+| Instalador                              | O código fica em                | binário `hermes`                         | Diretório de dados                       |
+| --------------------------------------- | ------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| Por usuário (instalador git)            | `~/.hermes/hermes-agent/`       | `~/.local/bin/hermes` (symlink)          | `~/.hermes/`                             |
+| Modo root (`sudo curl … \| sudo bash`)  | `/usr/local/lib/hermes-agent/`  | `/usr/local/bin/hermes`                  | `/root/.hermes/` (ou `$HERMES_HOME`)     |
+
+O **layout FHS em modo root** (`/usr/local/lib/…`, `/usr/local/bin/hermes`) combina com onde outras ferramentas de desenvolvimento do sistema caem no Linux. É útil para implantações de máquina compartilhada onde uma instalação de sistema deve servir a todos os usuários. A configuração por usuário (auth, skills, sessões) ainda vive no `~/.hermes/` de cada usuário ou no `HERMES_HOME` explícito.
+
+### Após a instalação
+
+Recarregue seu shell e comece a conversar:
+
+```bash
+source ~/.bashrc   # ou: source ~/.zshrc
+hermes             # Comece a conversar!
+```
+
+Para reconfigurar configurações individuais depois, use os comandos dedicados:
+
+```bash
+hermes model          # Escolha seu provedor e modelo de LLM
+hermes tools          # Configure quais ferramentas estão ativas
+hermes gateway setup  # Configure as plataformas de mensagens
+hermes config set     # Defina valores de configuração individuais
+hermes config get     # Inspecione valores de configuração individuais
+hermes setup          # Ou rode o assistente completo para configurar tudo de uma vez
+```
+
+:::tip Caminho mais rápido: Nous Portal
+Uma assinatura cobre 300+ modelos mais o [Tool Gateway](/user-guide/features/tool-gateway) (busca web, geração de imagens, TTS, navegador em nuvem). Evite o vai-e-vem de chaves por ferramenta:
+
+```bash
+hermes setup --portal
+```
+
+Isso faz login, define a Nous como provedor e ativa o Tool Gateway em um único comando.
+:::
+
+---
+
+## Pré-requisitos
+
+**Instalador:** Em plataformas não-Windows, o único pré-requisito é **Git**. No Linux, garanta também que `curl` e `xz-utils` estejam disponíveis (o instalador baixa o Node.js como arquivo `.tar.xz`). O aplicativo desktop adicionalmente requer `g++` (ou `build-essential` no Debian/Ubuntu) para compilar módulos nativos. O instalador cuida automaticamente de todo o resto:
+
+- **uv** (gerenciador de pacotes Python rápido)
+- **Python 3.11** (via uv, sem precisar de sudo)
+- **Node.js v22** (para automação de navegador e ponte do WhatsApp)
+- **ripgrep** (busca rápida de arquivos)
+- **ffmpeg** (conversão de formato de áudio para TTS)
+
+:::info
+Você **não** precisa instalar Python, Node.js, ripgrep ou ffmpeg manualmente. O instalador detecta o que falta e instala por você. Apenas garanta que o `git` esteja disponível (`git --version`). No Linux, garanta que `curl` e `xz-utils` estejam instalados (`sudo apt install curl xz-utils` no Debian/Ubuntu). Para o app desktop, instale também `build-essential` (`sudo apt install build-essential`).
+:::
+
+:::tip Usuários de Nix
+O Nix **não é mais um caminho de instalação explicitamente suportado** (apenas melhor esforço). Se você já usa Nix (no NixOS, macOS ou Linux), existe um caminho de configuração dedicado com flake Nix, módulo declarativo NixOS e modo de container opcional. Veja o guia **[Nix e NixOS](./nix-setup.md)**.
+:::
+
+---
+
+## Instalação Manual / para Desenvolvedores
+
+Se quiser clonar o repositório e instalar a partir do código-fonte — para contribuir, rodar de uma branch específica ou ter controle total sobre o ambiente virtual — veja a seção [Configuração de Desenvolvimento](../developer-guide/contributing.md#development-setup) no guia de Contribuição.
+
+---
+
+## Instalações Sem Sudo / para Usuários de Serviço de Sistema
+
+Rodar o Hermes como um usuário dedicado sem privilégios (por exemplo, uma conta de serviço `hermes` do systemd, ou qualquer usuário sem acesso `sudo`) é suportado. A única coisa no caminho de instalação que realmente precisa de root é o passo `--with-deps` do Playwright, que instala via `apt` as bibliotecas compartilhadas (`libnss3`, `libxkbcommon`, etc.) usadas pelo Chromium. O instalador detecta se o sudo está disponível e degrada graciosamente quando não está — instala o binário do Chromium no cache local do Playwright do usuário de serviço e imprime o comando exato que um administrador precisa executar separadamente.
+
+**Divisão recomendada (Debian/Ubuntu):**
+
+1. **Uma vez, como usuário admin com sudo**, instale as bibliotecas de sistema que o Chromium precisa:
+   ```bash
+   sudo npx playwright install-deps chromium
+   ```
+   (Você pode executar de qualquer lugar — o `npx` buscará o Playwright na hora.)
+
+2. **Como o usuário de serviço sem privilégios**, execute o instalador normal. Ele detectará o sudo ausente, pulará o `--with-deps` e instalará o Chromium no cache local do Playwright do usuário:
+   ```bash
+   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+   ```
+
+   Se quiser pular o passo do Playwright por completo — por exemplo, porque você está rodando sem interface (headless) e não precisa de automação de navegador — use `--skip-browser`:
+   ```bash
+   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser
+   ```
+
+3. **Disponibilize o `hermes` para os shells do usuário de serviço.** O instalador escreve o lançador em `~/.local/bin/hermes`. Contas de serviço de sistema muitas vezes têm um PATH mínimo que não inclui `~/.local/bin`. Ou adicione ao ambiente do usuário, ou crie um symlink para uma localização de sistema:
+   ```bash
+   # Opção A — adicione ao perfil do usuário de serviço
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+   # Opção B — symlink em todo o sistema (execute como admin)
+   sudo ln -s /home/hermes/.hermes/hermes-agent/venv/bin/hermes /usr/local/bin/hermes
+   ```
+
+4. **Verifique:** `hermes doctor` deve rodar sem erros. Se receber `ModuleNotFoundError: No module named 'dotenv'`, você está invocando o arquivo `hermes` da fonte do repositório (`~/.hermes/hermes-agent/hermes`) com o Python do sistema em vez do lançador do venv (`~/.hermes/hermes-agent/venv/bin/hermes`) — corrija o passo 3.
+
+O mesmo padrão funciona no Arch (o instalador usa pacman com a mesma lógica de detecção de sudo), Fedora/RHEL e openSUSE — essas distros não suportam `--with-deps` de forma alguma, então um administrador sempre instala as bibliotecas de sistema separadamente. Os comandos relevantes `dnf`/`zypper` são impressos pelo instalador.
+
+---
+
+## Solução de Problemas
+
+| Problema | Solução |
+|----------|---------|
+| `hermes: command not found` | Recarregue seu shell (`source ~/.bashrc`) ou verifique o PATH |
+| `API key not set` | Rode `hermes model` para configurar seu provedor, ou `hermes config set OPENROUTER_API_KEY sua_chave` |
+| Config ausente após atualização | Rode `hermes config check` e depois `hermes config migrate` |
+
+Para mais diagnósticos, rode `hermes doctor` — ele dirá exatamente o que está faltando e como corrigir.
+
+## Auto-detecção do método de instalação
+
+O Hermes auto-detecta se foi instalado via instalador git, Docker ou NixOS, e o `hermes update` imprime o comando de atualização correspondente para aquele caminho. Não há variável de ambiente para definir — a detecção é baseada no layout da instalação (checkout `~/.hermes/hermes-agent/`, stamp de imagem Docker ou caminho do store Nix). O `hermes doctor` também expõe o método detectado em seu resumo de ambiente.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/platform-support.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/platform-support.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 2.5
+title: "Suporte de Plataforma"
+description: "Quais sistemas operacionais, métodos de distribuição e recursos o Hermes Agent suporta."
+---
+
+# Suporte de Plataforma
+
+O Hermes Agent mantém suporte para muitas plataformas e métodos de distribuição, mas não podemos suportar todos os métodos de instalação possíveis.
+
+---
+
+## Nível 1
+
+Buscamos nunca quebrar as instalações e atualizações destas plataformas. Problemas e regressões no Nível 1 são nossa primeira prioridade e têm precedência sobre outras plataformas.
+
+| SO / Arquitetura                                                             | Métodos de instalação                                                                                                           | Notas                                                                                                                                                     |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **macOS** (Apple Silicon)                                                     | [Hermes Desktop](https://hermes-agent.nousresearch.com/), [`install.sh`](./installation.md#linux--macos--wsl2--android-termux) | |
+| [**Windows 10 / 11**](../user-guide/windows-native.md) (x86_64, aarch64)      | [Hermes Desktop](https://hermes-agent.nousresearch.com/), [`install.ps1`](./installation.md#windows-native)                    | Alguns recursos [não estão disponíveis](../user-guide/windows-native.md#feature-matrix).                                                                  |
+| **Linux / [WSL2](../user-guide/windows-wsl-quickstart.md)** (x86_64, aarch64) | [`install.sh`](./installation.md#linux--macos--wsl2--android-termux)                                                           | Testamos no Ubuntu e WSL2 mais recentes. Se sua distro tem glibc, systemd e segue o Filesystem Hierarchy Standard, é provável que funcione bem.             |
+| [**Container Docker**](../user-guide/docker.md#quick-start) (x86_64, aarch64) | [`docker pull`](../user-guide/docker.md#quick-start)                                                                           | Instalações via Docker não suportam `hermes update`. A atualização é feita rodando uma nova imagem.                                                        |
+
+---
+
+## Nível 2
+
+Estas plataformas são mantidas no repositório apenas por melhor esforço.
+Lançamentos podem quebrá-las, e não podemos prometer que as corrigiremos prontamente quando isso acontecer.
+
+PRs serão aceitos para corrigir problemas nelas, mas terão precedência abaixo da correção de problemas nas plataformas do Nível 1.
+
+| SO / Arquitetura              | Métodos de instalação                                                 | Notas                                                                        |
+| ----------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Android (Termux)** (aarch64) | [`install.sh`](./installation.md#linux--macos--wsl2--android-termux) | Alguns recursos [não estão disponíveis](./termux.md#known-limitations-on-phones). |
+| **Nix** (MacOS, Linux, NixOS) | [`install.sh`](./nix-setup.md)                                       | Quebra frequentemente por problemas de empacotamento do node.js. Boa sorte~! &lt;3       |
+
+## Sem suporte
+
+Estas plataformas e métodos de distribuição **não** são suportados.
+Sugerimos que você migre para um método ou plataforma de distribuição suportada.
+Elas podem estar quebradas agora, e podem quebrar mais no futuro.
+PRs para corrigi-las **não** serão aceitos, e qualquer código que mantenha compatibilidade com elas pode ser removido a qualquer momento.
+
+- instalações via AUR (podemos aceitar patches upstream se ajudar &lt;3)
+- macOS em processadores x86 (Intel)
+- instalações via `pypi` (por exemplo, `uv tool install hermes-agent`, `pip install hermes-agent`, etc.)
+- instalações via `brew` (`brew install hermes-agent`)
+
+Se você estiver usando um método de distribuição sem suporte, leia o [guia de instalação](./installation.md) para aprender como mudar para um suportado.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+title: "Início Rápido"
+description: "Sua primeira conversa com o Hermes Agent — da instalação ao chat em menos de 5 minutos"
+---
+
+# Início Rápido
+
+Este guia leva você do zero a uma configuração do Hermes que funciona de verdade. Instale, escolha um provedor, verifique um chat funcionando e saiba exatamente o que fazer quando algo quebrar.
+
+## Prefere assistir?
+
+O **Onchain AI Garage** preparou uma Masterclass com instalação, configuração e comandos básicos — um ótimo complemento a esta página se você prefere acompanhar por vídeo. Para mais, veja a playlist completa de [Tutoriais e Casos de Uso do Hermes Agent](https://www.youtube.com/playlist?list=PLmpUb_PWAkDxewld5ZYyKifuHxgIbiq2d).
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%', marginBottom: '1.5rem'}}>
+  <iframe
+    style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+    src="https://www.youtube-nocookie.com/embed/R3YOGfTBcQg"
+    title="Hermes Agent Masterclass: Instalação, Configuração e Comandos Básicos"
+    frameBorder="0"
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  ></iframe>
+</div>
+
+## Para quem é este guia
+
+- Quem é novo e quer o caminho mais curto até uma configuração funcionando
+- Quem está trocando de provedor e não quer perder tempo com erros de configuração
+- Quem está configurando o Hermes para uma equipe, bot ou fluxo sempre ativo
+- Quem está cansado de "instalou, mas não faz nada"
+
+## O caminho mais rápido
+
+Escolha a linha que combina com seu objetivo:
+
+| Objetivo | Faça isto primeiro | Depois faça isto |
+|---|---|---|
+| Quero o Hermes funcionando na minha máquina | `hermes setup` | Rode um chat real e verifique se ele responde |
+| Já conheço meu provedor | `hermes model` | Salve a configuração e comece a conversar |


### PR DESCRIPTION
## What this PR does

Adds **pt-BR** (Brazilian Portuguese) as a Docusaurus locale for the docs site, laying the foundation for community-driven Brazilian Portuguese translation — coordinated via the [Hermes-brasil](https://github.com/Hermes-brasil/hermes-brasil) community.

## Changes

- **`website/docusaurus.config.ts`** — register `pt-BR` in `i18n.locales` and `localeConfigs` (label + `htmlLang`), following the existing `zh-Hans` pattern.
- **`website/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started/`** — Brazilian Portuguese translations of:
  - `quickstart.md` (Início Rápido)
  - `installation.md` (Instalação)
  - `platform-support.md` (Suporte de Plataforma)

## Why

Hermes Agent already ships strong Portuguese i18n in the backend/CLI (`locales/pt.yaml`, `display.language: pt`), but the docs site only registered English and zh-Hans. There was no place to put Brazilian Portuguese doc translations. This PR creates that place and provides the first translated pages as reference for the community to build on.

The CLI/gateway already supports `pt`, so Brazilian users exist; a localized docs site makes Hermes more accessible to the large Portuguese-speaking community.

## Refs

- Issue: #68680
- Community: https://github.com/Hermes-brasil/hermes-brasil

## Next steps (follow-up PRs)

- Translate the remaining docs sections (user-guide, guides, integrations, reference)
- Add a `locales/pt` entry if the docs UI needs it (separate concern)
