### PR TITLE
fix(dashboard): pin TUI composer and restore wheel scroll

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14798,14 +14798,20 @@ def _resolve_chat_argv(
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
     _apply_tui_python_env(env)
     env.setdefault("NODE_ENV", "production")
-    # Browser-embedded chat should prefer stable wheel-based scrollback over
-    # native terminal mouse tracking. When mouse tracking is enabled, wheel
-    # events are consumed by the TUI and forwarded as terminal input, which
-    # makes browser-side transcript scrolling feel broken. Keep the terminal
-    # build unchanged for native CLI usage; only disable mouse tracking for
-    # the dashboard PTY path.
-    env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
-    env.setdefault("HERMES_TUI_INLINE", "1")
+    # The dashboard now uses the same fullscreen layout as the native TUI:
+    # transcript history lives in the TUI's internal ScrollBox while the
+    # composer stays pinned to the final terminal row.  The former inline
+    # primary-buffer mode left the Ink root at its content height after the
+    # browser resized the PTY (typically 80x24 -> ~97x48), so the composer sat
+    # halfway up the xterm pane with a large blank band below it.
+    #
+    # Force these values rather than using setdefault: dashboard children are a
+    # distinct surface and must not inherit stale shell exports from a prior
+    # native/Termux run.  Mouse tracking is required so xterm wheel/PageUp
+    # input reaches the internal transcript viewport.
+    env["HERMES_TUI_DISABLE_MOUSE"] = "0"
+    env["HERMES_TUI_MOUSE_TRACKING"] = "1"
+    env["HERMES_TUI_INLINE"] = "0"
     # The dashboard terminal is xterm.js, which always renders 24-bit RGB.
     # But chalk inside the TUI child decides its color depth from the
     # SERVER process env — and hosted/cloud deploys run the dashboard under

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3474,6 +3474,34 @@ class TestPtyWebSocket:
         q = {"token": tok, **params}
         return f"/api/pty?{urlencode(q)}"
 
+    def test_dashboard_tui_uses_fullscreen_scrollbox_layout(self, monkeypatch):
+        """Dashboard chat pins the composer via the TUI's internal viewport.
+
+        Explicit assignments must override stale shell exports; inline mode
+        otherwise leaves the composer above a large blank band after xterm
+        grows the PTY beyond its initial 80x24 size.
+        """
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setenv("HERMES_TUI_DISABLE_MOUSE", "1")
+        monkeypatch.setenv("HERMES_TUI_MOUSE_TRACKING", "0")
+        monkeypatch.setenv("HERMES_TUI_INLINE", "1")
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+        monkeypatch.setattr(self.ws_module, "_build_gateway_ws_url", lambda: None)
+
+        argv, cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert argv == ["node", "dist/entry.js"]
+        assert cwd == "/tmp/ui-tui"
+        assert env is not None
+        assert env["HERMES_TUI_DISABLE_MOUSE"] == "0"
+        assert env["HERMES_TUI_MOUSE_TRACKING"] == "1"
+        assert env["HERMES_TUI_INLINE"] == "0"
+
 
 
     def test_tui_python_command_uses_child_path(self, tmp_path):

--- a/web/src/lib/pty-wheel.test.ts
+++ b/web/src/lib/pty-wheel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { encodePtyWheel } from "./pty-wheel";
+
+describe("encodePtyWheel", () => {
+  it("encodes wheel up and down as SGR mouse reports", () => {
+    expect(encodePtyWheel(-1)).toBe("\u001b[<64;1;1M");
+    expect(encodePtyWheel(120)).toBe("\u001b[<65;1;1M");
+  });
+
+  it("preserves SGR modifier bits", () => {
+    expect(encodePtyWheel(-1, { shiftKey: true })).toBe("\u001b[<68;1;1M");
+    expect(encodePtyWheel(1, { altKey: true, ctrlKey: true })).toBe(
+      "\u001b[<89;1;1M",
+    );
+    expect(encodePtyWheel(-1, { metaKey: true })).toBe("\u001b[<72;1;1M");
+  });
+
+  it("ignores zero and non-finite deltas", () => {
+    expect(encodePtyWheel(0)).toBeNull();
+    expect(encodePtyWheel(Number.NaN)).toBeNull();
+    expect(encodePtyWheel(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/web/src/lib/pty-wheel.ts
+++ b/web/src/lib/pty-wheel.ts
@@ -1,0 +1,27 @@
+export interface PtyWheelModifiers {
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+}
+
+/** Encode a browser wheel event as an xterm SGR mouse report.
+ *
+ * The embedded TUI consumes button 64/65 as wheelUp/wheelDown and applies its
+ * own row-level acceleration. Coordinates are intentionally pinned to 1,1:
+ * transcript scrolling is handled globally and does not depend on a hit target.
+ */
+export function encodePtyWheel(
+  deltaY: number,
+  modifiers: PtyWheelModifiers = {},
+): string | null {
+  if (!Number.isFinite(deltaY) || deltaY === 0) return null;
+
+  const modifierBits =
+    (modifiers.shiftKey ? 4 : 0) +
+    (modifiers.altKey || modifiers.metaKey ? 8 : 0) +
+    (modifiers.ctrlKey ? 16 : 0);
+  const button = (deltaY < 0 ? 64 : 65) + modifierBits;
+
+  return `\u001b[<${button};1;1M`;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -38,6 +38,7 @@ import { api } from "@/lib/api";
 import { latchChatActivation } from "@/lib/chat-activation";
 import { normalizeSessionTitle } from "@/lib/chat-title";
 import { PtyResumeSanitizer } from "@/lib/pty-resume-sanitizer";
+import { encodePtyWheel } from "@/lib/pty-wheel";
 import {
   PTY_CONNECTING_TIMEOUT_MS,
   PTY_RECONNECT_INPUT_MESSAGE,
@@ -717,9 +718,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     fitRef.current = fit;
     term.loadAddon(fit);
 
-    // Dashboard chat should scroll the browser-side transcript, not send
-    // mouse-wheel protocol bytes through the PTY.
+    // Primary-buffer/inline sessions use xterm.js scrollback. Fullscreen
+    // dashboard chat runs in the alternate buffer so the TUI can keep its
+    // composer pinned and scroll the internal transcript viewport. Firefox
+    // does not reliably forward wheel reports through xterm's custom handler,
+    // so encode the standard SGR wheel report directly onto the PTY socket.
     term.attachCustomWheelEventHandler((ev) => {
+      if (term.buffer.active.type === "alternate") {
+        const sequence = encodePtyWheel(ev.deltaY, ev);
+        const ws = wsRef.current;
+        if (sequence && ws?.readyState === WebSocket.OPEN) {
+          ws.send(sequence);
+        }
+        ev.preventDefault();
+        ev.stopPropagation();
+        return false;
+      }
+
       const delta = ev.deltaY;
       if (!delta) {
         return false;


### PR DESCRIPTION
## Summary

- run dashboard chat in the TUI fullscreen/alternate-screen layout so the composer remains pinned to the final terminal row after xterm resizes the PTY
- route Firefox/browser wheel input to the TUI as standard SGR mouse reports, preserving the TUI's native wheel acceleration and modifier handling
- override stale inherited inline/mouse environment variables for dashboard PTY children
- add focused backend and frontend regression tests

## Reproduction

1. Start `hermes dashboard --no-open` in WSL.
2. Open `/chat` in Windows Firefox.
3. Resume a session from History and resize/load the xterm viewport above its initial 80x24 PTY size.
4. Before this change, the composer remains around the initial content height with a large blank band below it.
5. Switching to fullscreen pins the composer, but Firefox wheel events are then lost while PageUp/PageDown still work.

## Implementation notes

The dashboard now uses the same internal transcript `ScrollBox` as the native fullscreen TUI. In the alternate buffer, the custom wheel handler sends xterm SGR button 64/65 reports directly through the PTY websocket. Primary-buffer fallback behavior remains unchanged.

This is related to #42947, which routes wheel gestures as Shift+Up/Shift+Down. This PR also fixes the backend inline-layout/composer-height problem and preserves the TUI's native wheel event and acceleration path.

## Verification

- `uv run --frozen --extra dev pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket -o 'addopts=' -q` — 5 passed
- `npm --prefix web test` — 168 passed
- `npm --prefix web run typecheck`
- `npm --prefix web run build`
- `git diff --check`
- browser E2E via Chrome DevTools trusted `mouseWheel`: PTY websocket received `ESC[<64;1;1M` for wheel-up and the expected modifier-adjusted SGR report for wheel-down
- visual 1440x900 dashboard render: composer bottom aligned with the xterm viewport and no blank band below
