### PR TITLE
fix(auth): per-cred Codex pool visibility + same-account usage_limit failover

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4461,6 +4461,35 @@ def run_conversation(
                             _retry.primary_recovery_attempted = False
                             continue
 
+                # Hard usage-limit wall with no remaining pool recovery and no
+                # fallback activation above: skip the remaining same-provider
+                # backoff retries (they thrash the same exhausted ChatGPT
+                # account for ~attempt 1/3..3/3). Jump straight to the
+                # max_retries terminal path so the structured quota error
+                # surfaces immediately.
+                if (
+                    is_rate_limited
+                    and classified.reason == FailoverReason.rate_limit
+                    and not _ra()._pool_may_recover_from_rate_limit(
+                        agent._credential_pool,
+                    )
+                ):
+                    _ctx = error_context or {}
+                    _usage_wall = (
+                        "usage_limit_reached" in str(_ctx.get("reason") or "").lower()
+                        or "usage limit has been reached" in str(_ctx.get("message") or "").lower()
+                        or "usage limit reached" in str(_ctx.get("message") or "").lower()
+                    )
+                    if _usage_wall and retry_count < max_retries:
+                        logger.info(
+                            "usage_limit_reached with no recoverable pool entry — "
+                            "skipping remaining same-provider retries "
+                            "(%s/%s → terminal)",
+                            retry_count,
+                            max_retries,
+                        )
+                        retry_count = max_retries
+
                 # ── Auth-failure provider failover ───────────────────────
                 # A 401/403 that survives the per-provider credential-refresh
                 # attempt above (each guarded by its own

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -280,6 +280,68 @@ def label_from_token(token: str, fallback: str) -> str:
     return fallback
 
 
+def chatgpt_account_id_from_token(token: Optional[str]) -> Optional[str]:
+    """Return the ChatGPT account id claim from a Codex OAuth access token.
+
+    Used to detect when multiple pool entries are distinct OAuth *sessions*
+    of the same ChatGPT account (they share one usage-limit bucket). Returns
+    None for non-JWT tokens or when the claim is absent. Never logs the
+    raw token.
+    """
+    if not token or not isinstance(token, str):
+        return None
+    try:
+        claims = _decode_jwt_claims(token)
+    except Exception:
+        return None
+    if not isinstance(claims, dict):
+        return None
+    auth_blob = claims.get("https://api.openai.com/auth")
+    acct = None
+    if isinstance(auth_blob, dict):
+        acct = auth_blob.get("chatgpt_account_id")
+    if not acct:
+        acct = claims.get("chatgpt_account_id")
+    if isinstance(acct, str) and acct.strip():
+        return acct.strip()
+    return None
+
+
+def chatgpt_account_id_from_entry(entry: "PooledCredential") -> Optional[str]:
+    """Best-effort chatgpt_account_id for a pool entry (runtime key first)."""
+    token = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", None)
+    return chatgpt_account_id_from_token(token)
+
+
+def _error_context_is_account_quota_wall(
+    status_code: Optional[int],
+    error_context: Optional[Dict[str, Any]],
+) -> bool:
+    """True when the failure is an account-level quota/billing wall.
+
+    These failures are shared by every OAuth session of the same ChatGPT
+    account, so rotating to another token for that account is a no-op.
+    """
+    if status_code == 402:
+        return True
+    reason = ""
+    message = ""
+    if isinstance(error_context, dict):
+        reason = str(error_context.get("reason") or "").strip().lower()
+        message = str(error_context.get("message") or "").strip().lower()
+    if status_code == 429 and (
+        "usage_limit" in reason
+        or "usage_limit_reached" in reason
+        or "usage limit" in message
+        or "quota" in reason
+        or "quota" in message
+    ):
+        return True
+    if "usage_limit_reached" in reason or "usage limit has been reached" in message:
+        return True
+    return False
+
+
 def _next_priority(entries: List[PooledCredential]) -> int:
     return max((entry.priority for entry in entries), default=-1) + 1
 
@@ -2053,9 +2115,16 @@ class CredentialPool:
             # disconnects (a ~2.5min hang with no error surfaced to the user).
             # Mark every entry sharing the failed key so the pool can reach the
             # "no available entries" state and let the error propagate.
+            #
+            # Account-level quota walls (Codex ``usage_limit_reached``, 402
+            # billing) are also shared across every OAuth *session* of the
+            # same ChatGPT account. Two pool entries with different tokens but
+            # the same ``chatgpt_account_id`` are not two subscriptions — they
+            # share one quota bucket. Mark those siblings exhausted too so we
+            # don't burn a rotate hop that is guaranteed to 429 identically.
+            siblings_marked = False
             failed_runtime_key = getattr(entry, "runtime_api_key", None)
             if identity_supplied and failed_runtime_key:
-                siblings_marked = False
                 for sibling in self._entries:
                     if sibling.id == entry.id:
                         continue
@@ -2064,8 +2133,38 @@ class CredentialPool:
                             sibling, status_code, error_context, persist=False
                         )
                         siblings_marked = True
