### PR TITLE
fix(simplex): preserve animated GIFs in image sends

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -930,30 +930,35 @@ class SimplexAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _prepare_image(file_path: str) -> tuple[str, str]:
-        """Ensure *file_path* is a PNG and return ``(png_path, thumb_data_uri)``.
+        """Return ``(prepared_path, thumb_data_uri)`` for an inline image.
 
-        SimpleX clients can't display WebP and a few other formats inline.
-        This converts to PNG when needed and generates a small JPEG thumbnail
-        for the ``image`` field in the ``/_send`` payload so the chat shows
-        an inline preview. Uses Pillow when available, falls back to
-        ImageMagick ``convert``.
+        PNG, JPEG, and GIF attachments are sent unchanged; other
+        formats are converted to PNG because SimpleX clients cannot display
+        formats such as WebP inline. A static JPEG thumbnail is generated for
+        the ``image`` field in the ``/_send`` payload. Uses Pillow when
+        available and falls back to ImageMagick ``convert``.
         """
         import subprocess
         import tempfile
 
         p = Path(file_path)
-        png_path = file_path
+        suffix = p.suffix.lower()
+        needs_conversion = suffix not in (".png", ".jpg", ".jpeg", ".gif")
+        prepared_path = file_path
         thumb_uri = ""
 
         try:
             from PIL import Image
 
-            img = Image.open(file_path)
-            if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                png_path = str(p.with_suffix(".png"))
-                img.save(png_path, "PNG")
-            thumb = img.copy()
+            with Image.open(file_path) as img:
+                img.seek(0)
+                if needs_conversion:
+                    prepared_path = str(p.with_suffix(".png"))
+                    img.save(prepared_path, "PNG")
+                thumb = img.copy()
             thumb.thumbnail((128, 128))
+            if thumb.mode not in ("RGB", "L"):
+                thumb = thumb.convert("RGB")
             import io
 
             buf = io.BytesIO()
@@ -964,10 +969,10 @@ class SimplexAdapter(BasePlatformAdapter):
             )
         except ImportError:
             try:
-                if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                    png_path = str(p.with_suffix(".png"))
+                if needs_conversion:
+                    prepared_path = str(p.with_suffix(".png"))
                     subprocess.run(
-                        ["convert", file_path, png_path],
+                        ["convert", file_path, prepared_path],
                         check=True,
                         capture_output=True,
                         timeout=30,
@@ -977,7 +982,7 @@ class SimplexAdapter(BasePlatformAdapter):
                 subprocess.run(
                     [
                         "convert",
-                        file_path,
+                        f"{file_path}[0]" if suffix == ".gif" else file_path,
                         "-resize",
                         "128x128",
                         "-quality",
@@ -996,7 +1001,7 @@ class SimplexAdapter(BasePlatformAdapter):
             except (FileNotFoundError, subprocess.SubprocessError) as exc:
                 logger.warning("SimpleX: image conversion unavailable: %s", exc)
 
-        return png_path, thumb_uri
+        return prepared_path, thumb_uri
 
     async def send_image(
         self,
@@ -1022,14 +1027,14 @@ class SimplexAdapter(BasePlatformAdapter):
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
 
-        png_path, thumb_uri = self._prepare_image(file_path)
+        prepared_path, thumb_uri = self._prepare_image(file_path)
 
         # /_send addresses by numeric ID; /f only accepts display names which
         # breaks for group IDs.
         composed = json.dumps(
             [
                 {
-                    "filePath": png_path,
+                    "filePath": prepared_path,
                     "msgContent": {
                         "type": "image",
                         "image": thumb_uri,

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -928,30 +928,35 @@ class SimplexAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _prepare_image(file_path: str) -> tuple[str, str]:
-        """Ensure *file_path* is a PNG and return ``(png_path, thumb_data_uri)``.
+        """Return ``(prepared_path, thumb_data_uri)`` for an inline image.
 
-        SimpleX clients can't display WebP and a few other formats inline.
-        This converts to PNG when needed and generates a small JPEG thumbnail
-        for the ``image`` field in the ``/_send`` payload so the chat shows
-        an inline preview. Uses Pillow when available, falls back to
-        ImageMagick ``convert``.
+        PNG, JPEG, and GIF attachments are sent unchanged; other
+        formats are converted to PNG because SimpleX clients cannot display
+        formats such as WebP inline. A static JPEG thumbnail is generated for
+        the ``image`` field in the ``/_send`` payload. Uses Pillow when
+        available and falls back to ImageMagick ``convert``.
         """
         import subprocess
         import tempfile
 
         p = Path(file_path)
