### PR TITLE
fix(desktop): preserve brand and acronym casing in settings

### DIFF
--- a/apps/desktop/src/app/settings/config-field.test.ts
+++ b/apps/desktop/src/app/settings/config-field.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { SCHEMA_OPTION_LABELS } from './constants'
+
+describe('SCHEMA_OPTION_LABELS', () => {
+  it('uses the intended casing only for matching config keys', () => {
+    expect(SCHEMA_OPTION_LABELS['terminal.backend']?.ssh).toBe('SSH')
+    expect(SCHEMA_OPTION_LABELS['tts.provider']).toMatchObject({
+      openai: 'OpenAI',
+      xai: 'xAI',
+      elevenlabs: 'ElevenLabs',
+      minimax: 'MiniMax',
+      neutts: 'NeuTTS',
+      kittentts: 'KittenTTS'
+    })
+    expect(SCHEMA_OPTION_LABELS['stt.provider']).toMatchObject({
+      openai: 'OpenAI',
+      xai: 'xAI',
+      elevenlabs: 'ElevenLabs'
+    })
+    expect(SCHEMA_OPTION_LABELS['tts.neutts.device']).toMatchObject({ cpu: 'CPU', cuda: 'CUDA', mps: 'MPS' })
+    expect(SCHEMA_OPTION_LABELS['unrelated.setting']).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -28,6 +28,7 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
+import { SCHEMA_OPTION_LABELS } from './constants'
 import { enumOptionsFor, getNested, isExternalMemoryProvider, sectionFieldEntries, setNested } from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
@@ -339,11 +340,7 @@ export function ConfigSettings({
                 }
                 onChange={value => updateConfig(setNested(config, key, value))}
                 optionLabels={
-                  key === 'tts.elevenlabs.voice_id'
-                    ? elevenLabsVoiceLabels
-                    : key === 'terminal.backend'
-                      ? { ssh: 'SSH' }
-                      : undefined
+                  key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : SCHEMA_OPTION_LABELS[key]
                 }
                 schema={field}
                 schemaKey={key}

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -338,7 +338,13 @@ export function ConfigSettings({
                     : enumOptionsFor(key, getNested(config, key), config)
                 }
                 onChange={value => updateConfig(setNested(config, key, value))}
-                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
+                optionLabels={
+                  key === 'tts.elevenlabs.voice_id'
+                    ? elevenLabsVoiceLabels
+                    : key === 'terminal.backend'
+                      ? { ssh: 'SSH' }
+                      : undefined
+                }
                 schema={field}
                 schemaKey={key}
                 value={getNested(config, key)}

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -38,6 +38,22 @@ interface ProviderPrefix {
 export const EMPTY_SELECT_VALUE = '__hermes_empty__'
 export const CONTROL_TEXT = 'text-xs'
 
+// Labels are scoped by config key: identical stored values can mean different
+// things in other settings and must not change their display names there.
+export const SCHEMA_OPTION_LABELS: Record<string, Record<string, string>> = {
+  'terminal.backend': { ssh: 'SSH' },
+  'tts.provider': {
+    openai: 'OpenAI',
+    xai: 'xAI',
+    elevenlabs: 'ElevenLabs',
+    minimax: 'MiniMax',
+    neutts: 'NeuTTS',
+    kittentts: 'KittenTTS'
+  },
+  'stt.provider': { openai: 'OpenAI', xai: 'xAI', elevenlabs: 'ElevenLabs' },
+  'tts.neutts.device': { cpu: 'CPU', cuda: 'CUDA', mps: 'MPS' }
+}
+
 export const PROVIDER_GROUPS: ProviderPrefix[] = [
   {
     prefix: 'NOUS_',

--- a/apps/desktop/src/app/settings/voice-provider-fields.tsx
+++ b/apps/desktop/src/app/settings/voice-provider-fields.tsx
@@ -9,7 +9,7 @@ import type { HermesConfigRecord } from '@/types/hermes'
 import { setHermesConfigCache, useHermesConfigRecord } from '../hooks/use-config-record'
 
 import { ConfigField } from './config-field'
-import { SECTIONS } from './constants'
+import { SCHEMA_OPTION_LABELS, SECTIONS } from './constants'
 import { enumOptionsFor, getNested, inferFieldSchema, setNested } from './helpers'
 
 // The curated voice keys (Settings → Voice) are the single source of which
@@ -129,7 +129,7 @@ export function VoiceProviderFields({ section, providerKey }: { section: 'tts' |
             enumOptions={enumOptionsFor(key, value, config, isElVoice ? (elVoices ?? undefined) : undefined)}
             key={key}
             onChange={next => updateConfig(setNested(config, key, next))}
-            optionLabels={isElVoice ? elVoiceLabels : undefined}
+            optionLabels={isElVoice ? elVoiceLabels : SCHEMA_OPTION_LABELS[key]}
             schema={field}
             schemaKey={key}
             value={value}


### PR DESCRIPTION
## Summary
- display SSH and known provider/device acronyms with canonical casing in Desktop Settings
- scope labels by config key so unrelated and user-defined option names keep existing formatting
- preserve stored config values and live ElevenLabs voice labels
- leave the shared prettyName formatter unchanged

## Testing
- npm exec vitest run src/app/settings/config-field.test.ts src/app/settings/helpers.test.ts src/app/settings/terminal-backend-panel.test.tsx src/app/settings/voice-provider-fields.test.ts (45 passed)
- npm run typecheck
- git diff --check