-                if siblings_marked:
-                    self._persist()
+            if _error_context_is_account_quota_wall(status_code, error_context):
+                failed_account_id = chatgpt_account_id_from_entry(entry)
+                if failed_account_id:
+                    for sibling in self._entries:
+                        if sibling.id == entry.id:
+                            continue
+                        # Never downgrade a terminal DEAD entry back to
+                        # exhausted — DEAD is a stronger signal.
+                        if sibling.last_status == STATUS_DEAD:
+                            continue
+                        sibling_account_id = chatgpt_account_id_from_entry(sibling)
+                        if sibling_account_id and sibling_account_id == failed_account_id:
+                            if (
+                                sibling.last_status == STATUS_EXHAUSTED
+                                and sibling.last_error_code == status_code
+                                and sibling.last_error_reason
+                                == (error_context or {}).get("reason")
+                            ):
+                                continue
+                            self._mark_exhausted(
+                                sibling, status_code, error_context, persist=False
+                            )
+                            siblings_marked = True
+                            logger.info(
+                                "credential pool: marking %s exhausted "
+                                "(same chatgpt_account_id as %s; account-level "
+                                "quota wall)",
+                                sibling.label or sibling.id[:8],
+                                _label,
+                            )
+            if siblings_marked:
+                self._persist()
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
                 (e for e in self._entries if e.id == entry.id), entry,

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -14,6 +14,7 @@ from agent.credential_pool import (
     CUSTOM_POOL_PREFIX,
     SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE,
+    STATUS_DEAD,
     STATUS_EXHAUSTED,
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
@@ -22,6 +23,7 @@ from agent.credential_pool import (
     PooledCredential,
     _exhausted_until,
     _normalize_custom_pool_name,
+    chatgpt_account_id_from_entry,
     get_pool_strategy,
     label_from_token,
     list_custom_pool_providers,
@@ -123,17 +125,43 @@ def _classify_exhausted_status(entry) -> tuple[str, bool]:
     ):
         return "rate-limited", True
 
-    if code in {401, 403} or any(token in reason for token in ("invalid_token", "invalid_grant", "unauthorized", "forbidden", "auth")) or any(
-        token in message for token in ("unauthorized", "forbidden", "expired", "revoked", "invalid token", "authentication")
+    if code in {401, 403} or any(token in reason for token in ("invalid_token", "invalid_grant", "unauthorized", "forbidden", "auth", "token_revoked", "token_invalidated")) or any(
+        token in message for token in ("unauthorized", "forbidden", "expired", "revoked", "invalid token", "authentication", "invalidated")
     ):
         return "auth failed", False
 
     return "exhausted", True
 
 
+def _format_remaining(exhausted_until: float) -> str:
+    remaining = max(0, int(math.ceil(exhausted_until - time.time())))
+    if remaining <= 0:
+        return "ready to retry"
+    minutes, seconds = divmod(remaining, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {hours}h left"
+    if hours:
+        return f"{hours}h {minutes}m left"
+    if minutes:
+        return f"{minutes}m {seconds}s left"
+    return f"{seconds}s left"
 
-def _format_exhausted_status(entry) -> str:
-    if entry.last_status != STATUS_EXHAUSTED:
+
+def _format_entry_status(entry) -> str:
+    """Human-readable per-credential status suffix for list/status output.
+
+    Covers exhausted (with retry window) and dead (terminal) states. Never
+    includes token material.
+    """
+    status = getattr(entry, "last_status", None)
+    if status == STATUS_DEAD:
+        reason = getattr(entry, "last_error_reason", None)
+        reason_text = f" {reason}" if isinstance(reason, str) and reason.strip() else ""
+        code = f" ({entry.last_error_code})" if entry.last_error_code else ""
+        return f" DEAD{reason_text}{code} (re-auth required — will not rotate)"
+    if status != STATUS_EXHAUSTED:
         return ""
     label, show_retry_window = _classify_exhausted_status(entry)
     reason = getattr(entry, "last_error_reason", None)
@@ -144,21 +172,55 @@ def _format_exhausted_status(entry) -> str:
     exhausted_until = _exhausted_until(entry)
     if exhausted_until is None:
         return f" {label}{reason_text}{code}"
-    remaining = max(0, int(math.ceil(exhausted_until - time.time())))
-    if remaining <= 0:
+    window = _format_remaining(exhausted_until)
+    if window == "ready to retry":
         return f" {label}{reason_text}{code} (ready to retry)"
-    minutes, seconds = divmod(remaining, 60)
-    hours, minutes = divmod(minutes, 60)
-    days, hours = divmod(hours, 24)
-    if days:
-        wait = f"{days}d {hours}h"
-    elif hours:
-        wait = f"{hours}h {minutes}m"
-    elif minutes:
-        wait = f"{minutes}m {seconds}s"
-    else:
-        wait = f"{seconds}s"
-    return f" {label}{reason_text}{code} ({wait} left)"
+    return f" {label}{reason_text}{code} ({window})"
+
+
+def _format_exhausted_status(entry) -> str:
+    """Back-compat alias used by older call sites/tests."""
+    return _format_entry_status(entry)
+
+
+def _account_fp_for_entry(entry) -> str | None:
+    """Short non-secret fingerprint of chatgpt_account_id for display only."""
+    import hashlib
+
+    acct = chatgpt_account_id_from_entry(entry)
+    if not acct:
+        return None
+    return hashlib.sha256(acct.encode("utf-8")).hexdigest()[:12]
+
+
+def _duplicate_account_groups(entries) -> list[tuple[str, list]]:
+    """Return (acct_fp, [entries]) groups where ≥2 entries share an account."""
+    groups: dict[str, list] = {}
+    fps: dict[str, str] = {}
+    for entry in entries:
+        acct = chatgpt_account_id_from_entry(entry)
+        if not acct:
+            continue
+        fp = _account_fp_for_entry(entry)
+        if not fp:
+            continue
+        groups.setdefault(acct, []).append(entry)
+        fps[acct] = fp
+    return [(fps[acct], items) for acct, items in groups.items() if len(items) >= 2]
+
+
+def _print_duplicate_account_warning(entries) -> None:
+    dupes = _duplicate_account_groups(entries)
+    if not dupes:
+        return
+    for acct_fp, items in dupes:
+        labels = ", ".join(f"\"{e.label}\"" for e in items)
+        print(
+            f"  warning: {len(items)} credentials share one ChatGPT account "
+            f"(acct_fp={acct_fp}): {labels}. They share one usage-limit bucket — "
+            f"this is NOT multi-subscription failover. Add a distinct account "
+            f"to get real rotation."
+        )
 
 
 def auth_add_command(args) -> None:
@@ -455,9 +517,14 @@ def auth_list_command(args) -> None:
             marker = "  "
             if current is not None and entry.id == current.id:
                 marker = "← "
-            status = _format_exhausted_status(entry)
+            status = _format_entry_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            acct_fp = _account_fp_for_entry(entry)
+            acct_note = f" acct_fp={acct_fp}" if acct_fp else ""
+            print(
+                f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status}{acct_note} {marker}".rstrip()
+            )
+        _print_duplicate_account_warning(entries)
         print()
 
 
@@ -504,6 +571,10 @@ def auth_reset_command(args) -> None:
     pool = load_pool(provider)
     count = pool.reset_statuses()
     print(f"Reset status on {count} {provider} credentials")
+    print(
+        "note: reset clears LOCAL exhaustion/dead flags only. "
+        "It does not restore provider quota. A live probe may still 429."
+    )
 
 
 def auth_status_command(args) -> None:
@@ -517,13 +588,58 @@ def auth_status_command(args) -> None:
             print(f"{provider}: logged out ({reason})")
         else:
             print(f"{provider}: logged out")
+        # Still show pool rows when present — a pool can hold dead/exhausted
+        # credentials while the provider-level status says logged out.
+        _print_pool_credential_status(provider)
         return
 
     print(f"{provider}: logged in")
-    for key in ("auth_type", "client_id", "redirect_uri", "scope", "expires_at", "api_base_url"):
+    # Never print secrets (api_key / access_token / refresh_token).
+    safe_keys = (
+        "auth_type",
+        "client_id",
+        "redirect_uri",
+        "scope",
+        "expires_at",
+        "api_base_url",
+        "source",
+        "auth_mode",
+        "rate_limited",
+        "error_code",
+        "error",
+        "reset_at",
+        "last_refresh",
+    )
+    for key in safe_keys:
         value = status.get(key)
-        if value:
-            print(f"  {key}: {value}")
+        if value is None or value == "" or value is False:
+            continue
+        print(f"  {key}: {value}")
+    _print_pool_credential_status(provider)
+
+
+def _print_pool_credential_status(provider: str) -> None:
+    """Print per-credential pool rows for ``hermes auth status``."""
+    try:
+        pool = load_pool(provider)
+    except Exception:
+        return
+    entries = pool.entries()
+    if not entries:
+        return
+    current = pool.peek()
+    print(f"  pool: {len(entries)} credential(s), has_available={pool.has_available()}")
+    for idx, entry in enumerate(entries, start=1):
+        marker = " (active)" if current is not None and entry.id == current.id else ""
+        status = _format_entry_status(entry).strip() or "ok"
+        source = _display_source(entry.source)
+        acct_fp = _account_fp_for_entry(entry)
+        acct_note = f" acct_fp={acct_fp}" if acct_fp else ""
+        print(
+            f"  #{idx} {entry.label}  {entry.auth_type}/{source}  "
+            f"status={status}{acct_note}{marker}"
+        )
+    _print_duplicate_account_warning(entries)
 
 
 def auth_logout_command(args) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -320,8 +320,15 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
     retrying against the same exhausted quota — the daily-quota 429 will recur
     immediately, and the retry budget is burned.
 
+    Additionally, multiple OAuth sessions of the *same* ChatGPT account share
+    one usage-limit bucket.  If every still-available entry maps to the same
+    ``chatgpt_account_id`` as the currently selected entry (or there is only
+    one distinct account among available entries after a quota wall), rotation
+    cannot multiply capacity — treat the pool as non-recoverable so fallback
+    fires instead of thrashing.
+
     In that case we must fall back to the configured ``fallback_model``
-    instead.  Returns True only when rotation has somewhere to go.
+    instead.  Returns True only when rotation has somewhere useful to go.
 
     See issues #11314 and #13636.
     """
@@ -329,7 +336,33 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
         return False
     if not pool.has_available():
         return False
-    return len(pool.entries()) > 1
+    entries = pool.entries()
+    if len(entries) <= 1:
+        return False
+    # Distinct ChatGPT accounts among non-exhausted entries. If we can't
+    # read claims (non-JWT keys), fall back to the classic "more than one
+    # entry" signal so API-key pools keep rotating.
+    try:
+        from agent.credential_pool import (
+            STATUS_DEAD,
+            STATUS_EXHAUSTED,
+            chatgpt_account_id_from_entry,
+        )
+        candidates = [
+            e
+            for e in entries
+            if getattr(e, "last_status", None) not in (STATUS_EXHAUSTED, STATUS_DEAD)
+        ]
+        if not candidates:
+            return False
+        account_ids = [chatgpt_account_id_from_entry(e) for e in candidates]
+        if account_ids and all(account_ids) and len(set(account_ids)) <= 1:
+            # Every still-usable session is the same ChatGPT account — rotating
+            # cannot multiply quota.
+            return False
+    except Exception:
+        pass
+    return True
 
 
 def _qwen_portal_headers() -> dict:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -391,6 +391,146 @@ def test_429_rate_limit_still_uses_exhausted_not_dead(tmp_path, monkeypatch):
     assert persisted["last_error_code"] == 429
 
 
+def test_usage_limit_marks_same_chatgpt_account_siblings(tmp_path, monkeypatch):
+    """usage_limit_reached is account-scoped: same chatgpt_account_id siblings exhaust together.
+
+    Two OAuth sessions of one ChatGPT account are not two subscriptions. Rotating
+    between them after a usage_limit_reached 429 is a guaranteed no-op.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    same_acct = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct-shared-001"},
+        "sub": "auth0|shared",
+    }
+    other_acct = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct-other-002"},
+        "sub": "auth0|other",
+    }
+    tok_a = _jwt_with_claims({**same_acct, "jti": "a"})
+    tok_b = _jwt_with_claims({**same_acct, "jti": "b"})
+    tok_c = _jwt_with_claims({**other_acct, "jti": "c"})
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-a",
+                        "label": "session-a",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": tok_a,
+                        "refresh_token": "rt-a",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "session-b-same-account",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": tok_b,
+                        "refresh_token": "rt-b",
+                    },
+                    {
+                        "id": "cred-c",
+                        "label": "other-account",
+                        "auth_type": "oauth",
+                        "priority": 2,
+                        "source": "manual:device_code",
+                        "access_token": tok_c,
+                        "refresh_token": "rt-c",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import STATUS_EXHAUSTED, load_pool
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "cred-a"
+
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "resets_at": time.time() + 3600,
+        },
+        credential_id="cred-a",
+        api_key_hint=tok_a,
+    )
+    # Same-account sibling B is also exhausted; rotate lands on distinct account C.
+    assert next_entry is not None
+    assert next_entry.id == "cred-c"
+
+    by_id = {e.id: e for e in pool.entries()}
+    assert by_id["cred-a"].last_status == STATUS_EXHAUSTED
+    assert by_id["cred-b"].last_status == STATUS_EXHAUSTED
+    assert by_id["cred-c"].last_status != STATUS_EXHAUSTED
+
+
+def test_usage_limit_same_account_only_pool_rotates_to_none(tmp_path, monkeypatch):
+    """When every pool entry is the same ChatGPT account, usage_limit exhausts all."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    claims = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct-only"},
+        "sub": "auth0|only",
+    }
+    tok_1 = _jwt_with_claims({**claims, "jti": "1"})
+    tok_2 = _jwt_with_claims({**claims, "jti": "2"})
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "oauth-1",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": tok_1,
+                        "refresh_token": "rt-1",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "Account 2",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": tok_2,
+                        "refresh_token": "rt-2",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import STATUS_EXHAUSTED, load_pool
+
+    pool = load_pool("openai-codex")
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={
+            "reason": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+        },
+        credential_id="cred-1",
+        api_key_hint=tok_1,
+    )
+    assert next_entry is None
+    assert pool.has_available() is False
+    assert all(e.last_status == STATUS_EXHAUSTED for e in pool.entries())
+
+
 def test_generic_401_without_terminal_reason_still_uses_exhausted(tmp_path, monkeypatch):
     """A 401 with no specific code/reason should keep TTL semantics.
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -769,3 +769,140 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     assert is_source_suppressed("copilot", "env:GITHUB_TOKEN")
 
 
+
+
+def _jwt_with_account(account_id: str, *, jti: str = "x") -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+                "sub": f"auth0|{account_id}",
+                "jti": jti,
+            }
+        ).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}.signature"
+
+
+def test_auth_list_shows_dead_status(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "codex-alive",
+                        "label": "alive",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": _jwt_with_account("acct-a", jti="1"),
+                        "refresh_token": "rt-1",
+                    },
+                    {
+                        "id": "codex-dead",
+                        "label": "dead-session",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": _jwt_with_account("acct-a", jti="2"),
+                        "refresh_token": "rt-2",
+                        "last_status": "dead",
+                        "last_status_at": time.time(),
+                        "last_error_code": 401,
+                        "last_error_reason": "token_revoked",
+                        "last_error_message": "Encountered invalidated oauth token for user",
+                    },
+                ]
+            },
+        },
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_list_command
+
+    auth_list_command(SimpleNamespace(provider="openai-codex"))
+    out = capsys.readouterr().out
+    assert "DEAD" in out
+    assert "token_revoked" in out
+    assert "will not rotate" in out
+    assert "share one ChatGPT account" in out
+
+
+def test_auth_status_lists_per_credential_pool_rows(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    reset_at = time.time() + 7200
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "codex-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": _jwt_with_account("acct-z", jti="1"),
+                        "refresh_token": "rt-1",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                        "last_error_reason": "usage_limit_reached",
+                        "last_error_message": "The usage limit has been reached",
+                        "last_error_reset_at": reset_at,
+                    },
+                    {
+                        "id": "codex-2",
+                        "label": "secondary",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": _jwt_with_account("acct-z", jti="2"),
+                        "refresh_token": "rt-2",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                        "last_error_reason": "usage_limit_reached",
+                        "last_error_message": "The usage limit has been reached",
+                        "last_error_reset_at": reset_at,
+                    },
+                ]
+            },
+        },
+    )
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_status_command
+
+    auth_status_command(SimpleNamespace(provider="openai-codex"))
+    out = capsys.readouterr().out
+    assert "openai-codex: logged in" in out or "pool:" in out
+    assert "pool: 2 credential(s)" in out
+    assert "usage_limit_reached" in out
+    assert "acct_fp=" in out
+    assert "share one ChatGPT account" in out
+    # Must never dump token material
+    assert "rt-1" not in out
+    assert "rt-2" not in out
+    assert ".signature" not in out
+
+
+def test_auth_reset_prints_local_only_note(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_reset_command
+
+    auth_reset_command(SimpleNamespace(provider="openai-codex"))
+    out = capsys.readouterr().out
+    assert "Reset status on 1" in out
+    assert "LOCAL" in out


### PR DESCRIPTION
## Summary

Fleet incident: Codex pool showed 2 credentials but `usage_limit_reached` still thrashed the same account through 3 retries. Investigation found:

1. Both pool entries were **distinct OAuth sessions of one ChatGPT account** (same `chatgpt_account_id`) — not two Pro subscriptions.
2. `hermes auth status` printed only `logged in`; `hermes auth list` hid `DEAD` entries so operators could not see terminal/exhausted state.
3. Rotate-on-429 already existed, but same-account rotation is a no-op; after the pool was fully exhausted the conversation loop still burned 3 same-provider backoff retries.

## Changes

- **`hermes auth status/list`**: per-credential rows (status, reason/code, retry window, `acct_fp`), `DEAD` visibility, duplicate-account warning. Never prints secrets.
- **`hermes auth reset`**: notes that reset is **local-only** (does not restore provider quota).
- **`mark_exhausted_and_rotate`**: on account-level quota walls (`usage_limit_reached` / 402), also exhaust siblings sharing the same `chatgpt_account_id` so rotation does not hop to a same-bucket session.
- **`_pool_may_recover_from_rate_limit` + conversation_loop**: treat same-account-only pools as non-recoverable; fail-fast past remaining same-provider retries when usage_limit leaves no distinct account.

## Test plan

- [x] `PYTHONPATH=. pytest tests/agent/test_credential_pool.py::test_usage_limit_marks_same_chatgpt_account_siblings tests/agent/test_credential_pool.py::test_usage_limit_same_account_only_pool_rotates_to_none tests/agent/test_credential_pool.py::test_429_rate_limit_still_uses_exhausted_not_dead tests/hermes_cli/test_auth_commands.py::test_auth_list_shows_dead_status tests/hermes_cli/test_auth_commands.py::test_auth_status_lists_per_credential_pool_rows tests/hermes_cli/test_auth_commands.py::test_auth_reset_prints_local_only_note` (10 related tests green)
- [ ] Operator: after land, `hermes auth status openai-codex` shows per-cred exhausted/DEAD + acct_fp; dual-sub requires **distinct** acct_fp values

## Notes / non-goals

- Does **not** restore Codex quota (resets ~2026-08-08T03:34Z on the exhausted Pro account).
- Does **not** remove/re-add credentials.
- Draft for lander (Fable); authors do not merge.

Refs: fleet card t_d0265db0