### PR TITLE
fix: surface Supermemory credit exhaustion safely

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -55,6 +55,24 @@ _DEFAULT_ENTITY_CONTEXT = (
 )
 
 
+def _is_credit_exhaustion_error(exc: BaseException) -> bool:
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code == 402
+    try:
+        from supermemory import APIStatusError
+    except Exception:
+        return False
+    return isinstance(exc, APIStatusError) and getattr(exc.response, "status_code", None) == 402
+
+
+def _credit_exhaustion_message(operation: str) -> str:
+    return (
+        f"Supermemory {operation} failed because the API returned HTTP 402 Payment Required. "
+        "Supermemory credits may be exhausted; add credits or wait for the billing reset "
+        "before relying on long-term memory writes."
+    )
+
+
 def _default_config() -> dict:
     return {
         "container_tag": _DEFAULT_CONTAINER_TAG,
@@ -539,6 +557,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._turn_count = 0
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
+        self._credit_warning_lock = threading.Lock()
+        self._credit_exhaustion_warning = ""
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
         self._write_thread: Optional[threading.Thread] = None
@@ -655,6 +675,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._hermes_home = kwargs.get("hermes_home") or str(get_hermes_home())
         self._session_id = session_id
         self._turn_count = 0
+        with self._credit_warning_lock:
+            self._credit_exhaustion_warning = ""
         self._config = _load_supermemory_config(self._hermes_home)
         self._api_key = get_secret("SUPERMEMORY_API_KEY", "") or ""
 
@@ -720,6 +742,30 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 lines.append(f"\n{self._custom_container_instructions}")
         return "\n".join(lines)
 
+    def _record_credit_exhaustion(self, operation: str) -> str:
+        message = _credit_exhaustion_message(operation)
+        with self._credit_warning_lock:
+            self._credit_exhaustion_warning = message
+        logger.warning("%s", message)
+        return message
+
+    def _take_credit_exhaustion_warning(self) -> str:
+        with self._credit_warning_lock:
+            warning = self._credit_exhaustion_warning
+            self._credit_exhaustion_warning = ""
+        if not warning:
+            return ""
+        return (
+            "## Supermemory warning\n"
+            f"- {warning}\n"
+            "- Do not claim new long-term memories were saved until a later Supermemory operation succeeds."
+        )
+
+    def _format_operation_error(self, exc: BaseException, operation: str) -> str:
+        if _is_credit_exhaustion_error(exc):
+            return _credit_exhaustion_message(operation)
+        return str(exc)
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if not self._active or not self._auto_recall or not self._client or not query.strip():
             return ""
@@ -732,10 +778,13 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 search_results=profile["search_results"],
                 max_results=self._max_recall_results,
             )
-            return context
-        except Exception:
+            warning = self._take_credit_exhaustion_warning()
+            return "\n\n".join(part for part in (warning, context) if part)
+        except Exception as exc:
             logger.debug("Supermemory prefetch failed", exc_info=True)
-            return ""
+            if _is_credit_exhaustion_error(exc):
+                self._record_credit_exhaustion("prefetch")
+            return self._take_credit_exhaustion_warning()
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         if not self._active or not self._auto_capture or not self._write_enabled or not self._client:
@@ -774,10 +823,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
                     "message_count": len(cleaned),
                 },
             )
-        except urllib.error.HTTPError:
-            logger.warning("Supermemory session ingest failed", exc_info=True)
-        except Exception:
-            logger.warning("Supermemory session ingest failed", exc_info=True)
+        except Exception as exc:
+            if _is_credit_exhaustion_error(exc):
+                self._record_credit_exhaustion("session ingest")
+            else:
+                logger.warning("Supermemory session ingest failed", exc_info=True)
 
         # Clear buffer so shutdown() doesn't duplicate on normal exit
         self._session_turns = []
@@ -819,8 +869,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
                         "partial": not reset,
                     },
                 )
