### PR TITLE
fix(cli): prevent fork update prompts from blocking unattended runs

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1426,15 +1426,16 @@ def _is_fork(origin_url: Optional[str]) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
         return False
-    # Normalize URL for comparison (strip trailing .git if present)
-    normalized = origin_url.rstrip("/")
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
+
+    def _normalize_repo_url(url: str) -> str:
+        normalized = url.rstrip("/").casefold()
+        if normalized.endswith(".git"):
+            normalized = normalized[:-4]
+        return normalized
+
+    normalized = _normalize_repo_url(origin_url)
     for official in OFFICIAL_REPO_URLS:
-        official_normalized = official.rstrip("/")
-        if official_normalized.endswith(".git"):
-            official_normalized = official_normalized[:-4]
-        if normalized == official_normalized:
+        if normalized == _normalize_repo_url(official):
             return False
     return True
 
@@ -1510,7 +1511,13 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
     except Exception:
         return False
 
-def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
+def _sync_with_upstream_if_needed(
+    git_cmd: list[str],
+    cwd: Path,
+    *,
+    assume_yes: bool = False,
+    input_fn=None,
+) -> None:
     """Check if fork is behind upstream and sync if safe.
 
     This implements the fork upstream sync logic:
@@ -1531,13 +1538,24 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         print("ℹ Your fork is not tracking the official Hermes repository.")
         print("  This means you may miss updates from NousResearch/hermes-agent.")
         print()
-        try:
-            response = (
-                input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
+        prompt = "Add official repo as 'upstream' remote? [Y/n]:"
+        if assume_yes:
+            response = "y"
+        elif input_fn is not None:
+            gateway_prompt = "Add official repo as 'upstream' remote? [y/N]:"
+            response = input_fn(gateway_prompt, "n").strip().lower()
+        elif not (sys.stdin.isatty() and sys.stdout.isatty()):
+            print(
+                "  Skipping upstream setup in a non-interactive session. "
+                "Run again with --yes to add it automatically."
             )
-        except (EOFError, KeyboardInterrupt):
-            print()
-            response = "n"
+            return
+        else:
+            try:
+                response = input(f"{prompt} ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                response = "n"
 
         if response in {"", "y", "yes"}:
             print("→ Adding upstream remote...")
@@ -3838,7 +3856,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             # Even if origin is up to date, the fork may be behind upstream
             if is_fork and branch == "main":
-                _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
+                _m()._sync_with_upstream_if_needed(
+                    git_cmd,
+                    _m().PROJECT_ROOT,
+                    assume_yes=assume_yes,
+                    input_fn=gw_input_fn,
+                )
 
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:
@@ -4062,7 +4085,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
-            _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
+            _m()._sync_with_upstream_if_needed(
+                git_cmd,
+                _m().PROJECT_ROOT,
+                assume_yes=assume_yes,
+                input_fn=gw_input_fn,
+            )
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
         # breaks on this machine, keep base deps and reinstall the remaining extras

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -198,6 +198,138 @@ class TestCmdUpdateTermuxUvBootstrap:
         mock_run.assert_not_called()
 
 
+class TestForkDetection:
+    """Official GitHub URL spelling must not turn the checkout into a fork."""
+
+    @pytest.mark.parametrize(
+        "origin_url",
+        [
+            "https://github.com/nousresearch/hermes-agent",
+            "https://GITHUB.COM/NousResearch/Hermes-Agent.GIT/",
+            "git@github.com:nousresearch/hermes-agent.git",
+        ],
+    )
+    def test_official_repo_urls_are_case_insensitive(self, origin_url):
+        from hermes_cli import main as hm
+
+        assert hm._is_fork(origin_url) is False
+
+    def test_other_owner_is_still_a_fork(self):
+        from hermes_cli import main as hm
+
+        assert hm._is_fork("https://github.com/example/hermes-agent.git") is True
+
+
+class TestForkUpstreamPrompt:
+    """Fork setup follows the update command's interaction mode."""
+
+    def test_assume_yes_adds_upstream_without_reading_stdin(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        with patch.object(
+            update_cmd, "_has_upstream_remote", return_value=False
+        ), patch.object(
+            update_cmd, "_should_skip_upstream_prompt", return_value=False
+        ), patch.object(
+            update_cmd, "_add_upstream_remote", return_value=False
+        ) as add_upstream, patch("builtins.input") as terminal_input:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], tmp_path, assume_yes=True
+            )
+
+        terminal_input.assert_not_called()
+        add_upstream.assert_called_once_with(["git"], tmp_path)
+
+    def test_skip_marker_wins_over_assume_yes(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        with patch.object(
+            update_cmd, "_has_upstream_remote", return_value=False
+        ), patch.object(
+            update_cmd, "_should_skip_upstream_prompt", return_value=True
+        ), patch.object(update_cmd, "_add_upstream_remote") as add_upstream, patch(
+            "builtins.input"
+        ) as terminal_input:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], tmp_path, assume_yes=True
+            )
+
+        terminal_input.assert_not_called()
+        add_upstream.assert_not_called()
+
+    def test_non_interactive_update_skips_without_persisting_decline(
+        self, tmp_path, capsys
+    ):
+        from hermes_cli import update_cmd
+
+        with patch.object(
+            update_cmd, "_has_upstream_remote", return_value=False
+        ), patch.object(
+            update_cmd, "_should_skip_upstream_prompt", return_value=False
+        ), patch.object(update_cmd, "_add_upstream_remote") as add_upstream, patch.object(
+            update_cmd, "_mark_skip_upstream_prompt"
+        ) as mark_skip, patch.object(
+            update_cmd.sys.stdin, "isatty", return_value=False
+        ), patch.object(
+            update_cmd.sys.stdout, "isatty", return_value=False
+        ), patch(
+            "builtins.input"
+        ) as terminal_input:
+            update_cmd._sync_with_upstream_if_needed(["git"], tmp_path)
+
+        terminal_input.assert_not_called()
+        add_upstream.assert_not_called()
+        mark_skip.assert_not_called()
+        assert "non-interactive session" in capsys.readouterr().out
+
+    def test_gateway_input_callback_handles_prompt(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        prompts = []
+
+        def gateway_input(prompt, default):
+            prompts.append((prompt, default))
+            return "n"
+
+        with patch.object(
+            update_cmd, "_has_upstream_remote", return_value=False
+        ), patch.object(
+            update_cmd, "_should_skip_upstream_prompt", return_value=False
+        ), patch.object(
+            update_cmd, "_mark_skip_upstream_prompt"
+        ) as mark_skip, patch("builtins.input") as terminal_input:
+            update_cmd._sync_with_upstream_if_needed(
+                ["git"], tmp_path, input_fn=gateway_input
+            )
+
+        assert prompts == [("Add official repo as 'upstream' remote? [y/N]:", "n")]
+        terminal_input.assert_not_called()
+        mark_skip.assert_called_once_with()
+
+    def test_interactive_decline_keeps_existing_skip_behavior(self, tmp_path):
+        from hermes_cli import update_cmd
+
+        with patch.object(
+            update_cmd, "_has_upstream_remote", return_value=False
+        ), patch.object(
+            update_cmd, "_should_skip_upstream_prompt", return_value=False
+        ), patch.object(
+            update_cmd, "_mark_skip_upstream_prompt"
+        ) as mark_skip, patch.object(
+            update_cmd.sys.stdin, "isatty", return_value=True
+        ), patch.object(
+            update_cmd.sys.stdout, "isatty", return_value=True
+        ), patch(
+            "builtins.input", return_value="n"
+        ) as terminal_input:
+            update_cmd._sync_with_upstream_if_needed(["git"], tmp_path)
+
+        terminal_input.assert_called_once_with(
+            "Add official repo as 'upstream' remote? [Y/n]: "
+        )
+        mark_skip.assert_called_once_with()
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 
@@ -230,9 +362,49 @@ class TestCmdUpdateBranchFallback:
         expected_git_cmd = (
             ["git", "-c", "windows.appendAtomically=false"] if hm._is_windows() else ["git"]
         )
-        sync_mock.assert_called_once_with(expected_git_cmd, PROJECT_ROOT)
+        sync_mock.assert_called_once_with(
+            expected_git_cmd,
+            PROJECT_ROOT,
+            assume_yes=False,
+            input_fn=None,
+        )
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_gateway_update_passes_gateway_prompt_to_fork_sync(
+        self, mock_run, _mock_which, capsys
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+        args = SimpleNamespace(gateway=True)
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed") as sync_mock:
+            cmd_update(args)
+
+        expected_git_cmd = (
+            ["git", "-c", "windows.appendAtomically=false"]
+            if hm._is_windows()
+            else ["git"]
+        )
+        sync_mock.assert_called_once()
+        assert sync_mock.call_args.args == (expected_git_cmd, PROJECT_ROOT)
+        assert sync_mock.call_args.kwargs["assume_yes"] is False
+        gateway_input = sync_mock.call_args.kwargs["input_fn"]
+        assert callable(gateway_input)
+
+        with patch("hermes_cli.update_cmd._gateway_prompt", return_value="n") as prompt:
+            assert gateway_input("Question?", "n") == "n"
+        prompt.assert_called_once_with("Question?", "n")
+        assert "Already up to date!" in capsys.readouterr().out
 
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -50,6 +50,42 @@ def _make_run_side_effect(
 class TestUpdateYesConfigMigration:
     """--yes auto-answers the config-migration prompt and skips API-key prompts."""
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_yes_is_forwarded_to_fork_sync_without_input(
+        self, mock_run, _mock_which
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+        args = SimpleNamespace(yes=True)
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(
+            hm, "_sync_with_upstream_if_needed"
+        ) as sync_mock, patch(
+            "builtins.input"
+        ) as terminal_input:
+            cmd_update(args)
+
+        expected_git_cmd = (
+            ["git", "-c", "windows.appendAtomically=false"]
+            if hm._is_windows()
+            else ["git"]
+        )
+        sync_mock.assert_called_once_with(
+            expected_git_cmd,
+            hm.PROJECT_ROOT,
+            assume_yes=True,
+            input_fn=None,
+        )
+        terminal_input.assert_not_called()
+
     @patch("hermes_cli.config.migrate_config")
     @patch("hermes_cli.config.check_config_version", return_value=(1, 2))
     @patch("hermes_cli.config.get_missing_config_fields", return_value=[])
@@ -134,4 +170,3 @@ class TestUpdateYesConfigMigration:
 
 class TestUpdateYesStashRestore:
     """--yes auto-restores the pre-update autostash without prompting."""
-


### PR DESCRIPTION
## Related Issue

Fixes #60240

## What does this PR do?

`hermes update` compared official repository URLs case-sensitively. A lowercase or mixed-case GitHub URL could therefore be treated as a fork. The fork setup prompt also called terminal input directly, so `--yes` and gateway updates could still wait for a response.

This change normalizes URL case, a trailing slash, and the `.git` suffix before comparison. It also makes fork setup follow the update command's existing interaction mode:

- `--yes` adds the official `upstream` remote without reading stdin.
- Gateway updates use the existing IPC prompt callback.
- Other non-interactive updates print a clear message and skip setup without saving a permanent decline.
- Existing interactive accept/decline behavior and the skip marker stay unchanged.

PR #68959 overlaps with the URL spelling part and covers additional remote formats, but it explicitly leaves the upstream sync interaction unchanged. This PR addresses the unattended prompt reported in #60240 as well as its case-sensitivity regression.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Compare official HTTPS and SSH repository URLs without case sensitivity after removing optional URL suffixes.
- Add internal `assume_yes` and `input_fn` options to fork upstream setup.
- Pass the same interaction state from both fork sync call sites.
- Add regression coverage for URL spelling, `--yes`, gateway IPC, non-TTY sessions, interactive decline, and existing skip markers.

## How to Test

The new focused tests failed before the implementation because official lowercase URLs were classified as forks, the fork helper did not accept the interaction options, and non-TTY updates still called `input()`.

Verification run with the project virtual environment on macOS arm64:

```bash
python -m pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_yes_flag.py -q
# 34 passed

uvx --from ruff==0.15.10 ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_yes_flag.py
# All checks passed!

git diff --check origin/main...HEAD
```

`python -m pytest tests/ -q --maxfail=1` stops at the unrelated `tests/agent/lsp/test_client_e2e.py::test_client_lifecycle_clean` live-system guard failure after 145 tests pass. The same failure was reproduced in a clean `origin/main` worktree at `42708f8bb`, so this PR leaves it unchanged. A full unrestricted run was also attempted, but that baseline LSP failure led to cascading logging/thread errors, so the full suite is not claimed as passing.

The Windows footgun scan reports the same six existing bare-encoding findings in `tests/hermes_cli/test_cmd_update.py` on this branch and clean `origin/main`; none are on lines added by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and documented the partial overlap above
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for the bug fix
- [x] I've tested on macOS arm64 with focused pytest

### Documentation & Housekeeping

- [x] User documentation is N/A; no public command or setting changed
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; non-TTY behavior and existing Windows findings were checked
- [x] Tool descriptions and schemas are N/A; no model-facing tool contract changed
