### PR TITLE
fix(agent): count raw stream bytes (incl. SSE keepalive comments) as codex watchdog activity

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -791,7 +791,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # failure mode emits an opening SSE frame and then stalls forever in SSL
     # read; for that we watch the gap since the last Codex stream event. This
     # matches Codex CLI's stream_idle_timeout model: any valid SSE event is
-    # activity. Operators can tune via HERMES_CODEX_TTFB_TIMEOUT_SECONDS and
+    # activity — and since run_codex_stream wraps the response's raw byte
+    # stream, SSE comment lines (``: keepalive``, which the SDK drops before
+    # they can become events) count as activity too. Operators can tune via
+    # HERMES_CODEX_TTFB_TIMEOUT_SECONDS and
     # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each).
     _codex_watchdog_enabled = agent.api_mode == "codex_responses"
     _openai_codex_backend = _is_openai_codex_backend(agent)
@@ -996,6 +999,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Stream-idle detector: the Codex backend emitted at least one SSE
         # frame, then stopped emitting events. Valid keepalive / in_progress
         # frames refresh _codex_stream_last_event_ts and should not be killed.
+        # SSE *comment* keepalives (``: keepalive``) also refresh it via the
+        # raw-byte wrapper in codex_runtime — only genuine transport silence
+        # trips this detector.
         _last_codex_event_ts = getattr(agent, "_codex_stream_last_event_ts", None)
         if (
             _codex_idle_enabled

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1228,6 +1228,57 @@ def _consume_codex_event_stream(
     return final
 
 
+def _wrap_codex_stream_byte_activity(agent, raw_stream: Any) -> None:
+    """Count ANY inbound stream bytes — not just parsed SDK events — as activity.
+
+    The Codex TTFB / stream-idle watchdogs read
+    ``agent._codex_stream_last_event_ts``, which ``_on_event`` refreshes once
+    per *parsed* SSE event. Some Responses-API backends (observed: xAI Grok
+    with high reasoning effort) emit SSE *comment* lines (``: keepalive``)
+    every few seconds during long thinking phases. Per the SSE spec those
+    lines are comments, and the OpenAI SDK's ``SSEDecoder`` drops them, so
+    they never surface as stream events: a connection that is actively
+    streaming keepalives looks dead to the watchdog and gets killed mid-think
+    (the workaround was a large HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS).
+
+    The documented intent of the idle watchdog is that valid keepalive frames
+    count as activity, so wrap the underlying httpx response's ``iter_raw``
+    to refresh the same timestamp on every raw byte chunk. The SDK consumes
+    the body via ``response.iter_bytes()`` → ``self.iter_raw()``; an
+    instance-attribute wrapper therefore sees every byte the socket delivers,
+    including comment lines, while passing chunks through unchanged.
+    """
+    try:
+        response = getattr(raw_stream, "response", None)
+        if response is None:
+            return
+        if getattr(response, "_hermes_byte_activity_wrapped", False):
+            return
+        original_iter_raw: Callable[..., Any] | None = getattr(
+            response, "iter_raw", None
+        )
+        if not callable(original_iter_raw):
+            return
+
+        def iter_raw_with_activity(chunk_size=None):
+            for chunk in original_iter_raw(chunk_size=chunk_size):
+                # Any inbound bytes — data lines, comments, keepalives —
+                # prove the connection is alive. Refresh the same timestamp
+                # the TTFB / stream-idle watchdogs poll.
+                agent._codex_stream_last_event_ts = time.time()
+                yield chunk
+
+        response.iter_raw = iter_raw_with_activity
+        response._hermes_byte_activity_wrapped = True
+    except Exception:
+        # Never break a stream over liveness accounting — worst case we fall
+        # back to the pre-fix event-only behavior.
+        logger.debug(
+            "Could not install codex stream byte-activity wrapper",
+            exc_info=True,
+        )
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
@@ -1277,6 +1328,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             # Claim the delta sink for THIS physical attempt. A newer attempt
             # supersedes this token and fences late deltas out of the turn.
             writer_token["value"] = claim_stream_writer(agent)
+            # Liveness = any inbound bytes, including SSE keepalive comments
+            # the SDK swallows before they can become events.
+            _wrap_codex_stream_byte_activity(agent, _raw_stream)
 
         def _accept_codex_chunk(_chunk: Any) -> bool:
             token = writer_token["value"]

--- a/tests/agent/test_codex_stream_byte_activity.py
+++ b/tests/agent/test_codex_stream_byte_activity.py
@@ -1,0 +1,220 @@
+"""Regression tests: Codex stream watchdog counts ANY inbound bytes as activity.
+
+The Codex TTFB / stream-idle watchdogs read
+``agent._codex_stream_last_event_ts``. Historically that timestamp was only
+refreshed per *parsed SDK event*. Some Responses-API backends (observed: xAI
+Grok with high reasoning effort) emit SSE comment lines (``: keepalive``)
+every ~15s during long thinking phases. Per the SSE spec those lines are
+comments, and the OpenAI SDK's ``SSEDecoder`` drops them — so a connection
+actively streaming keepalives looked dead to the watchdog and was killed
+mid-think (operators worked around it with large
+HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS values).
+
+``codex_runtime._wrap_codex_stream_byte_activity`` wraps the underlying
+httpx response's ``iter_raw`` so every raw byte chunk — including comment
+lines the SDK swallows — refreshes the watchdog timestamp. The watchdog
+comment in ``chat_completion_helpers`` always documented keepalives as
+activity; this makes the implementation match the intent.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+# Stub optional heavy imports so run_agent imports cleanly in isolation.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _sse_response(chunks, delay: float = 0.0) -> httpx.Response:
+    """A real streaming httpx.Response yielding ``chunks`` (optionally spaced
+    by ``delay`` seconds) over the byte path the OpenAI SDK consumes."""
+
+    class _ByteStream(httpx.SyncByteStream):
+        def __iter__(self):
+            for chunk in chunks:
+                if delay:
+                    time.sleep(delay)
+                yield chunk
+
+        def close(self):
+            pass
+
+    return httpx.Response(
+        200,
+        headers={"Content-Type": "text/event-stream"},
+        stream=_ByteStream(),
+        request=httpx.Request("POST", "https://api.x.ai/v1/responses"),
+    )
+
+
+def _sdk_stream(response: httpx.Response):
+    """The real OpenAI SDK Stream over ``response`` — the same object
+    ``responses.create(stream=True)`` hands to ``run_codex_stream``."""
+    import openai
+    from openai._streaming import Stream
+
+    client = openai.OpenAI(api_key="sk-dummy")
+    return Stream(cast_to=object, response=response, client=client)
+
+
+def test_byte_activity_wrapper_counts_keepalive_comment_bytes():
+    """Keepalive comment chunks refresh the watchdog timestamp even though the
+    SDK's SSE decoder yields ZERO events for them."""
+    from agent.codex_runtime import _wrap_codex_stream_byte_activity
+
+    agent = SimpleNamespace(_codex_stream_last_event_ts=None)
+    body = b": keepalive\n\n: keepalive\n\n"
+    stream = _sdk_stream(_sse_response([body]))
+
+    _wrap_codex_stream_byte_activity(agent, stream)
+
+    events = list(stream)  # SDK surfaces nothing — comments are dropped
+    assert events == []
+    assert agent._codex_stream_last_event_ts is not None
+
+
+def test_byte_activity_wrapper_updates_timestamp_per_chunk():
+    """Each raw chunk advances the timestamp — liveness is tracked at byte
+    cadence, not event cadence."""
+    from agent.codex_runtime import _wrap_codex_stream_byte_activity
+
+    agent = SimpleNamespace(_codex_stream_last_event_ts=None)
+    response = _sse_response([b": keepalive\n\n", b": keepalive\n\n"])
+    _wrap_codex_stream_byte_activity(agent, SimpleNamespace(response=response))
+
+    iterator = response.iter_bytes()
+    next(iterator)
+    first_ts = agent._codex_stream_last_event_ts
+    assert first_ts is not None
+    time.sleep(0.01)
+    next(iterator)
+    assert agent._codex_stream_last_event_ts >= first_ts
+
+
+def test_byte_activity_wrapper_passes_bytes_through_unchanged():
+    """The wrapper is observational only — the byte stream is identical."""
+    from agent.codex_runtime import _wrap_codex_stream_byte_activity
+
+    agent = SimpleNamespace(_codex_stream_last_event_ts=None)
+    chunks = [
+        b": keepalive\n\n",
+        b'data: {"type":"response.output_text.delta","delta":"hi"}\n\n',
+        b": keepalive\n\n",
+    ]
+    response = _sse_response(chunks)
+    _wrap_codex_stream_byte_activity(agent, SimpleNamespace(response=response))
+
+    assert b"".join(response.iter_bytes()) == b"".join(chunks)
+
+
+def test_byte_activity_wrapper_noop_without_httpx_response():
+    """Fake/stub streams (plain iterables used across the test suite) have no
+    ``.response`` — the wrapper must no-op, never raise."""
+    from agent.codex_runtime import _wrap_codex_stream_byte_activity
+
+    agent = SimpleNamespace(_codex_stream_last_event_ts=None)
+    _wrap_codex_stream_byte_activity(agent, SimpleNamespace())  # no .response
+    _wrap_codex_stream_byte_activity(agent, object())
+    assert agent._codex_stream_last_event_ts is None
+
+
+def test_byte_activity_wrapper_is_idempotent():
+    """A second wrap of the same response must not chain another layer."""
+    from agent.codex_runtime import _wrap_codex_stream_byte_activity
+
+    agent = SimpleNamespace(_codex_stream_last_event_ts=None)
+    response = _sse_response([b": keepalive\n\n"])
+    stream = SimpleNamespace(response=response)
+    _wrap_codex_stream_byte_activity(agent, stream)
+    wrapped_once = response.iter_raw
+    _wrap_codex_stream_byte_activity(agent, stream)
+    assert response.iter_raw is wrapped_once
+
+
+def _make_codex_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="grok-4.5",
+        provider="xai-oauth",
+        api_key="sk-dummy",
+        base_url="https://api.x.ai/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    agent.api_mode = "codex_responses"
+    monkeypatch.setattr(agent, "_emit_status", lambda *a, **k: None)
+    # Keep the wall-clock stale timeout high so any early kill is unambiguously
+    # the TTFB / idle watchdog path, not the stale-call path.
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0
+    )
+    return agent
+
+
+def test_keepalive_comment_bytes_prevent_watchdog_kill(tmp_path, monkeypatch):
+    """E2E: a stream that emits ONLY ``: keepalive`` comments — zero SDK
+    events — for several times the TTFB cutoff must NOT be killed by the
+    watchdog. Before the fix this died with a TimeoutError via
+    ``codex_ttfb_kill``; now the stream runs to its natural end and surfaces
+    its own error (no terminal response), never a watchdog timeout."""
+    from agent import chat_completion_helpers as h
+    from agent import codex_runtime
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.5")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.7")
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_buffer_status", lambda *a, **k: None)
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent, "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    # Six keepalive-only chunks at 0.4s intervals ≈ 2.4s of byte activity with
+    # ZERO parseable SSE events — well past the 0.5s TTFB cutoff — then EOF.
+    keepalive_body = [b": keepalive\n\n"] * 6
+    sdk_stream = _sdk_stream(_sse_response(keepalive_body, delay=0.4))
+    fake_stream_client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kw: sdk_stream)
+    )
+
+    def _real_stream(api_kwargs, client=None, on_first_delta=None):
+        return codex_runtime.run_codex_stream(
+            agent, api_kwargs, client=fake_stream_client
+        )
+
+    monkeypatch.setattr(agent, "_run_codex_stream", _real_stream)
+
+    start = time.monotonic()
+    with pytest.raises(RuntimeError, match="terminal response"):
+        h.interruptible_api_call(agent, {"model": "grok-4.5", "input": "hi"})
+    elapsed = time.monotonic() - start
+
+    # The stream ran to its natural end (~2.4s), far past the 0.5s TTFB
+    # cutoff — the watchdog never fired. Loose lower bound only; sleeps make
+    # the stream strictly longer, never shorter.
+    assert elapsed >= 1.5
+    assert "codex_ttfb_kill" not in closes
+    assert "codex_stream_idle_kill" not in closes
+    assert agent._codex_stream_last_event_ts is not None


