### PR TITLE
fix(config): make MCP server transport mutually exclusive on profile merge (#78606)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2432,6 +2432,45 @@ def _merge_partial_save(raw: dict, override: dict) -> dict:
     return result
 
 
+def _merge_mcp_servers(base: dict, override: dict) -> dict:
+    """Merge two ``mcp_servers`` config dicts, enforcing transport exclusivity.
+
+    ``mcp_servers`` children are special because a single server is *either*
+    stdio (``command``/``args``/``env``) *or* HTTP (``url``/``headers``). The
+    generic ``_deep_merge`` would recurse per-field and leave both transports in
+    a server that an override switches from one to the other, producing a config
+    with ``url`` and ``command`` side by side, which registers duplicate tool
+    instances. See #78606.
+
+    When an override switches a server's transport, the opposite transport's
+    fields are dropped from the base before the normal field-level merge:
+
+    * override has ``url`` and no ``command`` -> drop ``command``/``args``/``env``
+    * override has ``command`` and no ``url`` -> drop ``url``/``headers``
+
+    Servers present in only one side, or keeping the same transport, merge as
+    usual via ``_deep_merge``.
+    """
+    result = base.copy()
+    for name, server_override in override.items():
+        if (
+            name not in result
+            or not isinstance(result[name], dict)
+            or not isinstance(server_override, dict)
+        ):
+            result[name] = server_override
+            continue
+        base_server = dict(result[name])
+        if "url" in server_override and "command" not in server_override:
+            for field in ("command", "args", "env"):
+                base_server.pop(field, None)
+        elif "command" in server_override and "url" not in server_override:
+            for field in ("url", "headers"):
+                base_server.pop(field, None)
+        result[name] = _deep_merge(base_server, server_override)
+    return result
+
+
 def _deep_merge(base: dict, override: dict) -> dict:
     """Recursively merge *override* into *base*, preserving nested defaults.
 
@@ -2444,6 +2483,10 @@ def _deep_merge(base: dict, override: dict) -> dict:
     default dict with ``None`` and crash every downstream consumer that
     expects a mapping (#58277). A ``None`` override of a dict default is
     ignored — same as the key being absent.
+
+    The ``mcp_servers`` key is special-cased so a server that an override
+    switches between stdio and HTTP transport does not end up with both
+    transports merged together (see ``_merge_mcp_servers`` / #78606).
     """
     result = base.copy()
     for key, value in override.items():
@@ -2452,7 +2495,10 @@ def _deep_merge(base: dict, override: dict) -> dict:
             and isinstance(result[key], dict)
             and isinstance(value, dict)
         ):
-            result[key] = _deep_merge(result[key], value)
+            if key == "mcp_servers":
+                result[key] = _merge_mcp_servers(result[key], value)
+            else:
+                result[key] = _deep_merge(result[key], value)
         elif key in result and isinstance(result[key], dict) and value is None:
             continue
         else:

