### PR TITLE
fix(auth): 原生登录空 provider 自动选择忽略密码 provider

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -315,14 +315,31 @@ async def auth_native_authorize(
         raise HTTPException(status_code=400, detail="code_challenge required")
     _validate_loopback_redirect_uri(redirect_uri)
 
-    # Resolve the provider. With exactly one session provider registered
-    # (the common hosted case) an empty ``provider`` selects it, mirroring
-    # the auto-SSO convenience so the desktop needn't hardcode the name.
+    # Resolve the provider. With exactly one brokerable session provider
+    # registered (the common hosted case) an empty ``provider`` selects it,
+    # mirroring the auto-SSO convenience so the desktop needn't hardcode the
+    # name. Password providers are session providers too, but they can never
+    # be the target of the native OAuth broker flow (rejected below), so they
+    # must not count toward "exactly one candidate": otherwise a normal
+    # SSO-with-password-fallback deployment (one OIDC provider + the bundled
+    # ``basic`` provider) would see two session providers, skip the
+    # auto-select, and fail desktop login with a misleading "Unknown provider".
     p = get_provider(provider) if provider else None
     if p is None and not provider:
-        sess_providers = list_session_providers()
-        if len(sess_providers) == 1:
-            p = sess_providers[0]
+        native_eligible = [
+            pp
+            for pp in list_session_providers()
+            if not getattr(pp, "supports_password", False)
+        ]
+        if len(native_eligible) == 1:
+            p = native_eligible[0]
+        elif not native_eligible:
+            # No brokerable provider at all. Preserve the old behaviour of
+            # selecting a lone password provider so the explicit 400 below
+            # (rather than a 404) explains why native OAuth is unavailable.
+            sess_providers = list_session_providers()
+            if len(sess_providers) == 1:
+                p = sess_providers[0]
     if p is None:
         raise HTTPException(
             status_code=404, detail=f"Unknown provider: {provider!r}"

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -51,6 +51,32 @@ def _make_pkce() -> tuple[str, str]:
     return verifier, challenge
 
 
+class _PasswordOnlyProvider(StubAuthProvider):
+    """Mirrors the bundled ``basic`` provider's flags: a session provider
+    (``supports_session`` defaults True) that authenticates by username +
+    password and can never be the target of the native OAuth broker flow.
+    ``start_login`` raises to prove the route must reject it before ever
+    attempting a redirect."""
+
+    name = "pwonly"
+    display_name = "Password Only (test)"
+    supports_password = True
+
+    def start_login(self, *, redirect_uri):
+        raise AssertionError(
+            "native authorize must reject a password provider before "
+            "calling start_login"
+        )
+
+
+class _SecondStubProvider(StubAuthProvider):
+    """A second brokerable OAuth provider, so tests can create an ambiguous
+    multi-provider deployment."""
+
+    name = "stub2"
+    display_name = "Stub IdP Two (test only)"
+
+
 # ---------------------------------------------------------------------------
 # native_flow broker unit tests
 # ---------------------------------------------------------------------------
@@ -179,6 +205,83 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
     )
     assert r.status_code == 400
     assert "loopback" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Empty-provider auto-select (the desktop omits ``provider``; the gateway
+# picks when there is exactly one brokerable candidate) — regression #78906
+# ---------------------------------------------------------------------------
+
+
+def _native_authorize_params(challenge, **overrides):
+    params = {
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "redirect_uri": "http://127.0.0.1:53999/cb",
+        "state": "s",
+    }
+    params.update(overrides)
+    return params
+
+
+def test_native_authorize_empty_provider_auto_selects_oauth_with_password_also_registered(
+    gated_client,
+):
+    """Regression for #78906: a password provider is a session provider but
+    can never be the target of the native OAuth broker flow, so it must not
+    count toward the empty-provider auto-select. With one OAuth provider +
+    one password provider (the normal SSO-with-password-fallback setup) the
+    desktop's empty-provider request must auto-select the OAuth provider
+    (302), not fail with ``Unknown provider: ''`` (404)."""
+    register_provider(_PasswordOnlyProvider())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge),
+    )
+    assert r.status_code == 302, r.text
+    assert "code=stub_code" in r.headers["location"]
+
+
+def test_native_authorize_empty_provider_auto_selects_single_oauth(gated_client):
+    """The common hosted case: exactly one brokerable provider; an empty
+    ``provider`` auto-selects it (302), so the desktop needn't hardcode the
+    name."""
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge),
+    )
+    assert r.status_code == 302, r.text
+    assert "code=stub_code" in r.headers["location"]
+
+
+def test_native_authorize_empty_provider_ambiguous_multiple_oauth_404(gated_client):
+    """Two brokerable providers: the empty-provider convenience cannot pick
+    unambiguously, so the request still fails — the desktop must pass
+    ``?provider=`` explicitly."""
+    register_provider(_SecondStubProvider())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge),
+    )
+    assert r.status_code == 404
+
+
+def test_native_authorize_empty_provider_password_only_rejected_400(gated_client):
+    """Password-only deployment: an empty ``provider`` must still select the
+    lone session provider and fail with the explicit 400 explaining that
+    password providers have no native OAuth flow — not a bare 404."""
+    clear_providers()
+    register_provider(_PasswordOnlyProvider())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_native_authorize_params(challenge),
+    )
+    assert r.status_code == 400
+    assert "does not support native OAuth login" in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

