### PR TITLE
fix(slack): insert resolved display names literally when humanizing mentions

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3911,7 +3911,17 @@ class SlackAdapter(BasePlatformAdapter):
             # (keeps the message intact rather than emptying a mention).
             display = (name or uid).strip() or uid
             # Replace both the bare and labelled forms of this exact ID.
-            text = re.sub(rf"<@{uid}(?:\|[^>]*)?>", f"@{display}", text)
+            # The replacement goes in as a *function* so the resolved name is
+            # inserted verbatim: as a template string, ``re`` parses backslash
+            # escapes in it, and a display name is arbitrary user-set text.
+            # ``dev\ops`` raises ``re.error: bad escape \o``, ``a\1b`` raises
+            # on the group reference, and ``\g<0>`` silently re-injects the
+            # raw ``<@UID>`` this method exists to remove.
+            text = re.sub(
+                rf"<@{uid}(?:\|[^>]*)?>",
+                lambda _m, _name=f"@{display}": _name,
+                text,
+            )
         return text
 
     def _build_identity_prompt(self, team_id: str = "") -> str:

--- a/tests/gateway/test_slack_mention_humanization.py
+++ b/tests/gateway/test_slack_mention_humanization.py
@@ -95,6 +95,46 @@ async def test_handles_labelled_mention_form():
     assert out == "@Alice Example hi"
 
 
+@pytest.mark.asyncio
+async def test_backslash_in_display_name_does_not_raise():
+    """A display name is arbitrary user-set text. Fed to ``re.sub`` as a
+    replacement template it is parsed for escapes, so ``dev\\ops`` blew up
+    with ``re.error: bad escape \\o`` and the inbound message was lost."""
+    adapter = _adapter_with_names({"U07DEV": r"dev\ops"})
+    out = await adapter._humanize_user_mentions("ping <@U07DEV> please", chat_id="C1")
+    assert out == r"ping @dev\ops please"
+
+
+@pytest.mark.asyncio
+async def test_group_reference_in_display_name_is_literal():
+    """``\\1`` in a name is a group reference in a replacement template — with
+    no groups in the pattern it raised ``invalid group reference``."""
+    adapter = _adapter_with_names({"U07ODD": r"a\1b"})
+    out = await adapter._humanize_user_mentions("hi <@U07ODD>", chat_id="C1")
+    assert out == r"hi @a\1b"
+
+
+@pytest.mark.asyncio
+async def test_named_group_reference_does_not_reinject_the_raw_id():
+    """``\\g<0>`` expands to the whole match, silently putting the opaque
+    ``<@UID>`` back — the exact token this method exists to remove."""
+    adapter = _adapter_with_names({"U07ODD": r"\g<0>"})
+    out = await adapter._humanize_user_mentions("hi <@U07ODD>", chat_id="C1")
+    assert "<@" not in out
+    assert out == r"hi @\g<0>"
+
+
+@pytest.mark.asyncio
+async def test_one_odd_name_does_not_break_the_other_mentions():
+    adapter = _adapter_with_names(
+        {"U07DEV": r"dev\ops", "U07ALICE": "Alice Example"}
+    )
+    out = await adapter._humanize_user_mentions(
+        "<@U07DEV> and <@U07ALICE> ship it", chat_id="C1"
+    )
+    assert out == r"@dev\ops and @Alice Example ship it"
+
+
 # ----- _build_identity_prompt --------------------------------------------------
 
 def test_identity_prompt_names_the_bot():


### PR DESCRIPTION
## What

`SlackAdapter._humanize_user_mentions` turns Slack's opaque `<@U123>` tokens into `@DisplayName` so the agent can tell participants apart — the fix from 5d747a91c (2026-07-22, fix(slack): humanize inbound user mentions + ground bot identity), salvaged from #55340 by @benbarclay. It resolves the name, then substitutes:

```python
display = (name or uid).strip() or uid
text = re.sub(rf"<@{uid}(?:\|[^>]*)?>", f"@{display}", text)
```

The second argument to `re.sub` is a **replacement template**, not a literal — `re` parses backslash escapes in it. A Slack display name is arbitrary user-set text, so those backslashes are the user's characters, not regex syntax. Running the real substitution:

```
  name='dev\\ops'           -> error: bad escape \o at position 4
  name='a\\1b'              -> error: invalid group reference 1 at position 3
  name='back\\slash'        -> error: bad escape \s at position 5
  name='\\g<0>'             -> OK   'hey @<@U123> can you look at this'
  name='plain name'         -> OK   'hey @plain name can you look at this'
```

Two distinct failures:

- **The raise.** The trigger-text call site (`_handle_slack_message`) is not inside any `try` — I checked the enclosing function's AST, no `Try` node covers it — and both Bolt handlers (`@self._app.event("message")` and `@self._app.event("app_mention")`) `await self._handle_slack_message(...)` bare. So `re.error` unwinds the whole inbound path: every message mentioning that person is dropped, with no reply, for as long as their name has a backslash in it. The `reply_to_text` call a few lines earlier *is* wrapped, which is what makes the unwrapped one easy to miss.
- **The silent one.** `\g<0>` expands to the entire match, so the raw `<@U123>` gets written straight back. No error, and the agent is handed exactly the opaque token this method exists to remove — the "bot thinks it's @someone-else" bug the original fix was for, quietly restored for that user.

The pattern side is fine: `uid` comes from `re.findall(r"<@([A-Z0-9]+)...")`, so it can only be `[A-Z0-9]+`. Only the replacement is unsafe.

## The fix

Pass the replacement as a function. `re` performs no template parsing on a callable's return value, so the name lands verbatim:

```python
text = re.sub(
    rf"<@{uid}(?:\|[^>]*)?>",
    lambda _m, _name=f"@{display}": _name,
    text,
)
```

This is the shape the Matrix adapter already uses for its outbound mention rewrite (`_OUTBOUND_MENTION_RE.sub(lambda match: ..., protected)`), so it matches existing practice rather than introducing a new convention. The default argument binds the name per iteration instead of closing over the loop variable.

Names without backslashes produce byte-identical output, so the existing behaviour is untouched.

Scope: this is the only site in the Slack adapter that puts resolved user text into a replacement template — every other `re.sub` there uses a literal, a group reference, or a callable — so there is no sibling to sweep.

## Tests

Added to `tests/gateway/test_slack_mention_humanization.py`, reusing its `_adapter_with_names` harness:

- a name containing `dev\ops` no longer raises and renders as `@dev\ops`
- `a\1b` is inserted literally instead of raising on the group reference
- `\g<0>` renders literally and the assertion `"<@" not in out` pins that the raw ID is never re-injected
- one odd name alongside a normal one leaves the normal mention correct — the failure previously took the whole message down, including other people's mentions

Results:

```
7 passed
```

The 3 pre-existing tests in the file are unchanged and still green.

Red without the source change (tests kept, `plugins/platforms/slack/adapter.py` reverted):

```
FAILED test_backslash_in_display_name_does_not_raise
E   re.error: bad escape \o at position 4
FAILED test_group_reference_in_display_name_is_literal
E   re.error: invalid group reference 1 at position 3
FAILED test_named_group_reference_does_not_reinject_the_raw_id
E   AssertionError: assert '<@' not in 'hi @<@U07ODD>'
FAILED test_one_odd_name_does_not_break_the_other_mentions
E   re.error: bad escape \o at position 4
4 failed, 3 passed
```

Regression run over 159 test files (everything under `tests/` mentioning Slack), against the same files on main:

```
main:      43 failed, 3099 passed   (39 pre-existing, plus the 4 new tests failing as above)
with fix:  41 failed, 3101 passed
```

The set difference is two tests — one in `tests/honcho_plugin/test_pin_peer_name.py` and one in `tests/test_mcp_serve.py::TestEventBridgePollE2E` — and both are flaky rather than caused by this change: run in isolation they fail 2, 1, 2 times across three consecutive runs on unmodified main and 2, 2, 1 with the fix applied. Neither touches Slack.

`tests/gateway/test_teams.py` is excluded from both runs: it errors at collection on an unrelated missing Teams dependency and aborts the session before any test executes. `scripts/check-windows-footguns.py` passes on both changed files.