### PR TITLE
fix(sessions): escape LIKE wildcards in prune/archive substring filters

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -170,6 +170,17 @@ def _delegate_from_json(col: str = "model_config") -> str:
     return f"json_extract(COALESCE({col}, '{{}}'), '$._delegate_from')"
 
 
+def _escape_like(text: str) -> str:
+    """Escape SQL LIKE wildcards so an operator-supplied filter matches
+    literally.  Pair with ``ESCAPE '\\'`` in the clause.
+
+    ``%`` and ``_`` are wildcards to LIKE, and ``_`` in particular is common
+    in the values these filters run against (branch names, session titles).
+    A filter documented as a substring match must not silently widen.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
     return "(s.cwd = ? OR s.cwd LIKE ? OR s.cwd LIKE ?)", [prefix, f"{prefix}/%", f"{prefix}\\%"]
@@ -8213,8 +8224,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.source = ?")
             params.append(source)
         if title_like:
-            clauses.append("LOWER(COALESCE(s.title, '')) LIKE ?")
-            params.append(f"%{title_like.lower()}%")
+            clauses.append("LOWER(COALESCE(s.title, '')) LIKE ? ESCAPE '\\'")
+            params.append(f"%{_escape_like(title_like.lower())}%")
         if end_reason:
             clauses.append("s.end_reason = ?")
             params.append(end_reason)
@@ -8229,8 +8240,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.message_count <= ?")
             params.append(max_messages)
         if model_like:
-            clauses.append("LOWER(COALESCE(s.model, '')) LIKE ?")
-            params.append(f"%{model_like.lower()}%")
+            clauses.append("LOWER(COALESCE(s.model, '')) LIKE ? ESCAPE '\\'")
+            params.append(f"%{_escape_like(model_like.lower())}%")
         if provider:
             clauses.append("LOWER(COALESCE(s.billing_provider, '')) = ?")
             params.append(provider.lower())
@@ -8244,8 +8255,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.chat_type = ?")
             params.append(chat_type)
         if branch_like:
-            clauses.append("LOWER(COALESCE(s.git_branch, '')) LIKE ?")
-            params.append(f"%{branch_like.lower()}%")
+            clauses.append("LOWER(COALESCE(s.git_branch, '')) LIKE ? ESCAPE '\\'")
+            params.append(f"%{_escape_like(branch_like.lower())}%")
         if min_tokens is not None:
             clauses.append(
                 "(COALESCE(s.input_tokens, 0) + COALESCE(s.output_tokens, 0)) >= ?"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1068,6 +1068,59 @@ class TestPruneSessionFilters:
 
 
 
+    def test_title_like_underscore_is_literal_not_a_wildcard(self, db):
+        """``_`` is a single-character wildcard in SQL LIKE, so an unescaped
+        filter deletes sessions the operator never selected. The filters are
+        documented (and shown in the CLI confirmation) as substring matches.
+        """
+        self._mk(db, "target", title="user_auth refactor")
+        self._mk(db, "bystander1", title="user-auth review")
+        self._mk(db, "bystander2", title="userXauth notes")
+        self._mk(db, "bystander3", title="user auth meeting")
+
+        rows = db.list_prune_candidates(title_like="user_auth")
+        assert {r["id"] for r in rows} == {"target"}
+
+        pruned = db.prune_sessions(older_than_days=None, title_like="user_auth")
+        assert pruned == 1
+        for survivor in ("bystander1", "bystander2", "bystander3"):
+            assert db.get_session(survivor) is not None
+
+    def test_percent_in_filter_does_not_select_everything(self, db):
+        """``%`` matches any run of characters — a bare one would delete the
+        whole table."""
+        self._mk(db, "a", title="alpha")
+        self._mk(db, "b", title="beta")
+        self._mk(db, "pct", title="100% coverage run")
+
+        # Only the title that really contains a percent sign matches.
+        assert {r["id"] for r in db.list_prune_candidates(title_like="%")} == {"pct"}
+        assert {r["id"] for r in db.list_prune_candidates(title_like="100%")} == {"pct"}
+
+    def test_branch_like_underscore_is_literal(self, db):
+        """Branch names carry underscores routinely."""
+        self._mk_rich(db, "want", git_branch="fix/session_prune")
+        self._mk_rich(db, "other", git_branch="fix/session-prune")
+
+        rows = db.list_prune_candidates(branch_like="session_prune")
+        assert {r["id"] for r in rows} == {"want"}
+
+    def test_model_like_underscore_is_literal(self, db):
+        self._mk_rich(db, "want", model="vendor/model_mini")
+        self._mk_rich(db, "other", model="vendor/model-mini")
+
+        rows = db.list_prune_candidates(model_like="model_mini")
+        assert {r["id"] for r in rows} == {"want"}
+
+    def test_plain_substring_filters_still_match(self, db):
+        """Guard against over-escaping: ordinary filters keep working, and a
+        literal backslash in the needle is matched as itself."""
+        self._mk(db, "smoke", title="Codex Smoke Test")
+        self._mk_rich(db, "winpath", title=r"build C:\tmp artifacts")
+
+        assert {r["id"] for r in db.list_prune_candidates(title_like="smoke")} == {"smoke"}
+        assert {r["id"] for r in db.list_prune_candidates(title_like=r"c:\tmp")} == {"winpath"}
+
     def test_unknown_filter_rejected(self, db):
         import pytest as _pytest
         with _pytest.raises(TypeError):


### PR DESCRIPTION
## What

`SessionDB._prune_filter_where` builds the shared WHERE clause for `prune_sessions`, `archive_sessions` and `list_prune_candidates`. Its docstring states the contract:

> String matching conventions: `model_like` / `branch_like` / `title_like` are case-insensitive **substring matches**

`prune_sessions`' own docstring repeats it, and the CLI renders these filters back to the operator as `title contains 'X'` / `git branch contains 'X'` (`hermes_cli/session_filters.py`). They reach that layer from `hermes sessions prune --title/--model/--branch`, `hermes sessions archive`, and the dashboard's `/api/sessions/prune`.

They were not substring matches. The needle went straight into a bare `LIKE ?`:

```python
clauses.append("LOWER(COALESCE(s.title, '')) LIKE ?")
params.append(f"%{title_like.lower()}%")
```

so `_` matched any single character and `%` any run. `prune_sessions` deletes the session rows **and** their on-disk transcripts, so the over-match is unrecoverable — and `_` is not an exotic character here: git branch names and session titles carry it routinely.

Real `SessionDB`, real SQLite, on main. Five ended sessions; the operator prunes their `user_auth` scratch work:

```
filter: title_like='user_auth'  (docstring: case-insensitive substring)
dry-run would touch: ['bystander1', 'bystander2', 'bystander3', 'target']
prune_sessions deleted: 4
surviving sessions: ['unrelated']
```

`user-auth review`, `userXauth notes` and `user auth meeting` were destroyed alongside the one session that was actually named. `--dry-run` does not save the operator: it runs through the same builder, so the preview is wrong in exactly the same direction. And a lone `%` selects the entire table.

After the fix, same script:

```
dry-run would touch: ['target']
prune_sessions deleted: 1
surviving sessions: ['bystander1', 'bystander2', 'bystander3', 'unrelated']
```

The filter surface arrived in 040a5e30d (2026-07-05, feat(sessions): full filter surface for prune + bulk archive subcommand, #59327), which describes `--model` as "substring on model slug" — the wildcard behaviour was never the intent, just an unescaped needle.

## The fix

Escape the operator's needle and add `ESCAPE '\'` to the three clauses. This is the convention the rest of `hermes_state.py` already follows — every other `LIKE` against operator or session-derived text uses `ESCAPE '\'`, and the title-collision query escapes inline with the reason spelled out:

```python
# Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
```

Rather than add a fourth inline copy, that became `_escape_like()` next to the other clause builders, used by all three filters. Needles without wildcards produce identical SQL matches to before, so ordinary filters are unaffected.

Scope deliberately not taken: `_cwd_prefix_clause` has the same unescaped shape, but it is shared by four call sites beyond prune, so widening it belongs in its own change rather than riding along with a data-loss fix.

## Tests

Added to `TestPruneSessionFilters` in `tests/test_hermes_state.py`, using the class's existing `_mk` / `_mk_rich` helpers:

- `title_like="user_auth"` selects only the session that literally contains it, and `prune_sessions` deletes exactly one — the three near-miss titles survive
- a lone `%` no longer selects everything; `100%` still finds the title that really contains a percent sign
- `branch_like="session_prune"` does not also match `session-prune`
- `model_like="model_mini"` does not also match `model-mini`
- ordinary substrings still match, and a literal backslash in the needle (`c:\tmp`) matches itself — a guard against over-escaping

Results:

```
183 passed
```

That is the whole `tests/test_hermes_state.py` file; the 178 pre-existing tests are untouched.

Red without the source change (tests kept, `hermes_state.py` reverted):

```
FAILED test_title_like_underscore_is_literal_not_a_wildcard
E  assert {'bystander1', 'bystander2', 'bystander3', 'target'} == {'target'}
FAILED test_percent_in_filter_does_not_select_everything
E  assert {'a', 'b', 'pct'} == {'pct'}
FAILED test_branch_like_underscore_is_literal
E  assert {'other', 'want'} == {'want'}
FAILED test_model_like_underscore_is_literal
E  assert {'other', 'want'} == {'want'}
4 failed, 4 passed
```

The over-escaping guard passes on both sides, which is the point of it.

Regression run over 160 test files — everything referencing `SessionDB`, `prune_sessions`, `archive_sessions`, `list_prune_candidates`, `_prune_filter_where`, `title_like` or `session_filters` — against the same files on main:

```
main:      39 failed, 2416 passed   (35 pre-existing, plus the 4 new tests failing as above)
with fix:  37 failed, 2418 passed
```

The set difference is two tests in `tests/test_mcp_serve.py::TestEventBridgePollE2E`. They are pre-existing and flaky, not caused by this change: run in isolation on unmodified main they fail 3, 3 and 2 times across three consecutive runs, and 2, 2, 2 with the fix applied. Nothing in that suite touches session filtering.

`scripts/check-windows-footguns.py` reports the identical 9 pre-existing findings in `tests/test_hermes_state.py` before and after (same lines, shifted by the added test block); `hermes_state.py` is clean.