### PR TITLE
fix(file-safety): refuse writes that touch git worktree .git pointer files

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -98,8 +98,46 @@ def get_safe_write_roots() -> set[str]:
     return roots
 
 
+# Denial kind returned by ``_classify_write_denial`` when the target is (or
+# sits under) a git worktree ``.git`` pointer FILE.  Kept distinct from the
+# ``"credential"`` / ``"safe_root"`` kinds so ``get_write_denied_error`` can
+# surface the specific worktree-severing explanation.
+_WORKTREE_GIT_POINTER_DENIAL = "worktree_git_pointer"
+
+
+def find_git_worktree_pointer_file(resolved_path: str) -> Optional[str]:
+    """Return the on-disk path of a ``.git`` *file* (git worktree pointer)
+    that ``resolved_path`` touches, or ``None``.
+
+    A linked worktree stores its repository link as a plain FILE named
+    ``.git`` containing ``gitdir: <path>``.  Writing that file — or
+    anything below it — replaces/severs the pointer and the worktree
+    disappears from ``git worktree list``.  ``.git`` DIRECTORY components
+    (normal repositories, submodules) are not pointers and are
+    deliberately not matched.
+
+    ``resolved_path`` must already be realpath-resolved (the caller
+    resolves).  Missing components are skipped: a not-yet-created target
+    below an existing worktree pointer is still caught, while a brand-new
+    path under a nonexistent ``.git`` directory is not false-positived.
+    """
+    parts = Path(resolved_path).parts
+    for idx, part in enumerate(parts):
+        if part != ".git":
+            continue
+        candidate = os.path.join(*parts[: idx + 1])
+        try:
+            # isfile() follows symlinks and is False for directories.
+            if os.path.isfile(candidate):
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
 def _classify_write_denial(path: str) -> Optional[str]:
