### PR TITLE
fix(hooks): register shell hooks on dashboard + TUI slash-worker startup

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -225,6 +225,35 @@ async def _lifespan(app: "FastAPI"):
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
 
+    # Declarative shell hooks (post_api_request, subagent_stop, …) only fire
+    # when register_from_config has run in THIS process. CLI chat and
+    # ``gateway run`` already do; dashboard/serve agent turns did not, so
+    # observability pipelines only saw cron/CLI traffic (#64178 / #50776).
+    # Mirror gateway/run.py: accept_hooks=False and let env/config resolve
+    # consent (hooks_auto_accept / HERMES_ACCEPT_HOOKS). Never block boot.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        _hooks_cfg = load_config()
+        register_from_config(_hooks_cfg, accept_hooks=False)
+        try:
+            from agent.outbound_webhooks import (
+                register_from_config as register_outbound_webhooks,
+            )
+
+            register_outbound_webhooks(_hooks_cfg)
+        except Exception:
+            _log.debug(
+                "outbound-webhook registration failed at dashboard startup",
+                exc_info=True,
+            )
+    except Exception:
+        _log.debug(
+            "shell-hook registration failed at dashboard startup",
+            exc_info=True,
+        )
+
     # Import hermes_cli.gateway eagerly *before* the lifespan yield so the
     # GIL-heavy .pyc compilation and Defender scan cost is absorbed during
     # backend initialisation — before the server socket accepts probes.

--- a/tests/hermes_cli/test_shell_hooks_surface_registration.py
+++ b/tests/hermes_cli/test_shell_hooks_surface_registration.py
@@ -1,0 +1,89 @@
+"""Shell hooks must register on dashboard + TUI slash-worker surfaces.
+
+CLI chat and ``gateway run`` already call ``register_from_config``. Dashboard
+chat sessions (``hermes_cli/web_server._lifespan``) and TUI slash workers
+(``tui_gateway/slash_worker._prepare_slash_worker_runtime``) run full agent
+turns without those entry points, so declarative hooks were silently dead
+on those surfaces (#64178 / #50776).
+
+These tests assert the two call sites actually invoke registration (with
+``accept_hooks=False``, matching gateway/run.py).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.web_server as web_server_mod
+
+
+def test_dashboard_lifespan_registers_shell_hooks():
+    """Dashboard/serve lifespan must call register_from_config(accept_hooks=False)."""
+    from fastapi.testclient import TestClient
+
+    cfg = {"hooks": {}}
+    register = MagicMock(return_value=[])
+    outbound = MagicMock(return_value=[])
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.shell_hooks.register_from_config", register),
+        patch("agent.outbound_webhooks.register_from_config", outbound),
+        patch.object(web_server_mod, "_warm_gateway_module", lambda: None),
+    ):
+        with TestClient(web_server_mod.app, raise_server_exceptions=False):
+            pass
+
+    register.assert_called_once_with(cfg, accept_hooks=False)
+    outbound.assert_called_once_with(cfg)
+
+
+def test_slash_worker_runtime_registers_shell_hooks():
+    """Slash-worker runtime prep must register hooks before HermesCLI turns."""
+    # slash_worker imports cli (prompt_toolkit-heavy) at module load; stub it
+    # so this unit test stays dependency-light.
+    stub_cli = types.ModuleType("cli")
+    stub_cli.HermesCLI = object  # type: ignore[attr-defined]
+    stub_hb = types.ModuleType("hermes_bootstrap")
+    stub_hb.harden_import_path = lambda: None  # type: ignore[attr-defined]
+    stub_rec = types.ModuleType("tui_gateway._stdin_recovery")
+    stub_rec.handle_spurious_eof = lambda *a, **k: False  # type: ignore[attr-defined]
+    stub_rich = types.ModuleType("rich")
+    stub_console = types.ModuleType("rich.console")
+    stub_console.Console = object  # type: ignore[attr-defined]
+
+    cfg = {"hooks": {}}
+    register = MagicMock(return_value=[])
+    outbound = MagicMock(return_value=[])
+
+    with patch.dict(
+        sys.modules,
+        {
+            "cli": stub_cli,
+            "hermes_bootstrap": stub_hb,
+            "tui_gateway._stdin_recovery": stub_rec,
+            "rich": stub_rich,
+            "rich.console": stub_console,
+        },
+    ):
+        # Force a clean import under stubs
+        sys.modules.pop("tui_gateway.slash_worker", None)
+        slash_worker = importlib.import_module("tui_gateway.slash_worker")
+
+        with (
+            patch(
+                "hermes_cli.mcp_startup.start_background_mcp_discovery",
+                MagicMock(),
+            ),
+            patch("hermes_cli.mcp_startup.wait_for_mcp_discovery", MagicMock()),
+            patch("hermes_cli.config.load_config", return_value=cfg),
+            patch("agent.shell_hooks.register_from_config", register),
+            patch("agent.outbound_webhooks.register_from_config", outbound),
+        ):
+            slash_worker._prepare_slash_worker_runtime()
+
+    register.assert_called_once_with(cfg, accept_hooks=False)
+    outbound.assert_called_once_with(cfg)

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -62,6 +62,11 @@ def _prepare_slash_worker_runtime() -> None:
 
     Each slash_worker child is its own process — the parent ``hermes serve``
     discovery thread does not populate this registry (issue #61891).
+
+    Also register declarative shell hooks here. Slash workers run full agent
+    turns (via HermesCLI) without going through CLI ``_prepare_agent_startup``
+    or gateway startup, so hooks configured under ``hooks:`` were silently
+    inactive on this surface (#64178 / #50776). Mirror gateway/run.py.
     """
     import logging
 
