### PR TITLE
fix(desktop): render MEDIA:-embedded markdown images (SVG) in chat

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -348,6 +348,19 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('leaves markdown image/link MEDIA destinations intact (bead 676.4.22.167)', () => {
+    // The bare tag form still becomes a #media: link…
+    expect(renderMediaTags('MEDIA:/Users/rmohid/code/atlas/a.svg')).toBe(
+      '[Image: a.svg](#media:%2FUsers%2Frmohid%2Fcode%2Fatlas%2Fa.svg)'
+    )
+    // …but the markdown image embed `![alt](MEDIA:…)` / `[link](MEDIA:…)` is left for
+    // the media renderer (MarkdownImage/MarkdownLink), which strips the prefix itself.
+    expect(renderMediaTags('![alt](MEDIA:/Users/rmohid/code/atlas/a.svg)')).toBe(
+      '![alt](MEDIA:/Users/rmohid/code/atlas/a.svg)'
+    )
+    expect(renderMediaTags('[link](MEDIA:/tmp/a.png)')).toBe('[link](MEDIA:/tmp/a.png)')
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -150,7 +150,17 @@ function mediaLink(value: string): string {
 }
 
 export function renderMediaTags(text: string): string {
-  return text
+  // Leave markdown image/link destinations (`![…](MEDIA:/path)` / `[…](MEDIA:/path)`)
+  // alone — the media renderer (MarkdownImage/MarkdownLink in markdown-text.tsx) owns that
+  // form and strips the MEDIA: prefix itself (see media.ts). Without this guard,
+  // MEDIA_TAG_RE's `\S+` branch also swallows the `)` that closes the destination,
+  // corrupting `![alt](MEDIA:/abs/file.svg)` into `![alt]([File: …)](#media:…))` and
+  // producing a broken image (bead 676.4.22.167). Protect those forms, rewrite the rest,
+  // restore.
+  const KEEP = '\u0000MEDIA\u0000'
+  const protected_ = text.replace(/(!?\[[^\]]*\]\()MEDIA:(?=[/~]|file:)/gi, `$1${KEEP}`)
+
+  const result = protected_
     .replace(
       MEDIA_LINE_RE,
       (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
@@ -158,6 +168,8 @@ export function renderMediaTags(text: string): string {
     .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
+
+  return result.replace(new RegExp(KEEP, 'g'), 'MEDIA:')
 }
 
 export function assistantTextPart(text: string): ChatMessagePart {

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -44,6 +44,13 @@ describe('filePathFromMediaPath', () => {
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
   })
+
+  it('strips a MEDIA: prefix to a plain path (bead 676.4.22.167)', () => {
+    expect(filePathFromMediaPath('MEDIA:/Users/rmohid/code/atlas/a.svg')).toBe(
+      '/Users/rmohid/code/atlas/a.svg'
+    )
+    expect(filePathFromMediaPath('MEDIA:file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
+  })
 })
 
 describe('mediaExternalUrl', () => {
@@ -137,6 +144,19 @@ describe('resolveMediaDisplaySrc', () => {
       'data:image/png;base64,bG9jYWw='
     )
     expect(readFileDataUrl).toHaveBeenCalledWith('/Users/me/project/a b.png')
+  })
+
+  it('resolves a MEDIA:-prefixed local file as an SVG data URL (bead 676.4.22.167)', async () => {
+    const readFileDataUrl = vi.fn(async () => 'data:image/svg+xml;base64,c3Zn')
+
+    vi.stubGlobal('window', { hermesDesktop: { readFileDataUrl } })
+    $connection.set({ mode: 'local' } as never)
+
+    await expect(resolveMediaDisplaySrc('MEDIA:/Users/me/project/a.svg')).resolves.toBe(
+      'data:image/svg+xml;base64,c3Zn'
+    )
+    // The MEDIA: prefix is stripped before the fs bridge reads the file.
+    expect(readFileDataUrl).toHaveBeenCalledWith('/Users/me/project/a.svg')
   })
 })
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -63,7 +63,9 @@ export function isInlineMediaSrc(path: string): boolean {
 }
 
 function isFileMediaPath(path: string): boolean {
-  return /^(?:file:|\/|~\/|[a-z]:[\\/]|\\\\)/i.test(path)
+  // `MEDIA:…` is a supported local media prefix (bead 676.4.22.167) and must resolve
+  // like the bare path form once the prefix is stripped.
+  return /^(?:file:|media:|\/|~\/|[a-z]:[\\/]|\\\\\\)/i.test(path)
 }
 
 export async function resolveMediaDisplaySrc(path: string): Promise<string> {
@@ -139,14 +141,16 @@ export function mediaPathFromMarkdownHref(href?: string): string | null {
 }
 
 export function filePathFromMediaPath(path: string): string {
-  if (!path.startsWith('file:')) {
-    return path
+  const bare = path.replace(/^media:/i, '')
+
+  if (!bare.startsWith('file:')) {
+    return bare
   }
 
   try {
-    return decodeURIComponent(new URL(path).pathname)
+    return decodeURIComponent(new URL(bare).pathname)
   } catch {
-    return path.replace(/^file:\/\//, '')
+    return bare.replace(/^file:\/\//, '')
   }
 }
 


### PR DESCRIPTION
## Problem

`MEDIA:` markdown **image/link** destinations — `![alt](MEDIA:/abs/path.svg)` / `[link](MEDIA:/path)` — do not render in the desktop chat (broken-image glyph). The SVG source (Robert's preferred diagram format) is well-formed; the fault is in the renderer.

Root cause, two coupled defects (both must be fixed):

1. **`renderMediaTags` corrupts the markdown destination** — `apps/desktop/src/lib/chat-messages.ts`, `MEDIA_TAG_RE` (line 137) applied in `renderMediaTags` (152–161) before the markdown renderer. Its `\S+` branch also swallows the markdown `)`, rewriting `![alt](MEDIA:/abs/x.svg)` into `![alt]([File: x.svg)](#media:%2F…))` — misclassified as `File:` and structurally corrupt, so no loadable `src` is produced.

2. **The media layer doesn't normalize the `MEDIA:` prefix** — `apps/desktop/src/lib/media.ts`, `isFileMediaPath` (65–67) / `resolveMediaDisplaySrc` (69–83). Even if the embed survived, `resolveMediaDisplaySrc('MEDIA:/abs/x.svg')` returns the literal URI unchanged; Chromium can't load the unknown `media:` scheme.

## Fix (2 files, ~6 lines + tests)

- `chat-messages.ts`: protect markdown image/link destinations (`](MEDIA:…)`) before the MEDIA rewrite, so they flow untouched to the media renderer (`MarkdownImage`/`MarkdownLink`).
- `media.ts`: recognize and strip the `MEDIA:` prefix in `isFileMediaPath` / `filePathFromMediaPath`, so a `MEDIA:/abs/x.svg` src resolves like the bare path → `data:image/svg+xml;base64,…`.

This fixes the whole bug class: any media type embedded via `MEDIA:` in a markdown image/link, not just SVG.

## Verification

- Added 3 unit tests (preserve markdown destinations; strip `MEDIA:` prefix; resolve `MEDIA:` file to an SVG data URL).
- `vitest` UI suite: **387 files / 3363 tests pass**.
- `eslint` 0 errors; `tsc --noEmit` clean.
