### PR TITLE
fix(codex): stop stale abandoned retries from reclaiming stream ownership

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -733,18 +733,28 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # builds it via this callback (openai- or anthropic-kind) so the
             # interrupt / stale-call detectors can force-close the worker's
             # connection without touching the shared client (#67142).
-            result["response"] = _dispatch_nonstreaming_api_request(
-                agent,
-                api_kwargs,
-                make_client=lambda reason, kind="openai": _set_request_client(
-                    agent._create_request_anthropic_client(reason=reason)
-                    if kind == "anthropic_messages"
-                    else agent._create_request_openai_client(
-                        reason=reason, api_kwargs=api_kwargs
+            def _dispatch() -> Any:
+                return _dispatch_nonstreaming_api_request(
+                    agent,
+                    api_kwargs,
+                    make_client=lambda reason, kind="openai": _set_request_client(
+                        agent._create_request_anthropic_client(reason=reason)
+                        if kind == "anthropic_messages"
+                        else agent._create_request_openai_client(
+                            reason=reason, api_kwargs=api_kwargs
+                        ),
+                        kind=kind,
                     ),
-                    kind=kind,
-                ),
-            )
+                )
+            if agent.api_mode == "codex_responses":
+                from agent.codex_runtime import codex_request_cancel_scope
+
+                with codex_request_cancel_scope(
+                    lambda: _request_cancelled["value"]
+                ):
+                    result["response"] = _dispatch()
+            else:
+                result["response"] = _dispatch()
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
             # handler, the transport error is the expected consequence of our
@@ -967,6 +977,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
                     f"Reconnecting."
                 )
+            _request_cancelled["value"] = True
             try:
                 _close_request_client_once("codex_ttfb_kill")
             except Exception:
@@ -1017,6 +1028,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 f"after first byte (model: {api_kwargs.get('model', 'unknown')}). "
                 f"Reconnecting."
             )
+            _request_cancelled["value"] = True
             try:
                 _close_request_client_once("codex_stream_idle_kill")
             except Exception:
@@ -1061,6 +1073,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
                     f"Aborting call."
                 )
