### PR TITLE
fix(desktop): gateway-pill demo plugin off by default

### DIFF
--- a/apps/desktop/src/plugins/gateway-pill/plugin.tsx
+++ b/apps/desktop/src/plugins/gateway-pill/plugin.tsx
@@ -350,6 +350,11 @@ function PillLabel() {
 const plugin: HermesPlugin = {
   id: 'gateway-pill',
   name: 'Gateway Pill',
+  // Reference/demo plugin: a 1:1 rebuild of the core gateway-health statusbar
+  // item through the SDK. Off by default like the other in-tree example
+  // plugins — otherwise every shipped app shows TWO gateway pills (core +
+  // plugin) in the statusbar.
+  defaultEnabled: false,
   register(ctx) {
     startReadinessPoll()
 


### PR DESCRIPTION
## Problem

The `gateway-pill` plugin (a reference/demo 1:1 rebuild of the core `gateway-health` statusbar item through the plugin SDK) ships **on by default**: it lacks `defaultEnabled: false`, while the other in-tree example plugins (`example`, `kanban`) correctly opt in.

Result: every shipped desktop app shows **two gateway pills** in the statusbar — the core item on the left and the plugin's copy on the right, both reading the same backend state and showing identical copy (e.g. "网关 需要设置"). Users cannot hide them via the statusbar context menu (both are locked-visible).

## Fix

Set `defaultEnabled: false` on the plugin, matching `example` / `kanban`. `pluginActive()` falls back to the plugin's default only when the user has **no persisted decision**, so:

- Fresh users: no duplicate gateway pill
- Users who explicitly enabled it: their choice is respected
- Developers: still can enable it for SDK reference work

## Verification

- `npx tsc --noEmit` passes
- `npx eslint src/plugins/gateway-pill/plugin.tsx` clean
- `npx vitest run src/contrib src/plugins` → 13 tests pass (plugin discovery/activation + runtime loader)