### PR TITLE
fix(provider): resolve solo custom provider when model section is empty

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -600,7 +600,45 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
     if env_provider:
         return env_provider
 
+    # cc-switch-style setups: the tray tool manages the custom_providers /
+    # providers section directly and replaces it wholesale on switch, so the
+    # section holds exactly the currently-active provider while model.* stays
+    # unset. When the model section is entirely empty (no provider AND no
+    # base_url) and exactly one usable custom provider is configured, that
+    # entry IS the default — resolve it by name instead of falling through to
+    # "auto", which fails with "No inference provider configured" even though
+    # the provider works (visible as a false "needs setup" in the desktop
+    # statusbar's setup.runtime_check). With zero or multiple entries we keep
+    # the historical "auto" behavior — guessing among several is wrong.
+    if not (model_cfg.get("provider") or model_cfg.get("base_url")):
+        solo = _single_enabled_custom_provider()
+        if solo:
+            return solo
+
     return "auto"
+
+
+def _single_enabled_custom_provider() -> Optional[str]:
+    """Return the name of the sole configured custom provider, or None.
+
+    Returns a name only when exactly one usable ``providers:`` /
+    ``custom_providers:`` entry exists (``providers_dict_to_custom_providers``
+    already drops ``enabled: false`` entries, and the legacy list has no
+    disabled state). Zero or multiple entries return None so callers keep
+    the historical "auto" behavior instead of guessing.
+    """
+    try:
+        entries = get_compatible_custom_providers(load_config())
+    except Exception:
+        return None
+
+    usable = [e for e in entries if isinstance(e, dict) and str(e.get("name") or "").strip()]
+
+    if len(usable) != 1:
+        return None
+
+    return str(usable[0].get("name") or "").strip().lower()
+
 
 
 def _try_resolve_from_custom_pool(

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1553,3 +1553,111 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     assert resolved["source"] == "pool:lmstudio-pool"
     assert resolved["provider"] == "custom"
     assert resolved["requested_provider"] == "custom:lmstudio"
+
+
+def _config_with_custom_providers(entries, model=None):
+    return {"custom_providers": entries, "model": model or {}}
+
+
+def test_solo_custom_provider_is_default_when_model_section_empty(monkeypatch):
+    """cc-switch layout: the sole custom_providers entry + an empty model
+    section resolves as the default provider instead of falling to 'auto'."""
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: _config_with_custom_providers(
+            [{"name": "ds", "base_url": "https://api.deepseek.com", "api_key": "sk-x"}]
+        ),
+    )
+
+    assert rp.resolve_requested_provider() == "ds"
+
+
+def test_multiple_custom_providers_keep_auto(monkeypatch):
+    """With several custom entries there is no unambiguous default — 'auto'."""
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: _config_with_custom_providers(
+            [
+                {"name": "ds", "base_url": "https://api.deepseek.com", "api_key": "sk-1"},
+                {"name": "other", "base_url": "https://other.example.com", "api_key": "sk-2"},
+            ]
+        ),
+    )
+
+    assert rp.resolve_requested_provider() == "auto"
+
+
+def test_no_custom_providers_keeps_auto(monkeypatch):
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(rp, "load_config", lambda: {"model": {}})
+
+    assert rp.resolve_requested_provider() == "auto"
+
+
+def test_solo_custom_provider_not_used_when_model_base_url_set(monkeypatch):
+    """model.base_url owns the auto path; a solo custom provider must not
+    hijack a user who pointed model.base_url at a local endpoint."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"base_url": "http://localhost:11434/v1"},
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: _config_with_custom_providers(
+            [{"name": "ds", "base_url": "https://api.deepseek.com", "api_key": "sk-x"}]
+        ),
+    )
+
+    assert rp.resolve_requested_provider() == "auto"
+
+
+def test_model_provider_wins_over_solo_custom_provider(monkeypatch):
+    """An explicit model.provider keeps priority over the solo-entry fallback."""
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openrouter"},
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: _config_with_custom_providers(
+            [{"name": "ds", "base_url": "https://api.deepseek.com", "api_key": "sk-x"}]
+        ),
+    )
+
+    assert rp.resolve_requested_provider() == "openrouter"
+
+
+def test_resolve_runtime_provider_resolves_solo_custom_provider_by_default(monkeypatch):
+    """The full resolution path (the one setup.runtime_check exercises) resolves
+    a solo custom_providers entry when model.* is empty — the cc-switch layout
+    that previously raised AuthError('No inference provider configured') and
+    surfaced as a false 'needs setup' in the desktop statusbar."""
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: _config_with_custom_providers(
+            [{"name": "ds", "base_url": "https://api.deepseek.com", "api_key": "sk-ds"}]
+        ),
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda *a, **k: SimpleNamespace(has_credentials=lambda: False),
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved is not None
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.deepseek.com"
+    assert resolved["api_key"] == "sk-ds"
+


### PR DESCRIPTION
## Problem

cc-switch (and similar tray tools) manage the `custom_providers` / `providers` config section directly and replace it wholesale on switch, so the section holds exactly the **currently-active provider** while `model.*` stays unset.

In that layout, `resolve_requested_provider()` fell through to `"auto"`, which fails with `AuthError('No inference provider configured')` even though the provider works fine. Symptoms:

- Desktop statusbar shows **"needs setup"** forever (via `setup.runtime_check` → `resolve_runtime_provider()` with no args → `ok: False`)
- `setup.status` simultaneously reports `provider_configured: True` — the two checks disagree
- Chats succeed because sessions pass an explicit provider (`ds`), so the UI misleads users about a working setup

## Fix

In `resolve_requested_provider()`, when the `model` section has **neither** `provider` **nor** `base_url` and **exactly one** usable custom provider (`providers:` or legacy `custom_providers:`) is configured, treat that entry as the default provider.

Guards keep the change minimal:

- Multiple custom providers → still `"auto"` (no guessing)
- Zero custom providers → still `"auto"`
- `model.base_url` set → still `"auto"` (the local-endpoint path owns it)
- Explicit `model.provider` → unchanged priority

## Verification

- Reproduced on a real cc-switch config: before the fix `resolve_runtime_provider()` raised `AuthError`; after, it resolves `provider=custom, model=deepseek-v4-flash` with usable credentials, and the full `setup.runtime_check` logic returns `ok: True`.
- Added 6 tests covering the fallback, the guards above, and the full `resolve_runtime_provider()` path. `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py` → 61 passed; related `test_model_switch_custom_providers.py` and `test_tui_gateway_server.py` also pass.