-            except Exception:
-                logger.debug("Supermemory session-switch ingest failed", exc_info=True)
+            except Exception as exc:
+                if _is_credit_exhaustion_error(exc):
+                    self._record_credit_exhaustion("session switch ingest")
+                else:
+                    logger.debug("Supermemory session-switch ingest failed", exc_info=True)
 
         # Reset for new session
         self._session_id = str(new_session_id or "").strip() or old_session_id
@@ -840,8 +893,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
                     metadata={"target": target, "type": "explicit_memory"},
                     entity_context=self._entity_context,
                 )
-            except Exception:
-                logger.debug("Supermemory on_memory_write failed", exc_info=True)
+            except Exception as exc:
+                if _is_credit_exhaustion_error(exc):
+                    self._record_credit_exhaustion("memory write")
+                else:
+                    logger.debug("Supermemory on_memory_write failed", exc_info=True)
 
         if self._write_thread and self._write_thread.is_alive():
             self._write_thread.join(timeout=2.0)
@@ -955,7 +1011,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 resp["container_tag"] = tag
             return json.dumps(resp)
         except Exception as exc:
-            return tool_error(f"Failed to store memory: {exc}")
+            return tool_error(f"Failed to store memory: {self._format_operation_error(exc, 'store memory')}")
 
     def _tool_search(self, args: dict) -> str:
         query = str(args.get("query") or "").strip()
@@ -985,7 +1041,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 resp["container_tag"] = tag
             return json.dumps(resp)
         except Exception as exc:
-            return tool_error(f"Search failed: {exc}")
+            return tool_error(f"Search failed: {self._format_operation_error(exc, 'search')}")
 
     def _tool_forget(self, args: dict) -> str:
         memory_id = str(args.get("id") or "").strip()
@@ -1002,7 +1058,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 return json.dumps({"forgotten": True, "id": memory_id})
             return json.dumps(self._client.forget_by_query(query, container_tag=tag))
         except Exception as exc:
-            return tool_error(f"Forget failed: {exc}")
+            return tool_error(f"Forget failed: {self._format_operation_error(exc, 'forget')}")
 
     def _tool_profile(self, args: dict) -> str:
         query = str(args.get("query") or "").strip() or None
@@ -1026,7 +1082,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 resp["container_tag"] = tag
             return json.dumps(resp)
         except Exception as exc:
-            return tool_error(f"Profile failed: {exc}")
+            return tool_error(f"Profile failed: {self._format_operation_error(exc, 'profile')}")
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         if not self._active or not self._client:

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -2,9 +2,11 @@ import json
 import os
 import stat
 import threading
+import urllib.error
 
 import pytest
 
+from agent.memory_manager import build_memory_context_block
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
     _clean_text_for_capture,
