### PR TITLE
fix(curator): protect cron skills referenced by absolute path

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2604,6 +2604,33 @@ def save_job_output(job_id: str, output: str):
 # Skill reference rewriting (curator integration)
 # =============================================================================
 
+def _canonical_skill_ref(raw: Any) -> str:
+    """Reduce one job skill reference to the bare name the curator matches on.
+
+    A job may store an absolute path under ``HERMES_HOME/skills`` or an
+    external skills dir; the scheduler resolves those through
+    ``normalize_skill_lookup_name`` before handing them to ``skill_view``.
+    The curator compares this set against bare skill names, so it has to
+    resolve them the same way — otherwise a path-referencing job's skill
+    looks unreferenced and gets archived out from under it.
+
+    Best-effort: if the resolver is unavailable or rejects the value, fall
+    back to the plain cleanup so a broken import can never lose a name.
+    """
+    value = str(raw or "").strip()
+    if not value:
+        return ""
+    try:
+        from agent.skill_utils import normalize_skill_lookup_name
+        value = normalize_skill_lookup_name(value) or value
+    except Exception:
+        logger.debug(
+            "referenced_skill_names: could not normalize skill ref %r", raw,
+            exc_info=True,
+        )
+    return value.strip().lstrip("/")
+
+
 def referenced_skill_names() -> Set[str]:
     """Return the set of skill names referenced by ANY cron job.
 
@@ -2612,6 +2639,9 @@ def referenced_skill_names() -> Set[str]:
     resuming it must still find its skills present. The curator uses this
     set to protect referenced skills from inactivity archival — a skill a
     live job depends on is "in use" regardless of when it was last loaded.
+
+    Names are canonicalized the way the scheduler resolves them at load
+    time, so a job that stores an absolute skill path is protected too.
 
     Best-effort: a corrupt/unreadable jobs store returns an empty set
     rather than raising, so a cron issue can never break the curator.
@@ -2627,7 +2657,7 @@ def referenced_skill_names() -> Set[str]:
         if not isinstance(job, dict):
             continue
         for name in _normalize_skill_list(job.get("skill"), job.get("skills")):
-            cleaned = str(name).strip().lstrip("/")
+            cleaned = _canonical_skill_ref(name)
             if cleaned:
                 names.add(cleaned)
     return names

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -191,6 +191,111 @@ def test_candidate_list_marks_cron_referenced_skills(curator_env, monkeypatch):
     assert "cron=no" in plain_line
 
 
+def _write_cron_job(home: Path, skill_ref: str, monkeypatch):
+    """Write a real jobs.json referencing *skill_ref* and reload ``cron.jobs``.
+
+    Deliberately does NOT stub ``_cron_referenced_skills`` — these cases
+    exercise the real protection lookup end to end. ``SKILLS_DIR`` is pinned
+    because the path resolver reads it at call time to decide which roots are
+    trusted (the same attribute the repo's other skill tests patch).
+    """
+    import importlib
+    import json
+
+    import tools.skills_tool as skills_tool
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", home / "skills")
+
+    cron_dir = home / "cron"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps([{
+            "id": "job1",
+            "name": "quarterly digest",
+            "enabled": True,
+            "prompt": "write the digest",
+            "skills": [skill_ref],
+            "schedule": {"kind": "cron", "expr": "0 9 1 */3 *"},
+        }]),
+        encoding="utf-8",
+    )
+    import cron.jobs as cron_jobs
+    importlib.reload(cron_jobs)
+    return cron_jobs
+
+
+def test_cron_referenced_skill_by_name_survives_inactivity(curator_env, monkeypatch):
+    """Control: the plain-name reference form has always been protected."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "quarterly-report")
+    _backdate(u, "quarterly-report", 200)
+    _write_cron_job(curator_env["home"], "quarterly-report", monkeypatch)
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts["archived"] == 0
+    assert u.load_usage()["quarterly-report"]["state"] == u.STATE_ACTIVE
+
+
+def test_cron_referenced_skill_by_absolute_path_survives_inactivity(curator_env, monkeypatch):
+    """A job may store an absolute skill path — the scheduler resolves it
+    before ``skill_view``. The protection set has to resolve it the same way,
+    or the skill is archived out from under a live job and the next run
+    silently proceeds without its instructions.
+    """
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "quarterly-report")
+    _backdate(u, "quarterly-report", 200)
+    _write_cron_job(curator_env["home"], str(skills_dir / "quarterly-report"), monkeypatch)
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts["archived"] == 0
+    assert u.load_usage()["quarterly-report"]["state"] == u.STATE_ACTIVE
+
+
+def test_referenced_names_canonicalize_absolute_paths(curator_env, monkeypatch):
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "quarterly-report")
+    cron_jobs = _write_cron_job(
+        curator_env["home"], str(skills_dir / "quarterly-report"), monkeypatch
+    )
+
+    assert cron_jobs.referenced_skill_names() == {"quarterly-report"}
+
+
+def test_unresolvable_reference_is_kept_verbatim(curator_env, tmp_path, monkeypatch):
+    """A path outside the skills roots can't be canonicalized; keep it rather
+    than dropping the name (the resolver passes such values through)."""
+    outside = tmp_path / "elsewhere" / "some-skill"
+    cron_jobs = _write_cron_job(curator_env["home"], str(outside), monkeypatch)
+
+    assert cron_jobs.referenced_skill_names() == {
+        str(outside).strip().lstrip("/")
+    }
+
+
+def test_unreferenced_skill_is_still_archived(curator_env, monkeypatch):
+    """Guard against over-protecting: a skill no job mentions still ages out."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "quarterly-report")
+    _write_skill(skills_dir, "orphan")
+    _backdate(u, "quarterly-report", 200)
+    _backdate(u, "orphan", 200)
+    _write_cron_job(curator_env["home"], str(skills_dir / "quarterly-report"), monkeypatch)
+
+    c.apply_automatic_transitions()
+
+    usage = u.load_usage()
+    assert usage["quarterly-report"]["state"] == u.STATE_ACTIVE
+    assert usage["orphan"]["state"] == u.STATE_ARCHIVED
+
+
 
 
 


### PR DESCRIPTION
## What

Two commits, nine days apart, that never met.

4c2961c51 (2026-06-28, fix(curator): never archive cron-referenced skills + floor use=0 pruning, #54443) added `cron.jobs.referenced_skill_names()` and taught the curator to skip those skills, because:

> A skill loaded only by a cron job had its usage bumped solely when the job fired, so paused jobs, infrequent (quarterly/annual) schedules, and far-future one-shots aged their skills out from under them — the next run then failed to load the now-archived skill.

62972060c (2026-07-07, fix(cron): normalize absolute skill paths before skill_view, #59824) then established that a job's `skills` entry can be an **absolute path**:

> Cron jobs may store absolute paths to skills under HERMES_HOME/skills or external_dirs, but skill_view rejects absolute names for security. Extract the slash-command normalization into agent.skill_utils and reuse it when cron loads job skills.

The scheduler now resolves those paths through `normalize_skill_lookup_name` before `skill_view` (`cron/scheduler.py`), but `referenced_skill_names()` still returns the raw string with only `.strip().lstrip("/")`. The curator compares that set against bare skill names from `curated_report()`, so a path never matches — and the protection from 4c2961c51 silently stopped covering the exact job shape 62972060c made legitimate.

Same job, same skill, same schedule, only the reference form differs. Real curator, real cron store, real `.usage.json` backdated 200 days:

```
=== job references the skill by name ===
  job stores        : 'quarterly-report'
  protection set    : ['quarterly-report']
  scheduler resolves: 'quarterly-report'
  curator sees name : ['quarterly-report']
  protected?        : True
  -> archived=0  final state='active'

=== job references the skill by absolute path ===
  job stores        : 'C:\...\skills\quarterly-report'
  protection set    : ['C:\...\skills\quarterly-report']
  scheduler resolves: 'quarterly-report'
  curator sees name : ['quarterly-report']
  protected?        : False
  -> archived=1  final state='archived'
```

The failure is quiet at both ends. The curator reports a routine inactivity archive, and at the next fire the scheduler behaves exactly as `rewrite_skill_refs`' docstring describes for a missing skill — logs a warning, skips it, and *runs the job without the instructions it was scheduled to follow*. A quarterly job can sit broken for a quarter before anyone notices.

The existing coverage could not catch this: `test_candidate_list_marks_cron_referenced_skills` monkeypatches `_cron_referenced_skills` with a literal set, so the real lookup never runs in tests.

## The fix

Canonicalize each reference the way the scheduler already resolves it, in the one place that produces the set:

```python
value = normalize_skill_lookup_name(value) or value
```

behind a `_canonical_skill_ref()` helper with a deferred import (`cron/jobs.py` has no module-level `agent.*` imports) and a verbatim fallback, so a resolver failure degrades to today's behaviour rather than dropping a name — `referenced_skill_names()` documents itself as best-effort precisely because a cron problem must never break the curator.

`referenced_skill_names()` has exactly one caller — `agent/curator.py:298`, the protection lookup — so nothing else observes the change. Names that are already bare pass through untouched, and a path outside the trusted skills roots is kept verbatim (that is what the resolver returns for it).

## Tests

Added to `tests/agent/test_curator.py`, driving the real `cron.jobs` lookup against a real `jobs.json` instead of stubbing `_cron_referenced_skills`:

- a job referencing the skill by absolute path leaves it `active` after `apply_automatic_transitions()`
- the by-name form still protects it (control — green on both sides)
- `referenced_skill_names()` canonicalizes an absolute path to the bare name
- a path outside the skills roots is kept verbatim rather than dropped
- a skill no job mentions is still archived — a guard against over-protecting

The helper pins `tools.skills_tool.SKILLS_DIR`, the attribute the resolver reads at call time to decide which roots are trusted and the same one the repo's other skill tests patch, so the cases don't depend on test order.

Results:

```
28 passed
```

That is the whole `tests/agent/test_curator.py` file; the 23 pre-existing tests are unchanged.

Red without the source change (tests kept, `cron/jobs.py` reverted):

```
FAILED test_cron_referenced_skill_by_absolute_path_survives_inactivity
E   assert 1 == 0                       # the skill was archived under a live job
FAILED test_referenced_names_canonicalize_absolute_paths
E   assert {'C:\\...\\quarterly-report'} == {'quarterly-report'}
FAILED test_unreferenced_skill_is_still_archived
E   assert 'archived' == 'active'
3 failed, 25 passed
```

The two that stay green on both sides are the control and the pass-through guard, which is what they are for.

Regression run over 69 test files (curator, skill usage/utils/tools, and the cron suites), against the same files on main:

```
main:      25 failed, 820 passed, 31 skipped   (22 pre-existing, plus the 3 new tests failing as above)
with fix:  22 failed, 823 passed, 31 skipped
```

Set difference is empty — no new failures. The 22 are identical before and after and sit in unrelated areas (POSIX file-mode assertions, symlink resolution, tilde expansion). `scripts/check-windows-footguns.py` passes on both changed files.