### PR TITLE
A model id missing its vendor prefix says so instead of 404ing

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4242,6 +4242,28 @@ def run_conversation(
                         f"      Check which providers support tools: https://openrouter.ai/models/{_model}"
                     )
 
+                # Actionable hint for a bare 404 on a provider whose catalogue
+                # uses ``vendor/model`` ids.  A model id that lost its prefix
+                # (e.g. ``nemotron-…`` instead of ``nvidia/nemotron-…``) gets
+                # a content-free "404 page not found" from the provider that
+                # never names the model, so it reads like an outage or an auth
+                # failure.  Name the real cause and the exact id to use (#78796).
+                if getattr(api_error, "status_code", None) == 404:
+                    try:
+                        from hermes_cli.model_normalize import suggest_prefixed_model_id
+
+                        _suggestion = suggest_prefixed_model_id(_provider, _model)
+                    except Exception:
+                        _suggestion = None
+                    if _suggestion:
+                        agent._buffer_vprint(
+                            f"   💡 Model '{_model}' is not a valid id for provider {_provider} — "
+                            f"it is missing its vendor prefix."
+                        )
+                        agent._buffer_vprint(
+                            f"      Did you mean '{_suggestion}'?  Re-pick it with `hermes model`."
+                        )
+
                 # Check for interrupt before deciding to retry
                 if agent._interrupt_requested:
                     # Preserve a pending redirect (mid-stream correction): the

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -339,6 +339,32 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no endpoints found that support tool use",
 ]
 
+
+def _model_id_missing_known_prefix(model: str, provider: str) -> bool:
+    """True when a bare model id is only known to the provider as ``vendor/id``.
+
+    Some providers answer a malformed model id with a naked 404 that names
+    nothing — NVIDIA NIM returns ``404 page not found`` for a bare
+    ``nemotron-3-ultra-550b-a55b``, indistinguishable from a bad endpoint
+    path. Consulting the curated catalogue tells the two apart: if the id
+    carries no ``/`` but the catalogue has exactly one entry ending in
+    ``/<id>``, the prefix was dropped and the failure is deterministic.
+
+    Never guesses — an id absent from the catalogue (a local NIM container,
+    a proxied model) returns False so genuine endpoint problems keep their
+    retryable ``unknown`` classification.
+    """
+    name = (model or "").strip()
+    if not name or "/" in name:
+        return False
+    try:
+        from hermes_cli.model_normalize import suggest_prefixed_model_id
+
+        return bool(suggest_prefixed_model_id((provider or "").strip(), name))
+    except Exception:
+        return False
+
+
 # Malformed-message-array 400s.  Deterministic request-shape rejections that
 # describe the *transcript* being invalid, not a parameter.  The canonical
 # case: a stream dies mid-response and Hermes persists a content-less
@@ -1056,6 +1082,18 @@ def _classify_by_status(
                 should_fallback=False,
             )
         if any(p in error_msg for p in _MODEL_NOT_FOUND_PATTERNS):
+            return result_fn(
+                FailoverReason.model_not_found,
+                retryable=False,
+                should_fallback=True,
+            )
+        # A bare id that the provider's catalogue only knows in prefixed form
+        # is a malformed model id, not a routing glitch — NVIDIA NIM answers
+        # one with a naked ``404 page not found`` that names nothing, so the
+        # generic branch below burns three retries and reports what looks
+        # like an outage (#78796). Deterministic: don't retry, and let the
+        # model_not_found surface carry the real cause.
+        if _model_id_missing_known_prefix(model, provider):
             return result_fn(
                 FailoverReason.model_not_found,
                 retryable=False,

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -109,6 +109,19 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "xai",
 })
 
+# Providers whose API serves ``vendor/model`` ids but whose endpoint can also
+# front arbitrary self-hosted models, so a bare name cannot be prefixed
+# blindly. A bare id is repaired only when the curated catalogue for that
+# provider holds exactly one entry ending in ``/<name>`` — a lookup, not a
+# guess. NVIDIA NIM is the case in hand: build.nvidia.com serves
+# ``nvidia/nemotron-…`` (and third-party ``z-ai/glm-…``), while the same
+# provider id also points at local NIM containers with their own naming.
+# Without this repair a bare ``nemotron-3-ultra-550b-a55b`` reaches the API
+# and returns a bare ``404 page not found`` that never names the model (#78796).
+_CATALOGUE_PREFIX_REPAIR_PROVIDERS: frozenset[str] = frozenset({
+    "nvidia",
+})
+
 # Providers whose APIs require lowercase model IDs.  Xiaomi's
 # ``api.xiaomimimo.com`` rejects mixed-case names like ``MiMo-V2.5-Pro``
 # that users might copy from marketing docs — it only accepts
