### PR TITLE
feat: throttle automatic Supermemory recall

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -52,6 +52,7 @@ Config file: `$HERMES_HOME/supermemory.json`
 | `auto_capture` | `true` | Store cleaned user-assistant turns after each response |
 | `max_recall_results` | `10` | Max recalled items to format into context |
 | `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
+| `recall_frequency` | `1` | Run automatic Supermemory recall on the first turn and every Nth turn; raise this to reduce recall API calls |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
 | `search_mode` | `hybrid` | Search mode: `hybrid` (profile + memories), `memories` (memories only), `documents` (documents only) |
 | `entity_context` | built-in default | Extraction guidance passed to Supermemory |

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CONTAINER_TAG = "hermes"
 _DEFAULT_MAX_RECALL_RESULTS = 10
 _DEFAULT_PROFILE_FREQUENCY = 50
+_DEFAULT_RECALL_FREQUENCY = 1
 _DEFAULT_CAPTURE_MODE = "all"
 _DEFAULT_SEARCH_MODE = "hybrid"
 _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
@@ -62,6 +63,7 @@ def _default_config() -> dict:
         "auto_capture": True,
         "max_recall_results": _DEFAULT_MAX_RECALL_RESULTS,
         "profile_frequency": _DEFAULT_PROFILE_FREQUENCY,
+        "recall_frequency": _DEFAULT_RECALL_FREQUENCY,
         "capture_mode": _DEFAULT_CAPTURE_MODE,
         "search_mode": _DEFAULT_SEARCH_MODE,
         "entity_context": _DEFAULT_ENTITY_CONTEXT,
@@ -135,6 +137,10 @@ def _load_supermemory_config(hermes_home: str) -> dict:
         config["profile_frequency"] = max(1, min(500, int(config.get("profile_frequency", _DEFAULT_PROFILE_FREQUENCY))))
     except Exception:
         config["profile_frequency"] = _DEFAULT_PROFILE_FREQUENCY
+    try:
+        config["recall_frequency"] = max(1, min(500, int(config.get("recall_frequency", _DEFAULT_RECALL_FREQUENCY))))
+    except Exception:
+        config["recall_frequency"] = _DEFAULT_RECALL_FREQUENCY
     config["capture_mode"] = "everything" if config.get("capture_mode") == "everything" else "all"
     raw_search_mode = str(config.get("search_mode", _DEFAULT_SEARCH_MODE)).strip().lower()
     config["search_mode"] = raw_search_mode if raw_search_mode in _VALID_SEARCH_MODES else _DEFAULT_SEARCH_MODE
@@ -537,6 +543,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._container_tag = _DEFAULT_CONTAINER_TAG
         self._session_id = ""
         self._turn_count = 0
+        self._needs_session_recall = True
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
@@ -546,6 +553,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_capture = True
         self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
         self._profile_frequency = _DEFAULT_PROFILE_FREQUENCY
+        self._recall_frequency = _DEFAULT_RECALL_FREQUENCY
         self._capture_mode = _DEFAULT_CAPTURE_MODE
         self._search_mode = _DEFAULT_SEARCH_MODE
         self._entity_context = _DEFAULT_ENTITY_CONTEXT
@@ -655,6 +663,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._hermes_home = kwargs.get("hermes_home") or str(get_hermes_home())
         self._session_id = session_id
         self._turn_count = 0
+        self._needs_session_recall = True
         self._config = _load_supermemory_config(self._hermes_home)
         self._api_key = get_secret("SUPERMEMORY_API_KEY", "") or ""
 
@@ -669,6 +678,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._auto_capture = self._config["auto_capture"]
         self._max_recall_results = self._config["max_recall_results"]
         self._profile_frequency = self._config["profile_frequency"]
+        self._recall_frequency = self._config["recall_frequency"]
         self._capture_mode = self._config["capture_mode"]
         self._search_mode = self._config["search_mode"]
         self._entity_context = self._config["entity_context"]
@@ -723,12 +733,20 @@ class SupermemoryMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if not self._active or not self._auto_recall or not self._client or not query.strip():
             return ""
+        is_profile_turn = self._turn_count <= 1 or self._turn_count % self._profile_frequency == 0
+        if (
+            not self._needs_session_recall
+            and self._turn_count > 1
+            and self._turn_count % self._recall_frequency != 0
+            and not is_profile_turn
+        ):
+            return ""
         try:
             profile = self._client.get_profile(query=query[:200])
-            include_profile = self._turn_count <= 1 or (self._turn_count % self._profile_frequency == 0)
+            self._needs_session_recall = False
             context = _format_prefetch_context(
-                static_facts=profile["static"] if include_profile else [],
-                dynamic_facts=profile["dynamic"] if include_profile else [],
+                static_facts=profile["static"] if is_profile_turn else [],
+                dynamic_facts=profile["dynamic"] if is_profile_turn else [],
                 search_results=profile["search_results"],
                 max_results=self._max_recall_results,
             )
@@ -794,6 +812,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if not self._active or not self._write_enabled or not self._client:
             self._session_id = str(new_session_id or "").strip() or self._session_id
             self._session_turns = []
+            self._needs_session_recall = True
             return
 
         old_session_id = self._session_id
@@ -826,6 +845,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._session_id = str(new_session_id or "").strip() or old_session_id
         self._session_turns = []
         self._turn_count = 0
+        self._needs_session_recall = True
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         if not self._active or not self._write_enabled or not self._client:

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -27,6 +27,7 @@ class FakeClient:
         self.add_calls = []
         self.search_results = []
         self.profile_response = {"static": [], "dynamic": [], "search_results": []}
+        self.profile_calls = []
         self.ingest_calls = []
         self.forgotten_ids = []
         self.forget_by_query_response = {"success": True, "message": "Forgot"}
@@ -46,6 +47,7 @@ class FakeClient:
         return self.search_results
 
     def get_profile(self, query=None, *, container_tag=None):
+        self.profile_calls.append({"query": query, "container_tag": container_tag})
         return self.profile_response
 
     def forget_memory(self, memory_id, *, container_tag=None):
@@ -110,6 +112,61 @@ def test_prefetch_includes_profile_on_first_turn(provider):
     assert "User Profile (Persistent)" in result
     assert "Recent Context" in result
     assert "Relevant Memories" in result
+
+
+def test_prefetch_throttles_recall_but_keeps_first_turn(provider, tmp_path):
+    _save_supermemory_config({"recall_frequency": 3}, str(tmp_path))
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    provider._client.profile_response = {
+        "static": [],
+        "dynamic": [],
+        "search_results": [{"memory": "Working on Hermes memory quota", "similarity": 0.9}],
+    }
+    calls = []
+    original_get_profile = provider._client.get_profile
+
+    def counted_get_profile(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_get_profile(*args, **kwargs)
+
+    provider._client.get_profile = counted_get_profile
+    provider.on_turn_start(1, "first turn")
+    first = provider.prefetch("first turn")
+    provider.on_turn_start(2, "second turn")
+    second = provider.prefetch("second turn")
+    provider.on_turn_start(3, "third turn")
+    third = provider.prefetch("third turn")
+
+    assert "Working on Hermes memory quota" in first
+    assert second == ""
+    assert "Working on Hermes memory quota" in third
+    assert len(calls) == 2
+
+
+def test_prefetch_always_recalls_first_turn_of_resumed_session(provider, tmp_path):
+    _save_supermemory_config({"recall_frequency": 3}, str(tmp_path))
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    provider._client.profile_response = {"static": [], "dynamic": [], "search_results": []}
+    provider.on_turn_start(38, "resumed turn")
+
+    provider.prefetch("resumed turn")
+
+    assert provider._client.profile_calls == [{"query": "resumed turn", "container_tag": None}]
+
+
+def test_prefetch_throttle_preserves_profile_refresh_turn(provider, tmp_path):
+    _save_supermemory_config({"recall_frequency": 3, "profile_frequency": 50}, str(tmp_path))
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    provider._client.profile_response = {
+        "static": ["Jordan prefers concise docs"],
+        "dynamic": [],
+        "search_results": [],
+    }
+    provider.on_turn_start(50, "profile refresh")
+
+    result = provider.prefetch("profile refresh")
+
+    assert "Jordan prefers concise docs" in result
 
 
 def test_sync_turn_buffers_short_messages(provider):

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -598,6 +598,7 @@ stays local.
 | `auto_capture` | `true` | Store cleaned user-assistant turns after each response |
 | `max_recall_results` | `10` | Max recalled items to format into context |
 | `profile_frequency` | `50` | Include profile facts on first turn and every N turns |
+| `recall_frequency` | `1` | Run automatic Supermemory recall on the first turn and every Nth turn; raise this to reduce recall API calls |
 | `capture_mode` | `all` | Skip tiny or trivial turns by default |
 | `search_mode` | `hybrid` | Search mode: `hybrid`, `memories`, or `documents` |
 | `api_timeout` | `5.0` | Timeout for SDK and ingest requests |


### PR DESCRIPTION
Supersedes #69622.

Adds configurable `recall_frequency` to reduce automatic Supermemory recall calls while retaining first-session recall and profile-refresh turns. Defaults to `1`, preserving existing behavior.

Documentation: plugin README and public memory-provider guide.

Validation: `python -m pytest tests/plugins/memory/test_supermemory_provider.py -o "addopts=" -q` (29 passed), Ruff, `py_compile`, and `git diff --check`.

Independent review: verified Claude Opus 5 `pass_with_watchlist` (high confidence); no blockers.