### PR TITLE
fix(desktop): new sessions use the configured default; sidebar follows the focused session

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -77,6 +77,7 @@ import {
   exitProjectScope,
   fetchProjectSessions,
   openProjectCreate,
+  projectScopeForFocusedSession,
   refreshProjects,
   refreshProjectTree,
   refreshWorktrees,
@@ -96,7 +97,12 @@ import {
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
-import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
+import {
+  $focusedSessionState,
+  $focusedStoredSessionId,
+  $workingSessionIds,
+  type SplitDir
+} from '@/store/session-states'
 
 import {
   type AppView,
@@ -792,6 +798,33 @@ export function ChatSidebar({
     syncProjectCwd(enteredProject)
     lastProjectCwdSyncRef.current = enteredProject.id
   }, [inProject, enteredProject, syncProjectCwd])
+
+  // The sidebar is a PROJECTION of the focused session, not an independent
+  // navigation origin: switching into a session whose workspace lives in a
+  // named project must bring the sidebar's project view along. The project
+  // scope itself never feeds back into session-creation decisions (see
+  // resolveNewSessionCwd) — display-only here.
+  // Conservative by design: only sessions that resolve to a NAMED project
+  // re-scope the sidebar. Drafts (null), detached / auto-project / kanban
+  // sessions keep the user's current navigation state — guessing Home or an
+  // auto project risks yanking the view to a bucket the backend groups
+  // differently.
+  useEffect(() => {
+    const unsubscribe = $focusedStoredSessionId.subscribe(focusedId => {
+      const projectId = projectScopeForFocusedSession(
+        focusedId,
+        $sessions.get(),
+        $projects.get(),
+        $focusedSessionState.get()
+      )
+
+      if (projectId) {
+        enterProject(projectId)
+      }
+    })
+
+    return unsubscribe
+  }, [])
 
   // A persisted scope can go stale (project archived/removed, or a profile
   // switch swapped the whole catalog). Once projects have loaded, drop back to

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -380,7 +380,7 @@ function isPathUnder(folder: string, target: string): boolean {
  * or a sibling worktree of a project repo), the folder match is authoritative;
  * only the repo-root AUTO-project fallback needs cwd-under-root confidence.
  */
-export function liveSessionProjectId(session: SessionInfo, explicitProjects: ProjectInfo[]): null | string {
+export function liveSessionProjectId(session: SessionInfo, explicitProjects: readonly ProjectInfo[]): null | string {
   const cwd = (session.cwd || '').trim()
   // A session may carry only a git_repo_root and no cwd — older/imported rows,
   // or ones captured before cwd tracking. The backend still groups those by repo

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -21,6 +21,7 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  applyConfiguredDefaultProjectDir,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setCurrentCwd,
@@ -447,6 +448,7 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentProvider.set('')
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
+    applyConfiguredDefaultProjectDir(null)
     vi.restoreAllMocks()
   })
 
@@ -546,7 +548,10 @@ describe('createBackendSessionForSend profile routing', () => {
     })
   })
 
-  it('falls back to the entered project cwd when the current cwd is blank', async () => {
+  it('falls back to the configured default cwd — not the entered project — when the current cwd is blank', async () => {
+    // The sidebar project scope is display-only navigation state: a blank
+    // draft cwd must resolve to the configured default, never to the project
+    // the sidebar happens to be scoped into.
     const params = await createWith(() => {
       $projectTree.set([
         {
@@ -559,9 +564,10 @@ describe('createBackendSessionForSend profile routing', () => {
       ])
       $projectScope.set('p_app')
       $currentCwd.set('')
+      applyConfiguredDefaultProjectDir('/repo/configured')
     })
 
-    expect(params).toMatchObject({ cwd: '/repo/app' })
+    expect(params).toMatchObject({ cwd: '/repo/configured' })
   })
 })
 

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -2,9 +2,11 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import type { SessionInfo } from '@/hermes'
 import { $sidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
+import type { ProjectInfo } from '@/types/hermes'
 
 import {
   $activeProjectId,
@@ -23,6 +25,7 @@ import {
   openProjectCreate,
   pickProjectFolder,
   projectNameForCwd,
+  projectScopeForFocusedSession,
   refreshProjects,
   refreshProjectTree,
   refreshWorktrees,
@@ -132,22 +135,24 @@ describe('resolveNewSessionCwd', () => {
     $sessions.set([])
   })
 
-  it('starts a chat detached inside Home, ignoring the configured default dir', () => {
-    // Attaching the default dir here would move the new chat out of Home the
-    // moment it was created — "no folder" is what the bucket means.
+  it('starts a new chat at the configured default even inside Home scope', () => {
+    // Home's "no folder" was a scope-driven exception to the configured
+    // default; the sidebar scope is display-only and must not feed
+    // session-creation decisions, so a new chat always reads the default.
     enterProject(NO_PROJECT_ID)
 
-    expect(resolveNewSessionCwd()).toBe('')
+    expect(resolveNewSessionCwd()).toBe('/home/user/configured')
   })
 
   it('still falls back to the configured default outside Home', () => {
     expect(resolveNewSessionCwd()).toBe('/home/user/configured')
   })
 
-  it('inherits the focused session workspace when not drilled into a project', () => {
-    // Simulate a primary session whose stored row carries a project cwd —
-    // the common case: you're in a chat that has a pwd, hit ⌘N/⌘T, and
-    // expect the new draft to stay in that project without sidebar drill-in.
+  it('ignores the focused session workspace — a new chat reads the configured default', () => {
+    // Regression: 883076ccd7 added focused-session inheritance ahead of the
+    // configured fallback, so ⌘N/⌘T from a project-bound chat recreated the
+    // project instead of the configured default. The focused session's cwd is
+    // NOT a data source for session creation.
     $selectedStoredSessionId.set('sess-a')
     $sessions.set([
       {
@@ -166,10 +171,10 @@ describe('resolveNewSessionCwd', () => {
       } as never
     ])
 
-    expect(resolveNewSessionCwd()).toBe('/Users/me/www/hermes-agent')
+    expect(resolveNewSessionCwd()).toBe('/home/user/configured')
   })
 
-  it('does not re-attach a remembered cwd when the focused session is detached', () => {
+  it('ignores a stale remembered cwd when the focused session is detached', () => {
     $currentCwd.set('/Users/me/stale-remembered')
     $selectedStoredSessionId.set('sess-detached')
     $sessions.set([
@@ -192,6 +197,131 @@ describe('resolveNewSessionCwd', () => {
     // Focused session has no workspace → fall through to configured default,
     // not the stale $currentCwd from an earlier chat.
     expect(resolveNewSessionCwd()).toBe('/home/user/configured')
+  })
+
+  it('detaches when no default project dir is configured', () => {
+    applyConfiguredDefaultProjectDir(null)
+
+    expect(resolveNewSessionCwd()).toBe('')
+  })
+})
+
+describe('projectScopeForFocusedSession', () => {
+  const session = (over: Partial<SessionInfo> & Pick<SessionInfo, 'id'>): SessionInfo =>
+    ({
+      archived: false,
+      cwd: null,
+      ended_at: null,
+      git_repo_root: null,
+      input_tokens: 0,
+      is_active: false,
+      last_active: 0,
+      message_count: 0,
+      model: null,
+      output_tokens: 0,
+      started_at: 0,
+      title: 't',
+      ...over
+    }) as never
+
+  const project = (id: string, folder: string): ProjectInfo =>
+    ({
+      archived: false,
+      color: null,
+      description: null,
+      folders: [{ path: folder }],
+      icon: null,
+      id,
+      name: id,
+      primary_path: folder
+    }) as never
+
+  it('scopes to the named project owning the focused row cwd', () => {
+    expect(
+      projectScopeForFocusedSession(
+        'sess-a',
+        [session({ id: 'sess-a', cwd: '/repo/app' })],
+        [project('p_app', '/repo/app')],
+        undefined
+      )
+    ).toBe('p_app')
+  })
+
+  it('prefers the live runtime cwd when the slice belongs to the focused session', () => {
+    expect(
+      projectScopeForFocusedSession(
+        'sess-a',
+        [session({ id: 'sess-a', cwd: '/repo/app' })],
+        [project('p_app', '/repo/app'), project('p_other', '/repo/other')],
+        { storedSessionId: 'sess-a', cwd: '/repo/other' }
+      )
+    ).toBe('p_other')
+  })
+
+  it('ignores a runtime slice that still describes the PREVIOUS session', () => {
+    // Right after a switch the focused slice may lag the selection — its cwd
+    // must not mask the stored row's (the ownership gate).
+    expect(
+      projectScopeForFocusedSession(
+        'sess-b',
+        [session({ id: 'sess-a', cwd: '/repo/other' }), session({ id: 'sess-b', cwd: '/repo/app' })],
+        [project('p_app', '/repo/app')],
+        { storedSessionId: 'sess-a', cwd: '/repo/other' }
+      )
+    ).toBe('p_app')
+  })
+
+  it('accepts a runtime slice sharing lineage with the focused session', () => {
+    // Compression rotates ids: the focused tip and the runtime slice's stored
+    // id share one lineage root, so the live cwd still belongs to the focus.
+    expect(
+      projectScopeForFocusedSession(
+        'sess-tip',
+        [
+          session({ _lineage_root_id: 'root-1', cwd: '/repo/other', id: 'root-1' }),
+          session({ _lineage_root_id: 'root-1', cwd: '/repo/app', id: 'sess-tip' })
+        ],
+        [project('p_other', '/repo/other'), project('p_app', '/repo/app')],
+        { storedSessionId: 'root-1', cwd: '/repo/other' }
+      )
+    ).toBe('p_other')
+  })
+
+  it('anchors on git_repo_root when the row has no cwd', () => {
+    expect(
+      projectScopeForFocusedSession(
+        'sess-a',
+        [session({ id: 'sess-a', cwd: null, git_repo_root: '/repo/app' })],
+        [project('p_app', '/repo/app')],
+        undefined
+      )
+    ).toBe('p_app')
+  })
+
+  it('returns null for a detached session (no workspace, no owning project)', () => {
+    expect(
+      projectScopeForFocusedSession(
+        'sess-detached',
+        [session({ id: 'sess-detached', cwd: null })],
+        [project('p_app', '/repo/app')],
+        undefined
+      )
+    ).toBeNull()
+  })
+
+  it('returns null when the cwd belongs to no named project', () => {
+    expect(
+      projectScopeForFocusedSession(
+        'sess-a',
+        [session({ id: 'sess-a', cwd: '/unregistered/dir' })],
+        [project('p_app', '/repo/app')],
+        undefined
+      )
+    ).toBeNull()
+  })
+
+  it('returns null for a draft (no focused stored session)', () => {
+    expect(projectScopeForFocusedSession(null, [], [], undefined)).toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1,12 +1,10 @@
 import { atom } from 'nanostores'
 
-import {
-  liveSessionProjectId,
-  NO_PROJECT_ID,
-  type SidebarProjectTree
-} from '@/app/chat/sidebar/projects/workspace-groups'
+import { liveSessionProjectId, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import type { ClientSessionState } from '@/app/types'
 import type { HermesGitBaseBranch, HermesGitBranch } from '@/global'
 import { getHermesConfig, type HermesGateway } from '@/hermes'
+import type { SessionInfo } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd, isDesktopFsRemoteMode, selectDesktopPaths, writeDesktopFileText } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
@@ -17,14 +15,12 @@ import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import { $activeGatewayProfile, requestFreshSession } from '@/store/profile'
 import {
-  $currentCwd,
   $selectedStoredSessionId,
   $sessions,
   idsShareLineage,
   sessionMatchesStoredId,
   workspaceCwdForNewSession
 } from '@/store/session'
-import { $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
 // First-class, per-profile Projects (named, multi-folder workspaces). State is
@@ -201,84 +197,68 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
 
 // The cwd a NEW chat should start in.
 //
-// Priority (first hit wins):
-//   1. Explicit sidebar project scope (drilled into a project / Home bucket)
-//   2. The FOCUSED session's workspace — so ⌘N / ⌘T from a chat that's already
-//      in a project/worktree stay there without requiring a sidebar drill-in
-//   3. Configured default project dir / remote remembered cwd (detached otherwise)
-//
-// The "active project" is just an atom ($projectScope) — so when you're inside
-// a project, a new session (cmd-n, the trunk "+") starts at that project's root
-// (its primary repo = the default-branch checkout). Outside a project it used
-// to fall straight to the plain default (detached), which dropped the workspace
-// of the chat you were looking at — that's the case (2) covers.
+// A new session's workspace comes from exactly two places, and neither is the
+// sidebar's navigation state:
+//   1. An explicit workspace action (Start Work / a project's "new session"
+//      button) passes a path through the composer's one-shot workspace target —
+//      that path never flows through this resolver (see startFreshSessionDraft
+//      and workspace-session-target).
+//   2. Otherwise the configured default wins: the default project dir on local
+//      backends, the remembered remote cwd otherwise — detached when unset.
+// The sidebar project scope ($projectScope) is display-only navigation state:
+// it must not feed session-creation decisions, and neither may the focused
+// session's workspace — "new chat" means "the configured default", not
+// "wherever I'm looking right now" (regression from 883076ccd7, which added
+// the focused-session inheritance ahead of the configured fallback).
 export function resolveNewSessionCwd(): string {
-  const scope = $projectScope.get()
-
-  // Inside Home, "no folder" is the point: a new chat must stay detached rather
-  // than silently attaching to the configured default dir and leaving Home.
-  if (scope === NO_PROJECT_ID) {
-    return ''
-  }
-
-  if (scope !== ALL_PROJECTS) {
-    const cwd = projectRootCwd($projectTree.get().find(node => node.id === scope))
-
-    if (cwd) {
-      return cwd
-    }
-  }
-
-  // Inherit the focused chat's workspace. ⌘N/⌘T from a session that already
-  // has a project/pwd should stay there — drilling into the sidebar project
-  // is the uncommon path, not the requirement.
-  const focusedCwd = focusedSessionWorkspaceCwd()
-
-  if (focusedCwd) {
-    return focusedCwd
-  }
-
   return workspaceCwdForNewSession()
 }
 
-/** Live workspace of the session the user is looking at (tile or primary). */
-function focusedSessionWorkspaceCwd(): string {
-  const focusedStoredId = $focusedStoredSessionId.get()
-  const state = $focusedSessionState.get()
-
-  // Prefer the live runtime slice when it belongs to the focused chat
-  // (agent can relocate mid-turn). Cold tabs / mid-switch lag fall through
-  // to the stored session row.
-  const stateCwd = state?.cwd?.trim() || ''
-  const stateStoredId = state?.storedSessionId?.trim() || ''
-
-  if (
-    stateCwd &&
-    (!focusedStoredId ||
-      !stateStoredId ||
-      stateStoredId === focusedStoredId ||
-      idsShareLineage(focusedStoredId, stateStoredId, $sessions.get()))
-  ) {
-    return stateCwd
+/**
+ * The named project the sidebar should scope to when `focusedId` becomes the
+ * focused session, or null when the session carries no workspace info or no
+ * named project owns it. Pure decision helper for the sidebar's
+ * focused-session projection — the sidebar is a display projection of the
+ * session's own workspace, and this never feeds session-creation decisions.
+ *
+ * The live runtime slice is trusted only when it belongs to the focused
+ * session (stored id match or shared lineage): right after a switch the
+ * runtime may still describe the PREVIOUS chat, and projecting its cwd would
+ * scope the sidebar to the wrong project. Otherwise the stored row's cwd /
+ * git repo root is the anchor.
+ */
+export function projectScopeForFocusedSession(
+  focusedId: null | string,
+  sessions: readonly SessionInfo[],
+  projects: readonly ProjectInfo[],
+  focusedState: Pick<ClientSessionState, 'cwd' | 'storedSessionId'> | undefined
+): null | string {
+  if (!focusedId) {
+    return null
   }
 
-  if (focusedStoredId) {
-    const row = $sessions.get().find(s => sessionMatchesStoredId(s, focusedStoredId))
-    const rowCwd = row?.cwd?.trim() || ''
+  const stateOwnsFocus =
+    !!focusedState?.storedSessionId &&
+    (focusedState.storedSessionId === focusedId || idsShareLineage(focusedId, focusedState.storedSessionId, sessions))
 
-    if (rowCwd) {
-      return rowCwd
-    }
+  const stateCwd = stateOwnsFocus ? focusedState?.cwd?.trim() || '' : ''
 
-    // Focused a real session with no workspace → stay detached. Do NOT fall
-    // through to `$currentCwd` (it may still hold a remembered path from an
-    // earlier chat and would re-attach a project the user left).
-    return ''
+  const session = sessions.find(s => sessionMatchesStoredId(s, focusedId))
+  const rowCwd = session?.cwd?.trim() || session?.git_repo_root?.trim() || ''
+
+  const anchor = stateCwd || rowCwd
+
+  if (!anchor) {
+    return null
   }
 
-  // No focused stored session: primary draft. The composer atom is the draft's
-  // workspace target (set by startFreshSession / startSessionInWorkspace).
-  return $currentCwd.get().trim()
+  const projectId = liveSessionProjectId({ cwd: anchor } as SessionInfo, projects)
+
+  // liveSessionProjectId falls back to the cwd's repo-root AUTO project when
+  // no named project owns it; the sidebar projection intentionally re-scopes
+  // only to NAMED projects (auto lanes surface through the backend tree and
+  // yanking the view to them would fight the overview grouping).
+  return projectId?.startsWith('p_') ? projectId : null
 }
 
 const underPath = (parent: string, child: string): boolean =>

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3205,7 +3205,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "_lineage_root_id", "cwd", "git_repo_root",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
         # Avoid exposing full system prompts/model_config through the client API;

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -104,7 +104,6 @@ class TestResponseStore:
         assert store.get("resp_2") is not None
         assert len(store) == 3
 
-
     def test_delete_clears_conversation_mapping(self):
         """Deleting a response also removes conversation mappings that reference it."""
         store = ResponseStore(max_size=10)
@@ -113,6 +112,45 @@ class TestResponseStore:
         assert store.get_conversation("chat-a") == "resp_1"
         store.delete("resp_1")
         assert store.get_conversation("chat-a") is None
+
+
+class TestSessionResponse:
+    """The /api/sessions row serializer.
+
+    The sidebar's focused-session projection resolves a session's named
+    project from its stored workspace, so the list must carry cwd /
+    git_repo_root — dropping them made switching sessions stop re-scoping the
+    sidebar (regression covered by the desktop projectScopeForFocusedSession
+    tests). Internal snapshots stay hidden.
+    """
+
+    def test_carries_cwd_and_git_repo_root(self):
+        out = APIServerAdapter._session_response(
+            {"id": "s1", "cwd": "/www/app", "git_repo_root": "/www/app", "title": "work"}
+        )
+        assert out["cwd"] == "/www/app"
+        assert out["git_repo_root"] == "/www/app"
+
+    def test_omits_absent_workspace_fields(self):
+        out = APIServerAdapter._session_response({"id": "s1", "title": "work"})
+        assert "cwd" not in out
+        assert "git_repo_root" not in out
+
+    def test_keeps_workspace_fields_out_of_absent_keys(self):
+        out = APIServerAdapter._session_response({"id": "s1", "cwd": None, "git_repo_root": None})
+        # The key is present (value None) — the desktop projection treats that
+        # as "no workspace" via `?.trim() || ''`, so it is safe to ship.
+        assert out.get("cwd") is None
+        assert out.get("git_repo_root") is None
+
+    def test_does_not_leak_internal_snapshots(self):
+        out = APIServerAdapter._session_response(
+            {"id": "s1", "cwd": "/w", "system_prompt": "secret", "model_config": {"x": 1}}
+        )
+        assert "system_prompt" not in out
+        assert "model_config" not in out
+        assert out["has_system_prompt"] is True
+        assert out["has_model_config"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related desktop workspace defects, fixed under one design framework: **the sidebar's navigation state must never feed session-creation decisions**, and **a session's workspace has exactly two sources** — the configured default (when creating a new session) and the session's own cwd (when switching into one).

1. **The + button / ⌘N no longer returns to the configured default workspace** — it recreated the focused chat's project instead.
2. **Switching sessions stopped re-scoping the sidebar** — the sidebar kept showing the previous project's workspace.

## Root causes

**New sessions.** `883076ccd7` (2026-08-01, "⌘N/⌘T keep the focused session's project") inserted a focused-session inheritance step ahead of the configured-default fallback in `resolveNewSessionCwd()`. The sidebar project scope and the focused session's cwd became data sources for session creation, so a new chat landed in whatever project the current chat was in (e.g. a GSC paper session) instead of the configured default (`terminal.cwd` / the default project dir).

**Sidebar projection.** The renderer's `$sessions` rows come from `GET /api/sessions`, whose row serializer (`_session_response`) whitelist omitted `cwd` and `git_repo_root`. Rows therefore carried **no workspace info at all** — every consumer of `session.cwd` silently no-op'd: the sidebar projection added here, the statusbar's tile path from `3707741d9` ("statusbar cwd follows the focused session"), and `overlayLivePreviews` project grouping. The backend stored the fields; the list API just never shipped them.

## Changes

**`resolveNewSessionCwd()` now reads the configured default only** (`workspaceCwdForNewSession()`). The `$projectScope` priority and the focused-session inheritance are gone; the dead `focusedSessionWorkspaceCwd()` helper and its imports are removed. Explicit workspace actions (Start Work / a project's "new session" button) still pass their own path through the composer's one-shot workspace target — that channel never flows through this resolver.

**The sidebar is now a projection of the focused session.** A new pure decision helper, `projectScopeForFocusedSession()` (store layer, unit-tested), resolves the focused session's workspace — preferring the live runtime slice only when it *belongs* to the focused session (id or lineage match), else the stored row's `cwd` / `git_repo_root` — and re-scopes the sidebar to the owning **named** project. Conservative by design: drafts, detached / auto-project / kanban sessions keep the current navigation state, so the display never yanks itself into a bucket the backend groups differently.

**The backend list now carries the workspace.** `_session_response`'s safe-keys whitelist gains `cwd` and `git_repo_root`, so every consumer of the session's stored workspace works again.

## Related issues

- Closes **#65274** — Desktop project-scoped fresh sessions fall back to home cwd on Windows
- Closes **#75537** — Make new session behavior predictable
- Closes **#77496** — New session should start in Home / under the configured default, not the current project
- Related: #38855 (historical), #70444, #75330 (project list order / sessions silently moving into Home)

## Related PRs

- **#77857** — same direction for the new-session half (drops focused inheritance), but keeps the `$projectScope` priority; this PR removes the sidebar scope from session creation entirely and also fixes the *switching* direction, which no open PR touches.
- **#76149** (draft) — opposite direction (keeps focused inheritance, adds a workspace picker to the draft); per the dataflow reasoning above, the fix belongs at the decision layer, not by adding downstream UI to compensate.
- **#67395** — stale (written before `883076ccd7`); **#66517** — closed, tests only.

## Testing

- Desktop (`vitest run --project ui`): `resolveNewSessionCwd` reads the configured default regardless of sidebar scope or focused session; `projectScopeForFocusedSession` covers row-cwd resolution, runtime-slice ownership (a lagging slice from the previous chat must not project the wrong project), lineage acceptance, `git_repo_root` anchoring, and detached cases.
- Backend: `TestSessionResponse` covers the `_session_response` whitelist (cwd/git_repo_root carried, internal snapshots still hidden).
- Full desktop `ui` suite: 386/388 files pass; the 3 remaining failures are pre-existing and environment/locale-dependent (Intl month names on zh-CN, billing bounds) — same list `#77857` reported.
- Manually verified on Windows: the + button creates new chats in the configured default workspace; switching into a session in a named project re-scopes the sidebar to it.

## Notes

The sidebar's `$projectScope` remains display-only throughout: it still drives drill-in navigation, but no session-creation or session-activation decision reads it.