+            _request_cancelled["value"] = True
             try:
                 # #67142: routes by client kind — anthropic now aborts the
                 # request-local client's sockets from this poll (stranger)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -13,9 +13,10 @@ compatibility.
 * ``run_codex_create_stream_fallback`` — recovery path when the
   Responses ``stream=True`` initial create fails.
 """
-
 from __future__ import annotations
 
+import threading
+from contextlib import contextmanager
 import json
 import logging
 import time
@@ -25,6 +26,48 @@ from typing import Any, Callable, Dict, List
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
+_CODEX_REQUEST_CANCEL_STATE = threading.local()
+
+
+@contextmanager
+def codex_request_cancel_scope(cancelled_check):
+    """Install a worker-thread request-cancellation predicate for Codex.
+
+    ``interruptible_api_call`` may abandon a logical request while its worker
+    thread still unwinds a physical Codex stream attempt. The abandoned worker
+    must not perform ``run_codex_stream``'s inner retry, reclaim stream-writer
+    ownership, or return a stale response into the replacement request. A
+    request-local predicate, stored thread-locally for the lifetime of that
+    worker dispatch, lets ``run_codex_stream`` observe the abandonment without
+    changing ordinary direct-call sites.
+    """
+
+    previous = getattr(_CODEX_REQUEST_CANCEL_STATE, "cancelled_check", None)
+    _CODEX_REQUEST_CANCEL_STATE.cancelled_check = cancelled_check
+    try:
+        yield
+    finally:
+        if previous is None:
+            try:
+                delattr(_CODEX_REQUEST_CANCEL_STATE, "cancelled_check")
+            except AttributeError:
+                pass
+        else:
+            _CODEX_REQUEST_CANCEL_STATE.cancelled_check = previous
+
+
+def _codex_request_cancelled() -> bool:
+    check = getattr(_CODEX_REQUEST_CANCEL_STATE, "cancelled_check", None)
+    if check is None:
+        return False
+    try:
+        return bool(check())
+    except Exception:
+        logger.debug(
+            "Codex request-cancellation predicate raised; treating request as live",
+            exc_info=True,
+        )
+        return False
 
 
 def _coerce_usage_int(value: Any) -> int:
@@ -1246,6 +1289,12 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
 
+    def _raise_if_request_cancelled(where: str) -> None:
+        if _codex_request_cancelled():
+            raise InterruptedError(
+                f"Codex stream request cancelled after watchdog abandonment ({where})"
+            )
+
     def _on_text_delta(text: str) -> None:
         agent._codex_streamed_text_parts.append(text)
         agent._fire_stream_delta(text)
@@ -1257,6 +1306,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         agent._fire_streamed_codex_commentary(text)
 
     def _on_event(event: Any) -> None:
+        _raise_if_request_cancelled("on_event")
         # TTFB watchdog and activity touch — runs once per SSE event.
         agent._codex_stream_last_event_ts = time.time()
         agent._touch_activity("receiving stream response")
@@ -1264,6 +1314,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
+        _raise_if_request_cancelled("before_retry")
 
         intercepted_events = []
         writer_token = {"value": None}
@@ -1274,11 +1325,13 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             return active_client.responses.create(**stream_kwargs)
 
         def _codex_stream_created(_raw_stream: Any) -> None:
+            _raise_if_request_cancelled("stream_created")
             # Claim the delta sink for THIS physical attempt. A newer attempt
             # supersedes this token and fences late deltas out of the turn.
             writer_token["value"] = claim_stream_writer(agent)
 
         def _accept_codex_chunk(_chunk: Any) -> bool:
+            _raise_if_request_cancelled("accept_chunk")
             token = writer_token["value"]
             if token is None or stream_writer_is_current(agent, token):
                 return True
@@ -1331,6 +1384,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             _httpx.ConnectError,
             ConnectionError,
         ) as exc:
+            _raise_if_request_cancelled("open_stream_retry")
             if attempt < max_stream_retries:
                 logger.debug(
                     "Codex Responses stream connect failed (attempt %s/%s); "
@@ -1366,6 +1420,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     interrupt_check=_interrupt_or_superseded,
                 )
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
+                _raise_if_request_cancelled("consume_retry")
                 if attempt < max_stream_retries:
                     logger.debug(
                         "Codex Responses stream transport failed mid-iteration "
@@ -1377,6 +1432,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 raise
             except RuntimeError:
                 if event_stream.final_response is not None:
+                    _raise_if_request_cancelled("final_response_fallback")
                     return event_stream.final_response
                 raise
 
@@ -1386,7 +1442,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             # finalizer — must NOT discard it or trigger a new physical
             # request. Record it as a non-fatal finalization warning and
             # still return the already-completed, already-billed response.
-            if not agent._interrupt_requested:
+            if not agent._interrupt_requested and not _codex_request_cancelled():
                 try:
                     for _ignored in event_stream:
                         pass
@@ -1399,6 +1455,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         agent._client_log_context(), exc,
                     )
 
+            _raise_if_request_cancelled("before_return")
             if final.status in {"incomplete", "failed"}:
                 logger.warning(
                     "Codex Responses stream terminal status=%s "

--- a/contributors/emails/stefan@noble-pro.com
+++ b/contributors/emails/stefan@noble-pro.com
@@ -1,0 +1,1 @@
+stefanpieter

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -17,10 +17,12 @@ stall.
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 # Stub optional heavy imports so run_agent imports cleanly in isolation.
@@ -55,10 +57,6 @@ def _make_codex_agent(tmp_path, monkeypatch):
         agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0
     )
     return agent
-
-
-
-
 
 
 def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
@@ -108,8 +106,6 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
-
-
 def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     """Once a stream event has arrived, a generation that runs past the TTFB
     cutoff is NOT killed by the watchdog — it completes normally."""
@@ -148,12 +144,6 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     assert "codex_ttfb_kill" not in closes
 
 
-
-
-
-
-
-
 @pytest.mark.parametrize(
     "stale_timeout",
     [float("inf"), float("-inf"), float("nan")],
@@ -176,10 +166,6 @@ def test_wait_notice_omits_reconnect_when_all_deadlines_are_non_finite(
     )
 
     assert recovery == ""
-
-
-
-
 
 
 def test_moa_heartbeat_survives_infinite_stale_timeout(monkeypatch):
@@ -285,14 +271,6 @@ def test_wait_notice_formatting_error_does_not_abort_request(monkeypatch):
     assert result is response
 
 
-
-
-
-
-
-
-
-
 def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkeypatch):
     """#64507 regression: a large Codex request (TTFB watchdog disabled by the
     size gate, stale floor *raised*) that never emits a single byte must still
