### PR TITLE
Discord : treat 'off' as disabled for DISCORD_REACTIONS

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -146,7 +146,7 @@ from gateway.platforms.helpers import (
     ThreadParticipationTracker,
     convert_table_to_bullets,
 )
-from utils import atomic_json_write, env_float, env_int
+from utils import atomic_json_write, env_float, env_int, env_var_enabled
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -2961,8 +2961,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
 
     def _reactions_enabled(self) -> bool:
-        """Check if message reactions are enabled via config/env."""
-        return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
+        """Check if message reactions are enabled via config/env.
+
+        Default on. Shared falsy aliases (including ``off``) disable the
+        processing lifecycle reactions.
+        """
+        return env_var_enabled("DISCORD_REACTIONS", default="true")
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction and record durable handling state."""

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -140,3 +140,20 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     adapter.send.assert_awaited_once()
 
 
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off", "OFF"])
+def test_reactions_enabled_falsy_aliases(adapter, monkeypatch, raw):
+    monkeypatch.setenv("DISCORD_REACTIONS", raw)
+    assert adapter._reactions_enabled() is False
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE"])
+def test_reactions_enabled_truthy_aliases(adapter, monkeypatch, raw):
+    monkeypatch.setenv("DISCORD_REACTIONS", raw)
+    assert adapter._reactions_enabled() is True
+
+
+def test_reactions_enabled_defaults_on(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    assert adapter._reactions_enabled() is True
+
+


### PR DESCRIPTION
## Summary
- Parse `DISCORD_REACTIONS` via `env_var_enabled` (default `true`) so aliases like `off` disable processing-lifecycle reactions.
- Previously only `false`/`0`/`no` were treated as disabled, so `DISCORD_REACTIONS=off` left reactions enabled.
