### PR TITLE
fix(gateway): don't tell an existing profile to recreate itself

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -560,20 +560,45 @@ class S6Error(RuntimeError):
 class GatewayNotRegisteredError(S6Error):
     """Raised when a lifecycle method targets a slot that doesn't exist.
 
-    Most commonly: ``hermes -p typo gateway start`` when no profile
-    ``typo`` exists. Carries the unprefixed profile name (not the
-    full ``gateway-<profile>`` service-dir name) so callers can phrase
-    a user-facing message like "no such gateway 'typo'".
+    Two distinct causes share this slot-missing symptom, and they need
+    different advice:
+
+    * The profile itself doesn't exist — most commonly a typo
+      (``hermes -p typo gateway start``). ``hermes profile create`` is
+      the right fix.
+    * The profile exists but has no *local* s6 slot — e.g. a split
+      gateway/dashboard container deployment, where
+      ``container_boot._is_dashboard_container()`` deliberately skips
+      slot registration in the dashboard container, or a best-effort
+      registration failure on a non-s6 host (issue #78803). Telling the
+      operator to (re)create an already-existing profile is actively
+      wrong here — for ``default`` it's not even possible.
+
+    ``profile_exists`` (cheap to check via
+    :func:`hermes_cli.profiles.profile_exists`) selects between the two
+    messages. Carries the unprefixed profile name (not the full
+    ``gateway-<profile>`` service-dir name) so callers can phrase a
+    user-facing message like "no such gateway 'typo'".
     """
 
-    def __init__(self, profile: str) -> None:
+    def __init__(self, profile: str, *, profile_exists: bool = False) -> None:
         self.profile = profile
-        super().__init__(
-            f"no such gateway {profile!r}: register it with "
-            f"`hermes profile create {profile}` first, or pass "
-            "an existing profile name via `-p <name>`",
-            service=f"gateway-{profile}",
-        )
+        self.profile_exists = profile_exists
+        if profile_exists:
+            message = (
+                f"gateway {profile!r} is not registered as a supervised "
+                "service in this container. If the gateway actually runs "
+                "elsewhere (e.g. a split gateway/dashboard deployment), "
+                "restart it there instead — this container has no local "
+                "slot for it to restart."
+            )
+        else:
+            message = (
+                f"no such gateway {profile!r}: register it with "
+                f"`hermes profile create {profile}` first, or pass "
+                "an existing profile name via `-p <name>`"
+            )
+        super().__init__(message, service=f"gateway-{profile}")
 
 
 class S6CommandError(S6Error):
@@ -835,7 +860,11 @@ class S6ServiceManager:
                 if name.startswith(S6_SERVICE_PREFIX)
                 else name
             )
