### PR TITLE
fix(whatsapp): default group_policy to open so groups reach gateway auth

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -18,9 +18,9 @@ mixin's methods are called (typically in ``__init__``):
 
     self.config        # gateway.config.PlatformConfig
     self.name          # str — adapter name (used in log lines)
-    self._dm_policy             # str: "open" | "allowlist" | "disabled"
+    self._dm_policy             # str: "open" | "allowlist" | "disabled" | "pairing"
     self._allow_from            # set[str]
-    self._group_policy          # str: "open" | "allowlist" | "disabled"
+    self._group_policy          # str: "open" | "allowlist" | "disabled" | "pairing"
     self._group_allow_from      # set[str]
     self._mention_patterns      # list[re.Pattern]
     self._reply_prefix          # Optional[str]
@@ -283,6 +283,8 @@ class WhatsAppBehaviorMixin:
         if self._group_policy == "allowlist":
             return self._matches_whatsapp_allowlist(chat_id, self._group_allow_from)
         if self._group_policy == "pairing":
+            # Pairing is a DM handshake; there is no group-level pairing
+            # flow. An explicit pairing policy therefore disables groups.
             return False
         if self._group_policy == "open":
             return True
@@ -399,6 +401,12 @@ class WhatsAppBehaviorMixin:
         if is_group:
             chat_id = chat_id_raw
             if not self._is_group_allowed(chat_id):
+                logger.info(
+                    "[%s] Dropping WhatsApp group message for %s: group_policy=%s",
+                    self.name,
+                    chat_id or "<unknown>",
+                    self._group_policy,
+                )
                 return False
         else:
             sender_id = str(data.get("senderId") or data.get("from") or "")

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -398,7 +398,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - session_path: Path to store WhatsApp session data
     - dm_policy: "open" | "allowlist" | "disabled" | "pairing" — how DMs are handled (default: "pairing")
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
-    - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
+    - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "open")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
     - send_read_receipts: Mark accepted inbound WhatsApp messages as read
 
@@ -448,7 +448,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._dm_allowlist_source = None
             allow_raw = None
         self._allow_from = self._coerce_allow_list(allow_raw)
-        self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
+        # Groups do not have a useful pairing handshake. Keep the default
+        # open here and let the gateway's normal authorization layer enforce
+        # the configured sender allowlist; an explicit ``pairing`` policy is
+        # still available when an operator wants to disable group intake.
+        self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
@@ -30,7 +31,7 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter._message_handler = AsyncMock()
     adapter._dm_policy = str(extra.get("dm_policy", "pairing")).strip().lower()
     adapter._allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("allow_from"))
-    adapter._group_policy = str(extra.get("group_policy", "pairing")).strip().lower()
+    adapter._group_policy = str(extra.get("group_policy", "open")).strip().lower()
     adapter._group_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_allow_from"))
     adapter._mention_patterns = adapter._compile_mention_patterns()
     adapter._free_response_chats = adapter._whatsapp_free_response_chats()
@@ -151,6 +152,29 @@ def test_dm_policy_disabled_still_allows_groups():
 
 
 # --- New group_policy tests ---
+
+
+def test_group_policy_defaults_to_open(monkeypatch, tmp_path):
+    """The Baileys adapter must not silently reject every group by default."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.delenv("WHATSAPP_GROUP_POLICY", raising=False)
+    monkeypatch.setattr(WhatsAppAdapter, "_DEFAULT_BRIDGE_DIR", tmp_path)
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True))
+
+    assert adapter._group_policy == "open"
+    assert adapter._should_process_message(_group_message("hello")) is True
+
+
+def test_group_policy_pairing_drop_is_logged(caplog):
+    adapter = _make_adapter(group_policy="pairing", require_mention=False)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.whatsapp_common"):
+        assert adapter._should_process_message(_group_message("hello")) is False
+
+    assert "Dropping WhatsApp group message" in caplog.text
+    assert "group_policy=pairing" in caplog.text
+    assert "120363001234567890@g.us" in caplog.text
 
 
 # --- Config bridging tests ---

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -130,6 +130,20 @@ whatsapp:
 - `unauthorized_dm_behavior: pair` is the global default. Unknown DM senders get a pairing code.
 - `whatsapp.unauthorized_dm_behavior: ignore` makes WhatsApp stay silent for unauthorized DMs, which is usually the better choice for a private number.
 
+Group messages use `group_policy: open` at the WhatsApp intake by default, so
+configured group chats are not discarded before the gateway can authorize them.
+The gateway still applies the normal WhatsApp/global allowlist, or an explicit
+allow-all opt-in. To restrict groups further, configure their JIDs explicitly:
+
+```yaml
+whatsapp:
+  group_policy: allowlist
+  group_allow_from:
+    - "120363001234567890@g.us"
+```
+
+Use `group_policy: disabled` to ignore all group messages.
+
 Then start the gateway:
 
 ```bash


### PR DESCRIPTION
## Summary

- Baileys WhatsApp adapter defaulted `group_policy` to `pairing`, but pairing is a DM-only handshake — intake therefore silently dropped every group message before gateway auth could run.
- Default `group_policy` to `open` to match the Cloud adapter; gateway allowlist / allow-all / default-deny still enforce authorization.
- Log drops when an explicit group policy rejects a chat; document the intake vs gateway allowlist split and how to lock groups down with `allowlist` / `disabled`.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py` (12 passed)
- [ ] Confirm a group message from an allowlisted sender is no longer dropped at intake with default config
- [ ] Confirm unauthorized group senders still fail closed at gateway auth without allowlist / allow-all
- [ ] Confirm explicit `group_policy: pairing` or `disabled` still rejects groups and logs the drop