### PR TITLE
fix(file-safety): refuse writes into git-managed state under .git directories

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -135,9 +135,79 @@ def find_git_worktree_pointer_file(resolved_path: str) -> Optional[str]:
     return None
 
 
+# Denial kind returned by ``_classify_write_denial`` when the target is (or
+# sits under) a ``.git`` DIRECTORY (normal repo / submodule) at a path git
+# owns — branch identity, refs, index, object store.  Kept distinct so
+# ``get_write_denied_error`` can explain the corruption risk instead of the
+# generic credential message.
+_GIT_STATE_DENIAL = "git_managed_state"
+
+# User-owned entries inside a ``.git`` DIRECTORY that git never rewrites.
+# ``config`` and ``description`` are exact files, ``info/exclude`` is the
+# per-repo ignore file, and ``hooks/`` is a whole subtree of user scripts.
+# Everything else under ``.git`` is git-managed state.
+_GIT_USER_OWNED_EXACT = ("config", "description", "info/exclude")
+
+
+def _is_git_user_owned_remainder(remainder: str) -> bool:
+    """Return True when ``remainder`` — the path relative to a ``.git``
+    DIRECTORY, ``''`` when the target IS the ``.git`` dir — is user-owned
+    configuration that git never rewrites.
+
+    Allowlist: ``config``, ``description``, ``info/exclude`` (exact
+    relative paths), and ``hooks/`` (the directory itself and anything
+    under it — user scripts).  Everything else is git-managed state.
+    """
+    if remainder in _GIT_USER_OWNED_EXACT:
+        return True
+    if remainder == "hooks" or remainder.startswith("hooks/"):
+        return True
+    return False
+
+
+def find_git_managed_state_target(resolved_path: str) -> Optional[str]:
+    """Return the ``.git`` DIRECTORY whose git-managed state ``resolved_path``
+    would replace, or ``None``.
+
+    For every ``.git`` path component that is a DIRECTORY (normal
+    repository / submodule — NOT the worktree-pointer FILE handled by
+    ``find_git_worktree_pointer_file``), classify the remainder relative to
+    that ``.git`` dir.  The target is refused unless the remainder is
+    user-owned: ``config``, ``description``, ``info/exclude``, or anything
+    under ``hooks/``.  Everything else — ``HEAD``, ``index``, ``refs/``,
+    ``objects/``, ``logs/``, ``packed-refs``, ``ORIG_HEAD``,
+    ``FETCH_HEAD``, ``MERGE_HEAD``, ``CHERRY_PICK_HEAD``, ``REBASE_HEAD``,
+    ``COMMIT_EDITMSG``, ``shallow``, ``info/`` (except ``info/exclude``),
+    the ``.git`` dir itself, anything unknown — is git-managed state whose
+    replacement corrupts the repository.
+
+    ``resolved_path`` must already be realpath-resolved (the caller
+    resolves).  ``.git`` FILE components are skipped — the worktree-pointer
+    guard owns them.  Missing components below an existing ``.git``
+    directory are still classified (a not-yet-created target is caught).
+    """
+    parts = Path(resolved_path).parts
+    for idx, part in enumerate(parts):
+        if part != ".git":
+            continue
+        candidate = os.path.join(*parts[: idx + 1])
+        try:
+            # isdir() follows symlinks and is False for files.
+            if not os.path.isdir(candidate):
+                # .git FILE — worktree pointer, owned by the sibling check.
+                continue
+        except OSError:
+            continue
+        remainder = "/".join(parts[idx + 1 :])
+        if _is_git_user_owned_remainder(remainder):
+            continue
+        return candidate
+    return None
+
+
 def _classify_write_denial(path: str) -> Optional[str]:
     """Return ``'credential'``, ``'safe_root'``, ``'worktree_git_pointer'``,
-    or ``None`` if writes are allowed."""
+    ``'git_managed_state'``, or ``None`` if writes are allowed."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
@@ -189,10 +259,23 @@ def _classify_write_denial(path: str) -> Optional[str]:
     # would replace or sever that pointer, making the worktree vanish from
     # ``git worktree list``.  Refuse any target that IS such a pointer file
     # or sits below one; ``.git`` DIRECTORY components (normal repos,
