### PR TITLE
fix(container_boot): skip gateway reconciliation in serve containers too (#78810)

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -350,16 +350,23 @@ def _is_legacy_gateway_run_request(argv: Sequence[str]) -> bool:
     return len(args) >= 2 and args[0] == "gateway" and args[1] == "run"
 
 
-def _is_dashboard_container(argv: Sequence[str]) -> bool:
-    """Return True when the container's command is the dashboard.
+def _is_non_gateway_container(argv: Sequence[str]) -> bool:
+    """Return True when the container's command is a non-gateway role.
 
-    A dashboard-only container (``hermes dashboard ...``) never spawns or
-    supervises per-profile gateways — that is the gateway container's job.
-    Reconciling profile gateway s6 slots there is not just wasted work: when
-    the gateway and dashboard containers share a bind-mounted HERMES_HOME,
+    A non-gateway container (``hermes dashboard ...``, ``hermes serve ...``,
+    ``hermes gui ...``, ``hermes desktop ...``) never spawns or supervises
+    per-profile gateways — that is the gateway container's job. Reconciling
+    profile gateway s6 slots there is not just wasted work: when the gateway
+    container and a non-gateway container share a bind-mounted HERMES_HOME,
     both race to ``flock()`` the same ``logs/gateways/<profile>/lock`` files,
-    producing "Resource busy" failures and an s6-log restart storm. So the
-    dashboard container skips reconciliation entirely.
+    producing "Resource busy" failures and an s6-log restart storm — and a
+    ``serve`` container even registers and auto-starts its own
+    ``gateway-default`` slot (see issue #78810). So non-gateway containers
+    skip reconciliation entirely.
+
+    The role set mirrors the GUI-mode entrypoints in
+    ``hermes_cli.main`` (``{"dashboard", "serve", "gui", "desktop"}``):
+    every one of them boots the dashboard/desktop server, never the gateway.
 
     Detected from PID 1 argv (``/proc/1/cmdline``) rather than an operator
     flag: the role is a fact about the container's command, not a tunable,
@@ -368,7 +375,13 @@ def _is_dashboard_container(argv: Sequence[str]) -> bool:
     in :func:`_is_legacy_gateway_run_request`.
     """
     args = _strip_container_argv_prefix(argv)
-    return bool(args) and args[0] == "dashboard"
+    return bool(args) and args[0] in _NON_GATEWAY_CONTAINER_ROLES
+
+
+# Non-gateway container roles that share HERMES_HOME with the gateway
+# container and must never reconcile per-profile gateway s6 slots.
+# Keep in sync with the GUI-mode entrypoint set in hermes_cli/main.py.
+_NON_GATEWAY_CONTAINER_ROLES = frozenset({"dashboard", "serve", "gui", "desktop"})
 
 
 def _read_desired_state(profile_dir: Path) -> str | None:
@@ -582,18 +595,20 @@ _LOG_ROTATE_BYTES = 256 * 1024
 
 def main() -> int:
     """Entry point invoked from /etc/cont-init.d/02-reconcile-profiles."""
-    # A dashboard-only container never spawns or supervises per-profile
-    # gateways, so reconciling their s6 slots here is pure waste — and
-    # actively harmful: when the gateway and dashboard containers share a
-    # bind-mounted HERMES_HOME, both race to flock() the same s6-log lock
-    # files under logs/gateways/<profile>/lock, producing "Resource busy"
-    # failures and a restart storm. Detect the role from PID 1 argv and
-    # skip reconciliation in the dashboard container. No operator flag:
+    # A non-gateway container (dashboard, serve, gui, desktop) never spawns
+    # or supervises per-profile gateways, so reconciling their s6 slots here
+    # is pure waste — and actively harmful: when the gateway container and a
+    # non-gateway container share a bind-mounted HERMES_HOME, both race to
+    # flock() the same s6-log lock files under logs/gateways/<profile>/lock,
+    # producing "Resource busy" failures and a restart storm — and a serve
+    # container even auto-starts its own duplicate gateway-default slot
+    # (issue #78810). Detect the role from PID 1 argv and skip
+    # reconciliation in every non-gateway container. No operator flag:
     # the role is a fact about the container's command, and a flag can be
     # forgotten in a hand-written manifest, reintroducing the storm.
-    if _is_dashboard_container(_read_container_argv()):
+    if _is_non_gateway_container(_read_container_argv()):
         print(
-            "reconcile: skipping (dashboard container — does not need "
+            "reconcile: skipping (non-gateway container — does not need "
             "per-profile gateways)"
         )
         return 0

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -283,7 +283,51 @@ def test_main_skips_reconcile_in_dashboard_container_s6v3(
     assert rc == 0
     assert not (scandir / "gateway-worker").exists()
     assert not (scandir / "gateway-default").exists()
-    assert "skipping (dashboard container" in capsys.readouterr().out
+    assert "skipping (non-gateway container" in capsys.readouterr().out
+
+
+def test_main_skips_reconcile_in_serve_container_s6v3(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A `serve` container must skip reconciliation like the dashboard.
+
+    Regression test for issue #78810: `serve` (the desktop-app headless
+    backend) boots the same server as `dashboard` and shares a bind-mounted
+    HERMES_HOME with the gateway container. Before the fix it was not
+    exempt, so it registered and auto-started its own `gateway-default`
+    slot — a duplicate live gateway racing on the dispatcher lock and the
+    s6-log lock files. Asserting the slot is absent proves the skip fires
+    for the serve role under the s6-overlay v3 argv shape.
+    """
+    from hermes_cli import container_boot
+
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(tmp_path, "worker", state="running")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("S6_PROFILE_GATEWAY_SCANDIR", str(scandir))
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: (
+            "/bin/sh",
+            "-e",
+            "/run/s6/basedir/scripts/rc.init",
+            "top",
+            "/opt/hermes/docker/main-wrapper.sh",
+            "serve",
+            "--host",
+            "0.0.0.0",
+        ),
+    )
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    assert not (scandir / "gateway-worker").exists()
+    assert not (scandir / "gateway-default").exists()
+    assert "skipping (non-gateway container" in capsys.readouterr().out
 
 
 


### PR DESCRIPTION
## Summary

Fixes #78810.

### Problem

`container_boot._is_dashboard_container()` exempted exactly one non-gateway role (`argv[0] == "dashboard"`) from per-profile gateway reconciliation. A container whose command is `serve` — the desktop-app headless backend, which boots the exact same server as `dashboard` — was **not** exempt. With a shared bind-mounted `HERMES_HOME` (the natural setup for running `gateway run` + `dashboard` + `serve` against one Hermes home), the `serve` container's `reconcile_profile_gateways()` registered **and auto-started** its own `gateway-default` slot whenever `gateway_state.json` said `running`, producing a second live gateway that raced on the kanban dispatcher lock and on the `logs/gateways/<profile>/lock` files the dashboard exemption exists to protect.

### Fix

- Renamed the role detector to `_is_non_gateway_container()` and made it recognize the full GUI-mode role set — `{"dashboard", "serve", "gui", "desktop"}` — the same set `hermes_cli/main.py` uses to classify GUI-mode entrypoints.
- Any non-gateway container now skips `reconcile_profile_gateways()` entirely, so `serve`/`gui`/`desktop` containers never spawn or supervise per-profile gateways.
- The skip log line now reads `reconcile: skipping (non-gateway container ...)`.

### Tests

- `tests/hermes_cli/test_container_boot.py`: 6 passed (existing dashboard s6v3 regression test updated for the new message, plus a new `test_main_skips_reconcile_in_serve_container_s6v3` proving the `serve` role skips reconciliation and creates no `gateway-default` slot).
- `python3 -m py_compile hermes_cli/container_boot.py` passes.
