### PR TITLE
fix(patch): keep literal \t/\r when the matched region is tab-indented or CRLF

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -1,5 +1,7 @@
 """Tests for the fuzzy matching module."""
 
+import json
+
 from tools.fuzzy_match import fuzzy_find_and_replace
 
 
@@ -554,6 +556,54 @@ class TestEscapeNormalizedNewString:
         assert err is None
         assert count == 1
         assert "return 2" in new
+
+    def test_tab_indented_file_keeps_its_literal_backslash_t(self):
+        """The literal-``\\t`` carve-out must survive tab indentation.
+
+        A tab-indented file puts a real tab in every matched region, so the
+        "region contains a real tab" test alone is always true there and the
+        legitimate literal gets rewritten — corrupting a line the edit never
+        targeted. Here only ``demo`` -> ``prod`` was requested.
+        """
+        content = '{\n\t"separator": "\\t",\n\t"name": "demo"\n}\n'
+        old_string = '\t"separator": "\\t",\n\t"name": "demo"'
+        new_string = '\t"separator": "\\t",\n\t"name": "prod"'
+        new, count, _, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert '"name": "prod"' in new
+        # The separator line is untouched: still the two-character sequence,
+        # so the file is still parseable (a raw tab is invalid inside a JSON
+        # string).
+        assert '"separator": "\\t"' in new
+        assert json.loads(new)["separator"] == "\t"
+
+    def test_crlf_file_keeps_its_literal_backslash_r(self):
+        """Same hole on the ``\\r`` arm — every CRLF region has a real CR."""
+        content = 'sep = "\\r"\r\nname = "demo"\r\n'
+        old_string = 'sep = "\\r"\r\nname = "demo"'
+        new_string = 'sep = "\\r"\r\nname = "prod"'
+        new, count, _, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert 'name = "prod"' in new
+        assert 'sep = "\\r"' in new
+
+    def test_tab_indented_file_without_a_literal_still_unescapes(self):
+        """The #33733 headline behaviour is unchanged.
+
+        Tab-indented file, no literal ``\\t`` anywhere in the region: the
+        model's escaped indentation is still converted to real tabs.
+        """
+        content = "def hello():\n\tprint(\"before\")\n"
+        old_string = "\tprint(\"before\")"
+        new_string = "\\tprint(\"after\")"
+        new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
+        assert err is None, f"Unexpected error: {err}"
+        assert count == 1
+        assert strategy == "exact"
+        assert "\tprint(\"after\")" in new
+        assert "\\t" not in new
 
 
 class TestContextAwareCorrectness:

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -390,10 +390,11 @@ def _maybe_unescape_new_string(new_string: str,
     The unescape is only applied per-sequence when the *matched region of
     the file* actually contains the corresponding control character — that
     is, we only convert ``\\t`` -> tab when the file region we're replacing
-    contains a real tab byte. Files that legitimately contain the literal
-    two-character string ``"\\t"`` (e.g. a Python source line that defines
-    ``sep = "\\t"``) get a backslash+t in the matched region instead of a
-    tab, so we leave new_string alone.
+    contains a real tab byte *and* does not itself contain the literal
+    two-character sequence. Files that legitimately contain ``"\\t"`` as text
+    (e.g. a Python source line that defines ``sep = "\\t"``) are left alone —
+    including when they are tab-indented, where the indentation would
+    otherwise satisfy the real-tab test on its own.
 
     ``\\n`` is intentionally excluded: newlines serialize correctly through
     JSON and rewriting backslash-n would corrupt escape sequences in
@@ -406,9 +407,16 @@ def _maybe_unescape_new_string(new_string: str,
 
     matched_regions = "".join(content[start:end] for start, end in matches)
     out = new_string
-    if "\\t" in out and "\t" in matched_regions:
+    # "the region has a real control byte" alone is not enough to conclude the
+    # model meant one: a tab-indented file puts a real tab in EVERY region, and
+    # a CRLF file a real CR in every region, so that test is always true there
+    # and the literal-sequence carve-out above never fires. When the region
+    # *also* carries the literal two-character sequence, the file demonstrably
+    # uses it as text and new_string's copy is ambiguous — leave it verbatim
+    # rather than rewriting content the edit never targeted.
+    if "\\t" in out and "\t" in matched_regions and "\\t" not in matched_regions:
         out = out.replace("\\t", "\t")
-    if "\\r" in out and "\r" in matched_regions:
+    if "\\r" in out and "\r" in matched_regions and "\\r" not in matched_regions:
         out = out.replace("\\r", "\r")
     return out
 


### PR DESCRIPTION
## What

`_maybe_unescape_new_string` rewrites `\t`/`\r` in `new_string` into real control bytes when the model serialized them as two-character sequences. 78be45860 (2026-05-28, fix(patch): widen new_string \t/\r unescape to all match strategies), extending @liuhao1024's e9f3f2b34, made that decision per-sequence by inspecting the matched region of the file, and stated the carve-out that keeps legitimate literals safe:

> keeps legitimate writes of the literal two-character string `"\t"` (e.g. patching `sep = "\t"` in Python source) untouched — those files have a backslash+t in the matched region, not a real tab, so new_string passes through verbatim.

That reasoning holds only when the file is space-indented. **A tab-indented file puts a real tab in every matched region**, so `"\t" in matched_regions` is unconditionally true there and the carve-out never fires — every legitimate `\t` in `new_string` gets rewritten to a tab byte. The `\r` arm has the same hole against **every CRLF file**, where each region carries a real CR.

The damage lands on lines the edit never targeted. Renaming `demo` → `prod` in a tab-indented JSON config, on main:

```
original repr:   '{\n\t"separator": "\\t",\n\t"name": "demo"\n}\n'

matches: 1 strategy: exact error: None
result repr:     '{\n\t"separator": "\t",\n\t"name": "prod"\n}\n'
RESULT: file is now INVALID JSON -> Invalid control character at: line 2 column 16 (char 17)
```

The separator line was not part of the requested change, a raw control character is not legal inside a JSON string, and the tool reports `error: None` — the corruption is silent. Same shape hits Makefiles, Go, and any tab-indented source that mentions an escape sequence as text.

The existing regression test for the carve-out (`test_exact_match_preserves_literal_backslash_t_in_string_literal`) uses `sep = "\t"` with no indentation at all, so the intersection — tab-indented file *with* a legitimate literal — was the untested cell of the matrix.

## The fix

One extra condition per arm: also require that the matched region does **not** itself contain the literal two-character sequence.

```python
if "\\t" in out and "\t" in matched_regions and "\\t" not in matched_regions:
```

When the region carries the literal sequence, the file demonstrably uses it as text, so `new_string`'s copy is ambiguous and passes through verbatim. When it does not, the behaviour from 78be45860 is unchanged — including the #33733 headline case, a tab-indented file whose escaped indentation still converts to real tabs.

The deliberate trade-off is the genuinely mixed region (real tabs *and* a literal `\t`, where the model escaped its indentation on the same lines). There is no way to tell the two apart, so this declines to guess and leaves a visible `\t` in the output rather than silently rewriting content the edit never touched. `\n` stays excluded exactly as before.

Same-region logic, so no call-site or signature changes: 2 changed conditions.

## Tests

Added to `TestEscapeNormalizedNewString` in `tests/tools/test_fuzzy_match.py`:

- tab-indented JSON keeps its literal `\t` — the untargeted line survives and `json.loads` still parses it
- CRLF file keeps its literal `\r` — the `\r` twin of the same hole
- tab-indented file with no literal still unescapes — pins the #33733 behaviour so the fix can't be widened into a regression

Results:

```
48 passed
```

All 45 pre-existing tests in the file are untouched and still green, including the four that assert the unescape *does* fire.

Red without the source change (tests kept, `tools/fuzzy_match.py` reverted):

```
FAILED test_tab_indented_file_keeps_its_literal_backslash_t
E  assert '"separator": "\\t"' in '{\n\t"separator": "\t",\n\t"name": "prod"\n}\n'

FAILED test_crlf_file_keeps_its_literal_backslash_r
E  assert 'sep = "\\r"' in 'sep = "\r"\r\nname = "prod"\r\n'
```

The third test passes on both sides, which is the point of it.

Regression run over every test file touching `fuzzy_match`, `patch_replace` or `file_operations` (30 files), compared against the same files on main:

```
main:      38 failed, 377 passed
with fix:  36 failed, 379 passed
new failures introduced: (none)
```

The delta is exactly the two tests above flipping green. The remaining 36 failures are identical before and after — ripgrep path resolution, symlink/umask permission cases and macOS path carve-outs, none of which this change touches. `scripts/check-windows-footguns.py` passes on both changed files.