### PR TITLE
feat(moa): per-reference duration/stats + metrics-lite independent of save_traces

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -149,6 +149,8 @@ def _redact_trace_accounting(acct: Any) -> Any:
         model=acct.model,
         provider=acct.provider,
         temperature=acct.temperature,
+        duration_s=getattr(acct, "duration_s", None),
+        stats=getattr(acct, "stats", None),
     )
 
 
@@ -196,6 +198,11 @@ class _RefAccounting:
     display ``text`` is a truncated preview and is not enough to audit what an
     advisor actually saw). They are only populated when tracing is on; they add
     negligible cost otherwise.
+
+    ``duration_s`` is wall-clock seconds for the reference call (observer
+    metrics / tokens-per-sec). ``stats`` is an optional provider-root stats
+    dict (local inference servers report tokens/sec, TTFT, speculative-draft
+    counts) — never includes message bodies.
     """
 
     __slots__ = (
@@ -208,6 +215,8 @@ class _RefAccounting:
         "model",
         "provider",
         "temperature",
+        "duration_s",
+        "stats",
     )
 
     def __init__(
@@ -222,6 +231,8 @@ class _RefAccounting:
         model: str | None = None,
         provider: str | None = None,
         temperature: Any = None,
+        duration_s: float | None = None,
+        stats: Any = None,
     ):
         self.usage = usage
         self.cost_usd = cost_usd
@@ -232,6 +243,8 @@ class _RefAccounting:
         self.model = model
         self.provider = provider
         self.temperature = temperature
+        self.duration_s = duration_s
+        self.stats = stats
 
 # Per-tool-result character budget for the advisory reference view. Tool
 # results can be huge (a full diff, a 5000-line file dump); replaying them
@@ -499,6 +512,7 @@ def _run_reference(
 
     label = _slot_label(slot)
     runtime = _slot_runtime(slot)
+    t0 = time.monotonic()
     try:
         # Prepend the advisory-role system prompt so the reference understands
         # it is analyzing state for an aggregator, not acting on the task. The
@@ -603,6 +617,11 @@ def _run_reference(
         except Exception:  # pragma: no cover - defensive
             pass
         _output_text = _extract_text(response) or "(empty response)"
+        # Provider-root stats (local servers: tokens/sec, TTFT). Only keep a
+        # plain non-empty dict — never message bodies.
+        _stats = getattr(response, "stats", None)
+        if not isinstance(_stats, dict) or not _stats:
+            _stats = None
         acct = _RefAccounting(
             usage,
             cost_usd,
@@ -613,6 +632,8 @@ def _run_reference(
             model=slot.get("model"),
             provider=runtime.get("provider") or slot.get("provider"),
             temperature=temperature,
+            duration_s=time.monotonic() - t0,
+            stats=_stats,
         )
         return label, _output_text, acct
     except Exception as exc:
@@ -624,6 +645,7 @@ def _run_reference(
             model=slot.get("model"),
             provider=runtime.get("provider") or slot.get("provider"),
             temperature=temperature,
+            duration_s=time.monotonic() - t0,
         )
 
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1649,10 +1649,11 @@ class MoAChatCompletions:
     ) -> None:
         """Flush the pending full-turn trace to disk, if one is pending.
 
-        No-op when tracing is off (``save_moa_turn`` checks the config), when
-        there is no pending trace (a cache-HIT iteration ran no references), or
-        when the aggregator input was never recorded. Clears the pending trace
-        so a repeat consume cannot double-write. Best-effort — never raises.
+        No-op when there is no pending fan-out (a cache-HIT iteration ran no
+        references) or when the aggregator input was never recorded. Full
+        traces still respect ``moa.save_traces``; metrics-lite always writes
+        on a pending fan-out. Clears the pending trace so a repeat consume
+        cannot double-write. Best-effort — never raises.
 
         ``aggregator_output_fallback`` is the aggregator's resolved acting text
         as the caller already holds it in memory (the streamed assistant text).
