### PR TITLE
fix(tui): surface classified turn-error detail instead of bare request failed

### DIFF
--- a/tests/tui_gateway/test_classified_turn_error.py
+++ b/tests/tui_gateway/test_classified_turn_error.py
@@ -1,0 +1,59 @@
+"""Classified turn-error messages for TUI/desktop frames (#64182 item 3)."""
+
+from __future__ import annotations
+
+import types
+
+from tui_gateway.server import _classify_turn_error_message, _fail_inflight_turn
+
+
+def test_classify_enriches_exception_with_agent_route():
+    class _Boom(Exception):
+        status_code = 429
+
+    agent = types.SimpleNamespace(
+        provider="xai",
+        model="grok-4.5",
+        base_url="https://api.x.ai/v1",
+        _summarize_api_error=lambda e: "rate limited",
+    )
+    msg = _classify_turn_error_message(_Boom("request failed"), agent)
+    assert "rate limited" in msg
+    assert "HTTP 429" in msg
+    assert "provider=xai" in msg
+    assert "model=grok-4.5" in msg
+
+
+def test_classify_result_dict_keeps_failure_reason():
+    agent = types.SimpleNamespace(
+        provider="openrouter",
+        model="foo",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    msg = _classify_turn_error_message(
+        {
+            "error": "credits exhausted",
+            "failure_reason": "billing",
+            "failed": True,
+        },
+        agent,
+    )
+    assert "credits exhausted" in msg
+    assert "reason=billing" in msg
+    assert "provider=openrouter" in msg
+
+
+def test_fail_inflight_uses_classified_message():
+    session = {
+        "agent": types.SimpleNamespace(
+            provider="ollama",
+            model="qwen",
+            base_url="http://127.0.0.1:11434",
+            _summarize_api_error=lambda e: "connection refused",
+        ),
+        "inflight_turn": {"user": "hi", "assistant": "", "started_at": 0},
+    }
+    _fail_inflight_turn(session, ConnectionError("request failed"))
+    err = session["inflight_turn"]["error"]
+    assert "connection refused" in err
+    assert "provider=ollama" in err

--- a/tests/tui_gateway/test_classified_turn_error.py
+++ b/tests/tui_gateway/test_classified_turn_error.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import types
 
-from tui_gateway.server import _classify_turn_error_message, _fail_inflight_turn
+from tui_gateway.server import _fail_inflight_turn, _summarize_turn_error_message
 
 
-def test_classify_enriches_exception_with_agent_route():
+def test_summarize_enriches_exception_with_agent_route():
     class _Boom(Exception):
         status_code = 429
 
@@ -17,20 +17,20 @@ def test_classify_enriches_exception_with_agent_route():
         base_url="https://api.x.ai/v1",
         _summarize_api_error=lambda e: "rate limited",
     )
-    msg = _classify_turn_error_message(_Boom("request failed"), agent)
+    msg = _summarize_turn_error_message(_Boom("request failed"), agent)
     assert "rate limited" in msg
     assert "HTTP 429" in msg
     assert "provider=xai" in msg
     assert "model=grok-4.5" in msg
 
 
-def test_classify_result_dict_keeps_failure_reason():
+def test_summarize_result_dict_keeps_failure_reason():
     agent = types.SimpleNamespace(
         provider="openrouter",
         model="foo",
         base_url="https://openrouter.ai/api/v1",
     )
