### PR TITLE
fix blender hard locking mcp version by removing the explicit version.

### DIFF
--- a/optional-mcps/blender/manifest.yaml
+++ b/optional-mcps/blender/manifest.yaml
@@ -23,10 +23,12 @@ transport:
   # Pinned per catalog dependency policy: exact version, and the release must
   # be at least 2 weeks old at pin time (supply-chain cooldown — same rule as
   # pyproject.toml dependencies). 1.6.4 released 2026-06-11. The catalog never
-  # auto-updates; bumping the pin is a PR to this manifest.
+  # auto-updates; bumping the pin is a PR to this manifest. This has been
+  # modified by allowing agnostic versioning for the uvx package, which is 
+  # a Hermes dependency. i recommend to also look at `hermes mcp install 
+  # blender' because that has the 1.6.4 reference.
   args:
-    - "blender-mcp==1.6.4"
-  version: "1.6.4"
+    - "blender-mcp"
   env:
     # Upstream ships anonymous telemetry, on by default. Hermes policy is
     # no outbound telemetry without explicit opt-in, so the catalog entry


### PR DESCRIPTION
fixing the mcp versioning which was prior defined as 1.6.4, i left the comment in there in case this needs to be changed later.

regarding https://github.com/NousResearch/hermes-agent/blob/main/optional-mcps/blender/manifest.yaml

the version is hard locked to 1.6.4 in the manifest via the lines:

```yaml
  args:
    - "blender-mcp==1.6.4"
  version: "1.6.4"
```

after a friend ( @boraned ) and i thoroughly tested this yesterday with Blender 5.2.0 LTS (after it initially didn't work), we found the following lines to work in the `config.yaml` of hermes, correctly implementing support for https://github.com/ahujasid/blender-mcp and enabling us to establish an MCP connection with blender from hermes.

```yaml
  blender:
    command: uvx
    args:
      - blender-mcp
    env:
      DISABLE_TELEMETRY: 'true'
    enabled: true
```
the blender mcp implementation as configured via `hermes mcp install blender` is currently broken, and I highly recommend this more generalized, agnostic and robust change to allow for future versions, as forcing blender-mcp==1.6.4 does not work correctly as of now. *A small note: the uvx command automatically resolves the ip and port of blender-mcp, which is usually resolved to localhost:9876. For this reason, the ip and port do not need to be explicitly specified. You already do not do this, so that's correct. Additionally, as you probably already know `uvx -v blender-mcp --help` can be used to test the uvx connection directly in case you need to debug it.*
 