### PR TITLE
fix(voice): lazy-install microphone capture dependencies

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12137,9 +12137,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         """Start capturing audio from the microphone."""
         if getattr(self, '_should_exit', False):
             return
-        from tools.voice_mode import create_audio_recorder, check_voice_requirements
+        from tools.voice_mode import (
+            _voice_capture_install_hint,
+            check_voice_requirements,
+            create_audio_recorder,
+        )
 
-        reqs = check_voice_requirements()
+        reqs = check_voice_requirements(install_audio=True)
         if not reqs["audio_available"]:
             if _is_termux_environment():
                 details = reqs.get("details", "")
@@ -12156,7 +12160,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 )
             raise RuntimeError(
                 "Voice mode requires sounddevice and numpy.\n"
-                f"Install with: {sys.executable} -m pip install sounddevice numpy"
+                f"Install with: {_voice_capture_install_hint()}"
             )
         if not reqs.get("stt_available", reqs.get("stt_key_set")):
             raise RuntimeError(
@@ -12696,18 +12700,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint(f"{_DIM}Voice mode is already enabled.{_RST}")
             return
 
-        from tools.voice_mode import check_voice_requirements, detect_audio_environment
+        from tools.voice_mode import (
+            _voice_capture_install_hint,
+            check_voice_requirements,
+            detect_audio_environment,
+        )
 
-        # Environment detection -- warn and block in incompatible environments
+        # Install optional capture packages before probing the environment;
+        # otherwise the probe mistakes a missing wheel for an incompatible host.
+        reqs = check_voice_requirements(install_audio=True)
         env_check = detect_audio_environment()
-        if not env_check["available"]:
-            _cprint(f"\n{_ACCENT}Voice mode unavailable in this environment:{_RST}")
-            for warning in env_check["warnings"]:
-                _cprint(f"  {_DIM}{warning}{_RST}")
-            return
-
-        reqs = check_voice_requirements()
-        if not reqs["available"]:
+        requirements_met = (
+            reqs.get("audio_available", reqs.get("available", False))
+            and reqs.get(
+                "stt_available",
+                reqs.get("stt_key_set", reqs.get("available", False)),
+            )
+        )
+        if not requirements_met:
             _cprint(f"\n{_ACCENT}Voice mode requirements not met:{_RST}")
             for line in reqs["details"].split("\n"):
                 _cprint(f"  {_DIM}{line}{_RST}")
@@ -12717,7 +12727,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     _cprint(f"  {_DIM}Then install/update the Termux:API Android app for microphone capture{_RST}")
                     _cprint(f"  {_BOLD}Option 2: pkg install python-numpy portaudio && python -m pip install sounddevice{_RST}")
                 else:
-                    _cprint(f"\n  {_BOLD}Install: {sys.executable} -m pip install {' '.join(reqs['missing_packages'])}{_RST}")
+                    _cprint(f"\n  {_BOLD}Install: {_voice_capture_install_hint()}{_RST}")
+            return
+
+        # Once imports succeed, surface actual host/device incompatibilities.
+        if not env_check["available"]:
+            _cprint(f"\n{_ACCENT}Voice mode unavailable in this environment:{_RST}")
+            for warning in env_check["warnings"]:
+                _cprint(f"  {_DIM}{warning}{_RST}")
             return
 
         with self._voice_lock:

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -120,6 +120,57 @@ class TestEnableVoiceModeReal:
         cli = _make_voice_cli()
         cli._enable_voice_mode()
         assert cli._voice_mode is True
+        _req.assert_called_once_with(install_audio=True)
+
+    def test_installs_audio_before_environment_probe(self):
+        events = []
+        requirements = {"available": True, "details": "OK"}
+        environment = {"available": True, "warnings": []}
+
+        with patch("cli._cprint"), \
+             patch("hermes_cli.config.load_config", return_value={"voice": {}}), \
+             patch(
+                 "tools.voice_mode.check_voice_requirements",
+                 side_effect=lambda **kwargs: events.append(("requirements", kwargs)) or requirements,
+             ), \
+             patch(
+                 "tools.voice_mode.detect_audio_environment",
+                 side_effect=lambda: events.append(("environment", {})) or environment,
+             ):
+            cli = _make_voice_cli()
+            cli._enable_voice_mode()
+
+        assert events == [
+            ("requirements", {"install_audio": True}),
+            ("environment", {}),
+        ]
+        assert cli._voice_mode is True
+
+    def test_portaudio_failure_reports_environment_not_python_packages(self):
+        requirements = {
+            "available": False,
+            "audio_available": True,
+            "stt_available": True,
+            "details": "Environment: PortAudio system library not found",
+            "missing_packages": [],
+        }
+        environment = {
+            "available": False,
+            "warnings": ["PortAudio system library not found; install libportaudio2"],
+        }
+
+        with patch("cli._cprint") as mock_print, \
+             patch("tools.voice_mode.check_voice_requirements", return_value=requirements), \
+             patch("tools.voice_mode.detect_audio_environment", return_value=environment):
+            cli = _make_voice_cli()
+            cli._enable_voice_mode()
+
+        output = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
+        assert "Voice mode unavailable in this environment" in output
+        assert "PortAudio system library not found" in output
+        assert "Voice mode requirements not met" not in output
+        assert "Install:" not in output
+        assert cli._voice_mode is False
 
 
     @patch("cli._cprint")
@@ -136,6 +187,27 @@ class TestEnableVoiceModeReal:
 
 class TestVoiceBeepConfigReal:
     """Tests the CLI voice beep toggle."""
+
+    @patch("tools.voice_mode._voice_capture_install_hint", return_value="uv pip install --python /venv/bin/python audio")
+    @patch(
+        "tools.voice_mode.check_voice_requirements",
+        return_value={
+            "available": False,
+            "audio_available": False,
+            "stt_available": True,
+            "details": "Audio capture: MISSING",
+            "missing_packages": ["sounddevice", "numpy"],
+        },
+    )
+    def test_missing_audio_reports_pipless_venv_install_command(self, _req, _hint):
+        cli = _make_voice_cli()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            cli._voice_start_recording()
+
+        message = str(exc_info.value)
+        assert "uv pip install --python /venv/bin/python audio" in message
+        assert " -m pip install " not in message
 
     @patch("hermes_cli.config.load_config", return_value={"voice": {"beep_enabled": False}})
     def test_beeps_can_be_disabled(self, _cfg):
@@ -177,6 +249,7 @@ class TestVoiceBeepConfigReal:
         cli = _make_voice_cli()
         cli._voice_start_recording()
 
+        _req.assert_called_once_with(install_audio=True)
         recorder.start.assert_called_once()
         mock_beep.assert_not_called()
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -268,6 +268,67 @@ class TestDetectAudioEnvironment:
 # check_voice_requirements
 # ============================================================================
 
+class TestAudioAvailability:
+    def test_portaudio_oserror_means_python_packages_are_installed(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.voice_mode._import_audio",
+            MagicMock(side_effect=OSError("PortAudio library not found")),
+        )
+
+        from tools.voice_mode import _audio_available
+
+        assert _audio_available() is True
+
+
+class TestVoiceCaptureInstallHint:
+    def test_managed_uv_targets_running_interpreter_and_registry_specs(self, monkeypatch, tmp_path):
+        venv_dir = tmp_path / "venv"
+        (venv_dir / "bin").mkdir(parents=True)
+        interpreter = venv_dir / "bin" / "python"
+        (venv_dir / "bin" / "pip").touch()
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: False)
+        monkeypatch.setattr("tools.voice_mode.sys.prefix", str(venv_dir))
+        monkeypatch.setattr("tools.voice_mode.sys.base_prefix", "/usr")
+        monkeypatch.setattr("tools.voice_mode.sys.executable", str(interpreter))
+        monkeypatch.setattr("tools.voice_mode.shutil.which", lambda command: None)
+        monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: "/managed/hermes/bin/uv")
+        monkeypatch.setitem(
+            __import__("tools.lazy_deps", fromlist=["LAZY_DEPS"]).LAZY_DEPS,
+            "voice.capture",
+            ("sounddevice==9.9.9", "numpy==8.8.8"),
+        )
+
+        from tools.voice_mode import _voice_capture_install_hint
+
+        hint = _voice_capture_install_hint()
+
+        assert hint.startswith(f"/managed/hermes/bin/uv pip install --python {interpreter}")
+        assert "sounddevice==9.9.9" in hint
+        assert "numpy==8.8.8" in hint
+
+    def test_windows_cmd_quotes_paths_without_posix_single_quotes(self, monkeypatch):
+        interpreter = r"C:\Program Files\Hermes\venv\Scripts\python.exe"
+        managed_uv = r"C:\Program Files\Hermes\bin\uv.exe"
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: False)
+        monkeypatch.setattr(
+            "tools.voice_mode._is_windows_command_shell",
+            lambda: True,
+            raising=False,
+        )
+        monkeypatch.setattr("tools.voice_mode.sys.executable", interpreter)
+        monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: managed_uv)
+
+        from tools.voice_mode import _voice_capture_install_hint
+
+        hint = _voice_capture_install_hint()
+
+        assert hint.startswith(
+            '"C:\\Program Files\\Hermes\\bin\\uv.exe" pip install --python '
+            '"C:\\Program Files\\Hermes\\venv\\Scripts\\python.exe"'
+        )
+        assert "'" not in hint
+
+
 class TestCheckVoiceRequirements:
     def test_all_requirements_met(self, monkeypatch):
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
@@ -282,6 +343,50 @@ class TestCheckVoiceRequirements:
         assert result["audio_available"] is True
         assert result["stt_available"] is True
         assert result["missing_packages"] == []
