### PR TITLE
Matrix : treat 'off' as disabled for MATRIX_REACTIONS

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -17,8 +17,9 @@ Environment variables:
     MATRIX_ALLOWED_USERS    Comma-separated Matrix user IDs (@user:server)
     MATRIX_ALLOWED_ROOMS    Comma-separated Matrix room IDs allowed to trigger turns
     MATRIX_HOME_ROOM        Room ID for cron/notification delivery
-    MATRIX_REACTIONS        Set "false" to disable processing lifecycle reactions
-                            (eyes/checkmark/cross). Default: true
+    MATRIX_REACTIONS        truthy aliases enable processing lifecycle reactions
+                            (eyes/checkmark/cross); falsy aliases including ``off``
+                            disable them. Default: true
     MATRIX_REQUIRE_MENTION      Require @mention in rooms (default: true)
     MATRIX_FREE_RESPONSE_ROOMS  Comma-separated room IDs exempt from mention requirement
                                 (alias of matrix.free_response_rooms)
@@ -71,6 +72,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
 from agent.secret_scope import UnscopedSecretError, get_secret
+from utils import env_var_enabled
 
 try:
     from mautrix.types import (
@@ -1177,9 +1179,10 @@ class MatrixAdapter(BasePlatformAdapter):
         ).lower() in ("true", "1", "yes")
 
         # Reactions: configurable via MATRIX_REACTIONS (default: true).
-        self._reactions_enabled: bool = os.getenv(
-            "MATRIX_REACTIONS", "true"
-        ).lower() not in {"false", "0", "no"}
+        # Shared falsy aliases (including ``off``) disable lifecycle reactions.
+        self._reactions_enabled: bool = env_var_enabled(
+            "MATRIX_REACTIONS", default="true"
+        )
         self._pending_reactions: dict[tuple[str, str], str] = {}
         # Delay before redacting reactions so Matrix homeservers have time to
         # deliver the final message event without tripping "missing event"

--- a/tests/gateway/test_matrix_reactions_truthy.py
+++ b/tests/gateway/test_matrix_reactions_truthy.py
@@ -1,0 +1,39 @@
+"""MATRIX_REACTIONS must honor shared truthy/falsy aliases (including 'off')."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    return MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+            },
+        )
+    )
+
+
+@pytest.mark.parametrize("raw", ["false", "0", "no", "off", "OFF"])
+def test_reactions_falsy_aliases_disable(monkeypatch, raw):
+    monkeypatch.setenv("MATRIX_REACTIONS", raw)
+    assert _make_adapter()._reactions_enabled is False
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE"])
+def test_reactions_truthy_aliases_enable(monkeypatch, raw):
+    monkeypatch.setenv("MATRIX_REACTIONS", raw)
+    assert _make_adapter()._reactions_enabled is True
+
+
+def test_reactions_defaults_on(monkeypatch):
+    monkeypatch.delenv("MATRIX_REACTIONS", raising=False)
+    assert _make_adapter()._reactions_enabled is True


### PR DESCRIPTION
## Summary
- Parse `MATRIX_REACTIONS` via `env_var_enabled` (default `true`) so aliases like `off` disable processing-lifecycle reactions.
- Previously only `false`/`0`/`no` were treated as disabled, so `MATRIX_REACTIONS=off` left reactions enabled.
