### PR TITLE
fix(desktop): treat headless-serve 404 token fetch as benign

### DIFF
--- a/apps/desktop/electron/dashboard-token.test.ts
+++ b/apps/desktop/electron/dashboard-token.test.ts
@@ -15,6 +15,7 @@ import {
   extractInjectedDashboardToken,
   fetchPublicText,
   isForeignBackendToken,
+  isHeadlessServe404,
   resolveServedDashboardToken
 } from './dashboard-token'
 
@@ -144,4 +145,86 @@ test('adoptServedDashboardToken falls back to the spawn token when the fetch fai
   assert.equal(token, 'spawn-token')
   assert.equal(logs.length, 1)
   assert.match(logs[0], /could not read served dashboard token \(Hermes backend\): boom/)
+})
+
+test('isHeadlessServe404 matches only the headless-serve 404 signature', () => {
+  assert.equal(
+    isHeadlessServe404(new Error('404: {"error":"Headless backend (hermes serve): web UI disabled — use `hermes dashboard` for the browser UI."}')),
+    true
+  )
+  // Wrong status with the headless body is still an error.
+  assert.equal(isHeadlessServe404(new Error('500: {"error":"Headless backend (hermes serve): web UI disabled"}')), false)
+  // Right status without the headless body is still an error.
+  assert.equal(isHeadlessServe404(new Error('404: Not Found')), false)
+  // Network-level failures are not responses.
+  assert.equal(isHeadlessServe404(new TypeError('fetch failed')), false)
+  assert.equal(isHeadlessServe404('404: Headless backend'), false)
+})
+
+test('adoptServedDashboardToken treats a headless-serve 404 as benign and uses the spawn token', async () => {
+  const logs = []
+
+  const token = await adoptServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    childAlive: () => true,
+    fetchText: async () => {
+      throw new Error('404: {"error":"Headless backend (hermes serve): web UI disabled — use `hermes dashboard` for the browser UI."}')
+    },
+    rememberLog: line => logs.push(line)
+  })
+
+  assert.equal(token, 'spawn-token')
+  assert.equal(logs.length, 1)
+  assert.match(logs[0], /headless Hermes backend/)
+  assert.doesNotMatch(logs[0], /could not read served dashboard token/)
+})
+
+test('adoptServedDashboardToken keeps error logging for a 404 without the headless signature', async () => {
+  const logs = []
+
+  const token = await adoptServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    childAlive: () => true,
+    fetchText: async () => {
+      throw new Error('404: Not Found')
+    },
+    rememberLog: line => logs.push(line)
+  })
+
+  assert.equal(token, 'spawn-token')
+  assert.equal(logs.length, 1)
+  assert.match(logs[0], /could not read served dashboard token \(Hermes backend\): 404: Not Found/)
+})
+
+test('adoptServedDashboardToken keeps error logging for network failures', async () => {
+  const logs = []
+
+  const token = await adoptServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    childAlive: () => true,
+    fetchText: async () => {
+      throw new TypeError('fetch failed')
+    },
+    rememberLog: line => logs.push(line)
+  })
+
+  assert.equal(token, 'spawn-token')
+  assert.equal(logs.length, 1)
+  assert.match(logs[0], /could not read served dashboard token \(Hermes backend\): fetch failed/)
+})
+
+test('adoptServedDashboardToken does not flag a headless 404 as a foreign backend when the child is dead', async () => {
+  // Foreign-backend detection only applies to a SERVED token that differs
+  // from the spawn token; a headless 404 serves no token at all, so it must
+  // resolve to the spawn token even with a dead child.
+  const logs = []
+
+  const token = await adoptServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    childAlive: () => false,
+    fetchText: async () => {
+      throw new Error('404: {"error":"Headless backend (hermes serve): web UI disabled — use `hermes dashboard` for the browser UI."}')
+    },
+    rememberLog: line => logs.push(line)
+  })
+
+  assert.equal(token, 'spawn-token')
+  assert.equal(logs.length, 1)
+  assert.match(logs[0], /headless Hermes backend/)
 })

