### PR TITLE
fix(tui): Windows stdin recovery + detach local env probes (#78820)

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -325,7 +325,11 @@ class RelayRuntime:
                         allow_closing=True,
                     )
                 except Exception as exc:
-                    failures.append(f"session scope close failed: {exc}")
+                    # When a session is forcefully closed mid-turn (e.g. from a gateway transport crash),
+                    # inner scopes might still be active, causing the pop to fail.
+                    # This is safe to ignore since the session is tearing down anyway.
+                    if "scope handle is not at the top of the stack" not in str(exc):
+                        failures.append(f"session scope close failed: {exc}")
         try:
             self.relay.subscribers.flush()
         except Exception as exc:

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -325,11 +325,7 @@ class RelayRuntime:
                         allow_closing=True,
                     )
                 except Exception as exc:
-                    # When a session is forcefully closed mid-turn (e.g. from a gateway transport crash),
-                    # inner scopes might still be active, causing the pop to fail.
-                    # This is safe to ignore since the session is tearing down anyway.
-                    if "scope handle is not at the top of the stack" not in str(exc):
-                        failures.append(f"session scope close failed: {exc}")
+                    failures.append(f"session scope close failed: {exc}")
         try:
             self.relay.subscribers.flush()
         except Exception as exc:

--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson

--- a/tests/tools/test_local_env_probe_stdin.py
+++ b/tests/tools/test_local_env_probe_stdin.py
@@ -1,0 +1,78 @@
+"""Local-env Windows probes must not inherit the caller's stdin (#78820).
+
+When the TUI gateway spawns a local environment, PowerShell/Git-Bash probes
+run with capture_output=True. Without stdin=DEVNULL the child inherits the
+gateway's Node→Python command pipe; on Windows that can corrupt the pipe and
+kill the gateway on the next readline with OSError(EINVAL).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import tools.environments.local as local_env
+
+
+def _local_py_source() -> str:
+    return Path(local_env.__file__).read_text(encoding="utf-8")
+
+
+def test_mandatory_aslr_probe_source_uses_devnull_stdin():
+    """Source guard: ASLR PowerShell probe detaches stdin."""
+    src = _local_py_source()
+    # Narrow window around the ForceRelocateImages probe body.
+    marker = "ForceRelocateImages.ToString()"
+    idx = src.index(marker)
+    window = src[idx : idx + 400]
+    assert "stdin=subprocess.DEVNULL" in window
+
+
+def test_bash_starts_probe_source_uses_devnull_stdin():
+    """Source guard: bash external-program probe detaches stdin."""
+    src = _local_py_source()
+    marker = "_BASH_EXTERNAL_PROGRAM_PROBE"
+    # Second occurrence is inside _bash_starts's subprocess.run call.
+    first = src.index(marker)
+    second = src.index(marker, first + 1)
+    window = src[second : second + 350]
+    assert "stdin=subprocess.DEVNULL" in window
+
+
+def test_bash_starts_passes_devnull_at_runtime(monkeypatch):
+    """Runtime: _bash_starts forwards stdin=DEVNULL into subprocess.run."""
+    local_env._bash_starts_cache.clear()
+    local_env._bash_probe_details_cache.clear()
+
+    calls: list[dict] = []
+
+    def _fake_run(*args, **kwargs):
+        calls.append(kwargs)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(local_env.subprocess, "run", _fake_run)
+    assert local_env._bash_starts("/usr/bin/bash") is True
+    assert calls, "subprocess.run was not called"
+    assert calls[0].get("stdin") is subprocess.DEVNULL
+
+
+def test_mandatory_aslr_passes_devnull_at_runtime(monkeypatch):
+    """Runtime: _mandatory_aslr_enabled forwards stdin=DEVNULL on Windows path."""
+    local_env._mandatory_aslr_enabled_cache = None
+
+    calls: list[dict] = []
+
+    def _fake_run(*args, **kwargs):
+        calls.append(kwargs)
+        return MagicMock(returncode=0, stdout="OFF\n", stderr="")
+
+    monkeypatch.setattr(local_env.subprocess, "run", _fake_run)
+    monkeypatch.setattr(local_env.shutil, "which", lambda _name: "powershell.exe")
+    # Force the Windows probe path even on Linux CI hosts.
+    monkeypatch.setattr(local_env, "_IS_WINDOWS", True, raising=False)
+
+    result = local_env._mandatory_aslr_enabled()
+    assert result is False
+    assert calls, "subprocess.run was not called"
+    assert calls[0].get("stdin") is subprocess.DEVNULL

--- a/tests/tui_gateway/test_stdin_oserror_recovery.py
+++ b/tests/tui_gateway/test_stdin_oserror_recovery.py
@@ -1,0 +1,217 @@
+"""Tests for Windows OSError recovery on TUI gateway stdin reads (#78820).
+
+On Windows, a child process inheriting the stdio pipe can corrupt its state,
+surfacing as ``OSError(EINVAL/EBADF/EPIPE)`` on ``sys.stdin.readline()``
+instead of the empty-read that POSIX produces.  Without recovery, this kills
+the gateway child mid-session, losing the in-flight turn.
+
+These tests exercise the ``handle_stdin_oserror`` recovery function and verify
+that both TUI entry points (entry.py, slash_worker.py) wire it into their
+stdin read loops.
+"""
+
+import errno
+import os
+import time
+
+import pytest
+
+from tui_gateway._stdin_recovery import (
+    MAX_RECOVERIES_PER_MINUTE,
+    handle_stdin_oserror,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for handle_stdin_oserror (real production function)
+# ---------------------------------------------------------------------------
+
+class TestHandleStdinOserror:
+    """Exercise every branch of the OSError recovery function."""
+
+    def test_non_recoverable_errno_returns_none(self):
+        """An OSError whose errno is NOT in the recoverable set must signal
+        re-raise (return None) so unexpected errors propagate normally."""
+        exc = OSError(errno.ECONNRESET, "Connection reset")
+        assert handle_stdin_oserror(exc, [], lambda r: None) is None
+
+    def test_einval_recoverable_under_limit(self):
+        """EINVAL is the primary Windows symptom — recoverable, returns True."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        times: list[float] = []
+        assert handle_stdin_oserror(exc, times, lambda r: None) is True
+        assert len(times) == 1
+
+    def test_ebadf_recoverable(self):
+        """EBADF (child closed inherited handle) is also recoverable."""
+        exc = OSError(errno.EBADF, os.strerror(errno.EBADF))
+        assert handle_stdin_oserror(exc, [], lambda r: None) is True
+
+    def test_epipe_recoverable(self):
+        """EPIPE on a read path is recoverable on Windows."""
+        exc = OSError(errno.EPIPE, os.strerror(errno.EPIPE))
+        assert handle_stdin_oserror(exc, [], lambda r: None) is True
+
+    def test_rate_limit_exceeded_returns_false(self):
+        """More than MAX_RECOVERIES_PER_MINUTE recoveries → graceful break."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        # Already at the cap with fresh timestamps.
+        now = time.time()
+        times = [now] * MAX_RECOVERIES_PER_MINUTE
+        assert handle_stdin_oserror(exc, times, lambda r: None) is False
+
+    def test_rate_limit_logs_before_breaking(self):
+        """The log_fn must be called so the crash-log explains the exit."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        now = time.time()
+        times = [now] * MAX_RECOVERIES_PER_MINUTE
+        messages: list[str] = []
+        handle_stdin_oserror(exc, times, messages.append)
+        assert any("rate" in m.lower() or "exceed" in m.lower() for m in messages)
+
+    def test_recovery_times_pruned(self):
+        """Recovery timestamps older than 60s are pruned on each call."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        old = time.time() - 120  # 2 minutes ago — outside the window
+        times = [old, old]
+        handle_stdin_oserror(exc, times, lambda r: None)
+        # Old entries removed, new entry appended.
+        assert all(t > old for t in times)
+        assert len(times) == 1
+
+    def test_recoverable_logs_retry_message(self):
+        """A successful recovery logs a diagnostic line."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        messages: list[str] = []
+        handle_stdin_oserror(exc, [], messages.append)
+        assert len(messages) == 1
+        assert "EINVAL" in messages[0] or "retry" in messages[0].lower()
+
+    def test_shared_rate_limit_with_spurious_eof(self):
+        """OSError recovery and spurious-EOF recovery share the same
+        recovery_times list so a single rate-limit budget covers both."""
+        exc = OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+        times = [time.time()]  # one spurious-EOF recovery already consumed
+        handle_stdin_oserror(exc, times, lambda r: None)
+        assert len(times) == 2  # shared list grew
+
+
+# ---------------------------------------------------------------------------
+# Source-level verification: both entry points wire up OSError handling
+# ---------------------------------------------------------------------------
+
+def _source(filename: str) -> str:
+    import pathlib
+    here = pathlib.Path(__file__).resolve()
+    repo_root = here.parent.parent.parent
+    return (repo_root / "tui_gateway" / filename).read_text(encoding="utf-8")
+
+
+def test_entry_wraps_readline_in_oserror_catch():
+    """entry.py must catch OSError around sys.stdin.readline() and route it
+    through handle_stdin_oserror instead of crashing (#78820)."""
+    source = _source("entry.py")
+    assert "handle_stdin_oserror" in source, (
+        "entry.py must import and call handle_stdin_oserror"
+    )
+    assert "except OSError" in source, (
+        "entry.py must catch OSError on the stdin read"
+    )
+    # The except must be near readline, not in an unrelated block.
+    readline_idx = source.index("sys.stdin.readline()")
+    except_idx = source.index("except OSError")
+    assert except_idx > readline_idx, (
+        "except OSError must follow the readline() call in entry.py"
+    )
+
+
+def test_slash_worker_wraps_readline_in_oserror_catch():
+    """slash_worker.py must catch OSError around sys.stdin.readline() too."""
+    source = _source("slash_worker.py")
+    assert "handle_stdin_oserror" in source, (
+        "slash_worker.py must import and call handle_stdin_oserror"
+    )
+    assert "except OSError" in source, (
+        "slash_worker.py must catch OSError on the stdin read"
+    )
+    readline_idx = source.index("sys.stdin.readline()")
+    except_idx = source.index("except OSError")
+    assert except_idx > readline_idx, (
+        "except OSError must follow the readline() call in slash_worker.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loop-pattern integration test (mirrors the exact entry.py loop structure)
+# ---------------------------------------------------------------------------
+
+def test_loop_pattern_recovers_then_reads_line():
+    """Exercise the loop pattern used by entry.py: an OSError on the first
+    read is caught and retried, then a valid JSON line is read successfully.
+
+    This mirrors the production loop's control flow (try/except OSError →
+    handle_stdin_oserror → continue/break/raise) using the real function.
+    """
+    import json
+
+    class _FakeStdin:
+        """Yields OSError once, then a JSON line, then EOF."""
+        def __init__(self):
+            self._n = 0
+
+        def readline(self):
+            self._n += 1
+            if self._n == 1:
+                raise OSError(errno.EINVAL, os.strerror(errno.EINVAL))
+            if self._n == 2:
+                return json.dumps({"jsonrpc": "2.0", "method": "ping"}) + "\n"
+            return ""  # genuine EOF
+
+    fake = _FakeStdin()
+    recovery_times: list[float] = []
+    lines_read: list[str] = []
+
+    # Exact mirror of the entry.py / slash_worker.py stdin loop.
+    while True:
+        try:
+            raw = fake.readline()
+        except OSError as exc:
+            action = handle_stdin_oserror(exc, recovery_times, lambda r: None)
+            if action is None:
+                raise
+            if action:
+                continue
+            break
+        if not raw:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        lines_read.append(line)
+
+    assert len(lines_read) == 1
+    parsed = json.loads(lines_read[0])
+    assert parsed["method"] == "ping"
+
+
+def test_loop_pattern_non_recoverable_errno_propagates():
+    """An unexpected OSError errno must propagate (not be swallowed)."""
+    class _FakeStdin:
+        def readline(self):
+            raise OSError(errno.ECONNRESET, "Connection reset")
+
+    fake = _FakeStdin()
+
+    with pytest.raises(OSError):
+        while True:
+            try:
+                raw = fake.readline()
+            except OSError as exc:
+                action = handle_stdin_oserror(exc, [], lambda r: None)
+                if action is None:
+                    raise
+                if action:
+                    continue
+                break
+            if not raw:
+                break

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -845,6 +845,10 @@ def _mandatory_aslr_enabled() -> "bool | None":
                 "(Get-ProcessMitigation -System).Aslr.ForceRelocateImages.ToString()",
             ],
             capture_output=True,
+            # Detach from the TUI gateway's stdio pipe. On Windows an inherited
+            # stdin handle can corrupt the parent's pipe state and surface as
+            # OSError(EINVAL) on the next gateway readline (#78820).
+            stdin=subprocess.DEVNULL,
             text=True, encoding="utf-8", errors="replace",
             timeout=10,
             creationflags=windows_hide_flags(),
@@ -911,6 +915,9 @@ def _bash_starts(bash: str) -> bool:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
             capture_output=True,
+            # Same stdin detach as _mandatory_aslr_enabled — Git Bash/MSYS
+            # probes must not inherit the TUI gateway command pipe (#78820).
+            stdin=subprocess.DEVNULL,
             text=True, encoding="utf-8", errors="replace",
             timeout=15,
             creationflags=windows_hide_flags() if _IS_WINDOWS else 0,

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -8,15 +8,19 @@ The gateway's next ``read()`` returns ``EAGAIN``, which CPython's buffered
 This module provides:
 - :func:`diagnose_stdin_state` — forensic diagnostic (``O_NONBLOCK`` / ``SO_RCVTIMEO``)
 - :func:`handle_spurious_eof` — check whether an empty ``readline()`` is a genuine
-  peer-close or a spurious EOF, and recover if spurious.
+  peer-close or a spurious EOF, and recover if spurious (POSIX ``fcntl`` path)
+- :func:`handle_stdin_oserror` — Windows-aware recovery when ``readline()`` *raises*
+  ``OSError`` (EINVAL/EBADF/EPIPE) instead of returning empty (#78820)
 
-The recovery is **POSIX-only** (``fcntl``).  On Windows, ``O_NONBLOCK`` on a
-shared file description is not a concern, so the guard simply reports a
-genuine EOF and lets the caller exit.
+``handle_spurious_eof`` is **POSIX-only** (``fcntl``).  On Windows, ``O_NONBLOCK``
+on a shared file description is not the usual failure mode, so that path reports
+a genuine EOF.  Windows pipe corruption from inherited stdin handles is covered
+by :func:`handle_stdin_oserror` instead.
 """
 
 from __future__ import annotations
 
+import errno
 import os
 import time
 
@@ -165,18 +169,11 @@ def handle_spurious_eof(
 # (ECONNRESET, ENOTCONN, permission errors, …) must propagate unchanged.
 
 _RECOVERABLE_STDIN_ERRNOS: frozenset[int] = frozenset({
-    getattr(os, "errno", None) and getattr(os.errno, "EINVAL", 22) or 22,   # corrupted pipe state (primary Windows symptom)
-    getattr(os, "errno", None) and getattr(os.errno, "EBADF", 9) or 9,    # child closed the inherited handle
-    getattr(os, "errno", None) and getattr(os.errno, "EPIPE", 32) or 32,    # broken pipe on the read path
+    errno.EINVAL,  # corrupted pipe state (primary Windows symptom)
+    errno.EBADF,   # child closed the inherited handle
+    errno.EPIPE,   # broken pipe on the read path
 })
 
-import errno
-
-_RECOVERABLE_STDIN_ERRNOS = frozenset({
-    errno.EINVAL,
-    errno.EBADF,
-    errno.EPIPE,
-})
 
 def handle_stdin_oserror(
     exc: OSError,
@@ -194,10 +191,18 @@ def handle_stdin_oserror(
       with fresh state.
     * ``None``  — the error is **not** recoverable; the caller should
       re-raise so unexpected failures surface normally.
+
+    ``recovery_times`` is the same list used by :func:`handle_spurious_eof`
+    so both recovery paths share a single rate-limit budget per process.
+
+    ``log_fn`` is called with a diagnostic string — ``_log_exit`` in
+    ``entry.py``, a stderr ``print`` in ``slash_worker.py``.
     """
     if exc.errno not in _RECOVERABLE_STDIN_ERRNOS:
         return None
 
+    # Mirror handle_spurious_eof's rate-limiting so the two recovery
+    # paths cannot gang up to create a busy-loop.
     now = time.time()
     recovery_times.append(now)
     recovery_times[:] = [t for t in recovery_times if t > now - 60]
@@ -213,5 +218,6 @@ def handle_stdin_oserror(
         f"{os.strerror(exc.errno)}), retrying"
     )
 
+    # Brief backoff so a persistently corrupted pipe doesn't burn CPU.
     time.sleep(0.1)
     return True

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -149,3 +149,69 @@ def handle_spurious_eof(
     # but does NOT stick EOF; after restoring blocking, the next call will
     # block until data arrives or the peer truly closes.
     return True
+
+
+# ---------------------------------------------------------------------------
+# Windows OSError recovery (#78820)
+# ---------------------------------------------------------------------------
+# On Windows, a child process inheriting the stdio pipe can corrupt its
+# state, surfacing as a *raised* ``OSError`` (EINVAL / EBADF / EPIPE) on
+# the next ``sys.stdin.readline()`` instead of the empty-read that POSIX
+# produces.  Without a guard the exception propagates out of the read loop
+# and kills the gateway child mid-session, losing the in-flight turn.
+#
+# The recoverable errno set is deliberately narrow: only transient
+# pipe-corruption errors that a retry can clear.  Anything else
+# (ECONNRESET, ENOTCONN, permission errors, …) must propagate unchanged.
+
+_RECOVERABLE_STDIN_ERRNOS: frozenset[int] = frozenset({
+    getattr(os, "errno", None) and getattr(os.errno, "EINVAL", 22) or 22,   # corrupted pipe state (primary Windows symptom)
+    getattr(os, "errno", None) and getattr(os.errno, "EBADF", 9) or 9,    # child closed the inherited handle
+    getattr(os, "errno", None) and getattr(os.errno, "EPIPE", 32) or 32,    # broken pipe on the read path
+})
+
+import errno
+
+_RECOVERABLE_STDIN_ERRNOS = frozenset({
+    errno.EINVAL,
+    errno.EBADF,
+    errno.EPIPE,
+})
+
+def handle_stdin_oserror(
+    exc: OSError,
+    recovery_times: list[float],
+    log_fn: object,
+) -> bool | None:
+    """Handle a raised ``OSError`` from ``sys.stdin.readline()``.
+
+    Returns a tri-state action code:
+
+    * ``True``  — the error is recoverable and under the rate limit; the
+      caller should retry the read (``continue`` the loop).
+    * ``False`` — the error is recoverable but the rate limit was exceeded;
+      the caller should exit gracefully (``break``) so the parent respawns
+      with fresh state.
+    * ``None``  — the error is **not** recoverable; the caller should
+      re-raise so unexpected failures surface normally.
+    """
+    if exc.errno not in _RECOVERABLE_STDIN_ERRNOS:
+        return None
+
+    now = time.time()
+    recovery_times.append(now)
+    recovery_times[:] = [t for t in recovery_times if t > now - 60]
+    if len(recovery_times) > MAX_RECOVERIES_PER_MINUTE:
+        log_fn(  # type: ignore[operator]
+            f"stdin OSError recovery rate exceeded "
+            f"({len(recovery_times)}/min, cap {MAX_RECOVERIES_PER_MINUTE})"
+        )
+        return False
+
+    log_fn(  # type: ignore[operator]
+        f"stdin OSError recovered (errno={exc.errno}, "
+        f"{os.strerror(exc.errno)}), retrying"
+    )
+
+    time.sleep(0.1)
+    return True

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -17,7 +17,7 @@ import threading
 import time
 import traceback
 
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import handle_spurious_eof, handle_stdin_oserror
 
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
@@ -467,7 +467,20 @@ def main():
         logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
 
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as _stdin_exc:
+            # Windows: a child process inheriting the stdio pipe can corrupt
+            # its state, surfacing as EINVAL/EBADF/EPIPE on the next read
+            # instead of the empty-read that POSIX produces.  Retry
+            # (rate-limited) instead of crashing the gateway child and
+            # losing the in-flight session (#78820).
+            _action = handle_stdin_oserror(_stdin_exc, _recovery_times, _log_exit)
+            if _action is None:
+                raise
+            if _action:
+                continue
+            break
         if not raw:
             # Stdin fell through — check if spurious (O_NONBLOCK flip by a
             # child on the shared open file description) or genuine EOF.

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -28,7 +28,7 @@ import time
 
 import cli as cli_mod
 from cli import HermesCLI
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import handle_spurious_eof, handle_stdin_oserror
 from rich.console import Console
 
 # Env-overridable so the integration test can drive sub-second timing.
@@ -152,7 +152,18 @@ def main():
         print(f"[slash-worker] {reason}", file=sys.stderr, flush=True)
 
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as _stdin_exc:
+            # Windows: a child process inheriting the stdio pipe can corrupt
+            # its state, surfacing as EINVAL/EBADF/EPIPE on the next read.
+            # Retry (rate-limited) instead of crashing the worker (#78820).
+            _action = handle_stdin_oserror(_stdin_exc, _sw_recovery_times, _sw_log)
+            if _action is None:
+                raise
+            if _action:
+                continue
+            break
         if not raw:
             if not handle_spurious_eof(_sw_recovery_times, _sw_log):
                 break


### PR DESCRIPTION
## What does this PR do?

Fixes [#78820](https://github.com/NousResearch/hermes-agent/issues/78820): on Windows, `hermes --tui` gateway child dies with unhandled `OSError: [Errno 22] Invalid argument` on `sys.stdin.readline()`, the parent prints `gateway exited — recovering your session`, and the in-flight turn is lost.

## Root cause

When the terminal tool creates a local environment on Windows, two probes in `tools/environments/local.py` run with `capture_output=True` but **without** detaching stdin:

- `_mandatory_aslr_enabled` — PowerShell `Get-ProcessMitigation`
- `_bash_starts` — Git Bash external-program probe

`stdin=None` means the child **inherits** the Node→Python TUI gateway command pipe. On Windows that inherited handle can corrupt pipe state; the gateway's next `readline()` raises `OSError(EINVAL)` instead of the empty-read POSIX produces. The existing `handle_spurious_eof` only handles empty reads (and is POSIX/`fcntl`-only), so the exception kills the child.

This is the same bug class as the ACP stdin-detach fixes, but on the TUI local-env probe path.

The same-second Relay warning (`scope handle is not at the top of the stack`) is a **teardown symptom** of killing the child mid-turn, not the primary cause — this PR does not paper over it with string matching.

## Fix (two layers)

### 1. Root — detach probe stdin
`tools/environments/local.py`: `stdin=subprocess.DEVNULL` on both Windows probes (same pattern as docker/ssh/ACP).

### 2. Defense — recover raised OSError on readline
`tui_gateway/_stdin_recovery.py`: `handle_stdin_oserror()` with a narrow recoverable set (`EINVAL` / `EBADF` / `EPIPE`), shared `MAX_RECOVERIES_PER_MINUTE` budget with spurious-EOF recovery, 0.1s backoff.

Wired into:
- `tui_gateway/entry.py` (main stdio loop)
- `tui_gateway/slash_worker.py`

## Why this is not a pure duplicate of #78894

[#78894](https://github.com/NousResearch/hermes-agent/pull/78894) implements the defensive readline recovery only. This PR keeps that layer (cleaned up) **and** adds the root `stdin=DEVNULL` detach on the probes that trigger the corruption, plus tests for both layers. Maintainers can still prefer landing #78894 first and taking the probe fix as a follow-up — either way the full class is covered here.

## Files changed

- `tools/environments/local.py` — root fix
- `tui_gateway/_stdin_recovery.py` — `handle_stdin_oserror`
- `tui_gateway/entry.py` / `slash_worker.py` — wire try/except
- `tests/tui_gateway/test_stdin_oserror_recovery.py` — recovery unit + loop pattern
- `tests/tools/test_local_env_probe_stdin.py` — source + runtime DEVNULL guards
- `contributors/emails/…` — attribution

## Verification

- [x] `tests/tui_gateway/test_stdin_oserror_recovery.py` + `tests/tools/test_local_env_probe_stdin.py` — 17 passed
- [x] `ruff`/syntax clean on touched files
- [ ] Windows smoke (recommended): `hermes --tui` → terminal tool / local env create → no `OSError [Errno 22]` / no mid-turn gateway respawn

## Type of Change

- [x] Bug fix (non-breaking)

Fixes #78820
