### PR TITLE
fix(api): bind workspace header per API session

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -987,7 +987,9 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, X-Hermes-Workspace"
+    ),
 }
 
 
@@ -1255,9 +1257,16 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    context: Optional[Dict[str, Any]] = None,
+) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
+    if context:
+        subset.update(context)
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
@@ -2042,6 +2051,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # (e.g. ``agent:main:webui:dm:user-42``) while staying small enough
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
+    _MAX_WORKSPACE_HEADER_LEN = 4096
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -2094,6 +2104,41 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         return raw, None
+
+    def _parse_workspace_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Extract ``X-Hermes-Workspace`` as an existing absolute directory."""
+        raw = request.headers.get("X-Hermes-Workspace", "").strip()
+        if not raw:
+            return None, None
+        if re.search(r"[\r\n\x00]", raw) or len(raw) > self._MAX_WORKSPACE_HEADER_LEN:
+            return None, web.json_response(
+                _openai_error("Invalid workspace header", code="invalid_workspace"),
+                status=400,
+            )
+        try:
+            workspace = Path(raw).expanduser()
+            if not workspace.is_absolute():
+                raise ValueError
+            workspace = workspace.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            return None, web.json_response(
+                _openai_error(
+                    "X-Hermes-Workspace must be an existing absolute directory",
+                    code="invalid_workspace",
+                ),
+                status=400,
+            )
+        if not workspace.is_dir():
+            return None, web.json_response(
+                _openai_error(
+                    "X-Hermes-Workspace must be a directory",
+                    code="invalid_workspace",
+                ),
+                status=400,
+            )
+        return str(workspace), None
 
     # ------------------------------------------------------------------
     # Session DB helper
@@ -3064,6 +3109,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "workspace_header": "X-Hermes-Workspace",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -3890,6 +3936,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if limited is not None:
             return limited
 
+        workspace_cwd, workspace_err = self._parse_workspace_header(request)
+        if workspace_err is not None:
+            return workspace_err
+
         # Parse request body
         try:
             body = await request.json()
@@ -4114,6 +4164,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                workspace_cwd=workspace_cwd,
                 **agent_overrides,
                 route=route,
             ))
@@ -4135,6 +4186,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                workspace_cwd=workspace_cwd,
                 **agent_overrides,
                 route=route,
             )
@@ -4144,6 +4196,7 @@ class APIServerAdapter(BasePlatformAdapter):
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                context={"workspace": workspace_cwd},
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -5052,6 +5105,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if limited is not None:
             return limited
 
+        workspace_cwd, workspace_err = self._parse_workspace_header(request)
+        if workspace_err is not None:
+            return workspace_err
+
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
@@ -5225,6 +5282,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                workspace_cwd=workspace_cwd,
                 **agent_overrides,
                 route=route,
             ))
@@ -5260,6 +5318,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                workspace_cwd=workspace_cwd,
                 **agent_overrides,
                 route=route,
             )
@@ -5278,6 +5337,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "model_options",
                     "tools",
                 ],
+                context={"workspace": workspace_cwd},
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -5927,6 +5987,7 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        cwd: str = "",
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
@@ -5945,11 +6006,25 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         from gateway.session_context import set_session_vars
 
+        session_cwd = cwd
+        if not session_cwd and session_id:
+            from tools.terminal_tool import get_session_cwd
+
+            session_cwd = get_session_cwd(session_id) or ""
+        if session_cwd and session_id:
+            from tools.terminal_tool import record_session_cwd
+
+            # API sessions share the default terminal environment, so updating
+            # its cwd here would move another session's active workspace.
+            # Commands and file tools resolve the raw session record directly.
+            record_session_cwd(session_id, session_cwd)
+
         return set_session_vars(
             platform="api_server",
             chat_id=chat_id,
             session_key=session_key,
             session_id=session_id,
+            cwd=session_cwd,
             async_delivery=False,
             cron_session="",
         )
@@ -5966,6 +6041,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        workspace_cwd: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -6014,6 +6090,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    cwd=workspace_cwd or "",
                 )
                 agent = None
                 try:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -356,6 +356,77 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    @pytest.mark.parametrize("workspace_source", ["header", "recorded"])
+    def test_bind_workspace_does_not_mutate_shared_terminal_env(
+        self, adapter, tmp_path, monkeypatch, workspace_source
+    ):
+        """API workspace binding must not move another session's shared env."""
+        from gateway.session_context import clear_session_vars
+        from tools import terminal_tool
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        session_id = "workspace-session"
+        shared_env = types.SimpleNamespace(cwd=str(tmp_path / "other-session"))
+        monkeypatch.setattr(terminal_tool, "_active_environments", {"default": shared_env})
+        monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+        monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+
+        if workspace_source == "recorded":
+            terminal_tool.record_session_cwd(session_id, str(workspace))
+
+        tokens = adapter._bind_api_server_session(
+            session_id=session_id,
+            cwd=str(workspace) if workspace_source == "header" else "",
+        )
+        try:
+            assert terminal_tool.get_session_cwd(session_id) == str(workspace)
+            assert shared_env.cwd == str(tmp_path / "other-session")
+        finally:
+            clear_session_vars(tokens)
+
+    @pytest.mark.asyncio
+    async def test_run_agent_binds_workspace_for_context_and_tools(self, adapter, tmp_path):
+        """An API workspace must reach prompt, file, and terminal resolution."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        session_id = "workspace-session"
+        captured = {}
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def _capture_workspace(*, task_id, **_kwargs):
+            from agent.runtime_cwd import resolve_agent_cwd
+            from tools.file_tools import _resolve_path_for_task
+            from tools.terminal_tool import get_session_cwd
+
+            captured["context"] = resolve_agent_cwd()
+            captured["file"] = _resolve_path_for_task("src/main.py", task_id)
+            captured["terminal"] = get_session_cwd(task_id)
+            return {"final_response": "ok"}
+
+        mock_agent.run_conversation.side_effect = _capture_workspace
+        try:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                await adapter._run_agent(
+                    user_message="hello",
+                    conversation_history=[],
+                    session_id=session_id,
+                    workspace_cwd=str(workspace),
+                )
+        finally:
+            from tools.terminal_tool import clear_task_env_overrides
+
+            clear_task_env_overrides(session_id)
+
+        assert captured == {
+            "context": workspace,
+            "file": workspace / "src" / "main.py",
+            "terminal": str(workspace),
+        }
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
@@ -872,6 +943,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["run_events_sse"] is True
             assert data["features"]["model_options"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
+            assert data["features"]["workspace_header"] == "X-Hermes-Workspace"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["model_options"] == {"method": "GET", "path": "/api/model/options"}
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
@@ -2436,6 +2508,61 @@ class TestSessionKeyHeader:
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
 
 
+class TestWorkspaceHeader:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("path", "payload"),
+        [
+            (
+                "/v1/chat/completions",
+                {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            ),
+            (
+                "/v1/responses",
+                {"model": "hermes-agent", "input": "hi", "store": False},
+            ),
+        ],
+    )
+    async def test_workspace_header_reaches_openai_endpoints(
+        self, adapter, tmp_path, path, payload
+    ):
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        request = MagicMock()
+        request.headers = {"X-Hermes-Workspace": str(workspace)}
+        request.json = AsyncMock(return_value=payload)
+        handler = (
+            adapter._handle_chat_completions
+            if path == "/v1/chat/completions"
+            else adapter._handle_responses
+        )
+
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (
+                mock_result,
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+            resp = await handler(request)
+
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["workspace_cwd"] == str(workspace.resolve())
+
+    @pytest.mark.asyncio
+    async def test_workspace_header_rejects_relative_directory(self, adapter):
+        request = MagicMock()
+        request.headers = {"X-Hermes-Workspace": "relative-project"}
+        request.json = AsyncMock(
+            return_value={"messages": [{"role": "user", "content": "hi"}]}
+        )
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            resp = await adapter._handle_chat_completions(request)
+
+        assert resp.status == 400
+        assert json.loads(resp.body)["error"]["code"] == "invalid_workspace"
+        mock_run.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Per-client model routing (model_routes)
 # ---------------------------------------------------------------------------
@@ -2859,4 +2986,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-


### PR DESCRIPTION
## What changed and why

Per the follow-up analysis on 2026-08-03, adds the `X-Hermes-Workspace` header to `/v1/chat/completions` and `/v1/responses`. The header accepts only existing absolute directories, then binds the existing request-local cwd and raw session task workspace so context discovery, file tools, terminal tools, and project-mode code execution resolve consistently. The workspace participates in idempotency fingerprints, is advertised through capabilities, and is allowed by configured CORS origins.

## Addressing maintainer feedback

- #17839 is closed unmerged; this salvages its header transport without its process-global `TERMINAL_CWD` mutation.
- #29265 is closed and scoped to QQBot/Weixin, so this remains confined to the OpenAI-compatible API server.
- #4431 remains open as the broader per-chat configuration request; this supplies only the concrete API workspace transport.
- #19292 is closed and provides session-cwd metadata; this uses the existing session/task cwd mechanisms rather than adding new persistence.
- #35028 is merged and #24882, #24969, and #27383 are closed by its global-CWD work; this addresses the remaining request-local isolation gap.

## How to test

- Send either OpenAI-compatible request with `X-Hermes-Workspace: /absolute/project/path` and confirm context files plus relative file, terminal, and project-mode code-execution paths use that project.
- Run `pytest tests/gateway/test_api_server.py::TestAgentExecution::test_run_agent_binds_workspace_for_context_and_tools tests/gateway/test_api_server.py::TestWorkspaceHeader -q --timeout=60`.

## What platforms tested on

- macOS (Darwin): targeted tests pass. The full suite command was also invoked; this sandbox prevents aiohttp from binding loopback test ports, so socket-based API tests need a normal development environment.

Refs #29531

<!-- autocontrib:worker-id=issue-followup-f4cf819d kind=pr-open -->