@@ -347,5 +325,164 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
         stop["flag"] = True
 
 
+def test_ttfb_abandoned_worker_cannot_supersede_replacement_request(
+    tmp_path, monkeypatch
+):
+    """A watchdog-abandoned Codex worker must not reclaim writer ownership via
+    run_codex_stream's inner retry after the outer layer has already started a
+    replacement request.
 
+    Timeline pinned here:
+    1. Request A opens a physical stream that never emits a first byte.
+    2. The TTFB watchdog aborts A and returns to the caller after the 2s join.
+    3. Replacement request B starts and claims the single-writer token.
+    4. The abandoned A worker finally sees its transport error.
+    5. Buggy behavior: A performs the inner retry, reclaims the writer token,
+       emits stale deltas, and fences B out before B reaches its terminal
+       response.
 
+    The fix must stop A before step 5: no inner retry, no stale deltas, B keeps
+    the writer token and consumes its terminal response.
+    """
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.2")
+
+    delivered: list[str] = []
+    setattr(agent, "stream_delta_callback", lambda text: delivered.append(text))
+    setattr(agent, "_stream_callback", None)
+
+    a_retry_started = threading.Event()
+    a_retry_finished = threading.Event()
+
+    def _event(event_type, **fields):
+        return SimpleNamespace(type=event_type, **fields)
+
+    class _AbortThenTimeoutStream:
+        def __init__(self, abort_event: threading.Event):
+            self._abort_event = abort_event
+            self._raised = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._raised:
+                raise StopIteration
+            assert self._abort_event.wait(timeout=5.0), "watchdog never aborted request A"
+            self._raised = True
+            # Outlive interruptible_api_call's fixed 2s join so the outer layer
+            # abandons this worker before the inner retry path wakes up.
+            time.sleep(2.05)
+            raise httpx.ReadTimeout("request A transport aborted")
+
+        def close(self):
+            self._abort_event.set()
+
+    class _A2RetryStream:
+        def __init__(self):
+            self._step = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self._step += 1
+            if self._step == 1:
+                return _event("response.output_text.delta", delta="A2")
+            if self._step == 2:
+                return _event(
+                    "response.completed",
+                    response=SimpleNamespace(
+                        id="resp_a2", status="completed", output=[], usage=None
+                    ),
+                )
+            a_retry_finished.set()
+            raise StopIteration
+
+        def close(self):
+            a_retry_finished.set()
+
+    class _ReplacementStream:
+        def __init__(self):
+            self._step = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self._step += 1
+            if self._step == 1:
+                return _event("response.output_text.delta", delta="B1")
+            if self._step == 2:
+                # Give the abandoned A worker a small window to attempt the
+                # buggy inner retry. Under the fix no retry ever starts, so we
+                # simply continue to B's tail delta and terminal event.
+                a_retry_started.wait(timeout=0.75)
+                return _event("response.output_text.delta", delta="B2")
+            if self._step == 3:
+                return _event(
+                    "response.completed",
+                    response=SimpleNamespace(
+                        id="resp_b", status="completed", output=[], usage=None
+                    ),
+                )
+            raise StopIteration
+
+        def close(self):
+            return None
+
+    class _FakeRequestClient:
+        def __init__(self, logical_name: str):
+            self.logical_name = logical_name
+            self.abort_event = threading.Event()
+            self._attempt = 0
+            self.responses = SimpleNamespace(create=self._create)
+
+        def _create(self, **_kwargs):
+            self._attempt += 1
+            if self.logical_name == "A":
+                if self._attempt == 1:
+                    return _AbortThenTimeoutStream(self.abort_event)
+                if self._attempt == 2:
+                    a_retry_started.set()
+                    return _A2RetryStream()
+                raise AssertionError(f"unexpected A attempt {self._attempt}")
+            if self.logical_name == "B":
+                if self._attempt == 1:
+                    return _ReplacementStream()
+                raise AssertionError(f"unexpected B attempt {self._attempt}")
+            raise AssertionError(f"unknown logical request {self.logical_name}")
+
+    client_order = iter(["A", "B"])
+
+    monkeypatch.setattr(
+        agent,
+        "_create_request_openai_client",
+        lambda **_kwargs: _FakeRequestClient(next(client_order)),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda client, reason=None: client.abort_event.set(),
+    )
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_buffer_status", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_emit_status", lambda *a, **k: None)
+
+    with pytest.raises(TimeoutError):
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "request A"})
+
+    replacement = h.interruptible_api_call(
+        agent, {"model": "gpt-5.5", "input": "request B"}
+    )
+    assert replacement is not None
+
+    if a_retry_started.is_set():
+        assert a_retry_finished.wait(timeout=2.0), "abandoned retry never finished"
+
+    assert not a_retry_started.is_set(), "abandoned request A retried after watchdog timeout"
+    assert delivered == ["B1", "B2"]
+    assert replacement.output_text == "B1B2"
+    assert replacement.id == "resp_b"


