### PR TITLE
fix(sessions): escape LIKE wildcards in the cwd-prefix clause

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -172,7 +172,16 @@ def _delegate_from_json(col: str = "model_config") -> str:
 
 def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
-    return "(s.cwd = ? OR s.cwd LIKE ? OR s.cwd LIKE ?)", [prefix, f"{prefix}/%", f"{prefix}\\%"]
+    # ``_`` and ``%`` are LIKE wildcards but ordinary characters in a path
+    # (``my_project``), so an unescaped prefix also matches sibling directories.
+    # Escape the needle and pair it with ESCAPE; the literal separator
+    # backslash in the Windows pattern needs escaping for the same reason. The
+    # ``=`` arm is an exact compare and keeps the raw prefix.
+    esc = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return (
+        "(s.cwd = ? OR s.cwd LIKE ? ESCAPE '\\' OR s.cwd LIKE ? ESCAPE '\\')",
+        [prefix, f"{esc}/%", f"{esc}\\\\%"],
+    )
 
 
 def _workspace_key_clause(key: str) -> Tuple[str, List[str]]:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1068,6 +1068,35 @@ class TestPruneSessionFilters:
 
 
 
+    def test_cwd_prefix_underscore_is_literal_not_a_wildcard(self, db):
+        """``_`` is a LIKE wildcard but an ordinary character in a path, so an
+        unescaped prefix also matched a same-length sibling directory — and
+        prune_sessions deletes what it matches."""
+        self._mk(db, "target", cwd="/home/me/my_project/src")
+        self._mk(db, "sibling", cwd="/home/me/myXproject/src")
+
+        rows = db.list_prune_candidates(cwd_prefix="/home/me/my_project")
+        assert {r["id"] for r in rows} == {"target"}
+
+        pruned = db.prune_sessions(older_than_days=None, cwd_prefix="/home/me/my_project")
+        assert pruned == 1
+        assert db.get_session("sibling") is not None
+
+    def test_cwd_prefix_percent_does_not_select_everything(self, db):
+        self._mk(db, "a", cwd="/home/me/one")
+        self._mk(db, "b", cwd="/home/me/two")
+
+        assert db.list_prune_candidates(cwd_prefix="/home/me/%") == []
+
+    def test_cwd_prefix_still_matches_the_directory_and_its_children(self, db):
+        """Control: the prefix must keep matching itself and anything under it."""
+        self._mk(db, "root", cwd="/home/me/proj")
+        self._mk(db, "child", cwd="/home/me/proj/src")
+        self._mk(db, "outside", cwd="/home/me/other")
+
+        rows = db.list_prune_candidates(cwd_prefix="/home/me/proj")
+        assert {r["id"] for r in rows} == {"root", "child"}
+
     def test_unknown_filter_rejected(self, db):
         import pytest as _pytest
         with _pytest.raises(TypeError):


### PR DESCRIPTION
## What

`_cwd_prefix_clause` builds the "cwd is this directory or somewhere under it" predicate used by session listing, workspace resume, and prune/archive. Both `LIKE` arms bound the raw prefix:

```python
return "(s.cwd = ? OR s.cwd LIKE ? OR s.cwd LIKE ?)", [prefix, f"{prefix}/%", f"{prefix}\\%"]
```

`_` and `%` are LIKE wildcards, and both are ordinary characters in a path. `_` matches any single character, so a same-length sibling directory with children falls inside the pattern. Real `SessionDB`, real SQLite:

```
cwd_prefix="/home/me/my_project"
  main -> ['sibling', 'target']     # sibling is /home/me/myXproject/src
  fix  -> ['target']
```

`prune_sessions()` deletes the rows this clause matches, along with their on-disk transcripts, so pruning one project's sessions takes an unrelated project's history with it. `list_prune_candidates` (which backs `--dry-run` and the confirmation preview) runs through the same builder, so the preview shows the same over-broad set rather than warning about it.

The bare-`%` case is the same class from the other direction — a prefix of `/home/me/%` matches every session under that root.

## The fix

Escape the needle and pair both `LIKE` arms with `ESCAPE '\'` — the convention the rest of `hermes_state.py` already follows for user-derived text. The literal separator backslash in the Windows pattern is escaped for the same reason. The `=` arm is an exact compare and keeps the raw prefix.

Directory-and-children matching is unchanged for prefixes without wildcards: the clause still matches the directory itself and everything below it.

This is the follow-up I flagged in #78681, which escaped the `title_like` / `model_like` / `branch_like` filters and deliberately left this helper alone because it is shared by four call sites beyond prune. The two changes touch `hermes_state.py` in unrelated regions and do not conflict.

## Tests

Added to `TestPruneSessionFilters` in `tests/test_hermes_state.py`:

- a prefix containing `_` selects only the real directory, and `prune_sessions` deletes exactly one session — the same-length sibling survives
- a bare `%` prefix selects nothing
- the prefix still matches the directory itself and its children, and not a neighbour — the guard against over-escaping

Results:

```
181 passed
```

That is the whole file; the 178 pre-existing tests are unchanged and there are no pre-existing failures in it.

Red without the source change:

```
FAILED TestPruneSessionFilters::test_cwd_prefix_underscore_is_literal_not_a_wildcard
E   AssertionError: assert {'sibling', 'target'} == {'target'}
1 failed, 2 passed
```

The two control cases pass on both sides, which is what they are for.