### PR TITLE
Prevent Kanban dispatcher from stranding capacity

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8372,10 +8372,12 @@ def _dispatch_once_locked(
         ).fetchone()[0]
         if in_progress >= max_in_progress:
             return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+        # Both values are live concurrency caps: the loop below compares
+        # ``running_count + spawned`` against ``max_spawn``.  Reducing
+        # ``max_spawn`` to the number of remaining slots would double-count
+        # already-running tasks and leave available capacity unused.
+        if max_spawn is None or max_spawn > max_in_progress:
+            max_spawn = max_in_progress
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1238,6 +1238,32 @@ def _make_task(**overrides) -> "kb.Task":
 # ---------------------------------------------------------------------------
 
 
+def test_dispatch_equal_live_caps_fills_last_available_slot(
+    kanban_home, all_assignees_spawnable
+):
+    """Running tasks count once when max_spawn and max_in_progress match."""
+    with kb.connect_closing() as conn:
+        running_a = kb.create_task(conn, title="running-a", assignee="alice")
+        running_b = kb.create_task(conn, title="running-b", assignee="bob")
+        ready_a = kb.create_task(conn, title="ready-a", assignee="carol")
+        ready_b = kb.create_task(conn, title="ready-b", assignee="dana")
+        assert kb.claim_task(conn, running_a)
+        assert kb.claim_task(conn, running_b)
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args: None,
+            max_spawn=3,
+            max_in_progress=3,
+        )
+
+        assert [task_id for task_id, _assignee, _workspace in result.spawned] == [
+            ready_a
+        ]
+        assert kb.get_task(conn, ready_a).status == "running"
+        assert kb.get_task(conn, ready_b).status == "ready"
+
+
 # Review column dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- preserve `max_spawn` and `max_in_progress` as live concurrency caps
- avoid double-counting already-running tasks when the caps are combined
- add a regression test for two running tasks with both caps set to three

## Root cause

The dispatcher converted `max_in_progress` into a remaining-slot count, then compared that value against `running_count + spawned`. With two workers already running and both caps set to three, the remaining count became one, so the loop saw `2 >= 1` and spawned nothing despite one available slot.

## Impact

Kanban boards now fill available worker capacity when `max_spawn` and `max_in_progress` are equal, while retaining the documented live-concurrency semantics for both limits.

## Validation

- `7 passed` across the focused dispatcher, default-assignee, per-profile-cap, and CLI cap-passthrough tests
- `31 passed` in `tests/hermes_cli/test_kanban_db.py`
- Ruff passes on both changed files
- `git diff --check` passes

The broader Kanban selection reached 155 passing tests with seven unrelated existing environment/configuration failures. `ty` also reports six existing diagnostics outside the changed block.
