### PR TITLE
fix(model-metadata): prefer max_input_tokens over max_tokens in local context probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2129,8 +2129,18 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
             resp = client.get(f"{server_url}/v1/models/{model}")
             if resp.status_code == 200:
                 data = resp.json()
-                # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
+                # vLLM returns max_model_len.  Anthropic-shaped payloads (e.g. a
+                # local relay proxying api.anthropic.com/v1/models) report
+                # max_input_tokens for the context window and max_tokens for the
+                # *output* cap — check max_input_tokens before falling back to
+                # max_tokens, otherwise a 1M-context model is read as its 128K
+                # output limit.
+                ctx = (
+                    data.get("max_model_len")
+                    or data.get("context_length")
+                    or data.get("max_input_tokens")
+                    or data.get("max_tokens")
+                )
                 if ctx and isinstance(ctx, (int, float)):
                     return int(ctx)
 
@@ -2155,6 +2165,8 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                     # vLLM/OpenAI keys are also checked. Runtime n_ctx is
                     # preferred over n_ctx_train (the training maximum, which
                     # can be larger than what the server actually allocates).
+                    # max_input_tokens precedes max_tokens: on Anthropic-shaped
+                    # payloads max_tokens is the *output* cap, not the window.
                     for source in (matched, matched.get("meta") or {}):
                         if not isinstance(source, dict):
                             continue
@@ -2164,6 +2176,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                             "context_window",
                             "max_model_len",
                             "max_context_length",
+                            "max_input_tokens",
                             "max_tokens",
                             "n_ctx_train",
                         ):

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -272,6 +272,107 @@ class TestQueryLocalContextLengthModelsList:
         assert result == 256000
 
 
+class TestQueryLocalContextLengthAnthropicShape:
+    """Anthropic-shaped /v1/models payloads: max_tokens is the *output* cap.
+
+    A local relay that proxies api.anthropic.com/v1/models reports
+    ``max_tokens`` (output token cap, e.g. 128000) alongside
+    ``max_input_tokens`` (the real context window, e.g. 1000000).  Treating
+    ``max_tokens`` as a context-length key silently caps such models at the
+    output limit.  vLLM-shaped payloads (``max_model_len``) must stay
+    unaffected.
+    """
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def _make_client(self, detail_resp, list_resp):
+        """Mock httpx.Client: first GET is /v1/models/{model}, second /v1/models."""
+        call_count = [0]
+
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            return detail_resp if call_count[0] == 1 else list_resp
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+        return client_mock
+
+    def test_model_detail_prefers_max_input_tokens_over_max_tokens(self):
+        """/v1/models/{model}: max_input_tokens wins over the max_tokens output cap."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "id": "claude-sonnet-5",
+            "type": "model",
+            "max_tokens": 128000,
+            "max_input_tokens": 1000000,
+        })
+        client_mock = self._make_client(detail_resp, self._make_resp(404, {}))
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("claude-sonnet-5", "http://127.0.0.1:9933/v1")
+
+        assert result == 1000000
+
+    def test_models_list_prefers_max_input_tokens_over_max_tokens(self):
+        """/v1/models list: max_input_tokens wins over the max_tokens output cap."""
+        from agent.model_metadata import _query_local_context_length
+
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "claude-sonnet-5",
+                    "type": "model",
+                    "max_tokens": 128000,
+                    "max_input_tokens": 1000000,
+                }
+            ]
+        })
+        client_mock = self._make_client(self._make_resp(404, {}), list_resp)
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("claude-sonnet-5", "http://127.0.0.1:9933/v1")
+
+        assert result == 1000000
+
+    def test_model_detail_vllm_shape_unaffected(self):
+        """/v1/models/{model}: max_model_len still wins for vLLM-shaped payloads."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {"id": "omnicoder-9b", "max_model_len": 262144})
+        client_mock = self._make_client(detail_resp, self._make_resp(404, {}))
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("omnicoder-9b", "http://localhost:8000/v1")
+
+        assert result == 262144
+
+    def test_models_list_vllm_shape_unaffected(self):
+        """/v1/models list: max_model_len still wins for vLLM-shaped payloads."""
+        from agent.model_metadata import _query_local_context_length
+
+        list_resp = self._make_resp(200, {
+            "data": [{"id": "omnicoder-9b", "max_model_len": 262144}]
+        })
+        client_mock = self._make_client(self._make_resp(404, {}), list_resp)
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("omnicoder-9b", "http://localhost:8000/v1")
+
+        assert result == 262144
+
+
 class TestQueryLocalContextLengthLmStudio:
     """_query_local_context_length with LM Studio native /api/v1/models response."""
 


