### PR TITLE
fix: point Signal setup UI at the native signal-cli daemon

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6172,7 +6172,9 @@ def _setup_signal():
             "    Linux:  download from https://github.com/AsamK/signal-cli/releases"
         )
         print_info("    macOS:  brew install signal-cli")
-        print_info("    Docker: bbernhard/signal-cli-rest-api")
+        print_info(
+            "    Docs:   https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal/"
+        )
         print()
         print_info("  After installing, link your account and start the daemon:")
         print_info('    signal-cli link -n "HermesAgent"')

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7644,8 +7644,8 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     },
     "signal": {
         "name": "Signal",
-        "description": "Connect through a signal-cli REST bridge.",
-        "docs_url": "https://github.com/bbernhard/signal-cli-rest-api",
+        "description": "Connect through the signal-cli HTTP daemon (JSON-RPC over HTTP/SSE).",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal/",
         "env_vars": ("SIGNAL_HTTP_URL", "SIGNAL_ACCOUNT", "SIGNAL_ALLOWED_USERS"),
         "required_env": ("SIGNAL_HTTP_URL", "SIGNAL_ACCOUNT"),
     },
@@ -7875,9 +7875,9 @@ _PLATFORM_ORDER: tuple[str, ...] = (
 # falls back here so the UI can still render a friendly label.
 _MESSAGING_ENV_FALLBACKS: dict[str, dict[str, Any]] = {
     "SIGNAL_HTTP_URL": {
-        "description": "signal-cli REST API base URL, e.g. http://127.0.0.1:8080",
-        "prompt": "Signal bridge URL",
-        "url": "https://github.com/bbernhard/signal-cli-rest-api",
+        "description": "signal-cli HTTP daemon base URL, e.g. http://127.0.0.1:8080",
+        "prompt": "Signal daemon URL",
+        "url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal/",
     },
     "SIGNAL_ACCOUNT": {
         "description": "Signal account phone number registered with the bridge",


### PR DESCRIPTION
## Summary

The gateway Signal adapter only speaks the **native signal-cli HTTP daemon** dialect:

- health check: `GET /api/v1/check`
- inbound messages: `GET /api/v1/events?account=...` (SSE)
- outbound: `POST /api/v1/rpc` (JSON-RPC)

The dashboard Signal channel card, the `SIGNAL_HTTP_URL` env-var hint, and the `hermes gateway setup` wizard all pointed users at the `bbernhard/signal-cli-rest-api` wrapper, which serves a **different** REST API (`/v1/send`, `/v2/send`, `/v1/receive`) and does not implement the daemon endpoints at all.

## Symptom

Following that guide leaves users stuck in an endless reconnect loop:

```
ERROR gateway.platforms.signal: Signal: health check failed (status 404)
WARNING gateway.run: ✗ signal failed to connect
```

`GET /api/v1/check` returns 404 on the wrapper, so the gateway never connects even though `curl /v2/send` works fine.

## Fix

Point the UI copy at the official Signal setup docs (`https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal/`) and describe the endpoint accurately:

- dashboard channel card: description + `docs_url`
- `_MESSAGING_ENV_FALLBACKS` → `SIGNAL_HTTP_URL`: description/prompt + url
- `hermes gateway setup` wizard: replace the misleading "Docker: bbernhard/signal-cli-rest-api" install option with a pointer to the official docs

## Test Plan

- `python3 -m py_compile hermes_cli/web_server.py hermes_cli/gateway.py` passes
- No remaining `bbernhard` / "REST bridge" references in the tree