### PR TITLE
Debug-helpers : accept shared truthy aliases for debug env flags

### DIFF
--- a/tests/tools/test_debug_helpers.py
+++ b/tests/tools/test_debug_helpers.py
@@ -4,6 +4,8 @@ import json
 import os
 from unittest.mock import patch
 
+import pytest
+
 from tools.debug_helpers import DebugSession
 
 
@@ -15,7 +17,6 @@ class TestDebugSessionDisabled:
         assert ds.active is False
         assert ds.enabled is False
 
-
     def test_get_session_info_disabled(self):
         ds = DebugSession("test_tool", env_var="FAKE_DEBUG_VAR_XYZ")
         info = ds.get_session_info()
@@ -24,15 +25,28 @@ class TestDebugSessionDisabled:
         assert info["log_path"] is None
         assert info["total_calls"] == 0
 
+    @pytest.mark.parametrize("raw", ["0", "false", "off", "no", ""])
+    def test_falsy_aliases_stay_disabled(self, raw):
+        with patch.dict(os.environ, {"TEST_DEBUG": raw}):
+            ds = DebugSession("test_tool", env_var="TEST_DEBUG")
+        assert ds.enabled is False
+        assert ds.active is False
+
 
 class TestDebugSessionEnabled:
-    """When the env var is set to 'true', DebugSession records and saves."""
+    """When the env var is truthy, DebugSession records and saves."""
 
-    def _make_enabled(self, tmp_path):
-        with patch.dict(os.environ, {"TEST_DEBUG": "true"}):
+    def _make_enabled(self, tmp_path, raw: str = "true"):
+        with patch.dict(os.environ, {"TEST_DEBUG": raw}):
             ds = DebugSession("test_tool", env_var="TEST_DEBUG")
         ds.log_dir = tmp_path
         return ds
+
+    @pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE", " On "])
+    def test_truthy_aliases_enable(self, tmp_path, raw):
+        ds = self._make_enabled(tmp_path, raw=raw)
+        assert ds.active is True
+        assert ds.enabled is True
 
     def test_active_when_env_set(self, tmp_path):
         ds = self._make_enabled(tmp_path)
@@ -42,7 +56,6 @@ class TestDebugSessionEnabled:
     def test_session_id_generated(self, tmp_path):
         ds = self._make_enabled(tmp_path)
         assert len(ds.session_id) > 0
-
 
     def test_save_empty_log(self, tmp_path):
         ds = self._make_enabled(tmp_path)

--- a/tools/debug_helpers.py
+++ b/tools/debug_helpers.py
@@ -24,11 +24,11 @@ Usage in a tool module:
 import datetime
 import json
 import logging
-import os
 import uuid
 from typing import Any, Dict
 
 from hermes_constants import get_hermes_home
+from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +37,13 @@ class DebugSession:
     """Per-tool debug session that records tool calls to a JSON log file.
 
     Activated by a tool-specific environment variable (e.g. WEB_TOOLS_DEBUG=true).
+    Shared truthy aliases (1/true/yes/on) enable the session; anything else is off.
     When disabled, all methods are cheap no-ops.
     """
 
     def __init__(self, tool_name: str, *, env_var: str) -> None:
         self.tool_name = tool_name
-        self.enabled = os.getenv(env_var, "false").lower() == "true"
+        self.enabled = env_var_enabled(env_var, default="false")
         self.session_id = str(uuid.uuid4()) if self.enabled else ""
         self.log_dir = get_hermes_home() / "logs"
         self._calls: list[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- Gate `DebugSession` activation through `env_var_enabled` so `1`/`true`/`yes`/`on` enable tool debug logging (previously only the literal `true` worked).
- Affects shared debug session infrastructure used by web, vision, and image tools.

