### PR TITLE
a2a  : accept shared truthy aliases for A2A_ALLOW_ALL_USERS

### DIFF
--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -34,6 +34,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from utils import env_var_enabled
+
 logger = logging.getLogger(__name__)
 
 
@@ -160,7 +162,8 @@ def is_trusted_peer(identity: str) -> bool:
     otherwise any *authenticated* identity is allowed (authentication is the
     primary gate — the allow-list is an optional restriction on top).
     """
-    if os.getenv("A2A_ALLOW_ALL_USERS", "").strip().lower() in ("1", "true", "yes"):
+    # Shared TRUTHY aliases (1/true/yes/on) — previously omitted "on".
+    if env_var_enabled("A2A_ALLOW_ALL_USERS"):
         return True
     if localhost_only():
         return True

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -136,6 +136,19 @@ class TestTrustedPeers:
         monkeypatch.setenv("A2A_TRUSTED_PEERS", "alice")
         assert security.is_trusted_peer("mallory") is True
 
+    @pytest.mark.parametrize("raw", ["1", "yes", "on", "TRUE", " On "])
+    def test_allow_all_users_truthy_aliases(self, monkeypatch, raw):
+        monkeypatch.setenv("A2A_BEARER_TOKEN", "secret")
+        monkeypatch.setenv("A2A_ALLOW_ALL_USERS", raw)
+        monkeypatch.setenv("A2A_TRUSTED_PEERS", "alice")
+        assert security.is_trusted_peer("mallory") is True
+
+    def test_allow_all_users_off_keeps_allowlist(self, monkeypatch):
+        monkeypatch.setenv("A2A_BEARER_TOKEN", "secret")
+        monkeypatch.setenv("A2A_ALLOW_ALL_USERS", "off")
+        monkeypatch.setenv("A2A_TRUSTED_PEERS", "alice")
+        assert security.is_trusted_peer("mallory") is False
+
 
 class TestInjectionFilter:
     def test_chatml_defanged(self):


### PR DESCRIPTION
## Summary
- Parse `A2A_ALLOW_ALL_USERS` via `env_var_enabled` so aliases like `on` override a trusted-peer allow-list (previously only `1`/`true`/`yes`).
- Aligns A2A trust gating with the shared `TRUTHY_STRINGS` contract.