-            raise GatewayNotRegisteredError(profile)
+            # Local import: hermes_cli.profiles already imports this module
+            # (locally, for the same reason) to reach the s6 backend, so a
+            # module-level import here would cycle.
+            from hermes_cli.profiles import profile_exists
+            raise GatewayNotRegisteredError(profile, profile_exists=profile_exists(profile))
 
         try:
             subprocess.run(

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -181,6 +181,54 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
 
 
 # ---------------------------------------------------------------------------
+# GatewayNotRegisteredError — must not recommend `hermes profile create`
+# for a profile that already exists (issue #78803: split gateway/dashboard
+# deployment). The s6 slot can be missing locally while the profile itself
+# is real — e.g. the dashboard container never registers a local slot
+# (container_boot._is_dashboard_container), or registration was skipped on
+# a non-s6 host. Telling the operator to (re)create an existing profile is
+# actively wrong there.
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_not_registered_error_suggests_profile_create_when_missing() -> None:
+    """Genuinely-missing profile (the common typo case) keeps the original,
+    actionable advice."""
+    from hermes_cli.service_manager import GatewayNotRegisteredError
+
+    err = GatewayNotRegisteredError("typo", profile_exists=False)
+    assert "hermes profile create typo" in str(err)
+
+
+def test_gateway_not_registered_error_does_not_suggest_create_when_profile_exists() -> None:
+    """An existing profile with no local s6 slot must not be told to
+    `profile create` itself — that's impossible for `default` and
+    misleading for any other profile."""
+    from hermes_cli.service_manager import GatewayNotRegisteredError
+
+    err = GatewayNotRegisteredError("default", profile_exists=True)
+    message = str(err)
+    assert "profile create" not in message
+    assert "default" in message
+
+
+def test_run_svc_checks_profile_exists_before_raising(
+    s6_scandir, fake_subprocess_run, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_run_svc` must consult `profiles.profile_exists()` — not just
+    raise the missing-slot error blind — so a real profile without a
+    local slot gets the accurate message end to end, not just when the
+    caller happens to pass `profile_exists=True` by hand."""
+    from hermes_cli.service_manager import GatewayNotRegisteredError, S6ServiceManager
+
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    with pytest.raises(GatewayNotRegisteredError) as excinfo:
+        mgr.start("gateway-default")
+    assert "profile create" not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
 # _seed_supervise_skeleton — unit tests
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary
Fixes #78803.

`GatewayNotRegisteredError` (raised by `S6ServiceManager._run_svc` in `hermes_cli/service_manager.py` whenever a lifecycle action finds no local s6 service-dir slot for the target profile) always suggested `hermes profile create <profile>` — correct for a genuine typo, but wrong whenever the profile exists and simply has no *local* slot. The most common real case: a split gateway/dashboard container deployment, where `container_boot._is_dashboard_container()` deliberately skips slot registration in the dashboard container (to avoid an s6-log `flock` storm on a shared `HERMES_HOME` — that rationale is sound and unchanged by this PR). The dashboard's "Restart Gateway" button hits exactly this path and told operators to run `hermes profile create default`, which is both nonsensical (`profile_exists("default")` is always `True` — you can't "create" the default profile) and does nothing to actually restart the gateway.

- `_run_svc()` now calls `hermes_cli.profiles.profile_exists()` (cheap directory check) before raising, and passes the result through.
- `GatewayNotRegisteredError` renders one of two messages: unchanged "register it with `hermes profile create`" advice when the profile is genuinely missing, or an accurate "not supervised in this container" message (pointing at restarting it where it actually runs) when the profile exists but the local slot doesn't.

This is the reporter's suggested fix #1 (smallest footprint) — detect the case and phrase the error correctly, without touching the (sound, documented) reason the dashboard container skips registration in the first place.

## Test plan
- [x] New tests in `tests/hermes_cli/test_service_manager.py`, written first against the unmodified code to confirm they failed for the right reason, then implemented:
  - `test_gateway_not_registered_error_suggests_profile_create_when_missing` — unchanged behavior for a genuinely-missing profile
  - `test_gateway_not_registered_error_does_not_suggest_create_when_profile_exists` — new message, no `profile create` suggestion
  - `test_run_svc_checks_profile_exists_before_raising` — end-to-end through `_run_svc`/`S6ServiceManager.start`, not just the exception class in isolation
- [x] `scripts/run_tests.sh tests/hermes_cli/test_service_manager.py` — 10/10 passing
- [x] `scripts/run_tests.sh tests/hermes_cli/test_gateway_s6_dispatch.py tests/hermes_cli/test_profiles_s6_hooks.py tests/hermes_cli/test_profiles.py` — 49/49 passing (no regressions in the adjacent dispatch/profile suites)
- [x] `ruff check` and `ty check` on both changed files — clean
- [ ] Not tested against a real split-container Docker Compose deployment (no such environment available here) — the unit coverage exercises the actual decision path (`profile_exists()` → message selection) rather than mocking around it, but a live confirmation on the reporter's DGX Spark setup would be a good sanity check before merge.

## Platforms tested
Linux (Ubuntu), unit tests only — no macOS/Windows-specific code touched.