-    # submodules) remain writable.
+    # submodules) are handled by the git-managed-state check below.
     worktree_git_pointer = find_git_worktree_pointer_file(resolved)
     if worktree_git_pointer is not None:
         return _WORKTREE_GIT_POINTER_DENIAL
+
+    # Git-managed state inside ``.git`` DIRECTORIES (#78793): normal
+    # repositories and submodules keep their database in a ``.git``
+    # directory.  Almost everything in it — HEAD, index, refs/, objects/,
+    # logs/, packed-refs, ORIG_HEAD / FETCH_HEAD / MERGE_HEAD /
+    # CHERRY_PICK_HEAD / REBASE_HEAD, COMMIT_EDITMSG, shallow — is
+    # git-owned state.  A generic write_file/patch/delete/move that
+    # replaces any of it corrupts branch identity, refs and the index;
+    # only user-owned entries git never rewrites (config, description,
+    # info/exclude, hooks/) stay writable.
+    git_state_dir = find_git_managed_state_target(resolved)
+    if git_state_dir is not None:
+        return _GIT_STATE_DENIAL
 
     safe_roots = get_safe_write_roots()
     if safe_roots:
@@ -229,6 +312,13 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
             f"file. Writing here replaces the 'gitdir: <path>' link that "
             f"attaches the worktree to its repository and severs the "
             f"worktree from git. Use the terminal or git commands instead."
+        )
+    if denial == _GIT_STATE_DENIAL:
+        return (
+            f"{verb} denied: '{path}' targets git-managed state inside a "
+            f".git directory. Writing here replaces repository state that "
+            f"git owns (branch identity, refs, index) and corrupts the "
+            f"repository. Use terminal git commands instead."
         )
     return f"{verb} denied: '{path}' is a protected system/credential file."
 

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -98,8 +98,46 @@ def get_safe_write_roots() -> set[str]:
     return roots
 
 
+# Denial kind returned by ``_classify_write_denial`` when the target is (or
+# sits under) a git worktree ``.git`` pointer FILE.  Kept distinct from the
+# ``"credential"`` / ``"safe_root"`` kinds so ``get_write_denied_error`` can
+# surface the specific worktree-severing explanation.
+_WORKTREE_GIT_POINTER_DENIAL = "worktree_git_pointer"
+
+
+def find_git_worktree_pointer_file(resolved_path: str) -> Optional[str]:
+    """Return the on-disk path of a ``.git`` *file* (git worktree pointer)
+    that ``resolved_path`` touches, or ``None``.
+
+    A linked worktree stores its repository link as a plain FILE named
+    ``.git`` containing ``gitdir: <path>``.  Writing that file — or
+    anything below it — replaces/severs the pointer and the worktree
+    disappears from ``git worktree list``.  ``.git`` DIRECTORY components
+    (normal repositories, submodules) are not pointers and are
+    deliberately not matched.
+
+    ``resolved_path`` must already be realpath-resolved (the caller
+    resolves).  Missing components are skipped: a not-yet-created target
+    below an existing worktree pointer is still caught, while a brand-new
+    path under a nonexistent ``.git`` directory is not false-positived.
+    """
+    parts = Path(resolved_path).parts
+    for idx, part in enumerate(parts):
+        if part != ".git":
+            continue
+        candidate = os.path.join(*parts[: idx + 1])
+        try:
+            # isfile() follows symlinks and is False for directories.
+            if os.path.isfile(candidate):
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
 def _classify_write_denial(path: str) -> Optional[str]:
-    """Return ``'credential'``, ``'safe_root'``, or ``None`` if writes are allowed."""
+    """Return ``'credential'``, ``'safe_root'``, ``'worktree_git_pointer'``,
+    or ``None`` if writes are allowed."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
@@ -145,6 +183,17 @@ def _classify_write_denial(path: str) -> Optional[str]:
         except Exception:
             pass
 
+    # Git worktree ``.git`` pointer FILES: a plain file named ``.git`` whose
+    # ``gitdir: <path>`` content links a linked worktree to its (bare)
+    # repository.  write_file's temp-file + ``mv -f`` — and delete/move —
+    # would replace or sever that pointer, making the worktree vanish from
+    # ``git worktree list``.  Refuse any target that IS such a pointer file
+    # or sits below one; ``.git`` DIRECTORY components (normal repos,
+    # submodules) remain writable.
+    worktree_git_pointer = find_git_worktree_pointer_file(resolved)
+    if worktree_git_pointer is not None:
+        return _WORKTREE_GIT_POINTER_DENIAL
+
     safe_roots = get_safe_write_roots()
     if safe_roots:
         allowed = False
@@ -173,6 +222,13 @@ def get_write_denied_error(path: str, *, verb: str = "Write") -> Optional[str]:
         return (
             f"{verb} denied: '{path}' is outside HERMES_WRITE_SAFE_ROOT "
             f"({roots_display}). Unset the variable or add this path's directory prefix."
+        )
+    if denial == _WORKTREE_GIT_POINTER_DENIAL:
+        return (
+            f"{verb} denied: '{path}' touches a git worktree .git pointer "
+            f"file. Writing here replaces the 'gitdir: <path>' link that "
+            f"attaches the worktree to its repository and severs the "
+            f"worktree from git. Use the terminal or git commands instead."
         )
     return f"{verb} denied: '{path}' is a protected system/credential file."
 

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -213,6 +213,53 @@ class TestCheckSensitivePathMacOSBypass:
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
 
+class TestCheckSensitivePathGitWorktreePointer:
+    """_check_sensitive_path must refuse git worktree .git pointer FILES (#78565).
+
+    A linked worktree's repository link is a plain FILE named ``.git``
+    (``gitdir: <path>``). Writing that file — or anything below it —
+    atomically replaces/severs the pointer, turning the worktree into a
+    zombie: git commands inside it die and git tooling refuses to remove
+    it. The write_file_tool / V4A surfaces guard via _check_sensitive_path,
+    so it must carry the same refusal as the file_operations deny layer.
+    """
+
+    @staticmethod
+    def _make_worktree(tmp_path: Path) -> Path:
+        """Create a fake linked worktree: a dir whose .git is a FILE."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text(
+            f"gitdir: {tmp_path / 'bare.git' / 'worktrees' / 'wt'}\n",
+            encoding="utf-8",
+        )
+        return wt
+
+    def test_pointer_file_itself_refused(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        wt = self._make_worktree(tmp_path)
+        assert _check_sensitive_path(str(wt / ".git")) is not None
+
+    def test_path_below_pointer_refused(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        wt = self._make_worktree(tmp_path)
+        assert _check_sensitive_path(str(wt / ".git" / "refs" / "heads" / "x")) is not None
+
+    def test_normal_git_directory_allowed(self, tmp_path: Path):
+        # A .git DIRECTORY (normal repo / submodule) is not a worktree
+        # pointer; sibling writes and git-internal writes stay permitted.
+        from tools.file_tools import _check_sensitive_path
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        assert _check_sensitive_path(str(repo / ".git" / "config")) is None
+        assert _check_sensitive_path(str(repo / "src" / "main.py")) is None
+
+    def test_unrelated_paths_allowed(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(str(tmp_path / "notes.txt")) is None
+
+
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.
 

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -260,6 +260,56 @@ class TestCheckSensitivePathGitWorktreePointer:
         assert _check_sensitive_path(str(tmp_path / "notes.txt")) is None
 
 
+class TestCheckSensitivePathGitManagedState:
+    """_check_sensitive_path refuses git-managed state inside ``.git``
+    DIRECTORIES (#78793).
+
+    A normal repository's ``.git`` directory holds git-owned state (HEAD,
+    index, refs/, objects/, logs/, packed-refs, ...).  The write_file_tool
+    / V4A surfaces guard via _check_sensitive_path, so they must refuse
+    replacing that state; only user-owned entries git never rewrites
+    (config, description, info/exclude, hooks/) stay writable.
+    """
+
+    @staticmethod
+    def _make_repo(tmp_path: Path) -> Path:
+        """A normal repository: <repo>/.git is a DIRECTORY."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        return repo
+
+    def test_git_managed_state_refused(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        repo = self._make_repo(tmp_path)
+        for rel in [
+            "HEAD",
+            "index",
+            "refs/heads/x",
+            "objects/ab/cdef",
+            "info/refs",
+        ]:
+            err = _check_sensitive_path(str(repo / ".git" / rel))
+            assert err is not None, rel
+            assert "git-managed state" in err
+
+    def test_git_dir_itself_refused_sibling_allowed(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        repo = self._make_repo(tmp_path)
+        assert _check_sensitive_path(str(repo / ".git")) is not None
+        assert _check_sensitive_path(str(repo / "src" / "main.py")) is None
+
+    def test_user_owned_git_entries_allowed(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        repo = self._make_repo(tmp_path)
+        for rel in [
+            "config",
+            "description",
+            "info/exclude",
+            "hooks/pre-commit",
+        ]:
+            assert _check_sensitive_path(str(repo / ".git" / rel)) is None, rel
+
+
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.
 

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.file_operations import _is_write_denied
 
 
@@ -93,3 +95,110 @@ class TestWriteAllowed:
         home = get_hermes_home()
         for name in ["auth.json", "config.yaml", "webhook_subscriptions.json"]:
             assert _is_write_denied(str(home / name)) is False, f"{name} should be writable"
+
+
+class TestGitWorktreePointerFileGuard:
+    """Writes that touch a git worktree ``.git`` pointer FILE are refused.
+
+    A linked worktree stores its ``gitdir: <path>`` link in a plain FILE
+    named ``.git``.  write_file's temp-file + ``mv -f`` (and delete/move)
+    would replace or sever that pointer, making the worktree vanish from
+    ``git worktree list`` (#78565).  Normal repositories whose ``.git`` is
+    a DIRECTORY must stay writable.
+    """
+
+    @pytest.fixture
+    def ops(self, tmp_path: Path):
+        from tools.environments.local import LocalEnvironment
+        from tools.file_operations import ShellFileOperations
+        env = LocalEnvironment(cwd=str(tmp_path))
+        return ShellFileOperations(env, cwd=str(tmp_path))
+
+    @pytest.fixture
+    def worktree(self, tmp_path: Path) -> Path:
+        """A fake linked worktree: <wt>/.git is a FILE pointing at a bare repo."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /srv/git/bare.git\n")
+        return wt
+
+    @pytest.fixture
+    def normal_repo(self, tmp_path: Path) -> Path:
+        """A normal repository: <repo>/.git is a DIRECTORY."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        return repo
+
+    def test_denied_when_target_is_pointer_file(self, worktree: Path):
+        from agent.file_safety import get_write_denied_error
+
+        assert _is_write_denied(str(worktree / ".git")) is True
+        err = get_write_denied_error(str(worktree / ".git"))
+        assert err is not None
+        assert "git worktree .git pointer file" in err
+        assert "severs" in err
+        assert "terminal or git" in err
+
+    def test_denied_when_pointer_file_is_intermediate_component(self, worktree: Path):
+        from agent.file_safety import get_write_denied_error
+
+        target = worktree / ".git" / "refs" / "heads" / "main"
+        assert _is_write_denied(str(target)) is True
+        err = get_write_denied_error(str(target), verb="Patch")
+        assert err is not None
+        assert "git worktree .git pointer file" in err
+        assert "severs" in err
+
+    def test_denied_for_all_mutating_verbs(self, ops, worktree: Path):
+        from agent.file_safety import get_write_denied_error
+
+        pointer = worktree / ".git"
+        # Write
+        res = ops.write_file(str(pointer), "gitdir: /evil.git\n")
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # The pointer file must be untouched.
+        assert (worktree / ".git").read_text() == "gitdir: /srv/git/bare.git\n"
+        # Patch
+        res = ops.patch_replace(str(pointer), "gitdir", "gitdir")
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # Delete
+        res = ops.delete_file(str(pointer))
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        assert (worktree / ".git").exists()
+        # Move (source side)
+        res = ops.move_file(str(pointer), str(worktree / "moved"))
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # Move (destination side)
+        res = ops.move_file(str(worktree / "x.txt"), str(pointer))
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+        # Verb-aware messages name the verb.
+        err = get_write_denied_error(str(pointer), verb="Delete")
+        assert err is not None and err.startswith("Delete denied")
+
+    def test_denied_for_paths_under_pointer_file_via_tools(self, ops, worktree: Path):
+        target = worktree / ".git" / "refs" / "heads" / "main"
+        res = ops.write_file(str(target), "deadbeef\n")
+        assert res.error is not None
+        assert "git worktree .git pointer file" in res.error
+
+    def test_normal_repo_with_git_directory_still_writable(self, ops, normal_repo: Path):
+        from agent.file_safety import get_write_denied_error
+
+        assert _is_write_denied(str(normal_repo / ".git")) is False
+        assert _is_write_denied(str(normal_repo / ".git" / "config")) is False
+        assert get_write_denied_error(str(normal_repo / ".git")) is None
+        sibling = normal_repo / "notes.txt"
+        res = ops.write_file(str(sibling), "hello\n")
+        assert res.error is None
+        assert sibling.read_text() == "hello\n"
+
+    def test_sibling_file_in_worktree_still_writable(self, ops, worktree: Path):
+        sibling = worktree / "notes.txt"
+        res = ops.write_file(str(sibling), "hello\n")
+        assert res.error is None
+        assert sibling.read_text() == "hello\n"

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -103,8 +103,9 @@ class TestGitWorktreePointerFileGuard:
     A linked worktree stores its ``gitdir: <path>`` link in a plain FILE
     named ``.git``.  write_file's temp-file + ``mv -f`` (and delete/move)
     would replace or sever that pointer, making the worktree vanish from
-    ``git worktree list`` (#78565).  Normal repositories whose ``.git`` is
-    a DIRECTORY must stay writable.
+    ``git worktree list`` (#78565).  ``.git`` DIRECTORY components (normal
+    repositories, submodules) are not pointers; their git-managed state is
+    covered by TestGitManagedState.
     """
 
     @pytest.fixture
@@ -189,9 +190,11 @@ class TestGitWorktreePointerFileGuard:
     def test_normal_repo_with_git_directory_still_writable(self, ops, normal_repo: Path):
         from agent.file_safety import get_write_denied_error
 
-        assert _is_write_denied(str(normal_repo / ".git")) is False
+        # The .git DIRECTORY itself is git-managed state — refused (#78793).
+        assert _is_write_denied(str(normal_repo / ".git")) is True
+        assert get_write_denied_error(str(normal_repo / ".git")) is not None
+        # User-owned config inside .git stays writable (see TestGitManagedState).
         assert _is_write_denied(str(normal_repo / ".git" / "config")) is False
-        assert get_write_denied_error(str(normal_repo / ".git")) is None
         sibling = normal_repo / "notes.txt"
         res = ops.write_file(str(sibling), "hello\n")
         assert res.error is None
@@ -202,3 +205,73 @@ class TestGitWorktreePointerFileGuard:
         res = ops.write_file(str(sibling), "hello\n")
         assert res.error is None
         assert sibling.read_text() == "hello\n"
+
+
+class TestGitManagedState:
+    """Writes into a ``.git`` DIRECTORY (normal repo / submodule) are refused
+    unless the relative path is user-owned (#78793).
+
+    Almost everything under a ``.git`` directory is git-managed state —
+    HEAD, index, refs/, objects/, logs/, packed-refs, ORIG_HEAD,
+    COMMIT_EDITMSG, info/refs and friends.  Replacing any of it with a
+    generic file tool corrupts the repository (branch identity, refs,
+    index).  Only user-owned entries git never rewrites stay writable:
+    ``config``, ``description``, ``info/exclude``, and anything under
+    ``hooks/``.  ``.git`` FILES (worktree pointers) are covered by
+    TestGitWorktreePointerFileGuard.
+    """
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        """A normal repository: <repo>/.git is a DIRECTORY."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        return repo
+
+    def test_refused_head_index_and_packed_refs(self, repo: Path):
+        for rel in ["HEAD", "index", "packed-refs"]:
+            assert _is_write_denied(str(repo / ".git" / rel)) is True, rel
+
+    def test_refused_heads_and_rebase_markers(self, repo: Path):
+        for rel in ["ORIG_HEAD", "COMMIT_EDITMSG", "MERGE_HEAD", "REBASE_HEAD"]:
+            assert _is_write_denied(str(repo / ".git" / rel)) is True, rel
+
+    def test_refused_refs_objects_and_logs(self, repo: Path):
+        for rel in [
+            "refs/heads/x",
+            "objects/ab/cdef",
+            "logs/HEAD",
+        ]:
+            assert _is_write_denied(str(repo / ".git" / rel)) is True, rel
+
+    def test_refused_info_refs_and_info_dir(self, repo: Path):
+        assert _is_write_denied(str(repo / ".git" / "info" / "refs")) is True
+        assert _is_write_denied(str(repo / ".git" / "info")) is True
+
+    def test_refused_git_dir_itself(self, repo: Path):
+        assert _is_write_denied(str(repo / ".git")) is True
+
+    def test_allowed_user_owned_entries(self, repo: Path):
+        for rel in [
+            "config",
+            "description",
+            "info/exclude",
+            "hooks/pre-commit",
+            "hooks/applypatch-msg",
+        ]:
+            assert _is_write_denied(str(repo / ".git" / rel)) is False, rel
+
+    def test_allowed_sibling_outside_git(self, repo: Path):
+        assert _is_write_denied(str(repo / "notes.txt")) is False
+
+    def test_denial_message_names_git_managed_state(self, repo: Path):
+        from agent.file_safety import get_write_denied_error
+
+        err = get_write_denied_error(str(repo / ".git" / "HEAD"))
+        assert err is not None
+        assert "git-managed state" in err
+        assert "corrupts" in err
+        assert "terminal git commands" in err
+        # Verb-aware messages name the verb.
+        err = get_write_denied_error(str(repo / ".git" / "HEAD"), verb="Patch")
+        assert err is not None and err.startswith("Patch denied")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -10,7 +10,7 @@ import sys
 import threading
 from pathlib import Path, PurePosixPath
 
-from agent.file_safety import get_read_block_error
+from agent.file_safety import find_git_worktree_pointer_file, get_read_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
@@ -698,6 +698,24 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             f"Refusing to write to Hermes config file: {filepath}\n"
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+        )
+    # Git worktree ``.git`` pointer FILES (#78565): a linked worktree's
+    # repository link is a plain FILE named ``.git`` containing
+    # ``gitdir: <path>``. Writing that file — or anything below it —
+    # atomically replaces/severs the pointer and the worktree becomes a
+    # zombie (git commands inside it die, and git tooling refuses to
+    # remove it). ``.git`` DIRECTORY components (normal repos,
+    # submodules) are not pointers and remain writable.
+    try:
+        resolved_real = os.path.realpath(os.path.expanduser(filepath))
+    except OSError:
+        resolved_real = filepath
+    if find_git_worktree_pointer_file(resolved_real) is not None:
+        return (
+            f"Refusing to write to git worktree .git pointer path: {filepath}\n"
+            "Writing here replaces the 'gitdir: <path>' link that attaches the "
+            "worktree to its repository and severs the worktree from git. "
+            "Use the terminal or git commands instead."
         )
     return None
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -10,7 +10,11 @@ import sys
 import threading
 from pathlib import Path, PurePosixPath
 
-from agent.file_safety import find_git_worktree_pointer_file, get_read_block_error
+from agent.file_safety import (
+    find_git_managed_state_target,
+    find_git_worktree_pointer_file,
+    get_read_block_error,
+)
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
@@ -716,6 +720,19 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Writing here replaces the 'gitdir: <path>' link that attaches the "
             "worktree to its repository and severs the worktree from git. "
             "Use the terminal or git commands instead."
+        )
+    # Git-managed state inside ``.git`` DIRECTORIES (#78793): HEAD, index,
+    # refs/, objects/, logs/, packed-refs, *_HEAD and friends are
+    # git-owned state.  Replacing any of it via write_file / patch /
+    # delete / move corrupts branch identity and the repository; only
+    # user-owned entries git never rewrites (config, description,
+    # info/exclude, hooks/) stay writable.
+    if find_git_managed_state_target(resolved_real) is not None:
+        return (
+            f"Refusing to write to git-managed state: {filepath}\n"
+            "Writing here replaces repository state that git owns (branch "
+            "identity, refs, index) and corrupts the repository. "
+            "Use terminal git commands instead."
         )
     return None
 


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #76246 #78565 #78652 #78653 #78793
## Summary

`write_file` / `patch` / `delete` / `move` silently rewrite git-managed state inside a
normal repository's `.git` **directory** (HEAD, index, refs/, objects/, logs/,
packed-refs, ...). Reproduced on current main:

- `.git/HEAD` → repo jumps to a phantom branch (`On branch nonexistent`), `git log` fatal
- `.git/refs/heads/x` → `git fsck: invalid sha1 pointer deadbeef…`
- `.git/index` → `git status`/`git fsck` fatal: `index file smaller than expected`

The #78565 guard (worktree `.git` pointer FILES, PR #78652) does not cover this — a
`.git` component that is a DIRECTORY passes it. This PR closes the class: git-managed
state under a `.git` directory is refused; user-owned paths stay writable.

## Fix

`agent/file_safety.py`:

- `find_git_managed_state_target(resolved_path)` — walks every `.git` component; for
  DIRECTORY components, classifies the remainder: refused unless user-owned
  (allowlist: `config`, `hooks/*`, `info/exclude`, `description`); empty remainder
  (the `.git` dir itself) refused; `.git` FILE components are left to the existing
  pointer check.
- New denial kind `git_managed_state` wired into `_classify_write_denial` and
  `get_write_denied_error` with a corruption-explaining message (use terminal git
  instead).
- Same wiring in `tools/file_tools.py:_check_sensitive_path` (the `write_file_tool` /
  V4A wrapper surface).

Allowlist verified against git's repository-layout semantics: git itself never
rewrites `config`, `hooks/*`, `info/exclude`, `description` during normal operations —
those are user-owned; everything else under `.git` is git state.

Class audit (verified at this SHA): every mutating file surface is chokepointed through
`get_write_denied_error` (write_file :1457, patch_replace :1675, `_python_delete`
:1351, move_file :1397) or `_check_sensitive_path` (write_file_tool, patch_tool V4A
incl. both Move endpoints); V4A ops route through guarded methods; the ACP shim passes
the same guard. A rule in both functions = zero bypass through tools. Reads stay
permissive; terminal unaffected. Bare repositories (no `.git` component) remain out of
scope, noted for a separate hardening.

## Note on the branch base

The #78565 guard family is not yet on main (open PR #78652). This branch cherry-picks
its two commits (`6499b55335`, `90483f2fe3`) as the foundation — the git-state tests
depend on the pointer guard existing. When #78652 merges, those hunks dedupe; the new
material here is the git-managed-state guard (HEAD of the branch).

## Tests

- `tests/tools/test_write_deny.py` — refuse: `.git/HEAD`, `.git/index`,
  `.git/refs/heads/x`, `.git/objects/ab/cdef`, `.git/logs/HEAD`, `.git/packed-refs`,
  `.git/ORIG_HEAD`, `.git/COMMIT_EDITMSG`, `.git/info/refs`, `.git` itself; allow:
  `.git/config`, `.git/hooks/pre-commit`, `.git/hooks/applypatch-msg`,
  `.git/info/exclude`, `.git/description`, sibling files outside `.git`, and the
  worktree-pointer cases.
- `tests/tools/test_file_write_safety.py` — `_check_sensitive_path` surface, same
  allow/refuse split.
- Targeted run on this host: **31 passed, 0 failed** (pointer-guard classes +
  git-state classes).

## Links

- Fixes #78793
- Foundation: #78565 / PR #78652 (pointer-file guard, cherry-picked onto this branch)
- Sibling: #76246 / PR #78653 (sensitive-path separator class)
- Premise receipts: `C:/tmp/wtgitstate-verify-scratch/verify-report.md`
- Class audit: `C:/tmp/wtgitstate-allow/class-audit-report.md`

Part of #78565