+
+    def test_install_audio_lazily_before_rechecking_requirements(self, monkeypatch):
+        audio_checks = iter((False, True))
+        ensure_calls = []
+        monkeypatch.setattr("tools.voice_mode._audio_available", lambda: next(audio_checks))
+        monkeypatch.setattr(
+            "tools.voice_mode._ensure_audio_capture_dependencies",
+            lambda: ensure_calls.append("voice.capture"),
+            raising=False,
+        )
+        monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
+                            lambda: {"available": True, "warnings": []})
+        monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
+
+        from tools.voice_mode import check_voice_requirements
+
+        result = check_voice_requirements(install_audio=True)
+
+        assert ensure_calls == ["voice.capture"]
+        assert result["available"] is True
+        assert result["audio_available"] is True
+        assert result["missing_packages"] == []
+
+    def test_termux_does_not_run_python_lazy_installer(self, monkeypatch):
+        ensure_calls = []
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: True)
+        monkeypatch.setattr("tools.voice_mode._termux_voice_capture_available", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._audio_available", lambda: False)
+        monkeypatch.setattr(
+            "tools.voice_mode._ensure_audio_capture_dependencies",
+            lambda: ensure_calls.append("voice.capture"),
+        )
+        monkeypatch.setattr(
+            "tools.voice_mode.detect_audio_environment",
+            lambda: {"available": False, "warnings": ["Termux:API missing"]},
+        )
+        monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
+
+        from tools.voice_mode import check_voice_requirements
+
+        result = check_voice_requirements(install_audio=True)
+
+        assert ensure_calls == []
+        assert result["audio_available"] is False
 
 
     def test_plugin_stt_provider(self, monkeypatch):
@@ -381,16 +486,65 @@ class TestTermuxAudioRecorder:
 
 
 class TestAudioRecorder:
+    def test_start_lazy_installs_audio_capture_when_import_missing(self, monkeypatch):
+        sd = MagicMock()
+        np = MagicMock()
+        import_calls = 0
+        ensure_calls = []
+
+        def _import_after_install():
+            nonlocal import_calls
+            import_calls += 1
+            if import_calls == 1:
+                raise ImportError("no sounddevice")
+            return sd, np
+
+        monkeypatch.setattr("tools.voice_mode._import_audio", _import_after_install)
+        monkeypatch.setattr(
+            "tools.lazy_deps.ensure",
+            lambda feature, *, prompt: ensure_calls.append((feature, prompt)),
+        )
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder.start()
+
+        assert ensure_calls == [("voice.capture", False)]
+        sd.InputStream.assert_called_once()
+        sd.InputStream.return_value.start.assert_called_once()
+        assert recorder.is_recording is True
+
     def test_start_raises_without_audio_libs(self, monkeypatch):
         def _fail_import():
             raise ImportError("no sounddevice")
         monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)