@@ -350,6 +363,63 @@ def _prepend_vendor(model_name: str) -> str:
     return model_name
 
 
+def _repair_prefix_from_catalogue(model_name: str, provider: str) -> str:
+    """Restore a dropped ``vendor/`` prefix using the provider's catalogue.
+
+    Unlike :func:`_prepend_vendor`, this never guesses from the model's name
+    shape — it only repairs a bare id that matches **exactly one** curated
+    entry for this provider modulo the prefix. That keeps self-hosted models
+    behind the same provider id (local NIM containers, proxies) untouched,
+    since they aren't in the catalogue.
+
+    Examples::
+
+        >>> _repair_prefix_from_catalogue("nemotron-3-ultra-550b-a55b", "nvidia")
+        'nvidia/nemotron-3-ultra-550b-a55b'
+        >>> _repair_prefix_from_catalogue("my-local-nim", "nvidia")
+        'my-local-nim'
+    """
+    if "/" in model_name:
+        return model_name
+    try:
+        from hermes_cli.models import _PROVIDER_MODELS
+    except Exception:
+        return model_name
+
+    catalogue = _PROVIDER_MODELS.get(provider) or []
+    # Compare against the catalogue's own suffix, tag included: a bare
+    # ``…:free`` id must resolve to the ``:free`` entry, not its paid sibling.
+    needle = model_name.strip().lower()
+    matches = {
+        entry
+        for entry in catalogue
+        if "/" in entry and entry.split("/", 1)[1].strip().lower() == needle
+    }
+    if len(matches) == 1:
+        return matches.pop()
+    return model_name
+
+
+def suggest_prefixed_model_id(provider: str, model_name: str) -> Optional[str]:
+    """Return the prefixed catalogue id for a bare *model_name*, if unambiguous.
+
+    The diagnostic counterpart to :func:`_repair_prefix_from_catalogue`: used
+    to explain a provider's content-free 404 when the configured id lost its
+    ``vendor/`` prefix. Returns ``None`` when the name already has a prefix,
+    the provider has no curated catalogue, or nothing matches — so callers can
+    stay silent rather than guess (#78796).
+    """
+    name = (model_name or "").strip()
+    if not name or "/" in name:
+        return None
+    try:
+        canonical = _normalize_provider_alias(provider)
+    except Exception:
+        return None
+    repaired = _repair_prefix_from_catalogue(name, canonical)
+    return repaired if repaired != name else None
+
+
 # ---------------------------------------------------------------------------
 # Main normalisation entry point
 # ---------------------------------------------------------------------------
@@ -491,6 +561,12 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         if provider in _LOWERCASE_MODEL_PROVIDERS:
             result = result.lower()
         return result
+
+    # --- Catalogue-backed prefix repair: restore a dropped ``vendor/`` on a
+    #     bare id that matches exactly one curated entry.  Unknown names (a
+    #     local NIM container, a proxied model) pass through untouched. ---
+    if provider in _CATALOGUE_PREFIX_REPAIR_PROVIDERS:
+        return _repair_prefix_from_catalogue(name, provider)
 
     # --- Authoritative native providers: preserve user-facing slugs as-is ---
     if provider in _AUTHORITATIVE_NATIVE_PROVIDERS:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -371,6 +371,39 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_fallback is False
 
+    def test_404_bare_model_id_missing_prefix_is_model_not_found(self):
+        """A bare id the provider only serves as ``vendor/id`` is malformed.
+
+        Regression for #78796: NVIDIA NIM answers a prefix-less
+        ``nemotron-3-ultra-550b-a55b`` with a naked ``404 page not found``.
+        Without the catalogue check this fell into the generic branch and
+        burned three retries on a deterministic failure, reporting what
+        looked like an outage.
+        """
+        e = MockAPIError("404 page not found", status_code=404)
+        result = classify_api_error(
+            e, provider="nvidia", model="nemotron-3-ultra-550b-a55b"
+        )
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+
+    def test_404_correctly_prefixed_model_stays_generic(self):
+        """A properly prefixed id hitting a 404 is a real endpoint problem —
+        it must keep the retryable generic classification."""
+        e = MockAPIError("404 page not found", status_code=404)
+        result = classify_api_error(
+            e, provider="nvidia", model="nvidia/nemotron-3-ultra-550b-a55b"
+        )
+        assert result.reason == FailoverReason.unknown
+        assert result.retryable is True
+
+    def test_404_unknown_bare_model_stays_generic(self):
+        """A local NIM container isn't in the catalogue — no verdict invented."""
+        e = MockAPIError("404 page not found", status_code=404)
+        result = classify_api_error(e, provider="nvidia", model="my-local-nim")
+        assert result.reason == FailoverReason.unknown
+        assert result.retryable is True
+
     # ── Provider policy-block (OpenRouter privacy/guardrail) ──
 
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -137,3 +137,53 @@ class TestDeepseekCanonicalAndReasonerMapping:
     def test_reasoner_keywords_map_to_v4_flash(self, model):
         assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
 
