### PR TITLE
fix(cli): support 'k'/'K' version prefix in model sort

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -820,7 +820,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
 
     for ch in rest:
         if state == "start":
-            if ch in "vV":
+            if ch in "vVkK":
                 state = "in_version"
             elif ch.isdigit():
                 state = "in_version"
@@ -864,7 +864,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
             if ch.isdigit():
                 state = "in_version"
                 num_buf = ch
-            elif ch in "vV":
+            elif ch in "vVkK":
                 state = "in_version"
             elif ch in "-_.":
                 pass

--- a/tests/hermes_cli/test_kimi_version_sort.py
+++ b/tests/hermes_cli/test_kimi_version_sort.py
@@ -1,0 +1,46 @@
+"""Regression tests for 'k'/'K' version prefix parsing in _model_sort_key (#78886).
+
+Ensures models prefixed with 'k' or 'K' (e.g., Moonshot Kimi: kimi-k3, kimi-k2.6,
+kimi-k3.5) get their numeric version correctly parsed so higher versions outrank
+lower ones when sorting catalog search results.
+"""
+
+from hermes_cli.model_switch import _model_sort_key
+
+
+class TestKimiVersionSort:
+    def test_k_version_parsing_keys(self):
+        p = "moonshotai/kimi"
+        key_k3 = _model_sort_key("moonshotai/kimi-k3", p)
+        key_k26 = _model_sort_key("moonshotai/kimi-k2.6", p)
+        key_k35 = _model_sort_key("moonshotai/kimi-k3.5", p)
+
+        assert key_k3[0] == -3.0
+        assert key_k26[0] == -2.6
+        assert key_k35[0] == -3.5
+
+    def test_k_version_ordering(self):
+        p = "moonshotai/kimi"
+
+        # kimi-k3 outranks kimi-k2.6
+        models1 = ["moonshotai/kimi-k2.6", "moonshotai/kimi-k3"]
+        models1.sort(key=lambda m: _model_sort_key(m, p))
+        assert models1[0] == "moonshotai/kimi-k3"
+
+        # kimi-k3.5 outranks kimi-k2.6
+        models2 = ["moonshotai/kimi-k2.6", "moonshotai/kimi-k3.5"]
+        models2.sort(key=lambda m: _model_sort_key(m, p))
+        assert models2[0] == "moonshotai/kimi-k3.5"
+
+    def test_capital_k_version_parsing(self):
+        p = "kimi"
+        key_k3 = _model_sort_key("kimi-K3", p)
+        key_k26 = _model_sort_key("kimi-K2.6", p)
+
+        assert key_k3[0] == -3.0
+        assert key_k26[0] == -2.6
+
+    def test_existing_version_prefixes_unchanged(self):
+        assert _model_sort_key("mimo-v2.5-pro", "mimo") == (-2.5, 0, "pro")
+        assert _model_sort_key("gpt-5.6-sol", "gpt") == (-5.6, 0, "sol")
+        assert _model_sort_key("claude-v4.5-opus", "claude") == (-4.5, 1, "opus")


### PR DESCRIPTION
## Summary

Fixes #78886. Updates `_model_sort_key` in `hermes_cli/model_switch.py` to recognize `k`/`K` as a version prefix alongside `v`/`V`.

Before this fix, models prefixed with `k`/`K` (such as Moonshot Kimi: `kimi-k3`, `kimi-k2.6`, `kimi-k3.5`) failed to parse their numeric versions, falling back to lexicographical string comparison where `k2.6 < k3` sorted `kimi-k2.6` above `kimi-k3`.

## Changes

- Update `ch in "vV"` to `ch in "vVkK"` in `start` and `between` states of `_model_sort_key`.
- Add unit tests in `tests/hermes_cli/test_kimi_version_sort.py` verifying numeric keys and sorting for `k`/`K` models while confirming existing `v` prefixes remain unaffected.

## Verification

Ran `scripts/run_tests.sh tests/hermes_cli/test_kimi_version_sort.py` (100% pass).