### PR TITLE
fix(checkpoint): one unreadable path no longer costs the whole snapshot (#78888)

### DIFF
--- a/contributors/emails/thisishoomfree@hotmail.com
+++ b/contributors/emails/thisishoomfree@hotmail.com
@@ -1,0 +1,2 @@
+willgitdata
+# PR for #78888 (checkpoint: unreadable path no longer aborts the snapshot)

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 
 from tools.checkpoint_manager import (
     CheckpointManager,
-    DEFAULT_EXCLUDES,
     _shadow_repo_path,
     _init_store,
     _run_git,
@@ -1067,6 +1066,34 @@ def _tracked_names(store, work_dir):
     return set(files.splitlines())
 
 
+def _seed_nested_repo(path, *, commit):
+    """A nested git repo, isolated from the developer's real git config.
+
+    Without the isolation a global ``commit.gpgsign = true`` (or a global
+    ``core.hooksPath``) makes the setup commit fail, which is exactly what
+    ``_init_store`` guards the real store against.
+    """
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True, env=env,
+                   capture_output=True)
+    (path / "f.txt").write_text("x\n")
+    if not commit:
+        return
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, env=env,
+                   capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "-c", "user.email=t@t", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", "commit", "-qm", "seed"],
+        check=True, env=env, capture_output=True,
+    )
+
+
 class TestUnreadablePaths:
     def test_node_compile_cache_is_excluded(self, mgr, work_dir, checkpoint_base):
         """Hermes' own Node compile cache never enters a snapshot."""
@@ -1135,8 +1162,60 @@ class TestUnreadablePaths:
         finally:
             blocked.chmod(0o644)
 