+        monkeypatch.setattr(
+            "tools.lazy_deps.ensure",
+            MagicMock(side_effect=RuntimeError("install unavailable")),
+        )
 
         from tools.voice_mode import AudioRecorder
 
         recorder = AudioRecorder()
         with pytest.raises(RuntimeError, match="sounddevice and numpy"):
             recorder.start()
+
+    def test_termux_direct_recorder_does_not_lazy_install_python_audio(self, monkeypatch):
+        ensure = MagicMock()
+        monkeypatch.setattr(
+            "tools.voice_mode._import_audio",
+            MagicMock(side_effect=ImportError("no sounddevice")),
+        )
+        monkeypatch.setattr("tools.voice_mode._is_termux_environment", lambda: True)
+        monkeypatch.setattr("tools.lazy_deps.ensure", ensure)
+
+        from tools.voice_mode import AudioRecorder
+
+        with pytest.raises(RuntimeError, match="pkg install python-numpy portaudio"):
+            AudioRecorder().start()
+
+        ensure.assert_not_called()
 
     def test_start_oserror_points_at_portaudio_not_pip(self, monkeypatch):
         """OSError from _import_audio means PortAudio's shared library is

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -143,6 +143,13 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),
+    # Microphone capture is shared by every STT provider. Keep it separate
+    # from faster-whisper so cloud/plugin STT users do not pull the local
+    # inference stack just to record audio.
+    "voice.capture": (
+        "sounddevice==0.5.5",
+        "numpy==2.4.3",
+    ),
     "stt.faster_whisper": (
         "faster-whisper==1.2.1",
         "sounddevice==0.5.5",

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -97,8 +97,54 @@ def _audio_available() -> bool:
     try:
         _import_audio()
         return True
-    except (ImportError, OSError):
+    except ImportError:
         return False
+    except OSError:
+        # sounddevice is installed, but its PortAudio system library is not.
+        # Treat the Python dependencies as present so environment diagnostics
+        # can report the correct system-package fix instead of reinstalling pip
+        # wheels that are already available.
+        return True
+
+
+def _ensure_audio_capture_dependencies() -> None:
+    """Install the optional microphone-capture packages on first use."""
+    from tools.lazy_deps import ensure
+
+    ensure("voice.capture", prompt=False)
+
+    # A package installed into the running interpreter becomes importable
+    # immediately, but invalidate finder caches before the caller rechecks.
+    import importlib
+    importlib.invalidate_caches()
+
+
+def _import_audio_for_capture():
+    """Import capture dependencies, lazy-installing them when absent."""
+    try:
+        return _import_audio()
+    except ImportError as exc:
+        if _is_termux_environment():
+            raise RuntimeError(
+                "Voice mode requires Termux microphone dependencies.\n"
+                f"Install with: {_voice_capture_install_hint()}"
+            ) from exc
+        try:
+            _ensure_audio_capture_dependencies()
+        except Exception as exc:
+            raise RuntimeError(
+                "Voice mode requires sounddevice and numpy.\n"
+                f"Automatic install failed: {exc}\n"
+                f"Install with: {_voice_capture_install_hint()}"
+            ) from exc
+
+    try:
+        return _import_audio()
+    except ImportError as exc:
+        raise RuntimeError(
+            "Voice mode requires sounddevice and numpy.\n"
+            f"Install with: {_voice_capture_install_hint()}"
+        ) from exc
 
 
 def _default_input_samplerate(sd) -> int:
@@ -120,23 +166,36 @@ def _default_input_samplerate(sd) -> int:
 from hermes_constants import is_termux as _is_termux_environment
 
 
+def _is_windows_command_shell() -> bool:
+    """Return whether recovery commands should use Windows cmd quoting."""
+    return os.name == "nt"
+
+
+def _quote_install_arg(value: str) -> str:
+    """Quote one recovery-command argument for the user's native shell."""
+    if _is_windows_command_shell():
+        return subprocess.list2cmdline([value])
+    return shlex.quote(value)
+
+
 def _voice_capture_install_hint() -> str:
     if _is_termux_environment():
         return "pkg install python-numpy portaudio && python -m pip install sounddevice"
