### PR TITLE
fix(memory): count holographic retrievals on the agent tool path

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -268,6 +268,14 @@ class HolographicMemoryProvider(MemoryProvider):
 
     # -- Tool handlers -------------------------------------------------------
 
+    def _bump_retrieval(self, results: list[dict]) -> None:
+        """Count retrieved facts so the memory janitor sees actual usage."""
+        if not results or self._store is None:
+            return
+        self._store.bump_retrieval(
+            [r["fact_id"] for r in results if r.get("fact_id") is not None]
+        )
+
     def _handle_fact_store(self, args: dict) -> str:
         try:
             action = args["action"]
@@ -289,6 +297,7 @@ class HolographicMemoryProvider(MemoryProvider):
                     min_trust=float(args.get("min_trust", self._min_trust)),
                     limit=int(args.get("limit", 10)),
                 )
+                self._bump_retrieval(results)
                 return json.dumps({"results": results, "count": len(results)})
 
             elif action == "probe":
@@ -297,6 +306,7 @@ class HolographicMemoryProvider(MemoryProvider):
                     category=args.get("category"),
                     limit=int(args.get("limit", 10)),
                 )
+                self._bump_retrieval(results)
                 return json.dumps({"results": results, "count": len(results)})
 
             elif action == "related":
@@ -305,6 +315,7 @@ class HolographicMemoryProvider(MemoryProvider):
                     category=args.get("category"),
                     limit=int(args.get("limit", 10)),
                 )
+                self._bump_retrieval(results)
                 return json.dumps({"results": results, "count": len(results)})
 
             elif action == "reason":

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -208,15 +208,28 @@ class HolographicMemoryProvider(MemoryProvider):
     # Tool handlers (self, args) -> str. KeyError from args[...] / Exception -> tool_error in handle_tool_call;
     # argument coercion order (and therefore which error surfaces first) mirrors the underlying call order.
 
+    def _bump_retrieval(self, results: list[dict]) -> None:
+        """Count retrieved facts so the memory janitor sees actual usage."""
+        if not results or self._store is None:
+            return
+        self._store.bump_retrieval(
+            [r["fact_id"] for r in results if r.get("fact_id") is not None]
+        )
+
+    def _wrap_retrieval(self, results: list[dict]) -> str:
+        """Wrap retriever output, counting the hits so the memory janitor sees actual usage."""
+        self._bump_retrieval(results)
+        return _results(results)
+
     def _entity_query(self, method: str, a: dict) -> str:
         """'probe' / 'related': single-entity retriever queries."""
