### PR TITLE
fix(desktop): bound boot retry loop and surface stale .env token hint on WS rejection

### DIFF
--- a/apps/desktop/electron/backend-start-failure.test.ts
+++ b/apps/desktop/electron/backend-start-failure.test.ts
@@ -2,7 +2,21 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import {
+  createTokenRejectionRetryGuard,
+  isSessionTokenRejectionError,
+  MAX_TOKEN_REJECTION_BOOT_RETRIES,
+  sessionTokenRejectionHint,
+  shouldLatchBackendStartFailure,
+  shouldLatchRemoteReauthFailure
+} from './backend-start-failure'
+
+// The exact message main.ts constructs when the local boot's WS probe fails
+// (see the `Local Hermes backend is HTTP-reachable but the WebSocket
+// (/api/ws) rejected the session token:` throw site in startHermes).
+function tokenRejectionError(message = 'Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: WebSocket connection failed.'): Error {
+  return new Error(message)
+}
 
 test('latches a LOCAL backend failure so the install-retry loop is broken', () => {
   assert.equal(shouldLatchBackendStartFailure({ attemptedRemote: false }), true)
@@ -49,4 +63,100 @@ test('the two latches never fire for the same failure', () => {
       assert.ok(!(start && reauth), `both latched for remote=${attemptedRemote} reauth=${isReauth}`)
     }
   }
+})
+
+test('classifies the WS session-token rejection boot failure by its exact message', () => {
+  // The primary-backend throw site in startHermes.
+  assert.equal(isSessionTokenRejectionError(tokenRejectionError()), true)
+  // The profile-pool variant is the same failure class.
+  assert.equal(
+    isSessionTokenRejectionError(
+      new Error(
+        'Hermes backend for profile "work" is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: 401'
+      )
+    ),
+    true
+  )
+})
+
+test('does not classify unrelated boot failures as session-token rejections', () => {
+  // Port timeouts, child exits, connection-test WS probes, remote auth gaps —
+  // none of these are the stale-.env class and none may trip the retry bound.
+  for (const message of [
+    'Timed out waiting for the Hermes backend port announcement',
+    'Hermes backend exited before it became ready (null).',
+    'fetch failed: connection refused on 127.0.0.1:8123',
+    'Reached the gateway over HTTP, but the live WebSocket (/api/ws) connection failed: blocked by proxy',
+    'Remote Hermes gateway is selected, but no session token is saved.',
+    'Hermes backend start was superseded by a newer connection attempt.'
+  ]) {
+    assert.equal(isSessionTokenRejectionError(new Error(message)), false, message)
+  }
+
+  assert.equal(isSessionTokenRejectionError(null), false)
+  assert.equal(isSessionTokenRejectionError('plain string, not an Error'), false)
+})
+
+test('token-rejection failure surfaces the actionable stale-.env hint', () => {
+  const envPath = 'C:\\Users\\test\\AppData\\Local\\hermes\\.env'
+  const hint = sessionTokenRejectionHint(envPath)
+
+  assert.match(hint, /HERMES_DASHBOARD_SESSION_TOKEN/)
+  assert.match(hint, /C:\\Users\\test\\AppData\\Local\\hermes\\.env/)
+  assert.match(hint, /hermes setup/)
+
+  // The full message main.ts surfaces (throw-site message + hint) carries both
+  // the rejection class marker AND the fix, so the failure overlay shows it.
+  const surfaced = `${tokenRejectionError().message} ${hint}`
+  assert.equal(isSessionTokenRejectionError(new Error(surfaced)), true)
+  assert.ok(surfaced.includes('Remove that line'))
+})
+
+test('retry guard increments per consecutive token rejection and exhausts after N', () => {
+  const guard = createTokenRejectionRetryGuard(MAX_TOKEN_REJECTION_BOOT_RETRIES)
+  assert.equal(MAX_TOKEN_REJECTION_BOOT_RETRIES, 3)
+  assert.equal(guard.count, 0)
+  assert.equal(guard.exhausted, false)
+
+  guard.recordFailure(tokenRejectionError())
+  guard.recordFailure(tokenRejectionError())
+  assert.equal(guard.count, 2)
+  assert.equal(guard.exhausted, false)
+
+  // The Nth consecutive rejection flips the bound: the reset loop must stop.
+  guard.recordFailure(tokenRejectionError())
+  assert.equal(guard.count, 3)
+  assert.equal(guard.exhausted, true)
+
+  // Further rejections keep it exhausted — the bound does not un-trip.
+  guard.recordFailure(tokenRejectionError())
+  assert.equal(guard.exhausted, true)
+})
+
+test('non-token-rejection failures keep the existing retry behavior (no regression)', () => {
+  const guard = createTokenRejectionRetryGuard(3)
+
+  // A run of unrelated failures never exhausts the bound.
+  guard.recordFailure(new Error('Timed out waiting for the Hermes backend port announcement'))
+  guard.recordFailure(new Error('Hermes backend exited before it became ready (null).'))
+  assert.equal(guard.count, 0)
+  assert.equal(guard.exhausted, false)
+
+  // An unrelated failure between rejections breaks the streak, so the bound
+  // only ever applies to CONSECUTIVE token rejections.
+  guard.recordFailure(tokenRejectionError())
+  guard.recordFailure(tokenRejectionError())
+  assert.equal(guard.count, 2)
+  guard.recordFailure(new Error('fetch failed: connection refused on 127.0.0.1:8123'))
+  assert.equal(guard.count, 0)
+  assert.equal(guard.exhausted, false)
+
+  // And a clean boot (reset) clears an exhausted guard for the next episode.
+  guard.recordFailure(tokenRejectionError())
+  guard.recordFailure(tokenRejectionError())
+  guard.recordFailure(tokenRejectionError())
+  assert.equal(guard.exhausted, true)
+  guard.reset()
+  assert.equal(guard.count, 0)
+  assert.equal(guard.exhausted, false)
 })

