### PR TITLE
feat(verification): ground analytical prose deliverables at turn-end

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7038,6 +7038,7 @@ def run_conversation(
 
                 try:
                     from agent.verification_stop import (
+                        build_grounding_nudge,
                         build_verify_on_stop_nudge,
                         verify_on_stop_enabled,
                     )
@@ -7048,6 +7049,15 @@ def run_conversation(
                             changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),
                             attempts=getattr(agent, "_verification_stop_nudges", 0),
                         )
+                        if _verify_nudge is None:
+                            # Prose grounding gate: catch analytical deliverables
+                            # (analysis/report/summary) written with no grounding
+                            # reads — the fabrication case the code gate skips.
+                            _verify_nudge = build_grounding_nudge(
+                                changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),
+                                session_messages=messages,
+                                attempts=getattr(agent, "_verification_stop_nudges", 0),
+                            )
                     else:
                         _verify_nudge = None
                 except Exception:

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -270,4 +270,113 @@ def build_verify_on_stop_nudge(
     )
 
 
-__all__ = ["build_verify_on_stop_nudge", "verify_on_stop_enabled"]
+# ── Prose grounding gate ──────────────────────────────────────────────────
+# The code-verification gate above intentionally drops prose/markdown (a README
+# or SKILL.md has nothing to compile). But that leaves analytical prose
+# deliverables — analysis reports, research briefs, audits, summaries — with no
+# automated truth-check, which is exactly where a model can fabricate: write a
+# confident "analysis" of files it never read. This gate closes that hole with a
+# mechanically-checkable heuristic: if a turn produced an ANALYTICAL prose
+# deliverable but the whole session made ZERO read/search/fetch/shell tool calls,
+# nothing was actually inspected, so nudge the model to ground its claims (or
+# mark them unverified) before finishing. Any grounding activity at all → stay
+# silent. Bounded + fail-safe, mirroring ``build_verify_on_stop_nudge``.
+
+_ANALYTICAL_DELIVERABLE_MARKERS = (
+    "analysis", "analyse", "analyze", "report", "finding", "audit", "review",
+    "assessment", "assess", "summary", "research", "brief", "evaluation",
+    "investigation", "result", "comparison", "benchmark",
+)
+
+# Substrings marking a tool call as genuine grounding (reading/fetching real
+# data), compared against the lowercased tool-call function name.
+_GROUNDING_TOOL_MARKERS = (
+    "read", "search", "grep", "glob", "fetch", "web", "http", "curl", "ssh",
+    "terminal", "shell", "bash", "find", "list_", "view", "browse", "open_file",
+    "cat", "download", "scrape", "crawl", "lookup", "query",
+)
+
+# Tool-name substrings that are writes/control, never grounding — checked first
+# so e.g. ``kanban_list`` or ``write_file`` never count as "inspected a source".
+_NON_GROUNDING_TOOL_HINTS = (
+    "kanban", "write", "patch", "create", "edit", "complete", "apply", "delete",
+    "commit", "push",
+)
+
+
+def _analytical_prose_deliverables(paths: Iterable[str]) -> list[str]:
+    """Prose files whose name implies factual claims about external material."""
+    out: list[str] = []
+    for raw in paths:
+        if not raw or not _is_non_code_path(raw):
+            continue
+        name = Path(str(raw)).name.lower()
+        if any(marker in name for marker in _ANALYTICAL_DELIVERABLE_MARKERS):
+            out.append(str(raw))
+    return sorted(set(out))
+
+
+def _session_did_grounding(session_messages) -> bool:
+    """True if any assistant turn called a read/search/fetch/shell tool."""
+    try:
+        for msg in session_messages or []:
+            if not isinstance(msg, dict):
+                continue
+            for tc in (msg.get("tool_calls") or []):
+                if not isinstance(tc, dict):
+                    continue
+                fn = str(((tc.get("function") or {}).get("name") or "")).lower()
+                if not fn:
+                    continue
+                if any(hint in fn for hint in _NON_GROUNDING_TOOL_HINTS):
+                    continue
+                if any(marker in fn for marker in _GROUNDING_TOOL_MARKERS):
+                    return True
+    except Exception:
+        # Fail-safe: on any inspection error, assume grounded and never nudge.
+        return True
+    return False
+
+
+def build_grounding_nudge(
+    *,
+    changed_paths: Iterable[str],
+    session_messages,
+    attempts: int = 0,
+    max_attempts: int = 2,
+) -> "str | None":
+    """Return a follow-up when an analytical prose deliverable lacks grounding.
+
+    Complements :func:`build_verify_on_stop_nudge` (the code path). Returns
+    ``None`` — stay silent — unless a turn produced an analysis/report/summary
+    -type prose file AND the session performed no read/search/fetch/shell tool
+    call. Bounded by ``attempts``; every failure mode returns ``None`` so it can
+    never break the stop loop or fire spuriously on error.
+    """
+    try:
+        if attempts >= max_attempts:
+            return None
+        deliverables = _analytical_prose_deliverables(changed_paths)
+        if not deliverables:
+            return None
+        if _session_did_grounding(session_messages):
+            return None
+        return (
+            "[System: This turn wrote an analytical deliverable:\n"
+            f"{_format_changed_paths(deliverables)}\n\n"
+            "but this session made no read, search, or fetch tool call — no "
+            "source material was actually inspected. An analysis, report, or "
+            "summary that is not grounded in real sources is a fabrication risk "
+            "and cannot be trusted.\n\n"
+            "Before finishing: actually read the files or fetch the sources you "
+            "describe (e.g. `read_file`, a search, or a shell command), then "
+            "revise the deliverable so every claim reflects what you truly "
+            "found. If a source is genuinely unreachable, say so explicitly in "
+            "the file rather than inventing its contents. Do not present unread "
+            "material as analyzed.]"
+        )
+    except Exception:
+        return None
+
+
+__all__ = ["build_grounding_nudge", "build_verify_on_stop_nudge", "verify_on_stop_enabled"]

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -294,6 +294,11 @@ _GROUNDING_TOOL_MARKERS = (
     "read", "search", "grep", "glob", "fetch", "web", "http", "curl", "ssh",
     "terminal", "shell", "bash", "find", "list_", "view", "browse", "open_file",
     "cat", "download", "scrape", "crawl", "lookup", "query",
+    # execute_code is terminal-class (see agent/display.py, which groups it with
+    # "terminal") and can read files exactly as a shell can, so excluding it while
+    # including "terminal" would nudge a genuinely grounded session. "vision"
+    # covers vision_analyze, the image-reading tool surfaced in every session.
+    "execute_code", "vision",
 )
 
 # Tool-name substrings that are writes/control, never grounding — checked first

