### PR TITLE
fix(telegram): acknowledge unhandled callback queries

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6747,7 +6747,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
-            await query.answer()
+            # Forward-compatible with #78619: if a plugin dispatch path is
+            # present, gate the ack on its result so plugin handlers that
+            # already call query.answer() do not see a second answerCallbackQuery.
+            dispatch = getattr(self, "_dispatch_plugin_callback_handlers", None)
+            if dispatch is None:
+                await query.answer()
+            else:
+                if not await dispatch(query, data):
+                    await query.answer()
             return
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6405,7 +6405,10 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> None:
         """Handle inline keyboard button clicks."""
         query = update.callback_query
-        if not query or not query.data:
+        if not query:
+            return
+        if not query.data:
+            await query.answer()
             return
         data = query.data
         query_message = getattr(query, "message", None)
@@ -6744,6 +6747,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
+            await query.answer()
             return
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -234,6 +234,37 @@ class TestTelegramClarifyCallback:
         assert adapter._clarify_state["cidC"] == "sk-auth"
 
 
+class TestTelegramUnknownCallback:
+    """Unknown and data-less callbacks must stop Telegram's spinner."""
+
+    @pytest.mark.asyncio
+    async def test_data_less_callback_is_acknowledged(self):
+        adapter = _make_adapter()
+        query = AsyncMock()
+        query.data = None
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_unknown_callback_is_acknowledged(self):
+        adapter = _make_adapter()
+        query = AsyncMock()
+        query.data = "stale_button"
+        query.message = MagicMock()
+        query.from_user = MagicMock()
+        query.answer = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_awaited_once_with()
+
+
 # ===========================================================================
 # Base adapter fallback render — text numbered list
 # ===========================================================================

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -264,6 +264,33 @@ class TestTelegramUnknownCallback:
 
         query.answer.assert_awaited_once_with()
 
+    @pytest.mark.asyncio
+    async def test_unknown_callback_plugin_dispatch_consumes_skips_ack(self):
+        """When a plugin dispatch claims the callback (returns True),
+        the adapter must NOT call query.answer() a second time. The
+        plugin handler is responsible for answering the callback itself
+        (forward-compatible with #78619)."""
+        adapter = _make_adapter()
+        query = AsyncMock()
+        query.data = "plugin:claimed"
+        query.message = MagicMock()
+        query.from_user = MagicMock()
+        query.answer = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        async def _fake_dispatch(q, d):
+            # Simulate plugin handler consuming the callback.
+            await q.answer()
+            return True
+
+        adapter._dispatch_plugin_callback_handlers = _fake_dispatch
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        # query.answer() called exactly once — by the plugin handler.
+        assert query.answer.await_count == 1
+
 
 # ===========================================================================
 # Base adapter fallback render — text numbered list


### PR DESCRIPTION
## Summary

- Acknowledge Telegram callback queries with no data so the client loading indicator is cleared.
- Acknowledge callback data that does not match a built-in Hermes namespace, including stale buttons.
- Preserve all existing built-in callback handling.
- Complement the plugin callback-handler work in #78619: callbacks that no handler consumes still receive an acknowledgement.

## Verification

- `python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_clarify_buttons.py`
- `uv run --extra dev --extra messaging python -m pytest tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_callback_auth_fail_closed.py -q` — 39 passed
- Regression test fails on the unfixed source and passes with this change (git-stash verification)
- `git diff --check`

Closes #78788