-    # If we're running inside a venv (e.g. the bundled Hermes venv at
-    # ~/.hermes/profiles/<name>/hermes-agent/venv/), `pip install` on the
-    # user's PATH won't reach the right site-packages — the bare hint sends
-    # them off to whichever Python their shell resolves first, which on macOS
-    # is often a system Python under Rosetta with a totally separate wheel
-    # index. Point them at the actual interpreter pip is sitting next to.
-    try:
-        if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
-            pip_in_venv = Path(sys.prefix) / "bin" / "pip"
-            if pip_in_venv.exists():
-                return f"{pip_in_venv} install sounddevice numpy"
-    except Exception:
-        pass
-    return "pip install sounddevice numpy"
+
+    from hermes_cli.managed_uv import resolve_uv
+    from tools.lazy_deps import LAZY_DEPS
+
+    # Source the pins from the same registry used by the automatic installer
+    # so recovery guidance cannot drift from the packages Hermes installs.
+    specs = " ".join(_quote_install_arg(spec) for spec in LAZY_DEPS["voice.capture"])
+
+    uv_bin = resolve_uv()
+    if uv_bin:
+        return (
+            f"{_quote_install_arg(uv_bin)} pip install --python "
+            f"{_quote_install_arg(sys.executable)} {specs}"
+        )
+    return f"{_quote_install_arg(sys.executable)} -m pip install {specs}"
 
 
 def _termux_microphone_command() -> Optional[str]:
