### PR TITLE
fix(cron): normalize string repeat values

### DIFF
--- a/contributors/emails/builder@local
+++ b/contributors/emails/builder@local
@@ -1,0 +1,2 @@
+sycamoregroupltd
+# fleet integration-builder cron repeat normalization (t_2dac0381)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -404,6 +404,49 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     return normalized
 
 
+def _normalize_repeat_value(repeat: Any) -> Optional[int]:
+    """Normalize the repeat argument from any accepted form into None or int.
+
+    The JSON schema declares ``repeat`` as ``type: integer``, but agents and
+    the ``cronjob`` tool description advertise the concept \"forever\" — which
+    some callers pass as the literal string ``"forever"``.  Normalizing here
+    prevents raw ``TypeError`` at comparison sites and gives clean behaviour.
+
+    Recognised values::
+        None      -> None      (infinite / not set)
+        <int <=0> -> None      (treat zero/negative as infinite)
+        "forever" -> None      (synonyms: "forever", "infinite", "inf", "")
+        >0 int    -> int       (finite recurrence count)
+
+    Raises ValueError for strings that don't match the recognised set.
+    """
+    if repeat is None:
+        return None
+    if isinstance(repeat, str):
+        stripped = repeat.strip().lower()
+        if stripped in ("forever", "infinite", "inf", ""):
+            return None
+        try:
+            value = int(stripped)
+        except ValueError:
+            raise ValueError(
+                f"repeat must be an integer or one of 'forever', 'infinite', "
+                f"'inf', got {repeat!r}"
+            )
+        repeat = value
+    # At this point repeat should be int (or coerceible)
+    try:
+        repeat = int(repeat)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"repeat must be an integer or one of 'forever', 'infinite', 'inf', "
+            f"got {repeat!r} ({type(repeat).__name__})"
+        )
+    if repeat <= 0:
+        return None
+    return repeat
+
+
 def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     """Return a job dict with canonical `skills` and legacy `skill` fields aligned."""
     normalized = dict(job)
@@ -1311,9 +1354,8 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
-    # Normalize repeat: treat 0 or negative values as None (infinite)
-    if repeat is not None and repeat <= 0:
-        repeat = None
+    # Normalize repeat: handle string synonyms ("forever"/"inf") and ints
+    repeat = _normalize_repeat_value(repeat)
 
     # Auto-set repeat=1 for one-shot schedules if not specified
     if parsed_schedule["kind"] == "once" and repeat is None:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -493,6 +493,49 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     return normalized
 
 
+def _normalize_repeat_value(repeat: Any) -> Optional[int]:
+    """Normalize the repeat argument from any accepted form into None or int.
+
+    The JSON schema declares ``repeat`` as ``type: integer``, but agents and
+    the ``cronjob`` tool description advertise the concept \"forever\" — which
+    some callers pass as the literal string ``"forever"``.  Normalizing here
+    prevents raw ``TypeError`` at comparison sites and gives clean behaviour.
+
+    Recognised values::
+        None      -> None      (infinite / not set)
+        <int <=0> -> None      (treat zero/negative as infinite)
+        "forever" -> None      (synonyms: "forever", "infinite", "inf", "")
+        >0 int    -> int       (finite recurrence count)
+
+    Raises ValueError for strings that don't match the recognised set.
+    """
+    if repeat is None:
+        return None
+    if isinstance(repeat, str):
+        stripped = repeat.strip().lower()
+        if stripped in ("forever", "infinite", "inf", ""):
+            return None
+        try:
+            value = int(stripped)
+        except ValueError:
+            raise ValueError(
+                f"repeat must be an integer or one of 'forever', 'infinite', "
+                f"'inf', got {repeat!r}"
+            )
+        repeat = value
+    # At this point repeat should be int (or coerceible)
+    try:
+        repeat = int(repeat)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"repeat must be an integer or one of 'forever', 'infinite', 'inf', "
+            f"got {repeat!r} ({type(repeat).__name__})"
+        )
+    if repeat <= 0:
+        return None
+    return repeat
+
+
 def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     """Return a job dict with canonical `skills` and legacy `skill` fields aligned."""
     normalized = dict(job)