### PR DESCRIPTION
## Summary

The Codex stream watchdogs (TTFB + stream-idle) counted only **parsed SDK events** as liveness. Responses-API backends such as **xAI Grok** emit SSE *comment* lines (`: keepalive`) every ~15s during long thinking phases — and per the SSE spec, the OpenAI SDK's `SSEDecoder` drops comment lines, so they never surface as events. A connection actively streaming keepalives looked dead to the watchdog and was killed mid-think.

**Measured reproduction** (direct streaming probe, grok-4.5, high reasoning effort, ~88K-token request):

| Time | Wire |
|---|---|
| 0.83s | HTTP 200, headers |
| 6.2–6.8s | 39 `reasoning_summary_text.delta` events |
| **6.8s → 91.4s** | **85s with ZERO SSE events** — only `: keepalive` comment lines every ~15s |
| 91.4s → 262s | continuous `output_text.delta` content |

In runs where thinking exceeded the idle cutoff (12s/60s/120s/180s by context size), Hermes killed the healthy connection (`codex_ttfb_kill` / `codex_stream_idle_kill`) and retried ×3. Bytes were flowing every 15s — no proxy would idle-kill that; Hermes was. The operator workaround was `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=900`.

## Root cause

`agent._codex_stream_last_event_ts` was refreshed only in `_on_event` (per parsed SDK event). The idle watchdog's own comment already documented the intended semantics — *"Valid keepalive / in_progress frames refresh `_codex_stream_last_event_ts` and should not be killed"* — but SSE **comment** keepalives never reached the code, because `SSEDecoder.decode()` returns `None` for lines starting with `:`.

