### PR TITLE
fix(tts): keep WeCom AMR voice bubbles native

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -37,6 +37,7 @@ _AUDIO_MIME_TYPES = {
     ".wav": "audio/wav",
     ".m4a": "audio/m4a",
     ".flac": "audio/flac",
+    ".amr": "audio/amr",
 }
 _AUDIO_EXTS = frozenset(_AUDIO_MIME_TYPES)
 # Telegram's Bot API sendAudio only accepts MP3 / M4A. Other audio

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -38,7 +38,7 @@ def _consume_detached_handler_exception(task: "asyncio.Task") -> None:
 # Hermes but not to sendAudio).
 _AUDIO_MIME_TYPES = {
     ".ogg": "audio/ogg", ".opus": "audio/opus", ".mp3": "audio/mpeg", ".m2a": "audio/mpeg",
-    ".wav": "audio/wav", ".m4a": "audio/m4a", ".flac": "audio/flac"}
+    ".wav": "audio/wav", ".m4a": "audio/m4a", ".flac": "audio/flac", ".amr": "audio/amr"}
 _AUDIO_EXTS = frozenset(_AUDIO_MIME_TYPES)
 # Outbound dispatch partition for MEDIA/local files (image batch vs send_video).
 _VIDEO_EXTS = frozenset({".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"})

--- a/tests/tools/test_tts_wecom_amr.py
+++ b/tests/tools/test_tts_wecom_amr.py
@@ -1,0 +1,105 @@
+"""Tests for WeCom AMR voice-bubble support (#78595).
+
+WeCom (企业微信) renders native voice bubbles only as ``audio/amr``. Two
+gateway/TTS gaps prevented AMR from reaching the adapter's existing
+``send_voice`` path: the gateway audio-extension whitelist missed ``.amr``,
+and the TTS ``voice_compatible`` logic transcoded every non-Ogg file to Opus
+— a format WeCom cannot render as a voice bubble.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from gateway.platforms.base import _AUDIO_EXTS, _AUDIO_MIME_TYPES
+from tools import tts_tool
+from tools.tts_tool import text_to_speech_tool
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: gateway audio whitelist must recognize .amr
+# ---------------------------------------------------------------------------
+
+def test_audio_mime_types_include_amr():
+    assert ".amr" in _AUDIO_MIME_TYPES
+    assert _AUDIO_MIME_TYPES[".amr"] == "audio/amr"
+    assert ".amr" in _AUDIO_EXTS
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: TTS must not transcode AMR to Opus on WeCom
+# ---------------------------------------------------------------------------
+
+def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
+    """Cross-platform shell command that copies {input_path} -> output."""
+    import shlex
+    import sys
+
+    interpreter = sys.executable
+    return (
+        f'"{interpreter}" -c "import shutil, sys; '
+        f'shutil.copyfile(sys.argv[1], sys.argv[2])" '
+        f'{{input_path}} {output_placeholder}'
+    )
+
+
+def _command_cfg(provider_name: str, output_format: str) -> dict:
+    return {
+        "provider": provider_name,
+        "providers": {
+            provider_name: {
+                "type": "command",
+                "command": _python_copy_command(),
+                "output_format": output_format,
+                "voice_compatible": True,
+            },
+        },
+    }
+
+
+def test_command_tts_wecom_keeps_amr_voice(tmp_path, monkeypatch):
+    """On WeCom, a voice_compatible command provider emitting .amr must keep
+    the AMR file and report voice-compatible — no Opus transcode."""
+    out = tmp_path / "clip.amr"
+    # ffmpeg missing / transcode failing: _convert_to_opus returns None
+    convert = Mock(return_value=None)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "wecom")
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+    with patch("tools.tts_tool._load_tts_config", return_value=_command_cfg("py-copy-amr", "amr")):
+        result = text_to_speech_tool(text="hi", output_path=str(out))
+
+    data = json.loads(result)
+    assert data["success"] is True, data
+    assert data["voice_compatible"] is True
+    assert data["file_path"].endswith(".amr"), data["file_path"]
+    assert data["media_tag"].startswith("[[audio_as_voice]]")
+    convert.assert_not_called()
+
+
+def test_command_tts_telegram_still_transcodes_amr_to_opus(tmp_path, monkeypatch):
+    """The Opus transcode path for Opus-native platforms must be unchanged:
+    on Telegram, an AMR-emitting command provider is still transcoded."""
+    out = tmp_path / "clip.amr"
+    opus = tmp_path / "clip.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+    with patch("tools.tts_tool._load_tts_config", return_value=_command_cfg("py-copy-amr", "amr")):
+        result = text_to_speech_tool(text="hi", output_path=str(out))
+
+    data = json.loads(result)
+    assert data["success"] is True, data
+    assert data["voice_compatible"] is True
+    assert data["file_path"].endswith(".ogg"), data["file_path"]
+    convert.assert_called_once_with(str(out))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3090,7 +3090,13 @@ def text_to_speech_tool(
         # formats for local/CLI playback and only convert when the current
         # platform actually needs Opus voice delivery.
         voice_compatible = False
-        if command_provider_config is not None:
+        # WeCom renders native voice bubbles only as ``audio/amr``
+        # (VOICE_SUPPORTED_MIMES in the WeCom adapter); transcoding AMR to
+        # Opus there would make the bubble undeliverable. Keep AMR as-is and
+        # mark it voice-compatible for WeCom sessions (#78595).
+        if platform == "wecom" and file_str.endswith(".amr"):
+            voice_compatible = True
+        elif command_provider_config is not None:
             # Command providers are documents by default. Voice-bubble
             # delivery only kicks in when the user explicitly opts in
             # via ``voice_compatible: true`` in their provider config.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -237,12 +237,19 @@ def _synthesize_builtin(engine: str, text: str, file_str: str, tts_config: Dict[
 
 def _finalize_voice_delivery(
     file_str: str, provider: str, command_provider_config: Optional[Dict[str, Any]], want_opus: bool,
+    platform: str = "",
 ) -> tuple:
     """Voice-bubble eligibility (Opus-converting when needed) -> ``(path, voice_compatible)``.
 
     Command/plugin providers are documents unless they opt in via ``voice_compatible``; native-Opus
     built-ins qualify when the platform wants Opus and they wrote .ogg; MP3/WAV built-ins are
     ffmpeg-converted only when the platform needs Opus."""
+    # WeCom renders native voice bubbles only as ``audio/amr``
+    # (VOICE_SUPPORTED_MIMES in the WeCom adapter); transcoding AMR to Opus
+    # there would make the bubble undeliverable. Keep AMR as-is and mark it
+    # voice-compatible for WeCom sessions (#78595).
+    if platform == "wecom" and file_str.endswith(".amr"):
+        return file_str, True
     if command_provider_config is not None:
         opted_in = _is_command_tts_voice_compatible(command_provider_config)
     elif provider not in BUILTIN_TTS_PROVIDERS:
@@ -328,6 +335,7 @@ def _tool_failure(prefix: str, provider: str, exc: BaseException) -> str:
 def _text_to_speech_single(
     text: str, file_str: str, *, provider: str, tts_config: Dict[str, Any],
     command_provider_config: Optional[Dict[str, Any]], want_opus: bool, instructions: Optional[str],
+    platform: str = "",
 ) -> str:
     """Synthesize one provider-safe chunk into *file_str*; returns the result envelope.
 
