### PR TITLE
fix(gateway): keep skill slash menus when HERMES_HOME is a symlink

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -18,6 +18,7 @@ import subprocess
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from utils import is_truthy_value
@@ -845,6 +846,60 @@ _clamp_telegram_names = _clamp_command_names
 # Shared skill/plugin collection for gateway platforms
 # ---------------------------------------------------------------------------
 
+def _skill_path_variants(path: str | Path) -> list[Path]:
+    """Return lexical and resolved forms of a skill or scan-root path.
+
+    The skill scanner walks configured paths as written, so discovered
+    ``skill_md_path`` values retain symlink components (e.g.
+    ``~/.hermes -> /mnt/hermes``).  Callers that resolve roots must still
+    match those lexical paths — keep both forms: resolving fixes aliases
+    such as a symlinked ``HERMES_HOME``, and retaining the lexical form
+    preserves intentionally symlinked skills under a local root.
+    """
+    path = Path(path)
+    variants = [path]
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError):
+        pass
+    else:
+        if resolved != path:
+            variants.append(resolved)
+    return variants
+
+
+def _unique_skill_path_variants(*paths: str | Path) -> list[Path]:
+    """Expand *paths* to lexical+resolved variants, preserving order."""
+    roots: list[Path] = []
+    for path in paths:
+        for variant in _skill_path_variants(path):
+            if variant not in roots:
+                roots.append(variant)
+    return roots
+
+
+def _matching_skill_root(
+    path: str | Path,
+    roots: list[Path],
+) -> tuple[Path, Path] | None:
+    """Return ``(path_variant, root)`` if *path* lives under any *root*.
+
+    The returned pair shares a path form (lexical or resolved) so callers
+    can safely compute ``path_variant.relative_to(root)`` for category
+    derivation.  Returns ``None`` when no root matches.
+    """
+    for path_variant in _skill_path_variants(path):
+        for root in roots:
+            if path_variant.is_relative_to(root):
+                return path_variant, root
+    return None
+
+
+def _path_is_under_any(path: str | Path, roots: list[Path]) -> bool:
+    """True if any form of *path* is relative to any entry in *roots*."""
+    return _matching_skill_root(path, roots) is not None
+
+
 def _collect_gateway_skill_entries(
     platform: str,
     max_slots: int,
@@ -917,27 +972,22 @@ def _collect_gateway_skill_entries(
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
-        # Build set of allowed directory prefixes: local skills dir + any
-        # user-configured ``skills.external_dirs``. Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
-        # Without this widening, external skills are visible in
-        # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
-        # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
-        _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
+
+        # Keep lexical + resolved forms so symlink-aliased HERMES_HOME and
+        # intentionally symlinked skill dirs both pass the membership filter.
+        _allowed_roots = _unique_skill_path_variants(
+            SKILLS_DIR, *get_external_skills_dirs(),
         )
+        _hub_roots = _skill_path_variants(Path(SKILLS_DIR) / ".hub")
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
+            if not _path_is_under_any(skill_path, _allowed_roots):
                 continue
-            if skill_path.startswith(_hub_dir):
+            if _path_is_under_any(skill_path, _hub_roots):
                 continue
             skill_name = info.get("name", "")
             if skill_name in _platform_disabled:
@@ -1053,9 +1103,12 @@ def discord_skill_commands_by_category(
     the agent's ``/skill-name`` dispatch but silently absent from Discord's
     ``/skill`` autocomplete.
 
-    Filtering mirrors :func:`discord_skill_commands`: hub skills excluded,
-    per-platform disabled excluded, names clamped to 32 chars, descriptions
-    clamped to 100 chars.
+    Filtering mirrors :func:`discord_skill_commands` via the shared path
+    helpers (:func:`_matching_skill_root` / :func:`_path_is_under_any`):
+    hub skills excluded, per-platform disabled excluded, names clamped to
+    32 chars, descriptions clamped to 100 chars.  Symlinked ``HERMES_HOME``
+    and intentionally symlinked skill directories are accepted the same way as
+    the flat collector.
 
     The legacy 25-group × 25-subcommand caps (from the old nested
     ``/skill <cat> <name>`` layout) are **not** applied — the live caller
@@ -1074,8 +1127,6 @@ def discord_skill_commands_by_category(
         - *hidden_count*: skills dropped due to name clamp collisions
           against already-registered command names.
     """
-    from pathlib import Path as _P
-
     _platform_disabled: set[str] = set()
     try:
         from agent.skill_utils import get_disabled_skill_names
@@ -1099,20 +1150,16 @@ def discord_skill_commands_by_category(
         from agent.skill_utils import get_external_skills_dirs
         from tools.skills_tool import SKILLS_DIR
 
-        _skills_dir = SKILLS_DIR.resolve()
-        _hub_dir = (SKILLS_DIR / ".hub").resolve()
-        # Build list of (resolved_root, is_local) tuples. Each external dir
-        # becomes its own scan root for category derivation — a skill at
-        # ``<external>/mlops/foo/SKILL.md`` is still categorized as "mlops".
-        _scan_roots: list[_P] = [_skills_dir]
+        # Lexical + resolved variants of each scan root so category
+        # derivation stays consistent with the flat collector's filter.
+        # A skill at ``<external>/mlops/foo/SKILL.md`` is still
+        # categorized as "mlops".
         try:
-            for ext in get_external_skills_dirs():
-                try:
-                    _scan_roots.append(_P(ext).resolve())
-                except Exception:
-                    continue
+            _external_dirs = list(get_external_skills_dirs())
         except Exception:
-            pass
+            _external_dirs = []
+        _scan_roots = _unique_skill_path_variants(SKILLS_DIR, *_external_dirs)
+        _hub_roots = _skill_path_variants(Path(SKILLS_DIR) / ".hub")
         skill_cmds = get_skill_commands()
 
         for cmd_key in sorted(skill_cmds):
@@ -1120,23 +1167,16 @@ def discord_skill_commands_by_category(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            sp = _P(skill_path).resolve()
             # Hub skills are loaded via the skill hub, not surfaced as
             # slash commands.
-            if str(sp).startswith(str(_hub_dir)):
+            if _path_is_under_any(skill_path, _hub_roots):
                 continue
-            # Accept skill if it lives under any scan root; record the
-            # matching root so we can derive the category correctly.
-            matched_root: _P | None = None
-            for root in _scan_roots:
-                try:
-                    sp.relative_to(root)
-                except ValueError:
-                    continue
-                matched_root = root
-                break
-            if matched_root is None:
+            # Accept skill if it lives under any scan root; record a
+            # form-matched (path, root) pair so relative_to stays valid.
+            matched = _matching_skill_root(skill_path, _scan_roots)
+            if matched is None:
                 continue
+            sp, matched_root = matched
 
             skill_name = info.get("name", "")
             if skill_name in _platform_disabled:

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,8 @@
 """Tests for the central command registry and autocomplete."""
 
+from pathlib import Path
+
+import pytest
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -622,6 +625,81 @@ class TestDiscordSkillCmdKeyDispatch:
         assert len(name) <= _CMD_NAME_LIMIT, "Name should be clamped to 32 chars"
         assert key == cmd_key, (
             f"cmd_key must be the original /{long_name}, got {key!r}"
+        )
+
+    def test_skill_menu_handles_symlinked_hermes_home(self, tmp_path, monkeypatch):
+        """Skills remain visible when HERMES_HOME is a symlink.
+
+        ``scan_skill_commands`` preserves the configured lexical path, while
+        the gateway collectors also check resolved roots.  This is the actual
+        layout used when ``~/.hermes`` points at another filesystem.  Flat
+        Discord/Telegram menus and Discord ``/skill``-by-category must all
+        agree.
+        """
+        from unittest.mock import patch
+
+        import agent.skill_commands as skill_commands_module
+        import tools.skills_tool as skills_tool_module
+        from agent.skill_commands import scan_skill_commands
+        from hermes_cli.commands import discord_skill_commands_by_category
+
+        real_home = tmp_path / "external-drive" / "hermes"
+        skill_dir = real_home / "skills" / "symlink-visible-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: symlink-visible-skill\n"
+            "description: A skill behind a symlink.\n"
+            "---\n\n"
+            "# Symlink-visible skill\n"
+        )
+
+        linked_home = tmp_path / "home" / ".hermes"
+        linked_home.parent.mkdir()
+        try:
+            linked_home.symlink_to(real_home, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        linked_skills = linked_home / "skills"
+        monkeypatch.setenv("HERMES_HOME", str(linked_home))
+        # Keep this scan isolated from other tests in this subprocess.
+        monkeypatch.setattr(skill_commands_module, "_skill_commands", {})
+        monkeypatch.setattr(skill_commands_module, "_skill_commands_platform", None)
+
+        with (
+            patch.object(skills_tool_module, "SKILLS_DIR", linked_skills),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            discovered = scan_skill_commands()
+            skill_path = Path(discovered["/symlink-visible-skill"]["skill_md_path"])
+            assert skill_path == linked_skills / "symlink-visible-skill" / "SKILL.md"
+            assert skill_path.resolve() != skill_path
+
+            discord_entries, hidden = discord_skill_commands(
+                max_slots=100, reserved_names=set(),
+            )
+            telegram_entries, _ = telegram_menu_commands(max_commands=100)
+            categories, uncategorized, cat_hidden = discord_skill_commands_by_category(
+                reserved_names=set(),
+            )
+
+        assert hidden == 0
+        assert any(
+            name == "symlink-visible-skill" and key == "/symlink-visible-skill"
+            for name, _desc, key in discord_entries
+        )
+        assert any(name == "symlink_visible_skill" for name, _desc in telegram_entries)
+        # Root-level skill under the scan root → uncategorized in /skill picker.
+        assert cat_hidden == 0
+        assert any(
+            name == "symlink-visible-skill" and key == "/symlink-visible-skill"
+            for name, _desc, key in uncategorized
+        )
+        assert not any(
+            name == "symlink-visible-skill"
+            for entries in categories.values()
+            for name, _desc, _key in entries
         )
 
 


### PR DESCRIPTION
## Summary

- Gateway skill collectors compared scanner paths (lexical, may retain symlink components) only against resolved roots, so a symlinked `HERMES_HOME` (e.g. `~/.hermes -> /mnt/hermes`) dropped every skill from Telegram/Discord slash menus.
- Match skills with shared path helpers that accept both lexical and resolved forms (`is_relative_to`), including hub exclusion and `skills.external_dirs`.
- Use the same helpers in `discord_skill_commands_by_category` so Discord `/skill` autocomplete stays consistent with the flat Telegram/Discord menus.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_commands.py` (53 passed)
- [x] Regression: skill visible under symlinked `HERMES_HOME` for Discord flat menu, Telegram menu, and Discord `/skill` by-category
- [ ] Manual: set `HERMES_HOME` to a directory symlink, restart gateway, confirm skill slash commands appear on Telegram and Discord