### PR TITLE
feat(providers): add Kiro ACP backend

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -715,8 +715,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in {"copilot-acp", "kiro-acp"}
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -1166,7 +1166,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "kiro-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2255,12 +2255,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if (
+        agent.provider in {"copilot-acp", "kiro-acp"}
+        or str(client_kwargs.get("base_url", "")).startswith("acp://")
+    ):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
         _ra().logger.info(
-            "Copilot ACP client created (%s, shared=%s) %s",
+            "ACP client created (%s, shared=%s) %s",
             reason,
             shared,
             agent._client_log_context(),

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -519,6 +519,9 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "kiro": "kiro-acp",
+    "kiro-cli": "kiro-acp",
+    "kiro-agent": "kiro-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -6307,21 +6310,25 @@ def resolve_provider_client(
             or _read_main_model_for_aux(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "kiro-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
+            if provider == "kiro-acp" and final_model:
+                args.extend(["--model", final_model])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external process "
+                    "credentials are incomplete",
+                    provider,
                 )
                 return None, None
             from agent.copilot_acp_client import CopilotACPClient

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2356,8 +2356,8 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in {"copilot-acp", "kiro-acp"}
+                    or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_KIRO_ACP_BASE_URL = "acp://kiro"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -231,6 +232,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "kiro-acp": ProviderConfig(
+        id="kiro-acp",
+        name="Kiro ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_KIRO_ACP_BASE_URL,
+        base_url_env_var="KIRO_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1976,6 +1984,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "kiro": "kiro-acp", "kiro-cli": "kiro-acp", "kiro-agent": "kiro-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
@@ -6953,13 +6962,17 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "kiro-acp":
+        command = os.getenv("KIRO_CLI_PATH", "").strip() or "kiro-cli"
+        args = ["acp"]
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6994,12 +7007,12 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
     # API-key providers
-    pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
@@ -7177,25 +7190,32 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "kiro-acp":
+        command = os.getenv("KIRO_CLI_PATH", "").strip() or "kiro-cli"
+        args = ["acp"]
+        product_name = "Kiro CLI"
+        missing_code = "missing_kiro_cli"
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+        product_name = "GitHub Copilot CLI"
+        missing_code = "missing_copilot_cli"
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {product_name} command '{command}'.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=missing_code,
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -792,6 +792,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_kiro_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3430,6 +3431,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "kiro-acp":
+        _model_flow_kiro_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1893,6 +1893,77 @@ def _model_flow_copilot(config, current_model=""):
     else:
         print("No change.")
 
+
+def _model_flow_kiro_acp(config, current_model=""):
+    """Kiro ACP flow using the authenticated local Kiro CLI."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "kiro-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "kiro-cli"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Kiro ACP delegates Hermes turns to `kiro-cli acp`.")
+    print("  Authentication is handled by your existing Kiro CLI login.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Install Kiro CLI and run `kiro-cli login`, then retry.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get(provider_id, ["claude-sonnet-5"])
+    selected = _prompt_model_selection(
+        model_list,
+        current_model=current_model,
+        confirm_provider=provider_id,
+        confirm_base_url=effective_base,
+        confirm_api_key=provider_id,
+    )
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model.update(
+        {
+            "provider": provider_id,
+            "default": selected,
+            "base_url": effective_base,
+            "api_mode": "chat_completions",
+        }
+    )
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_copilot_acp(config, current_model=""):
     """GitHub Copilot ACP flow using the local Copilot CLI."""
     from hermes_cli.auth import (

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -298,6 +298,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "kiro-acp": [
+        "claude-sonnet-5",
+        "claude-opus-5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1127,6 +1131,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("kiro-acp",       "Kiro ACP",                 "Kiro ACP (Spawns kiro-cli acp; uses your Kiro login)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1290,6 +1295,9 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "kiro": "kiro-acp",
+    "kiro-cli": "kiro-acp",
+    "kiro-agent": "kiro-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "kiro-acp": HermesOverlay(
+        transport="codex_responses",
+        auth_type="external_process",
+        base_url_override="acp://kiro",
+        base_url_env_var="KIRO_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2010,15 +2010,21 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "kiro-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
+        args = list(creds.get("args") or [])
+        if provider == "kiro-acp":
+            selected_model = str(
+                target_model or model_cfg.get("default") or "claude-sonnet-5"
+            ).strip()
+            args.extend(["--model", selected_model])
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),
             "command": creds.get("command", ""),
-            "args": list(creds.get("args") or []),
+            "args": args,
             "source": creds.get("source", "process"),
             "requested_provider": requested_provider,
         }

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,10 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "kiro-acp": [
+        "claude-sonnet-5",
+        "claude-opus-5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -506,6 +506,43 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_maps_kiro_acp_aliases(self):
+        assert _normalize_aux_provider("kiro") == "kiro-acp"
+        assert _normalize_aux_provider("kiro-cli") == "kiro-acp"
+
+
+def test_resolve_provider_client_builds_kiro_acp_client(monkeypatch):
+    import agent.auxiliary_client as aux
+
+    fake_client = MagicMock()
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_external_process_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "kiro-acp",
+            "base_url": "acp://kiro",
+            "command": "/usr/local/bin/kiro-cli",
+            "args": ["acp"],
+        },
+    )
+    with patch(
+        "agent.copilot_acp_client.CopilotACPClient",
+        return_value=fake_client,
+    ) as client_cls:
+        client, model = aux.resolve_provider_client(
+            "kiro-acp",
+            model="claude-opus-5",
+        )
+
+    assert client is fake_client
+    assert model == "claude-opus-5"
+    assert client_cls.call_args.kwargs["command"] == "/usr/local/bin/kiro-cli"
+    assert client_cls.call_args.kwargs["args"] == [
+        "acp",
+        "--model",
+        "claude-opus-5",
+    ]
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("kiro-acp", "Kiro ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -106,6 +107,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["kiro-acp"].inference_base_url == "acp://kiro"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["stepfun"].inference_base_url == STEPFUN_STEP_PLAN_INTL_BASE_URL
@@ -500,6 +502,20 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_kiro_acp_uses_kiro_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="kiro-acp")
+
+        assert result["provider"] == "kiro-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "kiro-acp"
+        assert result["base_url"] == "acp://kiro"
+        assert result["command"] == "/usr/local/bin/kiro-cli"
+        assert result["args"] == ["acp", "--model", "claude-sonnet-5"]
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_kiro_acp_provider.py
+++ b/tests/hermes_cli/test_kiro_acp_provider.py
@@ -1,0 +1,84 @@
+"""First-class Kiro ACP provider contracts."""
+
+from hermes_cli.models import (
+    CANONICAL_PROVIDERS,
+    _PROVIDER_MODELS,
+    normalize_provider,
+)
+from hermes_cli.providers import HERMES_OVERLAYS
+from hermes_cli import model_setup_flows
+
+
+def test_kiro_acp_is_visible_in_canonical_provider_picker():
+    entry = next(provider for provider in CANONICAL_PROVIDERS if provider.slug == "kiro-acp")
+
+    assert entry.label == "Kiro ACP"
+    assert "kiro-cli acp" in entry.tui_desc
+
+
+def test_kiro_acp_defaults_to_claude_sonnet_5():
+    assert _PROVIDER_MODELS["kiro-acp"] == [
+        "claude-sonnet-5",
+        "claude-opus-5",
+    ]
+
+
+def test_kiro_aliases_normalize_to_kiro_acp():
+    assert normalize_provider("kiro") == "kiro-acp"
+    assert normalize_provider("kiro-cli") == "kiro-acp"
+
+
+def test_kiro_acp_overlay_uses_external_process_transport():
+    overlay = HERMES_OVERLAYS["kiro-acp"]
+
+    assert overlay.auth_type == "external_process"
+    assert overlay.base_url_override == "acp://kiro"
+
+
+def test_kiro_model_flow_persists_selected_model_and_provider(monkeypatch):
+    saved = {}
+    config = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_external_process_provider_status",
+        lambda provider: {
+            "configured": True,
+            "resolved_command": "/usr/local/bin/kiro-cli",
+            "base_url": "acp://kiro",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_external_process_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "command": "/usr/local/bin/kiro-cli",
+            "base_url": "acp://kiro",
+            "args": ["acp"],
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda models, **kwargs: "claude-sonnet-5",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._save_model_choice",
+        lambda model: saved.setdefault("model_choice", model),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config",
+        lambda value: saved.setdefault("config", value.copy()),
+    )
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    flow = getattr(model_setup_flows, "_model_flow_kiro_acp", None)
+    assert callable(flow)
+    flow({}, "")
+
+    assert saved["model_choice"] == "claude-sonnet-5"
+    assert saved["config"]["model"] == {
+        "provider": "kiro-acp",
+        "default": "claude-sonnet-5",
+        "base_url": "acp://kiro",
+        "api_mode": "chat_completions",
+    }

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5240,6 +5240,36 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_uses_kiro_acp_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+    ):
+        acp_client = MagicMock()
+        mock_acp_client.return_value = acp_client
+
+        agent = AIAgent(
+            api_key="kiro-acp",
+            base_url="acp://kiro",
+            provider="kiro-acp",
+            acp_command="/usr/local/bin/kiro-cli",
+            acp_args=["acp", "--model", "claude-opus-5"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is acp_client
+    mock_openai.assert_not_called()
+    mock_acp_client.assert_called_once()
+    assert mock_acp_client.call_args.kwargs["base_url"] == "acp://kiro"
+    assert mock_acp_client.call_args.kwargs["api_key"] == "kiro-acp"
+    assert mock_acp_client.call_args.kwargs["command"] == "/usr/local/bin/kiro-cli"
+    assert mock_acp_client.call_args.kwargs["args"] == ["acp", "--model", "claude-opus-5"]
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -198,6 +198,25 @@ hermes chat --provider copilot-acp --model copilot-acp
 # Requires the GitHub Copilot CLI in PATH and an existing `copilot login` session
 ```
 
+**`kiro-acp` — Kiro ACP agent backend**. Spawns the authenticated Kiro CLI as
+an ACP subprocess. Claude Sonnet 5 is the default; Claude Opus 5 remains
+selectable:
+
+```bash
+# One session
+hermes chat --provider kiro-acp --model claude-sonnet-5
+
+# Make Kiro + Sonnet 5 the default orchestrator
+hermes config set model.provider kiro-acp
+hermes config set model.default claude-sonnet-5
+```
+
+Kiro CLI must be installed, available as `kiro-cli`, and logged in. You can
+also run `hermes model`, choose **Kiro ACP**, and select **Claude Sonnet 5**.
+The provider change takes effect in a new Hermes session; it does not replace
+the model inside a conversation that is already running. Set `KIRO_CLI_PATH`
+when the executable is not on `PATH`.
+
 **Permanent config:**
 ```yaml
 model:


### PR DESCRIPTION
## Summary

- add a first-class `kiro-acp` external-process provider backed by `kiro-cli acp`
- route main and auxiliary Hermes model calls through the existing ACP transport
- expose Kiro in provider discovery, aliases, setup/model picker, runtime resolution, and auth status
- default Kiro to `claude-sonnet-5` while retaining verified `claude-opus-5` selection
- document one-shot and persistent activation commands

## Activation

```bash
# Ensure Kiro CLI is installed and authenticated first.
kiro-cli chat --no-interactive --model claude-sonnet-5 'Reply with OK'

# Make Kiro + Sonnet 5 the Hermes default.
hermes config set model.provider kiro-acp
hermes config set model.default claude-sonnet-5

# Start a new session (existing sessions keep their current provider).
hermes
```

Alternatively, run `hermes model`, choose **Kiro ACP**, then **Claude Sonnet 5**.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_kiro_acp_provider.py tests/agent/test_auxiliary_client.py tests/run_agent/test_run_agent.py -q`
  - 518 passed, 0 failed after rebasing onto current upstream `main`
- Python bytecode compilation for all modified Python modules passed
- `git diff origin/main...HEAD --check` passed
- direct authenticated Kiro Sonnet probe returned `KIRO_SONNET_5_OK`
- live Hermes → Kiro ACP default-model probe returned `HERMES_KIRO_DEFAULT_SONNET_OK`
- recorded session metadata identified `claude-sonnet-5`
- live Hermes tool-use probe through Kiro returned the hidden `read_file` marker
- independent Kiro Sonnet diff review: PASS, no blocking security or logic defects

## Notes

- no API key is required; authentication stays in the user's Kiro CLI session
- `KIRO_CLI_PATH` can override the `kiro-cli` executable location
- provider changes apply to new Hermes sessions, not an already-running conversation
