### PR TITLE
fix(api-server): resolve reasoning for the request's model, not model.default

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2594,7 +2594,6 @@ class APIServerAdapter(BasePlatformAdapter):
             runtime_kwargs = _resolve_runtime_agent_kwargs()
         except RuntimeError as exc:
             raise _ProviderAuthResolutionError(str(exc)) from exc
-        reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
         # When the primary provider's auth fails (expired token / 429 quota
@@ -2610,8 +2609,6 @@ class APIServerAdapter(BasePlatformAdapter):
             model = runtime_model
 
         request_reasoning_config = _request_reasoning_config(model_options)
-        if request_reasoning_config is not None:
-            reasoning_config = request_reasoning_config
         request_service_tier = _request_service_tier(model_options)
 
         request_model = _clean_request_string(requested_model)
@@ -2814,6 +2811,20 @@ class APIServerAdapter(BasePlatformAdapter):
             None
             if confirmed_runtime_lock
             else GatewayRunner._load_fallback_model()
+        )
+
+        # Resolve reasoning against the model this request will actually
+        # run. Per-model ``agent.reasoning_overrides`` key off that model,
+        # and it is only settled after the precedence chain above (browser
+        # lock -> session /model -> session row -> route -> per-request ->
+        # defaults). Resolving at function entry keyed them off
+        # ``model.default`` instead — the defect e81d18dfb removed from the
+        # native gateway paths. An explicit per-request reasoning parameter
+        # still wins over config.
+        reasoning_config = (
+            request_reasoning_config
+            if request_reasoning_config is not None
+            else GatewayRunner._load_reasoning_config(model)
         )
 
         agent_kwargs = {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -209,7 +209,7 @@ class TestAdapterInit:
         )
         monkeypatch.setattr(
             "gateway.run.GatewayRunner._load_reasoning_config",
-            staticmethod(lambda: {"enabled": True, "effort": "xhigh"}),
+            staticmethod(lambda model="": {"enabled": True, "effort": "xhigh"}),
         )
         monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
         monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -82,3 +82,63 @@ class TestGatewaySessionEffectiveModel:
         assert result_default is not None
         assert result_default["effort"] == "low"
 
+
+
+class TestApiServerPerModelReasoning:
+    """The OpenAI-compatible surface must resolve reasoning for the model the
+    request actually runs, not ``model.default``.
+
+    e81d18dfb removed exactly this defect from the native gateway paths
+    ("the gateway resolving reasoning against config model.default instead of
+    the session's effective model"); the API server adapter kept it because it
+    resolved reasoning at function entry, before the model precedence chain.
+    """
+
+    @staticmethod
+    def _cfg():
+        return {
+            "model": {"default": "cheap/model-mini"},
+            "agent": {
+                "reasoning_effort": "low",
+                "reasoning_overrides": {"premium/model-max": "xhigh"},
+            },
+        }
+
+    def _run(self, monkeypatch, effective_model):
+        from unittest.mock import MagicMock, patch
+
+        from gateway.config import PlatformConfig
+        from gateway.platforms.api_server import APIServerAdapter
+
+        monkeypatch.setattr(
+            gateway_run, "_load_gateway_runtime_config", lambda: self._cfg(),
+        )
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.run._resolve_runtime_agent_kwargs") as kwargs_mock, \
+             patch("gateway.run._resolve_gateway_model") as model_mock, \
+             patch("gateway.run._load_gateway_config") as cfg_mock, \
+             patch("run_agent.AIAgent") as agent_cls:
+            kwargs_mock.return_value = {
+                "api_key": "k", "base_url": None, "provider": None,
+                "api_mode": None, "command": None, "args": [],
+            }
+            model_mock.return_value = effective_model
+            cfg_mock.return_value = self._cfg()
+            agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            return agent_cls.call_args.kwargs
+
+    def test_reasoning_follows_the_requested_model(self, monkeypatch):
+        kwargs = self._run(monkeypatch, "premium/model-max")
+
+        assert kwargs["model"] == "premium/model-max"
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+    def test_model_without_an_override_falls_back_to_global(self, monkeypatch):
+        kwargs = self._run(monkeypatch, "cheap/model-mini")
+
+        assert kwargs["reasoning_config"] == {"enabled": True, "effort": "low"}


