### PR TITLE
fix(sync): keep shared sessions live across clients

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -101,6 +101,10 @@ COMPACTION_STATUS = (
 COMPACTION_DONE_STATUS = "✓ Context compaction complete — continuing turn..."
 
 
+class _CompressionLeaseRebindError(RuntimeError):
+    """The active turn could not extend its lease to a rotation child."""
+
+
 def _emit_compaction_done(agent: Any) -> None:
     """Emit the structured terminal edge for a started compaction."""
     status_callback = getattr(agent, "status_callback", None)
@@ -3255,6 +3259,26 @@ def compress_context(
                         f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_"
                         f"{uuid.uuid4().hex[:6]}"
                     )
+                    # A leased turn must own the child id before the atomic
+                    # parent→child publication makes that continuation routable.
+                    # Otherwise another process can enter the child while this
+                    # turn is still finishing on it.
+                    _turn_lease_rebind = getattr(
+                        agent, "_durable_turn_lease_rebind", None
+                    )
+                    if callable(_turn_lease_rebind):
+                        try:
+                            _child_leased = bool(_turn_lease_rebind(new_session_id))
+                        except Exception as _lease_exc:
+                            raise _CompressionLeaseRebindError(
+                                "failed to bind the active turn lease to compression "
+                                f"child {new_session_id!r}"
+                            ) from _lease_exc
+                        if not _child_leased:
+                            raise _CompressionLeaseRebindError(
+                                "active turn lease rejected compression child "
+                                f"{new_session_id!r}"
+                            )
                     agent._session_db.publish_compression_child(
                         parent_session_id=old_session_id,
                         child_session_id=new_session_id,
@@ -3346,6 +3370,8 @@ def compress_context(
                     )
                 else:
                     logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
+                if isinstance(e, _CompressionLeaseRebindError):
+                    raise
 
         # Compaction-boundary bookkeeping, computed once. `old_session_id` is only
         # bound in the rotation branch; in-place leaves it unset. `_boundary_parent`

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -1,5 +1,8 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
+import { $sessionsChangeTick, notifySessionsChanged, setChangeEventsAvailable } from '@/store/live-sync'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -8,7 +11,7 @@ import {
   SESSION_WATCHDOG_TIMEOUT_MS
 } from '@/store/session-states'
 
-import { rehydrateLiveSessionStatuses } from './use-background-sync'
+import { reconcileActiveTranscript, rehydrateLiveSessionStatuses, useBackgroundSync } from './use-background-sync'
 
 describe('rehydrateLiveSessionStatuses', () => {
   beforeEach(() => {
@@ -16,8 +19,11 @@ describe('rehydrateLiveSessionStatuses', () => {
   })
 
   afterEach(() => {
+    cleanup()
     vi.clearAllTimers()
     vi.useRealTimers()
+    setChangeEventsAvailable(false)
+    $sessionsChangeTick.set(0)
     clearAllSessionStates()
   })
 
@@ -71,5 +77,90 @@ describe('rehydrateLiveSessionStatuses', () => {
     expect($workingSessionIds.get()).toEqual([])
     expect($attentionSessionIds.get()).toEqual([])
     expect($stalledSessionIds.get()).toEqual([])
+  })
+})
+
+describe('active stored transcript sync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setChangeEventsAvailable(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    setChangeEventsAvailable(false)
+    $sessionsChangeTick.set(0)
+  })
+
+  it('coalesces sessions.changed and refreshes an open desktop-source transcript', async () => {
+    const refreshActiveTranscript = vi.fn()
+
+    renderHook(() =>
+      useBackgroundSync({
+        activeGatewayProfile: 'default',
+        activeIsMessaging: false,
+        activeSessionId: 'runtime-desktop',
+        freshDraftReady: false,
+        gatewayState: 'open',
+        refreshActiveTranscript,
+        refreshCronJobs: vi.fn(),
+        refreshCurrentModel: vi.fn(),
+        refreshHermesConfig: vi.fn(),
+        refreshMessagingSessions: vi.fn(),
+        refreshSessions: vi.fn(),
+        requestGateway: vi.fn(async () => ({ sessions: [] })) as never
+      })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+    refreshActiveTranscript.mockClear()
+
+    act(() => {
+      notifySessionsChanged()
+      notifySessionsChanged()
+      notifySessionsChanged()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(249)
+    })
+    expect(refreshActiveTranscript).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(refreshActiveTranscript).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes the persisted external user row while preserving a live assistant tail', () => {
+    const history: ChatMessage[] = [
+      { id: 'stored-user-1', parts: [{ text: 'old prompt', type: 'text' }], role: 'user' },
+      { id: 'stored-assistant-1', parts: [{ text: 'old reply', type: 'text' }], role: 'assistant' }
+    ]
+
+    const stored = [
+      ...history,
+      { id: 'stored-iphone-user', parts: [{ text: 'sent from iPhone', type: 'text' }], role: 'user' }
+    ] satisfies ChatMessage[]
+
+    const current = [
+      ...history,
+      { id: 'optimistic-user', parts: [{ text: 'sent from iPhone', type: 'text' }], role: 'user' },
+      {
+        id: 'assistant-stream-1',
+        parts: [{ text: 'working', type: 'text' }],
+        pending: true,
+        role: 'assistant'
+      }
+    ] satisfies ChatMessage[]
+
+    const reconciled = reconcileActiveTranscript(stored, current)
+
+    expect(reconciled.filter(message => chatMessageText(message) === 'sent from iPhone')).toHaveLength(1)
+    expect(reconciled.at(-1)).toMatchObject({ id: 'assistant-stream-1', pending: true })
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -1,7 +1,9 @@
 import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
+import { type ChatMessage, preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { mergeInFlightMessages } from '@/lib/inflight-turn-journal'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
 import { refreshActiveProfile } from '@/store/profile'
@@ -25,7 +27,7 @@ const CRON_POLL_INTERVAL_MS = 30_000
 const CRON_BACKSTOP_INTERVAL_MS = 5 * 60_000
 const MESSAGING_POLL_INTERVAL_MS = 10_000
 const ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS = 5_000
-const ACTIVE_MESSAGING_SESSION_BACKSTOP_INTERVAL_MS = 30_000
+const ACTIVE_TRANSCRIPT_CHANGE_DEBOUNCE_MS = 250
 // Match the TUI's live-session refresh cadence. Auto-compression can rotate a
 // stored session id while its turn keeps running; until the next snapshot the
 // sidebar row points at the new id while the renderer still knows the old one.
@@ -171,13 +173,52 @@ interface BackgroundSyncParams {
   activeSessionId: null | string
   freshDraftReady: boolean
   gatewayState: string
-  refreshActiveMessagingTranscript: () => Promise<unknown> | unknown
+  refreshActiveTranscript: () => Promise<unknown> | unknown
   refreshCronJobs: () => Promise<unknown> | unknown
   refreshCurrentModel: (force?: boolean) => Promise<unknown> | unknown
   refreshHermesConfig: () => Promise<unknown> | unknown
   refreshMessagingSessions: () => Promise<unknown> | unknown
   refreshSessions: () => Promise<unknown> | unknown
   requestGateway: GatewayRequester
+}
+
+/** Reconcile a stored transcript refresh with the renderer's current tail.
+ * The backend rows are authoritative, while a not-yet-persisted assistant
+ * tail (including tool progress) stays visible until the stored transcript
+ * catches up. Equivalent optimistic user rows collapse onto the durable row. */
+export function reconcileActiveTranscript(
+  storedMessages: ChatMessage[],
+  currentMessages: ChatMessage[]
+): ChatMessage[] {
+  const withLocalErrors = preserveLocalAssistantErrors(storedMessages, currentMessages)
+
+  const liveAssistantIndex = currentMessages.findLastIndex(
+    message =>
+      message.role === 'assistant' &&
+      (message.pending || message.id.startsWith('assistant-stream-') || message.id.startsWith('inflight-assistant-'))
+  )
+
+  if (liveAssistantIndex < 0) {
+    return withLocalErrors
+  }
+
+  let tailStart = liveAssistantIndex
+
+  for (let index = liveAssistantIndex - 1; index >= 0; index -= 1) {
+    if (currentMessages[index].role !== 'user') {
+      continue
+    }
+
+    tailStart = index
+
+    while (tailStart > 0 && currentMessages[tailStart - 1].role === 'user') {
+      tailStart -= 1
+    }
+
+    break
+  }
+
+  return mergeInFlightMessages(withLocalErrors, currentMessages.slice(tailStart), { keepPending: true }).messages
 }
 
 /** Poll a callback while the tab is visible, on `intervalMs`; re-checks on tab
@@ -220,7 +261,7 @@ export function useBackgroundSync({
   activeSessionId,
   freshDraftReady,
   gatewayState,
-  refreshActiveMessagingTranscript,
+  refreshActiveTranscript,
   refreshCronJobs,
   refreshCurrentModel,
   refreshHermesConfig,
@@ -366,24 +407,39 @@ export function useBackgroundSync({
     )
   }, [changeEventsAvailable, cronChangeTick, gatewayState, refreshCronJobs])
 
-  // Only the open messaging transcript needs its own cadence — local chats are
-  // live over the websocket already. sessions.changed re-pulls it via the tick
-  // dep; the visible poll is the backstop.
+  // Another Hermes surface can write the active stored transcript without
+  // sharing this websocket. Coalesce sessions.changed bursts, then re-pull the
+  // open transcript regardless of source. Older backends do not advertise
+  // change events, so only messaging keeps the legacy visible poll there.
   useEffect(() => {
-    if (gatewayState !== 'open' || !activeIsMessaging) {
+    if (gatewayState !== 'open' || !activeSessionId) {
       return
     }
 
-    const dispose = visiblePoll(
-      changeEventsAvailable ? ACTIVE_MESSAGING_SESSION_BACKSTOP_INTERVAL_MS : ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS,
-      () => void refreshActiveMessagingTranscript()
-    )
+    if (changeEventsAvailable) {
+      const timer = window.setTimeout(() => void refreshActiveTranscript(), ACTIVE_TRANSCRIPT_CHANGE_DEBOUNCE_MS)
 
-    void refreshActiveMessagingTranscript()
+      return () => window.clearTimeout(timer)
+    }
+
+    if (!activeIsMessaging) {
+      return
+    }
+
+    const dispose = visiblePoll(ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS, () => void refreshActiveTranscript())
+
+    void refreshActiveTranscript()
 
     return dispose
-    // sessionsChangeTick: an inbound turn re-pulls the open transcript.
-  }, [activeIsMessaging, changeEventsAvailable, gatewayState, refreshActiveMessagingTranscript, sessionsChangeTick])
+    // sessionsChangeTick: an external turn re-pulls the open transcript.
+  }, [
+    activeIsMessaging,
+    activeSessionId,
+    changeEventsAvailable,
+    gatewayState,
+    refreshActiveTranscript,
+    sessionsChangeTick
+  ])
 
   // Messaging session lists against an older backend: no sessions.changed, so
   // keep the legacy visible poll. (Event-capable backends fold this into the

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -115,7 +115,7 @@ import { TitlebarControls } from '../shell/titlebar-controls'
 import { UpdatesOverlay } from '../updates-overlay'
 
 import { ContribWiringContext } from './context'
-import { useBackgroundSync } from './hooks/use-background-sync'
+import { reconcileActiveTranscript, useBackgroundSync } from './hooks/use-background-sync'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
@@ -151,7 +151,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // context (the sticky toast). The shell owns `navigate`, so it consumes the
   // intent counter here; the ref skips the initial mount value.
   const billingSettingsSeenRef = useRef(0)
-  const messagingTranscriptSignatureRef = useRef(new Map<string, string>())
+  const activeTranscriptSignatureRef = useRef(new Map<string, string>())
   // Stable identity for the whole callback surface (see WiringActions). Mutated
   // in place each render so memoized surfaces never re-render on churn.
   const actionsRef = useRef<WiringActions | null>(null)
@@ -356,10 +356,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
   )
 
-  // Refresh the open messaging transcript (inbound platform turns arrive via
-  // the background gateway, not the desktop websocket). Signature-gated so a
-  // no-change poll doesn't churn the thread.
-  const refreshActiveMessagingTranscript = useCallback(async () => {
+  // Refresh the open stored transcript when another Hermes surface writes it.
+  // Signature-gated so repeated change broadcasts do not churn the thread.
+  const refreshActiveTranscript = useCallback(async () => {
     const storedSessionId = selectedStoredSessionIdRef.current
     const runtimeSessionId = activeSessionIdRef.current
 
@@ -367,9 +366,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       return
     }
 
-    const stored = $messagingSessions.get().find(s => sessionMatchesStoredId(s, storedSessionId))
+    const stored = [...$sessions.get(), ...$messagingSessions.get()].find(s =>
+      sessionMatchesStoredId(s, storedSessionId)
+    )
 
-    if (!stored || !isMessagingSource(stored.source)) {
+    if (!stored) {
       return
     }
 
@@ -378,16 +379,16 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
       const sig = sessionMessagesSignature(latest.messages)
 
-      if (messagingTranscriptSignatureRef.current.get(signatureKey) === sig) {
+      if (activeTranscriptSignatureRef.current.get(signatureKey) === sig) {
         return
       }
 
-      messagingTranscriptSignatureRef.current.set(signatureKey, sig)
+      activeTranscriptSignatureRef.current.set(signatureKey, sig)
       const messages = toChatMessages(latest.messages)
 
       updateSessionState(
         runtimeSessionId,
-        state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
+        state => ({ ...state, messages: reconcileActiveTranscript(messages, state.messages) }),
         storedSessionId
       )
     } catch {
@@ -758,7 +759,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeSessionId,
     freshDraftReady,
     gatewayState,
-    refreshActiveMessagingTranscript,
+    refreshActiveTranscript,
     refreshCronJobs,
     refreshCurrentModel,
     refreshHermesConfig,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -94,6 +94,11 @@ from gateway.platforms.base import (
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
+from gateway.turn_lease import (
+    DurableTurnLease,
+    TurnLeaseCancelledError,
+    TurnLeaseTimeoutError,
+)
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -3582,19 +3587,27 @@ class APIServerAdapter(BasePlatformAdapter):
             if selection_error:
                 return web.json_response(_openai_error(selection_error), status=400)
         history = await self._conversation_history_for_session(session_id)
-        result, usage = await self._run_agent(
-            user_message=user_message,
-            conversation_history=history,
-            ephemeral_system_prompt=system_prompt,
-            session_id=session_id,
-            gateway_session_key=gateway_session_key,
-            route=route,
-            session_model=session_model,
-            requested_runtime=runtime_request.get("requested") or {},
-            route_source=runtime_request.get("route_source") or "global",
-            confirmed_runtime_lock=lock_active,
-            **agent_overrides,
-        )
+        try:
+            result, usage = await self._run_agent(
+                user_message=user_message,
+                conversation_history=history,
+                ephemeral_system_prompt=system_prompt,
+                session_id=session_id,
+                gateway_session_key=gateway_session_key,
+                route=route,
+                session_model=session_model,
+                requested_runtime=runtime_request.get("requested") or {},
+                route_source=runtime_request.get("route_source") or "global",
+                confirmed_runtime_lock=lock_active,
+                refresh_session_history=True,
+                **agent_overrides,
+            )
+        except TurnLeaseTimeoutError as exc:
+            return web.json_response(
+                _openai_error(str(exc), err_type="server_error", code="session_busy"),
+                status=503,
+                headers={"Retry-After": "30"},
+            )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
@@ -3758,6 +3771,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     requested_runtime=runtime_request.get("requested") or {},
                     route_source=runtime_request.get("route_source") or "global",
                     confirmed_runtime_lock=lock_active,
+                    refresh_session_history=True,
                     **agent_overrides,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -3796,6 +3810,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "messages": turn_messages,
                     "usage": usage,
                     "runtime": effective_runtime,
+                }))
+            except TurnLeaseTimeoutError as exc:
+                await queue.put(_event_payload("error", {
+                    "message": _redact_api_error_text(exc),
+                    "type": "server_error",
+                    "code": "session_busy",
+                    "retry_after": 30,
                 }))
             except Exception as exc:
                 logger.exception("[api_server] session chat stream failed")
@@ -4114,6 +4135,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                refresh_session_history=bool(provided_session_id),
                 **agent_overrides,
                 route=route,
             ))
@@ -4135,6 +4157,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                refresh_session_history=bool(provided_session_id),
                 **agent_overrides,
                 route=route,
             )
@@ -4147,6 +4170,12 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+            except TurnLeaseTimeoutError as e:
+                return web.json_response(
+                    _openai_error(str(e), err_type="server_error", code="session_busy"),
+                    status=503,
+                    headers={"Retry-After": "30"},
+                )
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
@@ -4156,6 +4185,12 @@ class APIServerAdapter(BasePlatformAdapter):
         else:
             try:
                 result, usage = await _compute_completion()
+            except TurnLeaseTimeoutError as e:
+                return web.json_response(
+                    _openai_error(str(e), err_type="server_error", code="session_busy"),
+                    status=503,
+                    headers={"Retry-After": "30"},
+                )
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
@@ -4386,17 +4421,26 @@ class APIServerAdapter(BasePlatformAdapter):
             }
             if finish_reason != "stop":
                 finish_chunk["choices"][0]["delta"] = {}
+                busy = isinstance(agent_error, TurnLeaseTimeoutError)
                 if err_msg:
                     finish_chunk["error"] = {
                         "message": err_msg,
-                        "type": type(agent_error).__name__ if agent_error else "agent_error",
+                        "type": "server_error" if busy else type(agent_error).__name__ if agent_error else "agent_error",
                     }
+                    if busy:
+                        finish_chunk["error"]["code"] = "session_busy"
                 finish_chunk["hermes"] = {
                     "completed": completed,
                     "partial": is_partial,
                     "failed": is_failed,
                     "error": err_msg,
-                    "error_code": "output_truncated" if finish_reason == "length" else "agent_error",
+                    "error_code": (
+                        "output_truncated"
+                        if finish_reason == "length"
+                        else "session_busy"
+                        if busy
+                        else "agent_error"
+                    ),
                 }
             await response.write(_sse_frame(finish_chunk))
             await response.write(b"data: [DONE]\n\n")
@@ -4540,6 +4584,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response_text = ""
         agent_error: Optional[str] = None
+        agent_error_code: Optional[str] = None
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
 
@@ -4853,6 +4898,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     final_response_text = agent_final
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
                     agent_error = _redact_api_error_text(result["error"])
+            except TurnLeaseTimeoutError as e:
+                logger.warning("Session busy for streaming response %s: %s", response_id, e)
+                agent_error = _redact_api_error_text(e)
+                agent_error_code = "session_busy"
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)
@@ -4925,6 +4974,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 failed_env = _envelope("failed")
                 failed_env["output"] = final_items
                 failed_env["error"] = {"message": _redact_api_error_text(agent_error), "type": "server_error"}
+                if agent_error_code:
+                    failed_env["error"]["code"] = agent_error_code
                 failed_env["usage"] = {
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
@@ -5029,6 +5080,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 failed_env = _envelope("failed")
                 failed_env["output"] = list(emitted_items)
                 failed_env["error"] = {"message": _redact_api_error_text(_exc, limit=500), "type": "server_error"}
+                if isinstance(_exc, TurnLeaseTimeoutError):
+                    failed_env["error"]["code"] = "session_busy"
                 failed_env["usage"] = {
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
@@ -5225,6 +5278,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                refresh_session_history=bool(stored_session_id),
                 **agent_overrides,
                 route=route,
             ))
@@ -5260,6 +5314,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                refresh_session_history=bool(stored_session_id),
                 **agent_overrides,
                 route=route,
             )
@@ -5281,6 +5336,12 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
+            except TurnLeaseTimeoutError as e:
+                return web.json_response(
+                    _openai_error(str(e), err_type="server_error", code="session_busy"),
+                    status=503,
+                    headers={"Retry-After": "30"},
+                )
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
@@ -5290,6 +5351,12 @@ class APIServerAdapter(BasePlatformAdapter):
         else:
             try:
                 result, usage = await _compute_response()
+            except TurnLeaseTimeoutError as e:
+                return web.json_response(
+                    _openai_error(str(e), err_type="server_error", code="session_busy"),
+                    status=503,
+                    headers={"Retry-After": "30"},
+                )
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
@@ -5974,6 +6041,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        refresh_session_history: bool = False,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -6005,6 +6073,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # run_in_executor threads, so the profile scope must be re-entered
         # inside _run() from this explicit value.
         request_profile = _api_request_profile.get()
+        cancel_lease_wait = threading.Event()
 
         def _run():
             from gateway.session_context import clear_session_vars
@@ -6016,7 +6085,24 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id or "",
                 )
                 agent = None
+                turn_lease = None
+                lease_rebind_installed = False
+                had_lease_rebind = False
+                previous_lease_rebind = None
                 try:
+                    run_history = conversation_history
+                    if refresh_session_history and session_id:
+                        db = self._ensure_session_db()
+                        turn_lease = DurableTurnLease.acquire(
+                            db,
+                            session_id,
+                            owner_key=f"api:{gateway_session_key or session_id}",
+                            generation=0,
+                            cancelled=cancel_lease_wait.is_set,
+                        )
+                        if db is not None and db.get_session(session_id) is not None:
+                            conversation_history[:] = db.get_messages_as_conversation(session_id)
+                            run_history = conversation_history
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
@@ -6032,6 +6118,16 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
                     )
+                    if turn_lease is not None:
+                        had_lease_rebind = hasattr(
+                            agent, "_durable_turn_lease_rebind"
+                        )
+                        if had_lease_rebind:
+                            previous_lease_rebind = getattr(
+                                agent, "_durable_turn_lease_rebind"
+                            )
+                        agent._durable_turn_lease_rebind = turn_lease.rebind
+                        lease_rebind_installed = True
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
@@ -6043,7 +6139,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     _publish_turn_process_ownership(agent, effective_task_id)
                     result = agent.run_conversation(
                         user_message=user_message,
-                        conversation_history=conversation_history,
+                        conversation_history=run_history,
                         task_id=effective_task_id,
                     )
                     usage = {
@@ -6057,6 +6153,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     _eff_sid = getattr(agent, "session_id", session_id)
                     if isinstance(_eff_sid, str) and _eff_sid:
                         result["session_id"] = _eff_sid
+                        if (
+                            turn_lease is not None
+                            and _eff_sid != turn_lease.session_id
+                            and not turn_lease.rebind(_eff_sid)
+                        ):
+                            logger.error(
+                                "Failed to rebind API turn lease after compression: %s -> %s",
+                                turn_lease.session_id,
+                                _eff_sid,
+                            )
                     # Signal whether context compression occurred during this turn
                     # so _build_response_conversation_history can skip the
                     # prior-concatenation path and store the compressed transcript
@@ -6163,6 +6269,14 @@ class APIServerAdapter(BasePlatformAdapter):
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
                 finally:
+                    if agent is not None and lease_rebind_installed:
+                        try:
+                            if had_lease_rebind:
+                                agent._durable_turn_lease_rebind = previous_lease_rebind
+                            else:
+                                delattr(agent, "_durable_turn_lease_rebind")
+                        except Exception:
+                            logger.exception("Failed to restore API turn lease callback")
                     # Turn finished (success, auth failure, or crash) — clear
                     # ownership markers so a disconnect landing after this
                     # point can't reap background work this turn left
@@ -6170,12 +6284,19 @@ class APIServerAdapter(BasePlatformAdapter):
                     # in gateway/run.py's _run_sync_with_timeout_lifecycle.
                     if agent is not None:
                         _clear_turn_process_ownership(agent)
-                    clear_session_vars(tokens)
+                    try:
+                        if turn_lease is not None:
+                            turn_lease.release()
+                    finally:
+                        clear_session_vars(tokens)
 
         self._activate_admitted_request()
         self._inflight_agent_runs += 1
         try:
             return await loop.run_in_executor(None, _run)
+        except asyncio.CancelledError:
+            cancel_lease_wait.set()
+            raise
         finally:
             self._inflight_agent_runs -= 1
 
@@ -6368,7 +6489,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id
+        stateful_session_id = body.get("session_id") or stored_session_id
+        session_id = stateful_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -6431,10 +6553,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
         request_profile = _api_request_profile.get()
+        cancel_lease_wait = threading.Event()
 
         async def _run_and_close():
+            agent = None
             try:
-                self._set_run_status(run_id, "running")
                 if run_id in self._stopping_run_ids:
                     _put_event_if_active({
                         "event": "run.cancelled",
@@ -6447,20 +6570,6 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="run.cancelled",
                     )
                     return
-                with self._profile_scope(request_profile):
-                    agent = self._create_agent(
-                        ephemeral_system_prompt=ephemeral_system_prompt,
-                        session_id=session_id,
-                        stream_delta_callback=_text_cb,
-                        tool_progress_callback=event_cb,
-                        gateway_session_key=gateway_session_key,
-                        requested_model=agent_overrides.get("requested_model"),
-                        requested_provider=agent_overrides.get("requested_provider"),
-                        model_options=agent_overrides.get("model_options"),
-                        route=route,
-                    )
-                self._active_run_agents[run_id] = agent
-
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
                     event = dict(approval_data or {})
                     # Redact credentials from the command before it enters the
@@ -6491,6 +6600,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         pass
 
                 def _run_sync():
+                    nonlocal agent
                     from gateway.session_context import clear_session_vars
                     from tools.approval import (
                         register_gateway_notify,
@@ -6502,8 +6612,61 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
+                    turn_lease = None
+                    lease_rebind_installed = False
+                    had_lease_rebind = False
+                    previous_lease_rebind = None
+                    run_history = conversation_history
                     with self._profile_scope(request_profile):
                         try:
+                            if stateful_session_id:
+                                db = self._ensure_session_db()
+                                turn_lease = DurableTurnLease.acquire(
+                                    db,
+                                    stateful_session_id,
+                                    owner_key=f"api-run:{gateway_session_key or run_id}",
+                                    generation=0,
+                                    cancelled=lambda: (
+                                        cancel_lease_wait.is_set()
+                                        or run_id in self._stopping_run_ids
+                                    ),
+                                )
+                                if db is not None and db.get_session(stateful_session_id) is not None:
+                                    conversation_history[:] = db.get_messages_as_conversation(
+                                        stateful_session_id
+                                    )
+                                    run_history = conversation_history
+                            if run_id in self._stopping_run_ids:
+                                raise TurnLeaseCancelledError(
+                                    f"run {run_id!r} stopped before agent start"
+                                )
+                            loop.call_soon_threadsafe(
+                                self._set_run_status,
+                                run_id,
+                                "running",
+                            )
+                            agent = self._create_agent(
+                                ephemeral_system_prompt=ephemeral_system_prompt,
+                                session_id=session_id,
+                                stream_delta_callback=_text_cb,
+                                tool_progress_callback=event_cb,
+                                gateway_session_key=gateway_session_key,
+                                requested_model=agent_overrides.get("requested_model"),
+                                requested_provider=agent_overrides.get("requested_provider"),
+                                model_options=agent_overrides.get("model_options"),
+                                route=route,
+                            )
+                            if turn_lease is not None:
+                                had_lease_rebind = hasattr(
+                                    agent, "_durable_turn_lease_rebind"
+                                )
+                                if had_lease_rebind:
+                                    previous_lease_rebind = getattr(
+                                        agent, "_durable_turn_lease_rebind"
+                                    )
+                                agent._durable_turn_lease_rebind = turn_lease.rebind
+                                lease_rebind_installed = True
+                            self._active_run_agents[run_id] = agent
                             # Bind approval/session identity for this API run via
                             # contextvars so concurrent runs do not share process
                             # environment state.
@@ -6529,35 +6692,64 @@ class APIServerAdapter(BasePlatformAdapter):
                             _publish_turn_process_ownership(agent, effective_task_id)
                             r = agent.run_conversation(
                                 user_message=user_message,
-                                conversation_history=conversation_history,
+                                conversation_history=run_history,
                                 task_id=effective_task_id,
                             )
+                            u = {
+                                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                            }
+                            effective_session_id = getattr(agent, "session_id", session_id)
+                            if isinstance(effective_session_id, str) and effective_session_id:
+                                if isinstance(r, dict):
+                                    r["session_id"] = effective_session_id
+                                if (
+                                    turn_lease is not None
+                                    and effective_session_id != turn_lease.session_id
+                                    and not turn_lease.rebind(effective_session_id)
+                                ):
+                                    logger.error(
+                                        "Failed to rebind /v1/runs turn lease after compression: %s -> %s",
+                                        turn_lease.session_id,
+                                        effective_session_id,
+                                    )
+                            return r, u
                         finally:
+                            if agent is not None and lease_rebind_installed:
+                                try:
+                                    if had_lease_rebind:
+                                        agent._durable_turn_lease_rebind = previous_lease_rebind
+                                    else:
+                                        delattr(agent, "_durable_turn_lease_rebind")
+                                except Exception:
+                                    logger.exception(
+                                        "Failed to restore /v1/runs turn lease callback"
+                                    )
                             # Worker finished (interrupted or complete) —
                             # clear turn ownership immediately so a later
                             # stop/cancel can't reap background work this
                             # run deliberately left running (same race-window
                             # guard as gateway/run.py and _run_agent above).
-                            _clear_turn_process_ownership(agent)
+                            if agent is not None:
+                                _clear_turn_process_ownership(agent)
                             try:
                                 unregister_gateway_notify(approval_session_key)
                             finally:
-                                if approval_token is not None:
-                                    try:
-                                        reset_current_session_key(approval_token)
-                                    except Exception:
-                                        pass
-                                if session_tokens:
-                                    try:
-                                        clear_session_vars(session_tokens)
-                                    except Exception:
-                                        pass
-                        u = {
-                            "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                            "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                            "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-                        }
-                        return r, u
+                                try:
+                                    if turn_lease is not None:
+                                        turn_lease.release()
+                                finally:
+                                    if approval_token is not None:
+                                        try:
+                                            reset_current_session_key(approval_token)
+                                        except Exception:
+                                            pass
+                                    if session_tokens:
+                                        try:
+                                            clear_session_vars(session_tokens)
+                                        except Exception:
+                                            pass
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
                 if run_id in self._stopping_run_ids:
@@ -6602,9 +6794,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         "completed",
                         output=final_response,
                         usage=usage,
+                        session_id=(
+                            result.get("session_id", session_id)
+                            if isinstance(result, dict)
+                            else session_id
+                        ),
                         last_event="run.completed",
                     )
             except asyncio.CancelledError:
+                cancel_lease_wait.set()
                 self._set_run_status(
                     run_id,
                     "cancelled",
@@ -6619,6 +6817,42 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
                 raise
+            except TurnLeaseCancelledError:
+                self._set_run_status(
+                    run_id,
+                    "cancelled",
+                    last_event="run.cancelled",
+                )
+                try:
+                    _put_event_if_active({
+                        "event": "run.cancelled",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    })
+                except Exception:
+                    pass
+            except TurnLeaseTimeoutError as exc:
+                error_msg = _redact_api_error_text(exc)
+                self._set_run_status(
+                    run_id,
+                    "failed",
+                    error=error_msg,
+                    error_code="session_busy",
+                    retry_after=30,
+                    last_event="run.failed",
+                )
+                try:
+                    _put_event_if_active({
+                        "event": "run.failed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "error": error_msg,
+                        "type": "server_error",
+                        "code": "session_busy",
+                        "retry_after": 30,
+                    })
+                except Exception:
+                    pass
             except _ProviderAuthResolutionError as exc:
                 # /v1/runs builds its own agent via _create_agent() and does
                 # not route through _run_agent() (see that method's own
@@ -6662,6 +6896,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
             finally:
+                cancel_lease_wait.set()
                 # If the asyncio wrapper is cancelled (for example via
                 # /stop), the executor thread can still be blocked waiting
                 # on an approval Event.  Unregistering here releases those

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -37,20 +37,20 @@ Safety properties:
 - **Bounded registry.** The per-session lease map is size-capped; eviction
   only ever removes idle (unheld, uncontended) entries, never a live lease.
 
-Known limits (deliberate, flagged on #64934):
-
-- A CLI process sharing the session via CLI-continuity is outside any
-  in-process lock — that pair needs a DB-level lease (separate design).
-- Mid-turn compression rotation leaves a small alias window: the tip-walk can
-  resolve a fresh child id while the parent-holding turn is still in flight.
-  The mid-turn binding-sync sites are the right place to alias the lease in a
-  follow-up.
+``SessionTurnLeaseRegistry`` remains the lightweight gateway-local guard.
+``DurableTurnLease`` uses the same token shape with a SQLite row for entry
+points that can share a session across processes (Desktop and API wake turns).
 """
 
 import asyncio
 import logging
+import os
+import threading
 import time
-from typing import Dict, Optional
+import uuid
+from threading import Event as _ThreadEvent
+from threading import Thread as _Thread
+from typing import Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +64,21 @@ DEFAULT_MAX_LEASES = 512
 # the gateway's default agent inactivity timeout so a stuck holder fails open
 # on the same clock the turn itself would be declared stuck on.
 DEFAULT_LEASE_WAIT = 1800.0
+
+# Durable rows are renewed well before expiry so a long tool-using turn cannot
+# be mistaken for a stale owner. A crashed process is reclaimed immediately by
+# SessionDB's structured-holder PID check; the TTL is the conservative fallback
+# for an unprobeable/recycled PID.
+DEFAULT_DURABLE_LEASE_TTL = 120.0
+DEFAULT_DURABLE_POLL_INTERVAL = 0.1
+
+
+class TurnLeaseTimeoutError(TimeoutError):
+    """A durable turn lease stayed owned for the full bounded wait."""
+
+
+class TurnLeaseCancelledError(RuntimeError):
+    """The caller stopped waiting before the durable lease was acquired."""
 
 
 class TurnLeaseToken:
@@ -95,6 +110,132 @@ class TurnLeaseToken:
             f"owner_key={self.owner_key!r}, generation={self.generation}, "
             f"degraded={self.degraded}, released={self.released})"
         )
+
+
+class DurableTurnLease(TurnLeaseToken):
+    """DB-backed turn lease shared by Desktop and API-server processes."""
+
+    __slots__ = ("db", "holder", "session_ids", "ttl", "_stop", "_thread")
+
+    @classmethod
+    def acquire(
+        cls,
+        db,
+        session_id: str,
+        *,
+        owner_key: str,
+        generation: int,
+        timeout: Optional[float] = None,
+        ttl_seconds: float = DEFAULT_DURABLE_LEASE_TTL,
+        cancelled: Optional[Callable[[], bool]] = None,
+    ) -> Optional["DurableTurnLease"]:
+        if db is None or not session_id:
+            return None
+        lease_methods = (
+            "try_acquire_session_turn_lease",
+            "get_session_turn_lease_holder",
+            "refresh_session_turn_lease",
+            "release_session_turn_lease",
+        )
+        if any(not callable(getattr(db, name, None)) for name in lease_methods):
+            return None
+        wait = float(timeout) if timeout and timeout > 0 else DEFAULT_LEASE_WAIT
+        deadline = time.monotonic() + wait
+        holder = (
+            f"pid={os.getpid()}:tid={threading.get_ident()}"
+            f":owner={str(owner_key or '?').replace(':', '_')[:80]}"
+            f":gen={int(generation)}:nonce={uuid.uuid4().hex[:8]}"
+        )
+        logged = False
+        while not db.try_acquire_session_turn_lease(
+            session_id, holder, ttl_seconds=ttl_seconds
+        ):
+            if cancelled is not None and cancelled():
+                raise TurnLeaseCancelledError(
+                    f"cancelled while waiting for session turn lease on {session_id!r}"
+                )
+            if not logged:
+                logged = True
+                logger.warning(
+                    "durable turn lease contention on session %s: %s waits behind %s",
+                    session_id,
+                    owner_key,
+                    db.get_session_turn_lease_holder(session_id) or "?",
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TurnLeaseTimeoutError(
+                    f"timed out after {wait:.0f}s waiting for session turn lease "
+                    f"on {session_id!r}"
+                )
+            time.sleep(min(DEFAULT_DURABLE_POLL_INTERVAL, remaining))
+
+        if cancelled is not None and cancelled():
+            db.release_session_turn_lease(session_id, holder)
+            raise TurnLeaseCancelledError(
+                f"cancelled while waiting for session turn lease on {session_id!r}"
+            )
+
+        token = cls(session_id, owner_key, generation)
+        token.db = db
+        token.holder = holder
+        token.session_ids = [session_id]
+        token.ttl = max(1.0, float(ttl_seconds))
+        # Keep stable references to the stdlib primitives.  Some TUI tests
+        # replace ``server.threading.Thread`` with an immediate runner; because
+        # ``threading`` is a shared module object, looking the class up through
+        # the module here would also make the lease refresher run synchronously
+        # and block forever inside ``acquire``.
+        token._stop = _ThreadEvent()
+        token._thread = _Thread(
+            target=token._refresh,
+            name="session-turn-lease-refresh",
+            daemon=True,
+        )
+        token._thread.start()
+        return token
+
+    def _refresh(self) -> None:
+        interval = max(0.1, min(30.0, self.ttl / 2.0))
+        while not self._stop.wait(interval):
+            for session_id in tuple(self.session_ids):
+                if not self.db.refresh_session_turn_lease(
+                    session_id, self.holder, ttl_seconds=self.ttl
+                ):
+                    logger.error(
+                        "lost durable turn lease for session %s (holder %s)",
+                        session_id,
+                        self.holder,
+                    )
+
+    def rebind(self, new_session_id: str) -> bool:
+        if self.released or not new_session_id or new_session_id == self.session_id:
+            return False
+        # Keep the old id leased too: a caller may still resume the parent
+        # while compression has already rotated this turn onto its child.
+        if not self.db.try_acquire_session_turn_lease(
+            self.session_id, self.holder, ttl_seconds=self.ttl
+        ) or not self.db.try_acquire_session_turn_lease(
+            new_session_id, self.holder, ttl_seconds=self.ttl
+        ):
+            return False
+        self.session_ids.append(new_session_id)
+        self.session_id = new_session_id
+        return True
+
+    def release(self) -> bool:
+        if self.released:
+            return False
+        self.released = True
+        self._stop.set()
+        if self._thread.is_alive() and threading.current_thread() is not self._thread:
+            self._thread.join(timeout=1.0)
+        released = False
+        for session_id in reversed(self.session_ids):
+            released = self.db.release_session_turn_lease(
+                session_id, self.holder
+            ) or released
+        return released
 
 
 class _SessionLease:

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -29,16 +29,18 @@ import asyncio
 import logging
 from typing import Any, Optional
 
+from gateway.turn_lease import DEFAULT_LEASE_WAIT
+
 logger = logging.getLogger(__name__)
 
-# A wake self-post runs the entire agent turn synchronously (stream=false);
-# generous ceiling so long tool-using turns aren't killed mid-flight.
-WAKE_TURN_TIMEOUT_SECONDS = 600.0
+# A wake self-post may first wait behind the active Desktop turn, then run its
+# own synchronous turn. Keep the client alive longer than the bounded lease
+# wait so it cannot abandon and duplicate a legitimately queued wake.
+WAKE_TURN_TIMEOUT_SECONDS = DEFAULT_LEASE_WAIT + 600.0
 
 # Backoff delays between retries on transient failures (429 concurrency cap,
-# connection errors). The API server has no per-session lock — concurrent
-# turns on one session are last-writer-wins — but it DOES enforce a global
-# max_concurrent_runs cap via HTTP 429, which is worth waiting out.
+# connection errors). The API server also enforces a global max_concurrent_runs
+# cap via HTTP 429, which is worth waiting out before joining the session queue.
 _RETRY_DELAYS_SECONDS = (2.0, 5.0, 10.0)
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3969,6 +3969,129 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._execute_write(_do)
 
     # ──────────────────────────────────────────────────────────────────────
+    # Cross-process session turn leases
+    # ──────────────────────────────────────────────────────────────────────
+
+    def try_acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        ttl_seconds: float = 120.0,
+    ) -> bool:
+        """Acquire/renew ``session_id`` for ``holder`` in one transaction."""
+        if not session_id or not holder:
+            return False
+        now = time.time()
+        expires_at = now + max(1.0, float(ttl_seconds))
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT holder, expires_at FROM session_turn_leases "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is not None:
+                current_holder = row["holder"]
+                if current_holder == holder:
+                    conn.execute(
+                        "UPDATE session_turn_leases SET expires_at = ? "
+                        "WHERE session_id = ? AND holder = ?",
+                        (expires_at, session_id, holder),
+                    )
+                    return True
+                if (
+                    float(row["expires_at"]) >= now
+                    and not _compression_lock_holder_process_is_dead(current_holder)
+                ):
+                    return False
+                conn.execute(
+                    "DELETE FROM session_turn_leases "
+                    "WHERE session_id = ? AND holder = ?",
+                    (session_id, current_holder),
+                )
+            conn.execute(
+                "INSERT INTO session_turn_leases "
+                "(session_id, holder, acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?)",
+                (session_id, holder, now, expires_at),
+            )
+            return True
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "try_acquire_session_turn_lease(%s) failed: %s",
+                session_id,
+                exc,
+            )
+            return False
+
+    def refresh_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        ttl_seconds: float = 120.0,
+    ) -> bool:
+        """Renew a turn lease only while ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+        expires_at = time.time() + max(1.0, float(ttl_seconds))
+
+        def _do(conn):
+            cur = conn.execute(
+                "UPDATE session_turn_leases SET expires_at = ? "
+                "WHERE session_id = ? AND holder = ?",
+                (expires_at, session_id, holder),
+            )
+            return cur.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "refresh_session_turn_lease(%s) failed: %s",
+                session_id,
+                exc,
+            )
+            return False
+
+    def release_session_turn_lease(self, session_id: str, holder: str) -> bool:
+        """Release ``session_id`` only when ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+
+        def _do(conn):
+            cur = conn.execute(
+                "DELETE FROM session_turn_leases "
+                "WHERE session_id = ? AND holder = ?",
+                (session_id, holder),
+            )
+            return cur.rowcount > 0
+
+        try:
+            return bool(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "release_session_turn_lease(%s) failed: %s",
+                session_id,
+                exc,
+            )
+            return False
+
+    def get_session_turn_lease_holder(self, session_id: str) -> Optional[str]:
+        """Return the current non-expired turn-lease holder, if any."""
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM session_turn_leases "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, time.time()),
+            ).fetchone()
+        return row["holder"] if row is not None else None
+
+    # ──────────────────────────────────────────────────────────────────────
     # Compression locks
     # ──────────────────────────────────────────────────────────────────────
     # Atomic per-session locks that prevent two compression paths from

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -318,6 +318,13 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS session_turn_leases (
+    session_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    acquired_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -39,6 +39,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from gateway.turn_lease import TurnLeaseTimeoutError
 
 
 # ---------------------------------------------------------------------------
@@ -1104,6 +1105,44 @@ class TestChatCompletionsEndpoint:
             fake_task.callbacks[0](fake_task)
             assert stream_q.get_nowait() is None
 
+    @pytest.mark.asyncio
+    async def test_stateful_chat_stream_lease_timeout_emits_session_busy(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        fake_db = MagicMock()
+        fake_db.get_messages_as_conversation.return_value = []
+
+        with (
+            patch.object(
+                auth_adapter,
+                "_ensure_session_db_async",
+                new=AsyncMock(return_value=fake_db),
+            ),
+            patch.object(
+                auth_adapter,
+                "_run_agent",
+                new=AsyncMock(side_effect=TurnLeaseTimeoutError("session is busy")),
+            ),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Id": "busy-chat-session",
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        assert '"code": "session_busy"' in body
+        assert '"error_code": "session_busy"' in body
+        assert "data: [DONE]" in body
+
 
     @pytest.mark.asyncio
     async def test_stream_includes_tool_progress(self, adapter):
@@ -1349,6 +1388,36 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+            assert mock_run.call_args.kwargs["refresh_session_history"] is False
+
+    @pytest.mark.asyncio
+    async def test_chained_response_lease_timeout_returns_controlled_busy_response(self, adapter):
+        adapter._response_store.put(
+            "resp_busy",
+            {
+                "response": {"id": "resp_busy", "status": "completed"},
+                "conversation_history": [{"role": "user", "content": "earlier"}],
+                "session_id": "busy-response-session",
+            },
+        )
+        app = _create_app(adapter)
+
+        with patch.object(
+            adapter,
+            "_run_agent",
+            new=AsyncMock(side_effect=TurnLeaseTimeoutError("session is busy")),
+        ) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"input": "continue", "previous_response_id": "resp_busy"},
+                )
+                payload = await resp.json()
+
+        assert resp.status == 503
+        assert resp.headers["Retry-After"] == "30"
+        assert payload["error"]["code"] == "session_busy"
+        assert mock_run.call_args.kwargs["refresh_session_history"] is True
 
 
     @pytest.mark.asyncio
@@ -1645,6 +1714,39 @@ class TestResponsesStreaming:
             assert stream_q.empty()
             fake_task.callbacks[0](fake_task)
             assert stream_q.get_nowait() is None
+
+    @pytest.mark.asyncio
+    async def test_chained_stream_lease_timeout_emits_typed_failed_event(self, adapter):
+        adapter._response_store.put(
+            "resp_stream_busy",
+            {
+                "response": {"id": "resp_stream_busy", "status": "completed"},
+                "conversation_history": [{"role": "user", "content": "earlier"}],
+                "session_id": "busy-stream-response-session",
+            },
+        )
+        app = _create_app(adapter)
+
+        with patch.object(
+            adapter,
+            "_run_agent",
+            new=AsyncMock(side_effect=TurnLeaseTimeoutError("session is busy")),
+        ) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "continue",
+                        "previous_response_id": "resp_stream_busy",
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        assert "event: response.failed" in body
+        assert '"code": "session_busy"' in body
+        assert mock_run.call_args.kwargs["refresh_session_history"] is True
 
 
     @pytest.mark.asyncio
@@ -2859,4 +2961,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -24,6 +24,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from gateway.turn_lease import TurnLeaseCancelledError, TurnLeaseTimeoutError
 from tools import approval as approval_mod
 
 
@@ -258,6 +259,141 @@ class TestStartRun:
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
 
+    @pytest.mark.asyncio
+    async def test_contended_stateful_run_stays_queued_until_lease_acquired(self, adapter):
+        app = _create_runs_app(adapter)
+        lease_waiting = threading.Event()
+        release_lease_wait = threading.Event()
+        run_started = threading.Event()
+        finish_run = threading.Event()
+        fake_lease = MagicMock(session_id="queued-session")
+        fake_db = MagicMock()
+        persisted_history = [
+            {"role": "user", "content": "persisted question"},
+            {"role": "assistant", "content": "persisted answer"},
+        ]
+        fake_db.get_session.return_value = {"id": "queued-session"}
+        fake_db.get_messages_as_conversation.return_value = persisted_history
+
+        def _acquire(*_args, **_kwargs):
+            lease_waiting.set()
+            release_lease_wait.wait(timeout=3)
+            return fake_lease
+
+        mock_agent = MagicMock()
+        mock_agent.session_id = "rotated-session"
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def _run(**_kwargs):
+            run_started.set()
+            finish_run.wait(timeout=3)
+            return {"final_response": "done"}
+
+        mock_agent.run_conversation.side_effect = _run
+
+        with (
+            patch.object(adapter, "_ensure_session_db", return_value=fake_db),
+            patch("gateway.platforms.api_server.DurableTurnLease.acquire", side_effect=_acquire),
+            patch.object(adapter, "_create_agent", return_value=mock_agent),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "queued-session"},
+                )
+                run_id = (await resp.json())["run_id"]
+                assert await asyncio.to_thread(lease_waiting.wait, 1)
+
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                assert (await status_resp.json())["status"] == "queued"
+
+                release_lease_wait.set()
+                assert await asyncio.to_thread(run_started.wait, 1)
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "running":
+                        break
+                    await asyncio.sleep(0.01)
+                assert status["status"] == "running"
+                finish_run.set()
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.01)
+                assert status["status"] == "completed"
+                assert status["session_id"] == "rotated-session"
+
+        assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == persisted_history
+        fake_lease.rebind.assert_called_once_with("rotated-session")
+        fake_lease.release.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stateless_run_does_not_acquire_durable_lease(self, adapter):
+        app = _create_runs_app(adapter)
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with (
+            patch("gateway.platforms.api_server.DurableTurnLease.acquire") as acquire,
+            patch.object(adapter, "_create_agent", return_value=mock_agent),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert status["status"] == "completed"
+        acquire.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_stateful_run_waiting_for_lease(self, adapter):
+        app = _create_runs_app(adapter)
+        lease_waiting = threading.Event()
+
+        def _acquire(*_args, cancelled, **_kwargs):
+            lease_waiting.set()
+            while not cancelled():
+                time.sleep(0.01)
+            raise TurnLeaseCancelledError("stopped")
+
+        with (
+            patch.object(adapter, "_ensure_session_db", return_value=MagicMock()),
+            patch("gateway.platforms.api_server.DurableTurnLease.acquire", side_effect=_acquire),
+            patch.object(adapter, "_create_agent") as create_agent,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "stopped-session"},
+                )
+                run_id = (await resp.json())["run_id"]
+                assert await asyncio.to_thread(lease_waiting.wait, 1)
+
+                stop_resp = await cli.post(f"/v1/runs/{run_id}/stop")
+                assert stop_resp.status == 200
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "cancelled":
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert status["status"] == "cancelled"
+        create_agent.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status
@@ -330,6 +466,37 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_lease_timeout_emits_typed_session_busy_failure(self, adapter):
+        app = _create_runs_app(adapter)
+        fake_db = MagicMock()
+
+        with (
+            patch.object(adapter, "_ensure_session_db", return_value=fake_db),
+            patch(
+                "gateway.platforms.api_server.DurableTurnLease.acquire",
+                side_effect=TurnLeaseTimeoutError("session is busy"),
+            ),
+            patch.object(adapter, "_create_agent") as create_agent,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "busy-run-session"},
+                )
+                run_id = (await resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                events_body = await events_resp.text()
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                status = await status_resp.json()
+
+        assert "run.failed" in events_body
+        assert '"code": "session_busy"' in events_body
+        assert status["status"] == "failed"
+        assert status["error_code"] == "session_busy"
+        assert status["retry_after"] == 30
+        create_agent.assert_not_called()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,6 @@
 """Focused tests for API server session-control endpoints."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
+from gateway.turn_lease import DurableTurnLease, TurnLeaseTimeoutError
 from hermes_state import SessionDB
 
 
@@ -124,6 +126,127 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
         "context_session_key": "request-key",
         "child_session_id": "request-session",
     }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_waits_then_reloads_persisted_session_history(
+    adapter, session_db, monkeypatch
+):
+    """An API wake queued behind Desktop must run on Desktop's flushed turn."""
+    session_id = session_db.create_session("shared-session", "tui")
+    holder_db = SessionDB(session_db.db_path)
+    holder = DurableTurnLease.acquire(
+        holder_db,
+        session_id,
+        owner_key="tui:desktop",
+        generation=1,
+        timeout=2,
+    )
+    observed = {}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self):
+            self.session_id = session_id
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            observed["history"] = conversation_history
+            observed["lease_rebind"] = getattr(
+                self, "_durable_turn_lease_rebind", None
+            )
+            return {"final_response": "wake handled"}
+
+    fake_agent = FakeAgent()
+    monkeypatch.setattr(adapter, "_create_agent", lambda **_kwargs: fake_agent)
+    initial_history = [{"role": "user", "content": "stale"}]
+    task = asyncio.create_task(
+        adapter._run_agent(
+            user_message="background task completed",
+            conversation_history=initial_history,
+            session_id=session_id,
+            refresh_session_history=True,
+        )
+    )
+    try:
+        await asyncio.sleep(0.1)
+        assert not task.done()
+        assert "history" not in observed
+
+        holder_db.append_message(session_id, "user", "desktop question")
+        holder_db.append_message(session_id, "assistant", "desktop answer")
+        assert holder is not None and holder.release()
+
+        result, _usage = await asyncio.wait_for(task, timeout=3)
+        assert result["final_response"] == "wake handled"
+        assert [
+            {"role": message["role"], "content": message["content"]}
+            for message in observed["history"]
+        ] == [
+            {"role": "user", "content": "desktop question"},
+            {"role": "assistant", "content": "desktop answer"},
+        ]
+        assert initial_history == observed["history"]
+        assert callable(observed["lease_rebind"])
+        assert not hasattr(fake_agent, "_durable_turn_lease_rebind")
+    finally:
+        if holder is not None:
+            holder.release()
+        if not task.done():
+            task.cancel()
+        holder_db.close()
+
+
+@pytest.mark.asyncio
+async def test_session_chat_lease_timeout_returns_controlled_busy_response(
+    adapter, session_db
+):
+    session_id = session_db.create_session("busy-session", "api_server")
+    app = _create_session_app(adapter)
+
+    with patch.object(
+        adapter,
+        "_run_agent",
+        new=AsyncMock(side_effect=TurnLeaseTimeoutError("session is busy")),
+    ):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hello"},
+            )
+            payload = await resp.json()
+
+    assert resp.status == 503
+    assert resp.headers["Retry-After"] == "30"
+    assert payload["error"]["code"] == "session_busy"
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_lease_timeout_emits_typed_busy_event(
+    adapter, session_db
+):
+    session_id = session_db.create_session("busy-stream-session", "api_server")
+    app = _create_session_app(adapter)
+
+    with patch.object(
+        adapter,
+        "_run_agent",
+        new=AsyncMock(side_effect=TurnLeaseTimeoutError("session is busy")),
+    ):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hello"},
+            )
+            body = await resp.text()
+
+    assert resp.status == 200
+    assert "event: error" in body
+    assert '"type": "server_error"' in body
+    assert '"code": "session_busy"' in body
+    assert "event: done" in body
 
 
 @pytest.mark.asyncio
@@ -606,5 +729,3 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
             body = await resp.json()
             assert body["error"]["code"] in {"model_lock_unavailable", "invalid_model_lock", "missing_model"}
     mock_run.assert_not_called()
-
-

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -18,10 +18,43 @@ Covers:
 """
 
 import asyncio
+import multiprocessing
+import threading
+import time
+from pathlib import Path
 
 import pytest
 
-from gateway.turn_lease import SessionTurnLeaseRegistry
+from gateway.turn_lease import (
+    DurableTurnLease,
+    SessionTurnLeaseRegistry,
+    TurnLeaseCancelledError,
+    TurnLeaseTimeoutError,
+)
+
+
+def _desktop_turn_process(db_path, session_id, acquired, release):
+    """Hold the Desktop side of a cross-process turn, then flush and release."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(Path(db_path))
+    lease = DurableTurnLease.acquire(
+        db,
+        session_id,
+        owner_key="tui:desktop",
+        generation=1,
+        timeout=5,
+    )
+    acquired.set()
+    try:
+        if not release.wait(10):
+            raise TimeoutError("test parent did not release Desktop turn")
+        db.append_message(session_id, "user", "desktop question")
+        db.append_message(session_id, "assistant", "desktop answer")
+    finally:
+        if lease is not None:
+            lease.release()
+        db.close()
 
 
 def _run(coro):
@@ -81,6 +114,130 @@ def test_distinct_sessions_do_not_contend():
     order = _run(scenario())
     # Both started before either finished — no serialization across sessions.
     assert order[:2] == ["start:sess-a", "start:sess-b"]
+
+
+def test_durable_lease_serializes_two_processes_and_waiter_reads_flushed_history(
+    tmp_path,
+):
+    """The API-side DB handle waits for Desktop, then sees its committed turn."""
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    setup_db = SessionDB(db_path)
+    session_id = setup_db.create_session("shared-session", "tui")
+    setup_db.close()
+
+    ctx = multiprocessing.get_context("spawn")
+    desktop_acquired = ctx.Event()
+    release_desktop = ctx.Event()
+    desktop = ctx.Process(
+        target=_desktop_turn_process,
+        args=(str(db_path), session_id, desktop_acquired, release_desktop),
+    )
+    desktop.start()
+    assert desktop_acquired.wait(10)
+
+    api_db = SessionDB(db_path)
+    waiter_acquired = threading.Event()
+    observed = {}
+
+    def api_wake():
+        lease = DurableTurnLease.acquire(
+            api_db,
+            session_id,
+            owner_key="api:wake",
+            generation=1,
+            timeout=5,
+        )
+        try:
+            observed["history"] = api_db.get_messages_as_conversation(session_id)
+            waiter_acquired.set()
+        finally:
+            if lease is not None:
+                lease.release()
+
+    waiter = threading.Thread(target=api_wake)
+    waiter.start()
+    time.sleep(0.15)
+    assert not waiter_acquired.is_set()
+
+    release_desktop.set()
+    assert waiter_acquired.wait(5)
+    waiter.join(timeout=5)
+    desktop.join(timeout=10)
+    api_db.close()
+
+    assert desktop.exitcode == 0
+    assert [
+        {"role": message["role"], "content": message["content"]}
+        for message in observed["history"]
+    ] == [
+        {"role": "user", "content": "desktop question"},
+        {"role": "assistant", "content": "desktop answer"},
+    ]
+
+
+def test_durable_lease_wait_is_bounded_and_cancellable_across_db_handles(tmp_path):
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    holder_db = SessionDB(db_path)
+    waiter_db = SessionDB(db_path)
+    holder = DurableTurnLease.acquire(
+        holder_db, "shared", owner_key="tui", generation=1, timeout=1
+    )
+    try:
+        with pytest.raises(TurnLeaseTimeoutError):
+            DurableTurnLease.acquire(
+                waiter_db, "shared", owner_key="api", generation=1, timeout=0.05
+            )
+
+        with pytest.raises(TurnLeaseCancelledError):
+            DurableTurnLease.acquire(
+                waiter_db,
+                "shared",
+                owner_key="api",
+                generation=2,
+                timeout=1,
+                cancelled=lambda: True,
+            )
+
+        assert holder is not None
+        assert waiter_db.release_session_turn_lease("shared", "wrong-holder") is False
+        assert waiter_db.get_session_turn_lease_holder("shared") == holder.holder
+    finally:
+        if holder is not None:
+            holder.release()
+        holder_db.close()
+        waiter_db.close()
+
+
+def test_durable_lease_rebinds_rotation_alias_and_renews_both_rows(tmp_path):
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    owner_db = SessionDB(db_path)
+    contender_db = SessionDB(db_path)
+    lease = DurableTurnLease.acquire(
+        owner_db,
+        "parent",
+        owner_key="tui",
+        generation=1,
+        timeout=1,
+        ttl_seconds=1,
+    )
+    try:
+        assert lease is not None and lease.rebind("child")
+        time.sleep(1.2)
+        assert contender_db.get_session_turn_lease_holder("parent") == lease.holder
+        assert contender_db.get_session_turn_lease_holder("child") == lease.holder
+        assert not contender_db.try_acquire_session_turn_lease("parent", "other", 1)
+        assert not contender_db.try_acquire_session_turn_lease("child", "other", 1)
+    finally:
+        if lease is not None:
+            lease.release()
+        owner_db.close()
+        contender_db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -21,6 +21,7 @@ import pytest
 from agent.conversation_compression import (
     finalize_context_engine_compression_notification,
 )
+from gateway.turn_lease import DurableTurnLease, TurnLeaseTimeoutError
 
 class TestCompressionBoundaryHook:
     def _make_agent(self, session_db):
@@ -137,6 +138,134 @@ class TestCompressionBoundaryHook:
                 )
 
             assert events == ["persist", "compression"]
+
+    def test_rotation_child_is_leased_before_publication_and_until_turn_release(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            owner_db = SessionDB(db_path=db_path)
+            contender_db = SessionDB(db_path=db_path)
+            lease = None
+            successor = None
+            agent = self._make_agent(owner_db)
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+            try:
+                lease = DurableTurnLease.acquire(
+                    owner_db,
+                    agent.session_id,
+                    owner_key="api:active-turn",
+                    generation=1,
+                    timeout=1,
+                )
+                assert lease is not None
+                published_child = []
+                original_publish = owner_db.publish_compression_child
+
+                def _publish_only_after_child_lease(*args, **kwargs):
+                    child_id = kwargs["child_session_id"]
+                    assert owner_db.get_session_turn_lease_holder(child_id) == lease.holder
+                    with pytest.raises(TurnLeaseTimeoutError):
+                        DurableTurnLease.acquire(
+                            contender_db,
+                            child_id,
+                            owner_key="api:contender",
+                            generation=2,
+                            timeout=0.05,
+                        )
+                    published_child.append(child_id)
+                    return original_publish(*args, **kwargs)
+
+                agent._durable_turn_lease_rebind = lease.rebind
+                with patch.object(
+                    owner_db,
+                    "publish_compression_child",
+                    side_effect=_publish_only_after_child_lease,
+                ):
+                    agent._compress_context(
+                        [{"role": "user", "content": f"request {i}"} for i in range(10)],
+                        "sys",
+                        approx_tokens=10_000,
+                    )
+
+                assert published_child == [agent.session_id]
+                with pytest.raises(TurnLeaseTimeoutError):
+                    DurableTurnLease.acquire(
+                        contender_db,
+                        agent.session_id,
+                        owner_key="api:still-running-contender",
+                        generation=3,
+                        timeout=0.05,
+                    )
+                lease.release()
+                lease = None
+                successor = DurableTurnLease.acquire(
+                    contender_db,
+                    agent.session_id,
+                    owner_key="api:next-turn",
+                    generation=4,
+                    timeout=1,
+                )
+                assert successor is not None
+            finally:
+                if hasattr(agent, "_durable_turn_lease_rebind"):
+                    delattr(agent, "_durable_turn_lease_rebind")
+                if lease is not None:
+                    lease.release()
+                if successor is not None:
+                    successor.release()
+                owner_db.close()
+                contender_db.close()
+
+    def test_rotation_aborts_before_publication_when_child_lease_rebind_fails(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+            parent_id = agent.session_id
+            agent._durable_turn_lease_rebind = lambda _child_id: False
+            try:
+                with patch.object(db, "publish_compression_child") as publish:
+                    with pytest.raises(
+                        RuntimeError,
+                        match="active turn lease rejected compression child",
+                    ):
+                        agent._compress_context(
+                            [
+                                {"role": "user", "content": f"request {i}"}
+                                for i in range(10)
+                            ],
+                            "sys",
+                            approx_tokens=10_000,
+                        )
+                publish.assert_not_called()
+                assert agent.session_id == parent_id
+                assert db.find_live_compression_child(parent_id) is None
+            finally:
+                delattr(agent, "_durable_turn_lease_rebind")
+                db.close()
 
     def test_failure_before_persistence_does_not_notify(self):
         from hermes_state import SessionDB
@@ -322,4 +451,3 @@ class TestSessionCompressEvent:
                 [{"role": "user", "content": "m"}], "sys", approx_tokens=100
             )
             assert compressed
-

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import subprocess
@@ -9533,6 +9534,109 @@ def test_run_prompt_submit_registers_turn_thread_for_interrupt(monkeypatch):
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert calls["interrupted"] is True
     finally:
+        server._sessions.pop("sid", None)
+
+
+def test_interrupt_cancels_tui_turn_waiting_for_durable_lease(monkeypatch, tmp_path):
+    """Stop must cancel a Desktop turn before it enters stale-history replay."""
+    from gateway.turn_lease import DurableTurnLease
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    holder_db = SessionDB(db_path)
+    waiter_db = SessionDB(db_path)
+    holder = DurableTurnLease.acquire(
+        holder_db,
+        "session-key",
+        owner_key="api:active",
+        generation=1,
+        timeout=1,
+    )
+    ran = threading.Event()
+    agent = types.SimpleNamespace(
+        clear_interrupt=lambda: None,
+        interrupt=lambda: None,
+        interim_assistant_callback=None,
+        run_conversation=lambda *_args, **_kwargs: ran.set(),
+        session_id="session-key",
+    )
+    session = _session(agent=agent, running=True)
+    server._sessions["sid"] = session
+    emitted = []
+
+    @contextlib.contextmanager
+    def turn_db(_session):
+        yield waiter_db
+
+    try:
+        monkeypatch.setattr(server, "_session_db", turn_db)
+        monkeypatch.setattr(server, "record_turn_start", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(server, "_retire_turn_marker", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(server, "_emit_settled_session_info", lambda *_args: None)
+        monkeypatch.setattr(server, "_emit", lambda *args, **_kwargs: emitted.append(args))
+
+        server._run_prompt_submit("1", "sid", session, "hello")
+        time.sleep(0.15)
+        assert session["_run_thread"].is_alive()
+        assert not ran.is_set()
+
+        response = server.handle_request(
+            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
+        )
+        assert response.get("result"), response
+        session["_run_thread"].join(timeout=2)
+
+        assert not session["_run_thread"].is_alive()
+        assert session["running"] is False
+        assert session.get("inflight_turn") is None
+        assert not ran.is_set()
+        assert not any(event[0] == "error" for event in emitted)
+        assert any(
+            event[0] == "message.complete" and event[2].get("status") == "interrupted"
+            for event in emitted
+        )
+    finally:
+        if holder is not None:
+            holder.release()
+        holder_db.close()
+        waiter_db.close()
+        server._sessions.pop("sid", None)
+
+
+def test_tui_turn_installs_and_restores_compression_lease_rebind(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("session-key", "tui")
+    observed = {}
+    original_rebind = lambda _session_id: "original"
+
+    class _Agent(_RecordingAgent):
+        session_id = "session-key"
+
+        def run_conversation(self, *args, **kwargs):
+            observed["rebind"] = self._durable_turn_lease_rebind
+            return super().run_conversation(*args, **kwargs)
+
+    agent = _Agent([])
+    agent._durable_turn_lease_rebind = original_rebind
+    session = _session(agent=agent, session_key="session-key", running=True)
+    server._sessions["sid"] = session
+
+    @contextlib.contextmanager
+    def _turn_db(_session):
+        yield db
+
+    try:
+        monkeypatch.setattr(server, "_session_db", _turn_db)
+        server._run_prompt_submit("1", "sid", session, "hello")
+
+        assert callable(observed["rebind"])
+        assert observed["rebind"] is not original_rebind
+        assert agent._durable_turn_lease_rebind is original_rebind
+    finally:
+        db.close()
         server._sessions.pop("sid", None)
 
 

--- a/tests/tui_gateway/test_session_observe_fanout.py
+++ b/tests/tui_gateway/test_session_observe_fanout.py
@@ -164,3 +164,63 @@ def test_delivery_result_true_when_observer_receives(server):
 
     assert server.write_json(_event_frame("s1")) is True
     assert len(observer.frames) == 1
+
+
+def _locked_session(server, sid: str, transport) -> dict:
+    import threading
+
+    session = {"session_key": f"k-{sid}", "transport": transport, "history_lock": threading.Lock()}
+    server._sessions[sid] = session
+    return session
+
+
+def test_claim_promotes_displaced_owner_to_observer(server):
+    """A client that loses ownership via a re-claim keeps receiving events."""
+    old_owner, new_owner = FakeTransport(), FakeTransport()
+    session = _locked_session(server, "s1", old_owner)
+
+    with session["history_lock"]:
+        server.claim_session_transport(session, new_owner)
+
+    assert server._sessions["s1"]["transport"] is new_owner
+    server.write_json(_event_frame("s1"))
+    assert len(new_owner.frames) == 1
+    assert len(old_owner.frames) == 1  # auto-promoted to observer, still fed
+
+
+def test_claim_same_transport_is_idempotent(server):
+    owner = FakeTransport()
+    session = _locked_session(server, "s1", owner)
+
+    with session["history_lock"]:
+        server.claim_session_transport(session, owner)
+
+    assert "observer_transports" not in session
+    server.write_json(_event_frame("s1"))
+    assert len(owner.frames) == 1
+
+
+def test_claim_none_and_first_claim_do_not_observe(server):
+    session = _locked_session(server, "s1", None)
+
+    server.claim_session_transport(session, None)  # no-op
+    assert session.get("transport") is None
+
+    owner = FakeTransport()
+    with session["history_lock"]:
+        server.claim_session_transport(session, owner)
+
+    assert "observer_transports" not in session
+    assert session["transport"] is owner
+
+
+def test_claim_skips_orphan_sentinel(server):
+    """The detached-WS sentinel is not a real client — never kept as observer."""
+    new_owner = FakeTransport()
+    session = _locked_session(server, "s1", server._detached_ws_transport)
+
+    with session["history_lock"]:
+        server.claim_session_transport(session, new_owner)
+
+    assert session["transport"] is new_owner
+    assert "observer_transports" not in session

--- a/tests/tui_gateway/test_session_observe_fanout.py
+++ b/tests/tui_gateway/test_session_observe_fanout.py
@@ -1,0 +1,166 @@
+"""Tests for session.observe + write_json observer fan-out.
+
+A live session's event frames normally route to exactly one transport (the
+session owner — last resumer wins). ``session.observe`` lets a second-screen
+client (LazoChat via the HermesBridge) subscribe to the same frames WITHOUT
+stealing ownership; ``write_json`` fans every event out to primary + observers,
+and the WS-disconnect teardown sweeps observer attachments.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    # Mocks are scoped to the initial import only (see
+    # tests/tui_gateway/test_protocol.py for the rationale).
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_observe")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+
+    yield mod
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+    mod._live_transports.clear()
+    mod._child_mirrors.clear()
+    mod._active_child_runs.clear()
+
+
+class FakeTransport:
+    """Minimal transport recording frames; identity-based like WSTransport."""
+
+    def __init__(self):
+        self.frames: list[dict] = []
+        self.closed = False
+
+    def write(self, obj: dict) -> bool:
+        if self.closed:
+            return False
+        self.frames.append(obj)
+        return True
+
+    def close(self):
+        self.closed = True
+
+
+def _event_frame(sid: str) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {"type": "chunk", "session_id": sid},
+    }
+
+
+def _observe_req(sid: str, observing: bool) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "session.observe",
+        "params": {"session_id": sid, "observe": observing},
+    }
+
+
+def test_write_json_fans_to_primary_and_observer(server):
+    primary, observer = FakeTransport(), FakeTransport()
+    server._sessions["s1"] = {"session_key": "k1", "transport": primary}
+
+    assert server.add_session_observer("s1", observer) is True
+    server.write_json(_event_frame("s1"))
+
+    assert len(primary.frames) == 1
+    assert len(observer.frames) == 1
+    assert observer.frames[0]["params"]["session_id"] == "s1"
+
+
+def test_observer_same_as_primary_not_duplicated(server):
+    primary = FakeTransport()
+    server._sessions["s1"] = {"session_key": "k1", "transport": primary}
+
+    server.add_session_observer("s1", primary)
+    server.write_json(_event_frame("s1"))
+
+    assert len(primary.frames) == 1
+
+
+def test_observe_does_not_steal_ownership(server):
+    """The primary transport stays untouched — observers are additive."""
+    primary = FakeTransport()
+    server._sessions["s1"] = {"session_key": "k1", "transport": primary}
+
+    server.add_session_observer("s1", FakeTransport())
+    assert server._sessions["s1"]["transport"] is primary
+
+
+def test_session_observe_rpc_attaches_calling_transport(server):
+    primary, observer = FakeTransport(), FakeTransport()
+    server._sessions["s1"] = {"session_key": "k1", "transport": primary}
+
+    resp = server.dispatch(_observe_req("s1", True), observer)
+    assert resp is not None
+    assert resp.get("result", {}).get("observing") is True
+
+    server.write_json(_event_frame("s1"))
+    assert len(observer.frames) == 1
+
+    resp = server.dispatch(_observe_req("s1", False), observer)
+    assert resp is not None
+    assert resp.get("result", {}).get("observing") is False
+
+    server.write_json(_event_frame("s1"))
+    assert len(observer.frames) == 1  # no new frames after unobserve
+
+
+def test_observe_accepts_stored_session_key(server):
+    observer = FakeTransport()
+    server._sessions["abc12345"] = {"session_key": "stored-key", "transport": FakeTransport()}
+
+    resp = server.dispatch(_observe_req("stored-key", True), observer)
+    assert resp.get("result", {}).get("session_id") == "abc12345"
+
+
+def test_observe_unknown_session_errors(server):
+    resp = server.dispatch(_observe_req("ghost", True), FakeTransport())
+    assert "error" in resp
+
+
+def test_transport_disconnect_sweeps_observer(server):
+    primary, observer = FakeTransport(), FakeTransport()
+    server._sessions["s1"] = {"session_key": "k1", "transport": primary}
+    server.add_session_observer("s1", observer)
+
+    # The single WS-disconnect teardown path (also detaches owned sessions;
+    # s1 is observer-only, so only the sweep matters here).
+    reaped, detached = server._close_sessions_for_transport(observer, end_reason="ws_disconnect")
+    assert (reaped, detached) == (0, 0)
+
+    server.write_json(_event_frame("s1"))
+    assert len(primary.frames) == 1
+    assert len(observer.frames) == 0
+
+
+def test_delivery_result_true_when_observer_receives(server):
+    """A dead primary must not zero the delivery result if an observer got it."""
+    dead = FakeTransport()
+    dead.close()
+    observer = FakeTransport()
+    server._sessions["s1"] = {"session_key": "k1", "transport": dead}
+    server.add_session_observer("s1", observer)
+
+    assert server.write_json(_event_frame("s1")) is True
+    assert len(observer.frames) == 1

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -127,7 +127,8 @@ def _(rid, params: dict) -> dict:
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
     if (t := current_transport()) is not None:
-        session["transport"] = t
+        with session["history_lock"]:
+            claim_session_transport(session, t)
     while True:
         busy_transport = None
         with session["history_lock"]:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2895,6 +2895,42 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "interrupted"})
 
 
+@method("session.observe")
+def _(rid, params: dict) -> dict:
+    """Subscribe/unsubscribe the CALLING transport to a live session's event
+    stream without taking ownership of it.
+
+    Session events normally route to exactly one client — the transport stored
+    on the session (last resumer wins). Second-screen viewers (LazoChat via
+    the HermesBridge watching a desktop-owned run) need the same frames without
+    stealing that ownership: observing adds the caller to the session's
+    observer set and ``write_json`` fans every event out to primary + observers.
+    Observers are swept automatically when their transport disconnects.
+    """
+    sid = str(params.get("session_id") or "").strip()
+    if not sid:
+        return _err(rid, 4000, "session.observe requires session_id")
+    observing = is_truthy_value(params.get("observe", True))
+    transport = current_transport()
+    if transport is None:
+        return _err(rid, 4023, "session.observe requires a client transport")
+    live_sid, session = sid, _sessions.get(sid)
+    if session is None:
+        # Be lenient: accept the stored session key too (clients usually pass
+        # the live id from session.active_list, but a stored key is
+        # unambiguous when the session is live).
+        found = _find_live_session_by_key(sid)
+        if found is not None:
+            live_sid, session = found
+    if session is None:
+        return _err(rid, 4004, "session not live")
+    if observing:
+        add_session_observer(live_sid, transport)
+    else:
+        remove_session_observer(live_sid, transport)
+    return _ok(rid, {"session_id": live_sid, "observing": observing})
+
+
 @method("delegation.status")
 def _(rid, params: dict) -> dict:
     from tools.delegate_tool import (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1100,6 +1100,14 @@ def _close_sessions_for_transport(
                 _schedule_ws_orphan_reap(sid)
             except Exception:
                 pass
+    # Sweep observer attachments too: observer-only sessions aren't "owned"
+    # above, and leaving the dead transport in their observer sets would aim
+    # later event writes at a closed socket.
+    with _session_observers_lock:
+        for session in _sessions.values():
+            observers = session.get("observer_transports")
+            if observers:
+                observers.discard(transport)
     return reaped, detached
 
 
@@ -1509,14 +1517,56 @@ def _default_session_cwd() -> str:
     return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
 
 
+# Per-session observer transports: extra clients that receive the session's
+# event frames WITHOUT owning it (second-screen viewers such as LazoChat via
+# the HermesBridge). The primary ``session["transport"]`` keeps its
+# last-resumer-wins ownership semantics (orphan reaping, close_on_disconnect);
+# observers are a pure fan-out set managed by ``session.observe`` and swept on
+# WS disconnect. Guarded by its own lock: emitters write from run threads
+# while observe/unobserve/teardown mutate from dispatch/teardown threads.
+_session_observers_lock = threading.Lock()
+
+
+def add_session_observer(sid: str, transport) -> bool:
+    """Attach ``transport`` as an event observer of the live session ``sid``.
+
+    Returns False when the session isn't live (nothing to observe) or the
+    transport is missing. Idempotent.
+    """
+    if transport is None:
+        return False
+    session = _sessions.get(sid)
+    if session is None:
+        return False
+    with _session_observers_lock:
+        observers = session.setdefault("observer_transports", set())
+        observers.add(transport)
+    return True
+
+
+def remove_session_observer(sid: str, transport) -> bool:
+    """Detach ``transport`` from the session's observer set. Idempotent."""
+    session = _sessions.get(sid)
+    if session is None:
+        return False
+    with _session_observers_lock:
+        observers = session.get("observer_transports")
+        if not observers:
+            return False
+        observers.discard(transport)
+    return True
+
+
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
     Precedence:
 
-    1. Event frames with a session id → the transport stored on that session,
-       so async events land with the client that owns the session even if
-       the emitting thread has no contextvar binding.
+    1. Event frames with a session id → the transport stored on that session
+       PLUS every registered observer transport (second-screen viewers), so
+       async events land with every client watching the session even if the
+       emitting thread has no contextvar binding. Observer writes are
+       best-effort and never poison the primary's delivery result.
     2. Otherwise the transport bound on the current context (set by
        :func:`dispatch` for the lifetime of a request).
     3. Otherwise the module-level stdio transport, matching the historical
@@ -1524,8 +1574,30 @@ def write_json(obj: dict) -> bool:
     """
     if obj.get("method") == "event":
         sid = ((obj.get("params") or {}).get("session_id")) or ""
-        if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
-            return t.write(obj)
+        if sid:
+            session = _sessions.get(sid) or {}
+            primary = session.get("transport")
+            with _session_observers_lock:
+                observers = [
+                    t
+                    for t in (session.get("observer_transports") or ())
+                    if t is not primary
+                ]
+            if primary is not None or observers:
+                delivered = False
+                if primary is not None:
+                    try:
+                        delivered = bool(primary.write(obj))
+                    except Exception:
+                        delivered = False
+                for observer in observers:
+                    try:
+                        delivered = bool(observer.write(obj)) or delivered
+                    except Exception:
+                        # A dead observer must not break delivery accounting —
+                        # the disconnect teardown sweeps it shortly.
+                        pass
+                return delivered
 
     return (current_transport() or _stdio_transport).write(obj)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1557,6 +1557,31 @@ def remove_session_observer(sid: str, transport) -> bool:
     return True
 
 
+def claim_session_transport(session: dict, transport) -> None:
+    """(Re)bind a session's primary transport, auto-promoting the displaced
+    owner to observer.
+
+    ``session[\"transport\"]`` keeps its last-resumer-wins semantics (orphan
+    reaping, close_on_disconnect), but a client that LOSES ownership must not
+    go dark: second-screen continuity relies on the previous owner receiving
+    the session's events after being displaced (e.g. the Hermes Desktop UI,
+    which never calls ``session.observe``). Idempotent — claiming with the
+    same transport adds nothing.
+
+    Caller MUST hold ``session[\"history_lock\"]`` (a non-reentrant Lock).
+    """
+    if transport is None:
+        return
+    previous = session.get("transport")
+    session["transport"] = transport
+    if previous is not None and previous is not transport:
+        # The orphan sentinel isn't a real client — never keep feeding it.
+        if previous is _detached_ws_transport:
+            return
+        with _session_observers_lock:
+            session.setdefault("observer_transports", set()).add(previous)
+
+
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
@@ -8005,7 +8030,7 @@ def _live_session_payload(
         if cols is not None:
             session["cols"] = cols
         if transport is not None:
-            session["transport"] = transport
+            claim_session_transport(session, transport)
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -37,6 +37,7 @@ from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+from gateway.turn_lease import DurableTurnLease, TurnLeaseCancelledError
 from tui_gateway import git_probe
 from tui_gateway.turn_marker import (
     clear_turn_marker,
@@ -9383,6 +9384,28 @@ def _run_prompt_submit(
         result = None  # turn outcome; read after the finally for leftover /steer
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
         thinking_started = False  # ambient thinking sound armed for this turn
+        history: list = []
+        history_version = 0
+        turn_db_context = None
+        turn_lease = None
+        lease_rebind_installed = False
+        had_lease_rebind = False
+        previous_lease_rebind = None
+
+        def _restore_turn_lease_rebind() -> None:
+            nonlocal lease_rebind_installed
+            if not lease_rebind_installed:
+                return
+            try:
+                if had_lease_rebind:
+                    agent._durable_turn_lease_rebind = previous_lease_rebind
+                else:
+                    delattr(agent, "_durable_turn_lease_rebind")
+            except Exception:
+                logger.exception("Failed to restore TUI turn lease callback")
+            finally:
+                lease_rebind_installed = False
+
         one_turn_restore = session.pop("one_turn_model_restore", None)
         # True once a failed turn's snapshot was retained for resume replay —
         # tells the finally below to skip the normal inflight clear.
@@ -9414,6 +9437,49 @@ def _run_prompt_submit(
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+
+            # Desktop and the API server are separate processes sharing
+            # state.db. Serialize the full load -> run -> flush region there,
+            # then reload history so a queued wake sees the turn it followed.
+            turn_db_context = _session_db(session)
+            turn_db = turn_db_context.__enter__()
+            turn_session_id = str(session.get("session_key") or "")
+            turn_lease = DurableTurnLease.acquire(
+                turn_db,
+                turn_session_id,
+                owner_key=f"tui:{sid}",
+                generation=int(session.get("history_version", 0)),
+                cancelled=lambda: bool(
+                    session.get("_turn_cancel_requested")
+                    or session.get("_finalized")
+                ),
+            )
+            if turn_lease is not None:
+                had_lease_rebind = hasattr(agent, "_durable_turn_lease_rebind")
+                if had_lease_rebind:
+                    previous_lease_rebind = getattr(
+                        agent, "_durable_turn_lease_rebind"
+                    )
+                agent._durable_turn_lease_rebind = turn_lease.rebind
+                lease_rebind_installed = True
+            get_session = getattr(turn_db, "get_session", None)
+            get_history = getattr(turn_db, "get_messages_as_conversation", None)
+            persisted = (
+                get_session(turn_session_id)
+                if callable(get_session) and callable(get_history)
+                else None
+            )
+            persisted_history = (
+                get_history(turn_session_id)
+                if persisted is not None
+                else None
+            )
+            with session["history_lock"]:
+                if persisted_history is not None and persisted_history != session["history"]:
+                    session["history"] = persisted_history
+                    session["history_version"] = int(session.get("history_version", 0)) + 1
+                history = list(session["history"])
+                history_version = int(session.get("history_version", 0))
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
@@ -9785,6 +9851,26 @@ def _run_prompt_submit(
                 _sync_session_key_after_compress(
                     sid, session, clear_pending_title=False, restart_slash_worker=True,
                 )
+                new_session_id = str(session.get("session_key") or "")
+                if (
+                    turn_lease is not None
+                    and new_session_id != turn_lease.session_id
+                    and not turn_lease.rebind(new_session_id)
+                ):
+                    logger.error(
+                        "Failed to rebind durable turn lease after compression: %s -> %s",
+                        turn_lease.session_id,
+                        new_session_id,
+                    )
+                # The transcript is flushed when run_conversation returns.
+                # Let the queued wake start before auxiliary title/goal/TTS work.
+                if turn_lease is not None:
+                    _restore_turn_lease_rebind()
+                    turn_lease.release()
+                    turn_lease = None
+                if turn_db_context is not None:
+                    turn_db_context.__exit__(None, None, None)
+                    turn_db_context = None
 
                 raw = result.get("final_response", "")
                 status = (
@@ -10000,6 +10086,17 @@ def _run_prompt_submit(
                     logger.warning("voice TTS skipped: hermes_cli.voice unavailable")
                 except Exception as e:
                     logger.warning("voice TTS dispatch failed: %s", e)
+        except TurnLeaseCancelledError:
+            # Stop while queued behind another process is a clean interrupt,
+            # not a failed turn to retain/replay on the next resume.
+            with session["history_lock"]:
+                _clear_inflight_turn(session)
+            _retire_turn_marker(session, marker_key)
+            _emit(
+                "message.complete",
+                sid,
+                {"text": "", "usage": _get_usage(agent), "status": "interrupted"},
+            )
         except Exception as e:
             import traceback
 
@@ -10032,6 +10129,13 @@ def _run_prompt_submit(
                 )
                 _emit("error", sid, {"message": str(e)})
         finally:
+            _restore_turn_lease_rebind()
+            if turn_lease is not None:
+                with contextlib.suppress(Exception):
+                    turn_lease.release()
+            if turn_db_context is not None:
+                with contextlib.suppress(Exception):
+                    turn_db_context.__exit__(None, None, None)
             # Drop both local snapshots of the pre-turn history before asking
             # glibc to return pages. session["history"] already points at the
             # new/pruned result; retaining either list defeats this trim.


### PR DESCRIPTION
## What does this PR do?

Keeps one Hermes session live and coherent when the active turn and a second-screen client share the same long-running `hermes serve` process.

The previous behavior had three separate gaps:

- concurrent inputs could race for the same persisted session;
- live session events were routed to the owning transport instead of observers;
- Desktop refreshed session lists but could leave the active transcript on a stale snapshot.

This PR serializes shared-session turns, adds explicit observer fan-out without stealing ownership, promotes a displaced owner to an observer, and refreshes active Desktop transcripts when the session changes.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added durable shared-session turn leases and deterministic queue/steer handling across API-server, wake, compression, and session state paths.
- Added `session.observe` plus subscriber fan-out for secondary WebSocket viewers.
- Preserved active ownership while automatically retaining a displaced transport as an observer.
- Reconciled the active Desktop transcript when background session updates arrive.
- Added regression coverage for turn serialization, observer fan-out, ownership promotion, and Desktop transcript refresh.

## How to Test

1. Run the focused gateway/session suite:
   ```bash
   pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_session_api.py tests/gateway/test_turn_lease.py tests/run_agent/test_compression_boundary_hook.py tests/test_tui_gateway_server.py tests/tui_gateway/test_session_observe_fanout.py -q
   ```
2. Run the Desktop regression and static checks:
   ```bash
   npm run test --workspace apps/desktop -- src/app/contrib/hooks/use-background-sync.test.ts
   npm run typecheck --workspace apps/desktop
   npm run lint --workspace apps/desktop
   npm run build --workspace apps/desktop
   ```
3. Point Desktop and a second client at the same `hermes serve`, start a turn from either side, and verify both clients receive live activity without rebinding the active owner.

## Verification

- 685 focused Python tests passed.
- Desktop background-sync regression passed.
- Desktop typecheck, lint, and production build passed.
- Ruff passed on all changed Python files.
- `git diff --check origin/main...HEAD` passed.
- `scripts/check-windows-footguns.py --diff origin/main` reports 10 pre-existing bare text-I/O findings in `tests/test_tui_gateway_server.py`; none of those lines are added or changed by this PR.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A; the change is covered by transport, session, and Desktop regression tests.
