### PR TITLE
fix: let plugin block directives veto approvals

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2150,8 +2150,9 @@ def _get_pre_tool_call_directive_details(
     - ``rule_key`` is optional and only honored for ``approve`` directives. It
       lets plugins choose the allowlist grain for `[a]lways` approvals.
 
-    The first valid directive wins. Invalid or irrelevant hook return values
-    are silently ignored so existing observer-only hooks are unaffected.
+    Any valid block vetoes the call, regardless of plugin discovery order.
+    Otherwise the first valid approval directive wins. Invalid or irrelevant
+    hook return values are silently ignored so observer-only hooks are unaffected.
     """
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
@@ -2173,6 +2174,7 @@ def _get_pre_tool_call_directive_details(
         middleware_trace=list(middleware_trace or []),
     )
 
+    first_approval: Optional[_PreToolCallDirective] = None
     for result in hook_results:
         if not isinstance(result, dict):
             continue
@@ -2185,13 +2187,18 @@ def _get_pre_tool_call_directive_details(
         # an approve directive can carry an optional reason.
         if action == "block" and not message:
             continue
-        rule_key = result.get("rule_key") if action == "approve" else None
+        if action == "block":
+            return _PreToolCallDirective(action="block", message=message)
+        rule_key = result.get("rule_key")
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key)
+        if first_approval is None:
+            first_approval = _PreToolCallDirective(
+                action="approve", message=message, rule_key=rule_key,
+            )
 
-    return _PreToolCallDirective()
+    return first_approval or _PreToolCallDirective()
 
 
 def get_pre_tool_call_directive(

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -393,6 +393,31 @@ class TestPreToolCallDirective:
         )
         assert get_pre_tool_call_directive("write_file", {}) == ("approve", None)
 
+    def test_block_vetoes_earlier_approval(self, monkeypatch):
+        from hermes_cli.plugins import get_pre_tool_call_directive
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "earlier gate"},
+                {"action": "block", "message": "later veto"},
+            ],
+        )
+        assert get_pre_tool_call_directive("terminal", {}) == ("block", "later veto")
+
+    def test_first_approval_wins_when_no_plugin_blocks(self, monkeypatch):
+        from hermes_cli.plugins import _get_pre_tool_call_directive_details
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "first", "rule_key": "first:key"},
+                {"action": "approve", "message": "second", "rule_key": "second:key"},
+            ],
+        )
+        result = _get_pre_tool_call_directive_details("terminal", {})
+        assert (result.action, result.message, result.rule_key) == (
+            "approve", "first", "first:key",
+        )
+
 
 class TestResolvePreToolBlock:
     """Tests for the single dispatch-site chokepoint that resolves a


### PR DESCRIPTION
## Problem
`pre_tool_call` currently accepts the first valid directive. An earlier plugin returning `approve` can therefore shadow a later security plugin returning `block`, even though the hook contract says a block vetoes the call. Plugin discovery order becomes a security boundary.

## Fix
- evaluate all valid hook directives
- return the first valid `block` regardless of ordering
- otherwise preserve the first valid `approve` and its rule key
- keep malformed/observer returns ignored

## Verification
- `tests/hermes_cli/test_plugins.py`: 37 passed
- `tests/test_model_tools.py`: 20 passed
- `git diff --check`: clean