### PR TITLE
Browserbase : accept shared truthy aliases for ADVANCED_STEALTH

### DIFF
--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -24,7 +24,7 @@ Optional feature knobs::
 
     BROWSERBASE_BASE_URL=...      # default https://api.browserbase.com
     BROWSERBASE_PROXIES=true      # default true
-    BROWSERBASE_ADVANCED_STEALTH=false
+    BROWSERBASE_ADVANCED_STEALTH=false  # truthy aliases: 1/true/yes/on
     BROWSERBASE_KEEP_ALIVE=true   # default true
     BROWSERBASE_SESSION_TIMEOUT=... (seconds, integer, max 21600 = 6h)
 """
@@ -40,6 +40,7 @@ import requests
 
 from agent.browser_provider import BrowserProvider
 from agent.secret_scope import get_secret
+from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +98,9 @@ class BrowserbaseBrowserProvider(BrowserProvider):
 
         # Optional env-var knobs
         enable_proxies = os.environ.get("BROWSERBASE_PROXIES", "true").lower() != "false"
-        enable_advanced_stealth = (
-            os.environ.get("BROWSERBASE_ADVANCED_STEALTH", "false").lower() == "true"
+        # Opt-in flag — accept shared truthy aliases (previously only literal "true").
+        enable_advanced_stealth = env_var_enabled(
+            "BROWSERBASE_ADVANCED_STEALTH", default="false"
         )
         enable_keep_alive = (
             os.environ.get("BROWSERBASE_KEEP_ALIVE", "true").lower() != "false"

--- a/tests/plugins/browser/test_browserbase_advanced_stealth_truthy.py
+++ b/tests/plugins/browser/test_browserbase_advanced_stealth_truthy.py
@@ -1,0 +1,48 @@
+"""BROWSERBASE_ADVANCED_STEALTH must honor shared truthy aliases."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.browser.browserbase.provider import BrowserbaseBrowserProvider
+
+
+def _capture_session_payload(monkeypatch: pytest.MonkeyPatch, stealth_raw: str):
+    monkeypatch.setenv("BROWSERBASE_API_KEY", "bb-key")
+    monkeypatch.setenv("BROWSERBASE_PROJECT_ID", "proj-1")
+    monkeypatch.setenv("BROWSERBASE_ADVANCED_STEALTH", stealth_raw)
+    # Default keep-alive/proxies would still be on — disable for a quieter payload.
+    monkeypatch.setenv("BROWSERBASE_KEEP_ALIVE", "false")
+    monkeypatch.setenv("BROWSERBASE_PROXIES", "false")
+
+    response = MagicMock()
+    response.status_code = 200
+    response.ok = True
+    response.json.return_value = {
+        "id": "sess-1",
+        "connectUrl": "wss://example/cdp",
+        "status": "RUNNING",
+    }
+
+    with patch(
+        "plugins.browser.browserbase.provider.requests.post",
+        return_value=response,
+    ) as post:
+        BrowserbaseBrowserProvider().create_session("task-1")
+
+    assert post.called
+    return post.call_args.kwargs["json"]
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE", " On "])
+def test_advanced_stealth_truthy_aliases_enable_setting(monkeypatch, raw):
+    payload = _capture_session_payload(monkeypatch, raw)
+    assert payload.get("browserSettings") == {"advancedStealth": True}
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "off", "no", ""])
+def test_advanced_stealth_falsy_aliases_skip_setting(monkeypatch, raw):
+    payload = _capture_session_payload(monkeypatch, raw)
+    assert "browserSettings" not in payload


### PR DESCRIPTION
## Summary
- Parse `BROWSERBASE_ADVANCED_STEALTH` via `env_var_enabled` so aliases like `1`/`yes`/`on` enable `browserSettings.advancedStealth` (previously only the literal `true` worked).
- Aligns the Browserbase opt-in knob with the shared `TRUTHY_STRINGS` contract.