### PR DESCRIPTION
## What

e81d18dfb (2026-07-14, refactor(reasoning): unify per-model reasoning resolution behind a single chokepoint) collapsed six per-surface copies of override-then-global resolution onto `resolve_reasoning_config()`. Its body states the second thing it fixed:

> Also fixes the gateway resolving reasoning against config `model.default` instead of the session's effective model.

Its file list is `agent/agent_runtime_helpers.py`, `agent/chat_completion_helpers.py`, `cli.py`, `cron/scheduler.py`, `gateway/run.py`, `gateway/slash_commands.py`, `hermes_constants.py`, `tui_gateway/server.py`. `gateway/platforms/api_server.py` is not among them, and it still carries exactly the defect that sentence describes.

`APIServerAdapter._create_agent()` resolved reasoning on its **first** line:

```python
reasoning_config = GatewayRunner._load_reasoning_config()   # no model
model = _resolve_gateway_model()
```

`_load_reasoning_config` takes the effective model precisely so per-model `agent.reasoning_overrides` can key off it; called bare, `resolve_reasoning_config` falls back to the config's `model.default`. But the model for this request is only settled ~200 lines later, after the precedence chain the function documents itself:

> confirmed Browser model lock → session `/model` override → session-persisted model → `model_routes` mapping selected by the request model alias → direct per-request provider/model → global defaults

So on the one surface where **every request names its own model**, the override was resolved against a different model than the one that runs. Same config, same request, at the chokepoint:

```
request model       : claude-opus-4-5
config model.default: cheap/model-mini

api_server today  (no model arg): {'enabled': True, 'effort': 'low'}
native gateway    (model passed): {'enabled': True, 'effort': 'high'}
```

A user who pins `reasoning_overrides: {claude-opus-4-5: high}` and calls `/v1/chat/completions` with that model silently gets the global `low` — wrong reasoning depth and wrong spend, with nothing logged. It misfires in both directions: a request for a model *without* an override inherits whatever `model.default`'s override happens to be.

Not the same as honoring a per-request `reasoning_effort` parameter (#62913, #24422) — that path already exists via `_request_reasoning_config` and still wins here. This is purely the config-driven per-model resolution keying off the wrong model.

## The fix

Move the resolution to after the precedence chain, where `model` is final:

```python
reasoning_config = (
    request_reasoning_config
    if request_reasoning_config is not None
    else GatewayRunner._load_reasoning_config(model)
)
```

The premature call at function entry is dropped, and the explicit request parameter keeps precedence over config — the same order the native gateway paths use. Requests whose model has no override are unaffected; they still get the global `agent.reasoning_effort`.

## Tests

Added `TestApiServerPerModelReasoning` to `tests/gateway/test_reasoning_config_per_model.py` — the file e81d18dfb created for this contract — using the `_create_agent` harness already established in `tests/gateway/test_api_server_toolset.py` (patch the runtime kwargs / gateway model / config, capture `AIAgent`'s kwargs):

- a request whose effective model carries an override gets that override, and `AIAgent` is constructed with both the model and the matching `reasoning_config`
- a model with no override still falls back to the global effort (control — green on both sides)

Results:

```
5 passed
```

That is the whole file; the 3 pre-existing chokepoint tests are unchanged.

Red without the source change:

```
FAILED TestApiServerPerModelReasoning::test_reasoning_follows_the_requested_model
E   AssertionError: assert {'effort': 'low', 'enabled': True}
                        == {'effort': 'xhigh', 'enabled': True}
1 failed, 4 passed
```

One existing stub needed updating: `tests/gateway/test_api_server.py` patched `_load_reasoning_config` with a zero-argument lambda, mirroring the old bare call. It now takes `model=""`, matching the production signature — and matching the other stub of the same function already in that file.

Regression run over the API-server suites, the reasoning tests and `tests/test_hermes_constants.py` (13 files), against the same files on main:

```
main:      5 failed, 220 passed, 9 skipped
with fix:  4 failed, 221 passed, 9 skipped
```

Set difference is empty — no new failures. The 4 are identical before and after (symlink and native-path cases in `test_hermes_constants.py`, unrelated to this change). `scripts/check-windows-footguns.py` passes on both changed source files.