## Fix

`run_codex_stream` now wraps the underlying httpx response's `iter_raw` so **every raw byte chunk** — data lines, comments, keepalives — refreshes the same watchdog timestamp. The SDK consumes the body via `response.iter_bytes()` → `self.iter_raw()`, so an instance-attribute wrapper sees every byte the socket delivers while passing chunks through unchanged.

- Genuine transport silence still trips both detectors (a wedged connection emits no bytes at all).
- The wall-clock stale timeout (and the Codex hard ceiling) still bounds total request time.
- The wrapper is idempotent, no-ops on stub streams without an httpx response (the test-suite's plain-iterable fakes), and never raises — worst case it falls back to pre-fix event-only behavior.

Scope note: the chat-completions streaming path deliberately kills ping-only connections ("connections kept alive by SSE pings but delivering no real chunks") — that is an intentional, separate design and is unchanged.

## Tests

New `tests/agent/test_codex_stream_byte_activity.py` (6 tests):

- **Unit**: timestamp refreshes per raw chunk; keepalive-comment-only bodies (zero SDK events) still advance it; bytes pass through unchanged; no-op on stub streams; idempotent wrapping. Uses the **real** OpenAI SDK `Stream` + real `httpx.Response` (no mocks of the byte path).
- **E2E**: `interruptible_api_call` with a keepalive-only stream (~2.4s of `: keepalive` chunks at 0.4s intervals, zero parseable events) past a 0.5s TTFB cutoff must NOT be watchdog-killed — the stream runs to its natural end and surfaces its own error.

**Verification:**

- New file: 6/6 pass with the fix.
- Same file on `origin/main` (pre-fix): 6/6 fail — the E2E test shows `codex_ttfb_kill` in the close reasons, i.e. the exact production symptom.
- Adjacent suites: `tests/agent/` (349 files, 3799 passed; the single failure in `test_credential_pool_routing.py` reproduces on clean `origin/main` — pre-existing, unrelated), plus `test_codex_ttfb_watchdog`, `test_codex_xai_oauth_recovery`, `test_run_agent_codex_responses`, `test_streaming`, and the stale/abort suites (9 files, 38 tests) — all green.
