### PR TITLE
fix(terminal): stop the lifecycle guard crashing on every command whose executable contains a slash

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: ``open: embedded null character in path``. A path
+        # candidate carrying a NUL byte can only come from tokenizing
+        # non-script bytes, so there is nothing to scan — and a guarded
+        # path must never crash the guard (#76762). ``_resolve_script_path``
+        # below already treats ValueError this way; os.open did not.
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -9,6 +9,7 @@ Covers:
 import json
 import os
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
@@ -694,6 +695,72 @@ class TestLifecycleGuardModule:
             '/usr/bin/python3 -c "print(1)"'
         )
         assert result is False
+
+    def test_nul_path_from_remote_reader_does_not_crash_guard(self, tmp_path):
+        """#76762 follow-up: the same crash came back through the OTHER reader.
+
+        The test above passes because it omits ``read_remote_script`` — but
+        tools/terminal_tool.py ALWAYS passes one (``_read_script_in_env``), and
+        that fallback returned replacement-decoded binaries. The scanner then
+        tokenized machine code into path candidates carrying NUL bytes and
+        ``os.open`` raised ``ValueError: open: embedded null character in path``,
+        which the ``except OSError`` in ``_read_referenced_script`` did not catch.
+
+        Effect on a real deployment: every terminal command whose executable
+        contains a "/" failed — ``.venv/bin/python -m pytest``, ``/bin/ls -la`` —
+        after burning ~28s in the scan first.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        binary = tmp_path / "fake-interpreter"
+        # Shaped like decoded machine code: NUL bytes glued to path-ish tokens.
+        binary.write_bytes(b"\x7fELF\x00\x00./setup.sh\x00/tmp/x.sh\x00\x01\x02")
+
+        def _decode_anything(script_path):
+            """Exactly what _read_script_in_env used to do.
+
+            ``except Exception`` matches the real callback — and is load-bearing:
+            the scanner feeds junk tokens back in, and ``Path.read_bytes`` on one
+            raises ``ValueError: embedded null byte``, not OSError.
+            """
+            try:
+                return Path(script_path).read_bytes().decode("utf-8", errors="replace")
+            except Exception:
+                return None
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"{binary} --version",
+            cwd=str(tmp_path),
+            read_remote_script=_decode_anything,
+        )
+        assert result is False
+
+    def test_remote_reader_binary_rejected_before_scanning(self):
+        """The root-cause fix: a binary payload is never handed to the scanner.
+
+        Covers ``tools.terminal_tool._script_text_if_not_binary``, which both
+        branches of ``_read_script_in_env`` now route through. Catching the
+        ValueError alone is not enough — it stops the crash but leaves the
+        scanner grinding through decoded machine code (measured at >80s per
+        command on a real interpreter, worse than failing fast).
+        """
+        from tools.terminal_tool import _script_text_if_not_binary
+
+        # Binaries: rejected, as bytes and as already-decoded text (NUL is valid
+        # UTF-8, so it survives an errors="replace" decode).
+        assert _script_text_if_not_binary(b"\x7fELF\x00\x02\x01") is None
+        assert _script_text_if_not_binary("\x7fELF\x00\x02\x01") is None
+        assert _script_text_if_not_binary(None) is None
+
+        # Real shell scripts: passed through unchanged, so the guard can still
+        # walk them (see test_shell_script_reference_walk_still_works).
+        assert _script_text_if_not_binary(
+            b"#!/bin/sh\nhermes gateway restart\n"
+        ) == "#!/bin/sh\nhermes gateway restart\n"
+        assert _script_text_if_not_binary("#!/bin/sh\ntrue\n") == "#!/bin/sh\ntrue\n"
+        # Invalid UTF-8 without NULs is still text-shaped; decode, do not drop.
+        assert _script_text_if_not_binary(b"#!/bin/sh\n\xff\xfe\n") is not None
 
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -373,6 +373,32 @@ def _check_all_guards(command: str, env_type: str,
                                   has_host_access=has_host_access)
 
 
+def _script_text_if_not_binary(data: "bytes | str | None") -> Optional[str]:
+    """Return scannable script text, or ``None`` when *data* is a binary.
+
+    The lifecycle guard feeds whatever a script reader returns straight back
+    into its recursive scanner, so replacement-decoded ELF/Mach-O/PE bytes make
+    it tokenize machine code into path candidates — junk that carries NUL bytes
+    and then blows up path handling (``ValueError: open: embedded null
+    character in path``, #76762).  ``cron.lifecycle_guard._read_referenced_script``
+    already refuses binaries this way for its own local reads; every other
+    reader handed to the guard has to agree, or a command as ordinary as
+    ``/bin/ls -la`` fails.
+
+    NUL is valid UTF-8 and survives an ``errors="replace"`` decode, so the same
+    check is correct for raw bytes and for already-decoded text.
+    """
+    if data is None:
+        return None
+    if isinstance(data, bytes):
+        if b"\x00" in data:
+            return None
+        return data.decode("utf-8", errors="replace")
+    if "\x00" in data:
+        return None
+    return data
+
+
 # Allowlist: characters that can legitimately appear in directory paths.
 # Covers Unicode letters/digits, path separators, Windows drive/UNC separators,
 # tilde, dot, hyphen, underscore, space, plus, at, equals, and comma.  Shell
@@ -2533,6 +2559,12 @@ def terminal_tool(
                 For local backends the script path is on the host filesystem. For
                 SSH/Modal/Daytona the same path is remote; the local read misses, so we
                 fall back to ``env.execute('cat ...')``.
+
+                Binaries are rejected rather than returned as replacement-decoded
+                text — see ``_script_text_if_not_binary`` for why that matters
+                (#76762). Both branches must agree on it: the `cat` fallback below is
+                what actually fed decoded ELF bytes back into the scanner, because a
+                multi-megabyte interpreter fails the local size check and falls through.
                 """
                 if env is None:
                     return None
@@ -2545,14 +2577,14 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
-                                return data.decode("utf-8", errors="replace")
+                                return _script_text_if_not_binary(data)
                 except Exception:
                     pass
                 # Remote / sandboxed backend: read via the environment's shell.
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        return _script_text_if_not_binary(result.get("output", ""))
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## The bug

When `_HERMES_GATEWAY=1`, `tools/terminal_tool.py` runs
`contains_gateway_lifecycle_command_or_referenced_script` over **every** terminal command, and
any slash-bearing executable is treated as a referenced shell script.
`cron/lifecycle_guard.py._read_referenced_script` correctly refuses binaries via its NUL check
(#76762), but the `read_remote_script` fallback the terminal tool passes
(`_read_script_in_env`) had no such check: it returned the binary decoded with
`errors="replace"`.

That decoded ELF/Mach-O/PE went straight back into the recursive scanner, which tokenized
machine code into path candidates carrying NUL bytes. `os.open` then raised `ValueError:
embedded null character in path` — and the handler on that call site only caught `OSError`, so
it escaped the guard.

Observed on a real deployment (v2026.8.3), scanning a multi-megabyte interpreter before
failing:

```
28.62s  ValueError  .venv/bin/python -m pytest tests/test_summarize.py -q
28.60s  ValueError  .venv/bin/python scripts/morning_brief.py
 0.45s  ValueError  /bin/ls -la
28.71s  ValueError  /usr/bin/python3 -m pytest -q
```

Note `/bin/ls`: this is not limited to interpreters or venvs. Every affected command surfaced
to the agent as `Failed to execute command: open: embedded nul...`. A kanban worker burned all
its allowed attempts unable to run either its program or its test suite, then was auto-blocked
for a protocol violation — with the work actually done and none of it reported.

## The fix, root cause first

- **`tools/terminal_tool.py`** — extract `_script_text_if_not_binary` and route **both**
  branches of `_read_script_in_env` through it, so a binary is never handed to the scanner.
  The `cat` fallback is the branch that actually did it: a multi-megabyte interpreter fails the
  local 1 MiB size check and falls through to `env.execute`. NUL is valid UTF-8 and survives an
  `errors="replace"` decode, so the same check is correct for bytes and for already-decoded
  output.
- **`cron/lifecycle_guard.py`** — catch `ValueError` alongside `OSError` on the `os.open` call.
  `_resolve_script_path` in the same recursion already treats a NUL path this way; `os.open`
  did not.

**The order matters.** Catching the `ValueError` alone stops the crash but leaves the scanner
walking decoded machine code — measured at **over 80s per command** on the same interpreter,
worse than failing fast. Rejecting the binary at source keeps it at 0.06s.

## Why the existing #76762 test did not catch it

`test_absolute_path_binary_does_not_crash_guard` passes on unfixed code because it **omits
`read_remote_script`** — which is exactly the blind spot: the callback the terminal tool always
supplies was never exercised. Added:

- `test_nul_path_from_remote_reader_does_not_crash_guard` — drives the guard with a reader that
  decodes anything, as the old callback did, and asserts no crash. Uses a small synthetic binary
  so it stays fast.
- `test_remote_reader_binary_rejected_before_scanning` — covers `_script_text_if_not_binary`
  directly: binaries rejected as bytes and as already-decoded text, real shell scripts passed
  through unchanged so the referenced-script walk still works, and non-UTF-8-but-NUL-free
  content still treated as text.

Both fail on the parent commit. `tests/hermes_cli/test_gateway_restart_loop.py` goes from
83 passed / 1 failed to **84 passed**; `tests/tools -k terminal` is **178 passed, 2 skipped**.

## Not a weakening

Lifecycle patterns are matched on the command itself before any path handling, so the
foot-guns this guard exists to stop are unaffected — verified that `hermes gateway
restart|stop`, `launchctl kickstart` and `systemctl restart hermes-gateway` are all still
blocked, and the neighbouring nested-script / launchctl-submit tests still pass.