修复 #78906: 当部署同时启用 basic 密码 provider 与一个 OAuth/OIDC session provider 时，桌面端空 provider 的 RFC 8252 原生登录请求失败，返回 404 `Unknown provider: ''`。

## 根因分析

`/auth/native/authorize` 的空 provider 自动选择使用 `list_session_providers()` 统计候选数量，只有恰好一个时才会自动选中。但密码 provider（如内置 `basic`）也是 session provider（`supports_session=True`），且永远无法成为原生 OAuth broker 流程的目标——紧跟着的检查就会因 `supports_password=True` 拒绝它。于是 `basic + 一个 OIDC`（常见的 SSO 带密码兜底部署）时 `len == 2`，自动选择被跳过，请求直接 404。显式传 `?provider=<oidc>` 则完全正常，说明只有自动选择的计数逻辑有误。

`/api/status` 的 `native_pkce` 能力宣告（web_server.py）早已使用 `supports_session 且非 supports_password` 的 "brokerable" 定义，本次修复让自动选择与其保持一致。

## 修复方式

`hermes_cli/dashboard_auth/routes.py` 的 `auth_native_authorize`:

- 自动选择改为只在可 broker 的 provider（`supports_session` 且非 `supports_password`）中计数：`basic + 一个 OIDC` 时 `len == 1`，正确自动选中 OIDC，桌面登录恢复可用。
- 没有任何可 broker provider 时保留原有逻辑（选中唯一的 session provider），让显式的 400 错误继续解释密码 provider 不支持原生 OAuth，而不是退化成误导性的 404。

## Who should enable this

使用 **Hermes Dashboard / Web UI 原生登录**（RFC 8252 PKCE OAuth flow）且部署了**密码 + OAuth 混合 provider** 的用户：

- 桌面端/网页端点"登录"直接 404 `Unknown provider: ''`
- 显式选择 OAuth provider 能登录，但空 provider 自动选择失败

修复随代码生效；纯密码部署、纯 OAuth 部署行为不变。

## Platform compatibility

| 平台 | 兼容性 |
|---|---|
| macOS | ✅ 完全兼容 |
| Linux | ✅ 完全兼容 |
| Windows | ✅ 完全兼容（纯后端逻辑，与平台无关） |

## Quick-start guide

1. `hermes update`（或拉取本 PR 分支）
2. 重启 gateway / web server（`hermes gateway restart` 或重启 dashboard）
3. 验证：`basic + OIDC` 部署下，桌面端点"登录"自动选中 OIDC，正常跳转授权
4. 纯密码部署：仍显示 400 明确提示（密码 provider 不支持原生 OAuth），不再退化为 404

## Troubleshooting

| 症状 | 原因 | 修复 |
|---|---|---|
| 原生登录 404 `Unknown provider: ''` | 空 provider 自动选择把密码 provider 计入候选 | 升级到本修复；自动选择只统计可 broker 的 provider |
| 纯密码部署登录失败 | 密码 provider 无法作为 OAuth broker | 正常行为：显式 400 说明不支持原生 OAuth；用密码表单登录 |
| 多个 OAuth provider 时自动选择 | 候选 >1 无法唯一确定 | 正常行为：显式指定 provider |

## 验证

- [x] 新增 4 个回归测试（basic+OIDC 并存自动选中 OIDC / 单 OAuth 自动选中 / 多 OAuth 歧义 404 / 纯密码部署保留 400）
- [x] `pytest tests/hermes_cli/test_dashboard_auth_native_flow.py tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_dashboard_auth_gate.py tests/plugins/dashboard_auth/` 共 283 passed, 1 skipped
- [x] ruff 检查通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #78906
