### PR TITLE
fix(anthropic): pin claude-cli User-Agent for AgentRouter proxy

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -467,6 +467,22 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     return normalized.rstrip("/").lower().startswith("https://api.kimi.com/coding")
 
 
+# AgentRouter (https://agentrouter.org) is a New API-style Anthropic-compatible
+# proxy that rejects any request whose User-Agent is not exactly
+# ``claude-cli/1.0.0 (external, cli)``. Without that fingerprint it returns
+# ``unauthorized_client_error`` / ``content-blocked`` / HTTP 405 even for a
+# valid API key. Mirror the Kimi /coding handling and pin the required UA.
+_AGENTROUTER_USER_AGENT = "claude-cli/1.0.0 (external, cli)"
+
+
+def _is_agentrouter_endpoint(base_url: str | None) -> bool:
+    """Return True for the AgentRouter proxy (agentrouter.org)."""
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    return base_url_host_matches(normalized, "agentrouter.org")
+
+
 # Model-name prefixes that identify the Kimi / Moonshot family.  Covers
 # - official slugs: ``kimi-k2.5``, ``kimi_thinking``, ``moonshot-v1-8k``
 # - common release lines: ``k1.5-...``, ``k2-thinking``, ``k25-...``, ``k2.5-...``,
@@ -875,6 +891,16 @@ def build_anthropic_client(
         kwargs["auth_token"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+    elif _is_agentrouter_endpoint(base_url):
+        # AgentRouter requires the exact claude-cli User-Agent fingerprint;
+        # any other UA (including the Anthropic SDK default) is rejected with
+        # ``unauthorized_client_error``. Check BEFORE the generic third-party
+        # branch so the required UA is pinned.
+        kwargs["api_key"] = api_key
+        kwargs["default_headers"] = {
+            "User-Agent": _AGENTROUTER_USER_AGENT,
+            **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
+        }
     elif _is_third_party_anthropic_endpoint(base_url):
         # Third-party proxies (Microsoft Foundry, AWS Bedrock, etc.) use their
         # own API keys with x-api-key auth. Skip OAuth detection — their keys


### PR DESCRIPTION
## Summary

Fixes #78839. AgentRouter (`https://agentrouter.org`), an Anthropic-compatible New API-style proxy, rejects any request whose `User-Agent` is not exactly `claude-cli/1.0.0 (external, cli)`. Hermes sends the Anthropic SDK default UA for third-party endpoints, so requests fail with `unauthorized_client_error` / `content-blocked` / HTTP 405 even with a valid API key.

## Change

In `agent/anthropic_adapter.py`:

- Added `_is_agentrouter_endpoint()` to detect the proxy by host (`agentrouter.org`).
- Added a branch in `build_anthropic_client()` that pins the required `User-Agent: claude-cli/1.0.0 (external, cli)` for that endpoint, mirroring the existing Kimi `/coding` handling.

## Verification

- Endpoint detection: `_is_agentrouter_endpoint("https://agentrouter.org")` → `True`; other endpoints → `False`.
- End-to-end: a request through the patched `build_anthropic_client()` with a valid key returned a successful `claude-opus-5` response (`PATCH-OK`).
- `hermes doctor` clean; gateway restart healthy with no agentrouter errors.