### PR TITLE
fix(guard): don't cat binaries via lifecycle-guard remote fallback

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -321,12 +321,28 @@ def _contains_unsafe_gateway_action(
         if resolved in visited:
             continue
         visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
+        try:
+            script_text, unsafe = _read_referenced_script(script_path)
+        except (OSError, ValueError):
+            # A NUL-laden path tokenized from binary content must never
+            # crash the guard (mirrors the resolve() guard above).
+            script_text, unsafe = None, False
         if unsafe:
             return True
         if script_text is None and read_remote_script is not None:
-            # Local path missing; try the remote backend if one is available.
-            script_text = read_remote_script(str(script_path))
+            # Only fall back to the remote backend when the local path is
+            # genuinely absent. _read_referenced_script deliberately returns
+            # None for NUL-skipped binaries ("nothing to scan") — treating
+            # that as "missing" made the guard `cat` the entire binary
+            # through the remote fallback and recursively scan machine code
+            # for minutes before crashing with ValueError: embedded null
+            # byte (same family as #76762, via the env.execute path).
+            try:
+                _local_missing = not resolved.exists() or not resolved.is_file()
+            except (OSError, ValueError):
+                _local_missing = True
+            if _local_missing:
+                script_text = read_remote_script(str(script_path))
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,59 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_existing_binary_path_does_not_trigger_remote_fallback(self, tmp_path):
+        """A command referencing an existing binary by absolute path must not
+        invoke the remote ``cat`` fallback.
+
+        Regression: ``_read_referenced_script`` returns None for NUL-skipped
+        binaries ("nothing to scan"), and that None used to be misread as
+        "path missing" — so with a ``read_remote_script`` supplied (as
+        terminal_tool always does), the guard `cat`-ed the whole binary via
+        the environment and recursively scanned machine code for minutes
+        before crashing with ``ValueError: embedded null byte``. The fallback
+        must only fire when the local path is genuinely absent.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        binary = tmp_path / "tool.bin"
+        binary.write_bytes(b"\x7fELF\x00\x01\x02\x03")  # NUL bytes -> binary
+        calls = []
+
+        def spy(path):
+            calls.append(path)
+            return None
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"{binary} --version",
+            cwd=str(tmp_path),
+            read_remote_script=spy,
+        )
+        assert result is False
+        assert calls == []
+
+    def test_missing_path_still_uses_remote_fallback(self, tmp_path):
+        """A genuinely absent path still goes to the remote backend — the
+        fallback exists for SSH/Modal/Daytona backends where the same path is
+        remote, and must keep working."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        missing = tmp_path / "no-such-script.sh"
+        calls = []
+
+        def spy(path):
+            calls.append(path)
+            return None
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            str(missing),
+            cwd=str(tmp_path),
+            read_remote_script=spy,
+        )
+        assert result is False
+        assert calls == [str(missing)]
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2549,10 +2549,21 @@ def terminal_tool(
                 except Exception:
                     pass
                 # Remote / sandboxed backend: read via the environment's shell.
+                # Cap the size and skip binary output: a NUL byte in the first
+                # chunk means an ELF/Mach-O binary, not a shell script. Without
+                # this, a command referencing a large binary by path made the
+                # guard `cat` the whole file through this fallback and
+                # recursively scan machine code for minutes before crashing
+                # with ValueError: embedded null byte.
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        _out = result.get("output", "")
+                        if len(_out) > 1024 * 1024:
+                            return None
+                        if "\x00" in _out[:4096]:
+                            return None
+                        return _out
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## Bug Description

Running a terminal command that references an existing binary by its absolute path (e.g. `--version` on a large native CLI installed under a full path) makes the terminal-tool **lifecycle guard hang for ~30 minutes**, then fail with:

```
ValueError: embedded null byte
```

Concrete symptoms: a `terminal` tool call that should return in <1s instead hangs the whole agent turn for 20–30 minutes and eventually errors out. Two occurrences of this exact signature were observed in production logs (1769s and 1944s tool-call durations), both triggered by commands that referenced a 275MB binary by full path.

## Root Cause

`tools/terminal_tool.py` runs `contains_gateway_lifecycle_command_or_referenced_script(command, ..., read_remote_script=_read_script_in_env)` before executing **every** command. The referenced-script walk (`cron/lifecycle_guard.py`) yields absolute executable paths from the command, then calls `_read_referenced_script` on each.

`_read_referenced_script` deliberately skips binaries — it reads the first chunk, sees a NUL byte, and returns `(None, False)` ("nothing to scan", #76762). The bug: the caller can't distinguish that from **"path missing"**, so when `read_remote_script` is supplied it falls back to:

```python
env.execute(f"cat {shlex.quote(script_path)}")
```

For a 275MB ELF binary this returns the **entire decoded machine code**, which the walk then recursively tokenizes and scans: ~800k junk segments, each doing `Path()`/`os.open()` work, recursing into any real paths embedded in the binary — a ~30 minute hang that finally crashes when a NUL-laden junk path reaches `os.open` (`ValueError: embedded null byte`). The existing #76762 fix only covered the `resolve()` site, not this `os.open` path through the remote fallback.

## Fix

**`cron/lifecycle_guard.py`**
- Only invoke the remote fallback when the local path is genuinely absent (`resolved.exists() and is_file()`). A NUL-skipped binary is "nothing to scan", not "missing" — so existing binaries are never `cat`-ed.
- Wrap `_read_referenced_script` in `try/except (OSError, ValueError)` so a NUL-laden junk path can never crash the guard, mirroring the existing `resolve()` guard.

**`tools/terminal_tool.py`** (defense in depth)
- `_read_script_in_env`: cap `env.execute` output at 1MB and return `None` when the first 4KB contains a NUL byte, so a genuinely *remote* large binary (SSH/Modal/Daytona) can't trigger the same explosion.

Remote-backend behavior is preserved: a genuinely missing path still goes through `read_remote_script`.

## How to Verify

1. `python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -o 'addopts=' -q` → 84 passed
2. Regression test `test_existing_binary_path_does_not_trigger_remote_fallback` fails on `main` (the fallback spy is invoked with the binary path) and passes with this fix.
3. Manual: `contains_gateway_lifecycle_command_or_referenced_script("<path-to-large-binary> --version", cwd="/", read_remote_script=<spy>)` returns in milliseconds with zero spy calls on the fixed code; the pre-fix code calls the spy with the binary path.

## Test Plan

- [x] Added regression tests (existing binary path → no remote fallback; missing path → fallback still fires)
- [x] Existing tests still pass (84/84 in the guard test module)
- [ ] Manual verification of the fix (see above)

## Risk Assessment

Low — the change only narrows *when* the remote `cat` fallback fires (existing local file → never) and hardens two crash sites. The genuinely-missing-path case (the only one remote backends rely on) is covered by a dedicated test.
