### PR TITLE
fix(tui): repair EBADENGINE when npm install output is silent (#78826)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2302,7 +2302,7 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
         "This usually means `hermes update` left tracked ui-tui files deleted.\n"
         "Recovery:\n"
         "  1. From the Hermes checkout, run `git restore -- ui-tui`\n"
-        "  2. Run `npm install --silent --no-fund --no-audit --progress=false`\n"
+        "  2. Run `npm install --no-fund --no-audit --progress=false`\n"
         "  3. Retry `hermes --tui`\n"
         "If the checkout is still inconsistent, run `hermes update --force`.",
         file=sys.stderr,
@@ -2429,7 +2429,10 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             # npm `omit=dev` config would silently skip them and the TUI
             # build would fail. See _run_npm_install_deterministic.
             "--include=dev",
-            "--silent",
+            # No --silent: engine-strict EBADENGINE must reach stderr so the
+            # repair below (and the failure preview) can see it. Quietness
+            # comes from capture_output + CI=1; --silent used to exit 1 with
+            # empty stdout/stderr and skip managed-Node auto-repair (#78826).
             "--no-fund",
             "--no-audit",
             "--progress=false",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2043,7 +2043,10 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             # npm `omit=dev` config would silently skip them and the TUI
             # build would fail. See _run_npm_install_deterministic.
             "--include=dev",
-            "--silent",
+            # No --silent: engine-strict EBADENGINE must reach stderr so the
+            # repair below (and the failure preview) can see it. Quietness
+            # comes from capture_output + CI=1; --silent used to exit 1 with
+            # empty stdout/stderr and skip managed-Node auto-repair (#78826).
             "--no-fund",
             "--no-audit",
             "--progress=false",

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -8,10 +8,13 @@ pins an ``engines.npm`` range, so an npm outside that range aborts every
     npm error notsup Required: {"node":">=26.0.0","npm":">=12.0.0"}
     npm error notsup Actual:   {"npm":"10.9.8","node":"v22.23.1"}
 
-Rather than predicting the failure (which would mean a semver range matcher and
-an ``npm --version`` probe before work that usually succeeds), we react to it:
-npm states the required range in the error, so the recovery reads the
-constraint straight out of the output it just produced.
+Rather than predicting the failure (which would mean probing before work that
+usually succeeds), we react to a failed install. Preferred signal is npm's own
+error text — it states the required range. When that text is missing (notably
+``npm install --silent``, which exits 1 with empty stdout/stderr), we fall
+back to probing the active ``npm --version`` against the checkout's
+``engines.npm`` and treat a mismatch the same way. Lockfile / network / etc.
+failures with diagnostic text still leave the original error alone.
 
 Scope of the repair is deliberately narrow. Hermes only upgrades an npm that
 lives inside its **own** managed Node tree (``$HERMES_HOME/node``), installing
@@ -44,6 +47,7 @@ from hermes_constants import (
 __all__ = [
     "is_ebadengine",
     "required_npm_range",
+    "npm_satisfies_range",
     "managed_npm_prefix",
     "upgrade_managed_npm",
     "maybe_repair_npm_engine",
@@ -117,6 +121,71 @@ def actual_npm_version(output: str) -> str | None:
         if isinstance(parsed, dict) and parsed.get("npm"):
             return str(parsed["npm"]).strip()
     return None
+
+
+def _parse_major_minor_patch(version: str) -> tuple[int, int, int]:
+    parts = version.split("-", 1)[0].split(".")
+    nums = [int(p) for p in parts[:3]]
+    while len(nums) < 3:
+        nums.append(0)
+    return nums[0], nums[1], nums[2]
+
+
+def _satisfies_clause(version: str, clause: str) -> bool:
+    """Evaluate one ``>=x.y.z`` / ``<x.y.z`` / ``^x.y.z`` comparator."""
+    clause = clause.strip()
+    if not clause:
+        return False
+    if clause.startswith("^"):
+        bound = clause[1:].strip()
+        have = _parse_major_minor_patch(version)
+        want = _parse_major_minor_patch(bound)
+        # ^x.y.z allows >=x.y.z within the same major (x > 0).
+        return have[0] == want[0] and have >= want
+    for op in (">=", "<=", "<", ">", "="):
+        if clause.startswith(op):
+            bound = clause[len(op) :].strip()
+            break
+    else:
+        op, bound = "=", clause
+    have = _parse_major_minor_patch(version)
+    want = _parse_major_minor_patch(bound)
+    if op == ">=":
+        return have >= want
+    if op == "<=":
+        return have <= want
+    if op == "<":
+        return have < want
+    if op == ">":
+        return have > want
+    return have == want
+
+
+def npm_satisfies_range(version: str, spec: str) -> bool:
+    """Whether *version* satisfies an ``engines.npm``-style range.
+
+    Supports the subset Hermes authors: ``||`` alternatives, space-joined
+    AND clauses, and ``>=`` / ``<=`` / ``<`` / ``>`` / ``=`` / ``^``
+    comparators. This is the same matcher ``tests/test_engines_satisfiable.py``
+    uses against the root manifest — one implementation, not a second parser.
+    Returns ``False`` on empty/unparseable input rather than raising: a probe
+    that cannot decide must not trigger a repair.
+    """
+    if not version or not spec:
+        return False
+    try:
+        for alternative in spec.split("||"):
+            clauses = [c for c in alternative.strip().split() if c]
+            if clauses and all(_satisfies_clause(version, c) for c in clauses):
+                return True
+    except (TypeError, ValueError):
+        return False
+    return False
+
+
+def _is_opaque_install_output(output: str) -> bool:
+    """True when a failed install left no diagnostic text to parse."""
+    return not (output or "").strip()
 
 
 def _repo_npm_range() -> str | None:
@@ -323,14 +392,36 @@ def maybe_repair_npm_engine(
     a managed npm upgrade cannot fix, or a failed upgrade/bootstrap — leaving
     the original failure to stand.
 
+    Detection is two-legged: prefer parsing ``EBADENGINE`` / ``Unsupported
+    engine`` text from *output*; when that text is absent because the install
+    produced no diagnostics (empty/whitespace output), probe the active
+    ``npm --version`` against the checkout's ``engines.npm`` and repair only
+    on a mismatch. Callers still invoke this only after an install failure
+    (react-to-failure), never as a speculative pre-check. Non-engine failures
+    that still printed a diagnostic (lockfile, network, 404, …) are left
+    alone even if the active npm happens to be out of range.
+
     The returned value is truthy exactly when the caller should retry once,
     so ``if maybe_repair_npm_engine(...)`` call sites keep working; they just
     must run the retry with the returned path.
     """
-    if not npm or not is_ebadengine(output):
+    if not npm:
         return None
 
-    npm_range = required_npm_range(output)
+    if is_ebadengine(output):
+        npm_range = required_npm_range(output)
+        actual_hint = actual_npm_version(output)
+    elif _is_opaque_install_output(output):
+        repo_range = _repo_npm_range()
+        if not repo_range:
+            return None
+        actual_hint = _probe_version(npm)
+        if not actual_hint or npm_satisfies_range(actual_hint, repo_range):
+            return None
+        npm_range = repo_range
+    else:
+        return None
+
     prefix = managed_npm_prefix(npm)
 
     if prefix is not None:
@@ -350,5 +441,5 @@ def maybe_repair_npm_engine(
         return managed
 
     if not quiet and npm_range:
-        _print_manual_fix(npm, npm_range, actual_npm_version(output))
+        _print_manual_fix(npm, npm_range, actual_hint)
     return None

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -8,10 +8,13 @@ pins an ``engines.npm`` range, so an npm outside that range aborts every
     npm error notsup Required: {"node":">=26.0.0","npm":">=12.0.0"}
     npm error notsup Actual:   {"npm":"10.9.8","node":"v22.23.1"}
 
-Rather than predicting the failure (which would mean a semver range matcher and
-an ``npm --version`` probe before work that usually succeeds), we react to it:
-npm states the required range in the error, so the recovery reads the
-constraint straight out of the output it just produced.
+Rather than predicting the failure (which would mean probing before work that
+usually succeeds), we react to a failed install. Preferred signal is npm's own
+error text — it states the required range. When that text is missing (notably
+``npm install --silent``, which exits 1 with empty stdout/stderr), we fall
+back to probing the active ``npm --version`` against the checkout's
+``engines.npm`` and treat a mismatch the same way. Lockfile / network / etc.
+failures with an in-range npm still leave the original error alone.
 
 Scope of the repair is deliberately narrow. Hermes only upgrades an npm that
 lives inside its **own** managed Node tree (``$HERMES_HOME/node``), installing
@@ -43,6 +46,7 @@ from hermes_constants import (
 __all__ = [
     "is_ebadengine",
     "required_npm_range",
+    "npm_satisfies_range",
     "managed_npm_prefix",
     "upgrade_managed_npm",
     "maybe_repair_npm_engine",
@@ -116,6 +120,68 @@ def actual_npm_version(output: str) -> str | None:
         if isinstance(parsed, dict) and parsed.get("npm"):
             return str(parsed["npm"]).strip()
     return None
+
+
+def _parse_major_minor_patch(version: str) -> tuple[int, int, int]:
+    parts = version.split("-", 1)[0].split(".")
+    cleaned: list[int] = []
+    for part in parts[:3]:
+        m = re.match(r"(\d+)", part)
+        if not m:
+            raise ValueError(f"not a semver segment: {part!r}")
+        cleaned.append(int(m.group(1)))
+    while len(cleaned) < 3:
+        cleaned.append(0)
+    return cleaned[0], cleaned[1], cleaned[2]
+
+
+def _satisfies_clause(version: str, clause: str) -> bool:
+    """Evaluate one ``>=x.y.z`` / ``<x.y.z`` / ``^x.y.z`` comparator."""
+    clause = clause.strip()
+    if not clause:
+        return False
+    if clause.startswith("^"):
+        bound = clause[1:].strip()
+        have = _parse_major_minor_patch(version)
+        want = _parse_major_minor_patch(bound)
+        return have[0] == want[0] and have >= want
+    for op in (">=", "<=", "<", ">", "="):
+        if clause.startswith(op):
+            bound = clause[len(op) :].strip()
+            break
+    else:
+        op, bound = "=", clause
+    have = _parse_major_minor_patch(version)
+    want = _parse_major_minor_patch(bound)
+    if op == ">=":
+        return have >= want
+    if op == "<=":
+        return have <= want
+    if op == "<":
+        return have < want
+    if op == ">":
+        return have > want
+    return have == want
+
+
+def npm_satisfies_range(version: str, spec: str) -> bool:
+    """Whether *version* satisfies an ``engines.npm``-style range.
+
+    Supports the subset Hermes authors: ``||`` alternatives, space-joined
+    AND clauses, and ``>=`` / ``<=`` / ``<`` / ``>`` / ``=`` / ``^``
+    comparators. Returns ``False`` on empty/unparseable input rather than
+    raising — a probe that cannot decide must not trigger a repair.
+    """
+    if not version or not spec:
+        return False
+    try:
+        for alternative in spec.split("||"):
+            clauses = [c for c in alternative.strip().split() if c]
+            if clauses and all(_satisfies_clause(version, c) for c in clauses):
+                return True
+    except (TypeError, ValueError):
+        return False
+    return False
 
 
 def _repo_npm_range() -> str | None:
@@ -308,14 +374,33 @@ def maybe_repair_npm_engine(
     a managed npm upgrade cannot fix, or a failed upgrade/bootstrap — leaving
     the original failure to stand.
 
+    Detection is two-legged: prefer parsing ``EBADENGINE`` / ``Unsupported
+    engine`` text from *output*; when that text is absent, probe the active
+    ``npm --version`` against the checkout's ``engines.npm`` and repair only
+    on a mismatch. Callers still invoke this only after an install failure
+    (react-to-failure), never as a speculative pre-check.
+
     The returned value is truthy exactly when the caller should retry once,
     so ``if maybe_repair_npm_engine(...)`` call sites keep working; they just
     must run the retry with the returned path.
     """
-    if not npm or not is_ebadengine(output):
+    if not npm:
         return None
 
-    npm_range = required_npm_range(output)
+    if is_ebadengine(output):
+        npm_range = required_npm_range(output)
+        actual_hint = actual_npm_version(output)
+    else:
+        # Opaque failure — e.g. TUI launch's historical ``npm install --silent``
+        # exits 1 with empty stdout/stderr, suppressing the EBADENGINE block.
+        repo_range = _repo_npm_range()
+        if not repo_range:
+            return None
+        actual_hint = _probe_version(npm)
+        if not actual_hint or npm_satisfies_range(actual_hint, repo_range):
+            return None
+        npm_range = repo_range
+
     prefix = managed_npm_prefix(npm)
 
     if prefix is not None:
@@ -335,5 +420,5 @@ def maybe_repair_npm_engine(
         return managed
 
     if not quiet and npm_range:
-        _print_manual_fix(npm, npm_range, actual_npm_version(output))
+        _print_manual_fix(npm, npm_range, actual_hint)
     return None

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -7,6 +7,7 @@ npm it owns, and every other case leaves the original failure alone.
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,52 @@ from hermes_cli.npm_engine import (
     maybe_repair_npm_engine,
     required_npm_range,
 )
+
+
+def _write_fake_npm(directory: Path, *, version: str) -> Path:
+    """A real npm-shaped executable that logs argv and answers ``--version``.
+
+    ``install --global`` succeeds (managed upgrade); any other ``install``
+    exits 1 with empty output (the historical ``--silent`` EBADENGINE).
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    script = directory / "_hermes_fake_npm.py"
+    script.write_text(
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        f"VERSION = {version!r}\n"
+        "log = Path(__file__).with_name('fake-npm-calls.json')\n"
+        "calls = json.loads(log.read_text()) if log.exists() else []\n"
+        "calls.append(sys.argv[1:])\n"
+        "log.write_text(json.dumps(calls))\n"
+        "if '--version' in sys.argv:\n"
+        "    print(VERSION)\n"
+        "    raise SystemExit(0)\n"
+        "raise SystemExit(0 if '--global' in sys.argv else 1)\n",
+        encoding="utf-8",
+    )
+    if sys.platform == "win32":
+        wrapper = directory / "npm.cmd"
+        wrapper.write_text(
+            f'@echo off\r\n"{sys.executable}" "{script}" %*\r\n'
+            "exit /b %ERRORLEVEL%\r\n",
+            encoding="utf-8",
+        )
+        return wrapper
+    wrapper = directory / "npm"
+    wrapper.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def _fake_npm_calls(npm: Path) -> list[list[str]]:
+    log = npm.parent / "fake-npm-calls.json"
+    if not log.is_file():
+        return []
+    return json.loads(log.read_text(encoding="utf-8"))
 
 
 # Verbatim npm 10 output shape (`npm error`), and the npm 9 shape (`npm ERR!`).
@@ -83,6 +130,28 @@ class TestDetection:
             "npm error notsup Required: {not json}\n"
         )
         assert required_npm_range(broken) is None
+
+
+class TestNpmSatisfiesRange:
+    """Opaque-failure repair reuses the engines.npm matcher the repo already
+    authors in tests/test_engines_satisfiable.py — not a second parser."""
+
+    def test_or_alternatives_and_and_clauses(self):
+        fn = getattr(npm_engine, "npm_satisfies_range", None)
+        assert fn is not None, "opaque repair needs npm_satisfies_range"
+        spec = "<11.10.0 || >=11.17.0"
+        assert fn("11.9.0", spec)
+        assert fn("11.17.0", spec)
+        assert fn("12.0.0", spec)
+        assert not fn("11.16.0", spec)
+        assert not fn("11.10.0", spec)
+
+    def test_empty_or_garbage_is_not_a_match(self):
+        fn = getattr(npm_engine, "npm_satisfies_range", None)
+        assert fn is not None, "opaque repair needs npm_satisfies_range"
+        assert not fn("", ">=12.0.0")
+        assert not fn("11.0.0", "")
+        assert not fn("not-a-version", ">=12.0.0")
 
 
 class TestManagedDetection:
@@ -365,6 +434,45 @@ class TestRepairDecision:
 
         monkeypatch.setattr(subprocess, "run", explode)
         assert not maybe_repair_npm_engine(str(managed_npm), node_only, quiet=True)
+
+
+class TestOpaqueEngineRepair:
+    """#78826 / #78878: empty install output still repairs when npm is
+    outside engines.npm, and does not false-repair when it is in range.
+
+    These go through a fake npm executable (``--version`` / ``install
+    --global``) rather than stubbing ``_probe_version``.
+    """
+
+    @pytest.fixture
+    def managed_tree(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        return home / "node" / "bin"
+
+    def test_opaque_failure_repairs_when_npm_outside_repo_range(self, managed_tree):
+        npm = _write_fake_npm(managed_tree, version="11.16.0")
+        repaired = maybe_repair_npm_engine(str(npm), "", quiet=True)
+        assert repaired == str(npm)
+        calls = _fake_npm_calls(npm)
+        assert any("--version" in c for c in calls), calls
+        assert any("--global" in c for c in calls), calls
+
+    def test_opaque_failure_with_in_range_npm_never_repairs(self, managed_tree):
+        npm = _write_fake_npm(managed_tree, version="11.17.0")
+        repaired = maybe_repair_npm_engine(str(npm), "\n", quiet=True)
+        assert not repaired
+        calls = _fake_npm_calls(npm)
+        assert any("--version" in c for c in calls), calls
+        assert not any("--global" in c for c in calls), calls
+
+    def test_non_engine_failure_never_probes_or_repairs(self, managed_tree):
+        """A lockfile mismatch with diagnostic text is not opaque — even an
+        out-of-range npm must leave the original error alone."""
+        npm = _write_fake_npm(managed_tree, version="11.16.0")
+        repaired = maybe_repair_npm_engine(str(npm), ELOCK_OUTPUT, quiet=True)
+        assert not repaired
+        assert _fake_npm_calls(npm) == []
 
 
 class TestRepoRangeIsSatisfiable:

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -6,6 +6,7 @@ npm it owns, and every other case leaves the original failure alone.
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -473,6 +474,58 @@ class TestOpaqueEngineRepair:
         repaired = maybe_repair_npm_engine(str(npm), ELOCK_OUTPUT, quiet=True)
         assert not repaired
         assert _fake_npm_calls(npm) == []
+
+    def test_opaque_failure_on_foreign_nvm_npm_provisions_managed_runtime(
+        self, tmp_path, monkeypatch
+    ):
+        """#78826: nvm/system npm outside engines.npm + empty install output.
+
+        The failing npm is a PATH shim that looks like nvm (not under
+        ``$HERMES_HOME/node``). Repair must probe ``npm --version`` on that
+        shim, provision a Hermes-managed runtime, return the managed npm,
+        and never run ``install --global`` against the foreign toolchain.
+        """
+        home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        nvm_bin = (
+            tmp_path / "nvm" / "versions" / "node" / "v24.18.1" / "bin"
+        )
+        foreign_npm = _write_fake_npm(nvm_bin, version="11.16.0")
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join([str(nvm_bin), os.environ.get("PATH", "")]),
+        )
+
+        assert managed_npm_prefix(foreign_npm) is None
+
+        provisioned: list[str] = []
+
+        def fake_bootstrap() -> str:
+            managed = _write_fake_npm(home / "node" / "bin", version="11.17.0")
+            provisioned.append(str(managed))
+            return str(managed)
+
+        monkeypatch.setattr(
+            npm_engine, "bootstrap_hermes_managed_node", fake_bootstrap
+        )
+
+        repaired = maybe_repair_npm_engine(str(foreign_npm), "", quiet=True)
+
+        assert provisioned, "foreign opaque failure must provision managed Node"
+        assert repaired == provisioned[0]
+        assert repaired != str(foreign_npm)
+        assert Path(repaired).resolve() != foreign_npm.resolve()
+
+        foreign_calls = _fake_npm_calls(foreign_npm)
+        assert any("--version" in c for c in foreign_calls), foreign_calls
+        assert not any("--global" in c for c in foreign_calls), (
+            "foreign/nvm npm must never be the target of install --global: "
+            f"{foreign_calls}"
+        )
+
+        managed_calls = _fake_npm_calls(Path(repaired))
+        assert any("--global" in c for c in managed_calls), managed_calls
 
 
 class TestRepoRangeIsSatisfiable:

--- a/tests/hermes_cli/test_npm_engine.py
+++ b/tests/hermes_cli/test_npm_engine.py
@@ -16,6 +16,7 @@ from hermes_cli.npm_engine import (
     is_ebadengine,
     managed_npm_prefix,
     maybe_repair_npm_engine,
+    npm_satisfies_range,
     required_npm_range,
 )
 
@@ -82,6 +83,24 @@ class TestDetection:
             "npm error notsup Required: {not json}\n"
         )
         assert required_npm_range(broken) is None
+
+
+class TestNpmSatisfiesRange:
+    """The probe-fallback matcher must evaluate the engines.npm shapes we ship."""
+
+    def test_or_alternatives_and_and_clauses(self):
+        # Current-style excluded band: npm 11.16.0 is out; 11.9 / 11.17 are in.
+        spec = "<11.10.0 || >=11.17.0"
+        assert npm_satisfies_range("11.9.0", spec)
+        assert npm_satisfies_range("11.17.0", spec)
+        assert npm_satisfies_range("12.0.0", spec)
+        assert not npm_satisfies_range("11.16.0", spec)
+        assert not npm_satisfies_range("11.10.0", spec)
+
+    def test_empty_or_garbage_is_not_a_match(self):
+        assert not npm_satisfies_range("", ">=12.0.0")
+        assert not npm_satisfies_range("11.0.0", "")
+        assert not npm_satisfies_range("not-a-version", ">=12.0.0")
 
 
 class TestManagedDetection:
@@ -248,12 +267,90 @@ class TestRepairDecision:
         err = capsys.readouterr().err
         assert 'npm install -g npm@"<11.10.0 || >=12.0.0"' in err
 
-    def test_non_engine_failure_never_repairs(self, managed_npm, monkeypatch):
+    def test_non_engine_failure_with_in_range_npm_never_repairs(
+        self, managed_npm, monkeypatch
+    ):
+        """A lockfile mismatch must not trigger repair when npm is already
+        inside engines.npm — the probe fallback must not over-fire."""
+        import hermes_cli.npm_engine as npm_engine
+
+        monkeypatch.setattr(npm_engine, "_probe_version", lambda _npm: "11.17.0")
+        # Force the repo range to something 11.17.0 satisfies regardless of
+        # whatever the checkout currently pins.
+        monkeypatch.setattr(
+            npm_engine, "_repo_npm_range", lambda: "<11.10.0 || >=11.17.0"
+        )
+
         def explode(cmd, **kwargs):  # pragma: no cover - must not be reached
             raise AssertionError("a lockfile mismatch must not trigger a repair")
 
         monkeypatch.setattr(subprocess, "run", explode)
-        assert not maybe_repair_npm_engine(str(managed_npm), ELOCK_OUTPUT, quiet=True)
+        assert not maybe_repair_npm_engine(
+            str(managed_npm), ELOCK_OUTPUT, quiet=True
+        )
+
+    def test_opaque_failure_repairs_when_npm_outside_repo_range(
+        self, managed_npm, monkeypatch
+    ):
+        """#78826: ``npm install --silent`` exits 1 with empty stdout/stderr,
+        so there is no EBADENGINE text to parse. The repair must still fire
+        by probing ``npm --version`` against the repo engines.npm range."""
+        import hermes_cli.npm_engine as npm_engine
+
+        monkeypatch.setattr(npm_engine, "_probe_version", lambda _npm: "11.16.0")
+        monkeypatch.setattr(
+            npm_engine, "_repo_npm_range", lambda: "<11.10.0 || >=11.17.0"
+        )
+
+        upgrades = []
+        monkeypatch.setattr(
+            npm_engine,
+            "upgrade_managed_npm",
+            lambda npm, rng, *, prefix, quiet=False: upgrades.append(rng) or True,
+        )
+
+        repaired = maybe_repair_npm_engine(str(managed_npm), "", quiet=True)
+        assert repaired == str(managed_npm)
+        assert upgrades == ["<11.10.0 || >=11.17.0"]
+
+    def test_opaque_failure_provisions_foreign_npm_outside_range(
+        self, tmp_path, monkeypatch
+    ):
+        """Same silent-output path, but the failing npm is the user's — we
+        provision a managed runtime instead of touching theirs."""
+        home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        system_npm = tmp_path / "usr-bin-npm"
+        system_npm.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        managed = home / "node" / "bin" / "npm"
+
+        import hermes_cli.npm_engine as npm_engine
+
+        def fake_bootstrap():
+            managed.parent.mkdir(parents=True, exist_ok=True)
+            managed.write_text("#!/bin/sh\n", encoding="utf-8")
+            managed.chmod(0o755)
+            return str(managed)
+
+        monkeypatch.setattr(npm_engine, "_probe_version", lambda _npm: "11.16.0")
+        monkeypatch.setattr(
+            npm_engine, "_repo_npm_range", lambda: "<11.10.0 || >=11.17.0"
+        )
+        monkeypatch.setattr(
+            npm_engine, "bootstrap_hermes_managed_node", fake_bootstrap
+        )
+        upgrades = []
+        monkeypatch.setattr(
+            npm_engine,
+            "upgrade_managed_npm",
+            lambda npm, rng, *, prefix, quiet=False: upgrades.append((npm, rng))
+            or True,
+        )
+
+        repaired = maybe_repair_npm_engine(str(system_npm), "\n", quiet=True)
+        assert repaired == str(managed)
+        assert upgrades == [(str(managed), "<11.10.0 || >=11.17.0")]
 
     def test_node_only_mismatch_on_foreign_npm_still_provisions(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -65,12 +65,17 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
     bundled_entry.write_text("// bundled TUI")
     monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
 
-    def which(name: str) -> str | None:
+    import hermes_constants
+
+    def fake_find(name: str) -> str | None:
         if name == "node":
             return "/usr/bin/node"
-        raise AssertionError(f"unexpected shutil.which({name!r}) call — bundled path must not need npm/git")
+        raise AssertionError(
+            f"unexpected find_node_executable({name!r}) — "
+            "bundled path must not need npm/git"
+        )
 
-    monkeypatch.setattr(main_mod.shutil, "which", which)
+    monkeypatch.setattr(hermes_constants, "find_node_executable", fake_find)
 
     def fail_run(*_args, **_kwargs):
         raise AssertionError("bundled TUI path must not spawn any subprocess (no npm install/build, no git restore)")
@@ -159,7 +164,14 @@ def test_make_tui_argv_omits_workspace_and_scrubs_esbuild_override(
     monkeypatch.setenv("PREFIX", "/usr")
     monkeypatch.setenv("ESBUILD_BINARY_PATH", "/opt/esbuild-0.28.2")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
-    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+
+    import hermes_constants
+
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/bin/{name}"
+    )
     calls = []
 
     def fake_run(*args, **kwargs):
@@ -182,3 +194,114 @@ def test_make_tui_argv_omits_workspace_and_scrubs_esbuild_override(
     assert "ESBUILD_BINARY_PATH" not in calls[0][1]["env"]
     assert calls[1][0][0][1:] == ["run", "build"]
     assert "ESBUILD_BINARY_PATH" not in calls[1][1]["env"]
+    # --silent used to suppress EBADENGINE and skip managed-Node repair (#78826)
+    assert "--silent" not in install_cmd
+
+
+def test_make_tui_argv_preserves_install_error_preview(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Failed TUI install must surface the last lines of npm stderr.
+
+    Quietness comes from capture_output + CI=1, not ``--silent`` — dropping
+    ``--silent`` is what makes this preview (and engine detection) possible.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "package-lock.json").write_text("{}")
+    _touch_tui_entry(tui_dir)
+    _touch_ink(tui_dir)
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setenv("HERMES_QUIET", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+
+    import hermes_constants
+
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/bin/{name}"
+    )
+
+    def fake_run(cmd, **kwargs):
+        _assert_utf8_replace_capture(kwargs)
+        if list(cmd[:2]) == ["/bin/npm", "install"]:
+            return types.SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="npm error code EUSAGE\nlockfile is out of sync\n",
+            )
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exited:
+        main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert exited.value.code == 1
+    out = capsys.readouterr().out
+    assert "npm install failed." in out
+    assert "lockfile is out of sync" in out
+
+
+def test_make_tui_argv_repairs_opaque_npm_engine_failure(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """TUI install failure with empty output still triggers engine repair.
+
+    Regression for #78826: even if stderr is empty (historical --silent),
+    maybe_repair_npm_engine must be consulted and a successful repair must
+    retry the install with the returned npm.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "package-lock.json").write_text("{}")
+    _touch_tui_entry(tui_dir)
+    _touch_ink(tui_dir)
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setenv("HERMES_QUIET", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+
+    import hermes_constants
+
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/bin/{name}"
+    )
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if list(cmd[:2]) == ["/bin/npm", "install"]:
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    import hermes_cli.npm_engine as npm_engine
+
+    repair_calls = []
+
+    def fake_repair(npm, output, *, quiet=False):
+        repair_calls.append((npm, output))
+        return "/managed/npm"
+
+    monkeypatch.setattr(npm_engine, "maybe_repair_npm_engine", fake_repair)
+
+    argv, cwd = main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert repair_calls, "opaque install failure must consult maybe_repair_npm_engine"
+    assert repair_calls[0][0] == "/bin/npm"
+    assert any(c[:2] == ["/managed/npm", "install"] for c in calls), (
+        f"repair must retry install with managed npm, got: {calls}"
+    )
+    assert argv == ["/bin/node", "--expose-gc", str(tui_dir / "dist" / "entry.js")]
+    assert cwd == tui_dir

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -65,12 +65,17 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
     bundled_entry.write_text("// bundled TUI")
     monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
 
-    def which(name: str) -> str | None:
+    import hermes_constants
+
+    def fake_find(name: str) -> str | None:
         if name == "node":
             return "/usr/bin/node"
-        raise AssertionError(f"unexpected shutil.which({name!r}) call — bundled path must not need npm/git")
+        raise AssertionError(
+            f"unexpected find_node_executable({name!r}) — "
+            "bundled path must not need npm/git"
+        )
 
-    monkeypatch.setattr(main_mod.shutil, "which", which)
+    monkeypatch.setattr(hermes_constants, "find_node_executable", fake_find)
 
     def fail_run(*_args, **_kwargs):
         raise AssertionError("bundled TUI path must not spawn any subprocess (no npm install/build, no git restore)")
@@ -157,7 +162,14 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
-    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+
+    import hermes_constants
+
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/bin/{name}"
+    )
     calls = []
 
     def fake_run(*args, **kwargs):
@@ -176,3 +188,67 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+    # --silent used to suppress EBADENGINE and skip managed-Node repair (#78826)
+    assert "--silent" not in install_cmd
+
+
+def test_make_tui_argv_repairs_opaque_npm_engine_failure(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    """TUI install failure with empty output still triggers engine repair.
+
+    Regression for #78826: even if stderr is empty (historical --silent),
+    maybe_repair_npm_engine must be consulted and a successful repair must
+    retry the install with the returned npm.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "package-lock.json").write_text("{}")
+    _touch_tui_entry(tui_dir)
+    _touch_ink(tui_dir)
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setenv("HERMES_QUIET", "1")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    import hermes_constants
+
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/bin/{name}"
+    )
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if list(cmd[:2]) == ["/bin/npm", "install"]:
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+        # Retry after repair, build, etc.
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    import hermes_cli.npm_engine as npm_engine
+
+    repair_calls = []
+
+    def fake_repair(npm, output, *, quiet=False):
+        repair_calls.append((npm, output))
+        return "/managed/npm"
+
+    monkeypatch.setattr(npm_engine, "maybe_repair_npm_engine", fake_repair)
+
+    argv, cwd = main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert repair_calls, "opaque install failure must consult maybe_repair_npm_engine"
+    assert repair_calls[0][0] == "/bin/npm"
+    assert any(c[:2] == ["/managed/npm", "install"] for c in calls), (
+        f"repair must retry install with managed npm, got: {calls}"
+    )
+    assert argv == ["/bin/node", "--expose-gc", str(tui_dir / "dist" / "entry.js")]
+    assert cwd == tui_dir

--- a/tests/test_engines_satisfiable.py
+++ b/tests/test_engines_satisfiable.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 import pytest
 
+from hermes_cli.npm_engine import npm_satisfies_range as _satisfies_range
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # npm releases bundled with a Node major, newest-per-major. Not a catalog
@@ -39,51 +41,6 @@ _STOCK_NPM_BY_NODE_MAJOR = {
 
 def _root_manifest() -> dict:
     return json.loads((REPO_ROOT / "package.json").read_text())
-
-
-def _parse_major_minor_patch(version: str) -> tuple[int, int, int]:
-    parts = version.split("-", 1)[0].split(".")
-    nums = [int(p) for p in parts[:3]]
-    while len(nums) < 3:
-        nums.append(0)
-    return nums[0], nums[1], nums[2]
-
-
-def _satisfies_clause(version: str, clause: str) -> bool:
-    """Evaluate one `>=x.y.z` / `<x.y.z` / `^x.y.z` comparator against *version*."""
-    clause = clause.strip()
-    if clause.startswith("^"):
-        bound = clause[1:].strip()
-        have = _parse_major_minor_patch(version)
-        want = _parse_major_minor_patch(bound)
-        # ^x.y.z allows >=x.y.z within the same major (x > 0).
-        return have[0] == want[0] and have >= want
-    for op in (">=", "<=", "<", ">", "="):
-        if clause.startswith(op):
-            bound = clause[len(op) :].strip()
-            break
-    else:
-        op, bound = "=", clause
-    have = _parse_major_minor_patch(version)
-    want = _parse_major_minor_patch(bound)
-    if op == ">=":
-        return have >= want
-    if op == "<=":
-        return have <= want
-    if op == "<":
-        return have < want
-    if op == ">":
-        return have > want
-    return have == want
-
-
-def _satisfies_range(version: str, spec: str) -> bool:
-    """Evaluate the `A || B` / space-joined-AND subset of semver we author."""
-    for alternative in spec.split("||"):
-        clauses = [c for c in alternative.strip().split() if c]
-        if clauses and all(_satisfies_clause(version, c) for c in clauses):
-            return True
-    return False
 
 
 class TestEnginesAreSatisfiable:


### PR DESCRIPTION
## What does this PR do?

TUI launch `npm install --silent` can exit 1 with **empty** stdout/stderr on
npm 11.x. `is_ebadengine` never fired, so managed-Node auto-repair no-oped.

On **opaque / empty** failed-install output, probe `npm --version` against repo
`engines.npm` and trigger repair on mismatch. Diagnostic-bearing failures
(lockfile, network, etc.) are left alone.

Foreign / nvm npm is **never modified**. Repair provisions a Hermes-managed
runtime and retries against that. Hermes-managed npm receives the global
upgrade; a probed foreign/nvm npm does not.

`--silent` is dropped from the TUI launch install so error preview + text
detection still work. Sibling `_run_npm_install_deterministic` still may pass
`--silent`; the opaque probe covers the empty-output engine-mismatch class
there without changing web-install verbosity.

`engines.npm` is **not** broadened (`<11.10.0 || >=11.17.0` at repo root).

Closes #78826.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Tests

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_npm_engine.py \
  tests/hermes_cli/test_tui_npm_install.py \
  tests/test_engines_satisfiable.py \
  -q --tb=short
```

**44 passed** (focused files).

Manual / extra evidence:

- Real npm **11.16.0** with `--silent`: exit 1, 0 bytes stdout/stderr (reproduced; live nvm npm was not modified)
- Opaque/empty probes `npm --version`; diagnostic-bearing non-engine failures do **not** trigger opaque fallback
- Foreign-nvm PATH-shim: opaque `""` failure probes `--version` on the shim, provisions managed runtime, foreign npm never receives `--global`

Tip: `df4c6c585fd700a144ad0af6f33da365023893e8` on `upstream/main` `74f99af470ae8ce47f0903cf431d106cecbd37f2`.