--- a/tests/agent/test_prose_grounding_gate.py
+++ b/tests/agent/test_prose_grounding_gate.py
@@ -1,0 +1,74 @@
+"""Tests for the prose grounding gate (agent.verification_stop.build_grounding_nudge)."""
+from agent.verification_stop import build_grounding_nudge
+
+
+def _tc(name):
+    return {"tool_calls": [{"function": {"name": name, "arguments": "{}"}}]}
+
+
+def test_fabrication_analytical_prose_no_grounding_nudges():
+    r = build_grounding_nudge(
+        changed_paths=["/w/analysis.md"],
+        session_messages=[_tc("write_file"), _tc("kanban_complete")],
+    )
+    assert r and "analytical deliverable" in r
+
+
+def test_grounded_read_file_is_silent():
+    r = build_grounding_nudge(
+        changed_paths=["/w/analysis.md"],
+        session_messages=[_tc("read_file"), _tc("write_file")],
+    )
+    assert r is None
+
+
+def test_grounded_terminal_is_silent():
+    r = build_grounding_nudge(
+        changed_paths=["/w/report.md"],
+        session_messages=[_tc("terminal"), _tc("write_file")],
+    )
+    assert r is None
+
+
+def test_grounded_web_search_is_silent():
+    r = build_grounding_nudge(
+        changed_paths=["/w/research-brief.md"],
+        session_messages=[_tc("web_search")],
+    )
+    assert r is None
+
+
+def test_non_analytical_prose_is_silent():
+    r = build_grounding_nudge(
+        changed_paths=["/w/README.md"], session_messages=[_tc("write_file")]
+    )
+    assert r is None
+
+
+def test_code_file_is_silent():
+    r = build_grounding_nudge(
+        changed_paths=["/w/main.py"], session_messages=[_tc("write_file")]
+    )
+    assert r is None
+
+
+def test_bounded_by_attempts():
+    r = build_grounding_nudge(
+        changed_paths=["/w/analysis.md"],
+        session_messages=[_tc("write_file")],
+        attempts=2,
+    )
+    assert r is None
+
+
+def test_kanban_list_is_not_grounding():
+    r = build_grounding_nudge(
+        changed_paths=["/w/findings.md"],
+        session_messages=[_tc("kanban_list"), _tc("write_file")],
+    )
+    assert r and "analytical deliverable" in r
+
+
+def test_empty_session_nudges():
+    r = build_grounding_nudge(changed_paths=["/w/audit-report.md"], session_messages=[])
+    assert r is not None

