### PR TITLE
Accept shared truthy aliases for NO_SUPERVISE

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -231,7 +231,11 @@ def _maybe_migrate_legacy_gateway_run_state(
     if state_file.exists():
         return None
 
-    if os.environ.get("HERMES_GATEWAY_NO_SUPERVISE", "").lower() in ("1", "true", "yes"):
+    # Match the rest of container_boot's truthy contract (GATEWAY_MULTIPLEX_PROFILES
+    # already uses is_truthy_value) so HERMES_GATEWAY_NO_SUPERVISE=on opts out.
+    from utils import is_truthy_value
+
+    if is_truthy_value(os.environ.get("HERMES_GATEWAY_NO_SUPERVISE", "")):
         return None
 
     argv = tuple(container_argv) if container_argv is not None else _read_container_argv()

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2161,7 +2161,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         self._polling_progress_event.set()
         self._polling_network_error_count = 0
-        if generation == self._polling_conflict_recovery_generation:
+        # Bare/test adapters may not have run ``__init__``; treat missing as
+        # "no conflict recovery in flight" (same defensive shape as teardown).
+        if generation == getattr(self, "_polling_conflict_recovery_generation", None):
             self._polling_conflict_recovery_generation = None
         else:
             self._polling_conflict_count = 0

--- a/tests/hermes_cli/test_container_boot_no_supervise_truthy.py
+++ b/tests/hermes_cli/test_container_boot_no_supervise_truthy.py
@@ -1,0 +1,46 @@
+"""HERMES_GATEWAY_NO_SUPERVISE must accept shared truthy aliases."""
+
+from __future__ import annotations
+
+from hermes_cli.container_boot import _maybe_migrate_legacy_gateway_run_state
+
+
+def test_no_supervise_on_alias_skips_legacy_migrate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_NO_SUPERVISE", "on")
+    result = _maybe_migrate_legacy_gateway_run_state(
+        tmp_path,
+        container_argv=("gateway", "run"),
+        dry_run=True,
+    )
+    assert result is None
+    assert not (tmp_path / "gateway_state.json").exists()
+
+
+def test_no_supervise_1_alias_skips_legacy_migrate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_NO_SUPERVISE", "1")
+    result = _maybe_migrate_legacy_gateway_run_state(
+        tmp_path,
+        container_argv=("gateway", "run"),
+        dry_run=True,
+    )
+    assert result is None
+
+
+def test_no_supervise_unset_still_migrates_legacy(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+    result = _maybe_migrate_legacy_gateway_run_state(
+        tmp_path,
+        container_argv=("gateway", "run"),
+        dry_run=True,
+    )
+    assert result == "running"
+
+
+def test_no_supervise_off_does_not_opt_out(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_GATEWAY_NO_SUPERVISE", "off")
+    result = _maybe_migrate_legacy_gateway_run_state(
+        tmp_path,
+        container_argv=("gateway", "run"),
+        dry_run=True,
+    )
+    assert result == "running"


### PR DESCRIPTION
## Summary
- Parse `HERMES_GATEWAY_NO_SUPERVISE` with `is_truthy_value` so aliases like `on` opt out of legacy gateway-run state seeding (previously only `1`/`true`/`yes`).
- Aligns with the same truthy contract already used for `GATEWAY_MULTIPLEX_PROFILES` in this module.
- Includes the Telegram bare-adapter `getattr` guard for `_polling_conflict_recovery_generation` to avoid CI flakes.
