### PR TITLE
fix(tools): exclude node-compile-cache from checkpoint snapshots

### DIFF
--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -1044,3 +1044,51 @@ class TestSessionDiff:
         assert result["success"] is True
         assert "feature.py" in result["diff"]
         assert "+x = 1" in result["diff"]
+
+
+# =========================================================================
+# node-compile-cache exclude tests (#78888)
+# =========================================================================
+
+class TestNodeCompileCacheExclude:
+    def test_default_excludes_contains_node_compile_cache(self):
+        from tools.checkpoint_manager import DEFAULT_EXCLUDES
+        assert "node-compile-cache/" in DEFAULT_EXCLUDES
+
+    def test_ensure_store_excludes_syncs_to_existing_store(self, tmp_path):
+        from tools.checkpoint_manager import _ensure_store_excludes
+        store = tmp_path / "store"
+        info_exclude = store / "info" / "exclude"
+        info_exclude.parent.mkdir(parents=True)
+        info_exclude.write_text("node_modules/\n.cache/\n", encoding="utf-8")
+
+        _ensure_store_excludes(store)
+
+        content = info_exclude.read_text(encoding="utf-8")
+        assert "node-compile-cache/" in content
+
+    def test_checkpoint_ignores_node_compile_cache(self, mgr, work_dir):
+        from tools.checkpoint_manager import _store_path, _ref_name, _project_hash, _run_git
+
+        (work_dir / "app.py").write_text("print('hello')\n")
+        cache_dir = work_dir / "node-compile-cache"
+        cache_dir.mkdir()
+        (cache_dir / "v26.5.1-x64-1234").write_text("cache data\n")
+
+        res = mgr.ensure_checkpoint(str(work_dir), "with cache dir")
+        assert res is True
+
+        checkpoints = mgr.list_checkpoints(str(work_dir))
+        assert len(checkpoints) >= 1
+
+        store = _store_path()
+        ok, files, _ = _run_git(
+            ["ls-tree", "-r", "--name-only", _ref_name(_project_hash(str(work_dir)))],
+            store,
+            str(work_dir),
+        )
+        assert ok
+        tracked_files = set(files.splitlines())
+        assert "app.py" in tracked_files
+        assert not any("node-compile-cache" in f for f in tracked_files)
+

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -95,6 +95,7 @@ DEFAULT_EXCLUDES = [
     ".pytest_cache/",
     ".mypy_cache/",
     ".ruff_cache/",
+    "node-compile-cache/",
     "coverage/",
     ".coverage",
     # Virtualenvs
@@ -418,6 +419,24 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     return legacy_root
 
 
+def _ensure_store_excludes(store: Path) -> None:
+    """Ensure all patterns in DEFAULT_EXCLUDES are present in store/info/exclude."""
+    info_exclude = store / "info" / "exclude"
+    try:
+        if not info_exclude.exists():
+            info_exclude.parent.mkdir(parents=True, exist_ok=True)
+            info_exclude.write_text("\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8")
+            return
+        content = info_exclude.read_text(encoding="utf-8")
+        existing = set(line.strip() for line in content.splitlines() if line.strip())
+        missing = [pat for pat in DEFAULT_EXCLUDES if pat not in existing]
+        if missing:
+            new_content = content.rstrip("\n") + "\n" + "\n".join(missing) + "\n"
+            info_exclude.write_text(new_content, encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not update excludes in checkpoint store %s: %s", store, exc)
+
+
 def _init_store(store: Path, working_dir: str) -> Optional[str]:
     """Initialise the shared shadow store if needed.  Returns error or None.
 
@@ -436,6 +455,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
+        _ensure_store_excludes(store)
         return None
 
     store.mkdir(parents=True, exist_ok=True)
@@ -477,11 +497,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
     _run_git(["config", "tag.gpgSign", "false"], store, cfg_wd)
     _run_git(["config", "gc.auto", "0"], store, cfg_wd)
 
-    info_dir = store / "info"
-    info_dir.mkdir(exist_ok=True)
-    (info_dir / "exclude").write_text(
-        "\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8"
-    )
+    _ensure_store_excludes(store)
 
     logger.debug("Initialised checkpoint store at %s", store)
     return None


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where `node-compile-cache/` in working directories (written by the launcher/desktop backend into `<workdir>/tmp/node-compile-cache/` or `<workdir>/node-compile-cache/`) was not excluded from shadow git checkpoint snapshots. When the compile cache was root-owned or partially written at snapshot time, `git add -A` aborted with `Permission denied (rc=128)`, causing affected working directories to accumulate zero checkpoints.

## Related Issue

Fixes #78888

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

1. **`tools/checkpoint_manager.py`**:
   - Added `"node-compile-cache/"` under `# Caches` in `DEFAULT_EXCLUDES`.
   - Added `_ensure_store_excludes(store: Path)` to automatically append missing `DEFAULT_EXCLUDES` patterns to existing stores' `store/info/exclude` file without requiring store re-initialization.
   - Called `_ensure_store_excludes` inside `_init_store` for both newly created and pre-existing stores (`(store / "HEAD").exists()`).

2. **`tests/tools/test_checkpoint_manager.py`**:
   - Added `TestNodeCompileCacheExclude` test class:
     - `test_default_excludes_contains_node_compile_cache`: verifies pattern presence.
     - `test_ensure_store_excludes_syncs_to_existing_store`: verifies sync logic appends missing pattern to existing stores.
     - `test_checkpoint_ignores_node_compile_cache`: verifies `ensure_checkpoint` succeeds when `node-compile-cache` is present in the workdir and asserts via `git ls-tree` that `node-compile-cache` files are not tracked.

3. **Contributor Attribution**:
   - Added contributor email mapping `StanleyStetson@users.noreply.github.com`.

## Verification

- **Unit Tests:** `uv run pytest tests/tools/test_checkpoint_manager.py -k TestNodeCompileCacheExclude -v` (3 passed in 1.32s).
- **Sweeper Review:** Certified `sweeper:blast-clean` by pre-flight review auditor.
- **Attribution Audit:** `python -X utf8 scripts/audit_pr_attribution.py` (All contributor emails mapped ✅).
- **Linter Fixer:** `npm run fix` executed cleanly (0 errors).
- **Syntax Check:** `python -m py_compile` clean.