-    msg = _classify_turn_error_message(
+    msg = _summarize_turn_error_message(
         {
             "error": "credits exhausted",
             "failure_reason": "billing",
@@ -43,7 +43,7 @@ def test_classify_result_dict_keeps_failure_reason():
     assert "provider=openrouter" in msg
 
 
-def test_fail_inflight_uses_classified_message():
+def test_fail_inflight_uses_summarized_message():
     session = {
         "agent": types.SimpleNamespace(
             provider="ollama",
@@ -57,3 +57,18 @@ def test_fail_inflight_uses_classified_message():
     err = session["inflight_turn"]["error"]
     assert "connection refused" in err
     assert "provider=ollama" in err
+
+
+def test_summarize_renders_fallback_chain_not_list_repr():
+    agent = types.SimpleNamespace(
+        provider="nous",
+        model="deepseek-v4-flash",
+        _fallback_chain=[
+            {"provider": "xai", "model": "grok-4.5"},
+            {"provider": "openrouter", "model": "foo"},
+        ],
+    )
+    msg = _summarize_turn_error_message(RuntimeError("request failed"), agent)
+    assert "fallback=grok-4.5 (xai) → foo (openrouter)" in msg
+    assert "[{" not in msg
+    assert "'provider'" not in msg

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -430,7 +430,15 @@ class ComputeHost:
         except Exception as exc:  # pragma: no cover - defensive host boundary
             with session.lock:
                 session.running = False
-            self.emit({"type": "turn.error", "sid": session.sid, "request_id": request_id, "message": str(exc)})
+            # Prefer classified summary when the agent is available (provider /
+            # model / HTTP status), not a bare str(exc).
+            try:
+                from tui_gateway.server import _classify_turn_error_message
+
+                _msg = _classify_turn_error_message(exc, getattr(session, "agent", None))
+            except Exception:
+                _msg = str(exc)
+            self.emit({"type": "turn.error", "sid": session.sid, "request_id": request_id, "message": _msg})
 
     # ── Real dashboard turn path ───────────────────────────────────────
 
@@ -520,7 +528,21 @@ class ComputeHost:
                         server._clear_inflight_turn(session)
             except Exception:
                 pass
-            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
+            try:
+                from tui_gateway.server import _classify_turn_error_message
+
+                _sess = None
+                try:
+                    from tui_gateway import server as _srv
+
+                    _sess = _srv._sessions.get(sid)
+                except Exception:
+                    _sess = None
+                _agent = (_sess or {}).get("agent") if isinstance(_sess, dict) else None
+                _msg = _classify_turn_error_message(exc, _agent)
+            except Exception:
+                _msg = str(exc)
+            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": _msg})
 
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
         sid = str(frame.get("sid") or "")

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -429,7 +429,15 @@ class ComputeHost:
         except Exception as exc:  # pragma: no cover - defensive host boundary
             with session.lock:
                 session.running = False
-            self.emit({"type": "turn.error", "sid": session.sid, "request_id": request_id, "message": str(exc)})
+            # Prefer classified summary when the agent is available (provider /
+            # model / HTTP status), not a bare str(exc).
+            try:
+                from tui_gateway.server import _classify_turn_error_message
+
+                _msg = _classify_turn_error_message(exc, getattr(session, "agent", None))
+            except Exception:
+                _msg = str(exc)
+            self.emit({"type": "turn.error", "sid": session.sid, "request_id": request_id, "message": _msg})
 
     # ── Real dashboard turn path ───────────────────────────────────────
 
@@ -519,7 +527,21 @@ class ComputeHost:
                         server._clear_inflight_turn(session)
             except Exception:
                 pass
-            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
+            try:
+                from tui_gateway.server import _classify_turn_error_message
+
+                _sess = None
+                try:
+                    from tui_gateway import server as _srv
+
+                    _sess = _srv._sessions.get(sid)
+                except Exception:
+                    _sess = None
+                _agent = (_sess or {}).get("agent") if isinstance(_sess, dict) else None
+                _msg = _classify_turn_error_message(exc, _agent)
+            except Exception:
+                _msg = str(exc)
+            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": _msg})
 
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
         sid = str(frame.get("sid") or "")

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -433,9 +433,9 @@ class ComputeHost:
             # Prefer classified summary when the agent is available (provider /
             # model / HTTP status), not a bare str(exc).
             try:
-                from tui_gateway.server import _classify_turn_error_message
+                from tui_gateway.server import _summarize_turn_error_message
 
-                _msg = _classify_turn_error_message(exc, getattr(session, "agent", None))
+                _msg = _summarize_turn_error_message(exc, getattr(session, "agent", None))
             except Exception:
                 _msg = str(exc)
             self.emit({"type": "turn.error", "sid": session.sid, "request_id": request_id, "message": _msg})
@@ -529,7 +529,7 @@ class ComputeHost:
             except Exception:
                 pass
             try:
-                from tui_gateway.server import _classify_turn_error_message
+                from tui_gateway.server import _summarize_turn_error_message
 
                 _sess = None
                 try:
@@ -539,7 +539,7 @@ class ComputeHost:
                 except Exception:
                     _sess = None
                 _agent = (_sess or {}).get("agent") if isinstance(_sess, dict) else None
-                _msg = _classify_turn_error_message(exc, _agent)
+                _msg = _summarize_turn_error_message(exc, _agent)
             except Exception:
                 _msg = str(exc)
             self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": _msg})

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7137,7 +7137,7 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
 
     Caller must hold ``session["history_lock"]``.
     """
-    message = str(error) if not isinstance(error, BaseException) else (str(error) or type(error).__name__)
+    message = _classify_turn_error_message(error, session.get("agent"))
     now = time.time()
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
@@ -7150,6 +7150,79 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
     turn["streaming"] = False
     turn["updated_at"] = now
     session["inflight_turn"] = turn
+
+
+def _classify_turn_error_message(error: Any, agent: Any = None) -> str:
+    """Build a human-readable turn-error summary for TUI/desktop frames.
+
+    Bare ``str(exc)`` / generic ``request failed`` strings hide the classified
+    detail that already exists in logs (provider, model, base_url, HTTP
+    status, fallback chain). Prefer agent._summarize_api_error when present,
+    then decorate with route context from the live agent. Never raises.
+    """
+    try:
+        if isinstance(error, dict):
+            # run_conversation result shape
+            parts: list[str] = []
+            err = error.get("error") or error.get("message") or error.get("final_response")
+            if err:
+                parts.append(str(err).strip())
+            reason = error.get("failure_reason")
+            if reason and str(reason) not in (parts[0] if parts else ""):
+                parts.append(f"reason={reason}")
+            # Prefer result-level route facts when present
+            for key, label in (
+                ("provider", "provider"),
+                ("model", "model"),
+                ("base_url", "endpoint"),
+            ):
+                val = error.get(key)
+                if val:
+                    parts.append(f"{label}={val}")
+            msg = " · ".join(p for p in parts if p) if parts else ""
+        elif isinstance(error, BaseException):
+            summarizer = getattr(agent, "_summarize_api_error", None) if agent is not None else None
+            if callable(summarizer):
+                try:
+                    msg = str(summarizer(error) or "").strip()
+                except Exception:
+                    msg = (str(error) or type(error).__name__).strip()
+            else:
+                msg = (str(error) or type(error).__name__).strip()
+            status = getattr(error, "status_code", None)
+            if status and f"HTTP {status}" not in msg:
+                msg = f"HTTP {status}: {msg}" if msg else f"HTTP {status}"
+        else:
+            msg = str(error or "").strip()
+
+        if not msg or msg.lower() in {"request failed", "error", "failed", "turn failed"}:
+            # Last-resort: still try to say something useful from the agent route
+            msg = msg or "request failed"
+
+        if agent is not None:
+            route_bits = []
+            for attr, label in (
+                ("provider", "provider"),
+                ("model", "model"),
+                ("base_url", "endpoint"),
+            ):
+                val = getattr(agent, attr, None)
+                if val and str(val) not in msg:
+                    route_bits.append(f"{label}={val}")
+            # Fallback chain if the agent exposed one
+            chain = getattr(agent, "_fallback_chain", None) or getattr(
+                agent, "fallback_model", None
+            )
+            if chain and "fallback" not in msg.lower():
+                route_bits.append(f"fallback={chain}")
+            if route_bits:
+                msg = f"{msg} ({', '.join(route_bits)})"
+        return msg or "turn failed"
+    except Exception:
+        try:
+            return str(error) or "turn failed"
+        except Exception:
+            return "turn failed"
 
 
 # ── Auto-continue: resume a turn killed by a process/machine death ────
@@ -9840,18 +9913,38 @@ def _run_prompt_submit(
                     # the failed turn for resume replay instead of clearing it.
                     # If this terminal frame is lost to a disconnect, resume's
                     # inflight payload is the only carrier of the failure.
+                    # Pass the full result dict so _classify_turn_error_message
+                    # can keep failure_reason / route facts when present.
                     _fail_inflight_turn(
                         session,
-                        result.get("error") if isinstance(result, dict) else raw,
+                        result if isinstance(result, dict) else raw,
                     )
                     turn_error_retained = True
                 else:
                     _clear_inflight_turn(session)
             if status == "error":
-                payload["error"] = str(
+                # Prefer the classified snapshot message (enriched with route
+                # facts) over a bare result["error"] string.
+                _classified = ""
+                with session["history_lock"]:
+                    _turn = session.get("inflight_turn") or {}
+                    _classified = str(_turn.get("error") or "")
+                payload["error"] = _classified or str(
                     (result.get("error") if isinstance(result, dict) else "") or raw
                 )
                 payload["recoverable"] = True
+                if isinstance(result, dict) and result.get("failure_reason"):
+                    payload["failure_reason"] = result.get("failure_reason")
+                # Keep visible text aligned with the classified error when the
+                # backend produced no assistant prose.
+                if payload.get("text", "").startswith("Error: ") or not payload.get("text"):
+                    payload["text"] = f"Error: {payload['error']}"
+                    try:
+                        rendered = render_message(payload["text"], cols)
+                        if rendered:
+                            payload["rendered"] = rendered
+                    except Exception:
+                        pass
             _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7354,7 +7354,7 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
 
     Caller must hold ``session["history_lock"]``.
     """
-    message = _classify_turn_error_message(error, session.get("agent"))
+    message = _summarize_turn_error_message(error, session.get("agent"))
     now = time.time()
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
@@ -7369,13 +7369,41 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
     session["inflight_turn"] = turn
 
 
-def _classify_turn_error_message(error: Any, agent: Any = None) -> str:
+def _format_fallback_chain(chain: Any) -> str:
+    """Render a fallback chain the same way agent_init.py does.
+
+    List-of-dicts → ``model (provider) → model (provider)``. A single
+    dict uses the same shape. Anything else falls back to ``str(chain)``
+    so a legacy string/model name still prints something readable.
+    """
+    entries: list[Any]
+    if isinstance(chain, dict):
+        entries = [chain]
+    elif isinstance(chain, (list, tuple)):
+        entries = list(chain)
+    else:
+        return str(chain).strip()
+
+    parts: list[str] = []
+    for item in entries:
+        if isinstance(item, dict) and item.get("model") and item.get("provider"):
+            parts.append(f"{item['model']} ({item['provider']})")
+        elif isinstance(item, dict) and item.get("model"):
+            parts.append(str(item["model"]))
+        elif item:
+            parts.append(str(item))
+    return " → ".join(parts)
+
+
+def _summarize_turn_error_message(error: Any, agent: Any = None) -> str:
     """Build a human-readable turn-error summary for TUI/desktop frames.
 
-    Bare ``str(exc)`` / generic ``request failed`` strings hide the classified
-    detail that already exists in logs (provider, model, base_url, HTTP
-    status, fallback chain). Prefer agent._summarize_api_error when present,
-    then decorate with route context from the live agent. Never raises.
+    Does not classify — only surfaces facts that already exist (result
+    fields, agent._summarize_api_error, route attrs). Bare ``str(exc)`` /
+    generic ``request failed`` strings hide the classified detail that
+    already exists in logs (provider, model, base_url, HTTP status,
+    fallback chain). Prefer agent._summarize_api_error when present, then
+    decorate with route context from the live agent. Never raises.
     """
     try:
         if isinstance(error, dict):
@@ -7431,7 +7459,9 @@ def _classify_turn_error_message(error: Any, agent: Any = None) -> str:
                 agent, "fallback_model", None
             )
             if chain and "fallback" not in msg.lower():
-                route_bits.append(f"fallback={chain}")
+                rendered = _format_fallback_chain(chain)
+                if rendered:
+                    route_bits.append(f"fallback={rendered}")
             if route_bits:
                 msg = f"{msg} ({', '.join(route_bits)})"
         return msg or "turn failed"
@@ -10289,7 +10319,7 @@ def _run_prompt_submit(
                     # the failed turn for resume replay instead of clearing it.
                     # If this terminal frame is lost to a disconnect, resume's
                     # inflight payload is the only carrier of the failure.
-                    # Pass the full result dict so _classify_turn_error_message
+                    # Pass the full result dict so _summarize_turn_error_message
                     # can keep failure_reason / route facts when present.
                     _fail_inflight_turn(
                         session,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7354,7 +7354,7 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
 
     Caller must hold ``session["history_lock"]``.
     """
-    message = str(error) if not isinstance(error, BaseException) else (str(error) or type(error).__name__)
+    message = _classify_turn_error_message(error, session.get("agent"))
     now = time.time()
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
@@ -7367,6 +7367,79 @@ def _fail_inflight_turn(session: dict, error: Any) -> None:
     turn["streaming"] = False
     turn["updated_at"] = now
     session["inflight_turn"] = turn
+
+
+def _classify_turn_error_message(error: Any, agent: Any = None) -> str:
+    """Build a human-readable turn-error summary for TUI/desktop frames.
+
+    Bare ``str(exc)`` / generic ``request failed`` strings hide the classified
+    detail that already exists in logs (provider, model, base_url, HTTP
+    status, fallback chain). Prefer agent._summarize_api_error when present,
+    then decorate with route context from the live agent. Never raises.
+    """
+    try:
+        if isinstance(error, dict):
+            # run_conversation result shape
+            parts: list[str] = []
+            err = error.get("error") or error.get("message") or error.get("final_response")
+            if err:
+                parts.append(str(err).strip())
+            reason = error.get("failure_reason")
+            if reason and str(reason) not in (parts[0] if parts else ""):
+                parts.append(f"reason={reason}")
+            # Prefer result-level route facts when present
+            for key, label in (
+                ("provider", "provider"),
+                ("model", "model"),
+                ("base_url", "endpoint"),
+            ):
+                val = error.get(key)
+                if val:
+                    parts.append(f"{label}={val}")
+            msg = " · ".join(p for p in parts if p) if parts else ""
+        elif isinstance(error, BaseException):
+            summarizer = getattr(agent, "_summarize_api_error", None) if agent is not None else None
+            if callable(summarizer):
+                try:
+                    msg = str(summarizer(error) or "").strip()
+                except Exception:
+                    msg = (str(error) or type(error).__name__).strip()
+            else:
+                msg = (str(error) or type(error).__name__).strip()
+            status = getattr(error, "status_code", None)
+            if status and f"HTTP {status}" not in msg:
+                msg = f"HTTP {status}: {msg}" if msg else f"HTTP {status}"
+        else:
+            msg = str(error or "").strip()
+
+        if not msg or msg.lower() in {"request failed", "error", "failed", "turn failed"}:
+            # Last-resort: still try to say something useful from the agent route
+            msg = msg or "request failed"
+
+        if agent is not None:
+            route_bits = []
+            for attr, label in (
+                ("provider", "provider"),
+                ("model", "model"),
+                ("base_url", "endpoint"),
+            ):
+                val = getattr(agent, attr, None)
+                if val and str(val) not in msg:
+                    route_bits.append(f"{label}={val}")
+            # Fallback chain if the agent exposed one
+            chain = getattr(agent, "_fallback_chain", None) or getattr(
+                agent, "fallback_model", None
+            )
+            if chain and "fallback" not in msg.lower():
+                route_bits.append(f"fallback={chain}")
+            if route_bits:
+                msg = f"{msg} ({', '.join(route_bits)})"
+        return msg or "turn failed"
+    except Exception:
+        try:
+            return str(error) or "turn failed"
+        except Exception:
+            return "turn failed"
 
 
 # ── Auto-continue: resume a turn killed by a process/machine death ────
@@ -10216,18 +10289,38 @@ def _run_prompt_submit(
                     # the failed turn for resume replay instead of clearing it.
                     # If this terminal frame is lost to a disconnect, resume's
                     # inflight payload is the only carrier of the failure.
+                    # Pass the full result dict so _classify_turn_error_message
+                    # can keep failure_reason / route facts when present.
                     _fail_inflight_turn(
                         session,
-                        result.get("error") if isinstance(result, dict) else raw,
+                        result if isinstance(result, dict) else raw,
                     )
                     turn_error_retained = True
                 else:
                     _clear_inflight_turn(session)
             if status == "error":
-                payload["error"] = str(
+                # Prefer the classified snapshot message (enriched with route
+                # facts) over a bare result["error"] string.
+                _classified = ""
+                with session["history_lock"]:
+                    _turn = session.get("inflight_turn") or {}
+                    _classified = str(_turn.get("error") or "")
+                payload["error"] = _classified or str(
                     (result.get("error") if isinstance(result, dict) else "") or raw
                 )
                 payload["recoverable"] = True
+                if isinstance(result, dict) and result.get("failure_reason"):
+                    payload["failure_reason"] = result.get("failure_reason")
+                # Keep visible text aligned with the classified error when the
+                # backend produced no assistant prose.
+                if payload.get("text", "").startswith("Error: ") or not payload.get("text"):
+                    payload["text"] = f"Error: {payload['error']}"
+                    try:
+                        rendered = render_message(payload["text"], cols)
+                        if rendered:
+                            payload["rendered"] = rendered
+                    except Exception:
+                        pass
             _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
 


### PR DESCRIPTION
## Summary

When a turn fails, TUI/desktop frames often showed a bare `request failed` while the classified detail (provider, model, base_url, HTTP status, `failure_reason`, fallback chain) only reached `logs/agent.log`.

## Changes
- New `_classify_turn_error_message(error, agent)` — prefers `agent._summarize_api_error`, keeps `failure_reason`, decorates with live route facts
- `_fail_inflight_turn` uses the classifier (so resume snapshots carry the same detail)
- Returned-error path in `_run_prompt_submit` passes the full result dict and aligns visible `Error: …` text with the classified message
- `compute_host` `turn.error` frames use the same classifier

Observer-side framing only — no delivery-path mutation. Composes with:
- #56720 `turn_failed` (carry classified payload out)
- #58524 `classify_api_error` (plugin owns enrichment)

## Test plan
- [x] `tests/tui_gateway/test_classified_turn_error.py` (3)
- [x] `tests/tui_gateway/test_failed_turn_retention.py` still green (8)

## Related
- #64182 item 3 · maintainer reply accepted the compose path
- Production-fork evidence on the tracker comment