### PR TITLE
feat(auth): share credential pool across profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -36,7 +36,6 @@ from hermes_cli.auth import (
     _resolve_zai_base_url,
     _same_path,
     _save_auth_store,
-    _save_provider_state,
     _store_provider_state,
     read_credential_pool,
     write_credential_pool,
@@ -206,6 +205,9 @@ class PooledCredential:
     agent_key: Optional[str] = None
     agent_key_expires_at: Optional[str] = None
     request_count: int = 0
+    # Profile singleton/.env/config seeds are runtime overlays. They may use
+    # the machine-wide manual pool, but must never become shared rows.
+    runtime_only: bool = False
     extra: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
@@ -229,6 +231,8 @@ class PooledCredential:
         # Rehydrated last_status_at may be an ISO string from to_dict() — normalize to float epoch
         if "last_status_at" in data and isinstance(data["last_status_at"], str):
             data["last_status_at"] = _parse_absolute_timestamp(data["last_status_at"])
+        if "runtime_only" in data:
+            data["runtime_only"] = bool(data["runtime_only"])
         extra = {k: payload[k] for k in _EXTRA_KEYS if k in payload and payload[k] is not None}
         data["extra"] = extra
         data.setdefault("id", uuid.uuid4().hex[:6])
@@ -250,7 +254,7 @@ class PooledCredential:
         }
         result: Dict[str, Any] = {}
         for field_def in fields(self):
-            if field_def.name in {"provider", "extra"}:
+            if field_def.name in {"provider", "extra", "runtime_only"}:
                 continue
             value = getattr(self, field_def.name)
             if value is not None or field_def.name in _ALWAYS_EMIT:
@@ -577,31 +581,19 @@ DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 1
 
 def _write_through_provider_state_to_global_root(
     provider_id: str, state: Dict[str, Any]
-) -> None:
-    """Persist a rotated OAuth ``state`` into the global-root auth.json.
+) -> bool:
+    """Durably persist rotated OAuth ``state`` into the global-root auth.json.
 
-    Best-effort write-through for the multi-profile rotation hazard
-    (#48415 / #43589): nous, openai-codex, and xai-oauth rotate the
-    refresh_token on refresh, so when a profile pool refresh rotates a grant
-    it resolved from the root fallback, the rotated chain must land back in
-    root. Otherwise root keeps a now-revoked refresh token and every other
-    profile reading the stale root grant dies with ``refresh_token_reused`` /
-    ``invalid_grant`` once its access token expires.
-
-    Only updates ``providers.<provider_id>`` in the root store; never touches
-    the profile store (the caller already saved that). Swallows all errors — a
-    failed write-through degrades to the pre-existing behavior (root stale), it
-    must never break the profile's own successful save. Mirrors
-    ``hermes_cli.auth._write_through_xai_oauth_to_global_root`` (which covers
-    the non-pool xAI refresh path) for the credential-pool refresh path.
+    Returns whether the write completed. Single-use refresh callers must not
+    report success when the source singleton still contains the consumed token.
     """
     try:
         global_path = auth_mod._global_auth_file_path()
     except Exception:
-        return
+        return False
     if global_path is None:
-        # Classic mode (profile == root); the profile save already hit root.
-        return
+        # This helper is only used for root-fallback state in profile mode.
+        return False
     # Seat belt: under pytest, refuse to write the real user's
     # ~/.hermes/auth.json even when HERMES_HOME points at a profile path
     # (mirrors the read-side guard in _load_global_auth_store). Uses the
@@ -612,9 +604,9 @@ def _write_through_provider_state_to_global_root(
             real_root = Path(real_home_env) / ".hermes" / "auth.json"
             try:
                 if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return
+                    return False
             except Exception:
-                return
+                return False
     try:
         auth_mod._persist_provider_state_to_store(
             provider_id,
@@ -622,12 +614,14 @@ def _write_through_provider_state_to_global_root(
             global_path,
             set_active=False,
         )
-    except Exception as exc:  # pragma: no cover - best effort
+    except Exception as exc:
         logger.debug(
             "%s pool refresh: write-through to global root failed: %s",
             provider_id,
             exc,
         )
+        return False
+    return True
 
 
 class CredentialPool:
@@ -636,11 +630,9 @@ class CredentialPool:
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
-        # RLock: the mutation primitives below (_replace_entry/_persist)
-        # self-acquire this lock so the DEFERRED single-use-token refresh
-        # path (which runs network I/O outside the lock by design) still
-        # serializes its pool mutations. In-lock callers re-acquire
-        # reentrantly at negligible cost.
+        # RLock: mutation primitives self-acquire, while single-use refreshes
+        # hold this lock before taking profile/shared auth locks. In-lock callers
+        # re-acquire reentrantly at negligible cost.
         self._lock = threading.RLock()
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
@@ -747,9 +739,8 @@ class CredentialPool:
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order.
 
-        Self-locking (RLock) so the deferred refresh path — which
-        deliberately runs outside the pool lock — cannot tear
-        ``self._entries`` against a concurrent select()/rotation.
+        Self-locking (RLock) so callers cannot tear ``self._entries`` against a
+        concurrent select()/rotation.
         """
         with self._lock:
             for idx, entry in enumerate(self._entries):
@@ -759,11 +750,15 @@ class CredentialPool:
 
     def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
-        # concurrent rotation when called from the deferred refresh path.
+        # concurrent rotation.
         with self._lock:
             write_credential_pool(
                 self.provider,
-                [entry.to_dict() for entry in self._entries],
+                [
+                    entry.to_dict()
+                    for entry in self._entries
+                    if not entry.runtime_only
+                ],
                 removed_ids=removed_ids,
             )
 
@@ -904,7 +899,7 @@ class CredentialPool:
         device_code-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
         """
-        if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):
+        if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
         try:
             with _auth_store_lock():
@@ -1036,15 +1031,13 @@ class CredentialPool:
     def _sync_xai_oauth_entry_from_pool_store(
         self, entry: PooledCredential
     ) -> PooledCredential:
-        """Adopt a token pair rotated by another pool instance.
+        """Re-read a single-use OAuth pool row while the shared lock is held.
 
-        Direct xAI integrations load a fresh ``CredentialPool`` for each
-        request. Their in-memory locks therefore cannot protect xAI's
-        single-use refresh token across concurrent requests or processes.
-        This helper is called while the shared auth-store lock is held and
-        re-reads the exact persisted row before a refresh POST is attempted.
+        Fresh pool instances and distinct profiles cannot coordinate with an
+        in-memory lock. Re-read the exact persisted Codex/xAI row before a
+        refresh POST so a waiter adopts the winner's rotated token chain.
         """
-        if self.provider != "xai-oauth":
+        if self.provider not in ("openai-codex", "xai-oauth"):
             return entry
         try:
             persisted = next(
@@ -1063,8 +1056,9 @@ class CredentialPool:
                 or stored.refresh_token != entry.refresh_token
             ):
                 logger.debug(
-                    "Pool entry %s: adopting xAI OAuth tokens rotated by another pool instance",
+                    "Pool entry %s: adopting %s tokens rotated by another pool instance",
                     entry.id,
+                    self.provider,
                 )
                 self._replace_entry(entry, stored)
                 return stored
@@ -1144,7 +1138,7 @@ class CredentialPool:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
         return entry
 
-    def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> None:
+    def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> bool:
         """Write refreshed pool entry tokens back to auth.json providers.
 
         After a pool-level refresh, the pool entry has fresh tokens but
@@ -1171,7 +1165,7 @@ class CredentialPool:
         # and must not write back to the singleton.  All singleton-seeded
         # device-code sources (nous, openai-codex, xAI) use ``device_code``.
         if entry.source != "device_code":
-            return
+            return True
         try:
             with _auth_store_lock():
                 auth_store = _load_auth_store()
@@ -1203,21 +1197,21 @@ class CredentialPool:
                         auth_store, "nous"
                     )
                     if state is None:
-                        return
+                        return False
                 elif self.provider == "openai-codex":
                     state, source_path = _load_provider_state_with_source(
                         auth_store, "openai-codex"
                     )
                     if not isinstance(state, dict):
-                        return
+                        return False
                 elif self.provider == "xai-oauth":
                     state, source_path = _load_provider_state_with_source(
                         auth_store, "xai-oauth"
                     )
                     if not isinstance(state, dict):
-                        return
+                        return False
                 else:
-                    return
+                    return False
 
                 global_root = _global_auth_file_path()
                 is_from_root = bool(
@@ -1248,7 +1242,7 @@ class CredentialPool:
                 elif self.provider == "openai-codex":
                     tokens = state.get("tokens")
                     if not isinstance(tokens, dict):
-                        return
+                        return False
                     tokens["access_token"] = entry.access_token
                     if entry.refresh_token:
                         tokens["refresh_token"] = entry.refresh_token
@@ -1258,7 +1252,7 @@ class CredentialPool:
                 elif self.provider == "xai-oauth":
                     tokens = state.get("tokens")
                     if not isinstance(tokens, dict):
-                        return
+                        return False
                     tokens["access_token"] = entry.access_token
                     if entry.refresh_token:
                         tokens["refresh_token"] = entry.refresh_token
@@ -1274,7 +1268,7 @@ class CredentialPool:
                     # _load_provider_state has root fallback, so the
                     # profile can always read fresh tokens from root
                     # without needing its own providers block.
-                    _write_through_provider_state_to_global_root(
+                    return _write_through_provider_state_to_global_root(
                         _wt_provider_id, state
                     )
                 else:
@@ -1284,8 +1278,10 @@ class CredentialPool:
                         auth_store, self.provider, state, set_active=False
                     )
                     _save_auth_store(auth_store)
+                    return True
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
+            return False
 
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
@@ -1303,28 +1299,58 @@ class CredentialPool:
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
         if self.provider in ("openai-codex", "xai-oauth"):
-            sync_entry = (
-                self._sync_codex_entry_from_auth_store
-                if self.provider == "openai-codex"
-                else self._sync_xai_oauth_entry_from_pool_store
-            )
-            with _auth_store_lock(
-                timeout_seconds=self._single_use_refresh_lock_timeout()
-            ):
-                synced = sync_entry(entry)
-                if self.provider == "openai-codex":
-                    if synced is not entry:
-                        entry = synced
-                        if not force and not self._entry_needs_refresh(entry):
-                            return entry
-                    return self._refresh_entry_impl(entry, force=force)
-                if (
-                    synced.access_token != entry.access_token
-                    or synced.refresh_token != entry.refresh_token
-                ):
-                    return synced
-                return self._refresh_entry_impl(synced, force=force)
+            # Every pool mutation path persists under self._lock and then takes
+            # auth-store locks. Take the pool lock first here too so a deferred
+            # refresh cannot hold auth while remove/status holds the pool lock.
+            with self._lock:
+                return self._refresh_single_use_entry(entry, force=force)
         return self._refresh_entry_impl(entry, force=force)
+
+    def _refresh_single_use_entry(
+        self, entry: PooledCredential, *, force: bool
+    ) -> Optional[PooledCredential]:
+        timeout_seconds = self._single_use_refresh_lock_timeout()
+        auth_mod._migrate_active_profile_credential_pool()
+        active_path = auth_mod._auth_file_path()
+        shared_path = auth_mod._credential_pool_auth_file_path()
+
+        def _refresh_under_both_store_locks() -> Optional[PooledCredential]:
+            synced = self._sync_xai_oauth_entry_from_pool_store(entry)
+            if (
+                synced.access_token != entry.access_token
+                or synced.refresh_token != entry.refresh_token
+            ):
+                return synced
+
+            # Singleton-seeded entries are profile-aware. Re-read their
+            # provider state only after both profile and shared locks are
+            # held; a root-fallback waiter then observes the winner's
+            # rotated chain and skips a second single-use-token POST.
+            if entry.source == "device_code":
+                singleton_sync = (
+                    self._sync_codex_entry_from_auth_store
+                    if self.provider == "openai-codex"
+                    else self._sync_xai_oauth_entry_from_auth_store
+                )
+                singleton_synced = singleton_sync(synced)
+                if (
+                    singleton_synced.access_token != synced.access_token
+                    or singleton_synced.refresh_token != synced.refresh_token
+                ):
+                    return singleton_synced
+                synced = singleton_synced
+            return self._refresh_entry_impl(synced, force=force)
+
+        # Canonical auth ordering remains profile auth.json first, shared root
+        # second, inside the outer pool lock.
+        with _auth_store_lock(timeout_seconds=timeout_seconds):
+            if _same_path(active_path, shared_path):
+                return _refresh_under_both_store_locks()
+            with _auth_store_lock(
+                timeout_seconds=timeout_seconds,
+                target_path=shared_path,
+            ):
+                return _refresh_under_both_store_locks()
 
     def _single_use_refresh_lock_timeout(self) -> float:
         """Lock timeout for single-use-refresh-token providers.
@@ -1500,7 +1526,10 @@ class CredentialPool:
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "xai-oauth") or {}
+                            state, source_path = _load_provider_state_with_source(
+                                auth_store, "xai-oauth"
+                            )
+                            state = state or {}
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
                                 if isinstance(tokens, dict):
@@ -1518,8 +1547,12 @@ class CredentialPool:
                                             "relogin_required": True,
                                             "at": datetime.now(timezone.utc).isoformat(),
                                         }
-                                        _save_provider_state(auth_store, "xai-oauth", state)
-                                        _save_auth_store(auth_store)
+                                        auth_mod._save_provider_state_to_source(
+                                            auth_store,
+                                            "xai-oauth",
+                                            state,
+                                            source_path,
+                                        )
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc
@@ -1575,7 +1608,10 @@ class CredentialPool:
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "openai-codex") or {}
+                            state, source_path = _load_provider_state_with_source(
+                                auth_store, "openai-codex"
+                            )
+                            state = state or {}
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
                                 if isinstance(tokens, dict):
@@ -1593,16 +1629,19 @@ class CredentialPool:
                                             "relogin_required": True,
                                             "at": datetime.now(timezone.utc).isoformat(),
                                         }
-                                        _save_provider_state(auth_store, "openai-codex", state)
-                                        _save_auth_store(auth_store)
+                                        auth_mod._save_provider_state_to_source(
+                                            auth_store,
+                                            "openai-codex",
+                                            state,
+                                            source_path,
+                                        )
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal Codex OAuth state: %s", clear_exc
                         )
                     # Read-modify-write of self._entries: must be atomic.