--- a/apps/desktop/electron/backend-start-failure.ts
+++ b/apps/desktop/electron/backend-start-failure.ts
@@ -70,3 +70,73 @@ export interface RemoteReauthFailureContext {
 export function shouldLatchRemoteReauthFailure(context: RemoteReauthFailureContext): boolean {
   return context.attemptedRemote && context.isReauth
 }
+
+/**
+ * The one LOCAL failure class that cannot self-heal across restarts: the
+ * backend is HTTP-reachable (so the install is healthy) but /api/ws rejects
+ * the session token. A stale HERMES_DASHBOARD_SESSION_TOKEN in the Hermes
+ * .env overrides the token the desktop injects into its own spawned backend,
+ * so every restart fails identically and the renderer's "Reload and retry"
+ * loop spins forever. Matching the exact message both WS-probe throw sites in
+ * main.ts construct keeps unrelated failures (port timeout, child exit,
+ * connection-test WS probes) out of this class.
+ */
+export const MAX_TOKEN_REJECTION_BOOT_RETRIES = 3
+
+export function isSessionTokenRejectionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return message.includes('WebSocket (/api/ws) rejected the session token')
+}
+
+/**
+ * Actionable hint appended to the surfaced failure so the user knows the fix
+ * instead of watching a silent retry loop. `envPath` is the resolved Hermes
+ * .env (the main process passes HERMES_HOME/.env).
+ */
+export function sessionTokenRejectionHint(envPath: string): string {
+  return (
+    `A stale HERMES_DASHBOARD_SESSION_TOKEN= line in ${envPath} can override the token the desktop ` +
+    'injects into its own backend and cause exactly this rejection. Remove that line (or run ' +
+    '`hermes setup`) and retry.'
+  )
+}
+
+export interface TokenRejectionRetryGuard {
+  /** Consecutive WS session-token rejections seen so far. */
+  readonly count: number
+  /** True once `count` has reached the bound; the reset loop must stop. */
+  readonly exhausted: boolean
+  /**
+   * Record one boot failure. Token rejections extend the streak; any other
+   * failure class breaks it (the bound only applies to CONSECUTIVE
+   * rejections, so unrelated failures keep their existing retry behavior).
+   */
+  recordFailure(error: unknown): void
+  /** Called on a clean boot completion so the next episode starts fresh. */
+  reset(): void
+}
+
+export function createTokenRejectionRetryGuard(
+  maxRetries: number = MAX_TOKEN_REJECTION_BOOT_RETRIES
+): TokenRejectionRetryGuard {
+  let consecutive = 0
+
+  return {
+    get count() {
+      return consecutive
+    },
+
+    get exhausted() {
+      return consecutive >= maxRetries
+    },
+
+    recordFailure(error) {
+      consecutive = isSessionTokenRejectionError(error) ? consecutive + 1 : 0
+    },
+
+    reset() {
+      consecutive = 0
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -45,7 +45,14 @@ import {
   verifyHermesCli
 } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
-import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from './backend-start-failure'
+import {
+  createTokenRejectionRetryGuard,
+  isSessionTokenRejectionError,
+  MAX_TOKEN_REJECTION_BOOT_RETRIES,
+  sessionTokenRejectionHint,
+  shouldLatchBackendStartFailure,
+  shouldLatchRemoteReauthFailure
+} from './backend-start-failure'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
@@ -626,6 +633,12 @@ const DEFAULT_UPDATE_BRANCH = 'main'
 // errors.log, gateway.log produced by hermes_logging.setup_logging — one log
 // directory per user, regardless of which UI surface produced the line.
 const DESKTOP_LOG_PATH = path.join(HERMES_HOME, 'logs', 'desktop.log')
+// The Hermes .env the backend loads at startup. A stale
+// HERMES_DASHBOARD_SESSION_TOKEN= line here overrides the token the desktop
+// injects into its own spawned backend, so every boot fails with a WS
+// session-token rejection no matter how often the renderer retries. Named in
+// the failure hint so the user knows exactly which file to fix.
+const HERMES_ENV_PATH = path.join(HERMES_HOME, '.env')
 const DESKTOP_LOG_FLUSH_MS = 120
 const DESKTOP_LOG_BUFFER_MAX_CHARS = 64 * 1024
 // Bound desktop.log on disk. It is an append-only forensic log, so a boot loop
@@ -1112,6 +1125,14 @@ let bootstrapRepairRequested = false
 // looping the user through a destructive venv reinstall.
 let bootstrapRepairAttempt = 0
 const MAX_BOOTSTRAP_REPAIR_SOFT_ATTEMPTS = 3
+// Bounds the renderer's "Reload and retry" loop for the WS session-token
+// rejection class: the backend comes up HTTP-fine on every restart and every
+// retry fails identically, so without a bound the app silently restarts for
+// hours (the stale HERMES_DASHBOARD_SESSION_TOKEN in the .env never changes
+// on its own). Once the streak reaches MAX_TOKEN_REJECTION_BOOT_RETRIES the
+// reset path holds the latched failure and the failure overlay stays up with
+// the actionable hint instead of restarting. Reset on every clean boot.
+const tokenRejectionRetryGuard = createTokenRejectionRetryGuard(MAX_TOKEN_REJECTION_BOOT_RETRIES)
 let connectionConfigCache = null
 let connectionConfigCacheMtime = null
 const hermesLog = []
@@ -8271,7 +8292,8 @@ async function spawnPoolBackend(profile, entry) {
 
   if (!wsProbe.ok) {
     throw new Error(
-      `Hermes backend for profile "${profile}" is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason}`
+      `Hermes backend for profile "${profile}" is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason} ` +
+        sessionTokenRejectionHint(HERMES_ENV_PATH)
     )
   }
 
@@ -8606,7 +8628,8 @@ async function startHermes() {
 
     if (!wsProbe.ok) {
       throw new Error(
-        `Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason}`
+        `Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason} ` +
+          sessionTokenRejectionHint(HERMES_ENV_PATH)
       )
     }
 
@@ -8622,8 +8645,10 @@ async function startHermes() {
     // chose over a hard reinstall, see #74874) means any in-flight repair
     // attempt counter has been honoured — reset it so the next genuine
     // failure starts fresh from attempt 1 instead of inheriting the
-    // accumulated count of the resolved episode.
+    // accumulated count of the resolved episode. Same for the token-rejection
+    // streak: a clean boot proves the token situation resolved itself.
     bootstrapRepairAttempt = 0
+    tokenRejectionRetryGuard.reset()
 
     return {
       baseUrl,
@@ -8645,6 +8670,23 @@ async function startHermes() {
     }
 
     const message = error instanceof Error ? error.message : String(error)
+
+    // Track the consecutive WS session-token rejection streak. This is the
+    // one local failure class that cannot self-heal across retries (a stale
+    // HERMES_DASHBOARD_SESSION_TOKEN in the .env overrides the injected
+    // token, so every restart fails identically) — once it exhausts the
+    // bound, the reset path holds the latched failure instead of restarting.
+    // Any other failure class breaks the streak and keeps its existing
+    // (unbounded) retry behavior.
+    tokenRejectionRetryGuard.recordFailure(error)
+
+    if (isSessionTokenRejectionError(error) && tokenRejectionRetryGuard.exhausted) {
+      rememberLog(
+        `[boot] WS session-token rejection streak reached ${tokenRejectionRetryGuard.count}; ` +
+          'holding the latched failure — further resets will not restart the backend ' +
+          `(stale HERMES_DASHBOARD_SESSION_TOKEN in ${HERMES_ENV_PATH}?)`
+      )
+    }
 
     // Only latch LOCAL boot failures. A remote failure (lapsed session / mint
     // timeout / host briefly unreachable across sleep) is transient and has no
@@ -9700,6 +9742,23 @@ ipcMain.on('hermes:pet-overlay:control', (_event, payload) => {
   mainWindow.webContents.send('hermes:pet-overlay:control', payload)
 })
 ipcMain.handle('hermes:bootstrap:reset', async () => {
+  // Bound the silent retry loop for the WS session-token rejection class.
+  // The backend comes up HTTP-reachable on every restart and every retry
+  // fails identically, so once the consecutive-rejection streak is exhausted
+  // a reset would only restart the same doomed boot. Refuse to clear the
+  // latched failure: bootProgressState keeps its error, the failure overlay
+  // stays up with the actionable .env hint, and the user can act on it (or
+  // use Repair, which is still available and has its own bounded attempts).
+  if (tokenRejectionRetryGuard.exhausted) {
+    rememberLog(
+      `[bootstrap] reset refused: WS session-token rejection streak ` +
+        `${tokenRejectionRetryGuard.count}/${MAX_TOKEN_REJECTION_BOOT_RETRIES} exhausted; ` +
+        `holding the latched failure (stale HERMES_DASHBOARD_SESSION_TOKEN in ${HERMES_ENV_PATH}?)`
+    )
+
+    return { ok: false, reason: 'token-rejection-retries-exhausted' }
+  }
+
   // Renderer's "Reload and retry" path. Clear the latched failure and
   // reset connection state so the next startHermes() call restarts the
   // full backend flow (including a fresh runBootstrap pass).


### PR DESCRIPTION
## What

Part of the coordinated close for #40680 (stale `.env` session token poisoning desktop auth). The desktop boot loop turned a 5-second failure into an **hour-long lockout**: `Desktop boot failed: ... WebSocket (/api/ws) rejected the session token` → `reset requested by renderer; clearing latched failure` → `Restarting desktop connection` → same failure, ~7+ times, with no actionable message and no bound.

This PR makes the token-rejection failure class:
1. **Actionable** — the failure surfaces a hint naming the exact fix: a stale `HERMES_DASHBOARD_SESSION_TOKEN` in the Hermes `.env` (resolved hermes home path) can cause this; remove the line or run `hermes setup`.
2. **Bounded** — after N consecutive token-rejection failures (N=3, consistent with the existing `attempt=1/3` repair pattern), the silent loop stops and the failure is surfaced persistently through the existing boot-failure surface. Non-token failures keep their existing retry behavior.

The existing repair path is preserved — only the token-rejection class is bounded.

**Dedup/composition note — overlapping open PR #74603 (authored by @Ahmett101):** #74603 also edits `apps/desktop/electron/main.ts`, but in the **probe path** (regions ~1648 `unwrapWindowsVenvHermesCommand`, ~7599 `spawnPoolBackend`, ~7856 `startHermes` — async capability probe for #74563). This PR edits the **failure-latch path** (`backendStartFailure` latch + renderer reset handling, ~8367/8655) plus `backend-start-failure.ts`, which #74603 does not touch. Same file, disjoint regions — they compose, but both PRs touching `main.ts` means the second to merge will need a trivial rebase.

## Reproduction (current vs expected)

**Current (pre-fix):** desktop.log shows the identical failure ~7× over an hour with no user-visible explanation:
```
[hermes] [boot] Desktop boot failed: Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: WebSocket connection failed.
[hermes] [bootstrap] reset requested by renderer; clearing latched failure
[hermes] [boot] Restarting desktop connection
```
The app silently retries forever; the only remedy is manually deleting a line from a hidden `.env` file.

**Expected (post-fix):** after 3 consecutive token-rejection failures the loop stops and the failure surface names the fix — a stale `HERMES_DASHBOARD_SESSION_TOKEN` in the Hermes `.env` (resolved path) can cause this; remove the line or run `hermes setup`. Non-token failures keep the existing retry behavior.

## How to test

```bash
cd <worktree>/apps/desktop && npx vitest run electron/backend-start-failure.test.ts
```

New cases: (a) token-rejection failure includes the `.env` hint; (b) retry counter increments per token-rejection and stops after N; (c) non-token failures keep existing retry behavior (no regression).

## Platforms tested

- Windows 11 — vitest electron project, targeted file green.

## Why this matters to users

Before: when desktop auth failed, the app silently retried the identical failing boot for an hour, and the user's only recourse was guessing (or being told to edit a hidden `.env` file with no explanation). After: the app tells you in plain words what to remove from where, and stops looping after 3 attempts so you can act instead of watching a spinner.
