### PR TITLE
fix(acp): match sessions opened from a \\wsl.localhost\ workspace

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -46,11 +46,17 @@ def _normalize_cwd_for_compare(cwd: str | None) -> str:
         raw = "."
     expanded = os.path.expanduser(raw)
 
-    # Normalize Windows drive paths into the equivalent WSL mount form so
-    # ACP history filters match the same workspace across Windows and WSL.
-    from hermes_constants import windows_path_to_wsl
+    # Normalize the Windows spellings into the POSIX form so ACP history
+    # filters match the same workspace across Windows and WSL. Both forms
+    # ``_translate_acp_cwd`` accepts have to be covered, and in the same
+    # order: a session opened from a ``\\wsl.localhost\`` workspace is stored
+    # POSIX-translated, so a UNC filter that never translates can never match
+    # its own rows.
+    from hermes_constants import windows_path_to_wsl, wsl_unc_path_to_posix
 
-    translated = windows_path_to_wsl(expanded)
+    translated = wsl_unc_path_to_posix(expanded)
+    if translated is None:
+        translated = windows_path_to_wsl(expanded)
     if translated is not None:
         expanded = translated
     elif re.match(r"^/mnt/[A-Za-z]/", expanded):

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -146,6 +146,56 @@ class TestWslCwdTranslation:
         assert updated is not None
         assert updated.cwd == "/mnt/c/Users/foo/project"
 
+    @pytest.mark.parametrize(
+        "unc",
+        [
+            r"\\wsl.localhost\Ubuntu\home\me\proj",
+            r"\\wsl$\Ubuntu\home\me\proj",
+        ],
+    )
+    def test_unc_workspace_normalizes_to_its_stored_form(self, unc, monkeypatch):
+        """A workspace and the cwd actually stored for it must compare equal.
+
+        ``_translate_acp_cwd`` stores the POSIX translation of a
+        ``\\\\wsl.localhost\\`` workspace, so a filter that leaves the UNC
+        spelling alone can never match the rows it created.
+        """
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        stored = acp_session._translate_acp_cwd(unc)
+        assert stored == "/home/me/proj"
+
+        assert acp_session._normalize_cwd_for_compare(unc) == (
+            acp_session._normalize_cwd_for_compare(stored)
+        )
+
+    def test_drive_workspace_normalizes_to_its_stored_form(self, monkeypatch):
+        """Control: the drive spelling already matched."""
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        stored = acp_session._translate_acp_cwd(r"E:\Projects\demo")
+        assert stored == "/mnt/e/Projects/demo"
+
+        assert acp_session._normalize_cwd_for_compare(r"E:\Projects\demo") == (
+            acp_session._normalize_cwd_for_compare(stored)
+        )
+
+    def test_unrelated_workspace_still_compares_different(self, monkeypatch):
+        """Guard against over-normalizing everything into one bucket."""
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        assert acp_session._normalize_cwd_for_compare(
+            r"\\wsl.localhost\Ubuntu\home\me\proj"
+        ) != acp_session._normalize_cwd_for_compare(
+            r"\\wsl.localhost\Ubuntu\home\me\other"
+        )
+
+    def test_create_session_stores_unc_workspace_in_posix_form(
+        self, manager, monkeypatch,
+    ):
+        """The stored side of the pair — what the filter has to match."""
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        state = manager.create_session(cwd=r"\\wsl.localhost\Ubuntu\home\me\proj")
+
+        assert state.cwd == "/home/me/proj"
+
 # ---------------------------------------------------------------------------
 # fork
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`SessionManager.list_sessions(cwd=...)` backs the editor's "threads for this workspace" list. It builds a comparison key with `_normalize_cwd_for_compare` and applies it to **both** sides — the incoming workspace and each stored row's `cwd`:

```python
normalized_cwd = _normalize_cwd_for_compare(cwd) if cwd else None
...
if normalized_cwd and _normalize_cwd_for_compare(s.cwd) != normalized_cwd:
    continue
```

That works only while both sides normalize the same spelling of a workspace. They stopped doing so.

