### PR TITLE
fix(cron): scan referenced files only when they can actually execute

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -177,6 +177,31 @@ def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
     return path
 
 
+def _is_plausible_script(path: Path) -> bool:
+    """True when *path* could really be executed as a script.
+
+    HERMES-LOCAL-PATCH: exec-only: a bare path token discovered inside a scanned file is
+    only worth following when the file could actually run. Data files that a
+    script merely NAMES -- config.yaml, .env, credentials.json -- are not
+    executable, cannot restart a gateway, and scanning them yields false
+    positives (a denylist entry reading "kill hermes/gateway" is prose, not a
+    command) while needlessly reading secrets. Scripts invoked explicitly via a
+    shell (``sh payload.json``) are yielded by the shell branch and bypass this
+    check entirely, so no genuine execution path stops being scanned.
+    """
+    try:
+        metadata = os.stat(path)
+    except OSError:
+        return False
+    if not stat.S_ISREG(metadata.st_mode):
+        # Defer to _read_referenced_script, which skips directories and still
+        # fails closed on fifos/devices.
+        return True
+    if metadata.st_mode & 0o111:
+        return True
+    return path.name.endswith((".sh", ".bash", ".zsh"))
+
+
 def _iter_referenced_shell_scripts(
     command: str,
     *,
@@ -190,7 +215,12 @@ def _iter_referenced_shell_scripts(
         executable = segment[index]
         executable_name = Path(executable).name
 
-        if executable_name in {".", "source"}:
+        # HERMES-LOCAL-PATCH: dot-source: `Path(".").name` is "", not ".", so matching
+        # on the basename alone let the POSIX dot builtin evade this branch
+        # while the spelled-out `source` was caught. Sourcing executes the
+        # file in the current shell, so it must be scanned. The raw token is
+        # tested too; a path-qualified `/usr/bin/source` still matches by name.
+        if executable in {".", "source"} or executable_name in {".", "source"}:
             if len(segment) > index + 1:
                 yield _resolve_terminal_script_path(segment[index + 1], cwd)
             continue
@@ -226,7 +256,10 @@ def _iter_referenced_shell_scripts(
         # (#77131). Skip pure-separator tokens.
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+                # HERMES-LOCAL-PATCH: exec-only
+                _candidate = _resolve_terminal_script_path(executable, cwd)
+                if _is_plausible_script(_candidate):
+                    yield _candidate
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
@@ -262,6 +295,18 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     try:
         metadata = os.fstat(descriptor)
+        # HERMES-LOCAL-PATCH: dir-skip
+        # A directory is never executable as a script -- both `sh somedir`
+        # and `./somedir` fail -- so there is nothing to scan and nothing to
+        # evade through. Directory-valued path tokens are common in the
+        # sources this scanner walks (a Python script with
+        # `ROOT = os.path.expanduser("~/some-dir")` is enough), and failing
+        # closed on them hard-blocks innocent commands with a bogus
+        # "cannot restart or stop the gateway" error. Same bug class as the
+        # bare-"/" token (#77131) and binaries (#76762): skip, don't block.
+        # FIFOs/devices/sockets stay fail-closed -- those CAN feed a shell.
+        if stat.S_ISDIR(metadata.st_mode):
+            return None, False
         if not stat.S_ISREG(metadata.st_mode):
             return None, True
         # Read a bounded chunk first — even for oversized files, the first

--- a/tests/cron/test_lifecycle_guard_referenced_scripts.py
+++ b/tests/cron/test_lifecycle_guard_referenced_scripts.py
@@ -1,0 +1,185 @@
+"""Tests for referenced-script scanning in the gateway lifecycle guard.
+
+Covers three defects in how `contains_gateway_lifecycle_command_or_referenced_script`
+walks the files a command references:
+
+- Directories were treated as unsafe (fail-closed), so an innocent script that
+  merely NAMED a directory in a string literal was hard-blocked.
+- Non-executable data files (config.yaml, .env, credentials.json) were read and
+  regex-scanned as if they were shell scripts, so prose inside them could block a
+  command -- and secrets were read for no reason.
+- The POSIX dot builtin (`. script.sh`) evaded the scan entirely, because
+  `Path(".").name` is `""` rather than `"."`. The spelled-out `source` form was
+  caught, so the bypass was inconsistent as well as unsafe.
+
+The unifying rule these tests pin down: a referenced file is scanned when it could
+actually be EXECUTED, and not merely because a path-shaped token mentions it.
+"""
+
+import os
+import stat
+
+import pytest
+
+from cron.lifecycle_guard import (
+    contains_gateway_lifecycle_command_or_referenced_script,
+)
+
+RESTART = "hermes gateway restart\n"
+
+
+def _write(path, body, mode=0o644):
+    path.write_text(body)
+    os.chmod(path, mode)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Directories must not fail closed
+# ---------------------------------------------------------------------------
+
+class TestDirectoryReferences:
+    """A directory can never execute as a script, so it must not block."""
+
+    def test_script_naming_a_directory_is_not_blocked(self, tmp_path):
+        workspace = tmp_path / "deliverables"
+        workspace.mkdir()
+        script = _write(
+            tmp_path / "health-check.py",
+            "import os\n"
+            f'WORKSPACE_ROOT = os.path.expanduser("{workspace}")\n'
+            'print("ok")\n',
+            0o755,
+        )
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            script, cwd=str(tmp_path)
+        )
+
+    def test_directory_passed_directly_is_not_blocked(self, tmp_path):
+        target = tmp_path / "somedir"
+        target.mkdir()
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            str(target), cwd=str(tmp_path)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data files are scanned only when actually executed
+# ---------------------------------------------------------------------------
+
+class TestDataFileReferences:
+    """Prose in a config file is not a command -- unless something runs it."""
+
+    @pytest.fixture
+    def config_with_prose(self, tmp_path):
+        # Mirrors a real denylist entry that reads like a command but is not one.
+        return _write(
+            tmp_path / "config.yaml",
+            "denied_actions:\n  - kill hermes/gateway process (self-termination)\n",
+            0o600,
+        )
+
+    def test_bare_mention_of_data_file_is_not_blocked(
+        self, tmp_path, config_with_prose
+    ):
+        script = tmp_path / "reader.py"
+        _write(script, f'CONFIG = "{config_with_prose}"\nprint(CONFIG)\n', 0o755)
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            str(script), cwd=str(tmp_path)
+        )
+
+    def test_data_file_referenced_directly_is_not_blocked(
+        self, tmp_path, config_with_prose
+    ):
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            config_with_prose, cwd=str(tmp_path)
+        )
+
+    @pytest.mark.parametrize("invocation", ["sh {path}", "bash {path}", ". {path}"])
+    def test_executing_a_data_file_IS_blocked(self, tmp_path, invocation):
+        payload = _write(tmp_path / "payload.json", RESTART, 0o644)
+        command = invocation.format(path=payload)
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        ), f"executing a data file must still be scanned: {command!r}"
+
+
+# ---------------------------------------------------------------------------
+# The POSIX dot builtin must not evade the scan
+# ---------------------------------------------------------------------------
+
+class TestSourceBuiltin:
+    """`. script` executes in the current shell and must be scanned."""
+
+    @pytest.mark.parametrize("verb", [".", "source"])
+    def test_sourcing_a_restart_is_blocked(self, tmp_path, verb):
+        payload = _write(tmp_path / "payload.sh", RESTART, 0o644)
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"{verb} {payload}", cwd=str(tmp_path)
+        )
+
+    def test_sourcing_relative_path_is_blocked(self, tmp_path):
+        _write(tmp_path / "payload.sh", RESTART, 0o644)
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            ". ./payload.sh", cwd=str(tmp_path)
+        )
+
+    def test_bare_dot_without_argument_is_harmless(self, tmp_path):
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            ".", cwd=str(tmp_path)
+        )
+
+    def test_relative_executable_is_unaffected(self, tmp_path):
+        _write(tmp_path / "innocent.sh", "#!/bin/sh\necho hi\n", 0o755)
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            "./innocent.sh", cwd=str(tmp_path)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Existing detection must not regress
+# ---------------------------------------------------------------------------
+
+class TestDetectionNotWeakened:
+    """Everything the guard caught before must still be caught."""
+
+    @pytest.mark.parametrize("command", [
+        "hermes gateway restart",
+        "hermes gateway stop",
+        "launchctl kickstart -k gui/501/ai.hermes.gateway",
+        "systemctl --user restart hermes-gateway",
+        "pkill -f hermes.*gateway",
+        "pkill -f gateway.*hermes",
+        "launchctl submit -l neutral.label -- /tmp/helper.sh",
+    ])
+    def test_direct_commands_still_blocked(self, command, tmp_path):
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        )
+
+    def test_executable_script_still_scanned(self, tmp_path):
+        script = _write(tmp_path / "deploy.sh", f"#!/bin/sh\n{RESTART}", 0o755)
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            script, cwd=str(tmp_path)
+        )
+
+    def test_non_executable_shell_extension_still_scanned(self, tmp_path):
+        """Extension alone qualifies -- a .sh is a script even without +x."""
+        script = _write(tmp_path / "deploy.sh", RESTART, 0o644)
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            script, cwd=str(tmp_path)
+        )
+
+    def test_gateway_start_remains_allowed(self, tmp_path):
+        assert not contains_gateway_lifecycle_command_or_referenced_script(
+            "hermes gateway start", cwd=str(tmp_path)
+        )
+
+    def test_fifo_still_fails_closed(self, tmp_path):
+        """Non-regular files that a shell CAN read must stay fail-closed."""
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo)
+        assert stat.S_ISFIFO(os.stat(fifo).st_mode)
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            f"sh {fifo}", cwd=str(tmp_path)
+        )


