### PR TITLE
Photon : treat 'off' as disabled for default-on env flags

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -64,6 +64,7 @@ from gateway.platforms.base import (
     SendResult,
 )
 from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
+from utils import env_var_enabled
 
 from .auth import load_project_credentials
 
@@ -571,12 +572,10 @@ def _markdown_enabled() -> bool:
 
     iMessage renders it natively; other Spectrum platforms degrade to
     readable plain text. On-device rendering can't be unit-tested, so
-    ``PHOTON_MARKDOWN=false`` is the kill-switch back to stripped plain
-    text without a release.
+    ``PHOTON_MARKDOWN=false`` (or ``off`` / ``0`` / ``no``) is the kill-switch
+    back to stripped plain text without a release.
     """
-    return os.getenv("PHOTON_MARKDOWN", "true").strip().lower() not in {
-        "false", "0", "no",
-    }
+    return env_var_enabled("PHOTON_MARKDOWN", default="true")
 
 
 def _url_only_candidate(text: str) -> Optional[str]:
@@ -733,9 +732,9 @@ class PhotonAdapter(BasePlatformAdapter):
         self._sidecar_token = (
             _get_scoped_secret("PHOTON_SIDECAR_TOKEN") or secrets.token_hex(16)
         )
-        self._autostart_sidecar = str(
-            os.getenv("PHOTON_SIDECAR_AUTOSTART", "true")
-        ).lower() not in ("0", "false", "no")
+        self._autostart_sidecar = env_var_enabled(
+            "PHOTON_SIDECAR_AUTOSTART", default="true"
+        )
         self._node_bin = os.getenv("PHOTON_NODE_BIN") or shutil.which("node") or "node"
 
         # Presence watchdog. spectrum-ts only reconnects when its inbound

--- a/tests/plugins/platforms/photon/test_env_truthy_defaults.py
+++ b/tests/plugins/platforms/photon/test_env_truthy_defaults.py
@@ -1,0 +1,48 @@
+"""Photon default-on env flags must treat 'off' as disabled."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter, _markdown_enabled
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    return PhotonAdapter(PlatformConfig(enabled=True, token="", extra={}))
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off", "OFF"])
+def test_markdown_falsy_aliases_disable(monkeypatch, raw):
+    monkeypatch.setenv("PHOTON_MARKDOWN", raw)
+    assert _markdown_enabled() is False
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE"])
+def test_markdown_truthy_aliases_enable(monkeypatch, raw):
+    monkeypatch.setenv("PHOTON_MARKDOWN", raw)
+    assert _markdown_enabled() is True
+
+
+def test_markdown_defaults_on(monkeypatch):
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    assert _markdown_enabled() is True
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off"])
+def test_sidecar_autostart_falsy_aliases_disable(monkeypatch, raw):
+    monkeypatch.setenv("PHOTON_SIDECAR_AUTOSTART", raw)
+    assert _make_adapter(monkeypatch)._autostart_sidecar is False
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on"])
+def test_sidecar_autostart_truthy_aliases_enable(monkeypatch, raw):
+    monkeypatch.setenv("PHOTON_SIDECAR_AUTOSTART", raw)
+    assert _make_adapter(monkeypatch)._autostart_sidecar is True
+
+
+def test_sidecar_autostart_defaults_on(monkeypatch):
+    monkeypatch.delenv("PHOTON_SIDECAR_AUTOSTART", raising=False)
+    assert _make_adapter(monkeypatch)._autostart_sidecar is True


### PR DESCRIPTION
## Summary
- Parse `PHOTON_MARKDOWN` and `PHOTON_SIDECAR_AUTOSTART` via `env_var_enabled` (default `true`).
- Fixes `=off` incorrectly leaving markdown/autostart enabled under the old inverted falsy checks (only `false`/`0`/`no`).