@@ -2299,9 +2300,10 @@ class MoAClient:
     ) -> None:
         """Flush the pending full-turn MoA trace via the completions facade.
 
-        No-op unless ``moa.save_traces`` is enabled and a turn is pending.
-        ``aggregator_output_fallback`` supplies the resolved acting text so the
-        streaming path's trace is self-contained (see the facade docstring).
+        Metrics-lite always writes on a pending fan-out. Full traces still
+        require ``moa.save_traces``. ``aggregator_output_fallback`` supplies
+        the resolved acting text so the streaming path's trace is
+        self-contained (see the facade docstring).
         """
         return self.chat.completions.consume_and_save_trace(
             session_id, aggregator_output_fallback=aggregator_output_fallback

--- a/agent/moa_trace.py
+++ b/agent/moa_trace.py
@@ -18,6 +18,8 @@ files, keyed by session id, and are safe to delete.
 
 Cost model note: gated OFF by default. When off, the only overhead is the
 ``_traces_enabled()`` config read (cheap) — no file I/O, no serialization.
+The metrics-lite record (``<hermes_home>/metrics/moa-refs.jsonl``) follows
+the same gate: it is written alongside the full trace, never before it.
 """
 
 from __future__ import annotations
@@ -122,9 +124,9 @@ def save_moa_turn(
     that resolved text was unavailable, it falls back to None and the record
     points at the session store via ``output_location``.
     """
-    # Metrics-lite always-on (independent of save_traces). Preset editors that
-    # rewrite the moa: block and drop save_traces must not silence proposer
-    # observability.
+    base = _traces_enabled_and_dir()
+    if base is None:
+        return
     try:
         _save_moa_metrics(
             session_id=session_id,
@@ -134,9 +136,6 @@ def save_moa_turn(
     except Exception as exc:  # pragma: no cover
         logger.debug("MoA metrics-lite write failed (session=%s): %s", session_id, exc)
 
-    base = _traces_enabled_and_dir()
-    if base is None:
-        return
     try:
         base.mkdir(parents=True, exist_ok=True)
         path = base / f"{_sanitize_session_id(session_id)}.jsonl"
@@ -187,11 +186,11 @@ def _save_moa_metrics(
     preset_name: str,
     reference_outputs: list[tuple[str, str, Any]],
 ) -> None:
-    """Append a metrics-lite MoA record (no message bodies) every turn.
+    """Append a metrics-lite MoA record (no message bodies) per trace turn.
 
-    Always-on observer path for per-proposer duration/usage/stats. Independent
-    of ``moa.save_traces`` so preset editors that rewrite the moa: block and
-    drop ``save_traces`` cannot silence proposer observability.
+    Observer path for per-proposer duration/usage/stats. Writes under the same
+    ``moa.save_traces`` gate as the full trace (caller checks it first), so
+    tracing off means no file I/O at all — matching the module docstring.
     """
     base = get_hermes_home() / "metrics"
     base.mkdir(parents=True, exist_ok=True)

--- a/agent/moa_trace.py
+++ b/agent/moa_trace.py
@@ -91,6 +91,8 @@ def _slot_trace(acct: Any, label: str) -> dict[str, Any]:
         "cost_usd": getattr(acct, "cost_usd", None),
         "cost_status": getattr(acct, "cost_status", None),
         "cost_source": getattr(acct, "cost_source", None),
+        "duration_s": getattr(acct, "duration_s", None),
+        "stats": getattr(acct, "stats", None),
     }
 
 
@@ -120,6 +122,18 @@ def save_moa_turn(
     that resolved text was unavailable, it falls back to None and the record
     points at the session store via ``output_location``.
     """
+    # Metrics-lite always-on (independent of save_traces). Preset editors that
+    # rewrite the moa: block and drop save_traces must not silence proposer
+    # observability.
+    try:
+        _save_moa_metrics(
+            session_id=session_id,
+            preset_name=preset_name,
+            reference_outputs=reference_outputs,
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.debug("MoA metrics-lite write failed (session=%s): %s", session_id, exc)
+
     base = _traces_enabled_and_dir()
     if base is None:
         return
@@ -165,3 +179,51 @@ def save_moa_turn(
             f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
     except Exception as exc:  # pragma: no cover - tracing must never break a turn
         logger.debug("MoA trace write failed (session=%s): %s", session_id, exc)
+
+
+def _save_moa_metrics(
+    *,
+    session_id: Optional[str],
+    preset_name: str,
+    reference_outputs: list[tuple[str, str, Any]],
+) -> None:
+    """Append a metrics-lite MoA record (no message bodies) every turn.
+
+    Always-on observer path for per-proposer duration/usage/stats. Independent
+    of ``moa.save_traces`` so preset editors that rewrite the moa: block and
+    drop ``save_traces`` cannot silence proposer observability.
+    """
+    base = get_hermes_home() / "metrics"
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / "moa-refs.jsonl"
+    refs = []
+    for label, _text, acct in reference_outputs:
+        usage = getattr(acct, "usage", None)
+        usage_dict: dict[str, Any] = {}
+        if usage is not None:
+            usage_dict = {
+                "input_tokens": getattr(usage, "input_tokens", 0),
+                "output_tokens": getattr(usage, "output_tokens", 0),
+                "cache_read_tokens": getattr(usage, "cache_read_tokens", 0),
+                "cache_write_tokens": getattr(usage, "cache_write_tokens", 0),
+                "reasoning_tokens": getattr(usage, "reasoning_tokens", 0),
+            }
+        refs.append(
+            {
+                "label": label,
+                "model": getattr(acct, "model", None),
+                "provider": getattr(acct, "provider", None),
+                "usage": usage_dict,
+                "cost_usd": getattr(acct, "cost_usd", None),
+                "duration_s": getattr(acct, "duration_s", None),
+                "stats": getattr(acct, "stats", None),
+            }
+        )
+    record = {
+        "ts": time.time(),
+        "session_id": session_id,
+        "preset": preset_name,
+        "references": refs,
+    }
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")

--- a/agent/moa_trace.py
+++ b/agent/moa_trace.py
@@ -16,10 +16,12 @@ with their own system prompt, not conversation turns, so persisting them as
 message rows would corrupt role alternation / replay. Traces live in their own
 files, keyed by session id, and are safe to delete.
 
-Cost model note: gated OFF by default. When off, the only overhead is the
-``_traces_enabled()`` config read (cheap) — no file I/O, no serialization.
-The metrics-lite record (``<hermes_home>/metrics/moa-refs.jsonl``) follows
-the same gate: it is written alongside the full trace, never before it.
+Cost model note: full traces are gated OFF by default. When off, the only
+overhead is one metrics-lite append per reference fan-out
+(``<hermes_home>/metrics/moa-refs.jsonl`` — duration/usage/stats, no message
+bodies). No full-trace serialization. Metrics-lite is independent of
+``moa.save_traces`` so preset editors that rewrite the moa block and drop
+``save_traces`` cannot silently kill proposer observability.
 """
 
 from __future__ import annotations
@@ -116,6 +118,10 @@ def save_moa_turn(
     Best-effort: any failure is logged at debug and swallowed — tracing must
     never break a live turn. Called once per turn on a reference cache MISS.
 
+    Metrics-lite (``metrics/moa-refs.jsonl``) writes on every reference
+    fan-out, independent of ``moa.save_traces``. The full trace file is
+    still gated.
+
     ``aggregator_output`` is the aggregator's synthesized text. On the
     non-streaming path (eval / quiet-mode / subagents) it was captured inline
     at call time. On the streaming path it is captured after the fact from the
@@ -124,9 +130,6 @@ def save_moa_turn(
     that resolved text was unavailable, it falls back to None and the record
     points at the session store via ``output_location``.
     """
-    base = _traces_enabled_and_dir()
-    if base is None:
-        return
     try:
         _save_moa_metrics(
             session_id=session_id,
@@ -135,6 +138,10 @@ def save_moa_turn(
         )
     except Exception as exc:  # pragma: no cover
         logger.debug("MoA metrics-lite write failed (session=%s): %s", session_id, exc)
+
+    base = _traces_enabled_and_dir()
+    if base is None:
+        return
 
     try:
         base.mkdir(parents=True, exist_ok=True)
@@ -186,11 +193,11 @@ def _save_moa_metrics(
     preset_name: str,
     reference_outputs: list[tuple[str, str, Any]],
 ) -> None:
-    """Append a metrics-lite MoA record (no message bodies) per trace turn.
+    """Append a metrics-lite MoA record (no message bodies) per fan-out.
 
-    Observer path for per-proposer duration/usage/stats. Writes under the same
-    ``moa.save_traces`` gate as the full trace (caller checks it first), so
-    tracing off means no file I/O at all — matching the module docstring.
+    Observer path for per-proposer duration/usage/stats. Independent of
+    ``moa.save_traces`` — one JSONL append per reference fan-out even when
+    the full-body trace is off. Never writes message bodies.
     """
     base = get_hermes_home() / "metrics"
     base.mkdir(parents=True, exist_ok=True)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2623,6 +2623,11 @@ class AIAgent:
         summary.pop("raw_usage", None)
         summary["prompt_tokens"] = cu.prompt_tokens
         summary["total_tokens"] = cu.total_tokens
+        # Optional provider-root stats (local servers: tokens/sec, TTFT).
+        # Only a plain non-empty dict — never message bodies.
+        stats = getattr(response, "stats", None)
+        if isinstance(stats, dict) and stats:
+            summary["stats"] = stats
         return summary
 
     @staticmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -2688,6 +2688,11 @@ class AIAgent:
         summary.pop("raw_usage", None)
         summary["prompt_tokens"] = cu.prompt_tokens
         summary["total_tokens"] = cu.total_tokens
+        # Optional provider-root stats (local servers: tokens/sec, TTFT).
+        # Only a plain non-empty dict — never message bodies.
+        stats = getattr(response, "stats", None)
+        if isinstance(stats, dict) and stats:
+            summary["stats"] = stats
         return summary
 
     @staticmethod

--- a/tests/agent/test_moa_reference_observability.py
+++ b/tests/agent/test_moa_reference_observability.py
@@ -1,0 +1,90 @@
+"""MoA per-reference duration/stats + metrics-lite (independent of save_traces)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.moa_loop import _RefAccounting
+from agent.moa_trace import _slot_trace, save_moa_turn
+from agent.usage_pricing import CanonicalUsage
+
+
+def test_slot_trace_includes_duration_and_stats():
+    acct = _RefAccounting(
+        CanonicalUsage(input_tokens=10, output_tokens=5),
+        duration_s=1.25,
+        stats={"tokens_per_second": 40.0, "ttft_ms": 12},
+    )
+    row = _slot_trace(acct, "ref-a")
+    assert row["duration_s"] == 1.25
+    assert row["stats"]["tokens_per_second"] == 40.0
+    assert row["usage"]["input_tokens"] == 10
+
+
+def test_save_moa_turn_writes_metrics_even_when_traces_off(tmp_path, monkeypatch):
+    """metrics/moa-refs.jsonl must write even if moa.save_traces is false."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Force traces off via config stub
+    with patch("agent.moa_trace._traces_enabled_and_dir", return_value=None):
+        save_moa_turn(
+            session_id="sess-1",
+            preset_name="test-preset",
+            reference_outputs=[
+                (
+                    "r1",
+                    "hello",
+                    _RefAccounting(
+                        CanonicalUsage(input_tokens=3, output_tokens=2),
+                        model="m1",
+                        provider="local",
+                        duration_s=0.5,
+                        stats={"ttft_ms": 8},
+                    ),
+                )
+            ],
+            aggregator_label="agg",
+            aggregator_model="agg-m",
+            aggregator_provider="xai",
+            aggregator_temperature=0.2,
+            aggregator_input_messages=[],
+            aggregator_output="done",
+            aggregator_streamed=False,
+        )
+
+    metrics_path = Path(tmp_path) / "metrics" / "moa-refs.jsonl"
+    assert metrics_path.is_file(), "metrics-lite must write without save_traces"
+    # traces dir must NOT appear
+    assert not (Path(tmp_path) / "moa-traces").exists()
+    line = metrics_path.read_text(encoding="utf-8").strip().splitlines()[-1]
+    rec = json.loads(line)
+    assert rec["session_id"] == "sess-1"
+    assert rec["preset"] == "test-preset"
+    assert rec["references"][0]["duration_s"] == 0.5
+    assert rec["references"][0]["stats"]["ttft_ms"] == 8
+    # no message bodies in metrics-lite
+    assert "input_messages" not in rec["references"][0]
+    assert "output" not in rec["references"][0]
+
+
+def test_usage_summary_forwards_response_stats():
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = "ollama"
+    agent.api_mode = "chat_completions"
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=11,
+            completion_tokens=7,
+            total_tokens=18,
+            prompt_tokens_details=None,
+            completion_tokens_details=None,
+        ),
+        stats={"tokens_per_second": 55.0},
+    )
+    summary = AIAgent._usage_summary_for_api_request_hook(agent, response)
+    assert summary is not None
+    assert summary["stats"]["tokens_per_second"] == 55.0

--- a/tests/agent/test_moa_reference_observability.py
+++ b/tests/agent/test_moa_reference_observability.py
@@ -1,4 +1,4 @@
-"""MoA per-reference duration/stats + metrics-lite (independent of save_traces)."""
+"""MoA per-reference duration/stats + metrics-lite (gated with save_traces)."""
 
 from __future__ import annotations
 
@@ -24,11 +24,10 @@ def test_slot_trace_includes_duration_and_stats():
     assert row["usage"]["input_tokens"] == 10
 
 
-def test_save_moa_turn_writes_metrics_even_when_traces_off(tmp_path, monkeypatch):
-    """metrics/moa-refs.jsonl must write even if moa.save_traces is false."""
+def test_save_moa_turn_writes_metrics_when_traces_on(tmp_path, monkeypatch):
+    """metrics/moa-refs.jsonl writes alongside the full trace when enabled."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    # Force traces off via config stub
-    with patch("agent.moa_trace._traces_enabled_and_dir", return_value=None):
+    with patch("agent.moa_trace._traces_enabled_and_dir", return_value=Path(tmp_path) / "moa-traces"):
         save_moa_turn(
             session_id="sess-1",
             preset_name="test-preset",
@@ -55,9 +54,8 @@ def test_save_moa_turn_writes_metrics_even_when_traces_off(tmp_path, monkeypatch
         )
 
     metrics_path = Path(tmp_path) / "metrics" / "moa-refs.jsonl"
-    assert metrics_path.is_file(), "metrics-lite must write without save_traces"
-    # traces dir must NOT appear
-    assert not (Path(tmp_path) / "moa-traces").exists()
+    assert metrics_path.is_file(), "metrics-lite must write when traces are on"
+    assert (Path(tmp_path) / "moa-traces" / "sess-1.jsonl").is_file()
     line = metrics_path.read_text(encoding="utf-8").strip().splitlines()[-1]
     rec = json.loads(line)
     assert rec["session_id"] == "sess-1"
@@ -67,6 +65,38 @@ def test_save_moa_turn_writes_metrics_even_when_traces_off(tmp_path, monkeypatch
     # no message bodies in metrics-lite
     assert "input_messages" not in rec["references"][0]
     assert "output" not in rec["references"][0]
+
+
+def test_save_moa_turn_writes_nothing_when_traces_off(tmp_path, monkeypatch):
+    """Tracing off must mean NO file I/O at all — full trace AND metrics-lite."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("agent.moa_trace._traces_enabled_and_dir", return_value=None):
+        save_moa_turn(
+            session_id="sess-off",
+            preset_name="test-preset",
+            reference_outputs=[
+                (
+                    "r1",
+                    "hello",
+                    _RefAccounting(
+                        CanonicalUsage(input_tokens=3, output_tokens=2),
+                        duration_s=0.5,
+                        stats={},
+                    ),
+                )
+            ],
+            aggregator_label="agg",
+            aggregator_model="agg-m",
+            aggregator_provider="xai",
+            aggregator_temperature=0.2,
+            aggregator_input_messages=[],
+            aggregator_output="done",
+            aggregator_streamed=False,
+        )
+
+    assert not (Path(tmp_path) / "metrics" / "moa-refs.jsonl").exists(), \
+        "metrics-lite must NOT write when save_traces is off"
+    assert not (Path(tmp_path) / "moa-traces").exists()
 
 
 def test_usage_summary_forwards_response_stats():

--- a/tests/agent/test_moa_reference_observability.py
+++ b/tests/agent/test_moa_reference_observability.py
@@ -1,4 +1,4 @@
-"""MoA per-reference duration/stats + metrics-lite (gated with save_traces)."""
+"""MoA per-reference duration/stats + metrics-lite (independent of save_traces)."""
 
 from __future__ import annotations
 
@@ -67,8 +67,8 @@ def test_save_moa_turn_writes_metrics_when_traces_on(tmp_path, monkeypatch):
     assert "output" not in rec["references"][0]
 
 
-def test_save_moa_turn_writes_nothing_when_traces_off(tmp_path, monkeypatch):
-    """Tracing off must mean NO file I/O at all — full trace AND metrics-lite."""
+def test_save_moa_turn_writes_metrics_when_traces_off(tmp_path, monkeypatch):
+    """metrics-lite still writes when save_traces is off; full trace does not."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("agent.moa_trace._traces_enabled_and_dir", return_value=None):
         save_moa_turn(
@@ -94,8 +94,12 @@ def test_save_moa_turn_writes_nothing_when_traces_off(tmp_path, monkeypatch):
             aggregator_streamed=False,
         )
 
-    assert not (Path(tmp_path) / "metrics" / "moa-refs.jsonl").exists(), \
-        "metrics-lite must NOT write when save_traces is off"
+    metrics_path = Path(tmp_path) / "metrics" / "moa-refs.jsonl"
+    assert metrics_path.is_file(), "metrics-lite must write even when traces are off"
+    rec = json.loads(metrics_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert rec["session_id"] == "sess-off"
+    assert rec["references"][0]["duration_s"] == 0.5
+    assert "output" not in rec["references"][0]
     assert not (Path(tmp_path) / "moa-traces").exists()
 
 


### PR DESCRIPTION
## Summary

Observer-only MoA proposer observability. Production local-inference forks need per-reference wall-clock duration and provider stats (tokens/sec, TTFT) without depending on `moa.save_traces` — preset editors (`hermes moa`, dashboard MoA panel) rewrite the `moa:` block and drop `save_traces`, which used to silently kill proposer observability.

## Changes
- `_RefAccounting` gains `duration_s` + `stats` (success and failure paths)
- `moa_trace` slot records include both fields
- **Always-on** metrics-lite write to `<hermes_home>/metrics/moa-refs.jsonl` (no message bodies) — independent of `moa.save_traces`
- `post_api_request` usage summary forwards non-empty `response.stats`

No MoA loop mutation (ground rule 3). Aggregator path already covered by `post_api_request`.

## Test plan
- [x] `tests/agent/test_moa_reference_observability.py` (3 tests)
- [ ] Optional: run a MoA turn against a local server that returns `stats`; confirm `metrics/moa-refs.jsonl` grows with `duration_s`

## Related
- #64182 item 2 · #64231 batch · RFC #58548 family
- Desired long-term shape: a plugin observer hook per completed MoA reference. This lands the data path so that hook has something real to observe.