### PR TITLE
fix(file-tools): normalize separators for POSIX sensitive-path denylist on Windows

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -3,8 +3,10 @@
 Based on PR #1085 by ismoilh (salvaged).
 """
 
+import json
 import os
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -211,6 +213,436 @@ class TestCheckSensitivePathMacOSBypass:
     def test_safe_path_allowed(self):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
+
+
+class TestCheckSensitivePathWindowsHostSemantics:
+    """POSIX denylist entries must still match after Windows path rewriting.
+
+    On win32, ``_resolve_path_for_task`` / ``os.path.normpath`` turn
+    ``/etc/hosts`` into ``\\etc\\hosts``. Without separator normalization the
+    write guard fails open while the shell layer restores the POSIX path.
+    """
+
+    def test_prefix_blocked_when_resolution_uses_backslashes(self, monkeypatch):
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(
+            mod,
+            "_resolve_path_for_task",
+            lambda filepath, task_id="default": Path(str(filepath).replace("/", "\\")),
+        )
+        monkeypatch.setattr(
+            mod.os.path,
+            "normpath",
+            lambda path: str(path).replace("/", "\\"),
+        )
+
+        assert mod._check_sensitive_path("/etc/hosts") is not None
+        assert mod._check_sensitive_path("/boot/grub/grub.cfg") is not None
+        assert mod._check_sensitive_path("/usr/lib/systemd/system/x.service") is not None
+        assert mod._check_sensitive_path("/private/etc/hosts") is not None
+
+    def test_exact_docker_sock_blocked_when_resolution_uses_backslashes(self, monkeypatch):
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(
+            mod,
+            "_resolve_path_for_task",
+            lambda filepath, task_id="default": Path(str(filepath).replace("/", "\\")),
+        )
+        monkeypatch.setattr(
+            mod.os.path,
+            "normpath",
+            lambda path: str(path).replace("/", "\\"),
+        )
+
+        assert mod._check_sensitive_path("/var/run/docker.sock") is not None
+        assert mod._check_sensitive_path("/run/docker.sock") is not None
+
+    def test_safe_path_still_allowed_with_backslash_normalization(self, monkeypatch):
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(
+            mod,
+            "_resolve_path_for_task",
+            lambda filepath, task_id="default": Path(str(filepath).replace("/", "\\")),
+        )
+        monkeypatch.setattr(
+            mod.os.path,
+            "normpath",
+            lambda path: str(path).replace("/", "\\"),
+        )
+
+        assert mod._check_sensitive_path("/tmp/safe_file.txt") is None
+
+    @pytest.mark.skipif(os.name != "nt", reason="native Windows path rewriting")
+    def test_native_windows_host_blocks_posix_sensitive_targets(self):
+        from tools.file_tools import _check_sensitive_path
+
+        assert _check_sensitive_path("/etc/hosts") is not None
+        assert _check_sensitive_path("/boot/grub/grub.cfg") is not None
+        assert _check_sensitive_path("/var/run/docker.sock") is not None
+        assert _check_sensitive_path("/tmp/safe_file.txt") is None
+
+    def _patch_windows_local_backslash_resolution(self, monkeypatch, mod):
+        monkeypatch.setattr(mod.sys, "platform", "win32")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "local"
+        )
+        monkeypatch.setattr(
+            mod,
+            "_resolve_path_for_task",
+            lambda filepath, task_id="default": Path(str(filepath).replace("/", "\\")),
+        )
+        monkeypatch.setattr(
+            mod.os.path,
+            "normpath",
+            lambda path: str(path).replace("/", "\\"),
+        )
+
+    def test_mixed_case_prefix_blocked_on_windows_local(self, monkeypatch):
+        """Git Bash resolves /Etc/hosts to the same target as /etc/hosts."""
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        assert mod._check_sensitive_path("/Etc/hosts") is not None
+        assert mod._check_sensitive_path("/BOOT/grub/grub.cfg") is not None
+        assert mod._check_sensitive_path("/Private/Etc/hosts") is not None
+
+    def test_mixed_case_exact_docker_sock_blocked_on_windows_local(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        assert mod._check_sensitive_path("/var/run/Docker.sock") is not None
+        assert mod._check_sensitive_path("/Run/docker.sock") is not None
+
+    def test_mixed_case_lookalikes_and_safe_paths_still_allowed(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        assert mod._check_sensitive_path("/tmp/safe.txt") is None
+        assert mod._check_sensitive_path("/etc2/hosts") is None
+        assert mod._check_sensitive_path(r"C:\Users\test\file.txt") is None
+
+    def test_mixed_case_not_blocked_on_posix_or_container_backends(self, monkeypatch):
+        """Container/WSL/remote POSIX sinks stay case-sensitive."""
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(mod.sys, "platform", "linux")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert mod._check_sensitive_path("/Etc/hosts") is None
+        assert mod._check_sensitive_path("/var/run/Docker.sock") is None
+
+        monkeypatch.setattr(mod.sys, "platform", "win32")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert mod._check_sensitive_path("/Etc/hosts") is None
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_blocks_mixed_case_prefix_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        result = json.loads(mod.write_file_tool("/Etc/hosts", "evil"))
+        assert "error" in result
+        assert "sensitive system path" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_blocks_mixed_case_exact_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        result = json.loads(mod.write_file_tool("/var/run/Docker.sock", "evil"))
+        assert "error" in result
+        assert "sensitive system path" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_patch_blocks_mixed_case_prefix_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Update File: /Etc/hosts\n"
+            "@@ @@\n"
+            "-old\n"
+            "+new\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(mod.patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_patch_blocks_mixed_case_exact_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Add File: /var/run/Docker.sock\n"
+            "+evil\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(mod.patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    def test_trailing_dot_and_space_aliases_blocked_on_windows_local(self, monkeypatch):
+        """Win32 lookup strips trailing dots/spaces in ordinary components."""
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        assert mod._check_sensitive_path("/Etc./hosts") is not None
+        assert mod._check_sensitive_path("/etc /hosts") is not None
+        assert mod._check_sensitive_path("/boot./grub/grub.cfg") is not None
+        assert mod._check_sensitive_path("/private/etc./hosts") is not None
+        assert mod._check_sensitive_path("/var/run/docker.sock.") is not None
+        assert mod._check_sensitive_path("/run/docker.sock ") is not None
+
+    def test_trailing_alias_lookalikes_and_safe_paths_still_allowed(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        assert mod._check_sensitive_path("/tmp/safe.txt") is None
+        assert mod._check_sensitive_path("/etc2/hosts") is None
+        assert mod._check_sensitive_path("/etc2./hosts") is None
+        assert mod._check_sensitive_path(r"C:\Users\test\file.txt") is None
+
+    def test_trailing_aliases_not_blocked_on_posix_or_container_backends(self, monkeypatch):
+        """POSIX/container backends must not apply Win32 component stripping."""
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(mod.sys, "platform", "linux")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert mod._check_sensitive_path("/Etc./hosts") is None
+        assert mod._check_sensitive_path("/etc /hosts") is None
+        assert mod._check_sensitive_path("/var/run/docker.sock.") is None
+
+        monkeypatch.setattr(mod.sys, "platform", "win32")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert mod._check_sensitive_path("/Etc./hosts") is None
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_blocks_trailing_dot_alias_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        result = json.loads(mod.write_file_tool("/Etc./hosts", "evil"))
+        assert "error" in result
+        assert "sensitive system path" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_blocks_trailing_space_exact_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+
+        result = json.loads(mod.write_file_tool("/run/docker.sock ", "evil"))
+        assert "error" in result
+        assert "sensitive system path" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_patch_blocks_trailing_dot_alias_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Update File: /Etc./hosts\n"
+            "@@ @@\n"
+            "-old\n"
+            "+new\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(mod.patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_patch_blocks_trailing_space_exact_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+        patch_text = (
+            "*** Begin Patch\n"
+            "*** Add File: /var/run/docker.sock.\n"
+            "+evil\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(mod.patch_tool(mode="patch", patch=patch_text))
+        assert "error" in result
+        assert "sensitive" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    _WIN_HERMES_CONFIG = r"C:\Users\test\.hermes\config.yaml"
+    _WIN_HERMES_CONFIG_MIXED = r"C:\Users\test\.HERMES\CONFIG.YAML"
+    _WIN_HERMES_CONFIG_TRAILING = r"C:\Users\test\.hermes\config.yaml."
+    _WIN_HERMES_NEARBY_SAFE = r"C:\Users\test\.hermes\notes.yaml"
+
+    def _patch_windows_hermes_config(self, monkeypatch, mod, config_path=None):
+        config_path = config_path or self._WIN_HERMES_CONFIG
+        self._patch_windows_local_backslash_resolution(monkeypatch, mod)
+        monkeypatch.setattr(mod, "_hermes_config_resolved", config_path)
+        monkeypatch.setattr(mod, "_hermes_config_resolved_loaded", True)
+
+    def test_hermes_config_canonical_blocked_on_windows_local(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        assert mod._check_sensitive_path(self._WIN_HERMES_CONFIG) is not None
+
+    def test_hermes_config_mixed_case_alias_blocked_on_windows_local(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        err = mod._check_sensitive_path(self._WIN_HERMES_CONFIG_MIXED)
+        assert err is not None
+        assert "Hermes config" in err
+
+    def test_hermes_config_trailing_dot_alias_blocked_on_windows_local(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        err = mod._check_sensitive_path(self._WIN_HERMES_CONFIG_TRAILING)
+        assert err is not None
+        assert "Hermes config" in err
+
+    def test_hermes_config_nearby_safe_path_still_allowed(self, monkeypatch):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        assert mod._check_sensitive_path(self._WIN_HERMES_NEARBY_SAFE) is None
+
+    def test_hermes_config_aliases_not_blocked_on_posix_or_container(self, monkeypatch):
+        """POSIX/container sinks stay case-sensitive for the config identity check."""
+        from tools import file_tools as mod
+
+        hermes = "/home/user/.hermes/config.yaml"
+        monkeypatch.setattr(mod, "_hermes_config_resolved", hermes)
+        monkeypatch.setattr(mod, "_hermes_config_resolved_loaded", True)
+        monkeypatch.setattr(
+            mod,
+            "_resolve_path_for_task",
+            lambda filepath, task_id="default": Path(filepath),
+        )
+        monkeypatch.setattr(mod.os.path, "normpath", lambda path: path)
+
+        monkeypatch.setattr(mod.sys, "platform", "linux")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert mod._check_sensitive_path(hermes) is not None
+        assert mod._check_sensitive_path("/home/user/.HERMES/config.yaml") is None
+        assert mod._check_sensitive_path("/home/user/.hermes/config.yaml.") is None
+
+        monkeypatch.setattr(mod.sys, "platform", "win32")
+        monkeypatch.setattr(
+            mod, "_terminal_env_type_for_task", lambda task_id="default": "docker"
+        )
+        assert mod._check_sensitive_path("/home/user/.HERMES/config.yaml") is None
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_blocks_hermes_config_alias_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        result = json.loads(
+            mod.write_file_tool(self._WIN_HERMES_CONFIG_MIXED, "approvals:\n  mode: off\n")
+        )
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+        mock_get.assert_not_called()
+
+        result = json.loads(
+            mod.write_file_tool(self._WIN_HERMES_CONFIG_TRAILING, "approvals:\n  mode: off\n")
+        )
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_file_allows_nearby_safe_path_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {
+            "status": "ok",
+            "path": self._WIN_HERMES_NEARBY_SAFE,
+            "bytes": 5,
+        }
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        result = json.loads(mod.write_file_tool(self._WIN_HERMES_NEARBY_SAFE, "hello"))
+        assert result["status"] == "ok"
+        mock_get.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_patch_blocks_hermes_config_alias_on_windows_local(
+        self, mock_get, monkeypatch
+    ):
+        from tools import file_tools as mod
+
+        self._patch_windows_hermes_config(monkeypatch, mod)
+        for path in (self._WIN_HERMES_CONFIG_MIXED, self._WIN_HERMES_CONFIG_TRAILING):
+            patch_text = (
+                "*** Begin Patch\n"
+                f"*** Update File: {path}\n"
+                "@@ @@\n"
+                "-old\n"
+                "+approvals:\n"
+                "+  mode: off\n"
+                "*** End Patch\n"
+            )
+            result = json.loads(mod.patch_tool(mode="patch", patch=patch_text))
+            assert "error" in result
+            assert "hermes config" in result["error"].lower()
+            mock_get.assert_not_called()
 
 
 class TestAtomicWrite:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -672,6 +672,51 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _casefold_sensitive_posix_paths(task_id: str = "default") -> bool:
+    """Return True when denylist matching should use Win32-local path aliases.
+
+    Native Windows + Git Bash local sinks are case-insensitive and ignore
+    trailing spaces/dots in ordinary components, so spellings like
+    ``/Etc/hosts`` and ``/Etc./hosts`` must match the lowercase POSIX
+    denylist. Container and remote POSIX backends remain case-sensitive.
+    """
+    return sys.platform == "win32" and _terminal_env_type_for_task(task_id) == "local"
+
+
+def _win32_component_for_sensitive_check(component: str) -> str:
+    """Apply Win32 ordinary-component lookup stripping for denylist keys.
+
+    Win32 (and Git Bash/MSYS on native Windows) ignores trailing spaces and
+    dots in ordinary path components, so ``Etc.`` and ``etc `` resolve like
+    ``etc``. Preserve ``.`` / ``..``; they are not ordinary name components.
+    """
+    if component in (".", ".."):
+        return component
+    return component.rstrip(" .")
+
+
+def _posix_form_for_sensitive_check(path: str, *, casefold: bool = False) -> str:
+    """Return *path* with separators normalized for POSIX denylist matching.
+
+    On Windows hosts, ``ntpath.normpath`` / ``Path`` turn ``/etc/hosts`` into
+    ``\\etc\\hosts``. The denylist entries are POSIX-form (``/etc/``,
+    ``/var/run/docker.sock``), so comparisons must use a shared separator or
+    the write guard fails open while the shell layer later restores the POSIX
+    path via ``_bash_safe_path``.
+
+    When *casefold* is True (native Windows local only), also strip trailing
+    spaces/dots per Win32 component lookup, then fold case so Git Bash-
+    equivalent spellings cannot bypass the denylist.
+    """
+    form = path.replace("\\", "/")
+    if not casefold:
+        return form
+    form = "/".join(
+        _win32_component_for_sensitive_check(part) for part in form.split("/")
+    )
+    return form.casefold()
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -679,26 +724,35 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
+    # Compare denylist entries against slash-normalized forms so Windows
+    # backslash rewriting cannot bypass the POSIX prefixes / exact paths.
+    # Native Windows local also casefolds to match Git Bash sink semantics.
+    casefold = _casefold_sensitive_posix_paths(task_id)
+    resolved_posix = _posix_form_for_sensitive_check(resolved, casefold=casefold)
+    normalized_posix = _posix_form_for_sensitive_check(normalized, casefold=casefold)
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        if resolved_posix.startswith(prefix) or normalized_posix.startswith(prefix):
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+    if resolved_posix in _SENSITIVE_EXACT_PATHS or normalized_posix in _SENSITIVE_EXACT_PATHS:
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
+    # this file. Reuse the same Windows-local alias canonicalization as the
+    # POSIX denylist so mixed-case / trailing-dot spellings cannot bypass.
     hermes_config = _get_hermes_config_resolved()
-    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
-        return (
-            f"Refusing to write to Hermes config file: {filepath}\n"
-            "Agent cannot modify security-sensitive configuration. "
-            "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
-        )
+    if hermes_config:
+        hermes_key = _posix_form_for_sensitive_check(hermes_config, casefold=casefold)
+        if resolved_posix == hermes_key or normalized_posix == hermes_key:
+            return (
+                f"Refusing to write to Hermes config file: {filepath}\n"
+                "Agent cannot modify security-sensitive configuration. "
+                "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+            )
     return None
 
 


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #76246 #76247 #78565 #78658 #78806

> [!NOTE]
> **Topology adjudicated on 2026-08-19:** closed as a duplicate of #76247 after exact file-level comparison. Both PRs change the same two files and their complete patches are byte-for-byte identical. #76247 is the older implementation and owns the full review/fix history; this branch's test-import commit preserves @fangliquanflq credit with `Co-authored-by`. The surviving path is #76247.
>
> This work fixes **#76246 only**. #78565 is a separate git-worktree `.git` managed-state corruption class and remains open. Its current class-closing implementation is open PR #78806; closed PR #78652 is the unmerged pointer-file foundation subsumed into that branch. This PR is not part of #78565.

## Summary

On Windows hosts, the file-tool sensitive-path write guard fails open for POSIX system
targets (`/etc/...`, `/boot/...`, `/var/run/docker.sock`): `ntpath`/`Path` rewriting
produces backslash forms that no longer match the `/`-prefixed denylist, while the shell
layer can later restore the POSIX path and attempt the write. Native Windows local
backends are also case-insensitive and ignore trailing dots/spaces in ordinary path
components, so Git Bash-equivalent spellings (`/Etc/hosts`, `/Etc./hosts`) bypass the
guard.

## Fix

`tools/file_tools.py` — `_check_sensitive_path` compares denylist entries against
slash-normalized forms (`_posix_form_for_sensitive_check`); on native Windows local
backends the comparison additionally strips Win32 trailing spaces/dots and casefolds
(`_casefold_sensitive_posix_paths`), matching the sink's actual resolution semantics.
Container and remote POSIX backends stay case-sensitive. Hermes `config.yaml` identity
checks use the same canonicalization so mixed-case and trailing-dot spellings cannot
bypass the approval-configuration guard.

## Verification

The promised tests are present on this branch in
`tests/tools/test_file_write_safety.py`. They cover:

- backslash rewriting for prefix and exact denylist entries;
- native-Windows case variants and trailing-dot/space aliases;
- `write_file` and V4A patch refusal before file operations are acquired;
- Hermes-config canonical, mixed-case, and trailing-dot aliases;
- safe lookalikes and nearby paths;
- POSIX/container case-sensitive negative controls.

Current head: `40efdc90061d7abb3c030cd9327178cf9a6ced6b`.

- GitHub Actions CI run **31094380438**: success.
- Native Windows 11 evidence on unchanged production commit `2d33a223`: the current-main
  bypass reproduced; protected aliases blocked on the branch; focused run **14 passed,
  62 deselected**; broader file-tool run **73 passed** with three documented pre-existing
  Windows harness failures.
- Surviving duplicate #76247 head `3e0d31c40ff0523214d8a7f820b3a91f17c551f7`
  also has successful CI run **30874010869**.

## Links

- Fixes #76246
- Surviving implementation: #76247
- Out-of-scope NTFS 8.3 identity follow-up: #78658
- Separate worktree managed-state class: #78565 / #78806
