### PR TITLE
fix(tui): recover from OSError on Windows stdin readline (#78820)

### DIFF
--- a/tests/tui_gateway/test_stdin_oserror_recovery.py
+++ b/tests/tui_gateway/test_stdin_oserror_recovery.py
@@ -1,0 +1,217 @@
+"""Tests for Windows OSError recovery on TUI gateway stdin reads (#78820).
+
+On Windows, a child process inheriting the stdio pipe can corrupt its state,
+surfacing as ``OSError(EINVAL/EBADF/EPIPE)`` on ``sys.stdin.readline()``
+instead of the empty-read that POSIX produces.  Without recovery, this kills
+the gateway child mid-session, losing the in-flight turn.
+
+These tests exercise the ``handle_stdin_oserror`` recovery function and verify
+that both TUI entry points (entry.py, slash_worker.py) wire it into their
+stdin read loops.
+"""
+
+import errno
+import os
+import time
+
+import pytest
+
+from tui_gateway._stdin_recovery import (
+    MAX_RECOVERIES_PER_MINUTE,
+    handle_stdin_oserror,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for handle_stdin_oserror (real production function)
+# ---------------------------------------------------------------------------
+
+class TestHandleStdinOserror:
+    """Exercise every branch of the OSError recovery function."""
+
+    def test_non_recoverable_errno_returns_none(self):
+        """An OSError whose errno is NOT in the recoverable set must signal
+        re-raise (return None) so unexpected errors propagate normally."""
+        exc = OSError(errno.ECONNRESET, "Connection reset")
+        assert handle_stdin_oserror(exc, [], lambda r: None) is None
+
+    def test_einval_recoverable_under_limit(self):
+        """EINVAL is the primary Windows symptom — recoverable, returns True."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        times: list[float] = []
+        assert handle_stdin_oserror(exc, times, lambda r: None) is True
+        assert len(times) == 1
+
+    def test_ebadf_recoverable(self):
+        """EBADF (child closed inherited handle) is also recoverable."""
+        exc = OSError(errno.EBADF, os.strerror(errno.EBADF))
+        assert handle_stdin_oserror(exc, [], lambda r: None) is True
+
+    def test_epipe_recoverable(self):
+        """EPIPE on a read path is recoverable on Windows."""
+        exc = OSError(errno.EPIPE, os.strerror(errno.EPIPE))
+        assert handle_stdin_oserror(exc, [], lambda r: None) is True
+
+    def test_rate_limit_exceeded_returns_false(self):
+        """More than MAX_RECOVERIES_PER_MINUTE recoveries → graceful break."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        # Already at the cap with fresh timestamps.
+        now = time.time()
+        times = [now] * MAX_RECOVERIES_PER_MINUTE
+        assert handle_stdin_oserror(exc, times, lambda r: None) is False
+
+    def test_rate_limit_logs_before_breaking(self):
+        """The log_fn must be called so the crash-log explains the exit."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        now = time.time()
+        times = [now] * MAX_RECOVERIES_PER_MINUTE
+        messages: list[str] = []
+        handle_stdin_oserror(exc, times, messages.append)
+        assert any("rate" in m.lower() or "exceed" in m.lower() for m in messages)
+
+    def test_recovery_times_pruned(self):
+        """Recovery timestamps older than 60s are pruned on each call."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        old = time.time() - 120  # 2 minutes ago — outside the window
+        times = [old, old]
+        handle_stdin_oserror(exc, times, lambda r: None)
+        # Old entries removed, new entry appended.
+        assert all(t > old for t in times)
+        assert len(times) == 1
+
+    def test_recoverable_logs_retry_message(self):
+        """A successful recovery logs a diagnostic line."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        messages: list[str] = []
+        handle_stdin_oserror(exc, [], messages.append)
+        assert len(messages) == 1
+        assert "EINVAL" in messages[0] or "retry" in messages[0].lower()
+
+    def test_shared_rate_limit_with_spurious_eof(self):
+        """OSError recovery and spurious-EOF recovery share the same
+        recovery_times list so a single rate-limit budget covers both."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        times = [time.time()]  # one spurious-EOF recovery already consumed
+        handle_stdin_oserror(exc, times, lambda r: None)
+        assert len(times) == 2  # shared list grew
+
+
+# ---------------------------------------------------------------------------
+# Source-level verification: both entry points wire up OSError handling
+# ---------------------------------------------------------------------------
+
+def _source(filename: str) -> str:
+    import pathlib
+    here = pathlib.Path(__file__).resolve()
+    repo_root = here.parent.parent.parent
+    return (repo_root / "tui_gateway" / filename).read_text(encoding="utf-8")
+
+
+def test_entry_wraps_readline_in_oserror_catch():
+    """entry.py must catch OSError around sys.stdin.readline() and route it
+    through handle_stdin_oserror instead of crashing (#78820)."""
+    source = _source("entry.py")
+    assert "handle_stdin_oserror" in source, (
+        "entry.py must import and call handle_stdin_oserror"
+    )
+    assert "except OSError" in source, (
+        "entry.py must catch OSError on the stdin read"
+    )
+    # The except must be near readline, not in an unrelated block.
+    readline_idx = source.index("sys.stdin.readline()")
+    except_idx = source.index("except OSError")
+    assert except_idx > readline_idx, (
+        "except OSError must follow the readline() call in entry.py"
+    )
+
+
+def test_slash_worker_wraps_readline_in_oserror_catch():
+    """slash_worker.py must catch OSError around sys.stdin.readline() too."""
+    source = _source("slash_worker.py")
+    assert "handle_stdin_oserror" in source, (
+        "slash_worker.py must import and call handle_stdin_oserror"
+    )
+    assert "except OSError" in source, (
+        "slash_worker.py must catch OSError on the stdin read"
+    )
+    readline_idx = source.index("sys.stdin.readline()")
+    except_idx = source.index("except OSError")
+    assert except_idx > readline_idx, (
+        "except OSError must follow the readline() call in slash_worker.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loop-pattern integration test (mirrors the exact entry.py loop structure)
+# ---------------------------------------------------------------------------
+
+def test_loop_pattern_recovers_then_reads_line():
+    """Exercise the loop pattern used by entry.py: an OSError on the first
+    read is caught and retried, then a valid JSON line is read successfully.
+
+    This mirrors the production loop's control flow (try/except OSError →
+    handle_stdin_oserror → continue/break/raise) using the real function.
+    """
+    import json
+
+    class _FakeStdin:
+        """Yields OSError once, then a JSON line, then EOF."""
+        def __init__(self):
+            self._n = 0
+
+        def readline(self):
+            self._n += 1
+            if self._n == 1:
+                raise OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+            if self._n == 2:
+                return json.dumps({"jsonrpc": "2.0", "method": "ping"}) + "\n"
+            return ""  # genuine EOF
+
+    fake = _FakeStdin()
+    recovery_times: list[float] = []
+    lines_read: list[str] = []
+
+    # Exact mirror of the entry.py / slash_worker.py stdin loop.
+    while True:
+        try:
+            raw = fake.readline()
+        except OSError as exc:
+            action = handle_stdin_oserror(exc, recovery_times, lambda r: None)
+            if action is None:
+                raise
+            if action:
+                continue
+            break
+        if not raw:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        lines_read.append(line)
+
+    assert len(lines_read) == 1
+    parsed = json.loads(lines_read[0])
+    assert parsed["method"] == "ping"
+
+
+def test_loop_pattern_non_recoverable_errno_propagates():
+    """An unexpected OSError errno must propagate (not be swallowed)."""
+    class _FakeStdin:
+        def readline(self):
+            raise OSError(errno.ECONNRESET, "Connection reset")
+
+    fake = _FakeStdin()
+
+    with pytest.raises(OSError):
+        while True:
+            try:
+                raw = fake.readline()
+            except OSError as exc:
+                action = handle_stdin_oserror(exc, [], lambda r: None)
+                if action is None:
+                    raise
+                if action:
+                    continue
+                break
+            if not raw:
+                break

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -17,6 +17,7 @@ genuine EOF and lets the caller exit.
 
 from __future__ import annotations
 
+import errno
 import os
 import time
 
@@ -148,4 +149,72 @@ def handle_spurious_eof(
     # ``_io.TextIOWrapper.readline`` returns an empty string on ``EAGAIN``
     # but does NOT stick EOF; after restoring blocking, the next call will
     # block until data arrives or the peer truly closes.
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Windows OSError recovery (#78820)
+# ---------------------------------------------------------------------------
+# On Windows, a child process inheriting the stdio pipe can corrupt its
+# state, surfacing as a *raised* ``OSError`` (EINVAL / EBADF / EPIPE) on
+# the next ``sys.stdin.readline()`` instead of the empty-read that POSIX
+# produces.  Without a guard the exception propagates out of the read loop
+# and kills the gateway child mid-session, losing the in-flight turn.
+#
+# The recoverable errno set is deliberately narrow: only transient
+# pipe-corruption errors that a retry can clear.  Anything else
+# (ECONNRESET, ENOTCONN, permission errors, …) must propagate unchanged.
+
+_RECOVERABLE_STDIN_ERRNOS: frozenset[int] = frozenset({
+    errno.EINVAL,   # corrupted pipe state (primary Windows symptom)
+    errno.EBADF,    # child closed the inherited handle
+    errno.EPIPE,    # broken pipe on the read path
+})
+
+
+def handle_stdin_oserror(
+    exc: OSError,
+    recovery_times: list[float],
+    log_fn: object,
+) -> bool | None:
+    """Handle a raised ``OSError`` from ``sys.stdin.readline()``.
+
+    Returns a tri-state action code:
+
+    * ``True``  — the error is recoverable and under the rate limit; the
+      caller should retry the read (``continue`` the loop).
+    * ``False`` — the error is recoverable but the rate limit was exceeded;
+      the caller should exit gracefully (``break``) so the parent respawns
+      with fresh state.
+    * ``None``  — the error is **not** recoverable; the caller should
+      re-raise so unexpected failures surface normally.
+
+    ``recovery_times`` is the same list used by :func:`handle_spurious_eof`
+    so both recovery paths share a single rate-limit budget per process.
+
+    ``log_fn`` is called with a diagnostic string — ``_log_exit`` in
+    ``entry.py``, a stderr ``print`` in ``slash_worker.py``.
+    """
+    if exc.errno not in _RECOVERABLE_STDIN_ERRNOS:
+        return None
+
+    # Mirror handle_spurious_eof's rate-limiting so the two recovery
+    # paths cannot gang up to create a busy-loop.
+    now = time.time()
+    recovery_times.append(now)
+    recovery_times[:] = [t for t in recovery_times if t > now - 60]
+    if len(recovery_times) > MAX_RECOVERIES_PER_MINUTE:
+        log_fn(  # type: ignore[operator]
+            f"stdin OSError recovery rate exceeded "
+            f"({len(recovery_times)}/min, cap {MAX_RECOVERIES_PER_MINUTE})"
+        )
+        return False
+
+    log_fn(  # type: ignore[operator]
+        f"stdin OSError recovered (errno={exc.errno}, "
+        f"{os.strerror(exc.errno)}), retrying"
+    )
+
+    # Brief backoff so a persistently corrupted pipe doesn't burn CPU.
+    time.sleep(0.1)
     return True

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -17,7 +17,7 @@ import threading
 import time
 import traceback
 
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import handle_spurious_eof, handle_stdin_oserror
 
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
@@ -467,7 +467,20 @@ def main():
         logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
 
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as _stdin_exc:
+            # Windows: a child process inheriting the stdio pipe can corrupt
+            # its state, surfacing as EINVAL/EBADF/EPIPE on the next read
+            # instead of the empty-read that POSIX produces.  Retry
+            # (rate-limited) instead of crashing the gateway child and
+            # losing the in-flight session (#78820).
+            _action = handle_stdin_oserror(_stdin_exc, _recovery_times, _log_exit)
+            if _action is None:
+                raise
+            if _action:
+                continue
+            break
         if not raw:
             # Stdin fell through — check if spurious (O_NONBLOCK flip by a
             # child on the shared open file description) or genuine EOF.

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -28,7 +28,7 @@ import time
 
 import cli as cli_mod
 from cli import HermesCLI
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import handle_spurious_eof, handle_stdin_oserror
 from rich.console import Console
 
 # Env-overridable so the integration test can drive sub-second timing.
@@ -152,7 +152,18 @@ def main():
         print(f"[slash-worker] {reason}", file=sys.stderr, flush=True)
 
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as _stdin_exc:
+            # Windows: a child process inheriting the stdio pipe can corrupt
+            # its state, surfacing as EINVAL/EBADF/EPIPE on the next read.
+            # Retry (rate-limited) instead of crashing the worker (#78820).
+            _action = handle_stdin_oserror(_stdin_exc, _sw_recovery_times, _sw_log)
+            if _action is None:
+                raise
+            if _action:
+                continue
+            break
         if not raw:
             if not handle_spurious_eof(_sw_recovery_times, _sw_log):
                 break


### PR DESCRIPTION
## What

On Windows, a child process inheriting the stdio pipe can corrupt its state, surfacing as a raised `OSError(EINVAL/EBADF/EPIPE)` on `sys.stdin.readline()` instead of the empty-read that POSIX produces. The existing `handle_spurious_eof` only catches the empty-read return value (`if not raw:`), not a raised exception — so the `OSError` propagates out of `main()` and crashes the gateway child mid-session, losing the in-flight turn (#78820).

## Fix

Add `handle_stdin_oserror()` to the shared `tui_gateway/_stdin_recovery.py` module. Tri-state return:

- **`True`** — recoverable errno (EINVAL/EBADF/EPIPE), under rate limit → retry the read
- **`False`** — recoverable but rate limit exceeded → graceful break (parent respawns)
- **`None`** — non-recoverable errno → re-raise so unexpected failures surface normally

Reuses the existing `MAX_RECOVERIES_PER_MINUTE` cap and the same `recovery_times` list so spurious-EOF and OSError recovery share a single rate-limit budget per process. Brief 0.1s backoff prevents busy-loop on a persistently corrupted pipe.

Wired into both TUI entry points: `entry.py` (main stdio command loop) and `slash_worker.py` (slash-command worker).

## Files Changed

- `tui_gateway/_stdin_recovery.py` — new `handle_stdin_oserror()` function + recoverable errno set
- `tui_gateway/entry.py` — `try/except OSError` around `sys.stdin.readline()`
- `tui_gateway/slash_worker.py` — same wiring
- `tests/tui_gateway/test_stdin_oserror_recovery.py` — 13 tests

## Verification

- 13 focused tests pass (all errnos, rate limit, pruning, shared budget, loop patterns, source wiring)
- 355 `tests/tui_gateway/` tests pass — 0 regressions
- `ruff check` clean
- One focused commit ahead of `upstream/main`

Cannot reproduce the Windows pipe corruption on macOS, so tests are mock-based + source-level (best validation possible for a platform-specific IO error on a non-Windows host).

## Competitor Analysis

No competing open PRs found for issue #78820.

Auto-published by Moonsong via Path B automated pipeline.