@@ -360,7 +368,7 @@ def _text_to_speech_single(
         # Sniff once for every provider: MP3/WAV bytes in a .ogg path render as 0-second bubbles.
         file_str = _repair_ogg_container(file_str)
         file_str, voice_compatible = _finalize_voice_delivery(
-            file_str, provider, command_provider_config, want_opus)
+            file_str, provider, command_provider_config, want_opus, platform)
         logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{os.path.getsize(file_str):,}", provider)
         return json.dumps({
             "success": True, "file_path": file_str, "media_tag": _media_tag([file_str], voice_compatible),
@@ -446,7 +454,7 @@ def text_to_speech_tool(
         encoded_paths, chunk_results = _synthesize_chunks(
             chunks, base_path, generated_artifacts, provider=provider, tts_config=tts_config,
             command_provider_config=command_provider_config, want_opus=want_opus,
-            instructions=instructions)
+            instructions=instructions, platform=platform)
         voice_compatible = bool(chunk_results) and all(bool(r.get("voice_compatible")) for r in chunk_results)
         delivery_base = base_path.with_suffix(Path(encoded_paths[0]).suffix)
         final_paths, combined_chunks = _build_audio_delivery_files(


### PR DESCRIPTION
Fixes #78595

## Summary

WeCom (企业微信) renders native voice bubbles only as `audio/amr` — the adapter already has the full path (`VOICE_SUPPORTED_MIMES = {"audio/amr"}`, `_detect_wecom_media_type` → `"voice"`, `send_voice`). Two gaps in the gateway/TTS layer prevented AMR voice bubbles from ever working, so `.amr` files fell through to `send_document()` as file attachments:

1. **`gateway/platforms/base.py`**: `_AUDIO_MIME_TYPES` had no `.amr` entry, so `_AUDIO_EXTS` never routed `.amr` files to `send_voice()`.
2. **`tools/tts_tool.py`**: the `voice_compatible` path transcoded every non-Ogg file to Opus — a format WeCom cannot render as a voice bubble — and then reported `voice_compatible=False` for anything that wasn't `.ogg`.

## Changes

- `gateway/platforms/base.py`: add `".amr": "audio/amr"` to `_AUDIO_MIME_TYPES` (flows through `_AUDIO_EXTS`).
- `tools/tts_tool.py`: when the session platform is `wecom` and the synthesized file is `.amr`, keep it as-is and mark it voice-compatible instead of transcoding to Opus. All other platforms (Telegram/Matrix/Feishu/WhatsApp/Signal) keep the existing Opus transcode path.
- `tests/tools/test_tts_wecom_amr.py`: regression coverage —
  - `.amr` is in `_AUDIO_MIME_TYPES` / `_AUDIO_EXTS` with `audio/amr`;
  - a `voice_compatible: true` command provider emitting `.amr` on WeCom keeps the AMR file, reports `voice_compatible: true`, and never calls `_convert_to_opus`;
  - the same provider on Telegram still transcodes AMR → Opus (Opus-native platforms unchanged).

## Testing

- New regression tests fail on `main` (`'.amr' not in _AUDIO_MIME_TYPES`; `voice_compatible is False` for WeCom+AMR) and pass with the fix.
- `pytest tests/tools/test_tts_wecom_amr.py` — 3 passed.
- Sibling suites: `test_tts_opus_routing.py`, `test_tts_command_providers.py`, `test_tts_container_repair.py`, `test_tts_plugin_dispatch.py`, `test_auto_voice_reply_format.py` — 72 passed; `tests/gateway/test_wecom.py` — 19 passed.
- `git diff --check` — clean.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
