### PR TITLE
fix(doctor): explain npm audit release-age cooldown

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -105,6 +105,29 @@ def _safe_which(cmd: str) -> str | None:
         return None
 
 
+def _npm_min_release_age_days(npm_bin: str, npm_dir: Path) -> int:
+    """Return npm's effective release-age gate for ``npm_dir``."""
+    try:
+        result = subprocess.run(
+            [npm_bin, "config", "get", "min-release-age"],
+            cwd=str(npm_dir),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+
+    value = result.stdout.strip()
+    if not value.isdigit():
+        return 0
+
+    days = int(value)
+    return days if days > 0 else 0
+
+
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     steps: list[str] = []
     step = 1
@@ -2059,10 +2082,17 @@ def run_doctor(args):
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
                     if fix_cmd:
+                        cooldown_days = _npm_min_release_age_days(_npm_bin, npm_dir)
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — run: {fix_cmd}"
                         )
+                        if cooldown_days:
+                            vuln_detail += (
+                                f"; npm min-release-age={cooldown_days} blocks fixes published "
+                                f"within the last {cooldown_days} days"
+                            )
                     else:
+                        cooldown_days = 0
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — "
                             "build-tool advisory; clears via lockfile bump"
@@ -2071,6 +2101,11 @@ def run_doctor(args):
                         f"{label} deps",
                         f"({vuln_detail})"
                     )
+                    if cooldown_days:
+                        check_info(
+                            "  ^ retry after the patched release ages out; do not bypass the "
+                            "supply-chain cooldown with `npm audit fix --force`"
+                        )
                     if audit_extra and audit_extra[0] == "--workspace":
                         # The web/ui-tui workspace advisories are in build-time
                         # tooling (esbuild/vite, etc.), not runtime code that ships

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,48 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+def test_npm_audit_fix_hint_explains_release_age_cooldown(monkeypatch, tmp_path):
+    """Regression for #78893: doctor must explain a blocked root audit fix."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(
+        doctor_mod,
+        "_safe_which",
+        lambda cmd: "/usr/bin/npm" if cmd == "npm" else None,
+    )
+
+    def mock_run(cmd, **kwargs):
+        if cmd[1:] == ["config", "get", "min-release-age"]:
+            return SimpleNamespace(returncode=0, stdout="14\n", stderr="")
+        if "audit" in cmd and "--workspaces=false" in cmd:
+            payload = (
+                '{"metadata": {"vulnerabilities": '
+                '{"critical": 0, "high": 2, "moderate": 0}}}'
+            )
+            return SimpleNamespace(returncode=1, stdout=payload, stderr="")
+        if "audit" in cmd:
+            payload = (
+                '{"metadata": {"vulnerabilities": '
+                '{"critical": 0, "high": 0, "moderate": 0}}}'
+            )
+            return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", mock_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "npm audit fix --workspaces=false" in out
+    assert "npm min-release-age=14 blocks fixes published within the last 14 days" in out
+    assert "do not bypass the supply-chain cooldown with `npm audit fix --force`" in out


### PR DESCRIPTION
## What does this PR do?

Makes `hermes doctor` explain when npm's effective `min-release-age` setting can block the suggested audit fix.

The root audit remediation remains useful once a patched release ages out, so the command is preserved. When npm reports a positive cooldown for the audited directory, doctor now:

- states that recently published fixes may be blocked for that many days
- tells users to retry after the patched release ages out
- warns against bypassing the repository's supply-chain guard with `npm audit fix --force`

The npm config lookup is best-effort; failures leave the existing diagnostic behavior unchanged.

## Related Issue

Fixes #78893

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/doctor.py`: read the effective npm release-age gate before displaying an actionable audit-fix hint and explain the cooldown when active.
- `tests/hermes_cli/test_doctor.py`: add a #78893 regression covering the root `--workspaces=false` remediation path.

## How to Test

1. Configure a positive npm release-age gate, such as `min-release-age=14`.
2. Run `hermes doctor` with a high-severity root npm advisory.
3. Confirm the output retains `npm audit fix --workspaces=false`, explains the 14-day gate, and warns against `--force`.

Automated validation:

```text
scripts/run_tests.sh tests/hermes_cli/test_doctor.py
# 50 passed

.venv/bin/ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py
# All checks passed

python scripts/check-windows-footguns.py hermes_cli/doctor.py
# No Windows footguns found

git diff --check
# clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs for #78893 and the npm cooldown symptoms
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; the focused doctor suite passed through the required wrapper)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python 3.13, npm 10.9.8

### Documentation & Housekeeping

- [x] Documentation update is not required; the user-facing diagnostic is covered by regression testing
- [x] `cli-config.yaml.example` update is not applicable
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are not applicable
- [x] Cross-platform impact considered; npm is resolved through the existing absolute executable path and subprocess encoding is explicit
- [x] Tool descriptions and schemas are not applicable

## Screenshots / Logs

Not applicable; this is terminal diagnostic output with automated regression coverage.