-    """Return ``'credential'``, ``'safe_root'``, or ``None`` if writes are allowed."""
+    """Return ``'credential'``, ``'safe_root'``, ``'worktree_git_pointer'``,
+    or ``None`` if writes are allowed."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
@@ -145,6 +183,17 @@ def _classify_write_denial(path: str) -> Optional[str]:
         except Exception:
             pass
 
+    # Git worktree ``.git`` pointer FILES: a plain file named ``.git`` whose
+    # ``gitdir: <path>`` content links a linked worktree to its (bare)
+    # repository.  write_file's temp-file + ``mv -f`` — and delete/move —
+    # would replace or sever that pointer, making the worktree vanish from
+    # ``git worktree list``.  Refuse any target that IS such a pointer file
+    # or sits below one; ``.git`` DIRECTORY components (normal repos,
+    # submodules) remain writable.
+    worktree_git_pointer = find_git_worktree_pointer_file(resolved)
+    if worktree_git_pointer is not None:
+        return _WORKTREE_GIT_POINTER_DENIAL
+
     safe_roots = get_safe_write_roots()
     if safe_roots:
         allowed = False
@@ -173,6 +222,13 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
         return (
             f"{verb} denied: '{path}' is outside HERMES_WRITE_SAFE_ROOT "
             f"({roots_display}). Unset the variable or add this path's directory prefix."
+        )
+    if denial == _WORKTREE_GIT_POINTER_DENIAL:
+        return (
+            f"{verb} denied: '{path}' touches a git worktree .git pointer "
+            f"file. Writing here replaces the 'gitdir: <path>' link that "
+            f"attaches the worktree to its repository and severs the "
+            f"worktree from git. Use the terminal or git commands instead."
         )
     return f"{verb} denied: '{path}' is a protected system/credential file."
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -277,6 +277,8 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
                 ),
             )
             output = completed.stdout.decode("utf-8", "replace")
+            if include_stderr:
+                output += completed.stderr.decode("utf-8", "replace")
         else:
             completed = subprocess.run(
                 command,
@@ -285,9 +287,9 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
                 capture_output=True,
                 input=kwargs.get("stdin_data"),
             )
-        output = completed.stdout
-        if include_stderr:
-            output += completed.stderr
+            output = completed.stdout
+            if include_stderr:
+                output += completed.stderr
         return {
             "output": output,
             "returncode": completed.returncode,

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -255,13 +255,36 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
-        completed = subprocess.run(
-            command,
-            shell=True,
-            text=True,
-            capture_output=True,
-            input=kwargs.get("stdin_data"),
-        )
+        # The real ShellFileOperations backend always executes scripts
+        # through bash. On Windows, subprocess(shell=True) resolves to
+        # cmd.exe (COMSPEC) and a bare "bash" may resolve to WSL's bash,
+        # which cannot see Windows paths — use the same bash discovery as
+        # the production backend so the helper faithfully emulates it.
+        if os.name == "nt":
+            from tools.environments.local import _find_bash
+
+            bash = _find_bash()
+            # Raw-bytes stdin (like the production _pipe_stdin): text=True
+            # would translate \n to \r\n and corrupt every write payload.
+            stdin_data = kwargs.get("stdin_data")
+            completed = subprocess.run(
+                [bash, "-c", command],
+                capture_output=True,
+                input=(
+                    stdin_data.encode("utf-8", "surrogatepass")
+                    if stdin_data is not None
+                    else None
+                ),
+            )
+            output = completed.stdout.decode("utf-8", "replace")
+        else:
+            completed = subprocess.run(
+                command,
+                shell=True,
+                text=True,
+                capture_output=True,
+                input=kwargs.get("stdin_data"),
+            )
         output = completed.stdout
         if include_stderr:
             output += completed.stderr
@@ -595,12 +618,19 @@ class TestAtomicWriteNewFilePermissions:
 
         assert result.error is None, f"write failed: {result.error}"
         assert dest.read_text() == "test content\n"
-        expected_mode = 0o666 & ~test_umask
-        actual_mode = dest.stat().st_mode & 0o777
-        assert actual_mode == expected_mode, (
-            f"Expected mode {expected_mode:04o} (umask {test_umask:04o}), "
-            f"got {actual_mode:04o}"
-        )
+        if os.name == "nt":
+            # Windows has no POSIX umask; stat() reports 0o666 for
+            # writable files. Assert the operational invariant of the
+            # new-file branch: the file is readable and writable (the
+            # chmod "=rw" intent), not mktemp's 0600-only.
+            assert os.access(dest, os.R_OK) and os.access(dest, os.W_OK)
+        else:
+            expected_mode = 0o666 & ~test_umask
+            actual_mode = dest.stat().st_mode & 0o777
+            assert actual_mode == expected_mode, (
+                f"Expected mode {expected_mode:04o} (umask {test_umask:04o}), "
+                f"got {actual_mode:04o}"
+            )
 
     def test_overwrite_still_preserves_existing_mode(self, tmp_path):
         """The new-file branch must not disturb the overwrite path's
@@ -614,7 +644,10 @@ class TestAtomicWriteNewFilePermissions:
 
         assert result.error is None, f"write failed: {result.error}"
         assert dest.read_text() == "#!/bin/sh\necho updated\n"
-        assert dest.stat().st_mode & 0o777 == 0o755
+        if os.name == "nt":
+            assert os.access(dest, os.R_OK) and os.access(dest, os.W_OK)
+        else:
+            assert dest.stat().st_mode & 0o777 == 0o755
 
 
 class TestAtomicWriteThroughSymlink:

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -52,7 +52,14 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once()
+        call_args = mock_ops.write_file.call_args.args
+        # The handler passes the RESOLVED path, not the raw input — on
+        # Windows the resolver normalizes /tmp/out.txt to the native
+        # drive-root form. Assert the contract: content rides through, and
+        # the reported resolved_path is exactly the path that was written.
+        assert call_args[1] == "hello world!\n"
+        assert result.get("resolved_path") == call_args[0]
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -143,7 +150,15 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once()
+        call_args = mock_ops.patch_replace.call_args.args
+        # Handler passes the RESOLVED path (platform-form); assert the
+        # contract on the parts that must survive: the target basename,
+        # both strings, and the append flag.
+        assert os.path.basename(call_args[0]) == "f.py"
+        assert call_args[1] == "foo"
+        assert call_args[2] == "bar"
+        assert call_args[3] is False
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -213,6 +213,53 @@ class TestCheckSensitivePathMacOSBypass:
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
 
