### PR TITLE
fix(desktop): render dash-separated model versions as dotted names

### DIFF
--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useI18n } from '@/i18n'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
-import { currentPickerSelection } from '@/lib/model-status-label'
+import { currentPickerSelection, displayModelName } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import type { ModelOptionProvider, ModelPricing } from '@/types/hermes'
 
@@ -227,7 +227,7 @@ function ModelResults({
                   value={`${provider.slug}:${model}`}
                 >
                   <span className="min-w-0 flex-1 truncate">
-                    <HighlightMatches query={search} text={model} />
+                    <HighlightMatches query={search} text={displayModelName(model)} />
                   </span>
                   {locked && (
                     <span className="shrink-0 text-[0.62rem] uppercase tracking-wide opacity-80">{copy.pro}</span>

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -12,8 +12,27 @@ describe('model-status-label', () => {
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {
-    expect(displayModelName('claude-opus-4-5-20251101')).toBe('Opus 4 5')
-    expect(displayModelName('anthropic/claude-haiku-4-5-20251001')).toBe('Haiku 4 5')
+    expect(displayModelName('claude-opus-4-5-20251101')).toBe('Opus 4.5')
+    expect(displayModelName('anthropic/claude-haiku-4-5-20251001')).toBe('Haiku 4.5')
+  })
+
+  // Providers that expose dash-separated ids (Kenari) must still render the
+  // canonical dotted, title-cased name — `gemini-3-6-flash` is "Gemini 3.6
+  // Flash", not "Gemini 3 6 flash".
+  it('restores dotted versions and title case for dash-separated ids', () => {
+    expect(displayModelName('gemini-3-6-flash')).toBe('Gemini 3.6 Flash')
+    expect(displayModelName('gemini-2-5-flash')).toBe('Gemini 2.5 Flash')
+    expect(displayModelName('qwen3-7-plus')).toBe('Qwen3.7 Plus')
+    expect(displayModelName('claude-opus-4-8')).toBe('Opus 4.8')
+    expect(displayModelName('gpt-5-5')).toBe('GPT-5.5')
+    expect(displayModelName('grok-4-5')).toBe('Grok 4.5')
+  })
+
+  // A trailing parameter size is not a minor version: the dash before it must
+  // survive as a space so `llama-3-70b` never collapses to "Llama 3.70b".
+  it('keeps parameter-size suffixes out of the version number', () => {
+    expect(displayModelName('llama-3-70b')).toBe('Llama 3 70b')
+    expect(displayModelName('qwen-2-72b')).toBe('Qwen 2 72b')
   })
 
   it('maps reasoning effort to compact labels', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -54,19 +54,26 @@ const VARIANT_TAGS: ReadonlyArray<readonly [RegExp, string]> = [
 const titleCase = (text: string): string => text.replace(/\b\w/g, char => char.toUpperCase()).trim()
 
 function prettifyBase(base: string): string {
-  if (/^claude-/i.test(base)) {
-    return titleCase(base.replace(/^claude-/i, '').replace(/-/g, ' '))
+  // A dash between digits is a version separator, so restore the dot the id
+  // dropped (opus-4-8 → opus 4.8, gemini-3-6 → gemini 3.6, gpt-5-5 → gpt 5.5).
+  // The lookahead protects parameter-size suffixes, where the trailing number
+  // is a size and not a minor version: llama-3-70b stays "Llama 3 70b", not
+  // "Llama 3.70b".
+  const versioned = base.replace(/(\d)-(\d{1,2})(?!\d*[bkm])/gi, '$1.$2')
+
+  if (/^claude-/i.test(versioned)) {
+    return titleCase(versioned.replace(/^claude-/i, '').replace(/-/g, ' '))
   }
 
-  if (/^gpt-/i.test(base)) {
-    return base.replace(/^gpt-/i, 'GPT-')
+  if (/^gpt-/i.test(versioned)) {
+    return versioned.replace(/^gpt-/i, 'GPT-')
   }
 
-  if (/^gemini-/i.test(base)) {
-    return base.replace(/^gemini-/i, 'Gemini ').replace(/-/g, ' ')
+  if (/^gemini-/i.test(versioned)) {
+    return titleCase(versioned.replace(/^gemini-/i, 'Gemini ').replace(/-/g, ' '))
   }
 
-  return titleCase(base.replace(/-/g, ' '))
+  return titleCase(versioned.replace(/-/g, ' '))
 }
 
 /** Split a model id into a clean display name plus an optional grayed variant


### PR DESCRIPTION
## Summary

Model IDs from OpenAI-compatible providers frequently use dashes where the canonical model name uses a dot (`gemini-3-6-flash`, `grok-4-5`, `gpt-5-5`). The desktop formatter (`prettifyBase` in `model-status-label.ts`) replaced every dash with a space, so the UI rendered **"Gemini 3 6 flash"** instead of **"Gemini 3.6 Flash"** — and the Gemini branch skipped title-casing entirely, leaving `flash` lowercase.

This affects any provider whose `/v1/models` returns dash-separated ids — including the bundled custom-provider path (a user-added OpenAI-compatible endpoint), not just third-party plugins.

## Changes

- **`model-status-label.ts`**: treat a dash *between digits* as a version separator and restore the dot (`opus-4-8` → `Opus 4.8`, `gemini-3-6` → `Gemini 3.6`, `gpt-5-5` → `GPT-5.5`). A lookahead protects parameter-size suffixes so `llama-3-70b` stays "Llama 3 70b" rather than collapsing to "Llama 3.70b". Title-case the Gemini branch for parity with the others.
- **`model-picker.tsx`**: route picker rows through the same `displayModelName` formatter so the full model picker, the composer menu, and the status bar all agree.
- **`model-status-label.test.ts`**: added coverage for dash-separated versions (Gemini/Qwen/GPT/Grok/Claude) and the parameter-size guard; corrected the date-pin expectations to the dotted form.

## Verification

- `npm run check:lint` — clean
- `npm run check:test:ui` — 342 files / 3047 tests pass, including the 13 model-status-label cases

## Example

| Model id | Before | After |
|---|---|---|
| `gemini-3-6-flash` | Gemini 3 6 flash | Gemini 3.6 Flash |
| `qwen3-7-plus` | Qwen3 7 Plus | Qwen3.7 Plus |
| `gpt-5-5` | GPT-5-5 | GPT-5.5 |
| `llama-3-70b` | Llama 3 70b | Llama 3 70b (unchanged — size suffix guarded) |