-                    # This runs on the DEFERRED refresh path (outside the
-                    # pool lock), so take it here. self._lock is an RLock,
-                    # so the still-locked callers re-enter safely.
+                    # self._lock is an RLock, so refresh callers that already
+                    # hold the canonical outer pool lock re-enter safely.
                     with self._lock:
                         removed_ids = [
                             item.id for item in self._entries
@@ -1641,7 +1680,10 @@ class CredentialPool:
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "nous") or {
+                            state, source_path = _load_provider_state_with_source(
+                                auth_store, "nous"
+                            )
+                            state = state or {
                                 "client_id": entry.client_id,
                                 "portal_base_url": entry.portal_base_url,
                                 "inference_base_url": entry.inference_base_url,
@@ -1662,8 +1704,12 @@ class CredentialPool:
                                     exc,
                                     reason="credential_pool_refresh_failure",
                                 )
-                                _save_provider_state(auth_store, "nous", state)
-                                _save_auth_store(auth_store)
+                                auth_mod._save_provider_state_to_source(
+                                    auth_store,
+                                    "nous",
+                                    state,
+                                    source_path,
+                                )
                     except Exception as clear_exc:
                         logger.debug("Failed to clear terminal Nous OAuth state: %s", clear_exc)
 
@@ -1698,11 +1744,23 @@ class CredentialPool:
             last_error_reset_at=None,
         )
         self._replace_entry(entry, updated)
+        # A singleton refresh has consumed a single-use token. Do not expose a
+        # successful result until the rotated pair is durable in the provider
+        # source. Keep the fresh pair in memory on failure so a retry in this
+        # process never replays the consumed token.
+        if not self._sync_device_code_entry_to_auth_store(updated):
+            unavailable = replace(
+                updated,
+                last_status=STATUS_EXHAUSTED,
+                last_status_at=time.time(),
+                last_error_reason="provider_state_save_failed",
+                last_error_message=(
+                    "Rotated OAuth tokens could not be saved to the provider source."
+                ),
+            )
+            self._replace_entry(updated, unavailable)
+            return None
         self._persist()
-        # Sync refreshed tokens back to auth.json providers so that
-        # _seed_from_singletons() on the next load_pool() sees fresh state
-        # instead of re-seeding stale/consumed tokens.
-        self._sync_device_code_entry_to_auth_store(updated)
         return updated
 
     def _codex_quota_restored_upstream(self, entry: PooledCredential) -> bool:
@@ -1787,19 +1845,15 @@ class CredentialPool:
             return self._select_unlocked()
 
     def _refresh_pending_entries(self, pending: List[tuple]) -> None:
-        """Refresh deferred single-use-token entries outside the lock.
+        """Refresh entries deferred until after the selection critical section.
 
-        Each entry is refreshed under the cross-process ``_auth_store_lock``
-        (which can block for 20+ seconds) and then merged into the pool.
+        ``_refresh_entry`` reacquires the pool lock before profile/shared auth
+        locks, keeping one lock order across refresh, removal, and status paths.
         On failure the entry is silently skipped.
         """
         for entry, sync_fn in pending:
             # _refresh_entry merges the refreshed entry into the pool
-            # internally. Its mutation primitives (_replace_entry, _persist)
-            # are self-locking, and the quarantine paths inside
-            # _refresh_entry_impl take self._lock explicitly around their
-            # read-modify-write of self._entries — required because this
-            # call site runs OUTSIDE the pool lock.
+            # internally under the canonical pool -> auth lock order.
             self._refresh_entry(entry, force=False)
 
     def _available_entries(
@@ -1812,18 +1866,16 @@ class CredentialPool:
         that need a token refresh are refreshed (skipped on failure).
 
         Single-use-token refreshes (openai-codex, xai-oauth) are returned as
-        *pending_refresh* tuples so the caller can execute them outside the
-        lock, avoiding stalling all pool consumers during cross-process flock
-        acquisition + OAuth network I/O.
+        *pending_refresh* tuples so selection finishes its current critical
+        section before entering the canonical pool -> auth lock sequence.
         """
         now = time.time()
         cleared_any = False
         entries_to_prune: List[str] = []
         available: List[PooledCredential] = []
         # Entries that need an OAuth refresh via a single-use token provider
-        # (openai-codex, xai-oauth).  These require a cross-process file lock
-        # that can block for 20+ seconds.  We collect them under self._lock
-        # and refresh outside the lock to avoid stalling all pool consumers.
+        # (openai-codex, xai-oauth). Collect them during selection, then let
+        # _refresh_entry reacquire the pool lock before profile/shared auth.
         pending_refresh: List[tuple] = []  # (entry, sync_entry_fn)
         # DEAD entries never re-enter rotation, so if at most one non-DEAD entry
         # exists there is nothing to rotate to: an exhausted sole credential
@@ -2314,10 +2366,8 @@ class CredentialPool:
                 replace(entry, priority=new_priority)
                 for new_priority, entry in enumerate(self._entries)
             ]
-            write_credential_pool(
-                self.provider,
-                [entry.to_dict() for entry in self._entries],
-                removed_ids=[removed.id],
+            self._persist(
+                removed_ids=[removed.id] if not removed.runtime_only else None,
             )
             if self._current_id == removed.id:
                 self._current_id = None
@@ -2357,10 +2407,22 @@ class CredentialPool:
             return entry
 
 
-def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:
+def _upsert_entry(
+    entries: List[PooledCredential],
+    provider: str,
+    source: str,
+    payload: Dict[str, Any],
+    *,
+    runtime_only: Optional[bool] = None,
+) -> bool:
+    if runtime_only is None:
+        # Seeding only needs to know whether this is a named profile. Avoid
+        # resolving the writable auth path here: pure seed helpers are used by
+        # tests and callers that must not touch the auth-store write seatbelt.
+        runtime_only = auth_mod._global_auth_file_path() is not None
     matching_indices = []
     for idx, entry in enumerate(entries):
-        if entry.source == source:
+        if entry.source == source and entry.runtime_only == runtime_only:
             matching_indices.append(idx)
 
     existing_idx = matching_indices[0] if matching_indices else None
@@ -2369,6 +2431,7 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
         entries[:] = [entry for idx, entry in enumerate(entries) if idx not in duplicate_indices]
 
     if existing_idx is None:
+        payload["runtime_only"] = runtime_only
         payload.setdefault("id", uuid.uuid4().hex[:6])
         payload.setdefault("priority", _next_priority(entries))
         payload.setdefault("label", payload.get("label") or source)
@@ -3094,7 +3157,31 @@ def load_pool(provider: str) -> CredentialPool:
         and sanitize_borrowed_credential_payload(payload, provider) != payload
         for payload in raw_entries
     )
-    entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+    persisted_entries = [
+        PooledCredential.from_dict(provider, payload) for payload in raw_entries
+    ]
+    # Shared auth.json owns only explicit/manual multi-account rows. Historical
+    # singleton/env/config rows remain preserved on disk for migration and
+    # downgrade safety, but are not interpreted as this profile's credential.
+    # The active profile rehydrates its own runtime-only overlay below.
+    runtime_only_seeds = not _same_path(
+        auth_mod._auth_file_path(),
+        auth_mod._credential_pool_auth_file_path(),
+    )
+    hidden_seed_ids = (
+        {
+            entry.id
+            for entry in persisted_entries
+            if not _is_manual_source(entry.source)
+        }
+        if runtime_only_seeds
+        else set()
+    )
+    entries = (
+        [entry for entry in persisted_entries if _is_manual_source(entry.source)]
+        if runtime_only_seeds
+        else persisted_entries
+    )
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)
         and _normalize_pool_auth_type(
@@ -3104,14 +3191,6 @@ def load_pool(provider: str) -> CredentialPool:
         ) != payload.get("auth_type", AUTH_TYPE_API_KEY)
         for payload in raw_entries
     )
-    if raw_needs_auth_normalization:
-        # A profile may be reading this provider from the global-root fallback.
-        # Keep that fallback read-only: only the store that owns these rows may
-        # rewrite them. Loading the default/root profile will heal global rows.
-        active_pool = _load_auth_store().get("credential_pool")
-        active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
-        raw_needs_auth_normalization = bool(active_entries)
-
     if provider.startswith(CUSTOM_POOL_PREFIX):
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
@@ -3138,10 +3217,16 @@ def load_pool(provider: str) -> CredentialPool:
         changed |= _normalize_pool_priorities(provider, entries)
 
     if changed:
-        new_ids = {entry.id for entry in entries}
+        new_ids = {
+            entry.id for entry in entries if not entry.runtime_only
+        } | hidden_seed_ids
         write_credential_pool(
             provider,
-            [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
+            [
+                entry.to_dict()
+                for entry in sorted(entries, key=lambda item: item.priority)
+                if not entry.runtime_only
+            ],
             removed_ids=disk_ids - new_ids,
         )
     return CredentialPool(provider, entries)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -981,10 +981,8 @@ def _global_auth_file_path() -> Optional[Path]:
 
     Returns ``None`` when the profile and global root resolve to the same
     directory (classic mode, or custom HERMES_HOME that is not a profile).
-    Used by read-only fallback paths so providers authed at the root are
-    visible to profile processes that haven't configured them locally.
-
-    See issue #18594 follow-up (credential_pool shadowing).
+    Used both by provider-state fallback reads and by the shared credential
+    pool, whose reads and writes always target the root store.
     """
     try:
         from hermes_constants import get_default_hermes_root
@@ -998,13 +996,29 @@ def _global_auth_file_path() -> Optional[Path]:
     except Exception:
         if profile_home == global_root:
             return None
-    # No pytest seat belt here: this is a pure read-only path, and
-    # ``_load_global_auth_store()`` wraps the read in a try/except so an
-    # unreadable global file can never break the profile process.  The
-    # write-side seat belt still lives on ``_auth_file_path()`` where it
-    # belongs (that's what protects the real user's auth store from being
-    # corrupted by a mis-configured test).
     return global_root / "auth.json"
+
+
+def _is_real_user_auth_store_under_test(path: Path) -> bool:
+    """Return whether *path* is the real OS-user auth store during pytest."""
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return False
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
+        real_base = (
+            Path(local_appdata)
+            if local_appdata
+            else Path.home() / "AppData" / "Local"
+        )
+        real_root = real_base / "hermes" / "auth.json"
+    else:
+        real_home_env = os.environ.get("HOME", "").strip()
+        real_home = Path(real_home_env) if real_home_env else Path.home()
+        real_root = real_home / ".hermes" / "auth.json"
+    try:
+        return path.resolve(strict=False) == real_root.resolve(strict=False)
+    except Exception:
+        return True
 
 
 def _load_global_auth_store() -> Dict[str, Any]:
@@ -1026,21 +1040,267 @@ def _load_global_auth_store() -> Dict[str, Any]:
     global_path = _global_auth_file_path()
     if global_path is None or not global_path.exists():
         return {}
-    if os.environ.get("PYTEST_CURRENT_TEST"):
-        real_home_env = os.environ.get("HOME", "")
-        if real_home_env:
-            real_root = Path(real_home_env) / ".hermes" / "auth.json"
-            try:
-                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return {}
-            except Exception:
-                pass
+    if _is_real_user_auth_store_under_test(global_path):
+        return {}
     try:
         return _load_auth_store(global_path)
     except Exception:
         # A malformed global store must not break profile reads. The
         # profile's own auth store is still authoritative.
         return {}
+
+
+def _credential_pool_auth_file_path() -> Path:
+    """Return the one machine-wide auth store that owns pool state."""
+    path = _global_auth_file_path() or _auth_file_path()
+    if _is_real_user_auth_store_under_test(path):
+        raise RuntimeError(
+            f"Refusing to use real user credential pool during test run: {path}. "
+            "Set HERMES_HOME and HOME to a tmp_path in the test fixture."
+        )
+    return path
+
+
+def _credential_pool_entry_identities(
+    provider_id: str,
+    entry: Dict[str, Any],
+) -> set[tuple]:
+    """Return non-ID identities used to deduplicate legacy pool copies.
+
+    Stable IDs are only row identifiers, not credential material identities.
+    Migration handles an ID collision separately by remapping the incoming row;
+    only matching secret/reference material is a true duplicate.
+    """
+    identities = set()
+
+    borrowed_fingerprint = str(entry.get("secret_fingerprint") or "").strip()
+    if borrowed_fingerprint:
+        identities.add(
+            (
+                provider_id,
+                "borrowed",
+                str(entry.get("source") or ""),
+                str(entry.get("base_url") or ""),
+                borrowed_fingerprint,
+            )
+        )
+        return identities
+
+    secret = (
+        entry.get("refresh_token")
+        or entry.get("agent_key")
+        or entry.get("access_token")
+        or entry.get("project_secret")
+        or ""
+    )
+    fingerprint = ""
+    if secret:
+        fingerprint = hashlib.sha256(
+            str(secret).encode("utf-8", errors="surrogatepass")
+        ).hexdigest()
+    if fingerprint:
+        identities.add(
+            (
+                provider_id,
+                "owned",
+                str(entry.get("base_url") or ""),
+                fingerprint,
+            )
+        )
+        return identities
+    ignored_identity_fields = {
+        "id",
+        "priority",
+        "last_status",
+        "last_status_at",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+        "request_count",
+    }
+    material = {
+        key: value
+        for key, value in entry.items()
+        if key not in ignored_identity_fields and value is not None
+    }
+    material_fingerprint = hashlib.sha256(
+        json.dumps(material, sort_keys=True, separators=(",", ":"), default=str).encode(
+            "utf-8", errors="surrogatepass"
+        )
+    ).hexdigest()
+    identities.add(
+        (
+            provider_id,
+            "reference",
+            material_fingerprint,
+        )
+    )
+    return identities
+
+
+def _merge_legacy_pool_state(
+    shared_store: Dict[str, Any],
+    profile_store: Dict[str, Any],
+) -> bool:
+    """Merge one legacy profile-local pool; return whether every row was understood."""
+    complete = True
+    shared_pool = shared_store.get("credential_pool")
+    if not isinstance(shared_pool, dict):
+        if "credential_pool" in shared_store:
+            complete = False
+            shared_pool = None
+        else:
+            shared_pool = {}
+            shared_store["credential_pool"] = shared_pool
+
+    profile_pool = profile_store.get("credential_pool")
+    if "credential_pool" in profile_store and not isinstance(profile_pool, dict):
+        complete = False
+    if isinstance(profile_pool, dict) and isinstance(shared_pool, dict):
+        for provider_id, raw_entries in profile_pool.items():
+            if not isinstance(raw_entries, list):
+                complete = False
+                continue
+            existing = shared_pool.get(provider_id)
+            if existing is not None and not isinstance(existing, list):
+                complete = False
+                continue
+            existing_entries = existing if isinstance(existing, list) else []
+            shared_pool[provider_id] = existing_entries
+            if any(not isinstance(item, dict) for item in existing_entries):
+                complete = False
+            identities = set().union(
+                *(
+                    _credential_pool_entry_identities(provider_id, item)
+                    for item in existing_entries
+                    if isinstance(item, dict)
+                )
+            )
+            used_ids = {
+                str(item.get("id"))
+                for item in existing_entries
+                if isinstance(item, dict) and item.get("id")
+            }
+            next_priority = max(
+                (
+                    item.get("priority", -1)
+                    for item in existing_entries
+                    if isinstance(item, dict)
+                    and isinstance(item.get("priority", -1), int)
+                ),
+                default=-1,
+            ) + 1
+            for raw_entry in raw_entries:
+                if not isinstance(raw_entry, dict):
+                    complete = False
+                    continue
+                entry = sanitize_borrowed_credential_payload(raw_entry, provider_id)
+                entry_identities = _credential_pool_entry_identities(provider_id, entry)
+                if not entry_identities.isdisjoint(identities):
+                    continue
+                entry = dict(entry)
+                entry_id = str(entry.get("id") or "")
+                while not entry_id or entry_id in used_ids:
+                    entry_id = uuid.uuid4().hex[:6]
+                    entry["id"] = entry_id
+                entry["priority"] = next_priority
+                next_priority += 1
+                existing_entries.append(entry)
+                identities.update(entry_identities)
+                used_ids.add(entry_id)
+
+    shared_suppressed = shared_store.get("suppressed_sources")
+    if not isinstance(shared_suppressed, dict):
+        if "suppressed_sources" in shared_store:
+            complete = False
+            shared_suppressed = None
+        else:
+            shared_suppressed = {}
+    profile_suppressed = profile_store.get("suppressed_sources")
+    if "suppressed_sources" in profile_store and not isinstance(
+        profile_suppressed, dict
+    ):
+        complete = False
+    if isinstance(profile_suppressed, dict) and isinstance(shared_suppressed, dict):
+        for provider_id, raw_sources in profile_suppressed.items():
+            if not isinstance(raw_sources, list):
+                complete = False
+                continue
+            sources = shared_suppressed.setdefault(provider_id, [])
+            if not isinstance(sources, list):
+                complete = False
+                continue
+            if any(not isinstance(source, str) for source in sources):
+                complete = False
+            for source in raw_sources:
+                if not isinstance(source, str):
+                    complete = False
+                    continue
+                if source not in sources:
+                    sources.append(source)
+    if isinstance(shared_suppressed, dict) and shared_suppressed:
+        shared_store["suppressed_sources"] = shared_suppressed
+    return complete
+
+
+def _migrate_active_profile_credential_pool() -> None:
+    """Move legacy active-profile pool state into the shared root store once."""
+    profile_path = _auth_file_path()
+    shared_path = _credential_pool_auth_file_path()
+    if _same_path(profile_path, shared_path) or not profile_path.exists():
+        return
+
+    # Pool reads are hot. Avoid taking the profile lock after migration has
+    # removed the legacy keys; re-check under the lock only when there is
+    # actually profile-local state to move.
+    profile_snapshot = _load_auth_store(profile_path)
+    if not (
+        isinstance(profile_snapshot.get("credential_pool"), dict)
+        or isinstance(profile_snapshot.get("suppressed_sources"), dict)
+    ):
+        return
+
+    # Preserve the established profile -> global lock order used by provider
+    # refresh transactions. Distinct profiles can wait on the shared lock
+    # without deadlocking one another.
+    with _auth_store_lock():
+        profile_store = _load_auth_store()
+        has_pool = isinstance(profile_store.get("credential_pool"), dict)
+        has_suppressions = isinstance(profile_store.get("suppressed_sources"), dict)
+        if not has_pool and not has_suppressions:
+            return
+        with _auth_store_lock(target_path=shared_path):
+            shared_store = _load_auth_store(shared_path)
+            migration_complete = _merge_legacy_pool_state(shared_store, profile_store)
+            _save_auth_store(shared_store, target_path=shared_path)
+
+        # Cleanup happens only after the root save succeeds. If cleanup fails,
+        # the next attempt is idempotent because migration deduplicates rows.
+        if not migration_complete:
+            logger.warning(
+                "Shared credential pool migration preserved unsupported legacy "
+                "state in %s; understood rows were copied but cleanup was skipped",
+                profile_path,
+            )
+            return
+        profile_store.pop("credential_pool", None)
+        profile_store.pop("suppressed_sources", None)
+        try:
+            _save_auth_store(profile_store)
+        except Exception as exc:
+            logger.warning(
+                "Shared credential pool migration succeeded, but legacy profile "
+                "state could not be removed from %s: %s",
+                profile_path,
+                exc,
+            )
+
+
+def _load_credential_pool_auth_store() -> tuple[Dict[str, Any], Path]:
+    _migrate_active_profile_credential_pool()
+    path = _credential_pool_auth_file_path()
+    return _load_auth_store(path), path
 
 
 def _auth_lock_path() -> Path:
@@ -1217,11 +1477,16 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
             )
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
-    if isinstance(raw, dict) and (
-        isinstance(raw.get("providers"), dict)
-        or isinstance(raw.get("credential_pool"), dict)
-    ):
-        raw.setdefault("providers", {})
+    auth_store_keys = {
+        "version",
+        "providers",
+        "credential_pool",
+        "suppressed_sources",
+        "active_provider",
+    }
+    if isinstance(raw, dict) and auth_store_keys.intersection(raw):
+        if "providers" not in raw:
+            raw["providers"] = {}
         if isinstance(raw.get("providers"), dict):
             _migrate_stale_nous_portal_url(raw["providers"])
         return raw
@@ -1490,51 +1755,40 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
-    """Return the persisted credential pool, or one provider slice.
-
-    In profile mode, the profile's credential pool is authoritative. If a
-    provider has no entries in the profile, entries from the global-root
-    ``auth.json`` are used as a read-only fallback — so workers spawned in a
-    profile can see providers that were only authenticated at global scope.
-
-    Profile entries always win: the global fallback only applies per-provider
-    when the profile has zero entries for that provider. Once the user runs
-    ``hermes auth add <provider>`` inside the profile, profile entries
-    fully shadow global for that provider on the next read.
-
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
-    See issue #18594 follow-up.
-    """
-    auth_store = _load_auth_store()
+def read_credential_pool(provider_id: Optional[str] = None) -> Any:
+    """Return the machine-wide credential pool, or one provider slice."""
+    auth_store, _path = _load_credential_pool_auth_store()
     pool = auth_store.get("credential_pool")
     if not isinstance(pool, dict):
         pool = {}
-
-    global_pool: Dict[str, Any] = {}
-    global_store = _load_global_auth_store()
-    maybe_global_pool = global_store.get("credential_pool") if global_store else None
-    if isinstance(maybe_global_pool, dict):
-        global_pool = maybe_global_pool
-
     if provider_id is None:
-        merged = dict(pool)
-        for gp_key, gp_entries in global_pool.items():
-            if not isinstance(gp_entries, list) or not gp_entries:
-                continue
-            # Per-provider shadowing: profile wins whenever it has ANY entries.
-            existing = merged.get(gp_key)
-            if isinstance(existing, list) and existing:
-                continue
-            merged[gp_key] = list(gp_entries)
-        return merged
-
+        return dict(pool)
     provider_entries = pool.get(provider_id)
-    if isinstance(provider_entries, list) and provider_entries:
-        return list(provider_entries)
-    # Profile has no entries for this provider — fall back to global.
-    global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    return list(provider_entries) if isinstance(provider_entries, list) else []
+
+
+def read_runtime_credential_pool(provider_id: str) -> List[Dict[str, Any]]:
+    """Return pool rows safe to consume directly as runtime credentials.
+
+    Named profiles may retain historical non-manual rows in the shared file for
+    downgrade-safe migration. Their active singleton/env values are rehydrated
+    as profile-local overlays by ``agent.credential_pool.load_pool``; raw token
+    fallbacks must not consume another profile's retained seed row.
+    """
+    entries = read_credential_pool(provider_id)
+    if not isinstance(entries, list):
+        return []
+    if _global_auth_file_path() is None:
+        return [entry for entry in entries if isinstance(entry, dict)]
+    return [
+        entry
+        for entry in entries
+        if isinstance(entry, dict)
+        and (
+            str(entry.get("source") or "") == "manual"
+            or str(entry.get("source") or "").startswith("manual:")
+        )
+    ]
 
 
 _POOL_STATUS_FIELDS = (
@@ -1629,8 +1883,10 @@ def write_credential_pool(
     merge does not resurrect them from the on-disk copy.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    _migrate_active_profile_credential_pool()
+    target_path = _credential_pool_auth_file_path()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1668,24 +1924,55 @@ def write_credential_pool(
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, target_path=target_path)
+
+
+def replace_credential_pool(
+    provider_id: str,
+    entries: List[Dict[str, Any]],
+) -> Path:
+    """Atomically replace one provider slice with last-writer-wins semantics.
+
+    Most credential-pool writers merge concurrent account rows. Singleton-like
+    providers instead need rotation to remove every obsolete secret-bearing
+    row, including IDs assigned during legacy profile migration. This helper
+    performs that replacement under the shared-store lock so a read/write gap
+    cannot preserve a concurrently migrated stale row.
+    """
+    _migrate_active_profile_credential_pool()
+    target_path = _credential_pool_auth_file_path()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
+        pool = auth_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            pool = {}
+            auth_store["credential_pool"] = pool
+        pool[provider_id] = [
+            sanitize_borrowed_credential_payload(entry, provider_id)
+            if isinstance(entry, dict)
+            else entry
+            for entry in entries
+        ]
+        return _save_auth_store(auth_store, target_path=target_path)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
     """Mark a credential source as suppressed so it won't be re-seeded."""
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    _migrate_active_profile_credential_pool()
+    target_path = _credential_pool_auth_file_path()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         suppressed = auth_store.setdefault("suppressed_sources", {})
         provider_list = suppressed.setdefault(provider_id, [])
         if source not in provider_list:
             provider_list.append(source)
-        _save_auth_store(auth_store)
+        _save_auth_store(auth_store, target_path=target_path)
 
 
 def is_source_suppressed(provider_id: str, source: str) -> bool:
     """Check if a credential source has been suppressed by the user."""
     try:
-        auth_store = _load_auth_store()
+        auth_store, _path = _load_credential_pool_auth_store()
         suppressed = auth_store.get("suppressed_sources", {})
         return source in suppressed.get(provider_id, [])
     except Exception:
@@ -1697,8 +1984,10 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
 
     Returns True if a marker was cleared, False if no marker existed.
     """
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    _migrate_active_profile_credential_pool()
+    target_path = _credential_pool_auth_file_path()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         suppressed = auth_store.get("suppressed_sources")
         if not isinstance(suppressed, dict):
             return False
@@ -1710,8 +1999,19 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
             suppressed.pop(provider_id, None)
         if not suppressed:
             auth_store.pop("suppressed_sources", None)
-        _save_auth_store(auth_store)
+        _save_auth_store(auth_store, target_path=target_path)
         return True
+
+
+def get_suppressed_credential_sources(provider_id: str) -> List[str]:
+    """Return shared suppression markers for one credential-pool provider."""
+    try:
+        auth_store, _path = _load_credential_pool_auth_store()
+        suppressed = auth_store.get("suppressed_sources", {})
+        sources = suppressed.get(provider_id, []) if isinstance(suppressed, dict) else []
+        return list(sources) if isinstance(sources, list) else []
+    except Exception:
+        return []
 
 
 def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
@@ -1827,7 +2127,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # env-backed pool entries. This intentionally excludes ambient borrowed
     # sources like gh_cli / claude_code / qwen-cli.
     try:
-        for entry in read_credential_pool(normalized):
+        for entry in read_runtime_credential_pool(normalized):
             if not isinstance(entry, dict):
                 continue
             source = str(entry.get("source") or "").strip().lower()
@@ -1857,39 +2157,61 @@ def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
     Clear auth state for a provider. Used by `hermes logout`.
     If provider_id is None, clears the active provider.
     Returns True if something was cleared.
+
+    The shared pool is the retry anchor in named-profile mode: remove it before
+    clearing the profile's provider/active state. In classic mode both live in
+    one auth.json and are committed by one atomic replace.
     """
+    _migrate_active_profile_credential_pool()
+    active_path = _auth_file_path()
+    shared_path = _credential_pool_auth_file_path()
+
     with _auth_store_lock():
         auth_store = _load_auth_store()
         target = provider_id or auth_store.get("active_provider")
         if not target:
             return False
 
-        providers = auth_store.get("providers", {})
+        providers = auth_store.get("providers")
         if not isinstance(providers, dict):
             providers = {}
             auth_store["providers"] = providers
 
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            pool = {}
-            auth_store["credential_pool"] = pool
+        if _same_path(active_path, shared_path):
+            pool = auth_store.get("credential_pool")
+            cleared = target in providers
+            providers.pop(target, None)
+            if isinstance(pool, dict) and target in pool:
+                del pool[target]
+                cleared = True
+            if auth_store.get("active_provider") == target:
+                auth_store["active_provider"] = None
+                cleared = True
+            if cleared:
+                _save_auth_store(auth_store)
+            return cleared
 
-        cleared = False
-        if target in providers:
-            del providers[target]
-            cleared = True
-        if target in pool:
-            del pool[target]
-            cleared = True
+        # Keep the profile lock outermost (the repository-wide profile -> root
+        # ordering), but durably delete shared state before mutating the profile
+        # snapshot. If this save fails, active_provider still identifies the
+        # same target so `clear_provider_auth()` can be retried without an ID.
+        shared_cleared = False
+        with _auth_store_lock(target_path=shared_path):
+            shared_store = _load_auth_store(shared_path)
+            shared_pool = shared_store.get("credential_pool")
+            if isinstance(shared_pool, dict) and target in shared_pool:
+                del shared_pool[target]
+                _save_auth_store(shared_store, target_path=shared_path)
+                shared_cleared = True
 
+        profile_cleared = target in providers
+        providers.pop(target, None)
         if auth_store.get("active_provider") == target:
             auth_store["active_provider"] = None
-            cleared = True
-
-        if not cleared:
-            return False
-        _save_auth_store(auth_store)
-    return True
+            profile_cleared = True
+        if profile_cleared:
+            _save_auth_store(auth_store)
+        return shared_cleared or profile_cleared
 
 
 def deactivate_provider() -> None:
@@ -3675,6 +3997,9 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    _migrate_active_profile_credential_pool()
+    shared_path = _credential_pool_auth_file_path()
+    active_path = _auth_file_path()
     with _auth_store_lock():
         auth_store = _load_auth_store()
         state = _load_provider_state(auth_store, "openai-codex") or {}
@@ -3690,13 +4015,28 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         if label and str(label).strip():
             state["label"] = str(label).strip()
         _save_provider_state(auth_store, "openai-codex", state)
-        _sync_codex_pool_entries(
-            auth_store,
-            tokens,
-            last_refresh,
-            previous_singleton_tokens=previous_singleton_tokens,
-        )
-        _save_auth_store(auth_store)
+        if _same_path(active_path, shared_path):
+            _sync_codex_pool_entries(
+                auth_store,
+                tokens,
+                last_refresh,
+                previous_singleton_tokens=previous_singleton_tokens,
+            )
+            _save_auth_store(auth_store)
+        else:
+            # Repair the shared alias first. If either file save fails, retrying
+            # sees an old singleton with an old alias or an already-repaired
+            # alias; it can never see a new singleton while the alias is stale.
+            with _auth_store_lock(target_path=shared_path):
+                shared_store = _load_auth_store(shared_path)
+                _sync_codex_pool_entries(
+                    shared_store,
+                    tokens,
+                    last_refresh,
+                    previous_singleton_tokens=previous_singleton_tokens,
+                )
+                _save_auth_store(shared_store, target_path=shared_path)
+            _save_auth_store(auth_store)
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
@@ -4222,8 +4562,10 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     """
     cleared = 0
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+        _migrate_active_profile_credential_pool()
+        target_path = _credential_pool_auth_file_path()
+        with _auth_store_lock(target_path=target_path):
+            auth_store = _load_auth_store(target_path)
             pool = auth_store.get("credential_pool")
             entries = pool.get("openai-codex") if isinstance(pool, dict) else None
             if not isinstance(entries, list):
@@ -4249,7 +4591,7 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
                 entry["last_error_reset_at"] = None
                 cleared += 1
             if cleared:
-                _save_auth_store(auth_store)
+                _save_auth_store(auth_store, target_path=target_path)
     except Exception:
         logger.debug("Failed to clear Codex pool quota cooldowns", exc_info=True)
     return cleared
@@ -4282,12 +4624,7 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
         return None
 
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return None
-        entries = pool.get("openai-codex")
+        entries = read_runtime_credential_pool("openai-codex")
         if not isinstance(entries, list):
             return None
         now = time.time()
@@ -4341,12 +4678,7 @@ def _pool_codex_access_token() -> str:
     the original AuthError).
     """
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return ""
-        entries = pool.get("openai-codex")
+        entries = read_runtime_credential_pool("openai-codex")
         if not isinstance(entries, list):
             return ""
 
@@ -4384,12 +4716,7 @@ def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str
         if access_token and refresh_token:
             return state
 
-    credential_pool = auth_store.get("credential_pool")
-    entries = (
-        credential_pool.get("xai-oauth")
-        if isinstance(credential_pool, dict)
-        else None
-    )
+    entries = read_runtime_credential_pool("xai-oauth")
     if isinstance(entries, list):
         for entry in entries:
             if not isinstance(entry, dict):
@@ -5569,24 +5896,38 @@ def _quarantine_nous_pool_entries(
     reason: str,
 ) -> bool:
     """Remove singleton-seeded Nous pool entries that contain dead OAuth state."""
-    pool = auth_store.get("credential_pool")
-    if not isinstance(pool, dict):
-        return False
-    entries = pool.get("nous")
-    if not isinstance(entries, list):
-        return False
-
-    retained = []
-    removed = False
     singleton_sources = {NOUS_DEVICE_CODE_SOURCE, f"manual:{NOUS_DEVICE_CODE_SOURCE}"}
-    for entry in entries:
-        if isinstance(entry, dict) and entry.get("source") in singleton_sources:
-            removed = True
-            continue
-        retained.append(entry)
+
+    def _remove_from(store: Dict[str, Any]) -> bool:
+        pool = store.get("credential_pool")
+        if not isinstance(pool, dict):
+            return False
+        entries = pool.get("nous")
+        if not isinstance(entries, list):
+            return False
+        retained = [
+            entry
+            for entry in entries
+            if not (
+                isinstance(entry, dict)
+                and entry.get("source") in singleton_sources
+            )
+        ]
+        if len(retained) == len(entries):
+            return False
+        pool["nous"] = retained
+        return True
+
+    removed = _remove_from(auth_store)
+    shared_path = _credential_pool_auth_file_path()
+    if not _same_path(shared_path, _auth_file_path()):
+        with _auth_store_lock(target_path=shared_path):
+            shared_store = _load_auth_store(shared_path)
+            if _remove_from(shared_store):
+                _save_auth_store(shared_store, target_path=shared_path)
+                removed = True
 
     if removed:
-        pool["nous"] = retained
         _oauth_trace(
             "nous_pool_device_code_quarantined",
             reason=reason,

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -185,11 +185,10 @@ def auth_add_command(args) -> None:
     if not provider.startswith(CUSTOM_POOL_PREFIX):
         try:
             from hermes_cli.auth import (
-                _load_auth_store,
+                get_suppressed_credential_sources,
                 unsuppress_credential_source,
             )
-            suppressed = _load_auth_store().get("suppressed_sources", {})
-            for src in list(suppressed.get(provider, []) or []):
+            for src in get_suppressed_credential_sources(provider):
                 unsuppress_credential_source(provider, src)
         except Exception:
             pass

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -75,35 +75,32 @@ def _prune_env_pool_entries(env_var: str) -> List[str]:
 
     Returns the list of provider ids that had entries pruned.
     """
-    from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
 
     source = f"env:{env_var}"
     pruned: List[str] = []
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return pruned
-        changed = False
-        for provider in list(pool.keys()):
-            entries = pool[provider]
-            if not isinstance(entries, list):
-                continue
-            kept = [
-                entry
-                for entry in entries
-                if not (isinstance(entry, dict) and entry.get("source") == source)
-            ]
-            if len(kept) == len(entries):
-                continue
-            changed = True
-            pruned.append(provider)
-            if kept:
-                pool[provider] = kept
-            else:
-                del pool[provider]
-        if changed:
-            _save_auth_store(auth_store)
+    pool = read_credential_pool(None)
+    if not isinstance(pool, dict):
+        return pruned
+    for provider, entries in list(pool.items()):
+        if not isinstance(entries, list):
+            continue
+        removed_ids = {
+            str(entry.get("id"))
+            for entry in entries
+            if isinstance(entry, dict)
+            and entry.get("source") == source
+            and entry.get("id")
+        }
+        kept = [
+            entry
+            for entry in entries
+            if not (isinstance(entry, dict) and entry.get("source") == source)
+        ]
+        if len(kept) == len(entries):
+            continue
+        pruned.append(provider)
+        write_credential_pool(provider, kept, removed_ids=removed_ids)
     return pruned
 
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2219,11 +2219,9 @@ def list_authenticated_providers(
         has_creds = any(os.environ.get(ev) for ev in env_vars)
         if not has_creds:
             try:
-                from hermes_cli.auth import _load_auth_store
-                store = _load_auth_store()
-                raw_pool_present = bool(
-                    store and store.get("credential_pool", {}).get(hermes_id)
-                )
+                from hermes_cli.auth import read_runtime_credential_pool
+
+                raw_pool_present = bool(read_runtime_credential_pool(hermes_id))
                 if raw_pool_present:
                     has_creds = _credential_pool_is_usable(
                         hermes_id, raw_pool_present=True

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2648,7 +2648,7 @@ def _resolve_copilot_catalog_api_key() -> str:
       1. ``resolve_api_key_provider_credentials("copilot")`` — env vars
          (``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``) plus
          the ``gh auth token`` CLI fallback.
-      2. ``read_credential_pool("copilot")`` — a token (typically a
+      2. ``read_runtime_credential_pool("copilot")`` — a token (typically a
          ``gho_*`` from device-code login, or a fine-grained PAT) stored in
          ``auth.json`` under ``credential_pool.copilot[]``. The pool is
          populated by ``hermes auth add copilot`` and by ``_seed_from_env``
@@ -2672,13 +2672,13 @@ def _resolve_copilot_catalog_api_key() -> str:
         pass
 
     try:
-        from hermes_cli.auth import read_credential_pool
+        from hermes_cli.auth import read_runtime_credential_pool
         from hermes_cli.copilot_auth import (
             exchange_copilot_token,
             validate_copilot_token,
         )
 
-        for entry in read_credential_pool("copilot"):
+        for entry in read_runtime_credential_pool("copilot"):
             if not isinstance(entry, dict):
                 continue
             raw = str(entry.get("access_token") or "").strip()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12621,11 +12621,10 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
         if not provider.startswith(CUSTOM_POOL_PREFIX):
             try:
                 from hermes_cli.auth import (
-                    _load_auth_store,
+                    get_suppressed_credential_sources,
                     unsuppress_credential_source,
                 )
-                suppressed = _load_auth_store().get("suppressed_sources", {})
-                for src in list(suppressed.get(provider, []) or []):
+                for src in get_suppressed_credential_sources(provider):
                     unsuppress_credential_source(provider, src)
             except Exception:
                 _log.exception("unsuppress after pool add failed (non-fatal)")

--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -179,13 +179,15 @@ def _save_auth(data: Dict[str, Any]) -> None:
 
 def load_photon_token() -> Optional[str]:
     """Return the device-flow bearer token stored by ``login()`` or ``None``."""
-    auth = _load_auth()
-    pool = auth.get("credential_pool", {}).get("photon") or []
+    from hermes_cli.auth import read_credential_pool
+
+    pool = read_credential_pool("photon")
     if isinstance(pool, list) and pool:
         token = pool[0].get("access_token") or pool[0].get("token")
         if token:
             return str(token)
     # Backwards-compat shape: providers.photon.access_token
+    auth = _load_auth()
     legacy = auth.get("providers", {}).get("photon", {})
     if legacy.get("access_token"):
         return str(legacy["access_token"])
@@ -194,14 +196,12 @@ def load_photon_token() -> Optional[str]:
 
 def store_photon_token(token: str) -> None:
     """Persist a dashboard bearer token under ``credential_pool.photon``."""
-    from hermes_cli.auth import _auth_store_lock
+    from hermes_cli.auth import replace_credential_pool
 
-    with _auth_store_lock():
-        auth = _load_auth()
-        auth.setdefault("credential_pool", {})["photon"] = [
-            {"access_token": token, "issued_at": int(time.time())}
-        ]
-        _save_auth(auth)
+    replace_credential_pool(
+        "photon",
+        [{"id": "photon", "access_token": token, "issued_at": int(time.time())}],
+    )
 
 
 def clear_photon_token() -> None:
@@ -209,13 +209,18 @@ def clear_photon_token() -> None:
 
     Used to discard a stale/expired token before re-authentication.
     """
-    auth = _load_auth()
-    pool = auth.get("credential_pool", {})
-    photon = pool.get("photon", [])
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    photon = read_credential_pool("photon")
     if isinstance(photon, list) and photon:
-        pool["photon"] = []
-        _save_auth(auth)
+        removed_ids = [
+            str(entry.get("id"))
+            for entry in photon
+            if isinstance(entry, dict) and entry.get("id")
+        ]
+        write_credential_pool("photon", [], removed_ids=removed_ids)
     # Also clear the legacy shape if present.
+    auth = _load_auth()
     providers = auth.get("providers", {})
     if "photon" in providers:
         providers["photon"] = {}
@@ -258,8 +263,9 @@ def load_project_credentials() -> Tuple[Optional[str], Optional[str]]:
     env_sec = _get_scoped_secret("PHOTON_PROJECT_SECRET")
     if env_id and env_sec:
         return env_id, env_sec
-    auth = _load_auth()
-    proj = auth.get("credential_pool", {}).get("photon_project") or []
+    from hermes_cli.auth import read_credential_pool
+
+    proj = read_credential_pool("photon_project")
     if isinstance(proj, list) and proj:
         entry = proj[0]
         # back-compat: old records used "project_id" for the spectrum id
@@ -280,8 +286,9 @@ def load_dashboard_project_id() -> Optional[str]:
     env_id = os.getenv("PHOTON_DASHBOARD_PROJECT_ID")
     if env_id:
         return env_id
-    auth = _load_auth()
-    proj = auth.get("credential_pool", {}).get("photon_project") or []
+    from hermes_cli.auth import read_credential_pool
+
+    proj = read_credential_pool("photon_project")
     if isinstance(proj, list) and proj:
         entry = proj[0]
         return (
@@ -308,21 +315,19 @@ def store_project_credentials(
     ``auth.json`` so management commands work even when ``.env`` hasn't been
     loaded into the current process.
     """
-    from hermes_cli.auth import _auth_store_lock
+    from hermes_cli.auth import replace_credential_pool
 
-    with _auth_store_lock():
-        auth = _load_auth()
-        record: Dict[str, Any] = {
-            "spectrum_project_id": spectrum_project_id,
-            "project_secret": project_secret,
-            "issued_at": int(time.time()),
-        }
-        if dashboard_project_id:
-            record["dashboard_project_id"] = dashboard_project_id
-        if name:
-            record["name"] = name
-        auth.setdefault("credential_pool", {})["photon_project"] = [record]
-        _save_auth(auth)
+    record: Dict[str, Any] = {
+        "spectrum_project_id": spectrum_project_id,
+        "project_secret": project_secret,
+        "issued_at": int(time.time()),
+    }
+    if dashboard_project_id:
+        record["dashboard_project_id"] = dashboard_project_id
+    if name:
+        record["name"] = name
+    record["id"] = "photon-project"
+    replace_credential_pool("photon_project", [record])
     _persist_runtime_env(spectrum_project_id, project_secret)
 
 
@@ -336,21 +341,19 @@ def store_user_numbers(
     """Persist non-secret Photon user numbers for offline ``status`` output."""
     if not phone_number and not assigned_phone_number:
         return
-    from hermes_cli.auth import _auth_store_lock
+    from hermes_cli.auth import replace_credential_pool
 
-    with _auth_store_lock():
-        auth = _load_auth()
-        record: Dict[str, Any] = {"issued_at": int(time.time())}
-        if phone_number:
-            record["phone_number"] = phone_number
-        if assigned_phone_number:
-            record["assigned_phone_number"] = assigned_phone_number
-        if user_id:
-            record["user_id"] = user_id
-        if dashboard_project_id:
-            record["dashboard_project_id"] = dashboard_project_id
-        auth.setdefault("credential_pool", {})["photon_user"] = [record]
-        _save_auth(auth)
+    record: Dict[str, Any] = {"issued_at": int(time.time())}
+    if phone_number:
+        record["phone_number"] = phone_number
+    if assigned_phone_number:
+        record["assigned_phone_number"] = assigned_phone_number
+    if user_id:
+        record["user_id"] = user_id
+    if dashboard_project_id:
+        record["dashboard_project_id"] = dashboard_project_id
+    record["id"] = "photon-user"
+    replace_credential_pool("photon_user", [record])
 
 
 def _persist_runtime_env(spectrum_project_id: str, project_secret: str) -> None:
@@ -943,8 +946,9 @@ def user_assigned_line(user: Optional[Dict[str, Any]]) -> Optional[str]:
 
 def load_user_numbers() -> Tuple[Optional[str], Optional[str]]:
     """Return ``(operator_phone_number, assigned_phone_number)`` for status."""
-    auth = _load_auth()
-    user_entries = auth.get("credential_pool", {}).get("photon_user") or []
+    from hermes_cli.auth import read_credential_pool
+
+    user_entries = read_credential_pool("photon_user")
     if isinstance(user_entries, list) and user_entries:
         entry = user_entries[0] or {}
         if isinstance(entry, dict):

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -18,6 +18,7 @@ mocking the save boundary, so they exercise the actual atomic write path.
 
 import json
 import threading
+from contextlib import contextmanager
 
 import pytest
 
@@ -185,6 +186,20 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
     monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
     monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "stale-access",
+                        "refresh_token": "stale-refresh",
+                    }
+                }
+            },
+        },
+    )
 
     lock_held: dict = {"during_post": None}
     real_lock = A._auth_store_lock
@@ -232,6 +247,362 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     assert refreshed.refresh_token == "rotated-refresh"
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
+
+
+@pytest.mark.parametrize("provider", ["openai-codex", "xai-oauth"])
+def test_named_profile_single_use_refresh_holds_profile_then_shared_lock_across_post(
+    provider, monkeypatch, tmp_path
+):
+    """Cross-profile refresh serialization is rooted at the shared pool store."""
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "auth.json"
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                provider: {
+                    "tokens": {
+                        "access_token": "before-access",
+                        "refresh_token": "before-refresh",
+                    }
+                }
+            },
+        },
+    )
+    entry = _entry(
+        provider,
+        id="shared-oauth",
+        access_token="before-access",
+        refresh_token="before-refresh",
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {provider: [entry.to_dict()]},
+        },
+    )
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    real_lock = A._auth_store_lock
+    depths = {profile_path: 0, root_path: 0}
+    outer_acquisitions = []
+    all_acquisitions = []
+
+    @contextmanager
+    def tracking_lock(*args, **kwargs):
+        target = kwargs.get("target_path") or A._auth_file_path()
+        all_acquisitions.append(target)
+        if depths.get(target, 0) == 0:
+            outer_acquisitions.append(target)
+        depths[target] = depths.get(target, 0) + 1
+        try:
+            with real_lock(*args, **kwargs):
+                yield
+        finally:
+            depths[target] -= 1
+
+    monkeypatch.setattr(A, "_auth_store_lock", tracking_lock)
+    monkeypatch.setattr(CP, "_auth_store_lock", tracking_lock)
+    observed = {}
+
+    def fake_refresh(_access_token, _refresh_token, **_kwargs):
+        observed["profile"] = depths[profile_path] > 0
+        observed["shared"] = depths[root_path] > 0
+        return {
+            "access_token": "after-access",
+            "refresh_token": "after-refresh",
+            "last_refresh": "2026-08-04T00:00:00Z",
+        }
+
+    refresh_name = (
+        "refresh_codex_oauth_pure"
+        if provider == "openai-codex"
+        else "refresh_xai_oauth_pure"
+    )
+    monkeypatch.setattr(A, refresh_name, fake_refresh)
+
+    refreshed = CredentialPool(provider, [entry])._refresh_entry(entry, force=True)
+
+    assert refreshed is not None
+    assert observed == {"profile": True, "shared": True}
+    assert outer_acquisitions[:2] == [profile_path, root_path]
+    assert all_acquisitions.count(profile_path) >= 2
+    assert all_acquisitions.count(root_path) >= 2
+
+
+def test_single_use_refresh_and_remove_overlap_without_pool_auth_deadlock(
+    monkeypatch, tmp_path
+):
+    """Refresh and removal must acquire pool/auth locks in one order."""
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "auth.json"
+    refresh_entry = _entry(
+        "openai-codex",
+        id="singleton",
+        access_token="before-access",
+        refresh_token="before-refresh",
+    )
+    manual_entry = PooledCredential(
+        provider="openai-codex",
+        id="manual",
+        label="manual",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=1,
+        source="manual:device_code",
+        access_token="manual-access",
+        refresh_token="manual-refresh",
+    )
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "before-access",
+                        "refresh_token": "before-refresh",
+                    }
+                }
+            },
+        },
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [refresh_entry.to_dict(), manual_entry.to_dict()]
+            },
+        },
+    )
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    remove_has_pool_lock = threading.Event()
+    allow_remove_to_wait_for_auth = threading.Event()
+    refresh_post_started = threading.Event()
+    allow_refresh_post_to_finish = threading.Event()
+    real_write_pool = CP.write_credential_pool
+
+    def paused_write_pool(*args, **kwargs):
+        if threading.current_thread().name == "pool-remove":
+            remove_has_pool_lock.set()
+            assert allow_remove_to_wait_for_auth.wait(timeout=5)
+        return real_write_pool(*args, **kwargs)
+
+    def fake_refresh(_access_token, _refresh_token, **_kwargs):
+        refresh_post_started.set()
+        assert allow_refresh_post_to_finish.wait(timeout=5)
+        return {
+            "access_token": "after-access",
+            "refresh_token": "after-refresh",
+            "last_refresh": "2026-08-04T00:00:00Z",
+        }
+
+    monkeypatch.setattr(CP, "write_credential_pool", paused_write_pool)
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+    pool = CredentialPool("openai-codex", [refresh_entry, manual_entry])
+    outcomes = {}
+    errors = []
+
+    def remove_manual():
+        try:
+            outcomes["removed"] = pool.remove_index(2)
+        except BaseException as exc:  # pragma: no cover - diagnostic capture
+            errors.append(exc)
+
+    def refresh_singleton():
+        try:
+            outcomes["refreshed"] = pool._refresh_entry(refresh_entry, force=True)
+        except BaseException as exc:  # pragma: no cover - diagnostic capture
+            errors.append(exc)
+
+    remover = threading.Thread(target=remove_manual, name="pool-remove", daemon=True)
+    refresher = threading.Thread(
+        target=refresh_singleton,
+        name="pool-refresh",
+        daemon=True,
+    )
+    remover.start()
+    assert remove_has_pool_lock.wait(timeout=5)
+    refresher.start()
+    # In the buggy ordering the refresher gets auth first and reaches the POST;
+    # in the fixed ordering it waits for the pool lock held by the remover.
+    assert not refresh_post_started.wait(timeout=0.5)
+    allow_remove_to_wait_for_auth.set()
+    allow_refresh_post_to_finish.set()
+    remover.join(timeout=5)
+    refresher.join(timeout=5)
+
+    assert not remover.is_alive()
+    assert not refresher.is_alive()
+    assert errors == []
+    assert outcomes["removed"].id == "manual"
+    assert outcomes["refreshed"].refresh_token == "after-refresh"
+
+
+@pytest.mark.parametrize(
+    ("provider", "refresh_name"),
+    [
+        ("openai-codex", "refresh_codex_oauth_pure"),
+        ("xai-oauth", "refresh_xai_oauth_pure"),
+    ],
+)
+def test_runtime_only_singleton_refresh_fails_when_provider_save_fails(
+    profile_and_root, monkeypatch, provider, refresh_name
+):
+    """A consumed singleton token cannot be reported as durably refreshed."""
+    profile_path, root_path = profile_and_root
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                provider: {
+                    "tokens": {
+                        "access_token": "before-access",
+                        "refresh_token": "before-refresh",
+                    }
+                }
+            },
+        },
+    )
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {}, "credential_pool": {provider: []}},
+    )
+    monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
+    entry = PooledCredential(
+        provider=provider,
+        id="profile-overlay",
+        label="profile singleton",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="device_code",
+        access_token="before-access",
+        refresh_token="before-refresh",
+        runtime_only=True,
+    )
+    monkeypatch.setattr(
+        A,
+        refresh_name,
+        lambda *_args, **_kwargs: {
+            "access_token": "after-access",
+            "refresh_token": "after-refresh",
+            "last_refresh": "2026-08-04T00:00:00Z",
+        },
+    )
+    real_save = A._save_auth_store
+
+    def fail_profile_save(store, target_path=None):
+        if target_path is None:
+            raise OSError("injected provider-state save failure")
+        return real_save(store, target_path=target_path)
+
+    monkeypatch.setattr(A, "_save_auth_store", fail_profile_save)
+    monkeypatch.setattr(CP, "_save_auth_store", fail_profile_save)
+    pool = CredentialPool(provider, [entry])
+
+    refreshed = pool._refresh_entry(entry, force=True)
+
+    assert refreshed is None
+    # Keep the rotated pair alive in memory so this process does not replay the
+    # consumed refresh token, even though the caller must treat persistence as failed.
+    retained = pool.entries()[0]
+    assert retained.access_token == "after-access"
+    assert retained.refresh_token == "after-refresh"
+    profile_tokens = _read_store(profile_path)["providers"][provider]["tokens"]
+    assert profile_tokens["refresh_token"] == "before-refresh"
+    assert "after-refresh" not in root_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("provider", ["xai-oauth", "openai-codex", "nous"])
+def test_terminal_refresh_quarantines_root_fallback_singleton_at_source(
+    provider, monkeypatch, tmp_path
+):
+    """Dead root singleton material cannot survive and re-seed the next pool."""
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "auth.json"
+    _write_store(profile_path, {"version": 1, "providers": {}})
+    if provider == "nous":
+        provider_state = {
+            "access_token": "root-access",
+            "refresh_token": "root-refresh",
+            "agent_key": "root-agent",
+            "client_id": "client",
+        }
+        error = A.AuthError(
+            "terminal",
+            provider="nous",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+    else:
+        provider_state = {
+            "tokens": {
+                "access_token": "root-access",
+                "refresh_token": "root-refresh",
+            }
+        }
+        error = A.AuthError(
+            "terminal",
+            provider=provider,
+            code=(
+                "xai_refresh_failed"
+                if provider == "xai-oauth"
+                else "codex_refresh_failed"
+            ),
+            relogin_required=True,
+        )
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {provider: provider_state}},
+    )
+    monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    monkeypatch.setattr(A, "_clear_shared_nous_state", lambda _reason: None)
+
+    def raise_terminal(*_args, **_kwargs):
+        raise error
+
+    if provider == "xai-oauth":
+        monkeypatch.setattr(A, "refresh_xai_oauth_pure", raise_terminal)
+    elif provider == "openai-codex":
+        monkeypatch.setattr(A, "refresh_codex_oauth_pure", raise_terminal)
+    else:
+        monkeypatch.setattr(A, "resolve_nous_runtime_credentials", raise_terminal)
+
+    entry = _entry(
+        provider,
+        id=f"{provider}-singleton",
+        access_token="root-access",
+        refresh_token="root-refresh",
+    )
+    pool = CredentialPool(provider, [entry])
+
+    assert pool._refresh_entry(entry, force=True) is None
+
+    root_state = _read_store(root_path)["providers"][provider]
+    if provider == "nous":
+        assert "access_token" not in root_state
+        assert "refresh_token" not in root_state
+        assert "agent_key" not in root_state
+    else:
+        assert "access_token" not in root_state["tokens"]
+        assert "refresh_token" not in root_state["tokens"]
+    profile_state = _read_store(profile_path)
+    assert provider not in profile_state.get("providers", {})
 
 
 def test_write_through_fires_on_every_refresh_not_just_first(

--- a/tests/agent/test_credential_pool_profile_overlays.py
+++ b/tests/agent/test_credential_pool_profile_overlays.py
@@ -1,0 +1,283 @@
+"""Profile-local singleton/env seeds stay runtime-only over the shared pool."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent import credential_pool as CP
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _profile_layout(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    profile_a = root / "profiles" / "a"
+    profile_b = root / "profiles" / "b"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    return root, profile_a, profile_b
+
+
+def test_same_env_source_is_profile_local_overlay_not_shared_row(
+    tmp_path, monkeypatch
+):
+    root, profile_a, profile_b = _profile_layout(tmp_path, monkeypatch)
+    root_path = root / "auth.json"
+    _write(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "shared-manual",
+                        "label": "shared",
+                        "source": "manual",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "access_token": "shared-manual-key",
+                    },
+                    {
+                        "id": "legacy-env-ref",
+                        "label": "OPENROUTER_API_KEY",
+                        "source": "env:OPENROUTER_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "secret_fingerprint": "sha256:legacy-reference",
+                    },
+                ]
+            },
+        },
+    )
+    profile_keys = {
+        str(profile_a): "profile-a-key",
+        str(profile_b): "profile-b-key",
+    }
+
+    def profile_env_value(key: str) -> str:
+        if key != "OPENROUTER_API_KEY":
+            return ""
+        return profile_keys[os.environ["HERMES_HOME"]]
+
+    monkeypatch.setattr(CP, "get_env_prefer_dotenv", profile_env_value)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    pool_a = CP.load_pool("openrouter")
+    env_a = next(e for e in pool_a.entries() if e.source.startswith("env:"))
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_b))
+    pool_b = CP.load_pool("openrouter")
+    env_b = next(e for e in pool_b.entries() if e.source.startswith("env:"))
+
+    assert env_a.access_token == "profile-a-key"
+    assert env_b.access_token == "profile-b-key"
+    assert env_a.id != "legacy-env-ref"
+    assert env_b.id != "legacy-env-ref"
+    stored = json.loads(root_path.read_text(encoding="utf-8"))
+    rows = stored["credential_pool"]["openrouter"]
+    assert next(row for row in rows if row["id"] == "shared-manual")[
+        "access_token"
+    ] == "shared-manual-key"
+    assert next(row for row in rows if row["id"] == "legacy-env-ref")[
+        "secret_fingerprint"
+    ] == "sha256:legacy-reference"
+
+
+def test_same_singleton_source_is_profile_local_overlay_not_shared_row(
+    tmp_path, monkeypatch
+):
+    root, profile_a, profile_b = _profile_layout(tmp_path, monkeypatch)
+    root_path = root / "auth.json"
+    _write(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "legacy-singleton-seed",
+                        "label": "legacy",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "legacy-access",
+                        "refresh_token": "legacy-refresh",
+                    },
+                    {
+                        "id": "shared-account",
+                        "label": "shared",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "access_token": "shared-access",
+                        "refresh_token": "shared-refresh",
+                    },
+                ]
+            },
+        },
+    )
+    for profile, suffix in ((profile_a, "a"), (profile_b, "b")):
+        _write(
+            profile / "auth.json",
+            {
+                "version": 1,
+                "providers": {
+                    "openai-codex": {
+                        "tokens": {
+                            "access_token": f"profile-{suffix}-access",
+                            "refresh_token": f"profile-{suffix}-refresh",
+                        }
+                    }
+                },
+            },
+        )
+    monkeypatch.setattr(CP, "get_env_prefer_dotenv", lambda _key: "")
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    pool_a = CP.load_pool("openai-codex")
+    singleton_a = next(e for e in pool_a.entries() if e.source == "device_code")
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_b))
+    pool_b = CP.load_pool("openai-codex")
+    singleton_b = next(e for e in pool_b.entries() if e.source == "device_code")
+
+    assert singleton_a.access_token == "profile-a-access"
+    assert singleton_b.access_token == "profile-b-access"
+    assert singleton_a.id != "legacy-singleton-seed"
+    assert singleton_b.id != "legacy-singleton-seed"
+    stored = json.loads(root_path.read_text(encoding="utf-8"))
+    rows = stored["credential_pool"]["openai-codex"]
+    assert next(row for row in rows if row["id"] == "legacy-singleton-seed")[
+        "refresh_token"
+    ] == "legacy-refresh"
+    assert next(row for row in rows if row["id"] == "shared-account")[
+        "refresh_token"
+    ] == "shared-refresh"
+
+
+def test_remove_manual_entry_never_persists_runtime_singleton_overlay(
+    tmp_path, monkeypatch
+):
+    root, profile_a, _profile_b = _profile_layout(tmp_path, monkeypatch)
+    root_path = root / "auth.json"
+    _write(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "shared-account",
+                        "label": "shared",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "shared-access",
+                        "refresh_token": "shared-refresh",
+                    }
+                ]
+            },
+        },
+    )
+    _write(
+        profile_a / "auth.json",
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "profile-access",
+                        "refresh_token": "profile-refresh",
+                    }
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    monkeypatch.setattr(CP, "get_env_prefer_dotenv", lambda _key: "")
+
+    pool = CP.load_pool("openai-codex")
+    manual_index = next(
+        index
+        for index, entry in enumerate(pool.entries(), start=1)
+        if entry.source.startswith("manual:")
+    )
+    assert pool.remove_index(manual_index) is not None
+
+    stored = json.loads(root_path.read_text(encoding="utf-8"))
+    assert stored["credential_pool"]["openai-codex"] == []
+    assert "profile-access" not in root_path.read_text(encoding="utf-8")
+
+
+def test_manual_codex_refresh_never_adopts_profile_singleton(tmp_path, monkeypatch):
+    root, profile_a, _profile_b = _profile_layout(tmp_path, monkeypatch)
+    _write(
+        root / "auth.json",
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "manual-account",
+                        "label": "manual",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "manual-access",
+                        "refresh_token": "manual-refresh",
+                    }
+                ]
+            },
+        },
+    )
+    _write(
+        profile_a / "auth.json",
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "singleton-access",
+                        "refresh_token": "singleton-refresh",
+                    }
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("HERMES_HOME", str(profile_a))
+    monkeypatch.setattr(CP, "get_env_prefer_dotenv", lambda _key: "")
+    observed = {}
+
+    def fake_refresh(access_token, refresh_token):
+        observed.update(access_token=access_token, refresh_token=refresh_token)
+        return {
+            "access_token": "manual-access-rotated",
+            "refresh_token": "manual-refresh-rotated",
+        }
+
+    monkeypatch.setattr(CP.auth_mod, "refresh_codex_oauth_pure", fake_refresh)
+    pool = CP.load_pool("openai-codex")
+    manual = next(
+        entry for entry in pool.entries() if entry.source == "manual:device_code"
+    )
+
+    refreshed = pool._refresh_entry(manual, force=True)
+
+    assert refreshed is not None
+    assert observed == {
+        "access_token": "manual-access",
+        "refresh_token": "manual-refresh",
+    }
+    stored = json.loads((root / "auth.json").read_text(encoding="utf-8"))
+    row = stored["credential_pool"]["openai-codex"][0]
+    assert row["refresh_token"] == "manual-refresh-rotated"

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -1,12 +1,9 @@
-"""Tests for cross-profile auth fallback.
+"""Tests for shared credential pools across profiles.
 
