### PR TITLE
fix(models): parse k-prefixed Kimi versions in model sort key

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -820,7 +820,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
 
     for ch in rest:
         if state == "start":
-            if ch in "vV":
+            if ch in "vVkK":
                 state = "in_version"
             elif ch.isdigit():
                 state = "in_version"
@@ -864,7 +864,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
             if ch.isdigit():
                 state = "in_version"
                 num_buf = ch
-            elif ch in "vV":
+            elif ch in "vVkK":
                 state = "in_version"
             elif ch in "-_.":
                 pass

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -818,9 +818,16 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
     state = "start"
     num_buf = ""
 
-    for ch in rest:
+    i = 0
+    while i < len(rest):
+        ch = rest[i]
+        nxt = rest[i + 1] if i + 1 < len(rest) else ""
         if state == "start":
-            if ch in "vVkK":
+            if ch in "vV":
+                state = "in_version"
+            elif ch in "kK" and nxt.isdigit():
+                # Consume Kimi k/K only when it introduces a numeric version
+                # (k3), never a plain suffix (king) or standalone text.
                 state = "in_version"
             elif ch.isdigit():
                 state = "in_version"
@@ -864,7 +871,9 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
             if ch.isdigit():
                 state = "in_version"
                 num_buf = ch
-            elif ch in "vVkK":
+            elif ch in "vV":
+                state = "in_version"
+            elif ch in "kK" and nxt.isdigit():
                 state = "in_version"
             elif ch in "-_.":
                 pass
@@ -873,6 +882,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
                 suffix_buf += ch
         elif state == "in_suffix":
             suffix_buf += ch
+        i += 1
 
     # Flush remaining buffer (strip trailing dots — "5.4." → "5.4")
     if num_buf and state == "in_version":

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -665,9 +665,13 @@ def _split_version_suffix(rest: str) -> tuple[list[float], str]:
         if ch in "-_.":
             pos += 1
             continue
-        if not (ch in "vV" or ch.isdigit()):
+        # Kimi ids (kimi-k3, kimi-k2.6) use k/K as the version marker, not v/V.
+        # Consume k/K only when it introduces a numeric version (k3), never a
+        # plain suffix (king) or standalone text (#78886).
+        k_version = ch in "kK" and pos + 1 < len(rest) and rest[pos + 1].isdigit()
+        if not (ch in "vV" or ch.isdigit() or k_version):
             break
-        if ch in "vV":
+        if ch in "vV" or k_version:
             pos += 1
         while pos < len(rest) and (rest[pos].isdigit() or rest[pos] == "."):
             if rest[pos] == "." and "." in run:

--- a/tests/hermes_cli/test_kimi_version_sort.py
+++ b/tests/hermes_cli/test_kimi_version_sort.py
@@ -44,3 +44,37 @@ def test_kimi_uppercase_k_prefix_parses():
     models = ["moonshotai/kimi-K2.6", "moonshotai/kimi-K3"]
     models.sort(key=lambda m: _model_sort_key(m, KIMI_PREFIX))
     assert models[0] == "moonshotai/kimi-K3"
+
+
+def test_kimi_non_numeric_k_suffix_keeps_its_text():
+    """k/K is a version marker only when it introduces a numeric version.
+
+    Regression for review feedback on #78892: ``kimi-king`` and ``kimi-ing``
+    must keep distinct sort keys — otherwise alias resolution can let catalog
+    order pick the model.
+    """
+    king = _model_sort_key("moonshotai/kimi-king", KIMI_PREFIX)
+    ing = _model_sort_key("moonshotai/kimi-ing", KIMI_PREFIX)
+    assert king != ing
+    # The leading k is not consumed as a version marker; both suffixes keep
+    # their full text.
+    assert king[-1] == "king"
+    assert ing[-1] == "ing"
+
+
+def test_kimi_k_marker_requires_following_digit():
+    """k/K introduces a version only when the next char is a digit."""
+    versioned = _model_sort_key("moonshotai/kimi-k3", KIMI_PREFIX)
+    suffix = _model_sort_key("moonshotai/kimi-kx", KIMI_PREFIX)
+    # k3 parses as a numeric version; kx keeps the k in the suffix.
+    assert versioned[0] == -3.0
+    assert suffix[-1] == "kx"
+
+
+def test_kimi_k_suffix_after_version_keeps_text():
+    """k/K after a version separator is not consumed as a new version marker."""
+    models = ["moonshotai/kimi-k2.6-king", "moonshotai/kimi-k2.6-ing"]
+    keys = [_model_sort_key(m, KIMI_PREFIX) for m in models]
+    assert keys[0] != keys[1]
+    assert keys[0][-1] == "king"
+    assert keys[1][-1] == "ing"

