### PR TITLE
fix(cli): preserve voice transcript intent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4188,9 +4188,8 @@ def _normalize_moa_model(model: Optional[str]) -> tuple[Optional[str], Optional[
 class _VoiceInputMessage:
     """Sentinel wrapper for voice-transcribed messages in ``_pending_input``.
 
-    Distinguishes STT output from manually typed text while voice mode is
-    active, so the concise-voice-response prefix is applied only to messages
-    that actually came from the microphone (#65827).
+    Distinguishes STT output from manually typed text so voice transcripts are
+    not mistaken for typed voice-control commands.
     """
 
     __slots__ = ("text",)
@@ -12735,10 +12734,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             pass
 
-        # Voice mode instruction is injected as a user message prefix (not a
-        # system prompt change) to avoid invalidating the prompt cache.  See
-        # _voice_message_prefix property and its usage in _process_message().
-
         tts_status = " (TTS enabled)" if self._voice_tts else ""
         # Use the startup-pinned cache so the advertised shortcut always
         # matches the live prompt_toolkit binding — reading live config
@@ -13646,8 +13641,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
-            voice_input: True when the message came from voice transcription
-                (gates the concise voice-response prefix, #65827)
+            voice_input: True when the message came from voice transcription.
+                This provenance must not alter the message sent to the agent.
             
         Returns:
             The agent's response, or None on error
@@ -13890,16 +13885,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if text_queue is not None:
                         text_queue.put(delta)
 
-            # When voice mode is active, prepend a brief instruction so the
-            # model responds concisely. The prefix is API-call-local only —
-            # run_conversation persists the original clean user message.
-            _voice_prefix = ""
-            if voice_input and isinstance(message, str):
-                _voice_prefix = (
-                    "[Voice input — respond concisely and conversationally, "
-                    "2-3 sentences max. No code blocks or markdown.] "
-                )
-
             def run_agent():
                 nonlocal result
                 # Set callbacks inside the agent thread so thread-local storage
@@ -13930,7 +13915,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 except Exception:
                     reset_current_session_key = None  # type: ignore[assignment]
                     _approval_session_token = None
-                agent_message = _voice_prefix + message if _voice_prefix else message
+                agent_message = message
                 # Prepend pending notes via _prepend_note_to_message, which
                 # handles both plain-string and multimodal content-parts list
                 # messages. Naive ``note + "\n\n" + agent_message`` crashed with
@@ -13956,12 +13941,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self._pending_moa_config = None
                 if _moa_cfg is None:
                     _moa_cfg = None
-                # Model/skill notes and voice instructions are API-local. Keep
+                # Model/skill notes are API-local. Keep
                 # the original staged input as the durable transcript value so a
                 # close-path marker follows the same dict into turn setup rather
                 # than producing a second noted user row (#63766).
                 _persist_clean_user_message = (
-                    message if (_voice_prefix or agent_message != message) else None
+                    message if agent_message != message else None
                 )
                 _one_turn_model_restore = getattr(
                     self, "_pending_one_turn_model_restore", None
@@ -17318,7 +17303,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         continue
 
                     # Voice-transcribed messages arrive wrapped in a sentinel
-                    # so only genuine STT output gets the voice prefix (#65827).
+                    # so their text is not mistaken for a typed voice command.
                     is_voice_input = isinstance(user_input, _VoiceInputMessage)
                     if is_voice_input:
                         user_input = user_input.text

--- a/tests/cli/test_cli_interrupt_ack_race.py
+++ b/tests/cli/test_cli_interrupt_ack_race.py
@@ -195,6 +195,44 @@ def test_chat_persists_clean_input_when_a_queued_note_changes_api_message():
     assert agent.captured["persist_user_message"] == "clean prompt"
 
 
+def test_voice_input_passes_user_message_to_agent_unchanged():
+    """Voice input must not carry an output-length or formatting instruction."""
+    cli = _make_cli()
+
+    class _CaptureAgent(_StubAgent):
+        def __init__(self, session_id):
+            super().__init__(session_id, turn_seconds=0)
+            self.captured = None
+
+        def run_conversation(self, **kwargs):
+            self.captured = kwargs
+            return {
+                "final_response": "done",
+                "messages": [{"role": "assistant", "content": "done"}],
+                "api_calls": 1,
+                "completed": True,
+                "partial": True,
+                "response_previewed": True,
+            }
+
+    agent = _CaptureAgent(cli.session_id)
+    cli.agent = agent
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    with patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": cli._active_agent_route_signature,
+             "model": None, "runtime": None, "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        cli.chat("Report the complete result", voice_input=True)
+
+    assert agent.captured is not None
+    assert agent.captured["user_message"] == "Report the complete result"
+    assert agent.captured["persist_user_message"] is None
+
+
 def test_chat_preserves_clean_multimodal_input_when_note_changes_api_message():
     """A queued note forwards original native parts as the persistence override."""
     cli = _make_cli()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5689,12 +5689,12 @@ class TestStreamCallbackNonStreamingProvider:
 
 
 # ---------------------------------------------------------------------------
-# Bugfix: API-only user message prefixes must not persist
+# API-only user message annotations must not persist
 # ---------------------------------------------------------------------------
 
 
 class TestPersistUserMessageOverride:
-    """Synthetic API-only user prefixes should never leak into transcripts."""
+    """Synthetic API-only annotations should never leak into transcripts."""
 
     def test_persist_session_rewrites_current_turn_user_message(self, agent):
         agent._session_db = MagicMock()
@@ -5705,10 +5705,7 @@ class TestPersistUserMessageOverride:
         messages = [
             {
                 "role": "user",
-                "content": (
-                    "[Voice input — respond concisely and conversationally, "
-                    "2-3 sentences max. No code blocks or markdown.] Hello there"
-                ),
+                "content": "[MODEL SWITCH NOTE]\n\nHello there",
             },
             {"role": "assistant", "content": "Hi!"},
         ]
@@ -5721,8 +5718,7 @@ class TestPersistUserMessageOverride:
         # API call (#48677).
         assert (
             messages[0]["content"]
-            == "[Voice input — respond concisely and conversationally, "
-            "2-3 sentences max. No code blocks or markdown.] Hello there"
+            == "[MODEL SWITCH NOTE]\n\nHello there"
         )
         # But the DB write must get the override.
         batch = agent._session_db.append_messages_batch.call_args_list[0].kwargs[

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -337,7 +337,7 @@ class TestVoiceStopAndTranscribeReal:
         cli._voice_stop_and_transcribe()
         queued = cli._pending_input.get_nowait()
         # Voice transcripts are wrapped in the _VoiceInputMessage sentinel so
-        # only genuine STT output gets the voice prefix (#65827).
+        # typed voice-control commands can still be distinguished from STT.
         from cli import _VoiceInputMessage
         assert isinstance(queued, _VoiceInputMessage)
         assert str(queued) == "hello world"


### PR DESCRIPTION
## Summary

- stop prepending a hidden length/style instruction to CLI voice transcripts
- preserve voice-input provenance for command handling without altering the text sent to the agent
- keep API-local model/skill annotations and their clean persistence override intact
- replace the obsolete voice-prefix persistence fixture with a generic API-local annotation fixture

## Root cause

PR #1299 (commit `a78249230`) introduced an API-local prefix that forced voice replies to be conversational, limited them to 2–3 sentences, and prohibited Markdown/code blocks. That changes user intent solely because input came through STT and can truncate technical answers. The per-message sentinel added for #65827 remains in place, so typed voice-control commands are still distinguishable from genuine STT output.

## Test plan

- `python -m pytest tests/cli/test_cli_interrupt_ack_race.py tests/tools/test_voice_cli_integration.py tests/run_agent/test_run_agent.py -o 'addopts=' -q`
- repository search confirms the removed instruction and `_voice_prefix` no longer exist
- `git diff --check`