-When ``HERMES_HOME`` points to a named profile, ``read_credential_pool()``
-and ``get_provider_auth_state()`` fall back to the global-root
-``auth.json`` per-provider when the profile has no entries for that
-provider.  Writes still target the profile only.
-
-See the #18594 follow-up report: profile workers couldn't see providers
-authenticated only at the global root.
+Provider singleton state remains profile-aware with a global-root fallback,
+but ``credential_pool`` and its suppression metadata are machine-wide state.
+Every profile reads and writes the one pool in the global-root ``auth.json``.
+Legacy profile-local pool rows are migrated into that shared store on access.
 """
 
 from __future__ import annotations
@@ -53,8 +50,137 @@ def _write(path: Path, payload: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# read_credential_pool — provider-slice reads
+# read_credential_pool — shared provider-slice reads and migration
 # ---------------------------------------------------------------------------
+
+
+def test_profile_entries_migrate_into_shared_pool(profile_env):
+    """Legacy profile rows join the root pool instead of shadowing it."""
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "glob-1",
+            "label": "global-key",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "sk-or-global",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "prof-1",
+            "label": "profile-key",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "sk-or-profile",
+        }],
+    }))
+
+    assert [entry["id"] for entry in read_credential_pool("openrouter")] == [
+        "glob-1",
+        "prof-1",
+    ]
+
+    shared = json.loads((profile_env["global"] / "auth.json").read_text())
+    assert [entry["id"] for entry in shared["credential_pool"]["openrouter"]] == [
+        "glob-1",
+        "prof-1",
+    ]
+    local = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert "credential_pool" not in local
+
+
+def test_repeated_profile_migration_deduplicates_cloned_rows(profile_env):
+    """A clone-all copy of root auth state must not duplicate credentials."""
+    from hermes_cli.auth import read_credential_pool
+
+    entry = {
+        "id": "shared-1",
+        "label": "same-account",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+    }
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [entry],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [dict(entry)],
+    }))
+
+    assert [item["id"] for item in read_credential_pool("openai-codex")] == [
+        "shared-1",
+    ]
+    assert [item["id"] for item in read_credential_pool("openai-codex")] == [
+        "shared-1",
+    ]
+
+
+def test_profile_migration_remaps_same_id_when_secret_material_differs(profile_env):
+    """An ID collision alone cannot discard a distinct migrated account."""
+    from hermes_cli.auth import read_credential_pool
+
+    shared_entry = {
+        "id": "shared-1",
+        "source": "manual:device_code",
+        "access_token": "current-access",
+        "refresh_token": "current-refresh",
+    }
+    stale_entry = {
+        **shared_entry,
+        "access_token": "stale-access",
+        "refresh_token": "stale-refresh",
+    }
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(pool={"openai-codex": [shared_entry]}),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(pool={"openai-codex": [stale_entry]}),
+    )
+
+    entries = read_credential_pool("openai-codex")
+    assert len(entries) == 2
+    assert entries[0]["id"] == "shared-1"
+    assert entries[0]["refresh_token"] == "current-refresh"
+    assert entries[1]["id"] != "shared-1"
+    assert entries[1]["refresh_token"] == "stale-refresh"
+
+
+def test_profile_migration_deduplicates_legacy_singleton_alias(profile_env):
+    """The old device-code/manual alias pair represents one OAuth account."""
+    from hermes_cli.auth import read_credential_pool
+
+    shared_entry = {
+        "id": "shared-1",
+        "label": "same-account",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "device_code",
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+    }
+    profile_entry = {
+        **shared_entry,
+        "id": "legacy-alias",
+        "source": "manual:device_code",
+    }
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [shared_entry],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [profile_entry],
+    }))
+
+    assert [item["id"] for item in read_credential_pool("openai-codex")] == [
+        "shared-1",
+    ]
 
 
 
@@ -81,6 +207,48 @@ def test_missing_global_auth_file_is_safe(profile_env):
 
     assert read_credential_pool("openrouter")[0]["id"] == "prof-1"
     assert read_credential_pool("anthropic") == []
+
+
+def test_shared_pool_pytest_seatbelt_uses_windows_auth_root(monkeypatch, tmp_path):
+    from hermes_cli import auth
+
+    local_appdata = tmp_path / "LocalAppData"
+    monkeypatch.setattr(auth.sys, "platform", "win32")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "seatbelt")
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+
+    assert auth._is_real_user_auth_store_under_test(
+        local_appdata / "hermes" / "auth.json"
+    )
+
+
+@pytest.mark.parametrize(
+    ("platform", "missing_env", "relative_auth_path"),
+    [
+        ("linux", "HOME", Path(".hermes/auth.json")),
+        ("win32", "LOCALAPPDATA", Path("AppData/Local/hermes/auth.json")),
+    ],
+)
+def test_shared_pool_pytest_seatbelt_uses_platform_fallback_when_env_missing(
+    monkeypatch,
+    tmp_path,
+    platform,
+    missing_env,
+    relative_auth_path,
+):
+    """Missing HOME/LOCALAPPDATA must not make the real-store guard fail open."""
+    from hermes_cli import auth
+
+    monkeypatch.setattr(auth.sys, "platform", platform)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "seatbelt")
+    monkeypatch.delenv(missing_env, raising=False)
+    real_auth_path = tmp_path / relative_auth_path
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: real_auth_path)
+
+    assert auth._is_real_user_auth_store_under_test(real_auth_path)
+    with pytest.raises(RuntimeError, match="real user credential pool"):
+        auth._credential_pool_auth_file_path()
 
 
 def test_malformed_global_auth_file_does_not_break_profile_read(profile_env):
@@ -136,6 +304,296 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
     assert get_provider_auth_state("nous") is None
 
 
+def test_profile_logout_removes_provider_from_shared_pool(profile_env):
+    from hermes_cli.auth import clear_provider_auth
+
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(pool={"openai-codex": [{
+            "id": "shared",
+            "source": "manual:device_code",
+            "access_token": "shared-access",
+            "refresh_token": "shared-refresh",
+        }]}),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        {
+            **_make_auth_store(providers={
+                "openai-codex": {"tokens": {"access_token": "profile-access"}},
+            }),
+            "active_provider": "openai-codex",
+        },
+    )
+
+    assert clear_provider_auth("openai-codex") is True
+
+    shared = json.loads(
+        (profile_env["global"] / "auth.json").read_text(encoding="utf-8")
+    )
+    local = json.loads(
+        (profile_env["profile"] / "auth.json").read_text(encoding="utf-8")
+    )
+    assert "openai-codex" not in shared.get("credential_pool", {})
+    assert "openai-codex" not in local.get("providers", {})
+
+
+def test_profile_logout_keeps_provider_retryable_when_shared_delete_fails(
+    profile_env, monkeypatch
+):
+    """A failed shared-pool save must leave active/provider state for retry."""
+    from hermes_cli import auth
+
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(
+        root_path,
+        _make_auth_store(pool={"openai-codex": [{
+            "id": "shared",
+            "source": "manual:device_code",
+            "access_token": "shared-access",
+            "refresh_token": "shared-refresh",
+        }]}),
+    )
+    _write(
+        profile_path,
+        {
+            **_make_auth_store(providers={
+                "openai-codex": {"tokens": {"access_token": "profile-access"}},
+            }),
+            "active_provider": "openai-codex",
+        },
+    )
+
+    real_save = auth._save_auth_store
+    failed_once = False
+
+    def fail_first_shared_save(store, target_path=None):
+        nonlocal failed_once
+        if target_path == root_path and not failed_once:
+            failed_once = True
+            raise OSError("injected shared save failure")
+        return real_save(store, target_path=target_path)
+
+    monkeypatch.setattr(auth, "_save_auth_store", fail_first_shared_save)
+
+    with pytest.raises(OSError, match="injected shared save failure"):
+        auth.clear_provider_auth()
+
+    local_after_failure = json.loads(profile_path.read_text(encoding="utf-8"))
+    assert local_after_failure["active_provider"] == "openai-codex"
+    assert "openai-codex" in local_after_failure["providers"]
+
+    assert auth.clear_provider_auth() is True
+    local_after_retry = json.loads(profile_path.read_text(encoding="utf-8"))
+    shared_after_retry = json.loads(root_path.read_text(encoding="utf-8"))
+    assert local_after_retry.get("active_provider") is None
+    assert "openai-codex" not in local_after_retry.get("providers", {})
+    assert "openai-codex" not in shared_after_retry.get("credential_pool", {})
+
+
+def test_classic_logout_deletes_provider_and_pool_in_one_save(
+    classic_env, monkeypatch
+):
+    """Same-file provider/pool cleanup is one atomic auth.json transaction."""
+    from hermes_cli import auth
+
+    auth_path = classic_env / "auth.json"
+    _write(
+        auth_path,
+        {
+            **_make_auth_store(
+                pool={"openai-codex": [{"id": "shared"}]},
+                providers={"openai-codex": {"tokens": {"access_token": "active"}}},
+            ),
+            "active_provider": "openai-codex",
+        },
+    )
+    real_save = auth._save_auth_store
+    saves = 0
+
+    def count_save(store, target_path=None):
+        nonlocal saves
+        saves += 1
+        return real_save(store, target_path=target_path)
+
+    monkeypatch.setattr(auth, "_save_auth_store", count_save)
+
+    assert auth.clear_provider_auth() is True
+    assert saves == 1
+    stored = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert stored.get("active_provider") is None
+    assert "openai-codex" not in stored.get("providers", {})
+    assert "openai-codex" not in stored.get("credential_pool", {})
+
+
+def test_profile_codex_reauth_updates_shared_pool_not_profile_pool(profile_env):
+    from hermes_cli.auth import _save_codex_tokens
+
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(pool={"openai-codex": [{
+            "id": "shared",
+            "source": "device_code",
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+        }]}),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(providers={
+            "openai-codex": {
+                "tokens": {
+                    "access_token": "old-access",
+                    "refresh_token": "old-refresh",
+                }
+            },
+        }),
+    )
+
+    _save_codex_tokens(
+        {"access_token": "new-access", "refresh_token": "new-refresh"},
+        last_refresh="2026-08-04T00:00:00Z",
+    )
+
+    shared = json.loads(
+        (profile_env["global"] / "auth.json").read_text(encoding="utf-8")
+    )
+    local = json.loads(
+        (profile_env["profile"] / "auth.json").read_text(encoding="utf-8")
+    )
+    shared_entry = shared["credential_pool"]["openai-codex"][0]
+    assert shared_entry["access_token"] == "new-access"
+    assert shared_entry["refresh_token"] == "new-refresh"
+    assert "credential_pool" not in local
+    assert (
+        local["providers"]["openai-codex"]["tokens"]["access_token"]
+        == "new-access"
+    )
+
+
+@pytest.mark.parametrize("failed_save", ["shared", "profile"])
+def test_profile_codex_reauth_retry_repairs_legacy_alias_after_partial_save(
+    profile_env, monkeypatch, failed_save
+):
+    """Either named-profile save can fail once without stranding an alias."""
+    from hermes_cli import auth
+
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(
+        root_path,
+        _make_auth_store(
+            pool={
+                "openai-codex": [
+                    {
+                        "id": "legacy-alias",
+                        "source": "manual:device_code",
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                        "last_status": "dead",
+                    },
+                    {
+                        "id": "singleton-seed",
+                        "source": "device_code",
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                        "last_status": "dead",
+                    },
+                    {
+                        "id": "independent-account",
+                        "source": "manual:device_code",
+                        "access_token": "independent-access",
+                        "refresh_token": "independent-refresh",
+                        "last_status": "exhausted",
+                        "last_error_code": 429,
+                    },
+                ]
+            }
+        ),
+    )
+    _write(
+        profile_path,
+        _make_auth_store(
+            providers={
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    }
+                }
+            }
+        ),
+    )
+    real_save = auth._save_auth_store
+    failed_once = False
+
+    def fail_selected_save(store, target_path=None):
+        nonlocal failed_once
+        is_selected = (
+            target_path == root_path
+            if failed_save == "shared"
+            else target_path is None
+        )
+        if is_selected and not failed_once:
+            failed_once = True
+            raise OSError(f"injected {failed_save} save failure")
+        return real_save(store, target_path=target_path)
+
+    monkeypatch.setattr(auth, "_save_auth_store", fail_selected_save)
+    new_tokens = {
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+    }
+
+    with pytest.raises(OSError, match=f"injected {failed_save} save failure"):
+        auth._save_codex_tokens(new_tokens, last_refresh="2026-08-04T00:00:00Z")
+
+    root_after_failure = json.loads(root_path.read_text(encoding="utf-8"))
+    profile_after_failure = json.loads(profile_path.read_text(encoding="utf-8"))
+    rows_after_failure = {
+        row["id"]: row
+        for row in root_after_failure["credential_pool"]["openai-codex"]
+    }
+    if failed_save == "shared":
+        assert rows_after_failure["legacy-alias"]["access_token"] == "old-access"
+        assert (
+            profile_after_failure["providers"]["openai-codex"]["tokens"][
+                "access_token"
+            ]
+            == "old-access"
+        )
+    else:
+        assert rows_after_failure["legacy-alias"]["access_token"] == "new-access"
+        assert (
+            profile_after_failure["providers"]["openai-codex"]["tokens"][
+                "access_token"
+            ]
+            == "old-access"
+        )
+
+    auth._save_codex_tokens(new_tokens, last_refresh="2026-08-04T00:00:00Z")
+
+    root_after_retry = json.loads(root_path.read_text(encoding="utf-8"))
+    profile_after_retry = json.loads(profile_path.read_text(encoding="utf-8"))
+    rows = {
+        row["id"]: row
+        for row in root_after_retry["credential_pool"]["openai-codex"]
+    }
+    for alias_id in ("legacy-alias", "singleton-seed"):
+        assert rows[alias_id]["access_token"] == "new-access"
+        assert rows[alias_id]["refresh_token"] == "new-refresh"
+        assert rows[alias_id]["last_status"] is None
+    assert rows["independent-account"]["access_token"] == "independent-access"
+    assert rows["independent-account"]["refresh_token"] == "independent-refresh"
+    assert rows["independent-account"]["last_status"] == "exhausted"
+    assert rows["independent-account"]["last_error_code"] == 429
+    assert (
+        profile_after_retry["providers"]["openai-codex"]["tokens"]
+        == new_tokens
+    )
+
+
 # ---------------------------------------------------------------------------
 # _load_provider_state — internal global fallback (issue #18594 follow-up)
 #
@@ -161,11 +619,11 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 
 
 # ---------------------------------------------------------------------------
-# Writes stay scoped to the profile
+# Writes and suppression metadata target the shared root
 # ---------------------------------------------------------------------------
 
 
-def test_write_credential_pool_targets_profile_not_global(profile_env):
+def test_write_credential_pool_targets_shared_root(profile_env):
     from hermes_cli.auth import read_credential_pool, write_credential_pool
 
     _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
@@ -188,16 +646,28 @@ def test_write_credential_pool_targets_profile_not_global(profile_env):
         "access_token": "sk-profile-new",
     }])
 
-    # Global auth.json unchanged.
+    # The shared root now owns both the existing and newly-added entries.
     global_data = json.loads((profile_env["global"] / "auth.json").read_text())
-    assert global_data["credential_pool"]["openrouter"][0]["id"] == "glob-1"
+    assert [entry["id"] for entry in global_data["credential_pool"]["openrouter"]] == [
+        "prof-new",
+        "glob-1",
+    ]
+    assert not (profile_env["profile"] / "auth.json").exists()
+    assert [e["id"] for e in read_credential_pool("openrouter")] == [
+        "prof-new",
+        "glob-1",
+    ]
 
-    # Profile auth.json holds the new entry.
-    profile_data = json.loads((profile_env["profile"] / "auth.json").read_text())
-    assert profile_data["credential_pool"]["openrouter"][0]["id"] == "prof-new"
 
-    # Subsequent read returns profile (shadows global).
-    assert [e["id"] for e in read_credential_pool("openrouter")] == ["prof-new"]
+def test_suppression_is_shared_across_profiles(profile_env):
+    from hermes_cli.auth import is_source_suppressed, suppress_credential_source
+
+    suppress_credential_source("openai-codex", "device_code")
+
+    shared = json.loads((profile_env["global"] / "auth.json").read_text())
+    assert shared["suppressed_sources"]["openai-codex"] == ["device_code"]
+    assert not (profile_env["profile"] / "auth.json").exists()
+    assert is_source_suppressed("openai-codex", "device_code") is True
 
 
 
@@ -288,3 +758,272 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+def test_named_profile_runtime_pool_excludes_retained_seed_rows(profile_env):
+    from hermes_cli.auth import read_runtime_credential_pool
+
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openai-codex": [
+                    {
+                        "id": "retained-seed",
+                        "source": "device_code",
+                        "access_token": "other-profile-access",
+                    },
+                    {
+                        "id": "shared-manual",
+                        "source": "manual:device_code",
+                        "access_token": "shared-access",
+                    },
+                ]
+            }
+        ),
+    )
+
+    assert [
+        entry["id"] for entry in read_runtime_credential_pool("openai-codex")
+    ] == ["shared-manual"]
+
+
+def test_classic_runtime_pool_keeps_legacy_seed_rows(classic_env):
+    from hermes_cli.auth import read_runtime_credential_pool
+
+    _write(
+        classic_env / "auth.json",
+        _make_auth_store(
+            pool={
+                "openai-codex": [
+                    {
+                        "id": "classic-seed",
+                        "source": "device_code",
+                        "access_token": "classic-access",
+                    }
+                ]
+            }
+        ),
+    )
+
+    assert [
+        entry["id"] for entry in read_runtime_credential_pool("openai-codex")
+    ] == ["classic-seed"]
+
+
+def test_profile_migration_preserves_distinct_photon_rows(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "photon_project": [
+                    {
+                        "id": "root-project",
+                        "project_id": "root",
+                        "project_secret": "root-secret",
+                    }
+                ],
+                "photon_user": [
+                    {
+                        "id": "root-user",
+                        "from_number": "+10000000001",
+                        "user_number": "+10000000002",
+                    }
+                ],
+            }
+        ),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "photon_project": [
+                    {
+                        "id": "profile-project",
+                        "project_id": "profile",
+                        "project_secret": "profile-secret",
+                    }
+                ],
+                "photon_user": [
+                    {
+                        "id": "profile-user",
+                        "from_number": "+10000000003",
+                        "user_number": "+10000000004",
+                    }
+                ],
+            }
+        ),
+    )
+
+    assert {entry["id"] for entry in read_credential_pool("photon_project")} == {
+        "root-project",
+        "profile-project",
+    }
+    assert {entry["id"] for entry in read_credential_pool("photon_user")} == {
+        "root-user",
+        "profile-user",
+    }
+
+
+def test_profile_migration_keeps_source_when_any_legacy_row_is_unsupported(
+    profile_env,
+):
+    from hermes_cli.auth import read_credential_pool
+
+    valid = {
+        "id": "valid-row",
+        "source": "manual",
+        "access_token": "valid-token",
+    }
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(pool={"openrouter": [valid, "unsupported-row"]}),
+    )
+
+    assert [entry["id"] for entry in read_credential_pool("openrouter")] == [
+        "valid-row"
+    ]
+    profile_store = json.loads(
+        (profile_env["profile"] / "auth.json").read_text(encoding="utf-8")
+    )
+    assert profile_store["credential_pool"]["openrouter"][1] == "unsupported-row"
+
+
+def test_profile_migration_preserves_top_level_unsupported_suppressions(profile_env):
+    from hermes_cli.auth import read_credential_pool
+
+    valid = {
+        "id": "valid-row",
+        "source": "manual",
+        "access_token": "valid-token",
+    }
+    profile_store = _make_auth_store(pool={"openrouter": [valid]})
+    profile_store["suppressed_sources"] = "unsupported-shape"
+    _write(profile_env["profile"] / "auth.json", profile_store)
+
+    assert [entry["id"] for entry in read_credential_pool("openrouter")] == [
+        "valid-row"
+    ]
+    preserved = json.loads(
+        (profile_env["profile"] / "auth.json").read_text(encoding="utf-8")
+    )
+    assert preserved["suppressed_sources"] == "unsupported-shape"
+    assert preserved["credential_pool"]["openrouter"][0]["id"] == "valid-row"
+
+
+def test_profile_migration_preserves_nested_malformed_shared_suppression(profile_env):
+    """An unsupported destination slice must not be replaced or cleaned up."""
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "suppressed_sources": {"openai-codex": "unsupported-shape"},
+        },
+    )
+    _write(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {},
+            "suppressed_sources": {"openai-codex": ["device_code"]},
+        },
+    )
+
+    from hermes_cli.auth import read_credential_pool
+
+    assert read_credential_pool("openai-codex") == []
+    root_store = json.loads(root_path.read_text(encoding="utf-8"))
+    profile_store = json.loads(profile_path.read_text(encoding="utf-8"))
+    assert root_store["suppressed_sources"]["openai-codex"] == "unsupported-shape"
+    assert profile_store["suppressed_sources"]["openai-codex"] == ["device_code"]
+
+
+def test_profile_migration_preserves_malformed_destination_elements(profile_env):
+    """Unsupported nested destination values keep the profile source intact."""
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(
+        root_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {"openrouter": ["unsupported-destination-row"]},
+            "suppressed_sources": {
+                "openrouter": ["env:EXISTING", {"unsupported": "source"}]
+            },
+        },
+    )
+    _write(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "profile-row",
+                        "source": "manual",
+                        "api_key": "profile-key",
+                    }
+                ]
+            },
+            "suppressed_sources": {"openrouter": ["env:PROFILE"]},
+        },
+    )
+
+    from hermes_cli.auth import read_credential_pool
+
+    rows = read_credential_pool("openrouter")
+    assert rows[0] == "unsupported-destination-row"
+    assert any(isinstance(row, dict) and row.get("id") == "profile-row" for row in rows)
+    root_store = json.loads(root_path.read_text(encoding="utf-8"))
+    profile_store = json.loads(profile_path.read_text(encoding="utf-8"))
+    assert root_store["suppressed_sources"]["openrouter"] == [
+        "env:EXISTING",
+        {"unsupported": "source"},
+        "env:PROFILE",
+    ]
+    assert profile_store["credential_pool"]["openrouter"][0]["id"] == "profile-row"
+    assert profile_store["suppressed_sources"]["openrouter"] == ["env:PROFILE"]
+
+
+@pytest.mark.parametrize(
+    "shared_pool",
+    ["unsupported-top-level", {"openrouter": {"unsupported": "provider-shape"}}],
+)
+def test_profile_migration_preserves_malformed_shared_pool(profile_env, shared_pool):
+    from hermes_cli.auth import read_credential_pool
+
+    _write(
+        profile_env["global"] / "auth.json",
+        {"version": 1, "credential_pool": shared_pool},
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "openrouter": [
+                    {
+                        "id": "profile-row",
+                        "source": "manual",
+                        "access_token": "profile-token",
+                    }
+                ]
+            }
+        ),
+    )
+
+    assert read_credential_pool("openrouter") == []
+    root_store = json.loads(
+        (profile_env["global"] / "auth.json").read_text(encoding="utf-8")
+    )
+    profile_store = json.loads(
+        (profile_env["profile"] / "auth.json").read_text(encoding="utf-8")
+    )
+    assert root_store["credential_pool"] == shared_pool
+    assert profile_store["credential_pool"]["openrouter"][0]["id"] == "profile-row"

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -1,6 +1,8 @@
 """Tests for is_provider_explicitly_configured()."""
 
 import json
+from pathlib import Path
+
 import pytest
 
 
@@ -50,6 +52,79 @@ def test_ambient_pool_source_does_not_count_as_explicit(tmp_path, monkeypatch):
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("copilot") is False
+
+
+def test_named_profile_retained_explicit_flow_row_does_not_unlock_provider(
+    tmp_path, monkeypatch
+):
+    """Another profile's retained singleton seed is not explicit here."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    for key in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    (root / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "copilot": [
+                        {
+                            "id": "other-profile-seed",
+                            "source": "device_code",
+                            "auth_type": "oauth",
+                            "access_token": "other-profile-token",
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    assert is_provider_explicitly_configured("copilot") is False
+
+
+def test_classic_retained_explicit_flow_row_still_unlocks_provider(
+    tmp_path, monkeypatch
+):
+    """Classic single-store installs preserve historical pool semantics."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    hermes_home = tmp_path / "classic"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for key in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "copilot": [
+                        {
+                            "id": "classic-seed",
+                            "source": "device_code",
+                            "auth_type": "oauth",
+                            "access_token": "classic-token",
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    assert is_provider_explicitly_configured("copilot") is True
 
 
 def test_returns_true_when_moa_reference_slot_uses_provider(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
+++ b/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
@@ -7,6 +7,9 @@ during no-provider ``/model`` resolution, wins the model name, and sticks as
 the session provider (the "sticky provider fallback pollution" bug).
 """
 
+import json
+from pathlib import Path
+
 import pytest
 
 
@@ -84,6 +87,75 @@ def test_opaque_legacy_pool_value_stays_visible(monkeypatch):
     )
 
     assert _credential_pool_is_usable("opencode-go", raw_pool_present=True)