--- a/tests/hermes_cli/test_mcp_transport_merge_exclusivity.py
+++ b/tests/hermes_cli/test_mcp_transport_merge_exclusivity.py
@@ -1,0 +1,184 @@
+"""Regression tests for transport mutual-exclusivity when merging MCP server
+configs via ``_deep_merge``.
+
+See issue #78606: a profile config that switches a server from stdio
+(``command``/``args``) to HTTP (``url``) must not leave the stdio fields in the
+merged config, otherwise the server ends up with *both* transports and the
+loader registers duplicate tool instances.
+"""
+
+from hermes_cli.config import _deep_merge
+
+
+class TestMcpServerTransportExclusivity:
+    """Layer 1-4: per-server transport switching during deep merge."""
+
+    def test_http_override_strips_stdio_fields(self):
+        """L1: override with ``url`` (no ``command``) drops stdio fields."""
+        base = {
+            "mcp_servers": {
+                "rca": {
+                    "command": "/usr/local/bin/node",
+                    "args": ["/path/to/server/index.js"],
+                    "env": {"NODE_ENV": "production"},
+                    "enabled": True,
+                }
+            }
+        }
+        override = {
+            "mcp_servers": {
+                "rca": {
+                    "url": "http://localhost:3001/mcp",
+                    "enabled": True,
+                }
+            }
+        }
+        merged = _deep_merge(base, override)
+        server = merged["mcp_servers"]["rca"]
+        assert "url" in server
+        assert server["url"] == "http://localhost:3001/mcp"
+        # stdio-only fields must be gone
+        assert "command" not in server
+        assert "args" not in server
+        assert "env" not in server
+
+    def test_stdio_override_strips_http_fields(self):
+        """L2: override with ``command`` (no ``url``) drops HTTP fields."""
+        base = {
+            "mcp_servers": {
+                "rca": {
+                    "url": "http://localhost:3001/mcp",
+                    "headers": {"Authorization": "Bearer x"},
+                    "enabled": True,
+                }
+            }
+        }
+        override = {
+            "mcp_servers": {
+                "rca": {
+                    "command": "/usr/local/bin/node",
+                    "args": ["/path/to/server/index.js"],
+                    "enabled": True,
+                }
+            }
+        }
+        merged = _deep_merge(base, override)
+        server = merged["mcp_servers"]["rca"]
+        assert "command" in server
+        assert server["command"] == "/usr/local/bin/node"
+        # HTTP-only fields must be gone
+        assert "url" not in server
+        assert "headers" not in server
+
+    def test_non_transport_fields_survive_transport_switch(self):
+        """L3: switching transport keeps non-transport fields from both."""
+        base = {
+            "mcp_servers": {
+                "rca": {
+                    "command": "/usr/local/bin/node",
+                    "args": ["index.js"],
+                    "description": "RCA stdio server",
+                    "enabled": True,
+                }
+            }
+        }
+        override = {
+            "mcp_servers": {
+                "rca": {
+                    "url": "http://localhost:3001/mcp",
+                    "enabled": False,  # override disables it
+                }
+            }
+        }
+        merged = _deep_merge(base, override)
+        server = merged["mcp_servers"]["rca"]
+        assert "url" in server
+        assert "command" not in server
+        # override's enabled wins
+        assert server["enabled"] is False
+        # base-only non-transport field survives
+        assert server["description"] == "RCA stdio server"
+
+    def test_same_transport_merge_unchanged(self):
+        """L4: both stdio — normal field-level recursion still applies."""
+        base = {
+            "mcp_servers": {
+                "rca": {
+                    "command": "/usr/local/bin/node",
+                    "args": ["old.js"],
+                    "enabled": True,
+                }
+            }
+        }
+        override = {
+            "mcp_servers": {
+                "rca": {
+                    "command": "/usr/local/bin/node",
+                    "args": ["new.js"],  # change args, keep command
+                }
+            }
+        }
+        merged = _deep_merge(base, override)
+        server = merged["mcp_servers"]["rca"]
+        assert server["command"] == "/usr/local/bin/node"
+        assert server["args"] == ["new.js"]
+        assert server["enabled"] is True
+
+    def test_both_http_same_transport_merge_unchanged(self):
+        """L4 (mirror): both HTTP — normal field-level recursion applies."""
+        base = {
+            "mcp_servers": {
+                "rca": {
+                    "url": "http://localhost:3001/mcp",
+                    "headers": {"X-Old": "1"},
+                    "enabled": True,
+                }
+            }
+        }
+        override = {
+            "mcp_servers": {
+                "rca": {
+                    "url": "http://localhost:3002/mcp",  # new url
+                    "headers": {"X-New": "2"},
+                }
+            }
+        }
+        merged = _deep_merge(base, override)
+        server = merged["mcp_servers"]["rca"]
+        assert server["url"] == "http://localhost:3002/mcp"
+        assert server["enabled"] is True
+
+    def test_new_server_added_normally(self):
+        """A server present only in the override is added as-is."""
+        base = {"mcp_servers": {"a": {"command": "x", "enabled": True}}}
+        override = {"mcp_servers": {"b": {"url": "http://x", "enabled": True}}}
+        merged = _deep_merge(base, override)
+        assert "a" in merged["mcp_servers"]
+        assert "b" in merged["mcp_servers"]
+        assert merged["mcp_servers"]["b"]["url"] == "http://x"
+
+
+class TestDeepMergeNotRegressed:
+    """Layer 5: generic merge behavior is unchanged for other keys."""
+
+    def test_generic_nested_merge_preserved(self):
+        """Non-mcp_servers keys still deep-merge recursively."""
+        base = {"tts": {"elevenlabs": {"voice_id": "v1", "model_id": "m1"}}}
+        override = {"tts": {"elevenlabs": {"voice_id": "v2"}}}
+        merged = _deep_merge(base, override)
+        assert merged["tts"]["elevenlabs"]["voice_id"] == "v2"
+        assert merged["tts"]["elevenlabs"]["model_id"] == "m1"
+
+    def test_generic_top_level_override(self):
+        base = {"a": 1, "b": 2}
+        override = {"b": 3}
+        assert _deep_merge(base, override) == {"a": 1, "b": 3}
+
+    def test_non_mcp_dict_named_mcp_servers_mirrors_is_handled(self):
+        """A top-level key literally named mcp_servers gets the special path."""
+        # Sanity: the special-casing keys on the string 'mcp_servers'.
+        base = {"mcp_servers": {"s": {"command": "c", "args": ["a"], "env": {"E": "1"}}}}
+        override = {"mcp_servers": {"s": {"url": "http://u"}}}
+        merged = _deep_merge(base, override)
+        assert "command" not in merged["mcp_servers"]["s"]
+        assert merged["mcp_servers"]["s"]["url"] == "http://u"


### PR DESCRIPTION
## What

When a global `config.yaml` defines an MCP server with stdio transport (`command`/`args`) and a profile override switches the same server to HTTP transport (`url`), `_deep_merge()` recursively merged both configs — leaving `command` AND `url` side by side. This produced a merged server dict with **both transports**, causing duplicate `McpServer` registration (one stdio, one HTTP), conflicting tool names, and spurious runtime errors.

## Root cause

`_deep_merge()` is generic — it recurses per-field and has no concept that stdio fields (`command`, `args`, `env`) and HTTP fields (`url`, `headers`) are mutually exclusive transport selectors.

## Fix

Added `_merge_mcp_servers()` helper; `_deep_merge()` dispatches to it on the `mcp_servers` key. When an override **switches** a server's transport, the opposite transport's fields are dropped from the base before the normal field-level merge:

- override has `url`, no `command` → drop `command`/`args`/`env` from base
- override has `command`, no `url` → drop `url`/`headers` from base

Same-transport overrides, new servers, and non-transport fields all merge unchanged. All non-`mcp_servers` keys are byte-for-byte unchanged.

## Verified

- **RED phase** (on `upstream/main` before fix): 4 transport-exclusivity tests fail — `command`/`args`/`env` survive an HTTP override, `url`/`headers` survive a stdio override.
- **GREEN phase** (after fix): 9/9 tests pass.
- **Nearby suites**: 156 passed, 0 failed (`test_config`, `test_mcp_config`, `test_apply_profile_override`, `test_profiles`, `test_config_loader_e2e`, `test_mcp_tools_config`).
- **ruff**: clean.
- One focused commit ahead of `upstream/main` (`0 1`).

Closes #78606.

Auto-published by Moonsong via Path B automated pipeline.