### PR TITLE
feat(tts): add Xiaomi MiMo TTS provider plugin

### DIFF
--- a/plugins/tts/mimo/README.md
+++ b/plugins/tts/mimo/README.md
@@ -1,0 +1,86 @@
+# Xiaomi MiMo TTS plugin
+
+Text-to-speech backend for [Xiaomi MiMo-V2.5-TTS](https://platform.xiaomimimo.com/),
+implementing the `TTSProvider` plugin surface (issue #46257, hook from #30398).
+
+## Why a dedicated plugin
+
+MiMo-V2.5-TTS serves synthesis through the OpenAI-compatible
+`/v1/chat/completions` endpoint with an `audio` output parameter — not the
+standard `/v1/audio/speech` route — and returns base64 WAV in
+`choices[0].message.audio.data`. Swapping `base_url` on the built-in OpenAI
+TTS provider therefore cannot work; this plugin implements the dedicated
+request/response shape.
+
+## Setup
+
+1. Get an API key from <https://platform.xiaomimimo.com/> (TTS is
+   free during the limited-time promotion).
+2. Add it to `~/.hermes/.env` (or your environment):
+
+   ```bash
+   XIAOMI_API_KEY=<your key>
+   # Optional — defaults to https://api.xiaomimimo.com/v1.
+   # Token Plan users can point at their regional endpoint, e.g.
+   # XIAOMI_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1
+   ```
+
+   `MIMO_API_KEY` / `MIMO_BASE_URL` are accepted as fallback aliases.
+3. Select the provider in `~/.hermes/config.yaml`:
+
+   ```yaml
+   tts:
+     provider: mimo
+     voice: 冰糖        # optional; default: mimo_default (cluster choice)
+     # output_format: wav  # optional; default is mp3 (needs ffmpeg)
+   ```
+
+## Configuration reference
+
+| Setting | Source | Purpose |
+|---|---|---|
+| API key | `XIAOMI_API_KEY` (or `MIMO_API_KEY`) | Authentication |
+| Endpoint | `XIAOMI_BASE_URL` > `MIMO_BASE_URL` > `tts.mimo.base_url` | Global / Token Plan endpoint |
+| Voice | `tts.voice` | Any preset voice id (see below) |
+| Model | `tts.model` | Defaults to `mimo-v2.5-tts` |
+| Style | `MIMO_TTS_STYLE` env or `tts.mimo.style` | Natural-language delivery instruction |
+| Timeout | `MIMO_TTS_TIMEOUT` env or `tts.mimo.timeout` | Seconds, default 60 |
+| Text cap | `tts.mimo.max_text_length` | Overrides the 4000-char fallback |
+
+## Preset voices
+
+| Voice ID | Language | Gender |
+|---|---|---|
+| `mimo_default` | cluster-dependent (冰糖 on China clusters, Mia elsewhere) | — |
+| `冰糖` | Chinese | female |
+| `茉莉` | Chinese | female |
+| `苏打` | Chinese | male |
+| `白桦` | Chinese | male |
+| `Mia` | English | female |
+| `Chloe` | English | female |
+| `Milo` | English | male |
+| `Dean` | English | male |
+
+## Style control
+
+MiMo follows natural-language delivery instructions. Set one globally via
+`MIMO_TTS_STYLE` / `tts.mimo.style`; it is sent as the optional `user`
+message (never spoken). Inline audio tags also work inside the synthesized
+text, e.g. `(笑声)`, `[开心]`, `[语速加快]`.
+
+## Output formats and ffmpeg
+
+MiMo natively returns WAV. `format: wav` writes the decoded bytes
+directly; other formats (the dispatcher default is mp3) are converted with
+`ffmpeg`, which must be on `PATH`. `voice_compatible` is enabled, so
+gateway voice-bubble delivery converts to Opus through the existing
+pipeline.
+
+## Limitations
+
+- Preset-voice model only (`mimo-v2.5-tts`); `voicedesign` / `voiceclone`
+  are not exposed here.
+- No streaming (`stream()` falls back to whole-file `synthesize`).
+- The numeric `speed` parameter is ignored — control pace with style
+  instructions / tags instead.
+- Transient failures (429 / connection errors) get exactly one retry.

--- a/plugins/tts/mimo/__init__.py
+++ b/plugins/tts/mimo/__init__.py
@@ -1,0 +1,366 @@
+"""Xiaomi MiMo-V2.5 TTS backend (issue #46257).
+
+MiMo-V2.5-TTS exposes speech synthesis through the OpenAI-compatible
+``/v1/chat/completions`` endpoint with an ``audio`` output parameter —
+NOT the standard ``/v1/audio/speech`` route — so it cannot be served by
+the built-in OpenAI TTS provider with a swapped ``base_url``. This
+plugin implements the dedicated request/response shape as a
+:class:`~agent.tts_provider.TTSProvider`:
+
+- request: ``messages=[{user: style instruction (optional)},
+  {assistant: text to synthesize}]`` + ``audio={"format": "wav",
+  "voice": ...}``
+- response: ``choices[0].message.audio.data`` = base64-encoded WAV
+
+Style control is a MiMo strength: the optional ``user`` message accepts
+a natural-language delivery instruction (emotion, pace, role-play), and
+inline audio tags such as ``(笑声)`` / ``[开心]`` work inside the
+synthesized text itself. See the plugin README for details.
+
+Credentials / endpoint resolution (first hit wins):
+
+1. ``XIAOMI_API_KEY`` (env / secret scope) — official docs name
+2. ``MIMO_API_KEY`` — accepted as a fallback alias
+3. ``base_url``: ``XIAOMI_BASE_URL`` > ``MIMO_BASE_URL`` >
+   ``tts.mimo.base_url`` in config.yaml > the global endpoint
+
+Output formats: MiMo natively returns WAV. ``format="wav"`` writes the
+decoded bytes directly; other formats (mp3/ogg/opus/flac, the dispatcher
+default is mp3) are converted with ``ffmpeg``, which Hermes voice
+delivery paths already depend on.
+
+Limitations (documented in README): preset-voice model only
+(``mimo-v2.5-tts``); no voicedesign/voiceclone; no streaming (the
+dispatcher falls back to ``synthesize`` + whole-file read); the numeric
+``speed`` parameter is ignored — MiMo controls pace via style tags.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.secret_scope import get_secret
+from agent.tts_provider import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_BASE_URL = "https://api.xiaomimimo.com/v1"
+DEFAULT_MODEL = "mimo-v2.5-tts"
+# Cluster-dependent default voice on the MiMo side ("冰糖" on China
+# clusters, "Mia" elsewhere). Passing the explicit meta id keeps the
+# provider deterministic across endpoints.
+DEFAULT_VOICE = "mimo_default"
+DEFAULT_TIMEOUT_SECONDS = 60.0
+# Single retry on rate-limit / transient connection errors, matching the
+# transient-retry behaviour added for other TTS backends (#75441).
+_RETRY_DELAY_SECONDS = 1.0
+
+# Preset voices for mimo-v2.5-tts (official docs, 2026-08). Voice IDs
+# are literal — Chinese voice ids are Chinese characters.
+_VOICES: List[Dict[str, Any]] = [
+    {"id": "mimo_default", "display": "MiMo default (cluster-dependent)",
+     "language": "zh-CN/en-US", "gender": ""},
+    {"id": "冰糖", "display": "冰糖 — bright female (Chinese)",
+     "language": "zh-CN", "gender": "female"},
+    {"id": "茉莉", "display": "茉莉 — gentle female (Chinese)",
+     "language": "zh-CN", "gender": "female"},
+    {"id": "苏打", "display": "苏打 — clear male (Chinese)",
+     "language": "zh-CN", "gender": "male"},
+    {"id": "白桦", "display": "白桦 — deep male (Chinese)",
+     "language": "zh-CN", "gender": "male"},
+    {"id": "Mia", "display": "Mia — natural female (English)",
+     "language": "en-US", "gender": "female"},
+    {"id": "Chloe", "display": "Chloe — warm female (English)",
+     "language": "en-US", "gender": "female"},
+    {"id": "Milo", "display": "Milo — relaxed male (English)",
+     "language": "en-US", "gender": "male"},
+    {"id": "Dean", "display": "Dean — steady male (English)",
+     "language": "en-US", "gender": "male"},
+]
+
+
+class MiMoTTSError(RuntimeError):
+    """Raised for any MiMo TTS failure; the dispatcher converts it into
+    the standard ``{success: False, error: ...}`` envelope."""
+
+
+def _load_mimo_tts_config() -> Dict[str, Any]:
+    """Read ``tts.mimo`` from config.yaml (best-effort)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("tts") if isinstance(cfg, dict) else None
+        mimo = section.get("mimo") if isinstance(section, dict) else None
+        return mimo if isinstance(mimo, dict) else {}
+    except Exception as exc:  # noqa: BLE001 — config failure is non-fatal
+        logger.debug("Could not load tts.mimo config: %s", exc)
+        return {}
+
+
+def _resolve_api_key() -> str:
+    """Return the MiMo API key (XIAOMI_API_KEY, MIMO_API_KEY fallback)."""
+    key = (get_secret("XIAOMI_API_KEY", "") or "").strip()
+    if not key:
+        key = (get_secret("MIMO_API_KEY", "") or "").strip()
+    return key
+
+
+def _resolve_base_url(cfg: Dict[str, Any]) -> str:
+    for env_key in ("XIAOMI_BASE_URL", "MIMO_BASE_URL"):
+        value = os.environ.get(env_key, "").strip()
+        if value:
+            return value.rstrip("/")
+    cfg_value = cfg.get("base_url") if isinstance(cfg, dict) else None
+    if isinstance(cfg_value, str) and cfg_value.strip():
+        return cfg_value.strip().rstrip("/")
+    return DEFAULT_BASE_URL
+
+
+def _resolve_style(cfg: Dict[str, Any]) -> str:
+    """Natural-language style instruction for the optional user message."""
+    env_style = os.environ.get("MIMO_TTS_STYLE", "").strip()
+    if env_style:
+        return env_style
+    cfg_style = cfg.get("style") if isinstance(cfg, dict) else None
+    if isinstance(cfg_style, str) and cfg_style.strip():
+        return cfg_style.strip()
+    return ""
+
+
+def _resolve_timeout(cfg: Dict[str, Any]) -> float:
+    env_timeout = os.environ.get("MIMO_TTS_TIMEOUT", "").strip()
+    raw: Any = env_timeout or (cfg.get("timeout") if isinstance(cfg, dict) else None)
+    try:
+        value = float(raw)  # type: ignore[arg-type]
+        if value > 0:
+            return value
+    except (TypeError, ValueError):
+        pass
+    return DEFAULT_TIMEOUT_SECONDS
+
+
+def _extract_wav_bytes(response: Any) -> bytes:
+    """Pull base64 WAV out of a chat-completions response or raise."""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise MiMoTTSError(
+            "MiMo TTS returned no choices. Check the model id and that "
+            "your API key has access to mimo-v2.5-tts."
+        )
+    message = getattr(choices[0], "message", None)
+    audio = getattr(message, "audio", None) if message is not None else None
+    data = None
+    if isinstance(audio, dict):
+        data = audio.get("data")
+    else:
+        data = getattr(audio, "data", None)
+    if not data:
+        raise MiMoTTSError(
+            "MiMo TTS response contained no audio.data. The request may "
+            "have been rejected (rate limit, content filter, or model "
+            "unavailable) — check the provider logs."
+        )
+    try:
+        return base64.b64decode(data)
+    except Exception as exc:  # noqa: BLE001
+        raise MiMoTTSError(f"MiMo TTS returned undecodable audio data: {exc}") from exc
+
+
+def _convert_with_ffmpeg(wav_path: str, output_path: str) -> None:
+    """Convert WAV to the requested container format via ffmpeg."""
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise MiMoTTSError(
+            "MiMo TTS natively outputs WAV and ffmpeg was not found to "
+            "convert to the requested format. Install ffmpeg or set "
+            "tts.output_format: wav."
+        )
+    result = subprocess.run(
+        [ffmpeg, "-y", "-i", wav_path, output_path],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()[-500:]
+        raise MiMoTTSError(f"ffmpeg conversion for MiMo TTS failed: {stderr}")
+
+
+class MiMoTTSProvider(TTSProvider):
+    """Xiaomi MiMo-V2.5 TTS via chat/completions + audio output param."""
+
+    @property
+    def name(self) -> str:
+        return "mimo"
+
+    @property
+    def display_name(self) -> str:
+        return "Xiaomi MiMo"
+
+    @property
+    def voice_compatible(self) -> bool:
+        # WAV output is fine for voice-bubble delivery: the gateway's
+        # delivery pipeline converts to Opus via ffmpeg when needed.
+        return True
+
+    def is_available(self) -> bool:
+        try:
+            return bool(_resolve_api_key())
+        except Exception:  # noqa: BLE001 — must never raise
+            return False
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        return [dict(entry) for entry in _VOICES]
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": DEFAULT_MODEL,
+                "display": "MiMo-V2.5-TTS (preset voices)",
+                "languages": ["zh", "en"],
+            },
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def default_voice(self) -> Optional[str]:
+        return DEFAULT_VOICE
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Xiaomi MiMo",
+            "badge": "free (limited-time)",
+            "tag": "MiMo-V2.5-TTS — expressive Chinese/English voices",
+            "env_vars": [
+                {
+                    "key": "XIAOMI_API_KEY",
+                    "prompt": "Xiaomi MiMo API key",
+                    "url": "https://platform.xiaomimimo.com/",
+                },
+            ],
+        }
+
+    def synthesize(
+        self,
+        text: str,
+        output_path: str,
+        *,
+        voice: Optional[str] = None,
+        model: Optional[str] = None,
+        speed: Optional[float] = None,  # noqa: ARG002 — MiMo uses style tags
+        format: str = "mp3",
+        **extra: Any,
+    ) -> str:
+        text = (text or "").strip()
+        if not text:
+            raise MiMoTTSError("MiMo TTS received empty text.")
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            raise MiMoTTSError(
+                "XIAOMI_API_KEY (or MIMO_API_KEY) is not set. Get a key "
+                "at https://platform.xiaomimimo.com/ and add it to your "
+                ".env, or run `hermes tools` -> Text-to-Speech -> Xiaomi MiMo."
+            )
+
+        cfg = _load_mimo_tts_config()
+        base_url = _resolve_base_url(cfg)
+        style = _resolve_style(cfg)
+        timeout = _resolve_timeout(cfg)
+        model_id = (model or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+        voice_id = (voice or DEFAULT_VOICE).strip() or DEFAULT_VOICE
+
+        try:
+            import openai
+        except ImportError as exc:
+            raise MiMoTTSError(
+                "openai Python package is not installed (pip install openai)."
+            ) from exc
+
+        # Target text goes in the assistant message; the optional user
+        # message carries a natural-language style instruction (docs:
+        # user-role content is never spoken).
+        messages: List[Dict[str, str]] = []
+        if style:
+            messages.append({"role": "user", "content": style})
+        messages.append({"role": "assistant", "content": text})
+
+        client = openai.OpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+        try:
+            response = self._create_with_retry(
+                client,
+                model=model_id,
+                messages=messages,
+                audio={"format": "wav", "voice": voice_id},
+            )
+        except MiMoTTSError:
+            raise
+        except Exception as exc:
+            raise MiMoTTSError(
+                f"MiMo TTS request failed ({base_url}): {exc}"
+            ) from exc
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+
+        wav_bytes = _extract_wav_bytes(response)
+
+        fmt = (format or "mp3").strip().lower()
+        if fmt == "wav":
+            Path(output_path).write_bytes(wav_bytes)
+            return output_path
+
+        # Non-WAV target: write the native WAV to a temp file, then
+        # convert with ffmpeg (Hermes voice delivery already depends on it).
+        tmp_wav = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                tmp.write(wav_bytes)
+                tmp_wav = tmp.name
+            _convert_with_ffmpeg(tmp_wav, output_path)
+        finally:
+            if tmp_wav and os.path.exists(tmp_wav):
+                try:
+                    os.remove(tmp_wav)
+                except OSError:
+                    pass
+        return output_path
+
+    def _create_with_retry(self, client: Any, **kwargs: Any) -> Any:
+        """chat.completions.create with one retry on transient failures."""
+        import time
+
+        try:
+            return client.chat.completions.create(**kwargs)
+        except Exception as exc:
+            if not _is_transient(exc):
+                raise
+            logger.warning(
+                "MiMo TTS transient failure (%s); retrying once...", exc
+            )
+            time.sleep(_RETRY_DELAY_SECONDS)
+            return client.chat.completions.create(**kwargs)
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """True for rate limits and connection errors worth one retry."""
+    status = getattr(exc, "status_code", None)
+    if status == 429:
+        return True
+    name = type(exc).__name__
+    return name in {"RateLimitError", "APIConnectionError", "APITimeoutError"}
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire MiMoTTSProvider into the TTS registry."""
+    ctx.register_tts_provider(MiMoTTSProvider())

--- a/plugins/tts/mimo/plugin.yaml
+++ b/plugins/tts/mimo/plugin.yaml
@@ -1,0 +1,7 @@
+name: mimo-tts
+version: 1.0.0
+description: "Xiaomi MiMo-V2.5 TTS backend via OpenAI-compatible /v1/chat/completions with the audio output parameter (base64 WAV). Preset voices for Chinese and English."
+author: SHT
+kind: backend
+requires_env:
+  - XIAOMI_API_KEY

--- a/tests/hermes_cli/test_plugins_tts_registration.py
+++ b/tests/hermes_cli/test_plugins_tts_registration.py
@@ -109,10 +109,14 @@ class TestRegisterTTSProvider:
             mgr = PluginManager()
             mgr.discover_and_load()
 
-        # Plugin loaded (register returned normally), but registry empty.
+        # Plugin loaded (register returned normally), but the invalid
+        # entry produced no registry entry. Bundled TTS backends (e.g.
+        # plugins/tts/mimo) may auto-load during discovery, so assert on
+        # the invalid name rather than an empty registry.
         assert mgr._plugins["bad-tts-plugin"].enabled is True
         assert tts_registry.get_provider("not a provider") is None
-        assert tts_registry.list_providers() == []
+        registered_names = {getattr(p, "name", None) for p in tts_registry.list_providers()}
+        assert "not a provider" not in registered_names
         assert "does not inherit from TTSProvider" in caplog.text
 
         tts_registry._reset_for_tests()

--- a/tests/hermes_cli/test_tts_picker.py
+++ b/tests/hermes_cli/test_tts_picker.py
@@ -69,10 +69,12 @@ class TestPluginTTSProviders:
         ``display_name`` and ``name`` only."""
         tts_registry.register_provider(_FakeTTSProvider(name="minimal"))
         rows = tools_config._plugin_tts_providers()
-        assert len(rows) == 1
-        assert rows[0]["name"] == "Minimal"  # display_name default
-        assert rows[0]["tts_provider"] == "minimal"
-        assert rows[0]["env_vars"] == []
+        # Bundled TTS backends (e.g. plugins/tts/mimo) may also surface
+        # here; pin only the row this test registers.
+        minimal_rows = [r for r in rows if r.get("tts_provider") == "minimal"]
+        assert len(minimal_rows) == 1
+        assert minimal_rows[0]["name"] == "Minimal"  # display_name default
+        assert minimal_rows[0]["env_vars"] == []
 
 
 
@@ -94,8 +96,9 @@ class TestVisibleProvidersInjectsTTSPlugins:
 
         # Plugin row has tts_provider key for write-path compat
         plugin_rows = [r for r in visible if r.get("tts_plugin_name")]
-        assert len(plugin_rows) == 1
-        assert plugin_rows[0]["tts_provider"] == "cartesia"
+        cartesia_rows = [r for r in plugin_rows if r.get("tts_plugin_name") == "cartesia"]
+        assert len(cartesia_rows) == 1
+        assert cartesia_rows[0]["tts_provider"] == "cartesia"
 
     def test_other_categories_unaffected_by_tts_plugins(self):
         """Registering a TTS plugin must not leak into the Image Generation

--- a/tests/plugins/tts/test_mimo_tts.py
+++ b/tests/plugins/tts/test_mimo_tts.py
@@ -1,0 +1,301 @@
+"""Tests for the bundled Xiaomi MiMo TTS plugin (issue #46257).
+
+Covers the plugin-specific contracts the generic dispatcher tests
+(``tests/tools/test_tts_plugin_dispatch.py``) cannot reach:
+
+1. MiMo's chat/completions request shape — assistant text message,
+   optional user style message, ``audio={"format": "wav", "voice": ...}``
+2. base64 WAV extraction + format handling (wav written directly;
+   other formats converted via ffmpeg; missing ffmpeg raises)
+3. Error surfacing (missing API key, no choices, no audio.data)
+4. One retry on transient (429/connection) failures
+5. Bundled discovery end-to-end: plugin.yaml + register(ctx) wire the
+   provider into ``agent.tts_registry``
+
+No real network calls — the openai SDK client is faked.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import plugins.tts.mimo as mimo_plugin
+from plugins.tts.mimo import MiMoTTSError, MiMoTTSProvider
+
+_REPO_MIMO_PLUGIN_DIR = Path(__file__).resolve().parents[3] / "plugins" / "tts" / "mimo"
+
+_WAV_BYTES = b"RIFF\x24\x00\x00\x00WAVEfmt fake-mimo-audio"
+
+
+def _b64_wav() -> str:
+    return base64.b64encode(_WAV_BYTES).decode()
+
+
+def _fake_response(audio_data: Optional[str] = "sentinel") -> SimpleNamespace:
+    """Shape of an openai chat-completions response with audio output."""
+    if audio_data == "sentinel":
+        audio_data = _b64_wav()
+    audio: Any = {"data": audio_data} if audio_data is not None else {}
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(audio=audio))]
+    )
+
+
+class _FakeOpenAI:
+    """Stands in for ``openai.OpenAI`` inside the plugin."""
+
+    captured: Dict[str, Any] = {}
+    response: Any = None
+    exc: Optional[BaseException] = None
+    call_count: int = 0
+
+    def __init__(self, api_key=None, base_url=None, timeout=None):
+        _FakeOpenAI.captured["api_key"] = api_key
+        _FakeOpenAI.captured["base_url"] = base_url
+        _FakeOpenAI.captured["timeout"] = timeout
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create)
+        )
+
+    def _create(self, **kwargs):
+        _FakeOpenAI.call_count += 1
+        _FakeOpenAI.captured["kwargs"] = kwargs
+        if _FakeOpenAI.exc is not None and _FakeOpenAI.call_count == 1:
+            raise _FakeOpenAI.exc
+        return _FakeOpenAI.response
+
+    def close(self):
+        _FakeOpenAI.captured["closed"] = True
+
+
+@pytest.fixture(autouse=True)
+def _isolation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for key in (
+        "XIAOMI_API_KEY", "MIMO_API_KEY",
+        "XIAOMI_BASE_URL", "MIMO_BASE_URL",
+        "MIMO_TTS_STYLE", "MIMO_TTS_TIMEOUT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    _FakeOpenAI.captured = {}
+    _FakeOpenAI.response = _fake_response()
+    _FakeOpenAI.exc = None
+    _FakeOpenAI.call_count = 0
+    monkeypatch.setattr("openai.OpenAI", _FakeOpenAI)
+    yield
+
+
+@pytest.fixture
+def _key(monkeypatch):
+    monkeypatch.setenv("XIAOMI_API_KEY", "test-key")
+
+
+# ---------------------------------------------------------------------------
+# Request shape
+# ---------------------------------------------------------------------------
+
+
+class TestRequestShape:
+    def test_writes_wav_directly_with_defaults(self, _key, tmp_path):
+        out = tmp_path / "speech.wav"
+        result = MiMoTTSProvider().synthesize("hello", str(out), format="wav")
+
+        assert result == str(out)
+        assert out.read_bytes() == _WAV_BYTES
+        kwargs = _FakeOpenAI.captured["kwargs"]
+        assert kwargs["model"] == "mimo-v2.5-tts"
+        assert kwargs["audio"] == {"format": "wav", "voice": "mimo_default"}
+        # No style configured -> assistant message only (docs: user-role
+        # content is never spoken, so omit it entirely when unused).
+        assert kwargs["messages"] == [{"role": "assistant", "content": "hello"}]
+
+    def test_voice_model_and_style_passthrough(self, _key, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIMO_TTS_STYLE", "Warm and upbeat")
+        out = tmp_path / "speech.wav"
+        MiMoTTSProvider().synthesize(
+            "hi there", str(out), voice="Chloe", model="mimo-v2.5-tts", format="wav"
+        )
+        kwargs = _FakeOpenAI.captured["kwargs"]
+        assert kwargs["audio"]["voice"] == "Chloe"
+        assert kwargs["messages"][0] == {"role": "user", "content": "Warm and upbeat"}
+        assert kwargs["messages"][1] == {"role": "assistant", "content": "hi there"}
+
+    def test_base_url_and_key_resolution(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIMO_API_KEY", "fallback-key")
+        monkeypatch.setenv("XIAOMI_BASE_URL", "https://token-plan-sgp.xiaomimimo.com/v1/")
+        out = tmp_path / "speech.wav"
+        MiMoTTSProvider().synthesize("hi", str(out), format="wav")
+        assert _FakeOpenAI.captured["api_key"] == "fallback-key"
+        # Trailing slash stripped.
+        assert _FakeOpenAI.captured["base_url"] == (
+            "https://token-plan-sgp.xiaomimimo.com/v1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Output format handling
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormats:
+    def test_mp3_triggers_ffmpeg_conversion(self, _key, tmp_path, monkeypatch):
+        calls: List[List[str]] = []
+
+        monkeypatch.setattr(mimo_plugin.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            # Simulate ffmpeg writing the target file.
+            Path(cmd[-1]).write_bytes(b"ID3fake-mp3")
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(mimo_plugin.subprocess, "run", _fake_run)
+
+        out = tmp_path / "speech.mp3"
+        result = MiMoTTSProvider().synthesize("hello", str(out), format="mp3")
+        assert result == str(out)
+        assert out.read_bytes() == b"ID3fake-mp3"
+        assert len(calls) == 1
+        assert calls[0][0] == "/usr/bin/ffmpeg"
+        assert calls[0][-1] == str(out)
+        # Input is a temp WAV that must have been cleaned up.
+        wav_input = calls[0][calls[0].index("-i") + 1]
+        assert wav_input.endswith(".wav")
+        assert not Path(wav_input).exists()
+
+    def test_mp3_without_ffmpeg_raises(self, _key, tmp_path, monkeypatch):
+        monkeypatch.setattr(mimo_plugin.shutil, "which", lambda name: None)
+        with pytest.raises(MiMoTTSError, match="ffmpeg"):
+            MiMoTTSProvider().synthesize("hello", str(tmp_path / "o.mp3"), format="mp3")
+
+    def test_ffmpeg_failure_raises_with_stderr(self, _key, tmp_path, monkeypatch):
+        monkeypatch.setattr(mimo_plugin.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(
+            mimo_plugin.subprocess, "run",
+            lambda cmd, **kw: SimpleNamespace(returncode=1, stderr="codec exploded"),
+        )
+        with pytest.raises(MiMoTTSError, match="codec exploded"):
+            MiMoTTSProvider().synthesize("hello", str(tmp_path / "o.ogg"), format="ogg")
+
+
+# ---------------------------------------------------------------------------
+# Error surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_missing_api_key_raises_with_guidance(self, tmp_path):
+        assert MiMoTTSProvider().is_available() is False
+        with pytest.raises(MiMoTTSError, match="XIAOMI_API_KEY"):
+            MiMoTTSProvider().synthesize("hello", str(tmp_path / "o.wav"), format="wav")
+
+    def test_empty_text_raises(self, _key, tmp_path):
+        with pytest.raises(MiMoTTSError, match="empty"):
+            MiMoTTSProvider().synthesize("   ", str(tmp_path / "o.wav"), format="wav")
+
+    def test_no_choices_raises(self, _key, tmp_path):
+        _FakeOpenAI.response = SimpleNamespace(choices=[])
+        with pytest.raises(MiMoTTSError, match="no choices"):
+            MiMoTTSProvider().synthesize("hello", str(tmp_path / "o.wav"), format="wav")
+
+    def test_missing_audio_data_raises(self, _key, tmp_path):
+        _FakeOpenAI.response = _fake_response(audio_data=None)
+        with pytest.raises(MiMoTTSError, match="audio.data"):
+            MiMoTTSProvider().synthesize("hello", str(tmp_path / "o.wav"), format="wav")
+
+    def test_undecodable_audio_raises(self, _key, tmp_path):
+        _FakeOpenAI.response = _fake_response(audio_data="!!!not-base64!!!")
+        with pytest.raises(MiMoTTSError, match="undecodable"):
+            MiMoTTSProvider().synthesize("hello", str(tmp_path / "o.wav"), format="wav")
+
+
+# ---------------------------------------------------------------------------
+# Transient retry
+# ---------------------------------------------------------------------------
+
+
+class TestTransientRetry:
+    def test_429_retried_once_then_succeeds(self, _key, tmp_path, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda seconds: None)
+        _FakeOpenAI.exc = type("RateLimit", (Exception,), {})(
+            "429 rate limited"
+        )
+        _FakeOpenAI.exc.status_code = 429  # type: ignore[attr-defined]
+
+        out = tmp_path / "speech.wav"
+        MiMoTTSProvider().synthesize("hello", str(out), format="wav")
+        assert _FakeOpenAI.call_count == 2
+        assert out.read_bytes() == _WAV_BYTES
+
+    def test_non_transient_error_not_retried(self, _key, tmp_path, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda seconds: None)
+        _FakeOpenAI.exc = type("Auth", (Exception,), {})("401 invalid key")
+        _FakeOpenAI.exc.status_code = 401  # type: ignore[attr-defined]
+
+        with pytest.raises(MiMoTTSError, match="failed"):
+            MiMoTTSProvider().synthesize(
+                "hello", str(tmp_path / "o.wav"), format="wav"
+            )
+        assert _FakeOpenAI.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Catalog surface
+# ---------------------------------------------------------------------------
+
+
+class TestCatalog:
+    def test_list_voices_covers_documented_presets(self):
+        ids = {voice["id"] for voice in MiMoTTSProvider().list_voices()}
+        assert {"mimo_default", "冰糖", "茉莉", "苏打", "白桦",
+                "Mia", "Chloe", "Milo", "Dean"} <= ids
+
+    def test_setup_schema_prompts_for_key(self):
+        schema = MiMoTTSProvider().get_setup_schema()
+        assert schema["env_vars"][0]["key"] == "XIAOMI_API_KEY"
+
+    def test_voice_compatible_for_voice_bubbles(self):
+        assert MiMoTTSProvider().voice_compatible is True
+
+
+# ---------------------------------------------------------------------------
+# Bundled discovery end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestBundledDiscovery:
+    def test_plugin_registers_via_plugin_manager(self, tmp_path, monkeypatch):
+        """Copy the shipped plugin into an isolated bundled dir, run real
+        discovery, assert the provider lands in the TTS registry."""
+        from agent import tts_registry
+        from hermes_cli.plugins import PluginManager
+
+        tts_registry._reset_for_tests()
+        try:
+            bundled = tmp_path / "bundled"
+            (bundled / "tts").mkdir(parents=True)
+            shutil.copytree(_REPO_MIMO_PLUGIN_DIR, bundled / "tts" / "mimo")
+            monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+            loaded = mgr._plugins.get("tts/mimo")
+            assert loaded is not None, "bundled mimo TTS plugin not discovered"
+            assert loaded.enabled, f"plugin failed to load: {loaded.error}"
+            provider = tts_registry.get_provider("mimo")
+            assert provider is not None
+            # The loader imports plugin modules under its own namespace
+            # (hermes_plugins.*), so assert the behavioural contract
+            # instead of class identity.
+            assert type(provider).__name__ == "MiMoTTSProvider"
+            assert provider.name == "mimo"
+            assert provider.voice_compatible is True
+        finally:
+            tts_registry._reset_for_tests()


### PR DESCRIPTION
## What does this PR do?

Adds Xiaomi MiMo-V2.5 TTS as a standalone `TTSProvider` plugin (`plugins/tts/mimo/`, `kind: backend`, selected via `tts.provider: mimo`).

MiMo-V2.5-TTS serves synthesis through the OpenAI-compatible `/v1/chat/completions` endpoint with an `audio` output parameter — **not** the standard `/v1/audio/speech` route — and returns base64 WAV in `choices[0].message.audio.data`. The built-in OpenAI TTS provider cannot serve it by swapping `base_url`, so this PR implements the dedicated request/response shape as a plugin, following the plugin direction recorded in the #46257 triage (hook from #30398) and superseding the in-tree built-in approach of #2882 (which predates the plugin surface and has merge conflicts).

Features:

- 9 preset voices (Chinese: 冰糖/茉莉/苏打/白桦, English: Mia/Chloe/Milo/Dean, plus cluster-default `mimo_default`)
- Natural-language style instructions via `MIMO_TTS_STYLE` env or `tts.mimo.style` (sent as the optional `user` message, never spoken)
- Configurable endpoint: `XIAOMI_BASE_URL` > `MIMO_BASE_URL` > `tts.mimo.base_url` > global default — works with both the global API and Token Plan endpoints
- Native WAV output; other formats (dispatcher default is mp3) converted via ffmpeg; `voice_compatible=True` so gateway voice-bubble delivery converts to Opus through the existing pipeline
- One retry on transient failures (429 / connection / timeout), matching the pattern from #75441

Scope: preset-voice TTS (`mimo-v2.5-tts`) only. The ASR part of #46257 stays open for the explicit maintainer decision (#42068 already prototypes the plugin route there); voicedesign / voiceclone / streaming can be follow-ups.

## Related Issue

Partially addresses #46257 (TTS part). Supersedes #2882.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] 🧪 Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `plugins/tts/mimo/plugin.yaml` — manifest (`kind: backend`, `requires_env: XIAOMI_API_KEY`)
- `plugins/tts/mimo/__init__.py` — `MiMoTTSProvider` + `register(ctx)` entry point
- `plugins/tts/mimo/README.md` — setup, configuration reference, voice table, style control, limitations
- `tests/plugins/tts/test_mimo_tts.py` — 17 new tests (request shape, format handling, error surfacing, transient retry, catalog, bundled-discovery end-to-end)
- `tests/hermes_cli/test_plugins_tts_registration.py` — registry assertion now tolerates bundled TTS backends auto-loading during discovery (previously assumed an empty registry)
- `tests/hermes_cli/test_tts_picker.py` — picker-row assertions pin the registered fake provider instead of exact row counts (bundled backends legitimately add rows)

## How to Test

1. Set `XIAOMI_API_KEY` in `~/.hermes/.env` (free at <https://platform.xiaomimimo.com/>); optionally `XIAOMI_BASE_URL` for Token Plan endpoints
2. Add to `~/.hermes/config.yaml`: `tts: {provider: mimo, voice: 冰糖}`
3. In `hermes chat`, ask the agent to send a voice message (or otherwise invoke `text_to_speech`)
4. Verify audio is produced; for non-wav formats `ffmpeg` must be on PATH

Verified end-to-end against the live MiMo API (Token Plan sgp endpoint) on WSL2, running this branch's bundled discovery + `tts_tool` dispatch path:

```
plugin discovered: True | enabled: True
registry provider: MiMoTTSProvider | is_available: True
OK [zh wav default voice] -> 176,684 bytes, 3.68s
OK [zh mp3 voice=冰糖]    -> 10,700 bytes, 2.62s (ffmpeg conversion)
OK [en mp3 voice=Chloe]   -> 15,212 bytes, 3.74s
OK [style instruction]    -> 84,524 bytes, 1.76s
voice bubble WAV->Opus    -> 14,570 bytes, 3.69s (libopus, mono, 16 kHz, 32k)
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commits follow the Conventional Commits specification
- [x] I have searched existing PRs and confirmed this is not a duplicate
- [x] This PR contains only relevant changes
- [x] `pytest tests/ -q` passes locally — 17 new tests + all 67 tests across `tests/plugins/tts`, `tests/tools/test_tts_plugin_dispatch.py`, `tests/hermes_cli/test_plugins_tts_registration.py`, `tests/hermes_cli/test_tts_picker.py`, `tests/agent/test_tts_registry.py` pass. (The wider `tests/plugins` suite has pre-existing failures in my Windows environment that I verified also fail on clean `upstream/main` without my changes.)
- [x] I have added tests that verify my changes
- [x] I have tested this on my platform: Windows 11 (unit tests) and WSL2 (real-API end-to-end)

### Documentation & Housekeeping

- [x] I have updated the documentation accordingly — `plugins/tts/mimo/README.md`
- [ ] I have updated `cli-config.yaml.example` — N/A: the example file has no existing `tts:` section; plugin configuration is documented in the plugin README
- [ ] I have updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I have considered cross-platform impact — POSIX/Windows safe (`shutil.which` for ffmpeg, `pathlib`, no shell=True)
- [ ] I have updated tool descriptions/schemas — N/A: plugin provider, no tool schema change

## Screenshots / Logs

See the end-to-end verification output above.