+
+
+@pytest.mark.parametrize(
+    ("named_profile", "expected_visible"),
+    [(True, False), (False, True)],
+)
+def test_section_one_pool_presence_uses_runtime_filtered_rows(
+    tmp_path, monkeypatch, named_profile, expected_visible
+):
+    """Retained profile seeds cannot authenticate a models.dev provider."""
+    import agent.models_dev as models_dev
+    import hermes_cli.models as models
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    if named_profile:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        root = tmp_path / ".hermes"
+        hermes_home = root / "profiles" / "coder"
+        hermes_home.mkdir(parents=True)
+        auth_path = root / "auth.json"
+    else:
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        hermes_home = tmp_path / "classic"
+        hermes_home.mkdir()
+        auth_path = hermes_home / "auth.json"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "deepseek": [
+                        {
+                            "id": "retained-explicit-seed",
+                            "source": "hermes_pkce",
+                            "auth_type": "api_key",
+                            "access_token": "other-profile-token",
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        models_dev, "PROVIDER_TO_MODELS_DEV", {"deepseek": "deepseek"}
+    )
+    monkeypatch.setattr(
+        models_dev,
+        "fetch_models_dev",
+        lambda: {"deepseek": {"env": ["DEEPSEEK_API_KEY"]}},
+    )
+    monkeypatch.setattr(models, "_PROVIDER_MODELS", {"deepseek": ["deepseek-chat"]})
+    monkeypatch.setattr(models, "cached_provider_model_ids", lambda _provider: [])
+
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    slugs = {
+        row["slug"]
+        for row in list_authenticated_providers(
+            current_provider="openrouter",
+            user_providers={},
+            custom_providers=[],
+        )
+    }
+    assert ("deepseek" in slugs) is expected_visible
 
 
 def test_picker_shows_exhausted_pool_provider(monkeypatch):

--- a/tests/hermes_cli/test_copilot_catalog_oauth_fallback.py
+++ b/tests/hermes_cli/test_copilot_catalog_oauth_fallback.py
@@ -23,7 +23,7 @@ class TestCopilotCatalogApiKeyResolution:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={"api_key": ""},
         ), patch(
-            "hermes_cli.auth.read_credential_pool",
+            "hermes_cli.auth.read_runtime_credential_pool",
             return_value=[{"access_token": "gho_abc123"}],
         ), patch(
             "hermes_cli.copilot_auth.exchange_copilot_token",
@@ -49,7 +49,7 @@ class TestCopilotCatalogApiKeyResolution:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={"api_key": ""},
         ), patch(
-            "hermes_cli.auth.read_credential_pool",
+            "hermes_cli.auth.read_runtime_credential_pool",
             return_value=[
                 {"access_token": "gho_unsupported_account"},
                 {"access_token": "gho_valid_token"},

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -49,8 +49,8 @@ def test_mapped_provider_credential_pool_visibility(monkeypatch):
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {"google-ai-studio": {"env": ["GEMINI_API_KEY"]}})
     monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"gemini": "google-ai-studio"})
     monkeypatch.setattr(
-        "hermes_cli.auth._load_auth_store",
-        lambda: {"providers": {}, "credential_pool": {"gemini": {"token": "fake"}}},
+        "hermes_cli.auth.read_credential_pool",
+        lambda provider_id: [{"token": "fake"}] if provider_id == "gemini" else [],
     )
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 

