### PR TITLE
docs: qualify TUI development commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,16 +464,17 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run these commands from the repository root:
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm run install:tui                  # first time
+npm run dev --workspace ui-tui       # watch mode (rebuilds hermes-ink + tsx --watch)
+npm run start --workspace ui-tui     # production
+npm run build --workspace ui-tui     # bundle TUI entrypoint with esbuild
+npm run typecheck --workspace ui-tui # typecheck only (tsc --noEmit)
+npm run lint --workspace ui-tui      # eslint
+npm run fmt --workspace ui-tui       # prettier
+npm run test --workspace ui-tui      # vitest
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)


### PR DESCRIPTION
## Summary

- Run the documented TUI development commands from the repository root.
- Use the root `install:tui` script and qualify each TUI lifecycle command with `--workspace ui-tui`.
- Correct the build description to match the current esbuild bundle.

## Verification

- PASS: manifest validator resolved all 8 documented commands to `package.json` or `ui-tui/package.json` scripts; 0 commands missing.
- PASS: `npm run build --workspace ui-tui`.
- PASS: `npm run typecheck --workspace ui-tui`.
- PASS: `npm run lint --workspace ui-tui` (0 errors, 1 pre-existing warning in untouched code).
- PASS: `npm exec --workspace ui-tui -- prettier --check "src/**/*.{ts,tsx}" "packages/**/*.{ts,tsx}"`.
- PASS: `git diff --check origin/main...HEAD`.
- NOT AVAILABLE: the root package does not define `npm run verify`.
- BASELINE WINDOWS FAILURES: `npm run check --workspace ui-tui` reached 1,516 passing and 8 skipped tests, with 8 failures in three untouched terminal/path suites. The branch changes only `AGENTS.md`; Linux CI remains authoritative.

## Pre-Landing Review

- Scope check: clean; only `AGENTS.md` changes.
- Findings: none.

## Base freshness

- Branch created from freshly fetched `origin/main` at `9712b8f0cc7112ced7d38ce789103c7090508c3d` with distance 0.
- Re-fetched and rebased before push onto `origin/main` at `b3e45a3d46ce1af52a267cc3aaa3cb6c4f52d1e8`.
- Final distance: 0 commits behind, 1 commit ahead.
