### PR TITLE
fix(cron): stop the timezone repair pass from swallowing manual triggers

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -705,6 +705,19 @@ def _stored_wall_clock_is_future(stored: datetime, current: datetime) -> bool:
     return stored.replace(tzinfo=None) > current.replace(tzinfo=None)
 
 
+def _is_manual_trigger(job: Dict[str, Any], next_run: str) -> bool:
+    """Return True when ``next_run_at`` is a pending human-requested run.
+
+    ``trigger_job`` records the same timestamp in both ``next_run_at`` and
+    ``manual_trigger_at``. Comparing them identifies a trigger that has not
+    fired yet, without a flag that could be left set: any later recompute of
+    ``next_run_at`` (a normal run, a fast-forward, a genuine migration repair)
+    makes the two diverge, so the marker stops matching on its own.
+    """
+    marker = job.get("manual_trigger_at")
+    return bool(marker) and marker == next_run
+
+
 def _recoverable_oneshot_run_at(
     schedule: Dict[str, Any],
     now: datetime,
@@ -1651,6 +1664,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
+    fire_at = _hermes_now().isoformat()
     return update_job(
         job["id"],
         {
@@ -1658,7 +1672,14 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
+            "next_run_at": fire_at,
+            # Mark this exact pending value as human-requested so the timezone
+            # migration-repair pass in get_due_jobs() does not mistake it for a
+            # stale persisted run and recompute it away (#78516). Storing the
+            # timestamp rather than a bare flag makes the marker self-expiring:
+            # once the job runs and next_run_at is recomputed, the two no longer
+            # match, so a genuine later migration still repairs normally.
+            "manual_trigger_at": fire_at,
         },
     )
 
@@ -2376,6 +2397,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             if (
                 kind == "cron"
                 and next_run_dt <= now
+                and not _is_manual_trigger(job, next_run)
                 and _timezone_offset_mismatch(raw_next_run_dt, now)
                 and _stored_wall_clock_is_future(raw_next_run_dt, now)
             ):

--- a/tests/cron/test_manual_trigger_tz_repair.py
+++ b/tests/cron/test_manual_trigger_tz_repair.py
@@ -1,0 +1,160 @@
+"""Manual "Run now" triggers must survive the timezone migration-repair pass.
+
+Regression tests for #78516. ``trigger_job`` sets ``next_run_at`` to now so the
+next scheduler tick fires the job. The migration-repair branch in
+``get_due_jobs`` recomputes ``next_run_at`` from the cron expression whenever a
+due cron job's stored offset differs from the current offset and its stored
+wall clock still reads as future — which silently discards the pending manual
+run.
+
+The offsets differ in practice because the trigger and the scheduler tick can
+observe different offsets: the dashboard/CLI writer and the gateway are separate
+processes, and a config timezone edit, host timezone change, or DST boundary
+between the two makes the stored offset stale by exactly the amount the repair
+branch keys on.
+
+These exercise the real store against a temp HERMES_HOME (no mocks) per the
+E2E-over-mocks discipline for file-touching code.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _daily_job(name="briefing"):
+    from cron.jobs import create_job
+
+    return create_job(
+        name=name,
+        schedule="0 8 * * *",
+        prompt="say hi",
+    )
+
+
+def _force_stored_offset(job_id, hours):
+    """Rewrite next_run_at (and any marker) to a different UTC offset.
+
+    Simulates the stored value having been written under a different timezone
+    than the one the scheduler now observes.
+    """
+    from cron.jobs import get_job, load_jobs, save_jobs
+
+    job = get_job(job_id)
+    stored = datetime.fromisoformat(job["next_run_at"])
+    shifted = stored.astimezone(timezone(timedelta(hours=hours)))
+    jobs = load_jobs()
+    for raw in jobs:
+        if raw["id"] == job_id:
+            raw["next_run_at"] = shifted.isoformat()
+            if raw.get("manual_trigger_at"):
+                raw["manual_trigger_at"] = shifted.isoformat()
+    save_jobs(jobs)
+    return shifted
+
+
+class TestManualTriggerSurvives:
+    def test_trigger_records_a_marker(self, temp_home):
+        from cron.jobs import get_job, trigger_job
+
+        job = _daily_job()
+        trigger_job(job["id"])
+        stored = get_job(job["id"])
+        assert stored.get("manual_trigger_at") == stored["next_run_at"], (
+            "trigger_job must mark the pending run as human-requested"
+        )
+
+    def test_triggered_job_is_due_despite_offset_mismatch(self, temp_home):
+        """The reported bug: the manual run must not be recomputed away."""
+        from cron.jobs import get_due_jobs, trigger_job
+
+        job = _daily_job()
+        trigger_job(job["id"])
+        # Stored value now carries an offset east of the local one, which is
+        # what makes _stored_wall_clock_is_future() read True.
+        _force_stored_offset(job["id"], hours=+10)
+
+        due = get_due_jobs()
+        assert any(j["id"] == job["id"] for j in due), (
+            "manual trigger was swallowed by the migration-repair branch"
+        )
+
+    def test_triggered_job_next_run_not_recomputed(self, temp_home):
+        from cron.jobs import get_due_jobs, get_job, trigger_job
+
+        job = _daily_job()
+        trigger_job(job["id"])
+        shifted = _force_stored_offset(job["id"], hours=+10)
+
+        get_due_jobs()
+        after = get_job(job["id"])
+        assert datetime.fromisoformat(after["next_run_at"]) == shifted, (
+            "next_run_at was rewritten, discarding the pending manual run"
+        )
+
+
+class TestMigrationRepairStillWorks:
+    """The fix must not disable the repair the branch exists for (#28934)."""
+
+    def test_untriggered_job_still_repaired(self, temp_home):
+        from cron.jobs import get_due_jobs
+
+        job = _daily_job()
+        _force_stored_offset(job["id"], hours=+10)
+
+        # With no manual marker, a future stored wall clock is a migration
+        # artifact rather than a pending run: the job must not fire early.
+        assert not any(j["id"] == job["id"] for j in get_due_jobs()), (
+            "a non-triggered job with a stale offset must not fire early"
+        )
+
+    def test_marker_does_not_persist_across_runs(self, temp_home):
+        """A stale marker must not keep suppressing repair forever."""
+        from cron.jobs import get_job, load_jobs, save_jobs, trigger_job
+        from cron.jobs import _is_manual_trigger
+
+        job = _daily_job()
+        trigger_job(job["id"])
+        stored = get_job(job["id"])
+        assert _is_manual_trigger(stored, stored["next_run_at"])
+
+        # Simulate the job having run: next_run_at moves to the next occurrence
+        # while the marker keeps its old value.
+        jobs = load_jobs()
+        for raw in jobs:
+            if raw["id"] == job["id"]:
+                raw["next_run_at"] = "2099-01-01T08:00:00+00:00"
+        save_jobs(jobs)
+
+        moved = get_job(job["id"])
+        assert not _is_manual_trigger(moved, moved["next_run_at"]), (
+            "marker must stop matching once next_run_at is recomputed"
+        )
+
+
+class TestMarkerHelper:
+    def test_absent_marker_is_not_a_trigger(self):
+        from cron.jobs import _is_manual_trigger
+
+        assert not _is_manual_trigger({}, "2026-08-04T10:00:00+00:00")
+
+    def test_empty_marker_is_not_a_trigger(self):
+        from cron.jobs import _is_manual_trigger
+
+        assert not _is_manual_trigger(
+            {"manual_trigger_at": ""}, "2026-08-04T10:00:00+00:00"
+        )
+
+    def test_mismatched_marker_is_not_a_trigger(self):
+        from cron.jobs import _is_manual_trigger
+
+        assert not _is_manual_trigger(
+            {"manual_trigger_at": "2026-08-04T09:00:00+00:00"},
+            "2026-08-04T10:00:00+00:00",
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes #78516 — "Run now" on a recurring cron job can be silently discarded. The job never runs, `next_run_at` snaps back to the next scheduled occurrence, and the only trace is an info log about recomputing for wall-clock intent.

`trigger_job()` sets `next_run_at` to now so the next tick fires the job. The migration-repair branch in `get_due_jobs()` (`cron/jobs.py:2384-2391`) then recomputes `next_run_at` from the cron expression whenever a due cron job's stored offset differs from the current offset **and** its stored wall clock still reads as future — which is exactly the shape a fresh manual trigger has once those offsets diverge. The pending run is overwritten before it can fire.

## Related Issue

Fixes #78516.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## A correction to the issue's root-cause analysis

The report attributes the offset mismatch to `trigger_job()` stamping UTC while the scheduler compares against local time, and concludes the button is "effectively broken for recurring cron jobs on any host running with a non-UTC local timezone."

That isn't quite right, and the distinction matters for the fix. Both sites call the same `hermes_time.now()`, which returns the *configured* timezone consistently — so in steady state the offsets match and the repair branch cannot fire:

```
stored offset  : -1 day, 20:00:00
now offset     : -1 day, 20:00:00
offset mismatch: False
```

The real window is narrower: the offset must change **between** the trigger and the next scheduler tick. That happens because the writer and the scheduler are separate processes — a config timezone edit, a host timezone change, or a DST boundary in that gap leaves the stored offset stale by precisely the amount the repair branch keys on.

There's also a second condition the report doesn't mention: `_stored_wall_clock_is_future()` must be true, so **only hosts whose stored offset is EAST of the current one are affected**. I verified a `+05:30` observer is immune (stored wall clock reads as past), while the reporter's UTC-3 host is exactly the vulnerable shape. That matches the report's environment and explains why this isn't universally reproducible.

## Changes Made

**`cron/jobs.py`** (+23/-1)

- `trigger_job()` records `manual_trigger_at` alongside `next_run_at`, both set to the same timestamp.
- New `_is_manual_trigger()` helper next to the other schedule predicates.
- The repair branch gains `and not _is_manual_trigger(job, next_run)`.

Storing the timestamp rather than a bare boolean makes the marker **self-expiring**: any later recompute of `next_run_at` — a normal run, a grace fast-forward, a genuine migration repair — makes the two values diverge, so the marker cannot get stuck permanently suppressing repair for that job. No cleanup path to forget, and no migration needed for existing `jobs.json` files (a missing key reads as "not a manual trigger", which is the current behaviour).

**The documented DST trade-off (#28934) is untouched.** The branch still fires for every job that was not manually triggered; the guard only exempts a run a human explicitly asked for, which is the one case where "preserve local wall-clock intent" is the wrong instinct — the user's intent was *now*.

**`tests/cron/test_manual_trigger_tz_repair.py`** (new, 8 tests)

## How to Test

```bash
pytest tests/cron/test_manual_trigger_tz_repair.py -q
```

Tests run against the **real store** with a temp `HERMES_HOME` — no mocks, per the E2E discipline for file-touching code. `_force_stored_offset()` rewrites a persisted `next_run_at` to a different UTC offset, reproducing the cross-process divergence without needing to actually change the host timezone mid-test.

| | with patch | patch reverted |
|---|---|---|
| 7 tests | pass | **fail** |
| 1 test (`test_untriggered_job_still_repaired`) | pass | pass |

That eighth test is the guard against over-fixing: it asserts a job with a stale offset and **no** manual marker still does not fire early. It passes either way, which is the point — it pins that repair behaviour is preserved.

**Regression surface:**

```
pytest tests/cron/ -q          → 398 passed
```

Wider `-k "cron or scheduler or trigger"` sweep, comparing failing test *names* between this branch and clean `main`:

```
branch=32  main=39
NEW failures introduced: 0
```

The 32 remaining failures are pre-existing on unmodified `main` (unrelated areas: `daytona`, `mcp_oauth`, `photon`); the 7-failure delta is exactly this PR's new tests, which fail on `main` by design. `ruff check`: no issues.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron):`)
- [x] I searched existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files, +183/-1)
- [x] I've run the suite and verified zero new failures against clean `main`
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping
- [x] No new config keys — `manual_trigger_at` is internal job state, not user-facing config
- [x] Docstrings explain *why* the marker is a timestamp rather than a flag
- [x] Backward compatible: existing jobs without the key behave exactly as today

## Notes for reviewers

An alternative fix shape would be to make `trigger_job()` write a naive timestamp, since `_timezone_offset_mismatch()` returns `False` for naive values and would sidestep the branch entirely. I avoided that: `_ensure_aware()`'s docstring is explicit that naive values are a *legacy compatibility* path, and deliberately writing new naive timestamps to exploit that would be building on something the code is trying to migrate away from.

Happy to reshape this if you'd prefer the guard live elsewhere — e.g. having the repair branch compare against `last_run_at` instead of carrying a marker field.
