### PR TITLE
fix(tools): refuse write_file/patch writes into git worktree .git paths (#78565)

### DIFF
--- a/tests/tools/test_worktree_git_guard.py
+++ b/tests/tools/test_worktree_git_guard.py
@@ -1,0 +1,253 @@
+"""Tests for the git worktree ``.git`` write guard in write_file/patch (#78565).
+
+In a git worktree, ``.git`` is a FILE containing a single line like
+``gitdir: /path/to/bare`` — not a directory.  ``write_file``/``patch``
+auto-create parent directories and atomically move content into place, so a
+write whose path touches that file (``<worktree>/.git`` itself, or anything
+under it) replaces the link file and destroys the worktree checkout.
+
+These tests pin the guard:
+  * writes into ``.git`` paths inside a worktree are refused with a clear
+    error and the link file survives untouched;
+  * normal writes keep working (including ``.gitignore`` / ``.github`` paths
+    that merely contain a ``.git``-prefixed component);
+  * read-only access (read_file / search_files) to ``.git`` paths stays
+    allowed;
+  * a real git worktree (bare repo + worktree in tmp) is used to prove the
+    ``.git`` link file survives a refused write.
+"""
+
+import json
+import os
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tools.file_tools import patch_tool, read_file_tool, search_tool, write_file_tool
+
+
+def _make_fake_worktree(tmp_path, name="wt"):
+    """Create a directory that looks like a git worktree: a ``.git`` FILE
+    containing a ``gitdir:`` pointer (the worktree link) plus a normal file."""
+    wt = tmp_path / name
+    wt.mkdir()
+    (wt / ".git").write_text(f"gitdir: {tmp_path}/bare.git/worktrees/{name}\n", encoding="utf-8")
+    (wt / "hello.txt").write_text("hello\n", encoding="utf-8")
+    return wt
+
+
+def _make_real_worktree(tmp_path):
+    """Create a REAL git worktree (bare repo + linked worktree) under tmp.
+
+    Returns the worktree directory; ``<wt>/.git`` is the ``gitdir:`` link file.
+    """
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "readme.md").write_text("seed\n", encoding="utf-8")
+    env = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(["git", "init", "-q", str(seed)], check=True)
+    subprocess.run(["git", "-C", str(seed), "add", "readme.md"], check=True)
+    subprocess.run(["git", "-C", str(seed), "commit", "-q", "-m", "seed"], check=True, env=env)
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(seed), str(bare)], check=True)
+    wt = tmp_path / "worktree"
+    subprocess.run(["git", "worktree", "add", "-q", str(wt)], check=True, cwd=str(bare))
+    assert (wt / ".git").is_file()
+    return wt
+
+
+class TestWriteFileWorktreeGitGuard:
+    def test_write_into_git_config_refused(self, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        result = json.loads(write_file_tool(str(wt / ".git" / "config"), "evil"))
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+        assert ".git" in result["error"]
+        # The link file is untouched.
+        assert (wt / ".git").read_text(encoding="utf-8").startswith("gitdir: ")
+
+    def test_write_to_git_file_itself_refused(self, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        result = json.loads(write_file_tool(str(wt / ".git"), "broken"))
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+        assert (wt / ".git").read_text(encoding="utf-8").startswith("gitdir: ")
+
+    def test_write_deep_under_git_refused(self, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        result = json.loads(write_file_tool(str(wt / ".git" / "objects" / "ab" / "cdef"), "x"))
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_normal_path_still_works(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": str(wt / "out.txt"), "bytes": 2}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        result = json.loads(write_file_tool(str(wt / "out.txt"), "ok"))
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_gitignore_and_github_components_not_blocked(self, mock_get, tmp_path):
+        # ".gitignore" / ".github" contain a ".git"-prefixed component but are
+        # NOT the ".git" component — they must keep working.
+        wt = _make_fake_worktree(tmp_path)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        for rel in (".gitignore", ".github/workflows/ci.yml"):
+            res = json.loads(write_file_tool(str(wt / rel), "data"))
+            assert res.get("status") == "ok", rel
+        assert mock_ops.write_file.call_count == 2
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_plain_git_directory_repo_not_blocked(self, mock_get, tmp_path):
+        # Normal repo: .git is a DIRECTORY, not a gitdir: link file — outside
+        # the worktree guard's scope (issue #78565 targets worktrees only).
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        result = json.loads(write_file_tool(str(repo / ".git" / "config"), "x"))
+        assert result["status"] == "ok"
+
+
+class TestPatchWorktreeGitGuard:
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_into_git_refused(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path=str(wt / ".git" / "config"),
+                old_string="a",
+                new_string="b",
+            )
+        )
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_mode_update_git_refused(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        v4a = (
+            "*** Begin Patch\n"
+            f"*** Update File: {wt}/.git/config\n"
+            "@@\n"
+            "-old\n"
+            "+new\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=v4a))
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_v4a_mode_add_under_git_refused(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        v4a = (
+            "*** Begin Patch\n"
+            f"*** Add File: {wt}/.git/hooks/pre-commit\n"
+            "+#!/bin/sh\n"
+            "*** End Patch\n"
+        )
+        result = json.loads(patch_tool(mode="patch", patch=v4a))
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_mode_normal_file_works(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path=str(wt / "hello.txt"),
+                old_string="hello",
+                new_string="bye",
+            )
+        )
+        assert result["status"] == "ok"
+        mock_ops.patch_replace.assert_called_once()
+
+
+class TestReadToolsUnaffected:
+    @patch("tools.file_tools._get_file_ops")
+    def test_read_file_can_read_git_link(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "gitdir: /tmp/bare\n"
+        result_obj.total_lines = 1
+        result_obj.to_dict.return_value = {"content": "gitdir: /tmp/bare\n", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        result = json.loads(read_file_tool(str(wt / ".git")))
+        assert "error" not in result
+        assert "gitdir" in result.get("content", "")
+        mock_ops.read_file.assert_called_once()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_files_can_search_git_dir(self, mock_get, tmp_path):
+        wt = _make_fake_worktree(tmp_path)
+        fake_result = SimpleNamespace(
+            matches=[],
+            to_dict=lambda densify=False: {"matches": [], "total": 0},
+        )
+        mock_ops = MagicMock()
+        mock_ops.search.return_value = fake_result
+        mock_get.return_value = mock_ops
+        result = json.loads(search_tool(pattern="*", target="files", path=str(wt / ".git")))
+        assert "error" not in result
+        mock_ops.search.assert_called_once()
+
+
+class TestRealWorktree:
+    def test_real_worktree_git_file_survives_refused_write(self, tmp_path):
+        wt = _make_real_worktree(tmp_path)
+        before = (wt / ".git").read_text(encoding="utf-8")
+        assert before.lstrip().startswith("gitdir: ")
+
+        with patch("tools.file_tools._get_file_ops") as mock_get:
+            result = json.loads(write_file_tool(str(wt / ".git" / "config"), "clobber"))
+        assert "error" in result
+        assert "worktree" in result["error"].lower()
+        mock_get.assert_not_called()
+        # The worktree link survived the refused write.
+        assert (wt / ".git").is_file()
+        assert (wt / ".git").read_text(encoding="utf-8") == before
+        # The worktree is still a usable git checkout.
+        subprocess.run(["git", "status", "--porcelain"], check=True, cwd=str(wt))
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_real_worktree_normal_write_still_works(self, mock_get, tmp_path):
+        wt = _make_real_worktree(tmp_path)
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        result = json.loads(write_file_tool(str(wt / "notes.md"), "note"))
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1049,6 +1049,64 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     )
 
 
+def _check_worktree_git_path(resolved: str) -> str | None:
+    """Return an error message when *resolved* (an absolute path) touches a
+    ``.git`` component that is a git worktree (or submodule) link file.
+
+    In a git worktree, ``.git`` is a regular FILE containing a single line
+    like ``gitdir: /path/to/bare`` — not a directory (#78565).  ``write_file``
+    and ``patch`` auto-create parent directories and atomically move content
+    into place, so a write whose path touches that file (``<worktree>/.git``
+    itself, ``<worktree>/.git/objects/...``, etc.) replaces the link file and
+    destroys the worktree checkout.  Such writes are refused here.
+
+    Reads (``read_file``/``search_files``) are deliberately unaffected, and
+    the ``terminal`` tool is untouched, so git itself can still manage
+    ``.git`` contents.
+
+    Returns ``None`` when the path is safe: no ``.git`` component, the
+    component is a real directory (normal repo), or the link file is not
+    present on disk.
+    """
+    try:
+        p = Path(os.path.abspath(resolved))
+    except Exception:
+        return None
+    for candidate in (p, *p.parents):
+        if candidate.name != ".git":
+            continue
+        try:
+            if not candidate.is_file():
+                continue
+            with open(candidate, "r", encoding="utf-8", errors="replace") as fh:
+                first_line = fh.readline()
+        except OSError:
+            continue
+        if first_line.lstrip().startswith("gitdir:"):
+            return (
+                f"Refusing to write to '{resolved}': the path touches the .git "
+                f"link file of a git worktree ({candidate}). In a git worktree "
+                f".git is a FILE pointing at the repository (gitdir: ...), not a "
+                f"directory — write_file/patch parent-directory creation would "
+                f"replace it and destroy the worktree checkout. Manage .git "
+                f"contents with git commands via the terminal tool, and use "
+                f"read_file or search_files to inspect them."
+            )
+    return None
+
+
+def _check_worktree_git_path_for_target(target: str, task_id: str = "default") -> str | None:
+    """Best-effort absolute resolution of *target*, then run the worktree
+    ``.git`` guard.  Falls back to ``abspath`` when task resolution fails so
+    the guard still fires on relative paths the shell layer would act on.
+    """
+    try:
+        resolved = str(_resolve_path_for_task(target, task_id))
+    except Exception:
+        resolved = os.path.abspath(os.path.expanduser(_expand_tilde(target)))
+    return _check_worktree_git_path(resolved)
+
+
 def _is_expected_write_exception(exc: Exception) -> bool:
     """Return True for expected write denials that should not hit error logs."""
     if isinstance(exc, PermissionError):
@@ -2043,6 +2101,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
             return tool_error(cross_warning)
+    worktree_err = _check_worktree_git_path_for_target(path, task_id)
+    if worktree_err:
+        return tool_error(worktree_err)
     if _is_internal_file_tool_content(content):
         return tool_error(
             "Refusing to write internal read_file display text as file content. "
@@ -2171,6 +2232,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:
                 return tool_error(cross_warning)
+        worktree_err = _check_worktree_git_path_for_target(_p, task_id)
+        if worktree_err:
+            return tool_error(worktree_err)
     # One approval prompt for the whole patch: a single protected file gates
     # the ENTIRE patch (deny applies nothing — see the helper's docstring).
     protected_err = _check_protected_instruction_write(_paths_to_check, task_id)


### PR DESCRIPTION
## Summary

`write_file` and `patch` silently destroy git worktree `.git` files (#78565). Both tools auto-create parent directories and atomically move content into place, so a write whose path touches `.git` inside a git worktree replaces the worktree link file and makes the checkout unusable. This has corrupted multiple worktrees in production.

## Root Cause

In a git worktree, `.git` is a regular **FILE** containing a single line like `gitdir: /path/to/bare` — not a directory. When a tool write targets a path that touches that file (e.g. `<worktree>/.git`, `<worktree>/.git/config`, `<worktree>/.git/objects/...`), the parent-directory creation and atomic `mv` in the write path replace the link file with a directory or plain file, destroying the worktree link.

## Change

Add a guard in `tools/file_tools.py` that runs before any filesystem mutation in both `write_file_tool` and `patch_tool` (replace mode and V4A mode, including `Update`/`Add`/`Delete`/`Move` headers):

- Walk the resolved absolute target path and its parents looking for a `.git` component.
- If that component exists on disk as a **file** whose first line starts with `gitdir:` (the worktree/submodule link marker), refuse the write with a clear error naming the offending path.
- Normal repositories (`.git` is a directory), `.gitignore`/`.github` paths, and worktrees without a `.git` component are unaffected.

Scope is deliberately write-only: `read_file` and `search_files` can still inspect `.git` paths, and the `terminal` tool is untouched so git commands continue to manage `.git` normally.

## Verification

- 14 new tests in `tests/tools/test_worktree_git_guard.py`:
  - `write_file` into `.git/config`, `.git` itself, and deep `.git/objects/...` paths inside a (simulated) worktree are refused with a clear error; the link file survives untouched.
  - `write_file`/`patch` on normal paths still work; `.gitignore` and `.github` components are not blocked; a plain repo (`.git` directory) is outside the guard's scope.
  - `patch` replace mode and V4A mode (`Update`/`Add`) into `.git` paths are refused.
  - `read_file`/`search_files` on `.git` paths remain allowed.
  - A **real** worktree (bare repo + `git worktree add` under tmp) proves the `.git` link file survives a refused write and the checkout still answers `git status`.
- Existing file-tools suites pass: 175 passed across `test_file_tools.py`, `test_file_tools_cwd_resolution.py`, `test_cross_profile_guard.py`, `test_patch_parser.py`, `test_patch_already_applied.py`, `test_file_staleness.py`, `test_write_verification.py`, `test_file_read_guards.py` and the new guard tests.
- Broad `-k "write_file or patch or worktree"` run: 1059 passed; the 14 failures are order/batch-dependent (they pass in isolation both with and without this diff, in unrelated modules: discord, web oauth dispatch, minimax oauth, clipboard, update quarantine).

Closes #78565
