### PR TITLE
Mem 0 : parse rerank with shared truthy aliases

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -43,6 +43,7 @@ from typing import Any, Dict, List
 from agent.memory_provider import MemoryProvider
 from agent.secret_scope import get_secret
 from tools.registry import tool_error
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -360,9 +361,7 @@ class Mem0MemoryProvider(MemoryProvider):
         # explicitly; per-call args still win. Platform-only feature — other
         # backends accept-and-ignore the flag.
         _rr = self._config.get("rerank", False)
-        self._rerank_default = (
-            _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
-        )
+        self._rerank_default = is_truthy_value(_rr, default=False)
         self._channel = kwargs.get("platform") or "cli"
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
@@ -538,10 +537,9 @@ class Mem0MemoryProvider(MemoryProvider):
             try:
                 top_k = max(1, min(int(args.get("top_k", 10)), 50))
                 rerank_raw = args.get("rerank", getattr(self, "_rerank_default", False))
-                if isinstance(rerank_raw, str):
-                    rerank = rerank_raw.lower() not in ("false", "0", "no")
-                else:
-                    rerank = bool(rerank_raw)
+                # Shared truthy aliases — previously treated anything other than
+                # false/0/no as True, so "off" incorrectly enabled rerank.
+                rerank = is_truthy_value(rerank_raw, default=False)
                 results = self._backend.search(query, filters=self._read_filters(), top_k=top_k, rerank=rerank)
                 self._record_success()
                 if not results:

--- a/tests/plugins/memory/test_mem0_rerank_truthy.py
+++ b/tests/plugins/memory/test_mem0_rerank_truthy.py
@@ -1,0 +1,77 @@
+"""mem0 rerank flag must use shared truthy aliases (and reject 'off')."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class _CaptureBackend:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def search(self, query, *, filters, top_k=10, rerank=False):
+        self.calls.append(
+            {"query": query, "filters": filters, "top_k": top_k, "rerank": rerank}
+        )
+        return [{"id": "m1", "memory": "ok", "score": 1.0}]
+
+
+def _provider_with_backend(backend, *, rerank_default=False) -> Mem0MemoryProvider:
+    provider = Mem0MemoryProvider()
+    provider._user_id = "u1"
+    provider._agent_id = "hermes"
+    provider._backend = backend
+    provider._rerank_default = rerank_default
+    return provider
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE", " On "])
+def test_mem0_search_truthy_rerank_aliases(raw):
+    backend = _CaptureBackend()
+    provider = _provider_with_backend(backend)
+    out = json.loads(
+        provider.handle_tool_call("mem0_search", {"query": "q", "rerank": raw})
+    )
+    assert out["count"] == 1
+    assert backend.calls[-1]["rerank"] is True
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off", "OFF", ""])
+def test_mem0_search_falsy_rerank_aliases(raw):
+    backend = _CaptureBackend()
+    provider = _provider_with_backend(backend, rerank_default=True)
+    provider.handle_tool_call("mem0_search", {"query": "q", "rerank": raw})
+    assert backend.calls[-1]["rerank"] is False
+
+
+def test_mem0_search_garbage_string_does_not_enable_rerank():
+    """Regression: previously anything not in {false,0,no} enabled rerank."""
+    backend = _CaptureBackend()
+    provider = _provider_with_backend(backend)
+    provider.handle_tool_call("mem0_search", {"query": "q", "rerank": "potato"})
+    assert backend.calls[-1]["rerank"] is False
+
+
+@pytest.mark.parametrize("raw", ["on", "1", "yes", "true"])
+def test_mem0_config_rerank_truthy_default(monkeypatch, tmp_path, raw):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MEM0_API_KEY", "test-key")
+    (tmp_path / "mem0.json").write_text(json.dumps({"rerank": raw}))
+    provider = Mem0MemoryProvider()
+    provider._create_backend = lambda: None  # type: ignore[method-assign]
+    provider.initialize("test-session")
+    assert provider._rerank_default is True
+
+
+def test_mem0_config_rerank_off_stays_false(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MEM0_API_KEY", "test-key")
+    (tmp_path / "mem0.json").write_text(json.dumps({"rerank": "off"}))
+    provider = Mem0MemoryProvider()
+    provider._create_backend = lambda: None  # type: ignore[method-assign]
+    provider.initialize("test-session")
+    assert provider._rerank_default is False


### PR DESCRIPTION
## Summary
- Coerce `mem0_search` `rerank` and the persisted `mem0.json` default through `is_truthy_value`.
- Fixes `rerank=off` (and other non-truthy strings) incorrectly enabling reranking; previously anything outside `false`/`0`/`no` was treated as True.
- Accepts shared aliases including `on` for both the tool arg and config default.