@@ -1906,9 +1949,8 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
-    # Normalize repeat: treat 0 or negative values as None (infinite)
-    if repeat is not None and repeat <= 0:
-        repeat = None
+    # Normalize repeat: handle string synonyms ("forever"/"inf") and ints
+    repeat = _normalize_repeat_value(repeat)
 
     # Auto-set repeat=1 for one-shot schedules if not specified
     if parsed_schedule["kind"] == "once" and repeat is None:

--- a/tests/cron/test_cron_repeat_string_normalization.py
+++ b/tests/cron/test_cron_repeat_string_normalization.py
@@ -1,0 +1,383 @@
+"""Regression tests for cron repeat string normalization (t_cd6a18cc / t_681ebac7).
+
+Covers the defect where ``repeat='forever'`` passed to
+``cronjob(action=create)`` or ``create_job()`` raised a raw TypeError::
+
+    '<=' not supported between instances of 'str' and 'int'
+
+This happened because two code paths compared the ``repeat`` parameter with
+an integer using ``<=`` without first normalising string inputs::
+
+    - cron/jobs.py::create_job  (~line 1315): ``if repeat <= 0:``
+    - tools/cronjob_tools.py::cronjob update path (~line 1003):
+      ``normalized_repeat = None if repeat <= 0 else repeat``
+
+Expected normalisation contract (what both sites must implement)::
+
+    None         -> None   (infinite)
+    <int <=0>    -> None   (zero/negative treated as infinite)
+    "forever"    -> None   (synonym: forever, infinite, inf, "")
+    >0 int       -> int    (finite recurrence count preserved)
+    numeric str  -> int    ("3" -> 3)
+    garbage str  -> ValueError  (clean error message, NOT TypeError)
+
+Tests are written to the RED-GREEN paradigm: on origin/main the unit
+tests for ``_normalize_repeat_value`` will FAIL RED because the helper
+hasn't landed yet; integration tests that call ``cronjob()`` will also
+FAIL because create/update will raise TypeError — once the builder's
+implementation lands, every test should go GREEN.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+# ===========================================================================
+# Direct unit tests for _normalize_repeat_value
+# ===========================================================================
+
+class TestNormalizeRepeatValueDirect:
+    """Unit tests for the shared normalisation helper.
+
+    After the fix lands these exercises ``cron.jobs._normalize_repeat_value``
+    directly. Before landing they are written to document the intended contract
+    and will FAIL RED — confirming the bug still exists.
+    """
+
+    def test_none_passes_through(self):
+        """None maps to None (infinite recurrence)."""
+        from cron.jobs import _normalize_repeat_value
+        assert _normalize_repeat_value(None) is None
+
+    def test_forever_becomes_none(self):
+        """'forever' normalises to None."""
+        from cron.jobs import _normalize_repeat_value
+        assert _normalize_repeat_value("forever") is None
+
+    @pytest.mark.parametrize(
+        "input_val",
+        [
+            "FOREVER",
+            "Forever",
+            "  FOREVER  ",
+            "infinite",
+            "Infinite",
+            "INF",
+            "inf",
+            "",
+            "  ",
+        ],
+    )
+    def test_all_synonyms_map_to_none(self, input_val):
+        """All recognised synonyms (case-insensitive, stripped) yield None."""
+        from cron.jobs import _normalize_repeat_value
+        result = _normalize_repeat_value(input_val)
+        assert result is None, f"{input_val!r} did not map to None"
+
+    def test_zero_int_becomes_none(self):
+        """Integer zero treats as infinite (same old semantics)."""
+        from cron.jobs import _normalize_repeat_value
+        assert _normalize_repeat_value(0) is None
+
+    def test_negative_int_becomes_none(self):
+        """Negative ints treat as infinite."""
+        from cron.jobs import _normalize_repeat_value
+        assert _normalize_repeat_value(-1) is None
+        assert _normalize_repeat_value(-999) is None
+
+    def test_positive_int_preserved(self):
+        """Positive integers pass through unchanged."""
+        from cron.jobs import _normalize_repeat_value
+        assert _normalize_repeat_value(1) == 1
+        assert _normalize_repeat_value(42) == 42
+        assert _normalize_repeat_value(9999) == 9999
+
+    def test_numeric_string_converted_to_int(self):
+        """Numeric strings get converted to int."""
+        from cron.jobs import _normalize_repeat_value
+        assert _normalize_repeat_value("3") == 3
+        assert _normalize_repeat_value("100") == 100
+        assert _normalize_repeat_value("-5") is None  # negative parsed out
+
+    def test_invalid_string_raises_valueerror_not_typeerror(self):
+        """Bogus strings produce ValueError with a helpful message."""
+        from cron.jobs import _normalize_repeat_value
+        with pytest.raises(ValueError, match="repeat must be an integer"):
+            _normalize_repeat_value("bogus")
+        with pytest.raises(ValueError, match="repeat must be an integer"):
+            _normalize_repeat_value("not-a-number")
+
+    def test_float_numeric_coercion(self):
+        """Floats get converted to int (e.g. 3.14 -> 3)."""
+        from cron.jobs import _normalize_repeat_value
+        result = _normalize_repeat_value(3.14)
+        assert result == 3  # numeric coercion accepted
+
+
+# ===========================================================================
+# Integration tests: create_job data-layer with string repeat values
+# ===========================================================================
+
+class TestCreateJobWithStringRepeat:
+    """Data-layer: create_job must accept string repeat without crashing."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        p = tmp_path / "cron"
+        monkeypatch.setattr("cron.jobs.CRON_DIR", p)
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", p / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", p / "output")
+
+    def test_create_with_repeat_forever_string_no_crash(self, tmp_path, monkeypatch):
+        """The original crash vector: repeat='forever' must not raise TypeError."""
+        from cron.jobs import create_job
+
+        job = create_job(prompt="test", schedule="every 1h", repeat="forever")
+        assert job["repeat"]["times"] is None
+        assert job["state"] == "scheduled"
+
+    def test_create_with_repeat_inf(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 2h", repeat="inf")
+        assert job["repeat"]["times"] is None
+
+    def test_create_with_repeat_infinite(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 30m", repeat="infinite")
+        assert job["repeat"]["times"] is None
+
+    def test_create_with_repeat_zero_string(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h", repeat="0")
+        assert job["repeat"]["times"] is None
+
+    def test_create_with_repeat_integer_still_works(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h", repeat=5)
+        assert job["repeat"]["times"] == 5
+
+    def test_create_with_no_repeat_defaults_to_none(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h")
+        assert job["repeat"]["times"] is None
+
+    def test_create_with_numeric_string_repeat(self, tmp_path, monkeypatch):
+        """String '7' should become int 7 in the stored record."""
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h", repeat="7")
+        assert job["repeat"]["times"] == 7
+
+    def test_create_with_invalid_repeat_raises_valueerror(self, tmp_path, monkeypatch):
+        """Invalid strings should raise ValueError, not TypeError."""
+        from cron.jobs import create_job
+        with pytest.raises(ValueError, match="repeat must be an integer"):
+            create_job(prompt="test", schedule="every 1h", repeat="garbagevalue")
+
+
+# ===========================================================================
+# Integration tests: tool cronjob(action=create|update) with string repeat
+# ===========================================================================
+
+class TestCronjobToolWithStringRepeat:
+    """API-layer: cronjob() tool must handle string repeat cleanly.
+
+    Both action='create' and action='update' touch the repeat field and must
+    never expose a raw TypeError to the caller.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        p = tmp_path / "cron"
+        monkeypatch.setattr("cron.jobs.CRON_DIR", p)
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", p / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", p / "output")
+
+    def test_tool_create_repeat_forever_succeeds(self, tmp_path, monkeypatch):
+        """The original crash site via the tool's create path."""
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import load_jobs
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Check server status",
+            schedule="every 1h",
+            name="Server Check",
+            repeat="forever",
+        ))
+        assert result["success"] is True, f"Unexpected error: {result}"
+        # Formatted display shows "forever"
+        assert result["job"]["repeat"] == "forever"
+        # Stored record confirms times=None (infinite)
+        jobs = load_jobs()
+        assert len(jobs) == 1
+        assert jobs[0]["repeat"]["times"] is None
+
+    def test_tool_create_repeat_inf(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create", prompt="x", schedule="every 2h", repeat="inf"
+        ))
+        assert result["success"] is True
+        assert result["job"]["repeat"] == "forever"
+
+    def test_tool_update_repeat_forever_on_existing_job(self, tmp_path, monkeypatch):
+        """Original crash: update path with repeat='forever'.
+
+        This was the second crash site at line ~1003 in cronjob_tools.py.
+        """
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import load_jobs
+
+        # Create with int repeat
+        created = json.loads(cronjob(
+            action="create", prompt="Baseline", schedule="every 1h", repeat=5
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+        assert created["job"]["repeat"] == "5 times"
+
+        # Update to 'forever' — this was the crash site
+        updated = json.loads(cronjob(
+            action="update", job_id=job_id, repeat="forever"
+        ))
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "forever"
+        jobs = load_jobs()
+        assert jobs[0]["repeat"]["times"] is None
+
+    def test_tool_update_repeat_to_zero_string(self, tmp_path, monkeypatch):
+        """Update: change finite repeat to '0' (should become infinite)."""
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(cronjob(
+            action="create", prompt="test", schedule="every 1h", repeat=10
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(
+            action="update", job_id=job_id, repeat="0"
+        ))
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "forever"
+
+    def test_tool_update_repeat_numeric_string(self, tmp_path, monkeypatch):
+        """Update: change repeat from one int to another via numeric string."""
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(cronjob(
+            action="create", prompt="test", schedule="every 1h", repeat=3
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(
+            action="update", job_id=job_id, repeat="50"
+        ))
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "50 times"
+
+    def test_tool_create_invalid_repeat_returns_error_not_crash(self, tmp_path, monkeypatch):
+        """Invalid repeat must return a JSON error object with success=False, not crash."""
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import load_jobs
+
+        result = json.loads(cronjob(
+            action="create", prompt="test", schedule="every 1h", repeat="invalidvalue"
+        ))
+        assert result["success"] is False
+        assert "repeat" in result.get("error", "").lower()
+        # No job persisted
+        jobs = load_jobs()
+        assert len(jobs) == 0
+
+    def test_tool_update_invalid_repeat_returns_error_not_crash(self, tmp_path, monkeypatch):
+        """Update with invalid repeat must also return a clean error."""
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import get_job
+
+        created = json.loads(cronjob(
+            action="create", prompt="test", schedule="every 1h", repeat=3
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(
+            action="update", job_id=job_id, repeat="badrepeat"
+        ))
+        assert updated["success"] is False
+        # Original job must be unchanged
+        stored = get_job(job_id)
+        assert stored is not None
+        assert stored["repeat"]["times"] == 3
+
+
+# ===========================================================================
+# Backward compatibility: existing int-repeat behaviour unchanged
+# ===========================================================================
+
+class TestRepeatIntBackwardCompatibility:
+    """Existing callers passing int repeat values must behave identically."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        p = tmp_path / "cron"
+        monkeypatch.setattr("cron.jobs.CRON_DIR", p)
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", p / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", p / "output")
+
+    def test_create_repeat_1_sets_once(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h", repeat=1)
+        assert job["repeat"]["times"] == 1
+
+    def test_create_repeat_3_preserved(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h", repeat=3)
+        assert job["repeat"]["times"] == 3
+
+    def test_create_repeat_none_means_infinite(self, tmp_path, monkeypatch):
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h", repeat=None)
+        assert job["repeat"]["times"] is None
+
+    def test_create_interval_without_repeat_is_finite(self, tmp_path, monkeypatch):
+        """Interval schedules with no explicit repeat default to None (infinite).
+        One-shot schedules auto-set repeat=1 via the parsed_schedule check.
+        """
+        from cron.jobs import create_job
+        job = create_job(prompt="test", schedule="every 1h")
+        assert job["repeat"]["times"] is None
+
+    def test_update_repeat_int_change(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+        from cron.jobs import load_jobs
+
+        created = json.loads(cronjob(
+            action="create", prompt="test", schedule="every 1h", repeat=3
+        ))
+        assert created["success"] is True
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(
+            action="update", job_id=job_id, repeat=10
+        ))
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "10 times"
+        jobs = load_jobs()
+        assert jobs[0]["repeat"]["times"] == 10
+
+    def test_tool_create_repeat_as_string_digit(self, tmp_path, monkeypatch):
+        """When agents pass repeat='3' (string digit), it works like int 3."""
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create", prompt="test", schedule="every 1h", repeat="3"
+        ))
+        assert result["success"] is True
+        assert result["job"]["repeat"] == "3 times"

--- a/tests/cron/test_repeat_string_normalization.py
+++ b/tests/cron/test_repeat_string_normalization.py
@@ -1,0 +1,273 @@
+"""Tests for repeat value normalization — string synonyms must never crash (t_cd6a18cc).
+
+Regression suite: cronjob(action=create|update) with repeat="forever" (or
+other string synonyms / zero / negative ints) must either create/update a
+job cleanly or return a ValueError, NOT raise a raw TypeError on `<=` comparison.
+
+Fix landed: _normalize_repeat_value() in cron/jobs.py, called from both
+create_job entry point and the tool's update path.
+"""
+
+import json
+import pytest
+
+from cron.jobs import (
+    _normalize_repeat_value,
+    create_job,
+    get_job,
+    load_jobs,
+)
+
+
+# ===========================================================================
+# Direct unit tests for _normalize_repeat_value
+# ===========================================================================
+
+class TestNormalizeRepeatValueDirect:
+    """Unit tests for the normalization helper itself."""
+
+    def test_none_passes_through(self):
+        assert _normalize_repeat_value(None) is None
+
+    def test_string_forever_becomes_none(self):
+        assert _normalize_repeat_value("forever") is None
+
+    def test_string_forever_case_insensitive(self):
+        assert _normalize_repeat_value("FOREVER") is None
+        assert _normalize_repeat_value("Forever") is None
+        assert _normalize_repeat_value("  FOREVER  ") is None
+
+    def test_string_infinite_becomes_none(self):
+        assert _normalize_repeat_value("infinite") is None
+        assert _normalize_repeat_value("Infinite") is None
+
+    def test_string_inf_becomes_none(self):
+        assert _normalize_repeat_value("inf") is None
+
+    def test_empty_string_becomes_none(self):
+        assert _normalize_repeat_value("") is None
+
+    def test_zero_int_becomes_none(self):
+        assert _normalize_repeat_value(0) is None
+
+    def test_negative_int_becomes_none(self):
+        assert _normalize_repeat_value(-1) is None
+        assert _normalize_repeat_value(-42) is None
+
+    def test_zero_string_becomes_none(self):
+        assert _normalize_repeat_value("0") is None
+
+    def test_positive_int_preserved(self):
+        assert _normalize_repeat_value(1) == 1
+        assert _normalize_repeat_value(99) == 99
+
+    def test_numeric_string_converted_to_int(self):
+        assert _normalize_repeat_value("3") == 3
+        assert _normalize_repeat_value("50") == 50
+
+    def test_invalid_string_raises_valueerror(self):
+        with pytest.raises(ValueError, match="repeat must be an integer"):
+            _normalize_repeat_value("notanumber")
+
+    def test_invalid_type_raises_valueerror(self):
+        with pytest.raises(ValueError, match="repeat must be an integer"):
+            _normalize_repeat_value([])
+
+    def test_invalid_type_dict_raises_valueerror(self):
+        with pytest.raises(ValueError, match="repeat must be an integer"):
+            _normalize_repeat_value({"key": "val"})
+
+
+# ===========================================================================
+# Integration tests: create_job with string repeat values
+# ===========================================================================
+
+class TestCreateJobWithStringRepeat:
+    """create_job must accept repeat as string without raising TypeError."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        p = tmp_path / "cron"
+        monkeypatch.setattr("cron.jobs.CRON_DIR", p)
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", p / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", p / "output")
+
+    def test_create_with_repeat_forever_string(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h", repeat="forever")
+        # The raw job record has {"times": None} which means infinite
+        assert job["repeat"]["times"] is None
+        assert job["state"] == "scheduled"
+
+    def test_create_with_repeat_inf_string(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 2h", repeat="inf")
+        assert job["repeat"]["times"] is None
+
+    def test_create_with_repeat_zero_string(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h", repeat="0")
+        assert job["repeat"]["times"] is None
+
+    def test_create_with_repeat_integer_still_works(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h", repeat=5)
+        assert job["repeat"]["times"] == 5
+
+    def test_create_with_no_repeat_default(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h")
+        assert job["repeat"]["times"] is None
+
+    def test_create_interval_no_repeat_is_finite(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h")
+        assert job["repeat"]["times"] is None
+
+
+# ===========================================================================
+# Integration tests: tool cronjob(action=create|update) with string repeat
+# ===========================================================================
+
+class TestCronjobToolWithStringRepeat:
+    """The cronjob() tool must handle string repeat values without crashing.
+
+    Note: the tool's _format_job() outputs "repeat" as a display string
+    via _repeat_display(job), e.g. "forever", "once", "5 times".
+    We assert on the formatted output string AND verify the stored record
+    directly via load_jobs().
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        p = tmp_path / "cron"
+        monkeypatch.setattr("cron.jobs.CRON_DIR", p)
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", p / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", p / "output")
+
+    def test_tool_create_with_repeat_forever(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Server Check",
+                repeat="forever",
+            )
+        )
+        assert result["success"] is True
+        # Formatted output shows "forever" (string display)
+        assert result["job"]["repeat"] == "forever"
+        # Stored record confirms times=None (infinite)
+        jobs = load_jobs()
+        assert len(jobs) == 1
+        assert jobs[0]["repeat"]["times"] is None
+
+    def test_tool_create_with_repeat_inf(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(action="create", prompt="test", schedule="every 2h", repeat="inf")
+        )
+        assert result["success"] is True
+        assert result["job"]["repeat"] == "forever"
+        jobs = load_jobs()
+        assert jobs[0]["repeat"]["times"] is None
+
+    def test_tool_update_with_repeat_forever(self, tmp_path, monkeypatch):
+        """Original crash site: update via tool with repeat='forever'."""
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(action="create", prompt="Baseline", schedule="every 1h", repeat=5)
+        )
+        assert created["success"] is True
+        job_id = created["job_id"]
+        assert created["job"]["repeat"] == "5 times"
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, repeat="forever")
+        )
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "forever"
+        # Verify stored record
+        jobs = load_jobs()
+        assert jobs[0]["repeat"]["times"] is None
+
+    def test_tool_update_with_repeat_zero_string(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(action="create", prompt="test", schedule="every 1h", repeat=10)
+        )
+        assert created["success"] is True
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, repeat="0")
+        )
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "forever"
+        jobs = load_jobs()
+        assert jobs[0]["repeat"]["times"] is None
+
+    def test_tool_create_with_numeric_string_repeat(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(action="create", prompt="test", schedule="every 1h", repeat="3")
+        )
+        assert result["success"] is True
+        assert result["job"]["repeat"] == "3 times"
+
+    def test_tool_invalid_repeat_returns_clean_error(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(
+            cronjob(action="create", prompt="test", schedule="every 1h", repeat="invalidvalue")
+        )
+        assert result["success"] is False
+        assert "repeat must be an integer" in result.get("error", "")
+        # No job should have been persisted
+        jobs = load_jobs()
+        assert len(jobs) == 0
+
+
+# ===========================================================================
+# Backward-compatibility: existing int-repeat behaviour unchanged
+# ===========================================================================
+
+class TestRepeatIntBackwardCompatibility:
+    """Existing callers passing int repeat values must behave identically."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        p = tmp_path / "cron"
+        monkeypatch.setattr("cron.jobs.CRON_DIR", p)
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", p / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", p / "output")
+
+    def test_create_repeat_1_sets_once(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h", repeat=1)
+        assert job["repeat"]["times"] == 1
+
+    def test_create_repeat_3_preserved(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h", repeat=3)
+        assert job["repeat"]["times"] == 3
+
+    def test_create_repeat_none_means_infinite(self, tmp_path, monkeypatch):
+        job = create_job(prompt="test", schedule="every 1h", repeat=None)
+        assert job["repeat"]["times"] is None
+
+    def test_update_repeat_int_change(self, tmp_path, monkeypatch):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(action="create", prompt="test", schedule="every 1h", repeat=3)
+        )
+        assert created["success"] is True
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, repeat=10)
+        )
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "10 times"
+        jobs = load_jobs()
+        assert jobs[0]["repeat"]["times"] == 10

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -51,6 +51,7 @@ from cron.jobs import (
     resolve_job_ref,
     resume_job,
     update_job,
+    _normalize_repeat_value,
 )
 
 
@@ -1609,8 +1610,9 @@ def cronjob(
                         )
                 updates["no_agent"] = target_no_agent
             if repeat is not None:
-                # Normalize: treat 0 or negative as None (infinite)
-                normalized_repeat = None if repeat <= 0 else repeat
+                # Normalize: handle string synonyms ("forever"/"inf") and ints.
+                # Delegated to _normalize_repeat_value so create/update share one path.
+                normalized_repeat = _normalize_repeat_value(repeat)
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state
@@ -1679,8 +1681,11 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "description": "Optional human-friendly name"
             },
             "repeat": {
-                "type": "integer",
-                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring)."
+                "oneOf": [
+                    {"type": "integer"},
+                    {"type": "string", "enum": ["forever"]}
+                ],
+                "description": "Optional repeat count (integer) or the literal string \"forever\" for infinite recurrence. Omit for defaults (once for one-shot, forever for recurring). Acceptable integer values: positive integers for finite repetitions; zero or negative normalizes to infinite (same as omitting). String value: \"forever\", \"infinite\", \"inf\", or empty string all normalize to infinite recurrence."
             },
             "deliver": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -50,6 +50,7 @@ from cron.jobs import (
     resolve_job_ref,
     resume_job,
     update_job,
+    _normalize_repeat_value,
 )
 
 
@@ -999,8 +1000,9 @@ def cronjob(
                         )
                 updates["no_agent"] = target_no_agent
             if repeat is not None:
-                # Normalize: treat 0 or negative as None (infinite)
-                normalized_repeat = None if repeat <= 0 else repeat
+                # Normalize: handle string synonyms ("forever"/"inf") and ints.
+                # Delegated to _normalize_repeat_value so create/update share one path.
+                normalized_repeat = _normalize_repeat_value(repeat)
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state


### PR DESCRIPTION
## t_cd6a18cc DEFECT FIX: cronjob repeat="forever" crashes create_job (TypeError)

### Symptom
`cronjob action=create` with `repeat="forever"` raises raw TypeError on `<=` comparison between str and int.

### Root Cause
- `cron/jobs.py::create_job` (line ~1315): direct comparison `if repeat <= 0` with str arg
- `tools/cronjob_tools.py::cronjob()` update path (line ~1003): same pattern

### Fix
Introduces `_normalize_repeat_value(repeat)` helper that:
- "forever", "infinite", "inf", "" → None (infinite synonyms)
- Integers ≤ 0 → None (preserves existing behavior)
- String integers → converted to int (e.g. "3" → 3)
- Invalid strings → clean ValueError (no more TypeError)

Imported and called from both `create_job` entry point and tool update path.

### Testing
- **30 regression tests** in `tests/cron/test_repeat_string_normalization.py`
- Unit tests: _normalize_repeat_value() direct unit tests
- Integration: create_job(string repeat) end-to-end
- Tool-level: cronjob tool create/update integration
- Backward compatibility: int-repeat, one-shot repeat=1, infinite default

All 30 tests pass green locally.

### Governance
- Review APPROVED by trading-risk-reviewer at t_2520d6f4
- PM delegated unblock: paper-only infra defect, no trading impact, no Frank A3 gate
- Rebased on origin/main@36cb5ae55 for clean merge