--- a/tests/hermes_cli/test_kimi_version_sort.py
+++ b/tests/hermes_cli/test_kimi_version_sort.py
@@ -1,0 +1,46 @@
+"""Tests for Kimi `k`-prefixed version parsing in the model sort key (#78886).
+
+`_model_sort_key` only recognized `v`/`V` as a version prefix, so Moonshot
+Kimi ids (`kimi-k3`, `kimi-k2.6`, `kimi-k1.5`) fell back to plain string
+comparison of the suffix. Because ``"k2.6" < "k3"`` lexicographically, the
+catalog-search branch of alias resolution picked `kimi-k2.6` as the "latest"
+model whenever a higher `k3.x` existed.
+"""
+from __future__ import annotations
+
+from hermes_cli.model_switch import _model_sort_key
+
+KIMI_PREFIX = "moonshotai/kimi"
+
+
+def test_kimi_k_versions_parse_numerically():
+    """k3 must outrank k2.6 regardless of lexicographic order."""
+    models = ["moonshotai/kimi-k2.6", "moonshotai/kimi-k3"]
+    models.sort(key=lambda m: _model_sort_key(m, KIMI_PREFIX))
+    assert models[0] == "moonshotai/kimi-k3"
+
+
+def test_kimi_k3_5_outranks_k3():
+    """A higher minor version must win even when the string sorts lower."""
+    models = ["moonshotai/kimi-k3", "moonshotai/kimi-k3.5"]
+    models.sort(key=lambda m: _model_sort_key(m, KIMI_PREFIX))
+    assert models[0] == "moonshotai/kimi-k3.5"
+
+
+def test_kimi_full_family_order():
+    """k1.5 < k2 < k2.6 < k3 with the whole family present."""
+    models = [
+        "moonshotai/kimi-k1.5",
+        "moonshotai/kimi-k2",
+        "moonshotai/kimi-k2.6",
+        "moonshotai/kimi-k3",
+    ]
+    models.sort(key=lambda m: _model_sort_key(m, KIMI_PREFIX))
+    assert models[0] == "moonshotai/kimi-k3"
+
+
+def test_kimi_uppercase_k_prefix_parses():
+    """Uppercase K must be recognized too (issue reports k/K)."""
+    models = ["moonshotai/kimi-K2.6", "moonshotai/kimi-K3"]
+    models.sort(key=lambda m: _model_sort_key(m, KIMI_PREFIX))
+    assert models[0] == "moonshotai/kimi-K3"


### PR DESCRIPTION
Fixes #78886

## Summary

`_model_sort_key` only recognized `v`/`V` as a version prefix. Moonshot Kimi model ids use a `k` prefix (`kimi-k3`, `kimi-k2.6`, `kimi-k1.5`), so their numeric versions were never parsed and the sort fell back to plain string comparison of the suffix. Since `"k2.6" < "k3"` lexicographically, the catalog-search branch of alias resolution picked `kimi-k2.6` as the "latest" model whenever a higher `k3.x` existed (e.g. the pair `k2.6`/`k3`, or any set containing `k3.5`).

## Changes

- `hermes_cli/model_switch.py`: recognize `k`/`K` as a version prefix in `_model_sort_key` — both the start state and the between state (`vV` → `vVkK`). `kimi-k3` now parses as version `[3]`, `kimi-k2.6` as `[2.6]`, `kimi-k3.5` as `[3.5]`, so the higher version sorts first.
- `tests/hermes_cli/test_kimi_version_sort.py`: regression coverage —
  - `k3` outranks `k2.6` (the reported failure);
  - `k3.5` outranks `k3`;
  - full family order `k1.5 < k2 < k2.6 < k3`;
  - uppercase `K` prefix parses too.

## Testing

- New tests fail on `main` (repro: `sorted([kimi-k2.6, kimi-k3], key=...)` returns `k2.6` first) and pass with the fix.
- `pytest tests/hermes_cli/test_kimi_version_sort.py tests/hermes_cli/test_gpt56_registration.py tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_search.py tests/hermes_cli/test_model_search_alias_dedup.py tests/hermes_cli/test_model_switch_parsing.py tests/hermes_cli/test_models.py tests/hermes_cli/test_kimi_cn_provider_listing.py` — 74 passed (existing `v`-prefixed sort invariants unchanged).
- `git diff --check` — clean.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] User input validated at boundaries