@@ -456,3 +458,140 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+def _http_error(status: int, reason: str) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://api.supermemory.ai/v4/memories",
+        code=status,
+        msg=reason,
+        hdrs={},
+        fp=None,
+    )
+
+
+def _sdk_http_error(status: int, reason: str):
+    sdk = pytest.importorskip("supermemory")
+    httpx = pytest.importorskip("httpx")
+    request = httpx.Request("POST", "https://api.supermemory.ai/v4/memories")
+    response = httpx.Response(status, request=request)
+    return sdk.APIStatusError(reason, response=response, body={"error": reason})
+
+
+def test_sdk_402_tool_error_is_actionable(provider):
+    def exhausted(*args, **kwargs):
+        raise _sdk_http_error(402, "Payment Required")
+
+    provider._client.add_memory = exhausted
+
+    result = json.loads(provider._tool_store({"content": "Remember this durable preference"}))
+
+    assert "HTTP 402 Payment Required" in result["error"]
+    assert "credits may be exhausted" in result["error"]
+
+
+@pytest.mark.parametrize("status", [401, 429, 500])
+def test_non_402_sdk_errors_do_not_claim_credit_exhaustion(provider, status):
+    def failed(*args, **kwargs):
+        raise _sdk_http_error(status, "Request failed")
+
+    provider._client.add_memory = failed
+
+    result = json.loads(provider._tool_store({"content": "Remember this durable preference"}))
+
+    assert "credits may be exhausted" not in result["error"]
+    assert provider.prefetch("What should I work on next?") == ""
+
+
+@pytest.mark.parametrize(
+    ("tool", "args", "client_method"),
+    [
+        ("_tool_search", {"query": "durable preference"}, "search_memories"),
+        ("_tool_forget", {"id": "mem_123"}, "forget_memory"),
+        ("_tool_profile", {}, "get_profile"),
+    ],
+)
+def test_402_is_actionable_for_every_remaining_tool(provider, tool, args, client_method):
+    def exhausted(*args, **kwargs):
+        raise _sdk_http_error(402, "Payment Required")
+
+    setattr(provider._client, client_method, exhausted)
+
+    result = json.loads(getattr(provider, tool)(args))
+
+    assert "HTTP 402 Payment Required" in result["error"]
+    assert "credits may be exhausted" in result["error"]
+
+
+def test_prefetch_402_returns_only_a_transient_warning_context(provider):
+    def exhausted(*args, **kwargs):
+        raise _sdk_http_error(402, "Payment Required")
+
+    provider._client.get_profile = exhausted
+
+    context = provider.prefetch("What should I work on next?")
+    injected = build_memory_context_block(context)
+
+    assert "<supermemory-context>" not in context
+    assert injected.count("<memory-context>") == 1
+    assert injected.count("HTTP 402 Payment Required") == 1
+
+
+def test_background_memory_write_402_merges_warning_with_next_recall(provider):
+    def exhausted(*args, **kwargs):
+        raise _sdk_http_error(402, "Payment Required")
+
+    provider._client.profile_response = {
+        "static": ["Jordan prefers concise docs"],
+        "dynamic": [],
+        "search_results": [],
+    }
+    provider._client.add_memory = exhausted
+    provider.on_memory_write("add", "memory", "Jordan likes concise docs")
+    provider._write_thread.join(timeout=1)
+
+    merged = provider.prefetch("What should I work on next?")
+
+    assert "Supermemory warning" in merged
+    assert "memory write" in merged
+    assert "Jordan prefers concise docs" in merged
+    assert "Supermemory warning" not in provider.prefetch("What should I work on next?")
+
+
+def test_session_switch_402_surfaces_once_on_next_prefetch(provider):
+    def exhausted(*args, **kwargs):
+        raise _http_error(402, "Payment Required")
+
+    provider.sync_turn("Please remember this project", "I will keep it in context")
+    provider._client.ingest_conversation = exhausted
+    provider.on_session_switch("session-2")
+
+    warning = provider.prefetch("What should I work on next?")
+
+    assert "Supermemory warning" in warning
+    assert "session switch ingest" in warning
+
+
+def test_session_end_402_surfaces_after_real_end_then_switch_ordering(provider):
+    def exhausted(*args, **kwargs):
+        raise _http_error(402, "Payment Required")
+
+    provider._client.ingest_conversation = exhausted
+    provider.on_session_end([
+        {"role": "user", "content": "Please remember this project"},
+        {"role": "assistant", "content": "I will keep it in context"},
+    ])
+    provider.on_session_switch("session-2")
+
+    warning = provider.prefetch("What should I work on next?")
+
+    assert "Supermemory warning" in warning
+    assert "session ingest" in warning
+
+
+def test_initialize_clears_pending_warning_from_prior_session(provider):
+    provider._record_credit_exhaustion("memory write")
+
+    provider.initialize("session-2", hermes_home=provider._hermes_home, platform="cli")
+
+    assert provider.prefetch("What should I work on next?") == ""


### PR DESCRIPTION
Supersedes #69624.

Handles confirmed HTTP 402 errors with actionable tool feedback and a one-shot, in-memory warning for automatic/background capture failures. The warning is injected only through next-turn recall context—never via the cached system prompt—and no warning state is persisted.

Validation: `python -m pytest tests/plugins/memory/test_supermemory_provider.py -o "addopts=" -q` (38 passed), Ruff, `py_compile`, and `git diff --check`.

Independent review: verified Claude Opus 5 `pass_with_watchlist` (high confidence); no blockers.