@@ -76,6 +81,29 @@ def _prepare_slash_worker_runtime() -> None:
         thread_name="slash-worker-mcp-discovery",
     )
     wait_for_mcp_discovery()
+
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        _hooks_cfg = load_config()
+        register_from_config(_hooks_cfg, accept_hooks=False)
+        try:
+            from agent.outbound_webhooks import (
+                register_from_config as register_outbound_webhooks,
+            )
+
+            register_outbound_webhooks(_hooks_cfg)
+        except Exception:
+            logger.debug(
+                "outbound-webhook registration failed at slash-worker startup",
+                exc_info=True,
+            )
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at slash-worker startup",
+            exc_info=True,
+        )
 
 
 def _start_parent_death_watchdog(original_ppid) -> None:


### PR DESCRIPTION
## Summary

Dashboard/serve (`hermes_cli/web_server._lifespan`) and TUI slash workers (`tui_gateway/slash_worker`) run full agent turns without ever calling `register_from_config()`, so declarative shell hooks (`post_api_request`, `subagent_stop`, …) silently never fired on those surfaces. Observability pipelines only saw cron/CLI traffic.

This is the minimal parity fix: call `register_from_config(load_config(), accept_hooks=False)` at both entry points, mirroring `gateway/run.py` (consent still via `hooks_auto_accept` / `HERMES_ACCEPT_HOOKS`). Also registers outbound webhooks the same way.

## Why this shape (not the `_AGENT_COMMANDS` allowlist patches)

Several open PRs try adjacent fixes by adding `serve`/`dashboard` to `_AGENT_COMMANDS` in `main.py`. That helps the CLI dispatch path, but:
- dashboard FastAPI lifespan is not that path
- slash_worker is a separate child process that never hits `main.py`

This PR hits the actual process entry points that run agent turns.

## Test plan
- [x] `tests/hermes_cli/test_shell_hooks_surface_registration.py` — asserts both call sites invoke `register_from_config(..., accept_hooks=False)` + outbound webhooks
- [ ] Manual: configure a `post_api_request` shell hook, run a dashboard chat turn + a TUI slash command that triggers an agent turn, confirm hook fires

## Related
- Fixes the slash-worker / dashboard half of #64178 / #50776
- Production-fork evidence registered on #64182 (item 1)
- Complements (does not replace) #64188 foundation work