### PR TITLE
fix: guard gateway file descriptor usage

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4133,6 +4133,15 @@ def generate_launchd_plist() -> str:
     <key>KeepAlive</key>
     <true/>
 
+    <!-- macOS launchd otherwise inherits a 256-descriptor soft limit. A gateway
+         serving concurrent conversations keeps SQLite, model, Telegram, MCP and
+         tool descriptors open, so retain headroom while leak guards catch growth. -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
+
     <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
          to 30s so a crash-looping gateway can't hammer launchd into a rapid
          respawn storm; ExitTimeOut gives the gateway 25s of graceful-drain

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -84,6 +84,7 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 logger = logging.getLogger(__name__)
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
+_MAX_CACHED_READ_CONNECTIONS = 32
 
 
 def _system_prompt_hash(system_prompt: str) -> str:
@@ -2255,28 +2256,32 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if getattr(self._read_local, "failed", False):
             return None
         try:
-            conn = _connect_tracked_db(
-                f"file:{self.db_path}?mode=ro",
-                tracking_path=self.db_path,
-                uri=True,
-                timeout=5.0,
-                isolation_level=None,
-            )
-            conn.row_factory = sqlite3.Row
-            apply_database_pragmas(conn, db_label="state.db")
-            # Load the CJK tokenizer extension on this connection so
-            # messages_fts_cjk queries work on the read path. The .so
-            # registers the tokenizer in the connection's in-memory
-            # registry, not the database file, so mode=ro is fine.
-            if self._fts_cjk_loaded:
-                load_fts5_cjk_extension(conn)
             with self._read_conns_lock:
                 if self._read_conns_closed:
-                    # close() already drained — don't register; close
-                    # immediately so no tracked fd leaks.
-                    conn.close()
                     self._read_local.failed = True
                     return None
+                if len(self._read_conns) >= _MAX_CACHED_READ_CONNECTIONS:
+                    # Gateway executor threads can be short-lived. Keeping one
+                    # SQLite reader for every thread until SessionDB.close()
+                    # otherwise grows without bound and exhausts RLIMIT_NOFILE.
+                    # Fall back to the existing locked writer read path.
+                    self._read_local.failed = True
+                    return None
+                conn = _connect_tracked_db(
+                    f"file:{self.db_path}?mode=ro",
+                    tracking_path=self.db_path,
+                    uri=True,
+                    timeout=5.0,
+                    isolation_level=None,
+                )
+                conn.row_factory = sqlite3.Row
+                apply_database_pragmas(conn, db_label="state.db")
+                # Load the CJK tokenizer extension on this connection so
+                # messages_fts_cjk queries work on the read path. The .so
+                # registers the tokenizer in the connection's in-memory
+                # registry, not the database file, so mode=ro is fine.
+                if self._fts_cjk_loaded:
+                    load_fts5_cjk_extension(conn)
                 self._read_conns.add(conn)
         except sqlite3.Error:
             # Mark this thread failed so we don't retry the open on every

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import plistlib
 import sys
 import time
 from pathlib import Path
@@ -888,6 +889,14 @@ class TestLaunchdPlistRespawnGovernance:
         assert "<key>ThrottleInterval</key>" in plist
         assert "<key>ExitTimeOut</key>" in plist
         assert "<key>KeepAlive</key>" in plist
+
+    def test_plist_raises_gateway_file_descriptor_soft_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.gateway import generate_launchd_plist
+
+        payload = plistlib.loads(generate_launchd_plist().encode("utf-8"))
+
+        assert payload["SoftResourceLimits"]["NumberOfFiles"] == 4096
 
 
 class TestPermissionErrorOnLockFile:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,6 +1,7 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
 import sqlite3
+import threading
 import time
 import json
 from unittest import mock
@@ -84,6 +85,28 @@ def db(tmp_path):
 
 
 class TestConnectionLifecycle:
+    def test_ephemeral_reader_threads_do_not_grow_connection_pool_without_bound(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "state.db"
+        session_db = SessionDB(db_path=db_path)
+        session_db.create_session("thread-reader", source="gateway")
+        results = []
+
+        def read_session():
+            results.append(session_db.get_session("thread-reader"))
+
+        try:
+            for _ in range(64):
+                thread = threading.Thread(target=read_session)
+                thread.start()
+                thread.join()
+
+            assert all(result is not None for result in results)
+            assert len(session_db._read_conns) <= 32
+        finally:
+            session_db.close()
+
     def test_read_only_close_never_requests_wal_checkpoint(self, tmp_path):
         db_path = tmp_path / "state.db"
         writable = SessionDB(db_path=db_path)


### PR DESCRIPTION
## Summary
- cap cached per-thread SQLite read connections at 32 and fall back to the serialized writer connection after the cap
- serialize cache creation/close to prevent races around shutdown and the cap
- install a launchd soft `NumberOfFiles` limit of 4096 for the gateway

## Tests
- 231 targeted tests passed: `tests/test_hermes_state.py` + `tests/gateway/test_status.py`
- Ruff passed on all four changed files
- full-suite attempt was isolated under a temporary HOME; upstream currently has unrelated baseline failures, while the affected suites are green

## Operational context
Observed a macOS gateway process near the default 256 soft nofile limit. This patch adds both an application-level connection bound and service-level headroom.