### PR TITLE
perf(buzz): optimize Path-3 native gateway defaults and connect/poll latency

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -178,6 +178,10 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "webhook":         _TIER_MINIMAL,
     "homeassistant":   _TIER_MINIMAL,
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
+
+    # Buzz — shared Nostr channels: final-answer-first, no tool-progress spam.
+    # Matches the recommended defaults in user-guide/messaging/buzz.md.
+    "buzz":            _TIER_LOW,
 }
 
 # Canonical set of per-platform overrideable keys (for validation).

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -5,10 +5,12 @@ A plugin-based gateway adapter that connects to a Buzz community relay
 (Block's open-source human+agent collaboration platform, built on the
 Nostr protocol) and relays messages to/from the Hermes agent.
 
-The adapter does not speak Nostr itself — it shells out to the ``buzz``
-CLI binary ("JSON in, JSON out") via ``asyncio.create_subprocess_exec``.
-Inbound delivery uses a poll loop (the CLI is request/response); see the
-"Known limitations" note in the platform docs.
+Outbound traffic shells out to the ``buzz`` CLI binary ("JSON in, JSON out")
+via ``asyncio.create_subprocess_exec``.  Inbound delivery defaults to a
+NIP-42-authenticated Nostr WebSocket subscription (near-instant push) with
+automatic fallback to CLI polling when the WebSocket cannot authenticate.
+Control transport via ``transport`` / ``BUZZ_TRANSPORT`` (``auto``, ``websocket``,
+``poll``).
 
 Configuration in config.yaml::
 
@@ -349,8 +351,9 @@ def _parse_json_list(stdout: str) -> List[dict]:
 # ---------------------------------------------------------------------------
 
 class BuzzAdapter(BasePlatformAdapter):
-    """Poll-based Buzz adapter implementing the BasePlatformAdapter interface.
+    """Buzz gateway adapter implementing the BasePlatformAdapter interface.
 
+    Inbound: WebSocket push (default) or CLI poll fallback.  Outbound: buzz CLI.
     Instantiated by the adapter_factory passed to register_platform().
     """
 
@@ -533,9 +536,9 @@ class BuzzAdapter(BasePlatformAdapter):
             return False
 
         # Seed high-water marks from the newest events so a (re)start never
-        # replays channel history into the agent.
-        for channel_id in watch:
-            await self._seed_channel(channel_id, chat_type="group")
+        # replays channel history into the agent.  Channels seed in parallel so
+        # connect latency scales with the slowest channel, not the sum.
+        await asyncio.gather(*(self._seed_channel(cid, chat_type="group") for cid in watch))
         await self._discover_dms(seed=True)
 
         # Inbound transport: prefer the NIP-42-authenticated WebSocket
@@ -909,8 +912,13 @@ class BuzzAdapter(BasePlatformAdapter):
                 try:
                     if self._poll_count % _DM_DISCOVERY_EVERY == 0:
                         await self._discover_dms(seed=False)
-                    for channel_id in list(self._channel_state):
-                        await self._poll_channel(channel_id)
+                    results = await asyncio.gather(
+                        *(self._poll_channel(channel_id) for channel_id in list(self._channel_state)),
+                        return_exceptions=True,
+                    )
+                    for result in results:
+                        if isinstance(result, Exception):
+                            logger.warning("Buzz: poll of channel failed", exc_info=result)
                 except asyncio.CancelledError:
                     raise
                 except Exception:

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -133,11 +133,18 @@ class TestPlatformDefaults:
 
 
     def test_low_tier_platforms(self):
-        """Signal, BlueBubbles, etc. default to 'off' tool progress."""
+        """Signal, BlueBubbles, Buzz, etc. default to 'off' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud"):
+        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud", "buzz"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
+
+    def test_buzz_final_answer_first_defaults(self):
+        """Buzz shared channels should not spam tool progress or interim chatter."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "buzz", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "buzz", "long_running_notifications") is False
 
 
     def test_telegram_mobile_chatter_defaults(self):

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -117,7 +117,8 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 
 ## Notes and limitations
 
-- **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
+- **Inbound transport.** By default (`transport: auto`), inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription (near-instant delivery). When the WebSocket cannot authenticate, the adapter falls back to CLI polling (`buzz messages get` per watched channel every `poll_interval` seconds, default 4). Pin `transport: poll` to force polling only, or `transport: websocket` to require WebSocket and fail connect otherwise.
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
-- New DM conversations are discovered automatically (every few poll sweeps).
+- New DM conversations are discovered automatically (via WebSocket membership events when connected over WS, or every few poll sweeps in poll mode).
+- Outbound messages always go through the `buzz` CLI.
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## Summary

Path ③ (native Hermes gateway ↔ Buzz) optimizations for operators running the bundled `buzz` platform plugin:

- **Display defaults:** register `buzz` in `_PLATFORM_DEFAULTS` with tier-low / final-answer-first settings (`tool_progress: off`, `interim_assistant_messages: false`) matching the recommended defaults already documented in `user-guide/messaging/buzz.md`.
- **Connect latency:** seed watched channels in parallel (`asyncio.gather`) so startup time scales with the slowest channel, not the sum of per-channel CLI round-trips.
- **Poll-fallback throughput:** when WebSocket auth fails and the adapter falls back to CLI polling, poll sweeps now run channels concurrently with isolated error handling.
- **Docs accuracy:** fix stale "inbound is polled, not streamed / websocket is a future optimization" notes — NIP-42 WebSocket push is the default `transport: auto` path since PR #73636.

## Test plan

- [x] `pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py tests/gateway/test_display_config.py` — 48 passed
- [ ] Reviewer: confirm Buzz gateway connect still succeeds on a relay with 2+ watched channels
- [ ] Reviewer: verify poll-fallback mode still de-dupes and dispatches correctly under concurrent sweeps


Made with [Cursor](https://cursor.com)