### PR TITLE
fix(cron): stop the lifecycle guard crashing on NUL-byte path tokens

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -171,7 +171,16 @@ def contains_launchctl_submit_command(command: str) -> bool:
 
 
 def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+    # ``Path.expanduser`` raises ValueError (not OSError) when the leading
+    # segment carries an embedded NUL — e.g. a "~\0/x.sh" token produced by
+    # tokenizing a binary's decoded bytes. Such a token cannot name a real
+    # script, so fall back to the raw path instead of crashing the guard and
+    # taking down the whole terminal call (#76762 sibling).
+    path = Path(candidate)
+    try:
+        path = path.expanduser()
+    except ValueError:
+        pass
     if not path.is_absolute():
         path = Path(cwd or Path.cwd()) / path
     return path
@@ -259,6 +268,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     try:
         descriptor = os.open(path, flags)
     except OSError:
+        return None, False
+    except ValueError:
+        # os.open raises ValueError (not OSError) for paths with embedded
+        # NUL bytes. Such a "path" cannot name a real script — treat it as
+        # nothing to scan rather than crashing the whole tool call.
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/cron/test_lifecycle_guard_nul_path.py
+++ b/tests/cron/test_lifecycle_guard_nul_path.py
@@ -1,0 +1,62 @@
+"""Regression: the lifecycle guard must not crash on paths with embedded NULs.
+
+``_iter_referenced_shell_scripts`` tokenizes command text, and a binary's
+decoded bytes can yield tokens carrying NUL characters. Two call sites raised
+``ValueError`` (not ``OSError``) on those tokens and propagated up, killing the
+entire terminal tool call (observed 2026-08-04, sibling of #76762):
+
+* ``_resolve_terminal_script_path`` — ``Path.expanduser()`` raises when the
+  leading ``~`` segment holds a NUL.
+* ``_read_referenced_script`` — ``os.open()`` raises on any NUL in the path.
+
+A token that cannot name a real script must be treated as "nothing to scan",
+never as a crash.
+"""
+
+from pathlib import Path
+
+from cron.lifecycle_guard import (
+    _read_referenced_script,
+    _resolve_terminal_script_path,
+    contains_gateway_lifecycle_command_or_referenced_script,
+)
+
+# Built at runtime so this source file stays free of literal NUL bytes.
+NUL = chr(0)
+
+
+class TestEmbeddedNullPath:
+    def test_resolve_script_path_survives_nul_in_tilde_segment(self):
+        # Path.expanduser() raises ValueError here; the guard must not.
+        resolved = _resolve_terminal_script_path(f"~{NUL}/evil.sh", "/tmp")
+        assert isinstance(resolved, Path)
+
+    def test_read_referenced_script_returns_nothing_for_nul_path(self):
+        text, unsafe = _read_referenced_script(Path(f"/tmp/has{NUL}nul.sh"))
+        assert text is None
+        assert unsafe is False
+
+    def test_guard_does_not_raise_on_nul_in_tilde_token(self):
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash ~{NUL}/evil.sh"
+        )
+        assert result is False
+
+    def test_guard_does_not_raise_on_bare_nul_tilde_token(self):
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"~{NUL}/evil.sh"
+        )
+        assert result is False
+
+    def test_guard_does_not_raise_on_nul_in_absolute_token(self):
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"bash /tmp/evil{NUL}script.sh"
+        )
+        assert result is False
+
+    def test_real_lifecycle_command_still_blocked(self):
+        # The NUL tolerance must not weaken the guard itself.
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "systemctl --user restart hermes-gateway.service"
+        )
+        assert result is True


### PR DESCRIPTION
## Symptom

A perfectly harmless `terminal` call dies before running anything:

```
ValueError: embedded null byte
  File "cron/lifecycle_guard.py", line 229, in _iter_referenced_shell_scripts
    yield _resolve_terminal_script_path(executable, cwd)
  File "cron/lifecycle_guard.py", line 174, in _resolve_terminal_script_path
    path = Path(candidate).expanduser()
```

The whole tool call is lost — the guard crashes instead of returning a verdict.

## Cause

`_iter_referenced_shell_scripts` tokenizes arbitrary command text, and a binary's decoded bytes can produce tokens carrying NUL characters. Two call sites raise `ValueError` (**not** `OSError`, so the existing `except OSError` handlers miss them) and propagate out of `contains_gateway_lifecycle_command_or_referenced_script`:

| Site | Raising call | Trigger |
|---|---|---|
| `_resolve_terminal_script_path` | `Path.expanduser()` | NUL in the leading `~` segment (`~\0/x.sh`) |
| `_read_referenced_script` | `os.open()` | any NUL in the path |

#76762 hardened `Path.resolve` and the binary-content scan against exactly this class of input; these two siblings were missed.

## Fix

Both sites degrade to "nothing to scan" — the raw path and `(None, False)` respectively — rather than crashing. A token that cannot name a real script was never scannable in the first place.

The guard's blocking behavior is untouched. The test file pins that a genuine lifecycle command is still blocked, so the NUL tolerance can't quietly widen the gate.

## Verification

`tests/cron/test_lifecycle_guard_nul_path.py` — proven RED against current `main`, GREEN with the fix:

```
# origin/main code
5 failed, 1 passed
# with fix
6 passed
```

The 1 pass in the RED run is the "real lifecycle command still blocked" pin — green by design on both sides.

Existing guard suite unaffected: `29 passed` (`pytest tests/cron/ -k "lifecycle or guard"`).

Note: the test builds NUL via `chr(0)` at runtime, so the source file itself contains no literal NUL bytes.
