### PR TITLE
Feishu : treat 'off' as disabled for FEISHU_REACTIONS

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -133,7 +133,7 @@ from gateway.platforms.base import (
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
-from utils import atomic_json_write, env_float, env_int
+from utils import atomic_json_write, env_float, env_int, env_var_enabled
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -3136,7 +3136,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _reactions_enabled(self) -> bool:
-        return os.getenv("FEISHU_REACTIONS", "true").strip().lower() not in {"false", "0", "no"}
+        """Default on; shared falsy aliases (including ``off``) disable reactions."""
+        return env_var_enabled("FEISHU_REACTIONS", default="true")
 
     async def _add_reaction(self, message_id: str, emoji_type: str) -> Optional[str]:
         """Return the reaction_id on success, else None. The id is needed later for deletion."""

--- a/tests/gateway/test_feishu_reactions_truthy.py
+++ b/tests/gateway/test_feishu_reactions_truthy.py
@@ -1,0 +1,30 @@
+"""FEISHU_REACTIONS must honor shared truthy/falsy aliases (including 'off')."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+@pytest.fixture()
+def adapter():
+    return FeishuAdapter(PlatformConfig())
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off", "OFF"])
+def test_reactions_falsy_aliases_disable(adapter, monkeypatch, raw):
+    monkeypatch.setenv("FEISHU_REACTIONS", raw)
+    assert adapter._reactions_enabled() is False
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE"])
+def test_reactions_truthy_aliases_enable(adapter, monkeypatch, raw):
+    monkeypatch.setenv("FEISHU_REACTIONS", raw)
+    assert adapter._reactions_enabled() is True
+
+
+def test_reactions_defaults_on(adapter, monkeypatch):
+    monkeypatch.delenv("FEISHU_REACTIONS", raising=False)
+    assert adapter._reactions_enabled() is True


### PR DESCRIPTION
## Summary
- Parse `FEISHU_REACTIONS` via `env_var_enabled` (default `true`) so aliases like `off` disable processing-lifecycle reactions.
- Previously only `false`/`0`/`no` were treated as disabled, so `FEISHU_REACTIONS=off` left reactions enabled.
