### PR TITLE
fix(skills): don't bump skill telemetry from the curator's review fork

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -410,6 +410,46 @@ class TestSkillView:
         assert result["name"] == "knowledge-brain"
 
 
+class TestSkillViewBump:
+    """`skill_view`'s telemetry bump must not fire from the curator's
+    background-review fork — else browsing candidates while judging them
+    inflates the very use_count/last_used_at signal the review reads."""
+
+    def test_bump_skipped_during_background_review(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skill_provenance.is_background_review", return_value=True),
+            patch("tools.skill_usage.bump_view") as mock_bump_view,
+            patch("tools.skill_usage.bump_use") as mock_bump_use,
+        ):
+            _make_skill(tmp_path, "my-skill")
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump({"name": "my-skill"})
+            )
+
+        assert result["success"] is True
+        mock_bump_view.assert_not_called()
+        mock_bump_use.assert_not_called()
+
+    def test_bump_still_fires_for_foreground_calls(self, tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skill_provenance.is_background_review", return_value=False),
+            patch("tools.skill_usage.bump_view") as mock_bump_view,
+            patch("tools.skill_usage.bump_use") as mock_bump_use,
+        ):
+            _make_skill(tmp_path, "my-skill")
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump({"name": "my-skill"})
+            )
+
+        assert result["success"] is True
+        mock_bump_view.assert_called_once_with("my-skill")
+        mock_bump_use.assert_called_once_with(
+            "my-skill", task_id=None, session_id=None
+        )
+
+
 class TestSkillViewSecureSetupOnLoad:
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1938,16 +1938,22 @@ def _skill_view_with_bump(args, **kw):
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name
             if resolved:
-                from tools.skill_usage import bump_use, bump_view
-                bump_view(str(resolved))
-                # A skill_view tool call is the agent actively loading the skill
-                # to act on it — that counts as use, not just a browse/view.
-                # Curator's stale timer keys off last_used_at (see agent/curator.py).
-                bump_use(
-                    str(resolved),
-                    task_id=kw.get("task_id"),
-                    session_id=kw.get("session_id"),
-                )
+                from tools.skill_provenance import is_background_review
+                # The curator's review fork calls skill_view to inspect
+                # candidates it's judging — that must not itself count as
+                # use, or the inspection inflates the very signal the
+                # review reads.
+                if not is_background_review():
+                    from tools.skill_usage import bump_use, bump_view
+                    bump_view(str(resolved))
+                    # A skill_view tool call is the agent actively loading the skill
+                    # to act on it — that counts as use, not just a browse/view.
+                    # Curator's stale timer keys off last_used_at (see agent/curator.py).
+                    bump_use(
+                        str(resolved),
+                        task_id=kw.get("task_id"),
+                        session_id=kw.get("session_id"),
+                    )
     except Exception:
         pass
     return result

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2068,16 +2068,22 @@ def _skill_view_with_bump(args, **kw):
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name
             if resolved:
-                from tools.skill_usage import bump_use, bump_view
-                bump_view(str(resolved))
-                # A skill_view tool call is the agent actively loading the skill
-                # to act on it — that counts as use, not just a browse/view.
-                # Curator's stale timer keys off last_used_at (see agent/curator.py).
-                bump_use(
-                    str(resolved),
-                    task_id=kw.get("task_id"),
-                    session_id=kw.get("session_id"),
-                )
+                from tools.skill_provenance import is_background_review
+                # The curator's review fork calls skill_view to inspect
+                # candidates it's judging — that must not itself count as
+                # use, or the inspection inflates the very signal the
+                # review reads.
+                if not is_background_review():
+                    from tools.skill_usage import bump_use, bump_view
+                    bump_view(str(resolved))
+                    # A skill_view tool call is the agent actively loading the skill
+                    # to act on it — that counts as use, not just a browse/view.
+                    # Curator's stale timer keys off last_used_at (see agent/curator.py).
+                    bump_use(
+                        str(resolved),
+                        task_id=kw.get("task_id"),
+                        session_id=kw.get("session_id"),
+                    )
     except Exception:
         pass
     return result


### PR DESCRIPTION
## Summary

`_skill_view_with_bump` bumps `use_count`/`last_used_at` for every caller unconditionally. The curator's background-review fork calls `skill_view` to inspect the candidates it is judging — so that inspection counts as *use*, inflating the very signal the curation decision reads back:

- `agent/curator.py` stale/archive cutoffs key off `last_used_at` (`get_stale_after_days()` / `get_archive_after_days()`);
- `_render_candidate_list()` surfaces `use_count` to the review prompt.

The longer a review pass browses a skill, the fresher that skill looks to the same pass. A skill genuinely idle for months can be re-dated to "used today" purely by having been considered for archival — and the next pass then reads that as evidence of use.

## Fix

Guard the bump with `tools.skill_provenance.is_background_review()`, the same provenance signal `skill_manager_tool._background_curator_guard` already uses to hold this fork to a different standard than a foreground agent (autonomous maintenance, no user in the loop). Foreground `skill_view` calls are unaffected — the branch is entered only when the caller *is* the review fork.

Scoped to the telemetry bump only; the repeat-view dedup stub above it and `skill_view` itself are untouched.

## Test plan

- `python -m pytest tests/tools/test_skills_tool.py` — 42 passed.
- New `TestSkillViewBump` covers both sides of the branch: suppressed under background review, still fires for foreground calls.
- Counter-check: replacing the new guard with `if True:` fails `test_bump_skipped_during_background_review` and only that test, confirming the assertion discriminates fixed from unfixed code.
- `python -m py_compile tools/skills_tool.py tests/tools/test_skills_tool.py`.
