### PR TITLE
fix(openviking): read .env BOM-tolerantly when rewriting credentials

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1186,7 +1186,16 @@ def _env_line_safe(value: Any) -> str:
 def _write_env_vars(env_path: Path, env_writes: dict, remove_keys: tuple[str, ...] = ()) -> None:
     env_path.parent.mkdir(parents=True, exist_ok=True)
     remove_set = set(remove_keys) - set(env_writes)
-    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    # Read exactly like the canonical .env reader in hermes_cli/config.py
+    # (save_env_value). A Windows editor can leave a UTF-8 BOM, which fails
+    # the key match on the first line so that key gets duplicated on write,
+    # or save the file as cp1252, which makes a strict utf-8 read raise and
+    # abort setup. Copying existing lines through must never do either.
+    existing_lines = (
+        env_path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        if env_path.exists()
+        else []
+    )
     updated_keys = set()
     new_lines = []
     for line in existing_lines:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1609,3 +1609,50 @@ def test_is_available_false_without_any_endpoint(monkeypatch):
         openviking_module, "_load_hermes_openviking_config", lambda: {}
     )
     assert OpenVikingMemoryProvider().is_available() is False
+
+
+class TestOpenVikingEnvWriter:
+    """``_write_env_vars`` copies existing .env lines through on every update,
+    so how it *reads* them decides whether a credential update lands.
+
+    f1ea4a56c ("cover the remaining setup-time .env reads with utf-8-sig")
+    swept this class; this writer was missed.
+    """
+
+    def test_bom_prefixed_env_updates_in_place(self, tmp_path):
+        from plugins.memory.openviking import _write_env_vars
+
+        env = tmp_path / ".env"
+        env.write_bytes(b"\xef\xbb\xbfOPENAI_API_KEY=old\nOTHER=1\n")
+
+        _write_env_vars(env, {"OPENAI_API_KEY": "new"})
+
+        lines = [l for l in env.read_text(encoding="utf-8-sig").splitlines() if l]
+        # The stale value must be gone, not shadowed by an appended duplicate:
+        # .env loaders keep the first occurrence, so a duplicate silently wins.
+        assert lines.count("OPENAI_API_KEY=new") == 1
+        assert not any(l.endswith("=old") for l in lines)
+        assert "OTHER=1" in lines
+
+    def test_non_utf8_env_does_not_abort_setup(self, tmp_path):
+        from plugins.memory.openviking import _write_env_vars
+
+        env = tmp_path / ".env"
+        env.write_bytes(b"NAME=caf\xe9\nOPENAI_API_KEY=old\n")
+
+        _write_env_vars(env, {"OPENAI_API_KEY": "new"})
+
+        lines = env.read_text(encoding="utf-8-sig").splitlines()
+        assert "OPENAI_API_KEY=new" in lines
+
+    def test_plain_env_is_unchanged_apart_from_the_write(self, tmp_path):
+        from plugins.memory.openviking import _write_env_vars
+
+        env = tmp_path / ".env"
+        env.write_text("A=1\nOPENAI_API_KEY=old\nB=2\n", encoding="utf-8")
+
+        _write_env_vars(env, {"OPENAI_API_KEY": "new"})
+
+        assert env.read_text(encoding="utf-8").splitlines() == [
+            "A=1", "OPENAI_API_KEY=new", "B=2",
+        ]


### PR DESCRIPTION
## What

75afc47ba (2026-07-10, fix(memory): read/write .env as UTF-8 in mem0 and hindsight setup) and then f1ea4a56c (2026-07-12, **fix(memory): cover the remaining setup-time .env reads with utf-8-sig**) hardened this exact class. `plugins/memory/openviking/__init__.py::_write_env_vars` was missed and still reads with strict UTF-8:

```python
existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
```

The function copies every existing line through on each update, so the *read* decides whether a credential update actually lands. Two failure modes, both on `.env` — the file that holds API keys. Real writer, real files:

```
--- on main
BOM case    -> ['OPENAI_API_KEY=old', 'OTHER=1', 'OPENAI_API_KEY=new']
cp1252 case -> RAISED UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9

--- with the fix
BOM case    -> ['OPENAI_API_KEY=new', 'OTHER=1']
cp1252 case -> OK
```

- **UTF-8 BOM** (what a Windows GUI editor leaves): the first line's key reads as `\ufeffOPENAI_API_KEY`, so it never matches. The stale line survives and the new value is appended as a *duplicate*. `.env` loaders keep the first occurrence, so the user changes their key, setup reports success, and the old key is still what gets loaded.
- **cp1252** (Notepad's other default): the read raises and openviking setup aborts.

CONTRIBUTING.md calls out both cases explicitly under Cross-Platform Compatibility, and the sibling writer in `plugins/memory/mem0/_setup.py` already carries a comment explaining precisely this hazard — it just never reached this file.

## The fix

Read exactly like the canonical `.env` reader, `hermes_cli/config.py::save_env_value`:

```python
env_path.read_text(encoding="utf-8-sig", errors="replace")
```

`utf-8-sig` strips a BOM if present and is a no-op otherwise; `errors="replace"` keeps a mis-encoded neighbouring line from aborting the write. A plain UTF-8 `.env` rewrites byte-identically.

One consequence worth naming: on a cp1252 file, an unrelated non-ASCII *value* is rewritten with a replacement character rather than its original bytes. That is the same trade the canonical writer already makes — the alternative is the current behaviour, where setup fails outright and nothing is written at all.

Scope: `hermes_cli/memory_setup.py` has the same read, but it is already the subject of #30281 and #60587, so it is deliberately left alone here. `plugins/memory/mem0/_setup.py` was fixed by f1ea4a56c; `hermes_cli/doctor.py` and `hermes_cli/main.py` already guard the decode.

## Tests

Added `TestOpenVikingEnvWriter` to `tests/plugins/memory/test_openviking_provider.py`:

- a BOM-prefixed `.env` updates the key in place — exactly one `OPENAI_API_KEY` line, no leftover `=old`
- a cp1252 `.env` no longer aborts the write
- a plain UTF-8 `.env` comes out with the same lines in the same order — the guard against the read change altering ordinary files

Results:

```
54 passed, 2 skipped
```

That is the whole file; the 51 pre-existing tests are unchanged.

Red without the source change:

```
FAILED TestOpenVikingEnvWriter::test_bom_prefixed_env_updates_in_place
E   assert not True          # an "=old" line survived alongside the new one
FAILED TestOpenVikingEnvWriter::test_non_utf8_env_does_not_abort_setup
E   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 8
```

The third test passes on both sides, which is what it is for.

Regression over `tests/plugins/memory/` against the same files on main:

```
main:      7 failed, 261 passed, 8 skipped   (excluding the 2 new tests failing as above)
with fix:  7 failed, 261 passed, 8 skipped
```

Set difference is empty — no new failures. The 7 are identical before and after and sit in the hindsight and holographic suites, unrelated to this change.