-    def test_default_excludes_lists_node_compile_cache(self):
-        assert "node-compile-cache/" in DEFAULT_EXCLUDES
+    def test_existing_store_picks_up_new_excludes(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """A store created by an older release must gain new exclude patterns.
+
+        ``info/exclude`` used to be written only when the store was created, so
+        every already-initialised store — i.e. every upgrading user — kept
+        snapshotting anything added to ``DEFAULT_EXCLUDES`` afterwards.
+        """
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "a.py").write_text("1\n")
+
+        # Create the store, then age it: drop the newest pattern back out, the
+        # way a store written by the previous release would look.
+        CheckpointManager(enabled=True, max_snapshots=5).ensure_checkpoint(str(wd), "seed")
+        store = _store_path(checkpoint_base)
+        exclude = store / "info" / "exclude"
+        aged = [ln for ln in exclude.read_text(encoding="utf-8").splitlines()
+                if ln != "node-compile-cache/"]
+        exclude.write_text("\n".join(aged) + "\n", encoding="utf-8")
+        assert "node-compile-cache/" not in exclude.read_text(encoding="utf-8")
+
+        # A later run (fresh manager == restarted process) must refresh it.
+        cache = wd / "node-compile-cache" / "v1"
+        cache.mkdir(parents=True)
+        (cache / "blob").write_bytes(b"compiled\n")
+        (wd / "a.py").write_text("2\n")
+        m2 = CheckpointManager(enabled=True, max_snapshots=5)
+        assert m2.ensure_checkpoint(str(wd), "after upgrade") is True
+
+        assert "node-compile-cache/" in exclude.read_text(encoding="utf-8")
+        names = _tracked_names(store, wd)
+        assert not any(n.startswith("node-compile-cache/") for n in names)
+
+    def test_exclude_refresh_is_a_no_op_when_current(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """The refresh sits on the per-checkpoint path — it must not rewrite."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "a.py").write_text("1\n")
+        CheckpointManager(enabled=True, max_snapshots=5).ensure_checkpoint(str(wd), "seed")
+
+        exclude = _store_path(checkpoint_base) / "info" / "exclude"
+        before = exclude.stat().st_mtime_ns
+
+        (wd / "a.py").write_text("2\n")
+        m2 = CheckpointManager(enabled=True, max_snapshots=5)
+        assert m2.ensure_checkpoint(str(wd), "next") is True
+
+        assert exclude.stat().st_mtime_ns == before, "unchanged excludes must not be rewritten"
 
     @needs_posix_perms
     def test_skipped_paths_are_logged_not_swallowed(
@@ -1175,10 +1254,7 @@ class TestUnreadablePaths:
         wd = tmp_path / "proj"
         wd.mkdir()
         (wd / "keep.py").write_text("kept = True\n")
-        nested = wd / "vendored"
-        nested.mkdir()
-        subprocess.run(["git", "init", "-q", str(nested)], check=True)
-        (nested / "f.txt").write_text("x\n")
+        _seed_nested_repo(wd / "vendored", commit=False)
 
         m = CheckpointManager(enabled=True, max_snapshots=5)
         assert m.ensure_checkpoint(str(wd), "initial") is True
@@ -1195,16 +1271,7 @@ class TestUnreadablePaths:
         wd = tmp_path / "proj"
         wd.mkdir()
         (wd / "keep.py").write_text("kept = True\n")
-        nested = wd / "vendored"
-        nested.mkdir()
-        subprocess.run(["git", "init", "-q", str(nested)], check=True)
-        (nested / "f.txt").write_text("x\n")
-        subprocess.run(["git", "-C", str(nested), "add", "-A"], check=True)
-        subprocess.run(
-            ["git", "-C", str(nested), "-c", "user.email=t@t", "-c", "user.name=t",
-             "commit", "-qm", "seed"],
-            check=True,
-        )
+        _seed_nested_repo(wd / "vendored", commit=True)
 
         m = CheckpointManager(enabled=True, max_snapshots=5)
         with caplog.at_level(logging.WARNING, logger="tools.checkpoint_manager"):

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import time
 import pytest
 from pathlib import Path
@@ -13,6 +14,7 @@ from unittest.mock import patch
 
 from tools.checkpoint_manager import (
     CheckpointManager,
+    DEFAULT_EXCLUDES,
     _shadow_repo_path,
     _init_store,
     _run_git,
@@ -1044,3 +1046,169 @@ class TestSessionDiff:
         assert result["success"] is True
         assert "feature.py" in result["diff"]
         assert "+x = 1" in result["diff"]
+
+
+# =========================================================================
+# CheckpointManager — unreadable paths must not abort the whole snapshot
+# =========================================================================
+
+needs_posix_perms = pytest.mark.skipif(
+    sys.platform == "win32" or os.geteuid() == 0,
+    reason="chmod-based access denial needs POSIX + non-root",
+)
+
+
+def _tracked_names(store, work_dir):
+    ok, files, _ = _run_git(
+        ["ls-tree", "-r", "--name-only", _ref_name(_project_hash(str(work_dir)))],
+        store, str(work_dir),
+    )
+    assert ok
+    return set(files.splitlines())
+
+
+class TestUnreadablePaths:
+    def test_node_compile_cache_is_excluded(self, mgr, work_dir, checkpoint_base):
+        """Hermes' own Node compile cache never enters a snapshot."""
+        cache = work_dir / "node-compile-cache" / "v26.5.1-x64"
+        cache.mkdir(parents=True)
+        (cache / "00bf0630").write_bytes(b"compiled\n")
+
+        assert mgr.ensure_checkpoint(str(work_dir), "initial") is True
+
+        names = _tracked_names(_store_path(checkpoint_base), work_dir)
+        assert "main.py" in names
+        assert not any(n.startswith("node-compile-cache/") for n in names)
+
+    @needs_posix_perms
+    def test_unreadable_file_does_not_abort_the_checkpoint(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """One unreadable path must cost that path — not the whole checkpoint.
+
+        Regression for #78888: ``git add -A`` exits 128 and stages *nothing*
+        when it cannot open a file, so a single root-owned cache entry left the
+        directory with zero checkpoints.
+        """
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "main.py").write_text("print('hello')\n")
+        blocked = wd / "secrets.bin"
+        blocked.write_bytes(b"unreadable\n")
+        blocked.chmod(0)
+
+        try:
+            m = CheckpointManager(enabled=True, max_snapshots=5)
+            assert m.ensure_checkpoint(str(wd), "initial") is True
+
+            names = _tracked_names(_store_path(checkpoint_base), wd)
+            assert "main.py" in names          # readable work is preserved
+            assert "secrets.bin" not in names  # the unreadable path is skipped
+        finally:
+            blocked.chmod(0o644)  # so pytest can clean up
+
+    @needs_posix_perms
+    def test_unreadable_path_outside_excludes_still_checkpoints(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """The fix is not specific to node-compile-cache.
+
+        Any root-owned/unreadable path — a socket, a foreign cache, a partially
+        written file — used to abort the snapshot. Excludes alone cannot cover
+        that class, so the resilience must live at the ``git add`` call.
+        """
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "keep.py").write_text("kept = True\n")
+        foreign = wd / "some-other-cache"
+        foreign.mkdir()
+        blocked = foreign / "blob"
+        blocked.write_bytes(b"nope\n")
+        blocked.chmod(0)
+
+        try:
+            m = CheckpointManager(enabled=True, max_snapshots=5)
+            assert m.ensure_checkpoint(str(wd), "initial") is True
+            assert "keep.py" in _tracked_names(_store_path(checkpoint_base), wd)
+        finally:
+            blocked.chmod(0o644)
+
+    def test_default_excludes_lists_node_compile_cache(self):
+        assert "node-compile-cache/" in DEFAULT_EXCLUDES
+
+    @needs_posix_perms
+    def test_skipped_paths_are_logged_not_swallowed(
+        self, tmp_path, checkpoint_base, monkeypatch, caplog,
+    ):
+        """A shrunken snapshot is tolerated, but never silent."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "keep.py").write_text("kept = True\n")
+        blocked = wd / "blocked.bin"
+        blocked.write_bytes(b"nope\n")
+        blocked.chmod(0)
+
+        try:
+            m = CheckpointManager(enabled=True, max_snapshots=5)
+            with caplog.at_level(logging.WARNING, logger="tools.checkpoint_manager"):
+                assert m.ensure_checkpoint(str(wd), "initial") is True
+            assert any(
+                "partially succeeded" in r.message and "blocked.bin" in r.message
+                for r in caplog.records
+            ), f"expected a warning naming the skipped path, got: {caplog.records}"
+        finally:
+            blocked.chmod(0o644)
+
+    def test_uncommitted_nested_repo_does_not_abort_the_checkpoint(
+        self, tmp_path, checkpoint_base, monkeypatch,
+    ):
+        """A freshly ``git init``-ed subdirectory is the same class of failure.
+
+        ``git add -A`` exits 128 with "does not have a commit checked out", so
+        before #78888 any project containing an uncommitted nested repo also got
+        zero checkpoints — no unusual file ownership required.
+        """
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "keep.py").write_text("kept = True\n")
+        nested = wd / "vendored"
+        nested.mkdir()
+        subprocess.run(["git", "init", "-q", str(nested)], check=True)
+        (nested / "f.txt").write_text("x\n")
+
+        m = CheckpointManager(enabled=True, max_snapshots=5)
+        assert m.ensure_checkpoint(str(wd), "initial") is True
+        assert "keep.py" in _tracked_names(_store_path(checkpoint_base), wd)
+
+    def test_clean_checkpoint_logs_no_warning(self, tmp_path, checkpoint_base, monkeypatch, caplog):
+        """An ordinary snapshot stays quiet.
+
+        ``git add`` writes ``warning:``/``hint:`` chatter to stderr while still
+        exiting 0 (an embedded repo that *does* have a commit), so the skip
+        warning must key off the exit code, not off stderr being non-empty.
+        """
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        wd = tmp_path / "proj"
+        wd.mkdir()
+        (wd / "keep.py").write_text("kept = True\n")
+        nested = wd / "vendored"
+        nested.mkdir()
+        subprocess.run(["git", "init", "-q", str(nested)], check=True)
+        (nested / "f.txt").write_text("x\n")
+        subprocess.run(["git", "-C", str(nested), "add", "-A"], check=True)
+        subprocess.run(
+            ["git", "-C", str(nested), "-c", "user.email=t@t", "-c", "user.name=t",
+             "commit", "-qm", "seed"],
+            check=True,
+        )
+
+        m = CheckpointManager(enabled=True, max_snapshots=5)
+        with caplog.at_level(logging.WARNING, logger="tools.checkpoint_manager"):
+            assert m.ensure_checkpoint(str(wd), "initial") is True
+        assert not [r for r in caplog.records if "partially succeeded" in r.message], (
+            f"clean add must not warn, got: {[r.message for r in caplog.records]}"
+        )

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -139,6 +139,8 @@ DEFAULT_EXCLUDES = [
     "Thumbs.db",
     # Logs
     "*.log",
+    # Hermes' own scratch caches
+    "node-compile-cache/",
 ]
 
 # Git subprocess timeout (seconds).
@@ -305,12 +307,18 @@ def _run_git(
     timeout: int = _GIT_TIMEOUT,
     allowed_returncodes: Optional[Set[int]] = None,
     index_file: Optional[Path] = None,
+    success_returncodes: Optional[Set[int]] = None,
 ) -> Tuple[bool, str, str]:
     """Run a git command against the shared store.  Returns (ok, stdout, stderr).
 
     ``allowed_returncodes`` suppresses error logging for known/expected non-zero
     exits while preserving the normal ``ok = (returncode == 0)`` contract.
     Example: ``git diff --cached --quiet`` returns 1 when changes exist.
+
+    ``success_returncodes`` goes further and reports those exits as ``ok``, for
+    commands whose partial success is the outcome we want.  Example:
+    ``git add --ignore-errors`` returns 1 when it skipped an unreadable path but
+    staged everything else.
     """
     normalized_working_dir = _normalize_path(working_dir)
     if not normalized_working_dir.exists():
@@ -324,7 +332,8 @@ def _run_git(
 
     env = _git_env(store, str(normalized_working_dir), index_file=index_file)
     cmd = ["git"] + list(args)
-    allowed_returncodes = allowed_returncodes or set()
+    success_returncodes = success_returncodes or set()
+    allowed_returncodes = (allowed_returncodes or set()) | success_returncodes
 
     try:
         result = subprocess.run(
@@ -340,9 +349,17 @@ def _run_git(
             # conhost flash on Windows (no-op on POSIX).
             creationflags=windows_hide_flags(),
         )
-        ok = result.returncode == 0
+        partial = result.returncode != 0 and result.returncode in success_returncodes
+        ok = result.returncode == 0 or partial
         stdout = result.stdout.strip()
         stderr = result.stderr.strip()
+        if partial:
+            # Tolerated, but the command did not do everything it was asked —
+            # don't let that shrink a snapshot silently.
+            logger.warning(
+                "Git command partially succeeded: %s (rc=%d) stderr=%s",
+                " ".join(cmd), result.returncode, stderr,
+            )
         if not ok and result.returncode not in allowed_returncodes:
             logger.error(
                 "Git command failed: %s (rc=%d) stderr=%s",
@@ -418,6 +435,27 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     return legacy_root
 
 
+def _write_excludes(store: Path) -> None:
+    """(Re)write the store's shared exclude file from ``DEFAULT_EXCLUDES``.
+
+    The list grows between releases, so a store created by an older version
+    has to pick up the new patterns — otherwise the exclude is only ever
+    honoured on machines that had no checkpoints when it landed.  The file is
+    Hermes-owned (see the module docstring), and the write is skipped when the
+    contents already match so this stays cheap on the per-checkpoint path.
+    """
+    body = "\n".join(DEFAULT_EXCLUDES) + "\n"
+    path = store / "info" / "exclude"
+    try:
+        if path.exists() and path.read_text(encoding="utf-8") == body:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    except OSError as exc:
+        # Never fatal — a stale exclude file costs snapshot size, not safety.
+        logger.warning("Could not refresh checkpoint excludes: %s", exc)
+
+
 def _init_store(store: Path, working_dir: str) -> Optional[str]:
     """Initialise the shared shadow store if needed.  Returns error or None.
 
@@ -436,6 +474,8 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
+        # Existing store: refresh the excludes, which grow between releases.
+        _write_excludes(store)
         return None
 
     store.mkdir(parents=True, exist_ok=True)
@@ -477,11 +517,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
     _run_git(["config", "tag.gpgSign", "false"], store, cfg_wd)
     _run_git(["config", "gc.auto", "0"], store, cfg_wd)
 
-    info_dir = store / "info"
-    info_dir.mkdir(exist_ok=True)
-    (info_dir / "exclude").write_text(
-        "\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8"
-    )
+    _write_excludes(store)
 
     logger.debug("Initialised checkpoint store at %s", store)
     return None
@@ -855,9 +891,13 @@ class CheckpointManager:
         dir_hash = _project_hash(abs_dir)
         index_file = _index_path(store, dir_hash)
 
-        # Stage current state into the per-project index to compare.
-        _run_git(["add", "-A"], store, abs_dir,
-                 timeout=_GIT_TIMEOUT * 2, index_file=index_file)
+        # Stage current state into the per-project index to compare.  Same
+        # ``--ignore-errors`` rationale as _take: an unreadable path must not
+        # abort staging, or the diff is computed against a stale index.  The
+        # result is advisory here, so rc=1 only needs its error log suppressed.
+        _run_git(["add", "-A", "--ignore-errors"], store, abs_dir,
+                 timeout=_GIT_TIMEOUT * 2, index_file=index_file,
+                 allowed_returncodes={1})
 
         ok_stat, stat_out, _ = _run_git(
             ["diff", "--stat", commit_hash, "--cached"],
@@ -1045,9 +1085,15 @@ class CheckpointManager:
         # via ``core.bigFileThreshold`` is not what we want — instead, we
         # rely on the exclude file for broad patterns and post-stage prune
         # any path whose size exceeds max_file_size_mb.
+        # ``--ignore-errors`` keeps one unreadable path (a root-owned cache, a
+        # socket, a file being rewritten) from costing the entire snapshot:
+        # without it ``git add -A`` exits 128 having staged *nothing*, so the
+        # directory silently accumulates zero checkpoints.  It stages the rest
+        # and exits 1 instead, which is the outcome we want.
         ok, _, err = _run_git(
-            ["add", "-A"], store, working_dir,
+            ["add", "-A", "--ignore-errors"], store, working_dir,
             timeout=_GIT_TIMEOUT * 2, index_file=index_file,
+            success_returncodes={1},
         )
         if not ok:
             logger.debug("Checkpoint git-add failed: %s", err)

--- a/website/docs/user-guide/checkpoints-and-rollback.md
+++ b/website/docs/user-guide/checkpoints-and-rollback.md
@@ -211,7 +211,8 @@ Restore just one file from a checkpoint without affecting the rest of the direct
 - **Total store size cap** — when the store exceeds `max_total_size_mb` (default 500 MB), the oldest commit per project is dropped round-robin until under the cap.
 - **Real pruning** — `max_snapshots` is enforced by rewriting the per-project ref and running `git gc --prune=now` afterwards, so loose objects don't accumulate.
 - **No-change snapshots** — if there are no changes since the last snapshot, the checkpoint is skipped.
-- **Non-fatal errors** — all errors inside the Checkpoint Manager are logged at debug level; your tools continue to run.
+- **Unreadable paths** — a file Hermes cannot open (a root-owned cache, a socket, a file mid-write) is skipped rather than failing the whole snapshot, and the skip is logged at warning level. Restoring never deletes a skipped path, so it stays exactly as it is on disk.
+- **Non-fatal errors** — all other errors inside the Checkpoint Manager are logged at debug level; your tools continue to run.
 
 ## Where Checkpoints Live
 


### PR DESCRIPTION
Fixes #78888

## Problem

`git add -A` exits **128 and stages nothing** when it cannot open a single file. `_take` treats that as total failure and returns early, so the whole working directory silently accumulates **zero** checkpoints while narrower project dirs snapshot normally.

```
tools.checkpoint_manager: Git command failed: git add -A (rc=128)
  stderr=error: open("node-compile-cache/v26.5.1-x64-8d7ad2ee-0/00bf0630"): Permission denied
  fatal: adding files failed
```

## Why the exclude alone couldn't fix it

The issue proposes adding `node-compile-cache/` to `DEFAULT_EXCLUDES`. That is worth doing, but on its own it does not fix the class:

1. **Existing stores never saw new patterns.** `info/exclude` was written only at store creation — `_init_store` early-returns once `HEAD` exists. Every already-initialised store, i.e. everyone who can hit this bug, kept the exclude list it was born with.
2. **The next unreadable path has a different name** — any root-owned file, socket, or file mid-write reproduces it.
3. **No unusual ownership is even required.** An uncommitted nested repo hits the identical abort:

```console
$ git add -A          # project containing a freshly `git init`-ed subdir
error: 'vendored/' does not have a commit checked out
fatal: adding files failed
rc=128, staged nothing
```

## Fix

**`--ignore-errors` at both staging call sites**, plus a `success_returncodes` parameter on `_run_git` so the resulting exit 1 reads as success in `_take`, where `ok` gates the snapshot.

```console
$ git add -A --ignore-errors
error: open("node-compile-cache/.../00bf0630"): Permission denied
rc=1, staged=[notes.md]        # ← everything readable, checkpoint proceeds
```

Exit 0 is unchanged when nothing is skipped, so this is behaviour-preserving in the normal case, and it works on **existing** stores with no exclude propagation needed.

**`_write_excludes` now refreshes `info/exclude`** so an existing store picks up patterns added in later releases (acceptance criterion 3 in the issue). The write is skipped when contents already match, since this sits on the per-checkpoint path.

`node-compile-cache/` is added to `DEFAULT_EXCLUDES` — Hermes' own scratch cache doesn't belong in a snapshot — but it is no longer load-bearing for the crash.

### Two details worth flagging

**The skip warning keys off the exit code, not stderr.** `git add` writes `warning:`/`hint:` chatter to stderr while still exiting 0 (an embedded repo that *does* have a commit), so an `if stderr:` check would warn on every checkpoint of any project with a vendored repo.

**Restore is unaffected.** `restore()` uses `git checkout <commit> -- .`, which only writes paths present in the commit and never deletes paths absent from it — so a partial snapshot degrades to "that one file isn't restorable", never "that file gets deleted". Verified explicitly, including the case where the path is unreadable at capture and readable at restore.

## Receipts

Same scenario as the issue, before and after:

```console
# upstream 43717123c
ensure_checkpoint -> False
list_checkpoints  -> 0 checkpoint(s)

# with this change
ensure_checkpoint -> True
list_checkpoints  -> 1 checkpoint(s)
snapshot contents -> ['notes.md']      # junk cache excluded
```

Simulated upgrade against a store written by the previous release (exclude entry stripped back out):

```console
1. aged store has node-compile-cache/: False
2. checkpoint taken on the AGED store: True
3. exclude refreshed:                  True
4. snapshot tree: ['a.py']
5. cache leaked into snapshot:         False
```

## Tests

`tests/tools/test_checkpoint_manager.py::TestUnreadablePaths` — 8 tests. 6 fail against the unpatched module; the other 2 are regression guards on the new behaviour (that a clean add stays quiet, and that the refresh doesn't rewrite an already-current file).

- unreadable file → readable work still snapshotted
- same outside `DEFAULT_EXCLUDES` (proves excludes can't cover the class)
- uncommitted nested repo no longer aborts
- existing store picks up newly added exclude patterns
- refresh is a no-op when already current (no mtime churn)
- skipped paths logged, not swallowed
- clean add stays quiet despite `warning:`/`hint:` stderr at exit 0
- `node-compile-cache/` excluded

chmod-based tests skip on Windows and as root, following `tests/tools/test_local_cwd_permission_fallback.py`. Nested-repo fixtures neutralise the global/system git config, so a developer's `commit.gpgsign = true` or `core.hooksPath` can't fail the setup commit — the same isolation `_init_store` applies to the real store (verified with gpg absent and `commit.gpgsign = true`).

```console
$ scripts/run_tests.sh tests/tools/test_checkpoint_manager.py \
    tests/hermes_cli/test_checkpoints_prune.py tests/hermes_cli/test_diff_command.py \
    tests/agent/test_tool_executor_checkpoint_paths.py tests/test_batch_runner_checkpoint.py \
    tests/integration/test_checkpoint_resumption.py
=== Summary: 6 files, 69 tests passed, 0 failed ===
```

Verified from a clean worktree of this branch. Full `tests/` matches baseline exactly — the same 8 pre-existing failures in 7 files with and without this change (missing optional extras locally, none checkpoint-related). `ruff check` clean.

## Relationship to #78929

#78929 was opened for the same issue shortly before this one, and we independently reached the same conclusion on one point — that `info/exclude` has to be refreshed for existing stores. Happy to defer or rebase if maintainers prefer that branch.

The difference is scope: #78929 excludes `node-compile-cache/` and syncs the exclude file, which resolves the reported symptom. It leaves the `rc=128` abort itself in place, so any *other* unopenable path still costs the whole snapshot — including the uncommitted-nested-repo case above, which needs no unusual file ownership. This PR fixes that abort at the `git add` call and keeps the exclude as a size optimisation rather than as the fix.

## Notes

- `_run_git` is module-private; `success_returncodes` defaults to `None`, so every existing caller is unaffected. The `diff` call site uses plain `allowed_returncodes={1}` since its result is advisory.
- `website/docs/user-guide/checkpoints-and-rollback.md` said all Checkpoint Manager errors are logged at debug level; updated, since the skip is the module's first warning-level condition.
- Complementary to #21940 (exclude reconcile), which also drops previously-tracked excluded paths — that remains useful, but is no longer required for this bug.
