### PR TITLE
fix: keep steered tool content valid for chat completions

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
+from agent.message_content import flatten_message_text
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED, credential_pool_matches_provider
@@ -3907,7 +3908,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     The steer is appended to the last ``role:"tool"`` message's content
     with a clear marker so the model understands it came from the user
     and NOT from the tool itself. Role alternation is preserved —
-    nothing new is inserted, we only modify existing content.
+    nothing new is inserted, we only modify existing content. Anthropic block
+    content is preserved only for the Anthropic Messages wire format; other
+    providers receive plain-string tool content.
 
     Args:
         messages: The running messages list.
@@ -3945,7 +3948,10 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         return
     marker = format_steer_marker(steer_text)
     existing_content = messages[target_idx].get("content", "")
-    if not isinstance(existing_content, str):
+    if (
+        not isinstance(existing_content, str)
+        and getattr(agent, "api_mode", "") == "anthropic_messages"
+    ):
         # Anthropic multimodal content blocks — preserve them and append
         # a text block at the end.
         try:
@@ -3955,6 +3961,10 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         except Exception:
             # Fall back to string replacement if content shape is unexpected.
             messages[target_idx]["content"] = f"{existing_content}{marker}"
+    elif not isinstance(existing_content, str):
+        # Chat-completions tool messages require a plain string. Flatten any
+        # provider content blocks instead of leaking Anthropic wire format.
+        messages[target_idx]["content"] = flatten_message_text(existing_content) + marker
     else:
         messages[target_idx]["content"] = existing_content + marker
     _ra().logger.info(

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -362,10 +362,11 @@ class TestSteerInjection:
         assert STEER_MARKER_OPEN in content
         assert "stop after next step" in content
 
-    def test_multimodal_content_list_preserved(self):
+    def test_multimodal_content_list_preserved_for_anthropic_messages(self):
         """Anthropic-style list content should be preserved, with the steer
         appended as a text block."""
         agent = _bare_agent()
+        setattr(agent, "api_mode", "anthropic_messages")
         agent.steer("extra note")
         original_blocks = [{"type": "text", "text": "existing output"}]
         messages = [
@@ -378,6 +379,29 @@ class TestSteerInjection:
         assert new_content[0] == {"type": "text", "text": "existing output"}
         assert new_content[1]["type"] == "text"
         assert "extra note" in new_content[1]["text"]
+
+    def test_multimodal_content_is_string_for_chat_completions(self):
+        """Chat-completions tool messages must not receive Anthropic blocks."""
+        agent = _bare_agent()
+        agent.steer("extra note")
+        messages = [
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "existing output"},
+                    {"type": "image", "source": {"type": "base64"}},
+                ],
+                "tool_call_id": "1",
+            }
+        ]
+
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+
+        content = messages[-1]["content"]
+        assert isinstance(content, str)
+        assert "existing output" in content
+        assert STEER_MARKER_OPEN in content
+        assert "extra note" in content
 
 
 


### PR DESCRIPTION
## Summary

- Fixes #78598.
- Preserve multimodal block content only for the Anthropic Messages wire format.
- Flatten non-string tool content to plain text before appending `/steer` markers for chat-completions and other non-Anthropic providers.

## Tests

- `scripts/run_tests.sh tests/run_agent/test_steer.py tests/agent/test_message_content.py` — 30 passed.
- `ruff check agent/agent_runtime_helpers.py tests/run_agent/test_steer.py` — passed.
- `python -m py_compile agent/agent_runtime_helpers.py tests/run_agent/test_steer.py` — passed.
- `scripts/run_tests.sh -j 32` — 64 failures across 26 unrelated files in this environment; affected `tests/run_agent/test_steer.py` passed.
