### PR TITLE
fix(gateway): keep route prefixes on Telegram/Discord model picker labels

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -269,6 +269,32 @@ def format_model_for_display(model_name: str) -> str:
     return model_name
 
 
+def format_model_picker_button_label(model_name: str, max_len: int = 38) -> str:
+    """Return a short picker-button label that keeps upstream route prefixes.
+
+    OpenCodex-style catalogs expose the same bare model under many upstream
+    paths (``opencode-go/glm-5.2``, ``cursor/glm-5.2``, …). Telegram/Discord
+    buttons used to show only the final path segment, so those entries looked
+    identical. Keep ``<first>/<last>`` so users can tell routes apart, then
+    truncate to *max_len* for messaging UI limits.
+
+    DISPLAY-ONLY — never send this string on the wire.
+    """
+    if not model_name:
+        return model_name
+    # Keep first + last segments so routes like opencode-go/x vs cursor/x differ.
+    parts = [part for part in str(model_name).split("/") if part]
+    if len(parts) >= 2:
+        short = f"{parts[0]}/{parts[-1]}"
+    else:
+        short = parts[0] if parts else str(model_name)
+    if max_len > 0 and len(short) > max_len:
+        if max_len <= 3:
+            return short[:max_len]
+        return short[: max_len - 3] + "..."
+    return short
+
+
 # ---------------------------------------------------------------------------
 def is_nous_hermes_non_agentic(model_name: str) -> bool:
     """Return True if *model_name* is a real Nous Hermes 3/4 chat model.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -33,6 +33,7 @@ from agent.async_utils import (
     consume_detached_task_result as _consume_background_task_result,
 )
 from agent.display import ToolPreview
+from hermes_cli.model_switch import format_model_picker_button_label
 
 logger = logging.getLogger(__name__)
 
@@ -8827,7 +8828,10 @@ def _define_discord_view_classes() -> None:
             models = provider.get("models", [])
             options = []
             for model_id in models[:25]:
-                short = model_id.split("/")[-1] if "/" in model_id else model_id
+                short = format_model_picker_button_label(
+                    model_id,
+                    max_len=_DISCORD_SELECT_FIELD_LIMIT,
+                )
                 options.append(
                     discord.SelectOption(
                         label=_truncate_discord_component_text(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -22,6 +22,8 @@ from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
+from hermes_cli.model_switch import format_model_picker_button_label
+
 logger = logging.getLogger(__name__)
 
 
@@ -5921,9 +5923,7 @@ class TelegramAdapter(BasePlatformAdapter):
         buttons: list = []
         for i, model_id in enumerate(page_models):
             abs_idx = start + i
-            short = model_id.split("/")[-1] if "/" in model_id else model_id
-            if len(short) > 38:
-                short = short[:35] + "..."
+            short = format_model_picker_button_label(model_id, max_len=38)
             buttons.append(
                 InlineKeyboardButton(short, callback_data=f"mm:{abs_idx}")
             )

--- a/tests/hermes_cli/test_model_picker_button_label.py
+++ b/tests/hermes_cli/test_model_picker_button_label.py
@@ -1,0 +1,26 @@
+"""Telegram/Discord model picker labels must keep upstream route prefixes."""
+
+from __future__ import annotations
+
+from hermes_cli.model_switch import format_model_picker_button_label
+
+
+def test_keeps_first_and_last_path_segments():
+    assert format_model_picker_button_label("opencode-go/glm-5.2") == "opencode-go/glm-5.2"
+    assert format_model_picker_button_label("cursor/glm-5.2") == "cursor/glm-5.2"
+    assert (
+        format_model_picker_button_label("vendor/group/nested/glm-5.2")
+        == "vendor/glm-5.2"
+    )
+
+
+def test_plain_model_ids_unchanged():
+    assert format_model_picker_button_label("gpt-5.6-luna") == "gpt-5.6-luna"
+
+
+def test_truncates_long_labels():
+    long_id = "very-long-upstream-name/" + ("x" * 40)
+    label = format_model_picker_button_label(long_id, max_len=20)
+    assert len(label) == 20
+    assert label.endswith("...")
+    assert label.startswith("very-long")


### PR DESCRIPTION
## Summary
- Telegram/Discord `/model` picker buttons previously showed only the final path segment of a model id (`split("/")[-1]`).
- OpenCodex-style catalogs expose the same bare model under many upstreams (`opencode-go/glm-5.2`, `cursor/glm-5.2`, …), so those entries looked identical.
- Add `format_model_picker_button_label()` and use it for picker **labels only**; wire/callback values stay the full model id.

## Test plan
- [x] Unit tests for `format_model_picker_button_label` (`tests/hermes_cli/test_model_picker_button_label.py`)
- [ ] Telegram `/model`: confirm OpenCodex entries show distinct labels like `opencode-go/glm-5.2` vs `cursor/glm-5.2`
- [ ] Discord `/model`: same distinct SelectOption labels; selecting still switches to the full model id


Made with [Cursor](https://cursor.com)