### PR TITLE
fix(agent): recognize URLs as natural response endings (#78359)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1687,6 +1687,13 @@ class AIAgent:
         # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
         if ord(last) >= 0x1F300:
             return True
+        # A URL at the end of a response is a complete response, not a
+        # truncation: the trailing path segment's last character (e.g. the
+        # "l" in "index.html") is not in the punctuation set above, so a
+        # bare-URL ending would otherwise be misreported as truncated.
+        last_token = stripped.split()[-1]
+        if last_token.startswith(("http://", "https://", "ftp://")):
+            return True
         return False
 
     def _is_ollama_glm_backend(self) -> bool:

--- a/tests/agent/test_natural_response_ending_url.py
+++ b/tests/agent/test_natural_response_ending_url.py
@@ -1,0 +1,62 @@
+"""Regression (#78359): a response ending in a bare URL is not truncated.
+
+``_has_natural_response_ending()`` only treated punctuation and emoji as
+natural endings. A URL such as ``http://host/index.html`` ends with ``l``,
+which is not in the punctuation set, so on Ollama-hosted GLM models
+``_should_treat_stop_as_truncated()`` fired spuriously, triggering a fake
+continuation whose text got glued to the URL without a separator.
+
+The fix: if the last whitespace-delimited token of the stripped content
+starts with ``http://``, ``https://``, or ``ftp://``, treat it as a
+natural ending. Any URL is a natural ending — no extension matching.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def has_natural_response_ending():
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        return AIAgent._has_natural_response_ending
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "http://host/index.html",
+        "https://example.com/path/to/page",
+        "ftp://server/file.txt",
+        "http://host:8731/path/index.html",
+        "Check this: http://host/page",
+    ],
+)
+def test_url_ending_is_natural(has_natural_response_ending, content):
+    assert has_natural_response_ending(content) is True
+
+
+def test_period_ending_is_natural(has_natural_response_ending):
+    assert has_natural_response_ending("Some text.") is True
+
+
+def test_no_punctuation_is_not_natural(has_natural_response_ending):
+    assert has_natural_response_ending("Some text") is False
+
+
+def test_text_after_url_is_not_natural(has_natural_response_ending):
+    # URL is not the last token, so it does not end the response.
+    assert has_natural_response_ending("http://host/page and more text") is False
+
+
+def test_empty_is_not_natural(has_natural_response_ending):
+    assert has_natural_response_ending("") is False
+
+
+def test_non_url_scheme_is_not_natural(has_natural_response_ending):
+    assert has_natural_response_ending("MEDIA:/tmp/file.png") is False


### PR DESCRIPTION
## Summary

Fixes #78359.

## The bug

When the agent's response ends with a bare URL (e.g. `http://host/index.html`), `_should_treat_stop_as_truncated()` incorrectly reports the response as truncated on Ollama-hosted GLM models. This triggers a spurious continuation prompt, and the agent produces extra text that gets concatenated onto the URL without a separator.

This happens on responses under 100 chars and is **not** caused by the output length limit.

Example failure:

```
Response: "See http://host/index.html"
finish_reason: stop
-> _should_treat_stop_as_truncated() returns True (wrong)
-> continuation fired
-> final output: "See http://host/index.htmlSure, here's more detail..."
```

## Root cause

`run_agent.py` — `_has_natural_response_ending()` checks whether the last character of the stripped content is in the punctuation set `.!?:)"\']}'` (plus CJK variants) or an emoji. A URL ending in `.html` ends with `l`, which is not in that set, so the function returns `False`.

Because `_should_treat_stop_as_truncated()` returns `not _has_natural_response_ending(...)`, any URL-ending response is misreported as truncated for Ollama-hosted GLM models, firing a fake continuation whose text glues onto the URL.

## The fix

In `_has_natural_response_ending()`, add a check: if the last whitespace-delimited token of the stripped content starts with `http://`, `https://`, or `ftp://`, treat it as a natural ending. A URL at the end of a response is a complete response, not truncated.

- No extension matching — any URL is a natural ending.
- `_should_treat_stop_as_truncated()` logic is unchanged.
- Only `run_agent.py` is modified.

## Test cases

New file `tests/agent/test_natural_response_ending_url.py`:

| # | Input | Expected | Notes |
|---|-------|----------|-------|
| 1 | `http://host/index.html` | `True` | URL ending (the bug) |
| 2 | `https://example.com/path/to/page` | `True` | |
| 3 | `ftp://server/file.txt` | `True` | |
| 4 | `http://host:8731/path/index.html` | `True` | URL with port |
| 5 | `Check this: http://host/page` | `True` | URL at end after text |
| 6 | `Some text.` | `True` | period (existing behavior) |
| 7 | `Some text` | `False` | no punctuation (existing behavior) |
| 8 | `http://host/page and more text` | `False` | text after URL, URL not last token |
| 9 | `` (empty) | `False` | empty (existing behavior) |
| 10 | `MEDIA:/tmp/file.png` | `False` | not a URL scheme |

All 10 tests pass.

## Test plan

```
python3 -m pytest tests/agent/test_natural_response_ending_url.py -v
```

Closes #78359