### PR DESCRIPTION
## Summary

- `_query_local_context_length_uncached()` treated `max_tokens` as a context-length key at **both** of its `/v1/models` probe sites.
- That is correct for vLLM-shaped payloads, but wrong for Anthropic-shaped ones, where `max_tokens` is the **output** token cap and `max_input_tokens` is the actual context window.
- Insert `max_input_tokens` ahead of `max_tokens` at both sites. `max_tokens` stays as a last-resort fallback, so no server that previously resolved a value starts resolving `None`.
- Adds 4 regression tests covering both probe sites × both payload shapes.

## The bug

`agent/model_metadata.py` probes a local server's `/v1/models` endpoints to discover a model's context window. Two sites resolved it:

```python
# /v1/models/{model}
ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")

# /v1/models list-matching
for key in ("n_ctx", "context_length", "context_window", "max_model_len",
            "max_context_length", "max_tokens", "n_ctx_train"):
```

The `/v1/models` response shape is not uniform across servers:

| Server shape | Context window key | `max_tokens` means |
|---|---|---|
| vLLM / llama.cpp / LM Studio | `max_model_len`, `n_ctx`, `context_length` | (usually absent) |
| Anthropic (`api.anthropic.com/v1/models`) | `max_input_tokens` | **output** token cap |

So for an Anthropic-shaped payload like:

```json
{ "id": "claude-sonnet-5", "type": "model",
  "max_tokens": 128000, "max_input_tokens": 1000000 }
```

…neither `max_model_len` nor `context_length` is present, the chain falls through to `max_tokens`, and the model's context window is read as **128000 instead of 1000000** — its output cap. This reproduces against any local relay that proxies `api.anthropic.com/v1/models` verbatim: Claude models get silently capped at 128K, and the wrong value is then persisted to `context_length_cache.yaml`.

## The fix

`max_input_tokens` is checked before `max_tokens` at both sites, with `max_tokens` retained as the final fallback so single-key servers that relied on it are unaffected.

This also brings the local probe in line with the module's own canonical key lists a few hundred lines up, which already make exactly this distinction:

```python
_CONTEXT_LENGTH_KEYS = (..., "max_model_len", "max_input_tokens", ...)   # max_tokens NOT here
_MAX_COMPLETION_KEYS = ("max_completion_tokens", "max_output_tokens", "max_tokens")
```

The two hand-rolled key chains inside `_query_local_context_length_uncached()` had drifted from that classification; this patch reconciles them.

## Test plan

Added `TestQueryLocalContextLengthAnthropicShape` to `tests/agent/test_model_metadata_local_ctx.py` — 4 tests, all with mocked `httpx` (no live server):

1. `/v1/models/{model}`, Anthropic-shaped → resolves `1000000`, not `128000`
2. `/v1/models` list, Anthropic-shaped → resolves `1000000`, not `128000`
3. `/v1/models/{model}`, vLLM-shaped (`max_model_len`) → unchanged at `262144`
4. `/v1/models` list, vLLM-shaped (`max_model_len`) → unchanged at `262144`

Tests 1 and 2 fail on `main` with `assert 128000 == 1000000`; 3 and 4 pass before and after, guarding against regression.

### Results

Scoped to the touched module:

```
$ ./scripts/run_tests.sh tests/agent/test_model_metadata_local_ctx.py \
    tests/agent/test_model_metadata.py tests/agent/test_model_metadata_ssl.py
=== Summary: 3 files, 92 tests passed, 0 failed (100% complete) in 3.4s (8 workers) ===
```

Full agent suite, to confirm no collateral impact:

```
$ ./scripts/run_tests.sh tests/agent/
=== Summary: 349 files, 3813 tests passed, 0 failed (100% complete) in 241.4s (8 workers) ===
```

## Before / after

Probing a local relay that proxies `api.anthropic.com/v1/models`:

```
before:  _query_local_context_length("claude-sonnet-5", "http://127.0.0.1:9933")  ->  128000
after:   _query_local_context_length("claude-sonnet-5", "http://127.0.0.1:9933")  ->  1000000
```

Note for anyone hitting this: a stale `128000` entry may already be cached in `~/.hermes/context_length_cache.yaml` for the affected model/endpoint and needs clearing for the corrected probe to take effect.