+
+# ── Regression: issue #78796 ───────────────────────────────────────────
+
+class TestIssue78796NvidiaPrefixRepair:
+    """A bare NVIDIA model id must regain its ``vendor/`` prefix.
+
+    build.nvidia.com serves ``nvidia/nemotron-…``; a bare
+    ``nemotron-3-ultra-550b-a55b`` returns a naked ``404 page not found``
+    that never names the model, so the failure reads like an outage.
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("nemotron-3-ultra-550b-a55b", "nvidia/nemotron-3-ultra-550b-a55b"),
+        ("nemotron-3-super-120b-a12b", "nvidia/nemotron-3-super-120b-a12b"),
+        (
+            "nemotron-3-nano-omni-30b-a3b-reasoning",
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+        ),
+    ])
+    def test_bare_nemotron_regains_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "nvidia") == expected
+
+    def test_third_party_model_gets_its_own_vendor(self):
+        """NIM also hosts third-party models — the prefix is the catalogue's,
+        not a hardcoded ``nvidia/``."""
+        assert normalize_model_for_provider("glm-5.2", "nvidia") == "z-ai/glm-5.2"
+
+    @pytest.mark.parametrize("model", [
+        "nvidia/nemotron-3-ultra-550b-a55b",
+        "z-ai/glm-5.2",
+    ])
+    def test_already_prefixed_is_untouched(self, model):
+        assert normalize_model_for_provider(model, "nvidia") == model
+
+    @pytest.mark.parametrize("model", [
+        "my-local-nim-container",
+        "some-finetune-v2",
+    ])
+    def test_unknown_names_pass_through(self, model):
+        """The same provider id fronts local NIM containers. An id absent from
+        the catalogue is a lookup miss, not a guess — leave it alone."""
+        assert normalize_model_for_provider(model, "nvidia") == model
+
+    def test_other_providers_unaffected(self):
+        assert normalize_model_for_provider("my-model", "custom") == "my-model"
+        assert (
+            normalize_model_for_provider("claude-sonnet-4.6", "openrouter")
+            == "anthropic/claude-sonnet-4.6"
+        )
+


### PR DESCRIPTION
A model id that lost its `vendor/` prefix now says so instead of returning a bare 404.

The reported case: NVIDIA NIM answers `nemotron-3-ultra-550b-a55b` with a content-free `404 page not found`. Nothing in that names the model, so it reads like an outage — the Discord thread it came from spent a while chasing auth before anyone looked at the id.

Root cause is narrower than it looks. `detect_vendor()` already resolves the bare name to `nvidia`, but `normalize_model_for_provider()` never asks: `nvidia` sits in none of its provider buckets, so it falls through to pass-through.

Three things, in the order the user hits them:

- **The id is repaired.** A bare name is looked up against the provider's curated catalogue and prefixed only when it matches exactly one entry. This is a lookup, not a guess from name shape — the same provider id fronts local NIM containers, and anything absent from the catalogue passes through untouched. It also picks up the right vendor for NIM's third-party models (`glm-5.2` → `z-ai/glm-5.2`), not a hardcoded `nvidia/`.
- **The 404 stops being retryable.** A catalogue-confirmed missing prefix is deterministic, so it classifies as `model_not_found` rather than burning three retries on a `retryable=True` unknown. Genuine endpoint 404s (misconfigured llama.cpp / Ollama / vLLM URLs) are untouched — they don't match the catalogue, so they keep the existing classification.
- **The trace names the id.** `Model 'nemotron-3-ultra-550b-a55b' is not a valid id for provider nvidia … Did you mean 'nvidia/nemotron-3-ultra-550b-a55b'?` Buffered like the neighbouring OpenRouter tool-support hint, so it only surfaces if retries and fallback are exhausted.

Not NVIDIA-specific by construction: `_CATALOGUE_PREFIX_REPAIR_PROVIDERS` takes any provider whose catalogue is `vendor/model` and whose endpoint can also front self-hosted models.

Fixes #78796

## Testing

`tests/hermes_cli/test_model_normalize.py` + `tests/agent/test_error_classifier.py` — bare nemotron ids regain the prefix, third-party models get their own vendor, already-prefixed and unknown ids are untouched, other providers unaffected, and the 404 classification flips only on a catalogue hit.

Five of them fail on `main` and pass here. 230 passed across the model-normalize, error-classifier, model-switch and per-provider suites; ruff clean.