### PR TITLE
Accept shared truthy aliases for server enabled flags

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -38,6 +38,7 @@ import yaml
 
 from hermes_constants import get_hermes_home, get_optional_mcps_dir
 from hermes_cli._subprocess_compat import noninteractive_git_env
+from utils import is_truthy_value
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import (
     load_config,
@@ -367,15 +368,26 @@ def is_installed(name: str) -> bool:
     return name in installed_servers()
 
 
+def parse_mcp_enabled_flag(value: Any, *, default: bool = True) -> bool:
+    """Coerce an MCP server ``enabled`` field with the shared truthy contract.
+
+    ``config.yaml`` authors often write ``enabled: on``; the previous
+    allowlist (true/1/yes) treated that as disabled and hid the server from
+    the picker/catalog while tools_config still loaded it.
+    """
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return is_truthy_value(value)
+    return bool(value)
+
+
 def is_enabled(name: str) -> bool:
     servers = installed_servers()
     cfg = servers.get(name)
     if not cfg:
         return False
-    enabled = cfg.get("enabled", True)
-    if isinstance(enabled, str):
-        return enabled.lower() in {"true", "1", "yes"}
-    return bool(enabled)
+    return parse_mcp_enabled_flag(cfg.get("enabled", True))
 
 
 # ─── Install ─────────────────────────────────────────────────────────────────

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -26,6 +26,7 @@ from hermes_cli.config import (
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
 from hermes_cli.mcp_security import validate_mcp_server_entry
+from hermes_cli.mcp_catalog import parse_mcp_enabled_flag
 from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
 
 logger = logging.getLogger(__name__)
@@ -707,10 +708,8 @@ def cmd_mcp_list(args=None):
         else:
             tools_str = "all"
 
-        # Enabled status
-        enabled = cfg.get("enabled", True)
-        if isinstance(enabled, str):
-            enabled = enabled.lower() in {"true", "1", "yes"}
+        # Enabled status — shared truthy contract (true/1/yes/on).
+        enabled = parse_mcp_enabled_flag(cfg.get("enabled", True))
         status = color("✓ enabled", Colors.GREEN) if enabled else color("✗ disabled", Colors.DIM)
 
         print(f"  {name:<16} {transport:<30} {tools_str:<12} {status}")

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -34,6 +34,7 @@ from hermes_cli.mcp_catalog import (
     is_installed,
     list_catalog,
     installed_servers,
+    parse_mcp_enabled_flag,
     uninstall_entry,
 )
 from hermes_cli.config import load_config, save_config
@@ -92,9 +93,7 @@ def _build_rows() -> List[_Row]:
     for name, cfg in sorted(installed_servers().items()):
         if name in catalog_names:
             continue
-        enabled = cfg.get("enabled", True)
-        if isinstance(enabled, str):
-            enabled = enabled.lower() in {"true", "1", "yes"}
+        enabled = parse_mcp_enabled_flag(cfg.get("enabled", True))
         status = _STATUS_CUSTOM_ENABLED if enabled else _STATUS_CUSTOM_DISABLED
         # Use the transport URL/command as the "description" for custom rows
         desc = cfg.get("url") or cfg.get("command") or "(no transport)"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_mcp_enabled_truthy.py
+++ b/tests/hermes_cli/test_mcp_enabled_truthy.py
@@ -1,0 +1,43 @@
+"""MCP enabled flags must accept shared truthy aliases like 'on'."""
+
+from __future__ import annotations
+
+from hermes_cli.mcp_catalog import is_enabled, parse_mcp_enabled_flag
+
+
+def test_parse_mcp_enabled_flag_accepts_on_alias():
+    assert parse_mcp_enabled_flag("on") is True
+    assert parse_mcp_enabled_flag("ON") is True
+    assert parse_mcp_enabled_flag("1") is True
+    assert parse_mcp_enabled_flag("yes") is True
+    assert parse_mcp_enabled_flag(" true ") is True
+
+
+def test_parse_mcp_enabled_flag_rejects_falsy():
+    assert parse_mcp_enabled_flag("off") is False
+    assert parse_mcp_enabled_flag("false") is False
+    assert parse_mcp_enabled_flag("0") is False
+    assert parse_mcp_enabled_flag("no") is False
+
+
+def test_parse_mcp_enabled_flag_bool_and_default():
+    assert parse_mcp_enabled_flag(True) is True
+    assert parse_mcp_enabled_flag(False) is False
+    assert parse_mcp_enabled_flag(None, default=True) is True
+    assert parse_mcp_enabled_flag(None, default=False) is False
+
+
+def test_is_enabled_accepts_on_alias(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.mcp_catalog.installed_servers",
+        lambda: {"demo": {"enabled": "on"}},
+    )
+    assert is_enabled("demo") is True
+
+
+def test_is_enabled_rejects_off_alias(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.mcp_catalog.installed_servers",
+        lambda: {"demo": {"enabled": "off"}},
+    )
+    assert is_enabled("demo") is False


### PR DESCRIPTION
## Summary
- Parse MCP server `enabled` with shared `is_truthy_value` aliases (`true` / `1` / `yes` / `on`) via `parse_mcp_enabled_flag` in catalog, list, and picker. `enabled: on` in `config.yaml` previously looked disabled in CLI UI while tools_config still loaded the server.
- Defensive Telegram bare-adapter getattr for `_polling_conflict_recovery_generation`.
