### PR TITLE
fix(otlp): span exporter now inherits configured resource_attributes

### DIFF
--- a/agent/monitoring/otlp_exporter.py
+++ b/agent/monitoring/otlp_exporter.py
@@ -116,14 +116,12 @@ def build_exporter(config: Dict[str, Any]):
 
 
 def _resource_attributes(config: Dict[str, Any]) -> Dict[str, str]:
-    from agent.monitoring.gateway_health import _safe_instance_id
-    from agent.monitoring.policy import ensure_install_id
+    # Lazy import: gateway_health_export imports this module back (for
+    # start_streaming), so the dependency must resolve at call time, not
+    # at module load, to avoid a circular import.
+    from agent.monitoring.gateway_health_export import _runtime_resource_attributes
 
-    return {
-        "service.name": "hermes-gateway",
-        "service.instance.id": _safe_instance_id(ensure_install_id(config)),
-        "telemetry.scope": "gateway_monitoring",
-    }
+    return _runtime_resource_attributes(config, telemetry_scope="gateway_monitoring")
 
 
 def _make_provider(config: Dict[str, Any]):

--- a/tests/monitoring/test_otlp_exporter.py
+++ b/tests/monitoring/test_otlp_exporter.py
@@ -66,6 +66,20 @@ def test_trace_resource_includes_stable_hashed_instance():
     assert attrs["telemetry.scope"] == "gateway_monitoring"
 
 
+def test_trace_resource_includes_configured_deployment_environment():
+    attrs = OE._resource_attributes({
+        "monitoring": {
+            "install_id": "private-install-id",
+            "gateway_health_export": {
+                "resource_attributes": {"deployment.environment.name": "production"},
+            },
+        },
+    })
+
+    assert attrs["deployment.environment.name"] == "production"
+    assert attrs["service.name"] == "hermes-gateway"
+
+
 
 
 def test_streamer_receives_events_and_respects_filter(monkeypatch):


### PR DESCRIPTION
## Summary

- Fixes #78897 — the OTLP gateway health exporter dropped operator-configured `resource_attributes` (e.g. `deployment.environment.name`) on **spans**. Metrics and diagnostic logs already applied them correctly.
- Root cause: `otlp_exporter.py::_resource_attributes()` had its own hardcoded resource dict (`service.name` / `service.instance.id` / `telemetry.scope` only), instead of reusing `gateway_health_export.py::_runtime_resource_attributes()`, which already applies the config `resource_attributes` allowlist (`_safe_resource_attributes`).
- Fix: span resource building now delegates to the same `_runtime_resource_attributes()` helper metrics/logs already use. No new abstraction added — the duplicate implementation was removed instead of patched in place, so all three OTLP signal types (spans, metrics, logs) share one resource-attribute builder going forward.

 

 ## Infographic
<img width="941" height="1672" alt="infographic" src="https://github.com/user-attachments/assets/35d876b7-fd91-4124-9c6d-d9283a570036" />

## Test plan

- [x] `pytest tests/monitoring/test_otlp_exporter.py tests/monitoring/test_gateway_health_export.py -q` — all pass (10 tests)
- [x] `pytest tests/monitoring/ -q` — full monitoring suite, 25 passed, no regressions
- [x] Added regression test `test_trace_resource_includes_configured_deployment_environment` proving spans now carry `deployment.environment.name` from config
- [x] Verified existing `test_trace_resource_includes_stable_hashed_instance` (hashed instance id, service.name, telemetry.scope, no PII leak) still passes unchanged
- [x] Checked codebase for duplicate `resource_attributes`/`Resource.create` builders in `agent/monitoring/` — confirmed only one remains after this fix (no reintroduced duplication)