### PR TITLE
Select multiple tabs and drag them to a zone together

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/model.ts
@@ -317,6 +317,66 @@ export function movePane(
   return shapeSignature(next) === shapeSignature(root) ? root : next
 }
 
+/**
+ * Move a SELECTION of panes together (multi-tab drag), preserving their strip
+ * order. The lead pane lands exactly like a single `movePane` (center joins at
+ * `before`, an edge opens the split); the rest stack in behind it. `activeId`
+ * (the pressed tab) fronts in the landing group. Same no-op guard as
+ * `movePane`: a drop that rebuilds the visible arrangement returns `root`.
+ */
+export function movePanes(
+  root: LayoutNode,
+  paneIds: readonly string[],
+  target: { groupId: string; pos: DropPosition; before?: null | string },
+  activeId: string = paneIds[0] ?? ''
+): LayoutNode {
+  if (paneIds.length <= 1) {
+    return paneIds.length === 1 ? movePane(root, paneIds[0], target) : root
+  }
+
+  let without: LayoutNode | null = root
+
+  for (const id of paneIds) {
+    without = without && removePane(without, id)
+  }
+
+  // The selection was the whole tree, or removal dissolved the target zone
+  // (the selection was its only occupancy) — nowhere left to land.
+  if (!without || !findGroup(without, target.groupId)) {
+    return root
+  }
+
+  // The lead insert decides geometry; the rest stack into the lead's group at
+  // the same slot (each lands before `before`, so the block keeps its order).
+  // Only the lead activates — `insertAtGroup(activate)` would otherwise front
+  // each follower in turn.
+  const lead = paneIds[0]
+  let next: LayoutNode | null = insertAtGroup(without, target.groupId, lead, target.pos, target.before)
+
+  for (let i = 1; next && i < paneIds.length; i++) {
+    const leadGroup = findGroupOfPane(next, lead)
+
+    if (!leadGroup) {
+      return root
+    }
+
+    const before = target.pos === 'center' ? (target.before ?? null) : null
+    next = insertAtGroup(next, leadGroup.id, paneIds[i], 'center', before, false)
+  }
+
+  if (!next) {
+    return root
+  }
+
+  const landed = findGroupOfPane(next, lead)
+
+  if (landed && landed.panes.includes(activeId)) {
+    next = setActivePane(next, landed.id, activeId)
+  }
+
+  return shapeSignature(next) === shapeSignature(root) ? root : next
+}
+
 /** Group ids of every leaf under a node, in tree order. */
 export function groupLeafIds(node: LayoutNode): string[] {
   return node.type === 'group' ? [node.id] : node.children.flatMap(groupLeafIds)
@@ -347,26 +407,32 @@ function findCover(node: LayoutNode, set: Set<string>): LayoutNode | null {
 }
 
 /**
- * FancyZones span: merge the highlighted zones into ONE group holding
- * `paneId`, absorbing any panes that lived in those zones as tabs. Only works
- * when the highlighted set forms a rectangular subtree (it always does for a
- * combined zone range on a guillotine tree); returns null otherwise so the
- * caller can fall back to a single-zone drop.
+ * FancyZones span: merge the highlighted zones into ONE group holding the
+ * dragged pane block (one pane, or a multi-tab selection in strip order),
+ * absorbing any panes that lived in those zones as tabs. Only works when the
+ * highlighted set forms a rectangular subtree (it always does for a combined
+ * zone range on a guillotine tree); returns null otherwise so the caller can
+ * fall back to a single-zone drop.
  */
-export function mergeZonesWithPane(root: LayoutNode, groupIds: string[], paneId: string): LayoutNode | null {
+export function mergeZonesWithPane(
+  root: LayoutNode,
+  groupIds: string[],
+  paneId: string | readonly string[]
+): LayoutNode | null {
+  const paneIds = typeof paneId === 'string' ? [paneId] : [...paneId]
   const set = new Set(groupIds)
 
   if (set.size <= 1 || !findCover(root, set)) {
     return null
   }
 
-  // Panes from the merged zones (tree order), minus the dragged one.
+  // Panes from the merged zones (tree order), minus the dragged block.
   const panesInSet: string[] = []
 
   const collect = (n: LayoutNode) => {
     if (n.type === 'group') {
       if (set.has(n.id)) {
-        panesInSet.push(...n.panes.filter(p => p !== paneId))
+        panesInSet.push(...n.panes.filter(p => !paneIds.includes(p)))
       }
     } else {
       n.children.forEach(collect)
@@ -375,16 +441,19 @@ export function mergeZonesWithPane(root: LayoutNode, groupIds: string[], paneId:
 
   collect(root)
 
-  // If the dragged pane lives OUTSIDE the merged set, pull it from its origin
+  // Any dragged pane living OUTSIDE the merged set is pulled from its origin
   // first (leaving that origin an empty zone). Inside the set it's absorbed.
-  const origin = findGroupOfPane(root, paneId)
   let working = root
 
-  if (origin && !set.has(origin.id)) {
-    working = removePane(root, paneId) ?? root
+  for (const id of paneIds) {
+    const origin = findGroupOfPane(working, id)
+
+    if (origin && !set.has(origin.id)) {
+      working = removePane(working, id) ?? working
+    }
   }
 
-  const merged = group([paneId, ...panesInSet])
+  const merged = group([...paneIds, ...panesInSet])
 
   const replace = (n: LayoutNode): LayoutNode => {
     if (sameSet(groupLeafIds(n), set)) {
@@ -409,16 +478,23 @@ export function setActivePane(root: LayoutNode, groupId: string, paneId: string)
   return mapGroups(root, g => (g.id === groupId && g.panes.includes(paneId) ? { ...g, active: paneId } : g))
 }
 
-/** Reorder a pane within its group's tab stack (browser-tab drag semantics). */
-export function reorderPaneInGroup(root: LayoutNode, groupId: string, paneId: string, toIndex: number): LayoutNode {
+/** Reorder a block of panes within a group as one unit (browser-tab drag
+ *  semantics; a single-tab drag is a one-id block): the block lands at
+ *  `toIndex` among the remaining tabs, keeping its own order. */
+export function reorderPanesInGroup(
+  root: LayoutNode,
+  groupId: string,
+  paneIds: readonly string[],
+  toIndex: number
+): LayoutNode {
   return mapGroups(root, g => {
-    if (g.id !== groupId || !g.panes.includes(paneId)) {
+    if (g.id !== groupId || !paneIds.every(p => g.panes.includes(p))) {
       return g
     }
 
-    const without = g.panes.filter(p => p !== paneId)
+    const without = g.panes.filter(p => !paneIds.includes(p))
     const index = Math.max(0, Math.min(without.length, toIndex))
-    const panes = [...without.slice(0, index), paneId, ...without.slice(index)]
+    const panes = [...without.slice(0, index), ...paneIds, ...without.slice(index)]
 
     return { ...g, panes }
   })

--- a/apps/desktop/src/components/pane-shell/tree/multi-tab-drag.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/multi-tab-drag.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import { findGroup, findGroupOfPane, group, mergeZonesWithPane, movePanes, reorderPanesInGroup, split } from './model'
+import { $tabSelection, clearTabSelection, selectionFor, selectTabRange, toggleTabSelected } from './tab-selection'
+
+describe('movePanes (multi-tab drag)', () => {
+  it('stacks the whole block into the target group at the divider slot, in strip order', () => {
+    const tree = split('row', [
+      group(['a', 'b', 'c'], { active: 'a', id: 'left' }),
+      group(['x', 'y'], { active: 'x', id: 'right' })
+    ])
+
+    const next = movePanes(tree, ['a', 'c'], { before: 'y', groupId: 'right', pos: 'center' }, 'c')
+    const right = findGroup(next, 'right')
+
+    expect(right).toMatchObject({ panes: ['x', 'a', 'c', 'y'], active: 'c' })
+    expect(findGroup(next, 'left')).toMatchObject({ panes: ['b'] })
+  })
+
+  it('an edge drop opens ONE split holding the block as tabs, pressed tab fronted', () => {
+    const tree = split('row', [
+      group(['a', 'b', 'c'], { active: 'a', id: 'left' }),
+      group(['x'], { active: 'x', id: 'right' })
+    ])
+
+    const next = movePanes(tree, ['b', 'c'], { groupId: 'right', pos: 'bottom' }, 'b')
+    const landed = findGroupOfPane(next, 'b')
+
+    expect(landed).toMatchObject({ panes: ['b', 'c'], active: 'b' })
+    // One new zone, not one per pane: b and c share a group.
+    expect(findGroupOfPane(next, 'c')).toBe(landed)
+    expect(findGroup(next, 'left')).toMatchObject({ panes: ['a'] })
+  })
+
+  it('dragging a whole zone into a sibling dissolves the source zone', () => {
+    const tree = split('row', [
+      group(['a', 'b'], { active: 'a', id: 'left' }),
+      group(['x'], { active: 'x', id: 'right' })
+    ])
+
+    const next = movePanes(tree, ['a', 'b'], { groupId: 'right', pos: 'center' }, 'a')
+
+    expect(next).toMatchObject({ type: 'group', panes: ['x', 'a', 'b'], active: 'a' })
+  })
+
+  it('is a no-op when removal dissolves the target zone itself', () => {
+    const tree = split('row', [
+      group(['a', 'b'], { active: 'a', id: 'left' }),
+      group(['x'], { active: 'x', id: 'right' })
+    ])
+
+    // Dropping right's only pane (as part of a block) "into right" — the
+    // target vanishes with the removal, so nothing moves.
+    expect(movePanes(tree, ['x', 'a'], { groupId: 'right', pos: 'center' }, 'x')).toBe(tree)
+  })
+
+  it('falls back to single-pane semantics for a one-id block', () => {
+    const tree = split('row', [
+      group(['a', 'b'], { active: 'a', id: 'left' }),
+      group(['x'], { active: 'x', id: 'right' })
+    ])
+
+    const next = movePanes(tree, ['b'], { groupId: 'right', pos: 'center' })
+
+    expect(findGroup(next, 'right')).toMatchObject({ panes: ['x', 'b'], active: 'b' })
+  })
+})
+
+describe('reorderPanesInGroup (block reorder)', () => {
+  it('moves a selection as one unit, preserving its internal order', () => {
+    const tree = group(['a', 'b', 'c', 'd'], { active: 'a', id: 'g' })
+
+    // [a, c] to the end: index 2 among the remaining [b, d].
+    expect(reorderPanesInGroup(tree, 'g', ['a', 'c'], 2)).toMatchObject({ panes: ['b', 'd', 'a', 'c'] })
+  })
+
+  it('leaves the group alone when any id is missing (stale selection)', () => {
+    const tree = group(['a', 'b'], { active: 'a', id: 'g' })
+
+    expect(reorderPanesInGroup(tree, 'g', ['a', 'ghost'], 0)).toBe(tree)
+  })
+})
+
+describe('mergeZonesWithPane with a multi-tab block', () => {
+  it('merges the span into one group led by the block in strip order', () => {
+    const tree = split('row', [
+      group(['a', 'b'], { active: 'a', id: 'left' }),
+      split('column', [group(['x'], { active: 'x', id: 'mid' }), group(['y'], { active: 'y', id: 'right' })])
+    ])
+
+    const next = mergeZonesWithPane(tree, ['mid', 'right'], ['a', 'b'])
+
+    expect(next).toMatchObject({ type: 'group', panes: ['a', 'b', 'x', 'y'] })
+  })
+
+  it('returns null for a non-rectangular span (caller falls back to a single-zone drop)', () => {
+    const tree = split('row', [
+      group(['a', 'b'], { active: 'a', id: 'left' }),
+      group(['x'], { active: 'x', id: 'mid' }),
+      group(['y'], { active: 'y', id: 'right' })
+    ])
+
+    expect(mergeZonesWithPane(tree, ['mid', 'right'], ['a', 'b'])).toBeNull()
+  })
+})
+
+describe('tab selection (Chrome grammar)', () => {
+  it('⌥-click seeds with the active tab, toggles, and dissolves at ≤1', () => {
+    clearTabSelection()
+    toggleTabSelected('g', 'c', 'a')
+
+    expect([...$tabSelection.get()!.ids].sort()).toEqual(['a', 'c'])
+
+    toggleTabSelected('g', 'c', 'a')
+
+    expect($tabSelection.get()).toBeNull()
+  })
+
+  it('shift-click ranges from the anchor and re-ranges on the next shift-click', () => {
+    clearTabSelection()
+
+    const order = ['a', 'b', 'c', 'd']
+    selectTabRange('g', order, 'c', 'a')
+
+    expect(selectionFor('g', order, 'b')).toEqual(['a', 'b', 'c'])
+
+    // Anchor holds at a (Chrome): re-ranging to d replaces, not extends.
+    selectTabRange('g', order, 'd', 'a')
+
+    expect(selectionFor('g', order, 'd')).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('selectionFor answers null for an unselected pressed tab and drops stale ids', () => {
+    clearTabSelection()
+    toggleTabSelected('g', 'b', 'a')
+    toggleTabSelected('g', 'c', 'a')
+
+    // Pressed tab outside the selection = single-tab drag.
+    expect(selectionFor('g', ['a', 'b', 'c', 'd'], 'd')).toBeNull()
+    // 'a' closed since: it silently falls out, strip order preserved.
+    expect(selectionFor('g', ['b', 'c', 'd'], 'b')).toEqual(['b', 'c'])
+    // Another zone never sees it.
+    expect(selectionFor('other', ['b', 'c'], 'b')).toBeNull()
+
+    clearTabSelection()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
@@ -35,7 +35,8 @@ import { ESCAPE_PRIORITY, pushEscapeLayer } from '@/lib/escape-layers'
 import { reorderCommitHaptic, reorderStepHaptic } from '@/lib/reorder'
 
 import type { DropPosition } from '../model'
-import { $dropHint, $treeDragging, type DropHint, mergeTreeZones, moveTreePane, reorderTreePane } from '../store'
+import { $dropHint, $treeDragging, type DropHint, mergeTreeZones, moveTreePanes, reorderTreePanes } from '../store'
+import { clearTabSelection } from '../tab-selection'
 import { type EngineZone, HighlightedZones, primaryZone, type ZoneRect } from '../zones-engine'
 
 const DRAG_THRESHOLD_PX = 4
@@ -96,10 +97,18 @@ const stripSlots = (strip: HTMLElement): StripSlot[] =>
   })
 
 /** Insertion slot from the pointer x against the OTHER tabs' midpoints:
- *  stack BEFORE the returned pane id (`null` = append). */
-export function slotBefore(slots: StripSlot[], x: number, excludePaneId = ''): { before: null | string } {
+ *  stack BEFORE the returned pane id (`null` = append). `exclude` is the
+ *  dragged tab — or the whole selection on a multi-tab drag, so the block
+ *  can't target a slot inside itself. */
+export function slotBefore(
+  slots: StripSlot[],
+  x: number,
+  exclude: readonly string[] | string = ''
+): { before: null | string } {
+  const excluded = typeof exclude === 'string' ? [exclude] : exclude
+
   for (const slot of slots) {
-    if (slot.id === excludePaneId) {
+    if (excluded.includes(slot.id)) {
       continue
     }
 
@@ -422,7 +431,11 @@ export function startPaneDrag(
   onTap?: () => void,
   reorder?: ReorderContext,
   double?: DoubleTapContext,
-  ghostLabel?: string
+  ghostLabel?: string,
+  /** Multi-tab selection riding this drag (strip order, includes `paneId`).
+   *  The whole block moves/reorders together; `paneId` stays the pressed tab
+   *  (it fronts at the destination). */
+  selection?: readonly string[]
 ) {
   if (e.button !== 0) {
     return
@@ -431,17 +444,28 @@ export function startPaneDrag(
   e.preventDefault()
   e.stopPropagation()
 
+  // The moving block: the selection when the pressed tab rides one, else just
+  // the pressed tab. Order is strip order (selectionFor guarantees it).
+  const moving: readonly string[] = selection && selection.length > 1 ? selection : [paneId]
+
   const highlighted = new HighlightedZones()
   let zones: EngineZone[] = []
   let strips: StripSnapshot[] = []
   let mode: 'reorder' | 'zone' | null = null
-  let dimmed: HTMLElement | null = null
+  let dimmed: HTMLElement[] = []
 
   const markSource = () => {
-    // The dragged tab dims for the drag's life — the divider says where it
-    // GOES, the dim says what MOVES. No live shuffle (placement-on-release).
-    dimmed ??= reorder?.strip.querySelector<HTMLElement>(`[data-tree-tab="${CSS.escape(paneId)}"]`) ?? null
-    dimmed?.style.setProperty('opacity', '0.45')
+    // Every dragged tab dims for the drag's life — the divider says where they
+    // GO, the dim says what MOVES. No live shuffle (placement-on-release).
+    if (dimmed.length === 0 && reorder) {
+      dimmed = moving
+        .map(id => reorder.strip.querySelector<HTMLElement>(`[data-tree-tab="${CSS.escape(id)}"]`))
+        .filter((el): el is HTMLElement => el !== null)
+    }
+
+    for (const el of dimmed) {
+      el.style.setProperty('opacity', '0.45')
+    }
   }
 
   const enterZoneMode = () => {
@@ -494,7 +518,7 @@ export function startPaneDrag(
             groupId: reorder!.groupId,
             groupIds: [reorder!.groupId],
             pos: 'center',
-            stack: slotBefore(reorderStrip().slots, x, paneId)
+            stack: slotBefore(reorderStrip().slots, x, moving)
           }
         }
 
@@ -525,7 +549,7 @@ export function startPaneDrag(
       const strip =
         groupIds.length === 1 && groupId ? strips.find(s => s.groupId === groupId && rectContains(s.rect, x, y)) : null
 
-      const stack = strip ? slotBefore(strip.slots, x, paneId) : undefined
+      const stack = strip ? slotBefore(strip.slots, x, moving) : undefined
 
       const pos: DropPosition = stack
         ? 'center'
@@ -537,17 +561,26 @@ export function startPaneDrag(
     },
 
     onCommit(hint) {
+      // A multi-tab selection is spent by a LANDED drop (reorder or zone) —
+      // a deny-area release keeps it, so a missed drop can just be retried.
+      const spendSelection = () => {
+        if (moving.length > 1) {
+          clearTabSelection()
+        }
+      }
+
       if (mode === 'reorder' && reorder && hint?.stack !== undefined) {
-        // Slot -> index among the OTHER tabs (reorderPaneInGroup inserts there).
+        // Slot -> index among the OTHER tabs (the block re-inserts there).
         const others = [...reorder.strip.querySelectorAll<HTMLElement>('[data-tree-tab]')]
           .map(el => el.dataset.treeTab)
-          .filter((id): id is string => Boolean(id) && id !== paneId)
+          .filter((id): id is string => Boolean(id) && !moving.includes(id!))
 
         const toIndex = hint.stack.before ? others.indexOf(hint.stack.before) : others.length
 
         if (toIndex >= 0) {
-          reorderTreePane(reorder.groupId, paneId, toIndex)
+          reorderTreePanes(reorder.groupId, moving, toIndex)
           reorderCommitHaptic()
+          spendSelection()
         }
       }
 
@@ -559,18 +592,28 @@ export function startPaneDrag(
         const targets = hint?.groupIds ?? []
 
         if (targets.length > 1) {
-          // Shift-span: merge the highlighted zones, dropping the pane across them.
-          mergeTreeZones([...targets], paneId, hint?.groupId ?? null)
+          // Shift-span: merge the highlighted zones, dropping the block across them.
+          mergeTreeZones([...targets], moving, hint?.groupId ?? null)
+          spendSelection()
         } else if (hint?.groupId) {
           // strip = stack at the divider slot; center = join the stack;
-          // an edge = split the zone and land there.
-          moveTreePane(paneId, { groupId: hint.groupId, pos: hint.pos ?? 'center', before: hint.stack?.before })
+          // an edge = split the zone and land there. The whole selection
+          // rides — the pressed tab fronts at the destination.
+          moveTreePanes(
+            moving,
+            { groupId: hint.groupId, pos: hint.pos ?? 'center', before: hint.stack?.before },
+            paneId
+          )
+          spendSelection()
         }
       }
     },
 
     onEnd() {
-      dimmed?.style.removeProperty('opacity')
+      for (const el of dimmed) {
+        el.style.removeProperty('opacity')
+      }
+
       highlighted.reset()
     }
   })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -50,6 +50,14 @@ import {
   setTreeGroupMinimized,
   treeTabCloseTargets
 } from '../store'
+import {
+  $tabSelection,
+  clearTabSelection,
+  isToggleSelectClick,
+  selectionFor,
+  selectTabRange,
+  toggleTabSelected
+} from '../tab-selection'
 
 import { type DoubleTapContext, startPaneDrag } from './drag-session'
 import { forceLoneHeaderForPanes } from './lone-header'
@@ -186,6 +194,9 @@ export function TreeGroup({
   const narrow = useStore($narrowViewport)
   const newSessionTabAction = useStore($newSessionTabAction)
   const panesWithCloser = useStore($panesWithCloser)
+  // Multi-tab selection (⌥/Ctrl-click, Shift-click) — null for every zone but
+  // the one holding it, so this subscription is quiet during normal use.
+  const tabSelection = useStore($tabSelection)
   // Reload epochs: only an explicit tab-menu Reload writes here, so this
   // subscription costs nothing on a normal render.
   const paneEpochs = useStore($treePaneEpochs)
@@ -435,6 +446,7 @@ export function TreeGroup({
                 const chrome = paneChrome(paneFor(paneId))
                 const closeable = closeableTab(paneId)
                 const title = paneFor(paneId)?.title ?? paneId
+                const isSelected = tabSelection?.groupId === node.id && tabSelection.ids.has(paneId)
 
                 const tab = (
                   <PaneTab
@@ -444,11 +456,36 @@ export function TreeGroup({
                     key={paneId}
                     onClose={closeable ? () => closeTab(paneId) : undefined}
                     onPointerDown={e => {
+                      // Chrome's tab-selection grammar, ahead of activate/drag:
+                      // Shift-click ranges from the anchor, ⌥-click (Ctrl-click
+                      // off-Mac) toggles. Neither activates nor starts a drag —
+                      // the press IS the selection edit. ⌘-click stays close
+                      // (PaneTab claims it first) and ⌃-click stays the macOS
+                      // context menu.
+                      if (e.button === 0 && e.shiftKey) {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        selectTabRange(node.id, shown, paneId, activeId)
+
+                        return
+                      }
+
+                      if (isToggleSelectClick(e)) {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        toggleTabSelected(node.id, paneId, activeId)
+
+                        return
+                      }
+
                       // Tabs ACTIVATE (restoring a collapsed group). Minimize
                       // lives on the chevron / single-pane label — overloading
                       // the active tab made double-click a minimize/restore/hide
-                      // lottery.
+                      // lottery. A plain click also collapses any multi-tab
+                      // selection back to the one tab (Chrome semantics).
                       const onTap = () => {
+                        clearTabSelection()
+
                         if (node.minimized) {
                           restoreTreePane(paneId)
                         }
@@ -463,6 +500,26 @@ export function TreeGroup({
                       if (e.button === 0) {
                         e.preventDefault()
                         e.stopPropagation()
+                      }
+
+                      // Dragging a SELECTED tab carries the whole selection as
+                      // one block through the generic pane move — a multi-tab
+                      // drag outranks the pane's own tab drag (the session drop
+                      // language is single-session).
+                      const dragSelection = selectionFor(node.id, shown, paneId)
+
+                      if (dragSelection) {
+                        startPaneDrag(
+                          paneId,
+                          e,
+                          onTap,
+                          stripRef.current ? { groupId: node.id, strip: stripRef.current } : undefined,
+                          hideHeaderDoubleTap,
+                          t.zones.tabCount(dragSelection.length),
+                          dragSelection
+                        )
+
+                        return
                       }
 
                       // A pane may own its tab drag (a session tab speaks the
@@ -481,6 +538,7 @@ export function TreeGroup({
                       }
                     }}
                     role="tab"
+                    selected={isSelected}
                     style={{ cursor: 'grab' }}
                   >
                     {chrome.tabLead ? (

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -28,9 +28,10 @@ import {
   mergeZonesWithPane as mergeZonesWithPaneOp,
   mirrorTreeHorizontal,
   movePane as movePaneOp,
+  movePanes as movePanesOp,
   normalize,
   removePane,
-  reorderPaneInGroup as reorderPaneInGroupOp,
+  reorderPanesInGroup as reorderPanesInGroupOp,
   setActivePane as setActivePaneOp,
   setGroupHeaderHidden as setGroupHeaderHiddenOp,
   setGroupMinimized,
@@ -1244,25 +1245,61 @@ export function applyTree(tree: LayoutNode, presetId: string) {
 }
 
 /**
- * Shift-drag span: merge the highlighted zones into one holding `paneId`. Falls
- * back to a single-zone move at `fallbackGroupId` when the set can't merge
- * (non-rectangular selection).
+ * Move a multi-tab SELECTION in one commit (drag any selected tab): the lead
+ * pane takes the drop geometry, the rest stack in behind it in strip order,
+ * and `activeId` (the pressed tab) fronts in the landing group.
  */
-export function mergeTreeZones(groupIds: string[], paneId: string, fallbackGroupId: string | null) {
+export function moveTreePanes(
+  paneIds: readonly string[],
+  target: { groupId: string; pos: DropPosition; before?: null | string },
+  activeId?: string
+) {
   const tree = $layoutTree.get()
 
   if (!tree) {
     return
   }
 
+  const next = movePanesOp(tree, paneIds, target, activeId)
+
+  if (next !== tree) {
+    commit(next)
+    markActivePreset('custom')
+
+    for (const paneId of paneIds) {
+      markPaneUserPlaced(paneId)
+    }
+  }
+}
+
+/**
+ * Shift-drag span: merge the highlighted zones into one holding `paneId`. Falls
+ * back to a single-zone move at `fallbackGroupId` when the set can't merge
+ * (non-rectangular selection).
+ */
+export function mergeTreeZones(
+  groupIds: string[],
+  paneId: string | readonly string[],
+  fallbackGroupId: null | string
+) {
+  const tree = $layoutTree.get()
+
+  if (!tree) {
+    return
+  }
+
+  const paneIds = typeof paneId === 'string' ? [paneId] : paneId
   const merged = mergeZonesWithPaneOp(tree, groupIds, paneId)
 
   if (merged) {
     commit(merged)
     markActivePreset('custom')
-    markPaneUserPlaced(paneId)
+
+    for (const id of paneIds) {
+      markPaneUserPlaced(id)
+    }
   } else if (fallbackGroupId) {
-    moveTreePane(paneId, { groupId: fallbackGroupId, pos: 'center' })
+    moveTreePanes(paneIds, { groupId: fallbackGroupId, pos: 'center' })
   }
 }
 
@@ -1274,11 +1311,13 @@ export function activateTreePane(groupId: string, paneId: string) {
   }
 }
 
-export function reorderTreePane(groupId: string, paneId: string, toIndex: number) {
+/** Reorder a tab block (multi-tab selection, or a single tab) within its
+ *  group's strip — the block keeps its own order. */
+export function reorderTreePanes(groupId: string, paneIds: readonly string[], toIndex: number) {
   const tree = $layoutTree.get()
 
   if (tree) {
-    commit(reorderPaneInGroupOp(tree, groupId, paneId, toIndex))
+    commit(reorderPanesInGroupOp(tree, groupId, paneIds, toIndex))
     markActivePreset('custom')
   }
 }

--- a/apps/desktop/src/components/pane-shell/tree/tab-selection.ts
+++ b/apps/desktop/src/components/pane-shell/tree/tab-selection.ts
@@ -1,0 +1,99 @@
+/**
+ * Multi-tab selection on a zone's tab strip — Chrome's tab-selection grammar:
+ *
+ *   - ⌥-click (Ctrl-click off-Mac)  → toggle the tab in/out of the selection;
+ *   - Shift-click                   → select the range from the anchor
+ *                                     (the last explicitly clicked tab, else
+ *                                     the active one) to the clicked tab;
+ *   - plain click                   → collapse back to a single tab.
+ *
+ * ⌘-click stays CLOSE (middle-click.ts) and ⌃-click stays the macOS context
+ * menu, so the toggle chord is ⌥ on Mac / Ctrl elsewhere. One selection at a
+ * time, scoped to one zone — dragging any selected tab carries the whole set
+ * (drag-session resolves it), and ids are validated against the strip's
+ * current tabs at use time, so closed/moved panes fall out on their own.
+ */
+
+import { atom } from 'nanostores'
+
+export interface TabSelection {
+  groupId: string
+  ids: ReadonlySet<string>
+  /** Range anchor: the last explicitly clicked tab (Chrome semantics). */
+  anchor: string
+}
+
+export const $tabSelection = atom<null | TabSelection>(null)
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navigator.platform)
+
+/** The toggle-select chord: ⌥-click on Mac (⌘ closes, ⌃ is the context menu),
+ *  Ctrl-click elsewhere — ⌥ is accepted everywhere for one muscle memory. */
+export const isToggleSelectClick = (event: { altKey: boolean; button: number; ctrlKey: boolean; metaKey: boolean }) =>
+  event.button === 0 && !event.metaKey && (event.altKey || (!isMac && event.ctrlKey))
+
+export function clearTabSelection() {
+  if ($tabSelection.get()) {
+    $tabSelection.set(null)
+  }
+}
+
+/** ⌥/Ctrl-click: toggle `paneId`. A fresh selection seeds with the active tab
+ *  (it is implicitly selected, as in Chrome); collapsing to ≤1 dissolves the
+ *  selection entirely — a single "selected" tab is just a tab. */
+export function toggleTabSelected(groupId: string, paneId: string, activeId: string) {
+  const current = $tabSelection.get()
+  const ids = new Set(current?.groupId === groupId ? current.ids : [activeId])
+
+  if (ids.has(paneId)) {
+    ids.delete(paneId)
+  } else {
+    ids.add(paneId)
+  }
+
+  if (ids.size <= 1) {
+    $tabSelection.set(null)
+
+    return
+  }
+
+  $tabSelection.set({ anchor: paneId, groupId, ids })
+}
+
+/** Shift-click: select the contiguous range anchor→`paneId` in strip order,
+ *  replacing the previous range (the anchor holds, Chrome-style). */
+export function selectTabRange(groupId: string, orderedPanes: readonly string[], paneId: string, activeId: string) {
+  const current = $tabSelection.get()
+  const anchor = current?.groupId === groupId && orderedPanes.includes(current.anchor) ? current.anchor : activeId
+  const a = orderedPanes.indexOf(anchor)
+  const b = orderedPanes.indexOf(paneId)
+
+  if (a === -1 || b === -1) {
+    return
+  }
+
+  const ids = new Set(orderedPanes.slice(Math.min(a, b), Math.max(a, b) + 1))
+
+  if (ids.size <= 1) {
+    $tabSelection.set(null)
+
+    return
+  }
+
+  $tabSelection.set({ anchor, groupId, ids })
+}
+
+/** The selection as an ordered slice of `orderedPanes` — but only when the
+ *  pressed tab rides it (dragging an unselected tab is a single-tab drag).
+ *  Stale ids (closed panes) drop out here. */
+export function selectionFor(groupId: string, orderedPanes: readonly string[], paneId: string): null | string[] {
+  const current = $tabSelection.get()
+
+  if (current?.groupId !== groupId || !current.ids.has(paneId)) {
+    return null
+  }
+
+  const ids = orderedPanes.filter(id => current.ids.has(id))
+
+  return ids.length > 1 ? ids : null
+}

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -31,12 +31,21 @@ const TAB_ACTIVE_UNDERLINE = 'shadow-[inset_0_-2px_0_var(--pane-tab-active-accen
 const TAB_IDLE =
   'text-(--ui-text-tertiary) [--tab-bg:var(--pane-tab-strip-bg,var(--ui-sidebar-surface-background))] hover:shadow-[inset_0_0_0_100vmax_color-mix(in_srgb,#000_var(--ui-tab-hover-darken),transparent)] hover:text-(--ui-text-secondary)'
 
+// A tab riding a multi-tab selection: an accent wash over whatever surface the
+// tab sits on. A background-image gradient (not a shadow) so it stacks cleanly
+// over `--tab-bg` without fighting the active underline / hover shadows.
+const TAB_SELECTED =
+  '[background-image:linear-gradient(color-mix(in_srgb,var(--ui-accent)_14%,transparent),color-mix(in_srgb,var(--ui-accent)_14%,transparent))] text-foreground'
+
 interface PaneTabProps extends React.ComponentProps<'div'> {
   active?: boolean
   dirty?: boolean
   /** Close gesture, no hover X (too easy to hit on small tabs): middle-click,
    *  or ⌘-click as the trackpad-friendly Mac equivalent. */
   onClose?: () => void
+  /** Part of a multi-tab selection (⌥/Ctrl-click, Shift-click) — an accent
+   *  wash marks every tab that a drag would carry, Chrome-style. */
+  selected?: boolean
   /** Vertical rail form (collapsed sidebar zones). */
   vertical?: boolean
   /** Content-facing edge of a vertical rail — the strip line the active tab cuts. */
@@ -59,6 +68,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
     onPointerDown,
     onPointerUp,
     onClickCapture,
+    selected = false,
     vertical = false,
     side = 'left',
     children,
@@ -81,9 +91,11 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
         active
           ? cn(TAB_ACTIVE, !vertical && TAB_ACTIVE_UNDERLINE)
           : cn(TAB_IDLE, edge && `${edge}-(--ui-stroke-tertiary)`),
+        selected && TAB_SELECTED,
         className
       )}
       data-active={active}
+      data-selected={selected || undefined}
       data-vertical={vertical || undefined}
       onClickCapture={event => {
         // Sites whose tab activates on the label's own onClick (the preview

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2265,7 +2265,8 @@ export const ar = defineLocale({
     layoutNamePlaceholder: fallback => `اسم التخطيط (${fallback})`,
     saveApply: 'حفظ وتطبيق',
     notExpressible: 'هذا الترتيب متشابك — لا يمكن تمثيله كتقسيمات متداخلة بعد',
-    zoneCount: count => `${count} مناطق`
+    zoneCount: count => `${count} مناطق`,
+    tabCount: count => `${count} تبويبات`
   },
   assistant: {
     thread: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2693,7 +2693,8 @@ export const en: Translations = {
     layoutNamePlaceholder: fallback => `Layout name (${fallback})`,
     saveApply: 'Save & apply',
     notExpressible: 'this arrangement interlocks (pinwheel) — not expressible as nested splits yet',
-    zoneCount: count => `${count} zones`
+    zoneCount: count => `${count} zones`,
+    tabCount: count => `${count} tabs`
   },
 
   assistant: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2519,7 +2519,8 @@ export const ja = defineLocale({
     layoutNamePlaceholder: fallback => `レイアウト名（${fallback}）`,
     saveApply: '保存して適用',
     notExpressible: 'この配置は互いに噛み合っています（風車型）— 入れ子の分割では表現できません',
-    zoneCount: count => `${count} ゾーン`
+    zoneCount: count => `${count} ゾーン`,
+    tabCount: count => `${count} 個のタブ`
   },
 
   assistant: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2293,6 +2293,7 @@ export interface Translations {
     saveApply: string
     notExpressible: string
     zoneCount: (count: number) => string
+    tabCount: (count: number) => string
   }
 
   assistant: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2439,7 +2439,8 @@ export const zhHant = defineLocale({
     layoutNamePlaceholder: fallback => `版面名稱（${fallback}）`,
     saveApply: '儲存並套用',
     notExpressible: '此排列互相咬合（風車形）——暫時無法表示為巢狀分割',
-    zoneCount: count => `${count} 個區域`
+    zoneCount: count => `${count} 個區域`,
+    tabCount: count => `${count} 個分頁`
   },
 
   assistant: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2871,7 +2871,8 @@ export const zh: Translations = {
     layoutNamePlaceholder: fallback => `布局名称（${fallback}）`,
     saveApply: '保存并应用',
     notExpressible: '此排列互相咬合（风车形）——暂无法表示为嵌套拆分',
-    zoneCount: count => `${count} 个区域`
+    zoneCount: count => `${count} 个区域`,
+    tabCount: count => `${count} 个标签页`
   },
 
   assistant: {


### PR DESCRIPTION
## Summary

Zone tab strips now speak Chrome's tab-selection grammar: Shift-click selects a range from the anchor, ⌥-click (Ctrl-click off-Mac) toggles individual tabs, and a plain click collapses back to a single tab. ⌘-click stays close-tab and ⌃-click stays the macOS context menu, so nothing existing moves.

Dragging any selected tab carries the whole block through the normal drop language — reorder within the strip, stack at another strip's caret slot, split a zone edge (all selected tabs land in the **one** new zone, as tabs), or Shift-span merge. Selected tabs wear an accent wash, every carried tab dims during the drag, the ghost chip counts the block ("3 tabs"), and the pressed tab fronts at the destination. A deny-area release keeps the selection so a missed drop can be retried; a landed drop spends it.

Under the hood the tree ops take a block of pane ids in strip order (`movePanes`, `reorderPanesInGroup`, `mergeZonesWithPane`) with the lead pane deciding geometry — the single-tab path is the one-id case of the same code. Selection lives in a small per-zone store validated against live tabs at use time, so closed or moved panes fall out silently.

## Test plan

- [x] `vitest` — new coverage for block move/reorder/span-merge and the selection grammar (25 tests), plus the existing pane-shell + session-states suites (118 total, green)
- [ ] Manual: ⌥-click two tabs + the active one, drag to another zone's edge → one new zone with all three as tabs, pressed tab active
- [ ] Manual: Shift-click a range, drag within the strip → block reorders as a unit at the caret