-        return _results(getattr(self._retriever, method)(a["entity"], category=a.get("category"), limit=_limit(a)))
+        return self._wrap_retrieval(getattr(self._retriever, method)(a["entity"], category=a.get("category"), limit=_limit(a)))
 
     _TOOL_HANDLERS = {
         "fact_store": _tool_handler({
             "add": lambda self, a: json.dumps({"fact_id": self._store.add_fact(
                 a["content"], category=a.get("category", "general"), tags=a.get("tags", "")), "status": "added"}),
-            "search": lambda self, a: _results(self._retriever.search(
+            "search": lambda self, a: self._wrap_retrieval(self._retriever.search(
                 a["query"], category=a.get("category"), min_trust=float(a.get("min_trust", self._min_trust)), limit=_limit(a))),
             "probe": lambda self, a: self._entity_query("probe", a),
             "related": lambda self, a: self._entity_query("related", a),

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -288,6 +288,23 @@ class MemoryStore:
 
             return results
 
+    def bump_retrieval(self, fact_ids: list[int]) -> None:
+        """Increment ``retrieval_count`` for the given facts.
+
+        Used by the agent tool path (search/probe/related), which retrieves
+        through ``FactRetriever`` rather than ``search_facts``.
+        """
+        if not fact_ids:
+            return
+        with self._lock:
+            placeholders = ", ".join("?" * len(fact_ids))
+            self._conn.execute(
+                f"UPDATE facts SET retrieval_count = retrieval_count + 1 "
+                f"WHERE fact_id IN ({placeholders})",
+                fact_ids,
+            )
+            self._conn.commit()
+
     def update_fact(
         self,
         fact_id: int,

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -188,6 +188,22 @@ class MemoryStore:
             self._rebuild_bank(row["category"])
             return True
 
+    def bump_retrieval(self, fact_ids: list[int]) -> None:
+        """Increment ``retrieval_count`` for the given facts.
+        Used by the agent tool path (search/probe/related), which retrieves
+        through ``FactRetriever`` rather than ``search_facts``.
+        """
+        if not fact_ids:
+            return
+        with self._lock:
+            placeholders = ", ".join("?" * len(fact_ids))
+            self._conn.execute(
+                f"UPDATE facts SET retrieval_count = retrieval_count + 1 "
+                f"WHERE fact_id IN ({placeholders})",
+                fact_ids,
+            )
+            self._conn.commit()
+
     def list_facts(self, category: str | None = None, min_trust: float = 0.0, limit: int = 50) -> list[dict]:
         """Browse facts ordered by trust_score descending, optionally filtered by category / min trust."""
         with self._lock:

--- a/tests/plugins/memory/test_holographic_retrieval_count.py
+++ b/tests/plugins/memory/test_holographic_retrieval_count.py
@@ -1,0 +1,91 @@
+"""Tests for retrieval_count increments on the agent tool path.
+
+The agent reads facts through the fact_store tool (search / probe / related),
+which routes through FactRetriever — not through store.search_facts(), the
+only path that used to bump retrieval_count. The memory janitor's staleness
+check ("facts with retrieval_count=0 older than 30 days are stale") therefore
+flagged every fact as never retrieved even when the agent actually used them.
+The tool path must count retrievals too (#78801).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("numpy")
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+@pytest.fixture
+def provider(tmp_path):
+    db_path = tmp_path / "memory.db"
+    provider = HolographicMemoryProvider(config={"db_path": str(db_path)})
+    provider.initialize(session_id="test-session")
+    return provider
+
+
+def _retrieval_count(provider, fact_id: int) -> int:
+    row = provider._store._conn.execute(
+        "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+    ).fetchone()
+    assert row is not None, f"fact {fact_id} not found"
+    return row[0]
+
+
+def _seed_fact(provider, content: str) -> int:
+    out = json.loads(
+        provider.handle_tool_call("fact_store", {"action": "add", "content": content})
+    )
+    return out["fact_id"]
+
+
+def _run(provider, action: str, **extra) -> dict:
+    args = {"action": action, **extra}
+    return json.loads(provider.handle_tool_call("fact_store", args))
+
+
+def test_search_increments_retrieval_count(provider):
+    fid = _seed_fact(provider, "Alice likes oolong tea with jasmine")
+    assert _retrieval_count(provider, fid) == 0
+
+    out = _run(provider, "search", query="oolong tea")
+
+    assert out["count"] >= 1
+    returned_ids = {f["fact_id"] for f in out["results"]}
+    assert fid in returned_ids
+    assert _retrieval_count(provider, fid) == 1
+
+
+def test_probe_increments_retrieval_count(provider):
+    fid = _seed_fact(provider, "Alice prefers oolong tea")
+    assert _retrieval_count(provider, fid) == 0
+
+    out = _run(provider, "probe", entity="alice")
+
+    assert out["count"] >= 1
+    returned_ids = {f["fact_id"] for f in out["results"]}
+    assert fid in returned_ids
+    assert _retrieval_count(provider, fid) == 1
+
+
+def test_related_increments_retrieval_count(provider):
+    fid = _seed_fact(provider, "Alice works on the deployment rollback")
+    assert _retrieval_count(provider, fid) == 0
+
+    out = _run(provider, "related", entity="alice")
+
+    assert out["count"] >= 1
+    returned_ids = {f["fact_id"] for f in out["results"]}
+    assert fid in returned_ids
+    assert _retrieval_count(provider, fid) == 1
+
+
+def test_non_retrieval_actions_do_not_bump(provider):
+    fid = _seed_fact(provider, "Bob prefers coffee")
+    assert _retrieval_count(provider, fid) == 0
+
+    # add / reason / feedback must not touch retrieval_count
+    _run(provider, "reason", entities=["bob"])
+    assert _retrieval_count(provider, fid) == 0


### PR DESCRIPTION
Fixes #78801

## Summary

`retrieval_count` never increments when facts are retrieved through the agent-facing tool path. The agent reads facts via `fact_store(action=search|probe|related)`, which routes through `FactRetriever` — not through `store.search_facts()`, the only path that bumps `retrieval_count`. Every fact in every deployment therefore stays at `retrieval_count = 0`, and the memory janitor's staleness check ("facts with retrieval_count=0 older than 30 days are stale") flags actively used facts as never retrieved.

## Changes

- `plugins/memory/holographic/store.py`: new `MemoryStore.bump_retrieval(fact_ids)` — the same `UPDATE facts SET retrieval_count = retrieval_count + 1` used by `search_facts()`, factored out so the tool path can reuse it.
- `plugins/memory/holographic/__init__.py`: `_handle_fact_store` now bumps `retrieval_count` for every fact returned by `search`, `probe`, and `related` (collects `fact_id` from the results, tolerates results without one). `add`, `reason`, and `fact_feedback` are untouched.
- `tests/plugins/memory/test_holographic_retrieval_count.py`: regression coverage exercising the public tool path —
  - `search`, `probe`, and `related` each increment `retrieval_count` for the facts they return;
  - `reason` does not touch `retrieval_count` (non-retrieval guard).

## Testing

- New regression tests fail on `main` (`assert 0 == 1` for all three actions) and pass with the fix.
- `pytest tests/plugins/memory/test_holographic_retrieval.py tests/plugins/memory/test_holographic_store.py tests/plugins/memory/test_holographic_auto_extract.py tests/plugins/memory/test_holographic_shutdown_closes_db.py tests/plugins/memory/test_holographic_retrieval_count.py` — 44 passed.
- `pytest tests/plugins/memory/` — 283 passed; the 6 failures in `test_hindsight_provider.py` are pre-existing on `main` with this shared venv (`ModuleNotFoundError: No module named 'hindsight_client_api'` — optional dependency of a different plugin), unrelated to this change.
- `git diff --check` — clean.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
