### PR TITLE
Mattermost : honor MATTERMOST_REQUIRE_MENTION=off as disable gate

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -32,6 +32,16 @@ from gateway.platforms.base import (
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
+from utils import env_var_enabled
+
+
+def _require_mention_enabled() -> bool:
+    """Channel messages require @mention by default.
+
+    Shared falsy aliases (including ``off``) disable the gate so every channel
+    message is processed unless other allowlists still filter it.
+    """
+    return env_var_enabled("MATTERMOST_REQUIRE_MENTION", default="true")
 
 
 def _get_scoped_secret(name, default=None):
@@ -871,9 +881,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 )
                 return
 
-            require_mention = os.getenv(
-                "MATTERMOST_REQUIRE_MENTION", "true"
-            ).lower() not in {"false", "0", "no"}
+            require_mention = _require_mention_enabled()
 
             free_channels_raw = os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -384,6 +384,23 @@ class TestMattermostMentionBehavior:
             await self.adapter._handle_ws_event(self._make_event("hello"))
             assert not self.adapter.handle_message.called
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw", ["false", "0", "no", "off", "OFF"])
+    async def test_require_mention_falsy_aliases_allow_without_mention(self, raw):
+        """Falsy aliases (including off) disable the @mention gate."""
+        with patch.dict(os.environ, {"MATTERMOST_REQUIRE_MENTION": raw}):
+            os.environ.pop("MATTERMOST_FREE_RESPONSE_CHANNELS", None)
+            await self.adapter._handle_ws_event(self._make_event("hello"))
+            assert self.adapter.handle_message.called
+
+    @pytest.mark.parametrize("raw", ["false", "0", "no", "off", "TRUE", "1", "yes", "on"])
+    def test_require_mention_helper_aliases(self, raw):
+        from plugins.platforms.mattermost.adapter import _require_mention_enabled
+
+        with patch.dict(os.environ, {"MATTERMOST_REQUIRE_MENTION": raw}):
+            expected = raw.strip().lower() in {"1", "true", "yes", "on"}
+            assert _require_mention_enabled() is expected
+
 
     @pytest.mark.asyncio
     async def test_free_response_channel_responds_without_mention(self):


### PR DESCRIPTION
## Summary
- `MATTERMOST_REQUIRE_MENTION` used an inverted falsy set that omitted `off`, so `=off` still required @mentions in channels.
- Route the flag through `env_var_enabled(..., default="true")` so `off`/`false`/`0`/`no` actually disable the gate.
- Add regression coverage for the shared falsy aliases.