--- a/tests/agent/test_prose_grounding_gate.py
+++ b/tests/agent/test_prose_grounding_gate.py
@@ -61,6 +61,24 @@ def test_bounded_by_attempts():
     assert r is None
 
 
+def test_grounded_execute_code_is_silent():
+    """execute_code is terminal-class and can read sources; it must count."""
+    r = build_grounding_nudge(
+        changed_paths=["/w/analysis.md"],
+        session_messages=[_tc("execute_code"), _tc("write_file")],
+    )
+    assert r is None
+
+
+def test_grounded_vision_analyze_is_silent():
+    """Inspecting an image IS inspecting source material."""
+    r = build_grounding_nudge(
+        changed_paths=["/w/findings.md"],
+        session_messages=[_tc("vision_analyze"), _tc("write_file")],
+    )
+    assert r is None
+
+
 def test_kanban_list_is_not_grounding():
     r = build_grounding_nudge(
         changed_paths=["/w/findings.md"],


### PR DESCRIPTION
## Summary

`verify_on_stop` only checks executable code — it deliberately skips prose and markdown, since a README has nothing to compile. That leaves analysis, report and summary deliverables with no automated truth-check, which is exactly where a model can fabricate: write a confident "analysis" of files it never opened, and finish unchallenged.

This adds a narrow grounding gate for that case.

## The failure it catches

Found in production. A task — *"deep code analysis of `<repo>`"* — completed and was marked done with a polished `analysis.md`. The analysis was entirely invented: it described a Python project with a `main.py`, while the real repository is TypeScript/Next.js. The model had never read a single file. Nothing in the stop path objected, because the deliverable was prose.

The tell is mechanical and cheap to detect: the session had made **zero** read/search/fetch/shell tool calls. Nothing was inspected, so nothing could have been analyzed.

## What it does

`build_grounding_nudge()` in `agent/verification_stop.py` fires only when **both** hold:

1. the turn wrote a prose file whose name is analytical — `analysis`, `report`, `findings`, `audit`, `review`, `summary`, `research`, `result`, …
2. the session made **no** grounding tool calls at all

It then returns a bounded follow-up asking the model to read its sources, or to mark the claims unverified, before finishing.

Any grounding tool call whatsoever suppresses it, so it stays silent on genuinely grounded work. Kanban/write/patch calls do **not** count as grounding — writing the file is not evidence of having read anything. Creative and non-analytical writing is unaffected, because the filename gate never matches.

Wired as a fallback after the existing code gate in `agent/conversation_loop.py`, reusing the existing `_verification_stop_nudges` counter and finish-reason handling, so it inherits the same bounded-retry semantics rather than inventing new ones.

Fail-safe throughout: every error path returns `None`, so the gate can neither break the stop loop nor fire spuriously.

## Scope — what this does not cover

This sits on the **turn-end stop path**, so it fires when a session stops naturally. It does **not** fire for flows that terminate by calling a completion tool rather than reaching a conversational stop — a kanban worker finishing via `kanban_complete` exits through the tool handler and never reaches this code.

Flagging that explicitly because it would be easy to read this as a universal fabrication guard, and it isn't. Enforcement for tool-terminated flows belongs in the completion tool handler, which is a separate concern from this PR.

## Testing

New `tests/agent/test_prose_grounding_gate.py` — 9 cases: the fabrication case fires; grounded sessions, non-analytical filenames, code deliverables, already-nudged (bounded) turns, and `kanban_list`-is-not-grounding all stay silent.

Existing related suites pass unchanged (`test_verification_stop.py`, `test_verification_stop_caching.py`, `test_verification_evidence.py`, `test_verification_evidence_fd_leak.py`, `test_kanban_stop.py`):

```
37 passed
```

## Risk

The gate only ever adds a bounded follow-up nudge on a turn that produced an analytical prose file from a session with zero grounding calls. It cannot block completion, and it inherits the existing nudge cap, so the worst case is one extra turn on a false positive.