### PR DESCRIPTION
## What does this PR do?

Fixes a Codex retry race where a watchdog-abandoned request worker can wake up later inside `run_codex_stream(...)`, perform an inner retry, reclaim the single-writer token, and invalidate the legitimate replacement request.

This change adds a request-local cancellation scope for watchdog-managed `codex_responses` calls and teaches `run_codex_stream(...)` to bail out once the logical request has already been cancelled.

## Related Issue

Follow-up to #65991: this closes a residual logical-request ownership race in the watchdog/inner-retry path. Related symptom report: #69486, but this PR does not claim to fix that issue's separate active-Relay Telegram delivery path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a request-local cancellation scope around watchdog-managed `codex_responses` worker dispatch in `agent/chat_completion_helpers.py`
- set the logical-request cancellation flag before TTFB, stream-idle, stale-call, and explicit interrupt aborts close the request-local client
- guard `run_codex_stream(...)` against continuing after logical cancellation:
  - before inner retry
  - before claiming writer ownership
  - before consuming chunks
  - before returning fallback / terminal responses
- add a deterministic regression in `tests/agent/test_codex_ttfb_watchdog.py` that reproduces the stale-worker retry ownership race
- preserve the existing #65991 single-writer fence and direct callers with no cancellation scope installed

## How to Test

1. Reproduce the new regression guard:
   - `bash scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py -k abandoned_worker_cannot_supersede_replacement_request -q`
2. Verify adjacent invariants still hold:
   - `bash scripts/run_tests.sh tests/run_agent/test_stream_single_writer_65991.py -q`
   - `bash scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -q`
   - `bash scripts/run_tests.sh tests/agent/test_cascading_interrupt_6600.py -q`
   - `bash scripts/run_tests.sh tests/run_agent/test_request_client_reuse_abort_races.py -q`
3. Run the focused full-file slice and lint:
   - `bash scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py -q`
   - `.venv/bin/ruff check agent/chat_completion_helpers.py agent/codex_runtime.py tests/agent/test_codex_ttfb_watchdog.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted local verification after rebasing onto current `origin/main` (`fdc342c082c837847ca8de4a77d489f36a4af354`):
- submitted head: `25ef289ef0f3ed0550b4e10e9691bc7e48ef3087`
- independently reviewed feature commit: `bf0bd53024442bed4a63c1ba53328bba5c3bbc02`
- final commit adds only the repository-required `stefan@noble-pro.com -> stefanpieter` contributor mapping
- feature patch SHA-256 (excluding the attribution-only final commit): `68b945a04bc5207bacfff2b5f7aba80cab889448a673e26c4078edcc14127555`
- focused test/lint slice passed locally
- two fresh standalone Technical Validators passed on the rebased feature commit; the final submitted commit changes only contributor attribution metadata
