### PR TITLE
fix(lifecycle_guard): catch ValueError on null-byte paths in _read_referenced_script

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/missing paths.
+        # ValueError: embedded NUL byte in path (binary content tokenized
+        # as a path by _iter_referenced_shell_scripts). Must not crash the
+        # guard (#76762).
         return None, False
     try:
         metadata = os.fstat(descriptor)


### PR DESCRIPTION
## Summary

```_read_referenced_script``` in ```cron/lifecycle_guard.py``` catches ```OSError``` from ```os.open(path, flags)``` but not ```ValueError```. When a terminal command contains binary content that gets tokenized as a path by ```_iter_referenced_shell_scripts```, ```Path()``` accepts the string but ```os.open()``` raises ```ValueError: embedded null byte```. The uncaught exception propagates up and crashes the ```terminal_tool``` call with a ~180s timeout.

## Root Cause

The ```except OSError``` clause at line 261 was written to handle unreadable/missing paths. However, ```os.open()``` raises ```ValueError``` (not ```OSError```) when the path contains an embedded NUL byte. This is the same class of issue referenced in the existing #76762 comment on line 281, which handles NUL bytes in file contents but not in the path itself.

The path with NUL bytes originates from ```_iter_referenced_shell_scripts``` tokenizing a terminal command string. If the command contains binary data (e.g. a pipe from a binary file), ```shlex``` may produce tokens that contain null bytes, which ```Path()``` silently accepts but ```os.open()``` rejects.

## Reproduction

```python
from pathlib import Path
import os

path = Path("testscript.sh")  # Path() accepts this silently
os.open(path, os.O_RDONLY)         # raises ValueError, not OSError
```

## Fix

Add ```ValueError``` to the existing ```except``` clause:

```python
# Before
    except OSError:
        return None, False

# After
    except (OSError, ValueError):
        return None, False
```

This treats null-byte paths the same as unreadable paths: return (None, False) - nothing to scan, not unsafe - which is correct since a path with embedded NUL bytes cannot reference a real shell script.

## Testing

- Before fix: 12 ValueError crashes in ~8 hours, each causing ~180s terminal_tool timeout
- After fix: 0 crashes in 30+ minutes of gateway uptime
- Verified on Hermes Agent v0.20.0 (v2026.8.3), Ubuntu 24.04, Python 3.11.15

## Impact

This bug affects any Hermes deployment where terminal commands may contain binary content that gets tokenized as paths. The ~180s timeout per occurrence significantly degrades agent responsiveness.