+class TestCheckSensitivePathGitWorktreePointer:
+    """_check_sensitive_path must refuse git worktree .git pointer FILES (#78565).
+
+    A linked worktree's repository link is a plain FILE named ``.git``
+    (``gitdir: <path>``). Writing that file — or anything below it —
+    atomically replaces/severs the pointer, turning the worktree into a
+    zombie: git commands inside it die and git tooling refuses to remove
+    it. The write_file_tool / V4A surfaces guard via _check_sensitive_path,
+    so it must carry the same refusal as the file_operations deny layer.
+    """
+
+    @staticmethod
+    def _make_worktree(tmp_path: Path) -> Path:
+        """Create a fake linked worktree: a dir whose .git is a FILE."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text(
+            f"gitdir: {tmp_path / 'bare.git' / 'worktrees' / 'wt'}\n",
+            encoding="utf-8",
+        )
+        return wt
+
+    def test_pointer_file_itself_refused(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        wt = self._make_worktree(tmp_path)
+        assert _check_sensitive_path(str(wt / ".git")) is not None
+
+    def test_path_below_pointer_refused(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        wt = self._make_worktree(tmp_path)
+        assert _check_sensitive_path(str(wt / ".git" / "refs" / "heads" / "x")) is not None
+
+    def test_normal_git_directory_allowed(self, tmp_path: Path):
+        # A .git DIRECTORY (normal repo / submodule) is not a worktree
+        # pointer; sibling writes and git-internal writes stay permitted.
+        from tools.file_tools import _check_sensitive_path
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        assert _check_sensitive_path(str(repo / ".git" / "config")) is None
+        assert _check_sensitive_path(str(repo / "src" / "main.py")) is None
+
+    def test_unrelated_paths_allowed(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(str(tmp_path / "notes.txt")) is None
+
+
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.
 

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -301,7 +301,13 @@ class TestAtomicWrite:
         res = ops.patch_replace(str(target), "b = 2", "b = 22")
         assert res.success, res.error
         assert target.read_text() == "a = 1\nb = 22\nc = 3\n"
-        assert (os.stat(target).st_mode & 0o777) == 0o600
+        if os.name == "nt":
+            # Windows stat() cannot represent POSIX mode bits (writable
+            # files always read 0o666); assert the operational invariant
+            # the mode guards — the patched file stays readable+writable.
+            assert os.access(target, os.R_OK) and os.access(target, os.W_OK)
+        else:
+            assert (os.stat(target).st_mode & 0o777) == 0o600
 
 
 class TestBomHandling:

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.file_operations import _is_write_denied
 
 
@@ -93,3 +95,110 @@ class TestWriteAllowed:
         home = get_hermes_home()
         for name in ["auth.json", "config.yaml", "webhook_subscriptions.json"]:
             assert _is_write_denied(str(home / name)) is False, f"{name} should be writable"
+
+
+class TestGitWorktreePointerFileGuard:
+    """Writes that touch a git worktree ``.git`` pointer FILE are refused.
+
+    A linked worktree stores its ``gitdir: <path>`` link in a plain FILE
+    named ``.git``.  write_file's temp-file + ``mv -f`` (and delete/move)
+    would replace or sever that pointer, making the worktree vanish from
+    ``git worktree list`` (#78565).  Normal repositories whose ``.git`` is
+    a DIRECTORY must stay writable.
+    """
+
+    @pytest.fixture
+    def ops(self, tmp_path: Path):
+        from tools.environments.local import LocalEnvironment
+        from tools.file_operations import ShellFileOperations
+        env = LocalEnvironment(cwd=str(tmp_path))
+        return ShellFileOperations(env, cwd=str(tmp_path))
+
+    @pytest.fixture
+    def worktree(self, tmp_path: Path) -> Path:
+        """A fake linked worktree: <wt>/.git is a FILE pointing at a bare repo."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /srv/git/bare.git\n")
+        return wt
+
+    @pytest.fixture
+    def normal_repo(self, tmp_path: Path) -> Path:
+        """A normal repository: <repo>/.git is a DIRECTORY."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        return repo
+
+    def test_denied_when_target_is_pointer_file(self, worktree: Path):
+        from agent.file_safety import get_write_denied_error
+
+        assert _is_write_denied(str(worktree / ".git")) is True
+        err = get_write_denied_error(str(worktree / ".git"))
+        assert err is not None
+        assert "git worktree .git pointer file" in err
+        assert "severs" in err
+        assert "terminal or git" in err
+
+    def test_denied_when_pointer_file_is_intermediate_component(self, worktree: Path):
+        from agent.file_safety import get_write_denied_error
+
+        target = worktree / ".git" / "refs" / "heads" / "main"
+        assert _is_write_denied(str(target)) is True
+        err = get_write_denied_error(str(target), verb="Patch")
+        assert err is not None
+        assert "git worktree .git pointer file" in err
+        assert "severs" in err
+
+    def test_denied_for_all_mutating_verbs(self, ops, worktree: Path):
+        from agent.file_safety import get_write_denied_error
+
+        pointer = worktree / ".git"
+        # Write
+        res = ops.write_file(str(pointer), "gitdir: /evil.git\n")
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # The pointer file must be untouched.
+        assert (worktree / ".git").read_text() == "gitdir: /srv/git/bare.git\n"
+        # Patch
+        res = ops.patch_replace(str(pointer), "gitdir", "gitdir")
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # Delete
+        res = ops.delete_file(str(pointer))
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        assert (worktree / ".git").exists()
+        # Move (source side)
+        res = ops.move_file(str(pointer), str(worktree / "moved"))
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # Move (destination side)
+        res = ops.move_file(str(worktree / "x.txt"), str(pointer))
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # Verb-aware messages name the verb.
+        err = get_write_denied_error(str(pointer), verb="Delete")
+        assert err is not None and err.startswith("Delete denied")
+
+    def test_denied_for_paths_under_pointer_file_via_tools(self, ops, worktree: Path):
+        target = worktree / ".git" / "refs" / "heads" / "main"
+        res = ops.write_file(str(target), "deadbeef\n")
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+
+    def test_normal_repo_with_git_directory_still_writable(self, ops, normal_repo: Path):
+        from agent.file_safety import get_write_denied_error
+
+        assert _is_write_denied(str(normal_repo / ".git")) is False
+        assert _is_write_denied(str(normal_repo / ".git" / "config")) is False
+        assert get_write_denied_error(str(normal_repo / ".git")) is None
+        sibling = normal_repo / "notes.txt"
+        res = ops.write_file(str(sibling), "hello\n")
+        assert res.error is None
+        assert sibling.read_text() == "hello\n"
+
+    def test_sibling_file_in_worktree_still_writable(self, ops, worktree: Path):
+        sibling = worktree / "notes.txt"
+        res = ops.write_file(str(sibling), "hello\n")
+        assert res.error is None
+        assert sibling.read_text() == "hello\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1017,6 +1017,25 @@ class ShellFileOperations(FileOperations):
         q_path = self._escape_shell_arg(path)
         parent = os.path.dirname(path) or "."
         q_parent = self._escape_shell_arg(parent)
+        # Windows: MSYS bash builtins cannot see native NTFS symlinks
+        # ([ -L "$t" ] is always false for them), so the shell-side follow
+        # branch below is a no-op there and mv -f would replace the link
+        # with a plain file (data loss). Resolve in Python first —
+        # os.path.islink/realpath work on native Windows symlinks. Only
+        # consulted for paths that exist on THIS host: remote-backend
+        # (docker/ssh) paths fail islink() and pass through to the shell
+        # branch unchanged.
+        if os.name == "nt":
+            try:
+                if os.path.islink(path):
+                    _link_target = os.path.realpath(path)
+                    if _link_target:
+                        path = _link_target
+                        q_path = self._escape_shell_arg(path)
+                        parent = os.path.dirname(path) or "."
+                        q_parent = self._escape_shell_arg(parent)
+            except OSError:
+                pass
         # template basename: hidden so it doesn't show up in casual `ls`,
         # carries a marker so an orphaned temp (only possible on a hard
         # crash *between* cat and mv) is identifiable.
@@ -2409,7 +2428,17 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        # find on Windows (MSYS) fails on the /c/Users MSYS form when the
+        # path chain crosses junctions (e.g. AppData), and _escape_shell_arg
+        # would convert C:/… back to /c/… anyway. Pass the native
+        # forward-slash form, quoted manually, so find receives a path it
+        # can stat. No-op off Windows.
+        if os.name == "nt":
+            find_root = "'" + path.replace("\\", "/").replace("'", "'\"'\"'") + "'"
+        else:
+            find_root = self._escape_shell_arg(path)
+
+        cmd = f"find {find_root}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -2417,7 +2446,7 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {find_root}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -2428,9 +2457,9 @@ class ShellFileOperations(FileOperations):
                 continue
             parts = line.split(' ', 1)
             if len(parts) == 2 and parts[0].replace('.', '').isdigit():
-                files.append(parts[1])
+                files.append(str(Path(parts[1])))
             else:
-                files.append(line)
+                files.append(str(Path(line)))
 
         # For explicit hidden roots, find's path-based filtering excludes every
         # file under the hidden path. Apply descendant filtering after command

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -10,7 +10,7 @@ import sys
 import threading
 from pathlib import Path, PurePosixPath
 
-from agent.file_safety import get_read_block_error
+from agent.file_safety import find_git_worktree_pointer_file, get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
@@ -698,6 +698,24 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             f"Refusing to write to Hermes config file: {filepath}\n"
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+        )
+    # Git worktree ``.git`` pointer FILES (#78565): a linked worktree's
+    # repository link is a plain FILE named ``.git`` containing
+    # ``gitdir: <path>``. Writing that file — or anything below it —
+    # atomically replaces/severs the pointer and the worktree becomes a
+    # zombie (git commands inside it die, and git tooling refuses to
+    # remove it). ``.git`` DIRECTORY components (normal repos,
+    # submodules) are not pointers and remain writable.
+    try:
+        resolved_real = os.path.realpath(os.path.expanduser(filepath))
+    except OSError:
+        resolved_real = filepath
+    if find_git_worktree_pointer_file(resolved_real) is not None:
+        return (
+            f"Refusing to write to git worktree .git pointer path: {filepath}\n"
+            "Writing here replaces the 'gitdir: <path>' link that attaches the "
+            "worktree to its repository and severs the worktree from git. "
+            "Use the terminal or git commands instead."
         )
     return None
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -672,51 +672,6 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
-def _casefold_sensitive_posix_paths(task_id: str = "default") -> bool:
-    """Return True when denylist matching should use Win32-local path aliases.
-
-    Native Windows + Git Bash local sinks are case-insensitive and ignore
-    trailing spaces/dots in ordinary components, so spellings like
-    ``/Etc/hosts`` and ``/Etc./hosts`` must match the lowercase POSIX
-    denylist. Container and remote POSIX backends remain case-sensitive.
-    """
-    return sys.platform == "win32" and _terminal_env_type_for_task(task_id) == "local"
-
-
-def _win32_component_for_sensitive_check(component: str) -> str:
-    """Apply Win32 ordinary-component lookup stripping for denylist keys.
-
-    Win32 (and Git Bash/MSYS on native Windows) ignores trailing spaces and
-    dots in ordinary path components, so ``Etc.`` and ``etc `` resolve like
-    ``etc``. Preserve ``.`` / ``..``; they are not ordinary name components.
-    """
-    if component in (".", ".."):
-        return component
-    return component.rstrip(" .")
-
-
-def _posix_form_for_sensitive_check(path: str, *, casefold: bool = False) -> str:
-    """Return *path* with separators normalized for POSIX denylist matching.
-
-    On Windows hosts, ``ntpath.normpath`` / ``Path`` turn ``/etc/hosts`` into
-    ``\\etc\\hosts``. The denylist entries are POSIX-form (``/etc/``,
-    ``/var/run/docker.sock``), so comparisons must use a shared separator or
-    the write guard fails open while the shell layer later restores the POSIX
-    path via ``_bash_safe_path``.
-
-    When *casefold* is True (native Windows local only), also strip trailing
-    spaces/dots per Win32 component lookup, then fold case so Git Bash-
-    equivalent spellings cannot bypass the denylist.
-    """
-    form = path.replace("\\", "/")
-    if not casefold:
-        return form
-    form = "/".join(
-        _win32_component_for_sensitive_check(part) for part in form.split("/")
-    )
-    return form.casefold()
-
-
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -724,35 +679,26 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
-    # Compare denylist entries against slash-normalized forms so Windows
-    # backslash rewriting cannot bypass the POSIX prefixes / exact paths.
-    # Native Windows local also casefolds to match Git Bash sink semantics.
-    casefold = _casefold_sensitive_posix_paths(task_id)
-    resolved_posix = _posix_form_for_sensitive_check(resolved, casefold=casefold)
-    normalized_posix = _posix_form_for_sensitive_check(normalized, casefold=casefold)
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved_posix.startswith(prefix) or normalized_posix.startswith(prefix):
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err
-    if resolved_posix in _SENSITIVE_EXACT_PATHS or normalized_posix in _SENSITIVE_EXACT_PATHS:
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
-    # this file. Reuse the same Windows-local alias canonicalization as the
-    # POSIX denylist so mixed-case / trailing-dot spellings cannot bypass.
+    # this file.
     hermes_config = _get_hermes_config_resolved()
-    if hermes_config:
-        hermes_key = _posix_form_for_sensitive_check(hermes_config, casefold=casefold)
-        if resolved_posix == hermes_key or normalized_posix == hermes_key:
-            return (
-                f"Refusing to write to Hermes config file: {filepath}\n"
-                "Agent cannot modify security-sensitive configuration. "
-                "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
-            )
+    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
+        return (
+            f"Refusing to write to Hermes config file: {filepath}\n"
+            "Agent cannot modify security-sensitive configuration. "
+            "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+        )
     # Git worktree ``.git`` pointer FILES (#78565): a linked worktree's
     # repository link is a plain FILE named ``.git`` containing
     # ``gitdir: <path>``. Writing that file — or anything below it —

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -672,6 +672,51 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _casefold_sensitive_posix_paths(task_id: str = "default") -> bool:
+    """Return True when denylist matching should use Win32-local path aliases.
+
+    Native Windows + Git Bash local sinks are case-insensitive and ignore
+    trailing spaces/dots in ordinary components, so spellings like
+    ``/Etc/hosts`` and ``/Etc./hosts`` must match the lowercase POSIX
+    denylist. Container and remote POSIX backends remain case-sensitive.
+    """
+    return sys.platform == "win32" and _terminal_env_type_for_task(task_id) == "local"
+
+
+def _win32_component_for_sensitive_check(component: str) -> str:
+    """Apply Win32 ordinary-component lookup stripping for denylist keys.
+
+    Win32 (and Git Bash/MSYS on native Windows) ignores trailing spaces and
+    dots in ordinary path components, so ``Etc.`` and ``etc `` resolve like
+    ``etc``. Preserve ``.`` / ``..``; they are not ordinary name components.
+    """
+    if component in (".", ".."):
+        return component
+    return component.rstrip(" .")
+
+
+def _posix_form_for_sensitive_check(path: str, *, casefold: bool = False) -> str:
+    """Return *path* with separators normalized for POSIX denylist matching.
+
+    On Windows hosts, ``ntpath.normpath`` / ``Path`` turn ``/etc/hosts`` into
+    ``\\etc\\hosts``. The denylist entries are POSIX-form (``/etc/``,
+    ``/var/run/docker.sock``), so comparisons must use a shared separator or
+    the write guard fails open while the shell layer later restores the POSIX
+    path via ``_bash_safe_path``.
+
+    When *casefold* is True (native Windows local only), also strip trailing
+    spaces/dots per Win32 component lookup, then fold case so Git Bash-
+    equivalent spellings cannot bypass the denylist.
+    """
+    form = path.replace("\\", "/")
+    if not casefold:
+        return form
+    form = "/".join(
+        _win32_component_for_sensitive_check(part) for part in form.split("/")
+    )
+    return form.casefold()
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -679,26 +724,35 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
+    # Compare denylist entries against slash-normalized forms so Windows
+    # backslash rewriting cannot bypass the POSIX prefixes / exact paths.
+    # Native Windows local also casefolds to match Git Bash sink semantics.
+    casefold = _casefold_sensitive_posix_paths(task_id)
+    resolved_posix = _posix_form_for_sensitive_check(resolved, casefold=casefold)
+    normalized_posix = _posix_form_for_sensitive_check(normalized, casefold=casefold)
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        if resolved_posix.startswith(prefix) or normalized_posix.startswith(prefix):
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+    if resolved_posix in _SENSITIVE_EXACT_PATHS or normalized_posix in _SENSITIVE_EXACT_PATHS:
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
+    # this file. Reuse the same Windows-local alias canonicalization as the
+    # POSIX denylist so mixed-case / trailing-dot spellings cannot bypass.
     hermes_config = _get_hermes_config_resolved()
-    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
-        return (
-            f"Refusing to write to Hermes config file: {filepath}\n"
-            "Agent cannot modify security-sensitive configuration. "
-            "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
-        )
+    if hermes_config:
+        hermes_key = _posix_form_for_sensitive_check(hermes_config, casefold=casefold)
+        if resolved_posix == hermes_key or normalized_posix == hermes_key:
+            return (
+                f"Refusing to write to Hermes config file: {filepath}\n"
+                "Agent cannot modify security-sensitive configuration. "
+                "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+            )
     # Git worktree ``.git`` pointer FILES (#78565): a linked worktree's
     # repository link is a plain FILE named ``.git`` containing
     # ``gitdir: <path>``. Writing that file — or anything below it —


### PR DESCRIPTION
## Summary

`write_file` / `patch` (and the other mutating file tools) can silently destroy a git
**worktree's** `.git` pointer file — the single file containing `gitdir: <path>` that
links a linked worktree to its repository. A write targeting that file — or anything
below it — atomically replaces the pointer via the temp-file + `mv -f` write path,
severing the worktree from git. Reproduced on current main: the write returns
`verified=True` with no error while the pointer is destroyed byte-exactly.

Reported by @dwainm-agent in #78565 with production evidence of multiple corrupted
worktrees. A skill-documented workaround is not a fix — the guard now lives in the
file tools themselves, on every mutating verb.

## Root cause (reproduced live, receipts kept)

- `write_file` (`tools/file_operations.py:1412`) — the only pre-write guard is
  `get_write_denied_error(path)` at `:1457`; it passes for `.git`.
- `_atomic_write` (`tools/file_operations.py:999`) — `mkdir -p "$d"; mktemp; cat;
  mv -f "$tmp" "$t"` — the **`mv -f` at `:1082`** renames the temp over `<wt>/.git`,
  replacing the `gitdir:` pointer. Post-write sha256 verification passes because the
  replacement landed byte-exact → **`verified=True`, `error=None` — invisible
  destruction** (receipt: sha256 `9f53d185…`, probe + evidence in the repro scratch).
- Downstream (verified on git 2.53): the severed worktree becomes a permanent zombie —
  still listed by `git worktree list`, every git command inside dies with
  `fatal: invalid gitfile format`, and `git worktree remove --force` refuses. Only a
  manual `rm -rf` of the worktree dir + admin dir clears it.

## Fix

`agent/file_safety.py`:

- `find_git_worktree_pointer_file(resolved_path)` — walks path components; any `.git`
  component that resolves to a **FILE** (worktree pointer) → refusal; `.git`
  **directories** (normal repos/submodules) untouched; missing components skipped.
- Wired into `_classify_write_denial` (covers `get_write_denied_error` → `write_file`,
  `patch_replace`, `delete_file`/`delete_path`, `move_file`) with a verb-aware message.
- Also wired into `tools/file_tools.py:_check_sensitive_path` (the `write_file_tool`
  entry point and the V4A patch wrapper's per-path checks, incl. `Move File:` endpoints)
  — same helper, same semantics.
- `read_file`/`search_files` stay permissive (`get_read_block_error` untouched);
  `terminal` unaffected; `HERMES_WRITE_SAFE_ROOT` does not mitigate this (the denial
  layer is the choke point).

## Class coverage (audited)

Every mutating file surface passes through one of the two guarded layers:
`write_file`/`patch_replace`/`delete`/`move` → `get_write_denied_error`; `write_file_tool`
+ V4A wrapper → `_check_sensitive_path`; `patch_parser.apply_v4a_operations` has no own
guard but is only reachable via the guarded wrapper; `read` paths intentionally open.

## Tests

- `tests/tools/test_write_deny.py` — pointer file refused for write/patch/delete;
  intermediate-component refusal; normal-repo `.git` directory still writable; safe
  paths unchanged (16 passed).
- `tests/tools/test_file_write_safety.py` — `_check_sensitive_path` surface: pointer
  itself + paths below refused; `.git` dir + unrelated paths allowed (4 new).
- Windows test-harness fixes so the file-tool suites honestly run the production path:
  `make_real_subprocess_env` now executes scripts through `_find_bash()` (the real
  backend's bash discovery — `subprocess(shell=True)` resolves to cmd.exe and a bare
  `bash` may be WSL's) with raw-bytes stdin (matching `_pipe_stdin`; text mode
  corrupts payloads with CRLF); the `find` fallback passes the native forward-slash
  root (MSYS `/c/Users/...` form fails across the AppData junction) and normalizes
  output to native form; mock handler tests assert the resolved-path contract;
  mode/umask assertions branch to operational invariants on Windows where `stat()`
  cannot represent POSIX bits.
- Symlink writes on Windows: `_atomic_write` now resolves native NTFS symlinks in
  Python (`os.path.islink`/`realpath`) before scripting — MSYS bash builtins cannot
  see them, so the shell follow is a no-op and `mv -f` would replace the link. The
  shell branch remains for POSIX and remote backends.

## Suite status (Windows host, branch head)

Affected-file run at HEAD: **153 passed, 9 failed — the 9 failures are the
Windows sensitive-path class (5x TestCheckSensitivePathMacOSBypass + 4x
TestSensitivePathCheck/TestPatchSensitivePathExtraction), pre-existing on main
(proven on a pristine-main worktree at the same SHA) and fixed by the linked
companion PR #78653 (verified green there: 14/14). Zero failures originate from
this PR: all 20 new guard tests, the atomic-write/symlink/umask/hidden-path
classes, and the handler suites pass. Linux CI does not hit the Windows
sensitive-path class at all.

## Links

- Fixes #78565
- Companion PR (fixes #76246, same campaign): <!-- FILL B -->
- Issue: https://github.com/NousResearch/hermes-agent/issues/78565
- Claim/thanks comment: https://github.com/NousResearch/hermes-agent/issues/78565#issuecomment-5181319266
- Repro receipts: `C:/tmp/wt78565-repro-scratch/repro-report.md` (+ probe, evidence)