### PR DESCRIPTION
## Summary

`contains_gateway_lifecycle_command_or_referenced_script` shlex-tokenizes the *source* of a referenced script and follows every token containing `/` as if it were another script. Three defects fall out of that — two that block innocent commands, and one that lets a real foot-gun through.

All three were found in production on a rig that runs scheduled health-check scripts through the gateway. Same family as the bare-`/` token fix (#77131) and the NUL-byte/binary fix (#76762) in this same function.

## The defects

### 1. Directories failed closed

`_read_referenced_script` returned `unsafe=True` for anything that is not a regular file. Because every quoted path in a Python source is a `/`-containing token, a script that merely **named a directory** was hard-blocked:

```python
WORKSPACE_ROOT = os.path.expanduser("~/dgx-deliverables")   # a directory
```

```
Blocked: command or referenced script cannot restart or stop the gateway
from inside the gateway process.
```

That script never touches the gateway — it creates a kanban task and verifies a deliverable. Note the bare command name passes and only the absolute-path form trips it, which makes it look maddeningly non-deterministic from the outside.

A directory cannot execute as a script (`sh somedir` and `./somedir` both fail), so there is nothing to scan and nothing to evade through. Fifos, devices and sockets stay fail-closed, since those *can* feed a shell.

### 2. Non-executable data files were scanned as shell scripts

Following bare path tokens meant `config.yaml`, `.env` and `credentials.json` were read and regex-matched. Ordinary prose then blocked a command — this line in a config denylist matched the `pkill` branch:

```yaml
denied_actions:
  - kill hermes/gateway process (self-termination)
```

Beyond the false positive, the scanner was reading credential files for no reason.

A bare token is now followed only when the file is executable or carries a shell extension. Data files are typically `0600`, real scripts `0755`, so they separate cleanly. Scripts invoked explicitly through a shell (`sh payload.json`) come from the shell branch and bypass this check entirely, so **no genuine execution path stops being scanned**.

### 3. The POSIX dot builtin evaded the scan entirely

`Path(".").name` is `""`, not `"."`, so the `{".", "source"}` branch never matched the dot builtin:

```sh
source ./payload.sh    # caught
. ./payload.sh         # NOT caught  ← ran unscanned
```

Sourcing executes the file in the current shell, so it is exactly as dangerous as running it. The raw token is now tested alongside the basename; a path-qualified `/usr/bin/source` still matches by name.

## The unifying rule

A referenced file is scanned when it could actually be **executed**, not merely because a path-shaped token mentions it. That produces a deliberate asymmetry the tests pin down:

| command | scanned? |
|---|---|
| a script that merely mentions `config.yaml` | no |
| `. config.yaml` (sources it — executes it) | yes |

## Testing

New `tests/cron/test_lifecycle_guard_referenced_scripts.py` — 23 cases covering all three defects, the asymmetry above, and the detection that must not weaken (direct commands, executable scripts, non-executable `.sh`, `hermes gateway start` still allowed, fifos still fail-closed).

The existing 82-case `tests/hermes_cli/test_gateway_restart_loop.py` suite passes unchanged.

```
105 passed
```

## Risk

Defects 1 and 2 only ever *unblock* commands that were being wrongly refused; they cannot make the guard permit a real lifecycle command, because every path that leads to execution is still scanned. Defect 3 is a strict tightening — it closes a bypass.