-        png_path = file_path
+        suffix = p.suffix.lower()
+        needs_conversion = suffix not in (".png", ".jpg", ".jpeg", ".gif")
+        prepared_path = file_path
         thumb_uri = ""
 
         try:
             from PIL import Image
 
-            img = Image.open(file_path)
-            if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                png_path = str(p.with_suffix(".png"))
-                img.save(png_path, "PNG")
-            thumb = img.copy()
+            with Image.open(file_path) as img:
+                img.seek(0)
+                if needs_conversion:
+                    prepared_path = str(p.with_suffix(".png"))
+                    img.save(prepared_path, "PNG")
+                thumb = img.copy()
             thumb.thumbnail((128, 128))
+            if thumb.mode not in ("RGB", "L"):
+                thumb = thumb.convert("RGB")
             import io
 
             buf = io.BytesIO()
@@ -962,10 +967,10 @@ class SimplexAdapter(BasePlatformAdapter):
             )
         except ImportError:
             try:
-                if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                    png_path = str(p.with_suffix(".png"))
+                if needs_conversion:
+                    prepared_path = str(p.with_suffix(".png"))
                     subprocess.run(
-                        ["convert", file_path, png_path],
+                        ["convert", file_path, prepared_path],
                         check=True,
                         capture_output=True,
                         timeout=30,
@@ -975,7 +980,7 @@ class SimplexAdapter(BasePlatformAdapter):
                 subprocess.run(
                     [
                         "convert",
-                        file_path,
+                        f"{file_path}[0]" if suffix == ".gif" else file_path,
                         "-resize",
                         "128x128",
                         "-quality",
@@ -994,7 +999,7 @@ class SimplexAdapter(BasePlatformAdapter):
             except (FileNotFoundError, subprocess.SubprocessError) as exc:
                 logger.warning("SimpleX: image conversion unavailable: %s", exc)
 
-        return png_path, thumb_uri
+        return prepared_path, thumb_uri
 
     async def send_image(
         self,
@@ -1020,14 +1025,14 @@ class SimplexAdapter(BasePlatformAdapter):
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
 
-        png_path, thumb_uri = self._prepare_image(file_path)
+        prepared_path, thumb_uri = self._prepare_image(file_path)
 
         # /_send addresses by numeric ID; /f only accepts display names which
         # breaks for group IDs.
         composed = json.dumps(
             [
                 {
-                    "filePath": png_path,
+                    "filePath": prepared_path,
                     "msgContent": {
                         "type": "image",
                         "image": thumb_uri,

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -190,6 +190,115 @@ async def test_send_group():
     assert result.success is True
 
 
+@pytest.fixture
+def animated_gif(tmp_path):
+    """Create a GIF that opens in Pillow's palette mode."""
+    from PIL import Image
+
+    path = tmp_path / "animated.gif"
+    first = Image.new("RGB", (16, 16), "blue")
+    second = Image.new("RGB", (16, 16), "green")
+    first.save(
+        path,
+        save_all=True,
+        append_images=[second],
+        duration=[100, 100],
+        loop=0,
+        optimize=False,
+    )
+    return path, path.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_send_image_preserves_animated_gif_in_payload(animated_gif):
+    import base64
+    import io
+
+    from PIL import Image
+
+    gif_path, original_bytes = animated_gif
+    adapter = _adapter_with_ws()
+    commands = []
+
+    async def capture_command(command, timeout=30.0):
+        commands.append(command)
+        return {"ok": True}
+
+    adapter._send_command = capture_command
+
+    result = await adapter.send_image_file(
+        "alice",
+        str(gif_path),
+    )
+
+    assert result.success is True
+    assert len(commands) == 1
+    command = commands[0]
+    prefix = "/_send @alice json "
+    assert command.startswith(prefix)
+
+    messages = json.loads(command.removeprefix(prefix))
+    assert len(messages) == 1
+    message = messages[0]
+    assert message["filePath"] == str(gif_path)
+
+    thumbnail_uri = message["msgContent"]["image"]
+    uri_prefix = "data:image/jpg;base64,"
+    assert thumbnail_uri.startswith(uri_prefix)
+    thumbnail_bytes = base64.b64decode(
+        thumbnail_uri.removeprefix(uri_prefix),
+        validate=True,
+    )
+    with Image.open(io.BytesIO(thumbnail_bytes)) as thumbnail:
+        assert thumbnail.format == "JPEG"
+
+    assert gif_path.read_bytes() == original_bytes
+    with Image.open(gif_path) as image:
+        assert image.n_frames == 2
+
+
+def test_prepare_image_imagemagick_preserves_gif_frame_zero(
+    animated_gif,
+    monkeypatch,
+):
+    import base64
+    import io
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    from PIL import Image
+
+    gif_path, _ = animated_gif
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (8, 8), "blue").save(buffer, "JPEG")
+    jpeg_bytes = buffer.getvalue()
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        output_path = Path(command[-1])
+        output_path.write_bytes(jpeg_bytes)
+        return subprocess.CompletedProcess(command, 0)
+
+    with monkeypatch.context() as patcher:
+        patcher.setitem(sys.modules, "PIL", None)
+        patcher.setattr(subprocess, "run", fake_run)
+        attachment_path, thumbnail_uri = SimplexAdapter._prepare_image(
+            str(gif_path)
+        )
+
+    assert attachment_path == str(gif_path)
+    assert len(calls) == 1
+    assert calls[0][1] == f"{gif_path}[0]"
+    assert base64.b64decode(
+        thumbnail_uri.removeprefix("data:image/jpg;base64,"),
+        validate=True,
+    ) == jpeg_bytes
+
+
 # ---------------------------------------------------------------------------
 # 7b. Channel directory enumeration (list_channels)
 # ---------------------------------------------------------------------------
@@ -386,5 +495,4 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
             },
         },
     }
-
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -161,6 +161,115 @@ async def test_send_group():
     assert result.success is True
 
 
+@pytest.fixture
+def animated_gif(tmp_path):
+    """Create a GIF that opens in Pillow's palette mode."""
+    from PIL import Image
+
+    path = tmp_path / "animated.gif"
+    first = Image.new("RGB", (16, 16), "blue")
+    second = Image.new("RGB", (16, 16), "green")
+    first.save(
+        path,
+        save_all=True,
+        append_images=[second],
+        duration=[100, 100],
+        loop=0,
+        optimize=False,
+    )
+    return path, path.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_send_image_preserves_animated_gif_in_payload(animated_gif):
+    import base64
+    import io
+
+    from PIL import Image
+
+    gif_path, original_bytes = animated_gif
+    adapter = _adapter_with_ws()
+    commands = []
+
+    async def capture_command(command, timeout=30.0):
+        commands.append(command)
+        return {"ok": True}
+
+    adapter._send_command = capture_command
+
+    result = await adapter.send_image_file(
+        "alice",
+        str(gif_path),
+    )
+
+    assert result.success is True
+    assert len(commands) == 1
+    command = commands[0]
+    prefix = "/_send @alice json "
+    assert command.startswith(prefix)
+
+    messages = json.loads(command.removeprefix(prefix))
+    assert len(messages) == 1
+    message = messages[0]
+    assert message["filePath"] == str(gif_path)
+
+    thumbnail_uri = message["msgContent"]["image"]
+    uri_prefix = "data:image/jpg;base64,"
+    assert thumbnail_uri.startswith(uri_prefix)
+    thumbnail_bytes = base64.b64decode(
+        thumbnail_uri.removeprefix(uri_prefix),
+        validate=True,
+    )
+    with Image.open(io.BytesIO(thumbnail_bytes)) as thumbnail:
+        assert thumbnail.format == "JPEG"
+
+    assert gif_path.read_bytes() == original_bytes
+    with Image.open(gif_path) as image:
+        assert image.n_frames == 2
+
+
+def test_prepare_image_imagemagick_preserves_gif_frame_zero(
+    animated_gif,
+    monkeypatch,
+):
+    import base64
+    import io
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    from PIL import Image
+
+    gif_path, _ = animated_gif
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (8, 8), "blue").save(buffer, "JPEG")
+    jpeg_bytes = buffer.getvalue()
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        output_path = Path(command[-1])
+        output_path.write_bytes(jpeg_bytes)
+        return subprocess.CompletedProcess(command, 0)
+
+    with monkeypatch.context() as patcher:
+        patcher.setitem(sys.modules, "PIL", None)
+        patcher.setattr(subprocess, "run", fake_run)
+        attachment_path, thumbnail_uri = SimplexAdapter._prepare_image(
+            str(gif_path)
+        )
+
+    assert attachment_path == str(gif_path)
+    assert len(calls) == 1
+    assert calls[0][1] == f"{gif_path}[0]"
+    assert base64.b64decode(
+        thumbnail_uri.removeprefix("data:image/jpg;base64,"),
+        validate=True,
+    ) == jpeg_bytes
+
+
 # ---------------------------------------------------------------------------
 # 7b. Channel directory enumeration (list_channels)
 # ---------------------------------------------------------------------------
@@ -299,5 +408,4 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
             },
         },
     }
