### PR TITLE
fix(doctor): annotate npm-audit hint when .npmrc enforces min-release-age cooldown (#78893)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2055,6 +2055,23 @@ def run_doctor(args):
                     fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
                 else:
                     fix_cmd = f"cd {npm_dir} && npm audit fix"
+                # Check whether .npmrc enforces a min-release-age cooldown
+                # that can make `npm audit fix` a silent no-op for fresh
+                # advisories (#78893).  Security advisories are published
+                # at or before the fix version, so for the first N days of
+                # every advisory's life npm refuses the fix version — the
+                # hint becomes a dead end that escalates toward --force.
+                _cooldown_days = 0
+                if fix_cmd:
+                    try:
+                        _mra = subprocess.run(
+                            [_npm_bin, "config", "get", "min-release-age"],
+                            cwd=str(npm_dir), capture_output=True, text=True,
+                            timeout=10,
+                        ).stdout.strip()
+                        _cooldown_days = int(_mra) if _mra.isdigit() else 0
+                    except Exception:
+                        _cooldown_days = 0
                 if total == 0:
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
@@ -2081,6 +2098,14 @@ def run_doctor(args):
                             "  ^ build-time tooling (not runtime); if manual npm remediation "
                             "errors with an arborist crash it's a known npm bug — clears "
                             "via a lockfile bump"
+                        )
+                    if fix_cmd and _cooldown_days > 0:
+                        check_info(
+                            f"  ^ .npmrc sets min-release-age={_cooldown_days}; "
+                            f"fixes published within the last {_cooldown_days} days "
+                            f"are refused — 'audit fix' may be a no-op; do NOT use "
+                            f"--force (bypasses the supply-chain guardrail; clears "
+                            f"via a lockfile bump)"
                         )
                     issues.append(
                         f"{label} has {total} npm "

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,101 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+# ── npm audit min-release-age cooldown annotation (#78893) ──
+
+
+class TestDoctorNpmAuditCooldown:
+    """doctor's npm-audit remediation hint must annotate min-release-age (#78893)."""
+
+    def _run_doctor_with_npm(self, monkeypatch, tmp_path, *, cooldown_stdout="14",
+                             fail_config=False):
+        """Run doctor with mocked npm and return captured stdout."""
+        import json as _json
+        import subprocess as _subprocess
+
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+        (project / "node_modules").mkdir(exist_ok=True)
+
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        home = tmp_path / ".hermes"
+        home.mkdir(exist_ok=True)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        # npm / node found
+        monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/" + cmd)
+
+        # Stub tool availability
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        # Stub auth checks
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        def fake_run(cmd, **kwargs):
+            cmd_list = list(cmd) if isinstance(cmd, (list, tuple)) else [str(cmd)]
+            # npm audit --json [extra...]
+            if "audit" in cmd_list and "--json" in cmd_list:
+                if "--workspaces=false" in cmd_list:
+                    stdout = _json.dumps({
+                        "metadata": {"vulnerabilities": {
+                            "critical": 0, "high": 2, "moderate": 0}}
+                    })
+                else:
+                    stdout = _json.dumps({
+                        "metadata": {"vulnerabilities": {
+                            "critical": 0, "high": 0, "moderate": 0}}
+                    })
+                return _subprocess.CompletedProcess(cmd_list, 0, stdout, "")
+            # npm config get min-release-age
+            if ("config" in cmd_list and "get" in cmd_list
+                    and "min-release-age" in cmd_list):
+                if fail_config:
+                    raise _subprocess.TimeoutExpired(cmd_list, 10)
+                return _subprocess.CompletedProcess(
+                    cmd_list, 0, cooldown_stdout, "")
+            # Everything else: safe no-op
+            return _subprocess.CompletedProcess(cmd_list, 0, "", "")
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_cooldown_annotates_audit_fix_hint(self, monkeypatch, tmp_path):
+        """When min-release-age>0, the hint must warn about the cooldown (#78893)."""
+        out = self._run_doctor_with_npm(monkeypatch, tmp_path, cooldown_stdout="14")
+        assert "2 high" in out
+        # The cooldown annotation must appear
+        assert "min-release-age" in out
+        # Must pre-empt the --force escalation
+        assert "--force" in out
+
+    def test_no_cooldown_emits_plain_hint(self, monkeypatch, tmp_path):
+        """When min-release-age=0 (or unset), the plain fix command is emitted."""
+        out = self._run_doctor_with_npm(monkeypatch, tmp_path, cooldown_stdout="0")
+        assert "2 high" in out
+        assert "npm audit fix" in out
+        # No cooldown annotation
+        assert "min-release-age" not in out
+
+    def test_config_get_failure_does_not_crash(self, monkeypatch, tmp_path):
+        """If `npm config get min-release-age` fails, doctor must degrade gracefully."""
+        out = self._run_doctor_with_npm(
+            monkeypatch, tmp_path, fail_config=True)
+        assert "2 high" in out
+        assert "npm audit fix" in out


### PR DESCRIPTION
## Problem

`hermes doctor` emits an `npm audit fix` remediation hint unconditionally. When `.npmrc` sets `min-release-age=14` (landed in #50901), npm refuses fix versions published within the last 14 days — exactly when `doctor` first surfaces fresh advisories. The hint becomes a silent no-op that escalates users toward `npm audit fix --force`, which (a) bypasses the supply-chain guardrail the cooldown installed and (b) dirties tracked `package.json`/`package-lock.json`.

## Fix

Query `npm config get min-release-age` per audit target. When the cooldown is a positive integer, emit a `check_info` annotation explaining why `audit fix` may be a no-op and explicitly warning against `--force` (naming the lockfile bump as the real remediation path). The command itself is still emitted — it remains useful when the fix version is already outside the cooldown window.

This mirrors the existing asymmetry with the `--workspace` branch immediately above, which already declines to hand over a command known to fail (`fix_cmd = None` + explanatory `check_info`).

## Layers addressed (5/5)

1. **Root-level fix_cmd** (`--workspaces=false`) — annotated when cooldown > 0
2. **Default fix_cmd** (WhatsApp bridge `else` branch) — same annotation applies
3. **`--force` escalation pre-empted** — annotation names the cooldown explicitly
4. **No cooldown** (min-release-age=0 or unset) — behavior unchanged, no annotation
5. **config-get failure** — degrades gracefully to cooldown=0, never crashes doctor

## Tests

- 3 new tests in `tests/hermes_cli/test_doctor.py` (`TestDoctorNpmAuditCooldown`):
  - `test_cooldown_annotates_audit_fix_hint` — RED on main (no annotation), GREEN with fix
  - `test_no_cooldown_emits_plain_hint` — baseline: plain hint, no annotation
  - `test_config_get_failure_does_not_crash` — graceful degradation on subprocess failure
- All 52 doctor suite tests pass
- `ruff check` clean

## Verification

```
git rev-list --left-right --count upstream/main...HEAD  →  0 1
```

Auto-published by Moonsong via Path B automated pipeline.