cb883f9e9 (2026-04-17, fix(acp): improve zed integration) added the comparison helper, handling the Windows **drive** form (`E:\Projects` → `/mnt/e/Projects`). 3c7b9f2e9 (2026-07-12, feat(gateway,acp): translate cross-boundary cwd when running in WSL) then widened the **store** path — its own body says it:

> De-dups the ACP adapter's private `_win_path_to_wsl` onto the shared helper and **extends it to the UNC spelling**.

`_translate_acp_cwd` now routes through `translate_cwd_for_wsl_backend`, whose translator chain is `wsl_unc_path_to_posix` then `windows_path_to_wsl`, so `create_session` / `update_cwd` / `fork_session` write the POSIX form for a `\\wsl.localhost\<distro>\...` workspace. The comparison helper a few lines above it was never given the second translator, so it still leaves UNC untouched:

```
--- drive path
  client sends : 'E:\Projects\demo'
  row stores   : '/mnt/e/Projects/demo'
  session listed for its own workspace? True

--- wsl.localhost UNC
  client sends : '\\wsl.localhost\Ubuntu\home\me\proj'
  row stores   : '/home/me/proj'
  filter key   : '\\wsl.localhost\Ubuntu\home\me\proj'
  stored key   : '/home/me/proj'
  session listed for its own workspace? False

--- legacy wsl$ UNC
  session listed for its own workspace? False
```

The row is written under a key the filter can never produce, so the thread list for that workspace comes back empty and none of its sessions can be resumed from the editor. The failure is silent — nothing errors, the list is just empty, which reads as "no history here yet."

Both UNC spellings `wsl_unc_path_to_posix` accepts are affected (`\\wsl.localhost\` and the legacy `\\wsl$\`), and the docstring on `_translate_acp_cwd` names UNC workspaces as an expected client input, so this is not a hypothetical shape.

## The fix

Give the comparison helper the same translator chain, in the same order:

```python
translated = wsl_unc_path_to_posix(expanded)
if translated is None:
    translated = windows_path_to_wsl(expanded)
```

The existing `/mnt/<drive>/` drive-letter lowercasing stays as the fallback for paths that are already POSIX. Deliberately *not* gated on `is_wsl()` — unlike the store path, this helper has to normalize on either host so a Windows-spelled filter matches a POSIX-stored row, which is the whole point of it. Inputs with neither Windows spelling, including plain POSIX paths, come out unchanged.

## Tests

Added to `TestWslCwdTranslation` in `tests/acp/test_session.py`, which previously only covered the drive form on the store side:

- both UNC spellings, parametrized: the workspace and the cwd actually stored for it normalize to the same key — the invariant the filter depends on
- the drive spelling does too (control — green on both sides)
- `create_session` stores the UNC workspace in POSIX form, pinning the other half of the pair
- two different UNC workspaces still compare different, so the fix can't degenerate into matching everything

Results:

```
20 passed
```

That is the whole file; the 15 pre-existing tests are unchanged.

Red without the source change (tests kept, `acp_adapter/session.py` reverted):

```
FAILED test_unc_workspace_normalizes_to_its_stored_form[\\wsl.localhost\Ubuntu\home\me\proj]
E   AssertionError: assert '\\wsl.localhost\Ubuntu\home\me\proj' == '/home/me/proj'
FAILED test_unc_workspace_normalizes_to_its_stored_form[\\wsl$\Ubuntu\home\me\proj]
E   AssertionError: assert '\\wsl$\Ubuntu\home\me\proj' == '/home/me/proj'
2 failed, 18 passed
```

The three control cases pass on both sides, which is what they are for.

Regression run over the ACP suites plus `tests/test_hermes_constants.py` and the `@`-path completion tests (18 files), against the same files on main:

```
main:      8 failed, 173 passed, 9 skipped   (6 pre-existing, plus the 2 new tests failing as above)
with fix:  6 failed, 175 passed, 9 skipped
```

Set difference is empty — no new failures. The 6 are identical before and after and are symlink/native-path cases unrelated to this change. `scripts/check-windows-footguns.py` passes on both changed files.