### PR TITLE
fix(agent): steer on non-string tool content only as anthropic blocks, coerce for chat-completions (#78598)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3900,6 +3900,26 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
 
 
 
+def _coerce_tool_content_to_string(content: Any) -> str:
+    """Serialize non-string tool content to a plain string.
+
+    Chat-completions wire format requires ``ChatCompletionToolMessage.content``
+    to be a ``str`` — an Anthropic-style block list is rejected with HTTP 400
+    by every OpenAI-compatible provider, and the poisoned message would stay
+    in the conversation history, breaking all subsequent calls (including
+    fallbacks). Used by ``apply_pending_steer_to_tool_results`` before
+    appending the steer marker.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(content)
+
+
 def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
     """Append any pending /steer text to the last tool result in this turn.
 
@@ -3946,15 +3966,25 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     marker = format_steer_marker(steer_text)
     existing_content = messages[target_idx].get("content", "")
     if not isinstance(existing_content, str):
-        # Anthropic multimodal content blocks — preserve them and append
-        # a text block at the end.
-        try:
-            blocks = list(existing_content) if existing_content else []
-            blocks.append({"type": "text", "text": marker.lstrip()})
-            messages[target_idx]["content"] = blocks
-        except Exception:
-            # Fall back to string replacement if content shape is unexpected.
-            messages[target_idx]["content"] = f"{existing_content}{marker}"
+        if (getattr(agent, "api_mode", "") or "") == "anthropic_messages":
+            # Anthropic Messages API supports multimodal content blocks —
+            # preserve them and append a text block at the end.
+            try:
+                blocks = list(existing_content) if existing_content else []
+                blocks.append({"type": "text", "text": marker.lstrip()})
+                messages[target_idx]["content"] = blocks
+            except Exception:
+                # Fall back to string replacement if content shape is unexpected.
+                messages[target_idx]["content"] = f"{existing_content}{marker}"
+        else:
+            # Chat-completions wire format (OpenRouter, Xiaomi, DeepSeek,
+            # DeepInfra, ...) requires tool content to be a plain string; a
+            # block list is rejected with HTTP 400 and the poisoned message
+            # would stay in the history, breaking every subsequent call
+            # including fallbacks. Coerce to a string first, then append.
+            messages[target_idx]["content"] = (
+                _coerce_tool_content_to_string(existing_content) + marker
+            )
     else:
         messages[target_idx]["content"] = existing_content + marker
     _ra().logger.info(

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -363,9 +363,10 @@ class TestSteerInjection:
         assert "stop after next step" in content
 
     def test_multimodal_content_list_preserved(self):
-        """Anthropic-style list content should be preserved, with the steer
-        appended as a text block."""
+        """Anthropic-style list content should be preserved in anthropic_messages
+        wire format, with the steer appended as a text block."""
         agent = _bare_agent()
+        agent.api_mode = "anthropic_messages"
         agent.steer("extra note")
         original_blocks = [{"type": "text", "text": "existing output"}]
         messages = [
@@ -378,6 +379,47 @@ class TestSteerInjection:
         assert new_content[0] == {"type": "text", "text": "existing output"}
         assert new_content[1]["type"] == "text"
         assert "extra note" in new_content[1]["text"]
+
+    def test_chat_completions_coerces_non_string_content_to_plain_string(self):
+        """Chat-completions wire format requires tool content to be a plain
+        string — a non-string (e.g. multimodal block list) content must be
+        coerced to a string BEFORE appending the steer marker, otherwise the
+        provider rejects the message with HTTP 400."""
+        agent = _bare_agent()  # api_mode defaults to "chat_completions"
+        agent.steer("extra note")
+        messages = [
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "existing output"},
+                    {"type": "image", "source": {"type": "base64", "data": "abc"}},
+                ],
+                "tool_call_id": "1",
+            }
+        ]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        new_content = messages[-1]["content"]
+        assert isinstance(new_content, str)
+        assert "existing output" in new_content
+        assert "base64" in new_content
+        assert STEER_MARKER_OPEN in new_content
+        assert "extra note" in new_content
+        # The steer marker must come AFTER the serialized content, never before.
+        assert new_content.index(STEER_MARKER_OPEN) > new_content.index("existing output")
+
+    def test_string_content_shape_unchanged_in_anthropic_mode(self):
+        """Plain-string tool content must stay a plain string with the marker
+        appended in anthropic_messages wire format too."""
+        agent = _bare_agent()
+        agent.api_mode = "anthropic_messages"
+        agent.steer("extra note")
+        messages = [{"role": "tool", "content": "existing output", "tool_call_id": "1"}]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        new_content = messages[-1]["content"]
+        assert isinstance(new_content, str)
+        assert "existing output" in new_content
+        assert STEER_MARKER_OPEN in new_content
+        assert "extra note" in new_content
 
 
 


### PR DESCRIPTION
## Summary

Fixes `/steer` on tool results with non-string content (e.g. multimodal block lists). `apply_pending_steer_to_tool_results()` in `agent/agent_runtime_helpers.py` unconditionally converted non-string tool content into an Anthropic Messages API block list. For chat-completions providers (OpenRouter, Xiaomi, DeepSeek, DeepInfra — routed via `/chat/completions`), `ChatCompletionToolMessage.content` must be a plain string; the block list is rejected with HTTP 400 and the poisoned message stays in the history, causing a 400 loop on every subsequent call including fallbacks.

## Root Cause

```python
if not isinstance(existing_content, str):
    blocks = list(existing_content) if existing_content else []
    blocks.append({"type": "text", "text": marker.lstrip()})
    messages[target_idx]["content"] = blocks
```

The block-list shape is only valid for the Anthropic Messages API wire format. The function never consulted the active wire format (`agent.api_mode`) before choosing the content shape.

## Change

- `agent/agent_runtime_helpers.py`:
  - `apply_pending_steer_to_tool_results()` now only builds the block-list shape when `agent.api_mode == "anthropic_messages"` (previous behavior preserved for Anthropic).
  - For any other wire format, non-string tool content is coerced to a plain string BEFORE appending the steer marker, via a new module-level helper `_coerce_tool_content_to_string()` (JSON serialization with `str()` fallback, matching the pattern already used elsewhere in the codebase).
- `tests/run_agent/test_steer.py`:
  - `test_multimodal_content_list_preserved` now pins `api_mode="anthropic_messages"` (block-list behavior is Anthropic-only).
  - New `test_chat_completions_coerces_non_string_content_to_plain_string` — chat-completions mode + block-list content produces a plain string with the marker appended after the serialized content.
  - New `test_string_content_shape_unchanged_in_anthropic_mode` — string content stays a string with the marker in both wire formats.

## Verification

- `python3 -m pytest tests/run_agent/test_steer.py -q` — 29 passed.
- `python3 -m pytest tests/ -k "steer or tool_result" -q` — 154 passed, 3 skipped, 0 failures.

## Closes

Closes #78598
