### PR TITLE
feat(telegram): plugin callback-query handler registration

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1059,6 +1059,76 @@ class PluginContext:
             action_id,
         )
 
+    # -- telegram callback handler registration ------------------------------
+
+    def register_telegram_callback_handler(
+        self,
+        prefix: str,
+        callback: Callable,
+    ) -> None:
+        """Register a Telegram callback-query handler from a plugin.
+
+        Hermes' Telegram adapter consults registered handlers when an
+        inline-keyboard button is tapped (a ``callback_query`` update)
+        whose ``data`` matched no built-in Hermes callback namespace.
+        The callback is invoked when the update's ``data`` string starts
+        with ``prefix``, so a plugin can own its own callback namespace
+        without forking the adapter — the Telegram counterpart of
+        :meth:`register_slack_action_handler`.
+
+        Callback signature::
+
+            async def handler(query, data) -> bool:
+                await query.answer()
+                ...
+                return True  # truthy = consumed
+
+        ``query`` is the python-telegram-bot ``CallbackQuery`` (use it to
+        ``answer()`` and ``edit_message_text()``); ``data`` is
+        ``query.data``. Returning a truthy value consumes the update;
+        returning falsy passes it to the next matching handler. Handlers
+        run for any user who can tap the button — a handler guarding a
+        sensitive action must authorize ``query.from_user`` itself.
+
+        Args:
+            prefix: Literal ``callback_data`` prefix to claim (e.g.
+                ``"myplugin:"``). Matching is ``data.startswith(prefix)``.
+                Unlike Slack's matcher this is a plain string only —
+                Telegram callback data is a flat string, not Block Kit.
+            callback: Async callable receiving ``(query, data)``.
+
+        Raises:
+            ValueError: if ``callback`` is not callable, or ``prefix`` is
+                empty or not a string.
+
+        Example::
+
+            async def _on_approve(query, data):
+                await query.answer(text="Approved")
+                # apply some workflow keyed on data
+                return True
+
+            ctx.register_telegram_callback_handler("inbox_sweep:", _on_approve)
+        """
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"callback handler with a non-callable callback."
+            )
+        if not isinstance(prefix, str) or not prefix.strip():
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"callback handler with an empty prefix."
+            )
+        self._manager._telegram_callback_handlers.append(
+            (prefix, callback, self.manifest.name)
+        )
+        logger.debug(
+            "Plugin %s registered Telegram callback handler: %s",
+            self.manifest.name,
+            prefix,
+        )
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -1290,6 +1360,13 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Telegram callback-query handlers registered by plugins. Each entry
+        # is (prefix, callback, plugin_name); the Telegram adapter consults
+        # them from _handle_callback_query for updates no built-in callback
+        # namespace claimed. ``prefix`` is a literal callback_data prefix
+        # string; ``callback`` is an async function ``(query, data)`` whose
+        # truthy return consumes the update.
+        self._telegram_callback_handlers: List[tuple] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -1319,6 +1396,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._telegram_callback_handlers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -1991,6 +2069,22 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    # -----------------------------------------------------------------------
+    # Telegram callback handler accessor
+    # -----------------------------------------------------------------------
+
+    def get_telegram_callback_handlers(self) -> List[tuple]:
+        """Return the list of plugin-registered Telegram callback handlers.
+
+        Each entry is a ``(prefix, callback, plugin_name)`` tuple.
+        Consumed by the Telegram adapter when dispatching callback_query
+        updates that no built-in callback namespace claimed.
+
+        Plugins register handlers via
+        :meth:`PluginContext.register_telegram_callback_handler`.
+        """
+        return list(self._telegram_callback_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6651,6 +6651,13 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
+            # --- Plugin-registered callback handlers (prefix-claimed) ---
+            # No built-in namespace matched: offer the update to plugin
+            # handlers (the Telegram counterpart of Slack's plugin Block
+            # Kit action handlers). Consulted only after every built-in
+            # prefix above declined, so a plugin can never shadow the
+            # approval/confirm/clarify buttons.
+            await self._dispatch_plugin_callback_handlers(query, data)
             return
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))
@@ -6686,6 +6693,59 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    async def _dispatch_plugin_callback_handlers(self, query, data: str) -> bool:
+        """Offer an unclaimed callback_query to plugin-registered handlers.
+
+        Plugins call ``ctx.register_telegram_callback_handler(prefix, cb)``
+        at register() time (the Telegram counterpart of
+        ``register_slack_action_handler``); the manager queues them and the
+        adapter consults the queue here for updates that matched no built-in
+        callback namespace. The first handler whose ``prefix`` matches
+        ``data`` and which returns truthy consumes the update; a falsy
+        return falls through to the next matching handler.
+
+        Each callback is guarded so a misbehaving plugin can't take down
+        the gateway: any exception inside the plugin handler is caught and
+        logged, the tap is answered best-effort so the button stops
+        spinning, and the update counts as consumed — the handler claimed
+        its prefix, and re-dispatching a half-processed tap risks double
+        effects.
+
+        Returns True when a handler consumed the update.
+        """
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            handlers = get_plugin_manager().get_telegram_callback_handlers()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "[%s] Could not load plugin callback handlers: %s",
+                self.name, _redact_telegram_error_text(exc),
+            )
+            return False
+        for prefix, callback, plugin_name in handlers:
+            if not data.startswith(prefix):
+                continue
+            try:
+                consumed = await callback(query, data)
+            except Exception as exc:
+                logger.error(
+                    "[%s] Plugin '%s' callback handler raised: %s",
+                    self.name, plugin_name, exc, exc_info=True,
+                )
+                # Best-effort answer so Telegram stops the button spinner.
+                try:
+                    await query.answer()
+                except Exception:
+                    pass
+                return True
+            if consumed:
+                logger.debug(
+                    "[%s] Plugin '%s' consumed callback prefix %s",
+                    self.name, plugin_name, prefix,
+                )
+                return True
+        return False
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/tests/gateway/test_telegram_plugin_callback_handlers.py
+++ b/tests/gateway/test_telegram_plugin_callback_handlers.py
@@ -1,0 +1,339 @@
+"""Tests for plugin-registered Telegram callback-query handlers.
+
+Covers:
+* ``PluginContext.register_telegram_callback_handler`` validation + queuing
+* ``PluginManager.get_telegram_callback_handlers`` accessor
+* ``TelegramAdapter._handle_callback_query`` offering unclaimed updates to
+  plugin handlers (prefix match, truthy-consumes, falsy falls through)
+* Built-in callback namespaces keep priority over plugin prefixes
+* Defensive wrapping: a plugin handler that raises does NOT take down the
+  gateway and the tap still gets answered.
+
+Mirrors ``test_slack_plugin_action_handlers.py`` for the Telegram adapter.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable when this test runs directly
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+from hermes_cli.plugins import (  # noqa: E402
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
+    """Build a fresh PluginManager + PluginContext bound to it."""
+    mgr = PluginManager()
+    manifest = PluginManifest(
+        name=name,
+        version="0.1.0",
+        description="test",
+    )
+    ctx = PluginContext(manifest=manifest, manager=mgr)
+    return mgr, ctx
+
+
+def _make_adapter():
+    """Create a TelegramAdapter with mocked internals."""
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_callback_update(data: str):
+    """Build a (update, context, query) triple for _handle_callback_query."""
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.from_user = MagicMock()
+    query.from_user.id = "12345"
+    query.from_user.first_name = "Norbert"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+    context = MagicMock()
+    return update, context, query
+
+
+def _fake_mgr(handlers: list) -> MagicMock:
+    mgr = MagicMock()
+    mgr.get_telegram_callback_handlers.return_value = handlers
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# PluginContext.register_telegram_callback_handler — validation + queuing
+# ---------------------------------------------------------------------------
+
+class TestRegisterTelegramCallbackHandlerAPI:
+    """Behaviour of ctx.register_telegram_callback_handler()."""
+
+    def test_prefix_handler_is_queued(self):
+        mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover - never called here
+            return True
+
+        ctx.register_telegram_callback_handler("inbox_sweep:", cb)
+
+        handlers = mgr.get_telegram_callback_handlers()
+        assert len(handlers) == 1
+        prefix, callback, plugin_name = handlers[0]
+        assert prefix == "inbox_sweep:"
+        assert callback is cb
+        assert plugin_name == "test_plugin"
+
+    def test_non_callable_callback_rejected(self):
+        _mgr, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="non-callable"):
+            ctx.register_telegram_callback_handler("inbox_sweep:", "not-a-fn")
+
+    def test_empty_prefix_rejected(self):
+        _mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            return True
+
+        with pytest.raises(ValueError, match="empty prefix"):
+            ctx.register_telegram_callback_handler("", cb)
+        with pytest.raises(ValueError, match="empty prefix"):
+            ctx.register_telegram_callback_handler("   ", cb)
+
+    def test_non_string_prefix_rejected(self):
+        """Telegram callback data is a flat string — no regex/dict matchers."""
+        import re as _re
+        _mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            return True
+
+        with pytest.raises(ValueError):
+            ctx.register_telegram_callback_handler(_re.compile(r"^x:"), cb)
+
+    def test_clear_on_forced_rediscovery(self):
+        """discover_and_load(force=True) must drop queued handlers."""
+        mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            return True
+
+        ctx.register_telegram_callback_handler("inbox_sweep:", cb)
+        assert mgr.get_telegram_callback_handlers()
+
+        with patch.object(mgr, "_discover_and_load_inner"):
+            mgr.discover_and_load(force=True)
+
+        assert mgr.get_telegram_callback_handlers() == []
+
+
+# ---------------------------------------------------------------------------
+# TelegramAdapter._handle_callback_query — plugin dispatch
+# ---------------------------------------------------------------------------
+
+class TestTelegramAdapterPluginCallbackDispatch:
+    """Unclaimed callback_query updates are offered to plugin handlers."""
+
+    @pytest.mark.asyncio
+    async def test_matching_prefix_handler_consumes_update(self):
+        adapter = _make_adapter()
+        handler = AsyncMock(return_value=True)
+        update, context, query = _make_callback_update("inbox_sweep:approve:7")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=_fake_mgr([("inbox_sweep:", handler, "test_plugin")]),
+        ):
+            await adapter._handle_callback_query(update, context)
+
+        handler.assert_awaited_once_with(query, "inbox_sweep:approve:7")
+
+    @pytest.mark.asyncio
+    async def test_falsy_return_falls_through_to_next_handler(self):
+        adapter = _make_adapter()
+        first = AsyncMock(return_value=False)
+        second = AsyncMock(return_value=True)
+        update, context, query = _make_callback_update("inbox_sweep:approve:7")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=_fake_mgr([
+                ("inbox_sweep:", first, "plugin_a"),
+                ("inbox_", second, "plugin_b"),
+            ]),
+        ):
+            await adapter._handle_callback_query(update, context)
+
+        first.assert_awaited_once()
+        second.assert_awaited_once_with(query, "inbox_sweep:approve:7")
+
+    @pytest.mark.asyncio
+    async def test_non_matching_prefix_handler_not_called(self):
+        adapter = _make_adapter()
+        handler = AsyncMock(return_value=True)
+        update, context, _query = _make_callback_update("otherns:whatever")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=_fake_mgr([("inbox_sweep:", handler, "test_plugin")]),
+        ):
+            await adapter._handle_callback_query(update, context)
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_builtin_namespaces_keep_priority(self):
+        """A plugin prefix can never shadow the built-in approval buttons."""
+        adapter = _make_adapter()
+        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        handler = AsyncMock(return_value=True)
+        update, context, _query = _make_callback_update("ea:once:5")
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False), \
+             patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve, \
+             patch(
+                 "hermes_cli.plugins.get_plugin_manager",
+                 return_value=_fake_mgr([("ea:", handler, "test_plugin")]),
+             ):
+            await adapter._handle_callback_query(update, context)
+
+        resolve.assert_called_once()
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_raising_handler_is_contained_and_answered(self):
+        """A plugin handler that raises must not propagate — and still acks."""
+        adapter = _make_adapter()
+
+        async def exploding(query, data):
+            raise RuntimeError("plugin bug")
+
+        fallback = AsyncMock(return_value=True)
+        update, context, query = _make_callback_update("inbox_sweep:approve:7")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=_fake_mgr([
+                ("inbox_sweep:", exploding, "plugin_a"),
+                ("inbox_sweep:", fallback, "plugin_b"),
+            ]),
+        ):
+            await adapter._handle_callback_query(update, context)
+
+        # Best-effort answer so the button stops spinning.
+        query.answer.assert_awaited_once()
+        # The raising handler claimed its prefix — no re-dispatch.
+        fallback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_plugin_loader_failure_does_not_break_callbacks(self, tmp_path):
+        """If get_plugin_manager() blows up, callbacks must keep working."""
+        adapter = _make_adapter()
+        update, context, _query = _make_callback_update("otherns:whatever")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            side_effect=RuntimeError("plugins broken"),
+        ):
+            await adapter._handle_callback_query(update, context)  # must not raise
+
+        # Built-in callbacks still work while the plugin layer is unhealthy.
+        b_update, b_context, b_query = _make_callback_update("update_prompt:y")
+        b_query.from_user.id = 123
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            side_effect=RuntimeError("plugins broken"),
+        ), patch("hermes_constants.get_hermes_home", return_value=tmp_path), \
+                patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}):
+            await adapter._handle_callback_query(b_update, b_context)
+        assert (tmp_path / ".update_response").read_text() == "y"
+
+    @pytest.mark.asyncio
+    async def test_no_handlers_is_a_noop(self):
+        """The common case — no plugin handlers registered — must be silent."""
+        adapter = _make_adapter()
+        update, context, query = _make_callback_update("otherns:whatever")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+            return_value=_fake_mgr([]),
+        ):
+            await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_not_awaited()
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_registration_reaches_dispatch(self):
+        """register_telegram_callback_handler → manager → adapter dispatch."""
+        mgr, ctx = _make_ctx()
+        seen = []
+
+        async def cb(query, data):
+            seen.append(data)
+            return True
+
+        ctx.register_telegram_callback_handler("inbox_sweep:", cb)
+
+        adapter = _make_adapter()
+        update, context, _query = _make_callback_update("inbox_sweep:approve:7")
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
+            await adapter._handle_callback_query(update, context)
+
+        assert seen == ["inbox_sweep:approve:7"]

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -915,6 +915,36 @@ def register(ctx):
 
 This is the public way for plugins to participate in Slack interactivity. Older plugins may patch `SlackAdapter.connect`; prefer this API instead.
 
+### Handle Telegram inline button taps
+
+The Telegram counterpart of the Slack action handlers above. Plugins that send messages with an `InlineKeyboardMarkup` can claim the resulting `callback_query` updates by `callback_data` prefix — no forking of the Telegram adapter required.
+
+```python
+def register(ctx):
+    async def _on_approve(query, data):
+        # query is python-telegram-bot's CallbackQuery.
+        await query.answer(text="Approved")
+        sweep_id = data.split(":", 2)[-1]
+        # ...do the deterministic work, then edit the message.
+        return True  # truthy = consumed
+
+    ctx.register_telegram_callback_handler("inbox_sweep:", _on_approve)
+```
+
+**Signature:** `ctx.register_telegram_callback_handler(prefix, callback) -> None`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `prefix` | `str` | Literal `callback_data` prefix to claim (matching is `data.startswith(prefix)`). Telegram callback data is a flat string, so unlike Slack there are no regex or constraint-dict matchers |
+| `callback` | async callable | Receives `(query, data)` — the `CallbackQuery` and its `data` string. Return truthy to consume the update; falsy passes it to the next matching handler |
+
+**Runtime behavior:**
+
+- The handler is queued at plugin-load time and consulted by the adapter's callback dispatch while the Telegram platform is connected.
+- Built-in Hermes callback namespaces (approval, confirm, clarify, model picker, …) always run first — a plugin prefix can never shadow them. Pick a distinct prefix for your plugin (e.g. `"myplugin:"`).
+- Each callback is guarded defensively: if your handler raises, the gateway logs the error, best-effort-answers the tap so the button stops spinning, and treats the update as consumed.
+- Handlers fire for any user who can tap the button. A handler guarding a sensitive action must authorize `query.from_user` itself.
+
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.
 :::


### PR DESCRIPTION
### Platform parity gap

Slack plugins can claim interactive actions:
`ctx.register_slack_action_handler(action_id, callback)` queues handlers on the
`PluginManager` and the Slack adapter wires them into its `slack_bolt.AsyncApp` at
connect time — the documented, public way for a plugin to receive Block Kit button
clicks.

Telegram plugins have no equivalent. A plugin that sends an
`InlineKeyboardMarkup` (an approval flow, a triage keyboard, a picker) gets its
`callback_query` updates silently swallowed by the adapter's built-in prefix
router — the only options today are forking the adapter or monkey-patching
`_handle_callback_query`. This PR closes that gap and unblocks approval-flow
plugins without an adapter fork.

### What it adds

`ctx.register_telegram_callback_handler(prefix, callback)` — a plugin claims
`callback_query` updates whose `data` starts with `prefix`. The plumbing mirrors
the Slack surface end to end:

- **`PluginContext.register_telegram_callback_handler`** validates (callable
  callback, non-empty string prefix) and queues `(prefix, callback, plugin_name)`
  on the manager — same shape, same error style as the Slack registrar.
- **`PluginManager._telegram_callback_handlers`** + accessor
  `get_telegram_callback_handlers()`; cleared on forced rediscovery, exactly like
  `_slack_action_handlers`.
- **Dispatch** lives in the Telegram adapter
  (`_dispatch_plugin_callback_handlers`, called from `_handle_callback_query`):
  the update is offered to plugin handlers only after every built-in callback
  namespace (model picker, choice picker, gmail-triage, exec approval,
  slash-confirm, clarify, update-prompt) has declined — so a plugin prefix can
  never shadow the approval/confirm/clarify buttons. This matches the Slack
  ordering, where built-in listeners are registered before plugin listeners and
  plugins cannot break built-ins.
- **Consume semantics:** matching is `data.startswith(prefix)`; the first handler
  returning truthy consumes the update, a falsy return falls through to the next
  matching handler, and an unconsumed update ends in the same silent ignore as any
  unknown callback today.
- **Defensive wrapping**, mirroring the Slack wrapper: a raising handler is caught
  and logged, the tap is answered best-effort so the button stops spinning, and
  the update counts as consumed — the handler claimed its prefix, and
  re-dispatching a half-processed tap risks double effects.
- **Docs:** a "Handle Telegram inline button taps" section in the plugin developer
  guide, directly after the Slack action-handler section it mirrors.

Handler signature is Telegram-native, the counterpart of slack_bolt's
`(ack, body, action)`:

```python
async def handler(query, data) -> bool:  # query: python-telegram-bot CallbackQuery
    await query.answer()
    ...
    return True  # truthy = consumed
```

### Deliberately no wider than Slack's surface

- Telegram callback data is a flat string, so the matcher is a plain prefix only —
  no regex/constraint-dict matchers (narrower than `slack_bolt.App.action()`, and
  nothing Slack's surface doesn't offer).
- Slack has **no plugin text pre-dispatch hook** (`register_slack_action_handler`
  is the entire plugin handler surface), so none is invented for Telegram either —
  `_handle_text_message` is untouched.
- Trust model matches Slack's: handlers fire for any user who can tap the button;
  the docstring and developer guide state that a handler guarding a sensitive
  action must authorize `query.from_user` itself.

### Tests

`tests/gateway/test_telegram_plugin_callback_handlers.py` mirrors
`test_slack_plugin_action_handlers.py`:

- registration API: queuing, non-callable/empty-prefix/non-string-prefix
  rejection, clearing on forced rediscovery;
- dispatch: matching prefix consumes (handler awaited with `(query, data)`),
  falsy return falls through to the next matching handler, non-matching prefix
  never called, built-in namespaces keep priority (an `ea:` plugin prefix never
  sees approval clicks), raising handler is contained + tap answered + not
  re-dispatched, plugin-loader failure doesn't break callbacks (built-ins still
  work), empty handler list is a silent no-op;
- one end-to-end test: real `PluginManager`/`PluginContext` registration reaching
  adapter dispatch.

## Test plan

```bash
python -m pytest tests/gateway/test_telegram_plugin_callback_handlers.py \
  tests/gateway/test_slack_plugin_action_handlers.py \
  tests/gateway/test_telegram_approval_buttons.py \
  tests/gateway/test_telegram_clarify_buttons.py \
  tests/gateway/test_telegram_thread_fallback.py \
  tests/hermes_cli/test_plugins.py \
  tests/hermes_cli/test_plugin_auxiliary_tasks.py -q
```

Results on this branch (Python 3.12.13, venv with `.[dev,messaging]` extras):
**91 passed** (13 new + all pre-existing Slack plugin-handler, Telegram button,
and plugin-manager suites unmodified). `ruff check` clean on all touched files.
