### PR TITLE
Debug bundles say where a missing client-side log lives

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -372,6 +372,35 @@ def _primary_log_path(log_name: str) -> Optional[Path]:
     return (get_hermes_home() / "logs" / filename) if filename else None
 
 
+# Logs written by a client process rather than by this backend. When the
+# desktop app talks to a remote/docker/SSH backend, `hermes debug share` runs
+# on the *backend* and can never see them — a bare "(file not found)" then
+# reads as "the app logged nothing" and sends triage down a dead end, which is
+# exactly the wrong answer when the client is the thing being debugged.
+_CLIENT_SIDE_LOGS = {
+    "desktop": (
+        "written by Hermes Desktop on the machine running the app, not by this "
+        "backend. If the desktop connects to a remote/docker/SSH backend, collect "
+        "it on that client machine"
+    ),
+}
+
+
+def _missing_log_note(log_name: str) -> str:
+    """Explain a missing log instead of stating a bare absence.
+
+    For a client-side log the absence is expected on a remote backend, so the
+    note names the writer and the path to collect by hand.
+    """
+    reason = _CLIENT_SIDE_LOGS.get(log_name)
+    if reason is None:
+        return "(file not found)"
+
+    primary = _primary_log_path(log_name)
+    where = f" — expected at {primary}" if primary else ""
+    return f"(not on this host: {reason}{where})"
+
+
 def _resolve_log_path(log_name: str) -> Optional[Path]:
     """Find the log file for *log_name*, falling back to the .1 rotation.
 
@@ -432,7 +461,11 @@ def _capture_log_snapshot(
     log_path = _resolve_log_path(log_name)
     if log_path is None:
         primary = _primary_log_path(log_name)
-        tail = "(file empty)" if primary and primary.exists() else "(file not found)"
+        tail = (
+            "(file empty)"
+            if primary and primary.exists()
+            else _missing_log_note(log_name)
+        )
         return LogSnapshot(path=None, tail_text=tail, full_text=None)
 
     try:

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -146,6 +146,63 @@ class TestCaptureLogSnapshot:
         assert len(kept) == 10
 
 
+class TestMissingLogNote:
+    """A missing log explains itself when the writer isn't this backend.
+
+    `hermes debug share` runs on the backend, so a desktop connected to a
+    remote/docker/SSH backend can never contribute desktop.log. Reporting a
+    bare absence sends triage after a client-side bug it cannot see.
+    """
+
+    def test_backend_written_log_reports_plain_absence(self, hermes_home):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        (hermes_home / "logs" / "agent.log").unlink()
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+        assert snap.full_text is None
+        assert snap.tail_text == "(file not found)"
+
+    def test_client_written_log_names_its_writer_and_path(self, hermes_home):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        (hermes_home / "logs" / "desktop.log").unlink()
+
+        snap = _capture_log_snapshot("desktop", tail_lines=10)
+        assert snap.full_text is None
+        assert "not on this host" in snap.tail_text
+        assert "Hermes Desktop" in snap.tail_text
+        # The reader needs the path to collect by hand on the client machine.
+        assert str(hermes_home / "logs" / "desktop.log") in snap.tail_text
+
+    def test_present_client_log_is_captured_normally(self, hermes_home):
+        """A local backend still reads desktop.log — the note is only for a miss."""
+        from hermes_cli.debug import _capture_log_snapshot
+
+        snap = _capture_log_snapshot("desktop", tail_lines=10)
+        assert "backend spawned" in snap.tail_text
+        assert "not on this host" not in snap.tail_text
+
+    def test_empty_client_log_is_empty_not_absent(self, hermes_home):
+        """An empty file means the app ran and logged nothing — a different fact."""
+        from hermes_cli.debug import _capture_log_snapshot
+
+        (hermes_home / "logs" / "desktop.log").write_text("")
+
+        snap = _capture_log_snapshot("desktop", tail_lines=10)
+        assert snap.tail_text == "(file empty)"
+
+    def test_report_carries_the_note_for_a_remote_backend(self, hermes_home):
+        """The uploaded report — what people paste into support — must explain it."""
+        from hermes_cli.debug import collect_debug_report
+
+        (hermes_home / "logs" / "desktop.log").unlink()
+
+        report = collect_debug_report(log_lines=10, dump_text="dump\n")
+        assert "--- desktop.log" in report
+        assert "not on this host" in report
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`hermes debug share` runs on the backend. When the desktop app talks to a remote, docker, or SSH backend, `desktop.log` is written by Electron on the *client* machine and can never be in the bundle — but the report printed a bare `(file not found)` for it, which reads as "the app logged nothing."

That is a costly wrong answer precisely when the client is the thing being debugged. It cost a real support thread two round trips today: a user filed two bundles from a Windows desktop against a remote Linux backend, both showed `desktop.log: (file not found)`, and the maintainer asked twice for a file the bundle was structurally incapable of carrying.

Now the slot names its writer and the path to collect by hand:

```
--- desktop.log (last 100 lines) ---
(not on this host: written by Hermes Desktop on the machine running the app,
not by this backend. If the desktop connects to a remote/docker/SSH backend,
collect it on that client machine — expected at /root/.hermes/logs/desktop.log)
```

The fix sits in `_capture_log_snapshot`, the single collector behind the CLI, the dashboard `POST /api/ops/debug-share`, and the desktop Maintenance button, so all three surfaces get it without new API or renderer surface. `_CLIENT_SIDE_LOGS` is a one-entry map rather than a special case, since Electron is not the only client that could ever write into the log dir.

Three behaviors are deliberately preserved: backend-written logs still report `(file not found)`, a locally-running desktop still has its `desktop.log` captured in full, and an empty file still reports `(file empty)` — "the app ran and logged nothing" is a different fact from "the file is on another host," and collapsing them would recreate the bug in the other direction.

## Validation

- `tests/hermes_cli/test_debug.py` — **51 passed**.
- Reverting only `hermes_cli/debug.py` fails the two new assertions and passes the other three, so the tests exercise the fix rather than the fixture.
- `ruff check` on both changed files: passed. `git diff --check`: clean.