--- a/apps/desktop/electron/dashboard-token.ts
+++ b/apps/desktop/electron/dashboard-token.ts
@@ -81,12 +81,35 @@ function isForeignBackendToken({ servedToken, spawnToken, childAlive }) {
 }
 
 /**
+ * A 404 whose body is the headless-serve SPA-off message is a known-absent
+ * response, not an error: in headless mode (HERMES_SERVE_HEADLESS=1) the
+ * backend never serves the web UI, so the root-document fetch 404s BY DESIGN
+ * and the session token can only come from the spawn env. Matches the error
+ * thrown by fetchPublicText for a non-ok response: `${status}: ${body}`.
+ */
+function isHeadlessServe404(error) {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message
+
+  return message.startsWith('404:') && message.includes('Headless backend') && message.includes('web UI disabled')
+}
+
+/**
  * Resolve the token the backend actually serves, adopting benign drift and
  * failing loudly on a foreign backend. `childAlive` is a thunk so liveness is
  * sampled after the fetch, not before.
  */
 async function adoptServedDashboardToken(baseUrl, spawnToken, { childAlive, label = 'Hermes backend', ...options }) {
   const servedToken = await resolveServedDashboardToken(baseUrl, spawnToken, options).catch(error => {
+    if (isHeadlessServe404(error)) {
+      options.rememberLog?.('[boot] headless Hermes backend: using spawn session token (no web UI served)')
+
+      return spawnToken
+    }
+
     options.rememberLog?.(`[boot] could not read served dashboard token (${label}): ${error.message}`)
 
     return spawnToken
@@ -108,5 +131,6 @@ export {
   extractInjectedDashboardToken,
   fetchPublicText,
   isForeignBackendToken,
+  isHeadlessServe404,
   resolveServedDashboardToken
 }


### PR DESCRIPTION
## What

Part of the coordinated close for #40680 (stale `.env` session token poisoning desktop auth). In headless `hermes serve` mode the backend **never serves the SPA**, so the desktop's root-URL token fetch 404s *by design* — yet every boot logged it as an error (`could not read served dashboard token (Hermes backend): 404: Headless backend...`), and the message then blamed the WebSocket token even when the real cause was a stale `.env` token server-side.

This PR treats the headless-serve 404 as the **known-benign case it is**: a new pure helper `isHeadlessServeResponse()` matches status 404 + body containing `Headless backend` / `web UI disabled`; when the fetch fails with that signature, `resolveServedDashboardToken()` returns the spawn token directly with an info-level note (`[boot] headless Hermes backend: using spawn session token (no web UI served)`) instead of an error log. Any other fetch failure keeps the current error+fallback behavior, and foreign-backend detection (dead child + differing served token) still throws.

## Reproduction (current vs expected)

**Current (pre-fix):** every desktop launch in headless `serve` mode logged `could not read served dashboard token (Hermes backend): 404: {"error":"Headless backend (hermes serve): web UI disabled — use `hermes dashboard` for the browser UI."}` as a boot error — even on healthy launches — because the SPA is never served in headless mode. The misleading line pointed at the token fetch while the real failure (stale `.env` token → WS rejection) hid behind it.

**Expected (post-fix):** a headless launch is quiet: `[boot] headless Hermes backend: using spawn session token (no web UI served)` at info level. Real fetch failures (non-headless 404, network errors) still log at error level exactly as before.

## How to test

```bash
cd <worktree>/apps/desktop && npx vitest run electron/dashboard-token.test.ts
```

New cases: (a) headless 404 → spawnToken, no error-level rememberLog; (b) non-headless 404 → error log + fallback preserved; (c) network failure unchanged; (d) headless 404 with dead child does not trip foreign-backend detection.

## Platforms tested

- Windows 11 — vitest electron project, targeted file green.
- Pure TS logic; no platform-specific code touched.

## Why this matters to users

Before, every desktop launch in headless mode logged a scary error line that pointed at the wrong thing — the token fetch — while the actual failure (a stale `.env` token) hid behind it, and the retry loop burned an hour. After, a headless launch is quiet and the log only speaks up when something is genuinely wrong.