@@ -1039,7 +1098,7 @@ class AudioRecorder:
         or if a recording is already in progress.
         """
         try:
-            sd, _ = _import_audio()
+            sd, _ = _import_audio_for_capture()
         except OSError as e:
             # sounddevice imports but PortAudio's shared library is missing —
             # a pip install can't fix that; point at the system package
@@ -1055,11 +1114,6 @@ class AudioRecorder:
                 "PortAudio system library not found -- install it first:\n"
                 f"{portaudio_hint}\n"
                 "Then retry /voice on."
-            ) from e
-        except ImportError as e:
-            raise RuntimeError(
-                "Voice mode requires sounddevice and numpy.\n"
-                f"Install with: {sys.executable} -m pip install sounddevice numpy"
             ) from e
 
         with self._lock:
@@ -2173,8 +2227,11 @@ def _check_plugin_stt_provider(provider: str) -> bool:
         return False
 
 
-def check_voice_requirements() -> Dict[str, Any]:
+def check_voice_requirements(*, install_audio: bool = False) -> Dict[str, Any]:
     """Check if all voice mode requirements are met.
+
+    ``install_audio`` opts action paths into the standard lazy-dependency
+    installer. Status/probe callers keep the default read-only behavior.
 
     Returns:
         Dict with ``available``, ``audio_available``, ``stt_available``,
@@ -2216,6 +2273,18 @@ def check_voice_requirements() -> Dict[str, Any]:
     missing: List[str] = []
     termux_capture = _termux_voice_capture_available()
     has_audio = _audio_available() or termux_capture
+
+    if (
+        install_audio
+        and not has_audio
+        and not termux_capture
+        and not _is_termux_environment()
+    ):
+        try:
+            _ensure_audio_capture_dependencies()
+        except Exception as exc:
+            logger.warning("Voice capture dependency install failed: %s", exc)
+        has_audio = _audio_available()
 
     if not has_audio:
         missing.extend(["sounddevice", "numpy"])


### PR DESCRIPTION
## Bug Description

Fresh core installs can enable an STT provider without installing the shared microphone capture packages. Starting voice mode then fails with:

`Voice mode requires sounddevice and numpy.`

The suggested `<venv>/bin/python -m pip install ...` command is also unusable in Hermes environments created by `uv`, because those environments intentionally do not bundle pip.

## Root Cause

`sounddevice` and `numpy` were only registered as transitive lazy dependencies of the local `faster-whisper` provider. Cloud and plugin STT providers still need them for microphone capture, but their voice paths only checked imports and returned an error; they never entered the standard lazy dependency installer.

In addition, `/voice on` ran the environment probe before any install attempt, so a missing optional wheel was classified as an incompatible environment.

## Fix

- Add a provider-independent `voice.capture` lazy dependency feature for `sounddevice==0.5.5` and `numpy==2.4.3`.
- Lazy-install those packages on `/voice on`, record-key capture, and direct `AudioRecorder.start()` paths.
- Keep status/probe calls read-only unless the caller explicitly opts into installation.
- Preserve Termux's package/API path and PortAudio system-library diagnostics.
- Distinguish missing Python packages (`ImportError`) from missing PortAudio (`OSError`).
- Generate fallback guidance from the lazy dependency registry, resolve Hermes's managed `uv`, target the running interpreter, and use native Windows/POSIX shell quoting.

## How to Verify

1. Create a core-only venv: `uv venv /tmp/hermes-voice/venv && uv pip install --python /tmp/hermes-voice/venv/bin/python -e .`
2. Confirm `sounddevice` and `numpy` are absent.
3. Run `check_voice_requirements(install_audio=True)`.
4. Confirm `audio_available` is true and the installed versions are `sounddevice==0.5.5` and `numpy==2.4.3`.

## Test Plan

- [x] Regression tests cover `/voice on` ordering, direct recorder lazy installation, managed-uv recovery guidance, native Windows quoting, PortAudio classification, and both Termux entry paths.
- [x] Voice/lazy-dependency/metadata/managed-runtime tests: 171 passed, 22 skipped.
- [x] Ruff and `git diff --check` pass.
- [x] Fresh core-only venv smoke verified missing packages are installed and the host audio probe becomes available.

## Risk Assessment

Low — installation uses the existing lazy-dependency security gate and exact package pins. Status checks remain side-effect free; Termux and system PortAudio handling retain their platform-specific paths.
