### PR TITLE
fix(desktop): canonicalize brand casing and variant tokens in model labels

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -137,7 +137,7 @@ describe('ModelMenuPanel current selection', () => {
     const { content } = renderPanel()
 
     const currentRow = (await content.findByText(/Gemini 3\.1 Pro/i)).closest('[role="menuitem"]')
-    const staleRow = content.getByText('Deepseek Chat').closest('[role="menuitem"]')
+    const staleRow = content.getByText('DeepSeek Chat').closest('[role="menuitem"]')
 
     expect(currentRow?.querySelector('.codicon-check')).not.toBeNull()
     expect(staleRow?.querySelector('.codicon-check')).toBeNull()
@@ -159,7 +159,7 @@ describe('ModelMenuPanel search', () => {
     $currentModel.set('deepseek-v4-pro')
     const { content } = renderPanel()
 
-    await content.findByText(/Deepseek V4 Pro/i)
+    await content.findByText(/DeepSeek V4 Pro/i)
 
     const input = screen.getByRole('textbox', { name: 'Search models' })
     fireEvent.change(input, { target: { value: 'gemini' } })
@@ -167,7 +167,7 @@ describe('ModelMenuPanel search', () => {
     await vi.waitFor(() => {
       expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
     })
-    expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
+    expect(rowWithText(content, /DeepSeek V4 Pro/i)).toBeNull()
   })
 
   it('Enter in the search field commits the first match', async () => {
@@ -271,8 +271,8 @@ describe('ModelMenuPanel provider collapse', () => {
     const { content } = renderPanel()
 
     await content.findByText('DeepSeek')
-    expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
-    expect(content.queryByText('Deepseek Chat')).not.toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).not.toBeNull()
+    expect(content.queryByText('DeepSeek Chat')).not.toBeNull()
   })
 
   it('collapses provider models when header is clicked', async () => {
@@ -282,7 +282,7 @@ describe('ModelMenuPanel provider collapse', () => {
     fireEvent.click(header)
 
     // Models should disappear but header stays
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
     expect(content.queryByText('DeepSeek')).not.toBeNull()
   })
 
@@ -292,11 +292,11 @@ describe('ModelMenuPanel provider collapse', () => {
     const header = await content.findByText('DeepSeek')
     // Collapse
     fireEvent.click(header)
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
     // Expand
     fireEvent.click(header)
     await vi.waitFor(() => {
-      expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
+      expect(content.queryByText('DeepSeek V4 Pro')).not.toBeNull()
     })
   })
 
@@ -311,7 +311,7 @@ describe('ModelMenuPanel provider collapse', () => {
     // The current provider is collapsible like any other — clicking its header
     // hides its models rather than forcing them to stay open.
     await vi.waitFor(() => {
-      expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+      expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
     })
   })
 
@@ -320,7 +320,7 @@ describe('ModelMenuPanel provider collapse', () => {
 
     const header = await content.findByText('DeepSeek')
     fireEvent.click(header)
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
 
     // Type in the search bar (auto-focused by DropdownMenuSearch)
     const input = screen.getByRole('textbox', { name: 'Search models' })
@@ -333,7 +333,7 @@ describe('ModelMenuPanel provider collapse', () => {
     await vi.waitFor(() => {
       expect(
         content.queryByText(
-          (_, element) => element?.tagName === 'SPAN' && (element.textContent ?? '').startsWith('Deepseek V4 Pro')
+          (_, element) => element?.tagName === 'SPAN' && (element.textContent ?? '').startsWith('DeepSeek V4 Pro')
         )
       ).not.toBeNull()
     })
@@ -346,7 +346,7 @@ describe('ModelMenuPanel provider collapse', () => {
     // Radix DropdownMenuItem fires onSelect on Enter from the onKeyDown handler
     fireEvent.keyDown(header.closest('[role="menuitem"]') ?? header, { key: 'Enter' })
 
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
   })
 
   // The collapsed-providers set is a global presentation preference

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -25,6 +25,9 @@ describe('model-status-label', () => {
     expect(displayModelName('deepseek/deepseek-v4-pro')).toBe('DeepSeek V4 Pro')
     expect(displayModelName('glm-5-2')).toBe('GLM 5 2')
     expect(displayModelName('opencode-go/deepseek-v4-flash')).toBe('DeepSeek V4 Flash')
+    // Malformed trailing dash must not leak a space into the label.
+    expect(displayModelName('gpt-5.6-sol-')).toBe('GPT-5.6 Sol')
+    expect(displayModelName('-leading-dash')).toBe('Leading Dash')
   })
 
   it('maps reasoning effort to compact labels', () => {

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -7,13 +7,24 @@ describe('model-status-label', () => {
   it('formats display names consistently', () => {
     expect(displayModelName('anthropic/claude-opus-4.8-fast')).toBe('Opus 4.8')
     expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
-    expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
+    expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('DeepSeek V4 Pro')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
   })
 
   it('strips trailing date-pin snapshots from the display name', () => {
     expect(displayModelName('claude-opus-4-5-20251101')).toBe('Opus 4 5')
     expect(displayModelName('anthropic/claude-haiku-4-5-20251001')).toBe('Haiku 4 5')
+  })
+
+  it('title-cases variant tokens on dotted ids and canonicalizes brand casing', () => {
+    expect(displayModelName('gpt-5.6-sol')).toBe('GPT-5.6 Sol')
+    expect(displayModelName('gpt-5.6-luna')).toBe('GPT-5.6 Luna')
+    expect(displayModelName('gpt-4.1-mini')).toBe('GPT-4.1 Mini')
+    // Digit-leading tokens are not variants: `4o` keeps its casing.
+    expect(displayModelName('gpt-4o')).toBe('GPT-4o')
+    expect(displayModelName('deepseek/deepseek-v4-pro')).toBe('DeepSeek V4 Pro')
+    expect(displayModelName('glm-5-2')).toBe('GLM 5 2')
+    expect(displayModelName('opencode-go/deepseek-v4-flash')).toBe('DeepSeek V4 Flash')
   })
 
   it('maps reasoning effort to compact labels', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -71,10 +71,12 @@ const applyBrandCasing = (text: string): string =>
 
 // Split on dashes and capitalize lowercase letter-leading tokens (`sol` → `Sol`)
 // while digit-leading tokens stay untouched (`4o`, `70b`). Joining with spaces
-// matches the normalization the titleCase paths apply.
+// matches the normalization the titleCase paths apply; empty tokens (leading,
+// trailing, or doubled dashes) are dropped so malformed ids never leak spaces.
 const smartTitle = (text: string): string =>
   text
     .split('-')
+    .filter(Boolean)
     .map(token =>
       /^[a-z]/.test(token) && token === token.toLowerCase()
         ? token[0].toUpperCase() + token.slice(1)

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -53,20 +53,55 @@ const VARIANT_TAGS: ReadonlyArray<readonly [RegExp, string]> = [
 
 const titleCase = (text: string): string => text.replace(/\b\w/g, char => char.toUpperCase()).trim()
 
+// Brand names whose canonical casing is not word-initial, so titleCasing alone
+// would render "Deepseek" or "Glm". Applied to the finished fallback label;
+// whole-word matches only, so version tokens are never touched.
+const BRAND_CASING: Readonly<Record<string, string>> = {
+  deepseek: 'DeepSeek',
+  opencode: 'OpenCode',
+  openrouter: 'OpenRouter',
+  glm: 'GLM'
+}
+
+const applyBrandCasing = (text: string): string =>
+  Object.entries(BRAND_CASING).reduce(
+    (acc, [raw, canonical]) => acc.replace(new RegExp(`\\b${raw}\\b`, 'gi'), canonical),
+    text
+  )
+
+// Split on dashes and capitalize lowercase letter-leading tokens (`sol` → `Sol`)
+// while digit-leading tokens stay untouched (`4o`, `70b`). Joining with spaces
+// matches the normalization the titleCase paths apply.
+const smartTitle = (text: string): string =>
+  text
+    .split('-')
+    .map(token =>
+      /^[a-z]/.test(token) && token === token.toLowerCase()
+        ? token[0].toUpperCase() + token.slice(1)
+        : token
+    )
+    .join(' ')
+
 function prettifyBase(base: string): string {
   if (/^claude-/i.test(base)) {
     return titleCase(base.replace(/^claude-/i, '').replace(/-/g, ' '))
   }
 
   if (/^gpt-/i.test(base)) {
-    return base.replace(/^gpt-/i, 'GPT-')
+    const tail = base.replace(/^gpt-/i, '')
+
+    // Dotted ids already carry the canonical version separator, so the
+    // remaining dash tokens are variant words (`gpt-5.6-sol` → `GPT-5.6 Sol`).
+    // Dash-form tails (`gpt-5-5`) stay untouched — restoring the dot is a
+    // separate normalization for dash-separated ids.
+    return tail.includes('.') ? `GPT-${smartTitle(tail)}` : `GPT-${tail}`
   }
 
   if (/^gemini-/i.test(base)) {
     return base.replace(/^gemini-/i, 'Gemini ').replace(/-/g, ' ')
   }
 
-  return titleCase(base.replace(/-/g, ' '))
+  return applyBrandCasing(smartTitle(base))
 }
 
 /** Split a model id into a clean display name plus an optional grayed variant


### PR DESCRIPTION
## Summary

The desktop model label formatter title-cases word starts only, so brands whose canonical casing is not word-initial render wrong ("Deepseek", "Glm"), and the GPT branch returns its tail untouched, leaving variant tokens lowercase ("GPT-5.6-sol"). This closes those two display gaps. Dash-version normalization (restoring `5-5` → `5.5`) is intentionally left to #78663; this PR deliberately does not reimplement it.

## Change

- `smartTitle`: split dash tokens, capitalize lowercase letter-leading tokens, leave digit-leading tokens alone (`4o`, `70b`), drop empty tokens so malformed ids never leak spaces.
- GPT branch: dotted tails now render variant tokens title-cased (`gpt-5.6-sol` → `GPT-5.6 Sol`); dash-form tails (`gpt-5-5`) are untouched — that normalization belongs to #78663.
- Fallback path: route through `smartTitle` plus a whole-word brand map (`deepseek` → `DeepSeek`, `opencode` → `OpenCode`, `openrouter` → `OpenRouter`, `glm` → `GLM`).
- Updated existing model-menu assertions that pinned the old casing (`model-menu-panel.test.tsx`).

## Verification

- `npx vitest run --project ui src/lib/model-status-label.test.ts src/app/shell/model-menu-panel.test.tsx` → 31 passed (12 label cases incl. GPT Sol/Luna/Mini, `gpt-4o` guard, DeepSeek/GLM brands, provider-prefix brand, malformed-dash guards; 19 menu cases).
- Full desktop `--project ui` suite: clean (regression sweep run by independent adversarial review — the only failures before this commit were the updated menu assertions).
- Regression proven both directions: with the source fix stashed the new label expectations fail (2 failed | 10 passed); with the fix applied, 12 passed.
- `npx eslint` on all changed files → clean.

| Model id | Before | After |
|---|---|---|
| `gpt-5.6-sol` | GPT-5.6-sol | GPT-5.6 Sol |
| `deepseek/deepseek-v4-pro` | Deepseek V4 Pro | DeepSeek V4 Pro |
| `glm-5-2` | Glm 5 2 | GLM 5 2 |
| `gpt-4o` | GPT-4o | GPT-4o (unchanged) |

## Coordination with #78663

Both PRs fork the same `prettifyBase` blob, so the diffs collide at the hunk level even though the intents are complementary. Recommended order: land #78663 first (this PR explicitly defers dash-version normalization to it), then rebase this PR with:

1. Apply #78663's `versioned` dot-restore first, then this PR's `smartTitle`/brand logic on the versioned tail (a naive resolution keeping the raw tail silently breaks #78663's `gpt-5-5` → `GPT-5.5` case).
2. Update the `glm-5-2` expectation to `GLM 5.2` (real GLM versions are dotted) and add a `gpt-5-5` case to lock the combined behavior.
3. Keep #78663's title-cased Gemini branch.

If this PR lands first, the reverse resolution is the same rules in the other direction; dash-form ids simply remain unimproved until #78663 merges.