--- a/tests/hermes_cli/test_xai_oauth_profile_auth.py
+++ b/tests/hermes_cli/test_xai_oauth_profile_auth.py
@@ -14,21 +14,18 @@ def test_read_xai_oauth_tokens_uses_credential_pool_when_provider_tokens_empty(m
     or stale. Treating that as missing auth makes cron keep failing after the
     user has successfully re-authenticated.
     """
-    store = {
-        "providers": {"xai-oauth": {"tokens": {}, "last_auth_error": {}}},
-        "credential_pool": {
-            "xai-oauth": [
-                {
-                    "access_token": "pool-access",
-                    "refresh_token": "pool-refresh",
-                    "token_type": "Bearer",
-                    "last_refresh": "2026-06-03T19:00:00Z",
-                }
-            ]
-        },
-    }
-    monkeypatch.setattr(auth, "_load_auth_store", lambda: store)
+    store = {"providers": {"xai-oauth": {"tokens": {}, "last_auth_error": {}}}}
+    pool_entries = [
+        {
+            "access_token": "pool-access",
+            "refresh_token": "pool-refresh",
+            "token_type": "Bearer",
+            "last_refresh": "2026-06-03T19:00:00Z",
+        }
+    ]
+    monkeypatch.setattr(auth, "_load_auth_store", lambda *_args, **_kwargs: store)
     monkeypatch.setattr(auth, "_load_global_auth_store", lambda: {})
+    monkeypatch.setattr(auth, "read_credential_pool", lambda provider_id: pool_entries)
 
     resolved = auth._read_xai_oauth_tokens(_lock=False)
 

--- a/tests/plugins/platforms/photon/test_auth.py
+++ b/tests/plugins/platforms/photon/test_auth.py
@@ -106,6 +106,63 @@ def test_store_project_credentials_round_trip(
     assert photon_auth.load_dashboard_project_id() == "sp-123"
 
 
+def test_singleton_stores_replace_migrated_id_bearing_rows(
+    tmp_hermes_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rotation must remove obsolete migrated Photon secrets and metadata."""
+    monkeypatch.setattr(photon_auth, "_persist_runtime_env", lambda *a, **k: None)
+    (tmp_hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "photon": [
+                        {"id": "migrated-token", "access_token": "obsolete-token"}
+                    ],
+                    "photon_project": [
+                        {
+                            "id": "migrated-project",
+                            "spectrum_project_id": "obsolete-project",
+                            "project_secret": "obsolete-secret",
+                        }
+                    ],
+                    "photon_user": [
+                        {
+                            "id": "migrated-user",
+                            "phone_number": "+155****0000",
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    photon_auth.store_photon_token("current-token")
+    photon_auth.store_project_credentials(
+        spectrum_project_id="current-project",
+        project_secret="current-secret",
+    )
+    photon_auth.store_user_numbers(phone_number="+155****1111")
+
+    store = json.loads((tmp_hermes_home / "auth.json").read_text(encoding="utf-8"))
+    pool = store["credential_pool"]
+    assert [entry["id"] for entry in pool["photon"]] == ["photon"]
+    assert [entry["id"] for entry in pool["photon_project"]] == [
+        "photon-project"
+    ]
+    assert [entry["id"] for entry in pool["photon_user"]] == ["photon-user"]
+    serialized = json.dumps(pool, sort_keys=True)
+    for obsolete in (
+        "obsolete-token",
+        "obsolete-project",
+        "obsolete-secret",
+        "+155****0000",
+    ):
+        assert obsolete not in serialized
+
+
 def test_load_user_numbers_falls_back_to_home_channel(
     tmp_hermes_home: Path,
 ) -> None:

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import os
 import uuid
 from typing import Any, Dict, Optional
@@ -45,12 +44,9 @@ def has_xai_credentials() -> bool:
         if (get_secret("XAI_API_KEY", "") or "").strip():
             return True
     try:
-        from hermes_constants import get_hermes_home
+        from hermes_cli.auth import _load_auth_store, read_runtime_credential_pool
 
-        auth_path = get_hermes_home() / "auth.json"
-        if not auth_path.exists():
-            return False
-        store = json.loads(auth_path.read_text(encoding="utf-8"))
+        store = _load_auth_store()
         providers = store.get("providers") if isinstance(store, dict) else None
         xai_state = providers.get("xai-oauth") if isinstance(providers, dict) else None
         tokens = xai_state.get("tokens") if isinstance(xai_state, dict) else None
@@ -59,12 +55,7 @@ def has_xai_credentials() -> bool:
             return True
         # Pool-only grants (multi-account ``auth add``) never write the
         # providers singleton; still count as present credentials.
-        credential_pool = store.get("credential_pool") if isinstance(store, dict) else None
-        entries = (
-            credential_pool.get("xai-oauth")
-            if isinstance(credential_pool, dict)
-            else None
-        )
+        entries = read_runtime_credential_pool("xai-oauth")
         if isinstance(entries, list):
             for entry in entries:
                 if not isinstance(entry, dict):

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -198,7 +198,7 @@ Never run two Hermes **gateway** containers against the same data directory simu
 
 ## Multi-profile support
 
-Hermes supports [multiple profiles](../reference/profile-commands.md) — separate `~/.hermes/` subdirectories that let you run independent agents (different SOUL, skills, memory, sessions, credentials) from a single installation. **Inside the official Docker image, the s6 supervision tree treats each profile as a first-class supervised service**, so the recommended deployment is **one container hosting all profiles**.
+Hermes supports [multiple profiles](../reference/profile-commands.md) — separate `~/.hermes/` subdirectories that let you run independent agents (different SOUL, skills, memory, sessions, and profile `.env` files) from a single installation. Credential-pool entries, including OAuth accounts added through `hermes auth`, are shared through the root `auth.json`; use separate installations or containers when credentials must be isolated. **Inside the official Docker image, the s6 supervision tree treats each profile as a first-class supervised service**, so the recommended deployment is **one container hosting all profiles**.
 
 Each profile created with `hermes profile create <name>` gets:
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Profiles: Running Multiple Agents
 
-Run multiple independent Hermes agents on the same machine — each with its own config, API keys, memory, sessions, skills, and gateway state.
+Run multiple independent Hermes agents on the same machine — each with its own config, environment-backed API keys, memory, sessions, skills, and gateway state. Credential-pool entries, including OAuth accounts added through `hermes auth`, are shared across profiles.
 
 ## What are profiles?
 
@@ -270,6 +270,14 @@ Add the line to your `~/.bashrc` or `~/.zshrc` for persistent completion. Comple
 ## How it works
 
 Profiles use the `HERMES_HOME` environment variable. When you run `coder chat`, the wrapper script sets `HERMES_HOME=~/.hermes/profiles/coder` before launching hermes. Since 119+ files in the codebase resolve paths via `get_hermes_home()`, Hermes state automatically scopes to the profile's directory — config, sessions, memory, skills, state database, gateway PID, logs, and cron jobs.
+
+The credential pool is the exception. Hermes stores pooled credentials and
+source-suppression state once in the root `~/.hermes/auth.json`, so adding an
+OAuth account through `hermes auth`, rotating to another account, or removing a
+pool entry is visible from every profile. Existing `credential_pool` data in a
+named profile's `auth.json` is merged into the shared root pool on first access
+and then removed from the profile file. Provider singleton state and profile
+`.env` files remain profile-aware; only the multi-account pool is machine-wide.
 
 This is separate from terminal working directory. Tool execution starts from `terminal.cwd` (or the launch directory when `cwd: "."` on the local backend), not automatically from `HERMES_HOME`.
 


### PR DESCRIPTION
## Summary
- make the root Hermes `auth.json` the single authoritative credential pool and suppression store for all named profiles
- migrate legacy profile-local pool rows into the shared store idempotently while preserving unsupported data for recovery
- keep profile-local singleton/env credentials as runtime-only overlays so profiles do not leak ambient credentials into the shared pool
- serialize single-use OAuth refreshes and make Codex/xAI write-through, logout, removal, and Photon replacement crash/concurrency safe
- document the credential-sharing exception to normal profile isolation

## Compatibility and security
- classic/custom `HERMES_HOME` installs retain their existing single-store behavior
- environment/borrowed credentials are usable at runtime but never persisted to the shared store
- existing profile-local pools migrate only after the root write succeeds; unsupported source or destination shapes skip cleanup
- profile-specific provider singleton state, config, memory, sessions, and skills remain isolated

## Verification
- `357 passed` across auth, credential-pool, model-picker, Photon, Codex, xAI, and environment fallback suites after rebasing onto current `main`
- `uvx ruff check .`
- `scripts/check-windows-footguns.py --all`
- canonical full test runner reached the same known environment/optional-dependency baseline failures only (11 files / 44 tests), with no feature-related failures
- temp-home CLI smoke: credentials added from two profiles appeared in one root pool and no profile-local pool was created