-
 


### PR DESCRIPTION
**Rebased onto Hermes `v2026.8.18` / `0.20.4` (`e624e9fde561e1add9388384012b295fde669ade`) so this still applies on that release.**

## What does this PR do?

On current `main`, the SimpleX adapter converts GIF attachments to PNG in
`SimplexAdapter._prepare_image()`. That removes animation. Paletted GIFs can
also fail when the adapter tries to save their thumbnail directly as JPEG with
`cannot write mode P as JPEG`.

This preserves the original GIF as the attachment and uses its first frame for
the static JPEG thumbnail required by the SimpleX message payload. Other image
formats keep their existing behavior.

One practical use case is an agent generating a five-second video with
ComfyUI/H3, converting the complete clip to an animated GIF, and sending it
inline through SimpleX instead of reducing it to one frame.

## Related Issue

No related issue; reproduced on current `main`.

The bug is distinct from #77766, but that PR also changes `_prepare_image` for
temporary-file cleanup. This branch will need to be rebased if it merges first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve GIF attachments in `plugins/platforms/simplex/adapter.py` instead of
  converting them to PNG.
- Generate a JPEG thumbnail from frame zero after converting palette or alpha
  modes to a JPEG-compatible mode.
- Add behavioral regression coverage for both the Pillow and ImageMagick paths
  in `tests/gateway/test_simplex_plugin.py`.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py -q`.
2. Send a multi-frame GIF through `send_image_file()`.
3. Confirm that the structured `/_send` payload references the original GIF
   and includes a valid JPEG thumbnail.
4. Open the received attachment in SimpleX and confirm that it animates.

Automated validation:

- `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py -q` — 15 passed
- `ruff check .`
- `python scripts/check-windows-footguns.py --all`
- `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (focused SimpleX suite passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 LTS (x86_64), Hermes Agent 0.20.4, SimpleX Chat 7.0.0.11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; no user-facing configuration changed
- [x] `cli-config.yaml.example` is N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; Pillow files are closed before cleanup and ImageMagick receives paths as subprocess arguments
- [x] Tool descriptions and schemas are N/A; no tool surface changed

## Screenshots / Logs

Sent a complete two-frame GIF through the patched adapter to SimpleX Chat
7.0.0.11 and confirmed that it animated in the receiving client. The attachment
remained the original GIF and its message thumbnail was a valid JPEG.
