### PR TITLE
fix(deps): relax cryptography pin to patched releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,14 @@ dependencies = [
   "urllib3>=2.7.0,<3",
   # cryptography is pulled in transitively by PyJWT[crypto]; pin it explicitly
   # so the WeCom/Weixin crypto paths can't drift below the CVE-fixed floor.
-  "cryptography==48.0.1",  # CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf; ==48.0.1 (not 49.x): msal and alibabacloud-tea-openapi cap <49, hindsight-api-slim needs >=48.0.1
+  # cryptography is pulled in transitively by PyJWT[crypto]; pin it explicitly
+  # so the WeCom/Weixin crypto paths can't drift below the CVE-fixed floor.
+  # Floor: 48.0.1 (CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf). Open
+  # upper range so installs without [dingtalk] resolve to the patched releases
+  # (GHSA-jwv3-5hgf-82ww / GHSA-m2h6-j472-r4p4 fixed in 49.0.0, GHSA-g6cj-pr64-35w5
+  # in 50.0.0); [dingtalk]'s alibabacloud-tea-openapi caps <49, so dingtalk
+  # installs keep 48.0.1 until upstream relaxes (#78543).
+  "cryptography>=48.0.1,<51",
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
   # out of the box.  ``tzdata`` ships the Olson database as a data package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,6 @@ dependencies = [
   "urllib3>=2.7.0,<3",
   # cryptography is pulled in transitively by PyJWT[crypto]; pin it explicitly
   # so the WeCom/Weixin crypto paths can't drift below the CVE-fixed floor.
-  # cryptography is pulled in transitively by PyJWT[crypto]; pin it explicitly
-  # so the WeCom/Weixin crypto paths can't drift below the CVE-fixed floor.
   # Floor: 48.0.1 (CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf). Open
   # upper range so installs without [dingtalk] resolve to the patched releases
   # (GHSA-jwv3-5hgf-82ww / GHSA-m2h6-j472-r4p4 fixed in 49.0.0, GHSA-g6cj-pr64-35w5

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T16:38:42.729819205Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1819,7 +1819,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.5.20" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
-    { name = "cryptography", specifier = "==48.0.1" },
+    { name = "cryptography", specifier = ">=48.0.1,<51" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -3998,7 +3998,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4053,7 +4053,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4692,11 +4692,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
Fixes #78543

## Summary

`cryptography==48.0.1` is pinned in the base dependency list, but the only constraint that forces that version is `alibabacloud-tea-openapi`'s `cryptography<49` cap, which is reachable **only** through the optional `[dingtalk]` extra. Every install — including the large majority that never installs `[dingtalk]` — is therefore held at a version carrying open HIGH advisories:

- `GHSA-jwv3-5hgf-82ww` (HIGH) — fixed in 49.0.0
- `GHSA-m2h6-j472-r4p4` (MODERATE) — fixed in 49.0.0
- `GHSA-g6cj-pr64-35w5` (HIGH) — fixed in 50.0.0

The original `<49` blockers have since relaxed: `msal` now allows `cryptography<51`, and `hindsight-api-slim` only requires `>=48.0.1`.

## Changes

- `pyproject.toml`: replace the exact pin with `cryptography>=48.0.1,<51` — the CVE-fixed floor (CVE-2026-39892, CVE-2026-34073, GHSA-537c-gmf6-5ccf) is preserved, while installs without `[dingtalk]` resolve to the patched 49.x/50.x releases. `[dingtalk]` installs keep `48.0.1` (their `alibabacloud-tea-openapi` still caps `<49`) — the constraint now applies only where the extra that needs it is selected, per the issue's suggested fix.
- `uv.lock`: regenerated via `uv lock` (the repo's documented lock refresh; `uv lock --check` passes).

## Validation

- `uv pip compile pyproject.toml` (base): resolves `cryptography==49.0.0` (pre-fix baseline: `==48.0.1`).
- `uv pip compile pyproject.toml --extra dingtalk`: still resolves cleanly at `cryptography==48.0.1` — no install is broken.
- Smoke test in a fresh venv with `cryptography==49.0.0` + `PyJWT[crypto]==2.13.0`: RSA PKCS1v15 sign/verify, Fernet roundtrip, and PyJWT HS256/RS256 all pass (the WeCom/Weixin crypto paths the pin protects).
- `uv lock --check`: passes (blocking CI check).

## Note

`cryptography==50.0.0` (which also fixes `GHSA-g6cj-pr64-35w5`) was published 2026-07-31 and is currently excluded by the repo's `exclude-newer = "14 days"` policy; it becomes eligible shortly, at which point the base resolution will move to 50.x with no further change needed.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] Dependency advisories addressed (HIGH advisories fixed for non-dingtalk installs)
