### PR TITLE
fix(delegation): report batch runtime models

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -65,6 +65,26 @@ def _drain_for(delegation_id, timeout=5.0):
     return None
 
 
+def _complete_batch(results, model=None):
+    dispatched = ad.dispatch_async_delegation_batch(
+        goals=[f"task {index + 1}" for index in range(len(results))],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=model,
+        session_key="",
+        max_async_children=1,
+        runner=lambda: {
+            "results": results,
+            "total_duration_seconds": 0.1,
+        },
+    )
+    assert dispatched["status"] == "dispatched"
+    event = _drain_for(dispatched["delegation_id"])
+    assert event is not None
+    return event
+
+
 def test_active_for_session_counts_every_live_delegation_state():
     with ad._records_lock:
         ad._records.update(
@@ -621,6 +641,83 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     text = format_process_notification(evt)
     assert text is not None
     assert "the real task" in text
+
+
+def test_batch_completion_promotes_inherited_runtime_model():
+    runtime_model = "runtime-model"
+    event = _complete_batch([
+        {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "identified",
+            "model": runtime_model,
+        }
+    ])
+
+    assert event["model"] == runtime_model
+    assert event["models"] == [runtime_model]
+    assert event["model_source"] == "runtime_result"
+    text = format_process_notification(event)
+    assert text is not None
+    assert f"Model: {runtime_model}" in text
+    assert "Model: ?" not in text
+
+    # Durable events written before runtime model promotion still carry the
+    # child model in each result; the formatter should recover it on replay.
+    legacy_event = dict(event)
+    legacy_event.pop("models")
+    legacy_event["model"] = None
+    legacy_text = format_process_notification(legacy_event)
+    assert legacy_text is not None
+    assert f"Model: {runtime_model}" in legacy_text
+
+
+def test_batch_completion_preserves_mixed_runtime_models():
+    event = _complete_batch([
+        {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "first",
+            "model": "runtime-a",
+        },
+        {
+            "task_index": 1,
+            "status": "completed",
+            "summary": "second",
+            "model": "runtime-b",
+        },
+    ])
+
+    assert event["model"] is None
+    assert event["models"] == ["runtime-a", "runtime-b"]
+    assert event["model_source"] == "runtime_results"
+    text = format_process_notification(event)
+    assert text is not None
+    assert "Models: runtime-a, runtime-b" in text
+    assert "model=runtime-a" in text
+    assert "model=runtime-b" in text
+    assert "Model: ?" not in text
+
+
+def test_batch_completion_uses_dispatch_model_without_runtime_identity():
+    dispatch_model = "configured-model"
+    event = _complete_batch(
+        [
+            {
+                "task_index": 0,
+                "status": "error",
+                "error": "pre-run failure",
+            }
+        ],
+        model=dispatch_model,
+    )
+
+    assert event["model"] == dispatch_model
+    assert event["models"] == []
+    assert event["model_source"] == "dispatch"
+    text = format_process_notification(event)
+    assert text is not None
+    assert f"Model: {dispatch_model}" in text
 
 
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -1074,6 +1074,23 @@ def _finalize_batch(
     _finish_finalization(delegation_id, status)
 
 
+def _runtime_result_models(results: Any) -> List[str]:
+    """Return ordered, unique model identities reported by child results."""
+    models: List[str] = []
+    if not isinstance(results, list):
+        return models
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        model = result.get("model")
+        if not isinstance(model, str):
+            continue
+        model = model.strip()
+        if model and model not in models:
+            models.append(model)
+    return models
+
+
 def _push_batch_completion_event(
     event_record: Dict[str, Any], combined: Dict[str, Any], status: str
 ) -> None:
@@ -1090,6 +1107,22 @@ def _push_batch_completion_event(
 
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
+    results = combined.get("results") or []
+    runtime_models = _runtime_result_models(results)
+    dispatch_model = event_record.get("model")
+    if isinstance(dispatch_model, str):
+        dispatch_model = dispatch_model.strip() or None
+    else:
+        dispatch_model = None
+    if len(runtime_models) == 1:
+        effective_model = runtime_models[0]
+        model_source = "runtime_result"
+    elif runtime_models:
+        effective_model = None
+        model_source = "runtime_results"
+    else:
+        effective_model = dispatch_model
+        model_source = "dispatch" if dispatch_model else None
     evt = {
         "type": "async_delegation",
         "delegation_id": event_record.get("delegation_id"),
@@ -1102,12 +1135,19 @@ def _push_batch_completion_event(
         "context": event_record.get("context"),
         "toolsets": event_record.get("toolsets"),
         "role": event_record.get("role"),
-        "model": event_record.get("model"),
+        # Prefer identities reported by the completed child agents over the
+        # dispatch request. With inherited delegation settings the latter is
+        # intentionally empty, while every child result records its resolved
+        # runtime model. Preserve heterogeneous batches instead of assigning a
+        # misleading single identity to the whole fan-out.
+        "model": effective_model,
+        "models": runtime_models,
+        "model_source": model_source,
         "status": status,
         "is_batch": True,
         # The full per-task results list — the formatter renders a
         # consolidated multi-task block from this.
-        "results": combined.get("results") or [],
+        "results": results,
         # Per-task live transcript log paths (cache/delegation/live/...).
         # They persist after completion and double as the full-fidelity
         # operational record of each child's run.

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2240,6 +2240,32 @@ def _format_async_delegation(evt: dict) -> str:
     batch_results = evt.get("results")
     if evt.get("is_batch") or isinstance(batch_results, list):
         results = batch_results or []
+        batch_models = []
+        event_models = evt.get("models")
+        if not isinstance(event_models, list):
+            event_models = []
+        for candidate in event_models:
+            if isinstance(candidate, str):
+                candidate = candidate.strip()
+                if candidate and candidate not in batch_models:
+                    batch_models.append(candidate)
+        if not batch_models:
+            # Backward compatibility for durable events persisted before the
+            # batch event promoted result-level runtime model metadata.
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                candidate = result.get("model")
+                if isinstance(candidate, str):
+                    candidate = candidate.strip()
+                    if candidate and candidate not in batch_models:
+                        batch_models.append(candidate)
+        if len(batch_models) == 1:
+            model_label = f"Model: {batch_models[0]}"
+        elif batch_models:
+            model_label = f"Models: {', '.join(batch_models)}"
+        else:
+            model_label = f"Model: {model}"
         goals = evt.get("goals") or []
         n = len(results) if results else len(goals)
         total_dur = evt.get("total_duration_seconds", duration)
@@ -2259,7 +2285,7 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append(f"Context you provided: {context}")
         if toolsets:
             lines.append(f"Toolsets: {', '.join(toolsets)}")
-        lines.append(f"Role: {role}   Model: {model}   Total duration: {total_dur}s")
+        lines.append(f"Role: {role}   {model_label}   Total duration: {total_dur}s")
         if error and not results:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
@@ -2278,6 +2304,8 @@ def _format_async_delegation(evt: dict) -> str:
             header += f"  (status={r_status}"
             if r.get("api_calls"):
                 header += f", api_calls={r['api_calls']}"
+            if len(batch_models) > 1 and r.get("model"):
+                header += f", model={r['model']}"
             if r.get("duration_seconds") is not None:
                 header += f", {r['duration_seconds']}s"
             header += ") ---"


### PR DESCRIPTION
## Summary

- promote resolved runtime model identities from completed child results into async batch completion events
- render one homogeneous runtime model or preserve heterogeneous per-task models without inventing a shared label
- retain explicit dispatch-model fallback and recover result-level models when replaying older durable events

## Problem

Background `delegate_task` fan-outs use the batch completion path, including one-child delegations. When delegation model settings are inherited, the dispatch record intentionally has no model. The batch event copied only that empty dispatch value even though each completed child result already records its resolved runtime model, so notifications rendered `Model: ?`.

The non-batch path already prioritizes result-level runtime identity. This applies the same contract to batches while preserving mixed-model fan-outs.

## Verification

- live Desktop probe: `Model: gpt-5.6-sol`, `model_source=runtime_result`, one API call, no tools
- red baseline on current upstream: all three new behavior tests failed before the implementation
- `scripts/run_tests.sh tests/tools/test_async_delegation.py -q`: 23 passed
- focused post-rebase model regressions: 3 passed
- Ruff lint, Python compilation, range-scoped formatting, and `git diff --check`: passed
- broader process-registry run: 42 passed, 9 skipped, with 3 unrelated Windows PTY/process failures reproduced identically on untouched `origin/main`