### PR TITLE
fix(tui-gateway): fall back to config default when resumed session's provider is gone

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2994,12 +2994,12 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
     assert "launch_update" not in captured
 
 
-def test_stored_session_runtime_overrides_skips_bare_billing_provider():
+def test_stored_session_runtime_overrides_skips_bare_billing_provider(monkeypatch):
     """A bare billing bucket ("custom"/"auto"/"openrouter") must not be restored as the
     provider identity on resume. A custom endpoint that never used `/model` persists only
     `billing_provider="custom"`; restoring that broke `session.resume` with "No LLM provider
     configured" (agent_init treats it as non-routable). A real provider, or an explicit
-    `model_config.provider`, is still restored.
+    `model_config.provider` that still resolves in config, is still restored.
     """
     # Bare "custom" bucket, no explicit model_config.provider: no provider override restored.
     ov = server._stored_session_runtime_overrides({"model": "my-model", "billing_provider": "custom"})
@@ -3015,7 +3015,32 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert ov["provider_override"] == "anthropic"
     assert ov["model_override"]["provider"] == "anthropic"
 
-    # An explicit routable provider in model_config wins over the bare billing bucket.
+    # An explicit provider in model_config wins over the bare billing bucket —
+    # but only while it still resolves in config. A `custom:<name>` slug whose
+    # entry was deleted (dead endpoint — GH #75128) must be dropped so resume
+    # falls back to the configured default instead of failing agent init with
+    # "Unknown provider '<name>'".
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.setattr(rp, "load_config", lambda: {"custom_providers": []})
+    ov = server._stored_session_runtime_overrides(
+        {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
+    )
+    assert "provider_override" not in ov
+    # The stale model goes with it — a model without its provider would
+    # mismatch the configured default provider.
+    assert "model_override" not in ov
+
+    # The same explicit provider IS restored when the config entry still exists.
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {"name": "myendpoint", "base_url": "https://myendpoint.example/v1"}
+            ]
+        },
+    )
     ov = server._stored_session_runtime_overrides(
         {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
     )

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -27,6 +27,8 @@ import json
 import types
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import hermes_cli.runtime_provider as rp
 
 MIMO_URL = "https://token-plan-cn.xiaomimimo.com/v1"
@@ -341,5 +343,221 @@ class TestModelNameRecoversEntryIdentity:
             rp.find_custom_provider_identity_by_model("hermes-ultra-sft")
             == "custom:hermes-ultra"
         )
+
+
+# --- Regression: custom:<name> slug whose config entry was deleted (GH #75128) ---
+#
+# A session row persisted while a custom endpoint existed keeps
+# ``provider: custom:<name>`` in ``model_config``. When that entry is later
+# deleted from config (a dead HuggingFace endpoint, a retired gateway, …),
+# restoring the stored identity fails agent init with "Unknown provider
+# 'custom:<name>'" on Desktop/TUI while the CLI — which never restores
+# session runtime — resumes the same session fine with the configured
+# default. These tests lock the two-layer fallback: stored overrides are
+# dropped at restore time, and _make_agent degrades to the configured
+# default for any stale override that still reaches it.
+
+DELETED_SLUG = "custom:deepseek-v4-0731"
+DELETED_URL = (
+    "https://q5dh1rfszfym23hj.us-east-2.aws.endpoints.huggingface.cloud/v1"
+)
+
+NO_CUSTOM_ENTRY_CONFIG = {
+    # The dead endpoint's entry is gone; the global default is a built-in.
+    "model": {"default": "deepseek/deepseek-v4-flash-0731", "provider": "nous"},
+    "custom_providers": [],
+}
+
+DEFAULT_MIMO_CONFIG = {
+    "model": {"default": "mimo-v2.5-pro", "provider": "custom:mimo-v2.5-pro"},
+    "custom_providers": [
+        {
+            "name": "mimo-v2.5-pro",
+            "base_url": MIMO_URL,
+            "api_key": MIMO_KEY,
+            "api_mode": "chat_completions",
+        }
+    ],
+}
+
+STALE_ROW = {
+    "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+    "model_config": json.dumps(
+        {
+            "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "provider": DELETED_SLUG,
+            "base_url": DELETED_URL,
+            "api_mode": "chat_completions",
+            "reasoning_config": {"enabled": True, "effort": "max"},
+            "service_tier": "normal",
+        }
+    ),
+    "billing_provider": "custom",
+}
+
+
+class TestStaleCustomProviderSlugFallsBackToDefault:
+    def test_stored_overrides_drop_deleted_slug(self, monkeypatch):
+        """A deleted custom endpoint must not be restored: resume falls back
+        to the configured default (CLI parity) instead of failing with
+        'Unknown provider'."""
+        monkeypatch.setattr(rp, "load_config", lambda: NO_CUSTOM_ENTRY_CONFIG)
+
+        from tui_gateway.server import _stored_session_runtime_overrides
+
+        overrides = _stored_session_runtime_overrides(STALE_ROW)
+
+        assert "model_override" not in overrides
+        assert "provider_override" not in overrides
+        # Orthogonal session preferences survive the staleness gate.
+        assert overrides["reasoning_config_override"] == {
+            "enabled": True,
+            "effort": "max",
+        }
+
+    def test_stored_overrides_keep_existing_entry(self, monkeypatch):
+        """A still-configured custom entry keeps restoring (no regression)."""
+        monkeypatch.setattr(rp, "load_config", lambda: LEGACY_LIST_CONFIG)
+
+        from tui_gateway.server import _stored_session_runtime_overrides
+
+        row = {
+            "model": "mimo-v2.5-pro",
+            "model_config": json.dumps(
+                {
+                    "model": "mimo-v2.5-pro",
+                    "provider": "custom:mimo-v2.5-pro",
+                    "base_url": MIMO_URL,
+                    "api_mode": "chat_completions",
+                }
+            ),
+            "billing_provider": "custom",
+        }
+        overrides = _stored_session_runtime_overrides(row)
+
+        assert overrides["provider_override"] == "custom:mimo-v2.5-pro"
+        assert overrides["model_override"]["provider"] == "custom:mimo-v2.5-pro"
+
+    def test_stored_overrides_keep_builtin_provider(self, monkeypatch):
+        """Built-in providers are untouched by the staleness gate."""
+        monkeypatch.setattr(rp, "load_config", lambda: {})
+
+        from tui_gateway.server import _stored_session_runtime_overrides
+
+        row = {
+            "model": "claude-sonnet-4-5",
+            "model_config": json.dumps(
+                {"model": "claude-sonnet-4-5", "provider": "anthropic"}
+            ),
+            "billing_provider": "anthropic",
+        }
+        overrides = _stored_session_runtime_overrides(row)
+
+        assert overrides["provider_override"] == "anthropic"
+        assert overrides["model_override"]["provider"] == "anthropic"
+
+    def test_make_agent_falls_back_to_default_end_to_end(self, monkeypatch):
+        """The exact failing path: a stale override slug reaches _make_agent;
+        the agent must build with the configured default instead of failing
+        with 'Unknown provider'."""
+        override = {
+            "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "provider": DELETED_SLUG,
+            "base_url": DELETED_URL,
+            "api_mode": "chat_completions",
+        }
+        fake_cfg = {
+            "agent": {"system_prompt": ""},
+            "model": {
+                "default": "mimo-v2.5-pro",
+                "provider": "custom:mimo-v2.5-pro",
+            },
+        }
+        monkeypatch.setattr(rp, "load_config", lambda: DEFAULT_MIMO_CONFIG)
+        monkeypatch.setattr(
+            rp, "_get_model_config", lambda: DEFAULT_MIMO_CONFIG["model"]
+        )
+        monkeypatch.setattr(
+            rp, "_try_resolve_from_custom_pool", lambda *a, **k: None
+        )
+
+        from tui_gateway import server as srv
+
+        with (
+            patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+            patch("tui_gateway.server._get_db", return_value=MagicMock()),
+            patch("tui_gateway.server._load_reasoning_config", return_value=None),
+            patch("tui_gateway.server._load_service_tier", return_value=None),
+            patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+            patch("run_agent.AIAgent") as mock_agent,
+        ):
+            from tui_gateway.server import _make_agent
+
+            _make_agent("sid-stale", "key-stale", model_override=override)
+
+        kwargs = mock_agent.call_args.kwargs
+        assert kwargs["model"] == "mimo-v2.5-pro"
+        assert kwargs["provider"] == "custom"
+        assert kwargs["base_url"] == MIMO_URL
+        assert kwargs["api_key"] == MIMO_KEY
+        assert DELETED_URL not in (kwargs.get("base_url") or "")
+
+
+class TestResolveRuntimeOrDefault:
+    def test_unknown_provider_falls_back_to_startup_default(self, monkeypatch):
+        from hermes_cli.auth import AuthError
+
+        from tui_gateway import server as srv
+
+        def _boom(*args, **kwargs):
+            raise AuthError(
+                "Unknown provider 'custom:deepseek-v4-0731'",
+                code="invalid_provider",
+            )
+
+        monkeypatch.setattr(srv, "_resolve_runtime_with_fallback", _boom)
+        monkeypatch.setattr(
+            srv, "_resolve_startup_runtime", lambda: ("default-model", "nous")
+        )
+
+        captured = {}
+
+        def _fake_resolve(**kwargs):
+            captured.update(kwargs)
+            return {
+                "provider": "nous",
+                "base_url": "https://nous.inference.example",
+                "api_key": "tok",
+                "api_mode": "chat_completions",
+            }
+
+        monkeypatch.setattr(rp, "resolve_runtime_provider", _fake_resolve)
+
+        resolution = srv._resolve_runtime_or_default(
+            {"requested": DELETED_SLUG}, DELETED_SLUG
+        )
+
+        assert resolution.used_fallback is True
+        assert resolution.selected_model == "default-model"
+        assert resolution.runtime["provider"] == "nous"
+        # The fallback must resolve the CONFIG default, not the stale slug.
+        assert captured == {"requested": "nous", "target_model": "default-model"}
+
+    def test_other_auth_errors_propagate(self, monkeypatch):
+        """Credential/availability failures must stay loud — only the
+        unknown-provider class degrades to the configured default."""
+        from hermes_cli.auth import AuthError
+
+        from tui_gateway import server as srv
+
+        def _boom(*args, **kwargs):
+            raise AuthError("no usable credentials", code="auth_unavailable")
+
+        monkeypatch.setattr(srv, "_resolve_runtime_with_fallback", _boom)
+
+        with pytest.raises(AuthError) as exc_info:
+            srv._resolve_runtime_or_default({"requested": "nous"}, "nous")
+
+        assert exc_info.value.code == "auth_unavailable"
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3589,6 +3589,38 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
 _BARE_BILLING_PROVIDERS = {"auto", "openrouter", "custom"}
 
 
+def _provider_identity_routable(provider: str) -> bool:
+    """Return whether a stored provider identity can still be resolved today.
+
+    ``session.resume`` restores the model/provider a chat actually used, but
+    only while that identity still exists. A ``custom:<name>`` slug whose
+    ``providers:`` / ``custom_providers:`` entry was deleted (e.g. a dead
+    HuggingFace endpoint — GH #75128) would otherwise fail agent init with
+    "Unknown provider '<name>'" even though the CLI resumes the same session
+    fine with the configured default. Bare ``custom`` only reaches this check
+    with a base_url (see the heal in _stored_session_runtime_overrides), where
+    the direct-alias path is routable. Built-ins go through the normal
+    registry check. Lookup failures never drop a session identity (return
+    True) — a config parse hiccup must not silently rewrite routing.
+    """
+    p = str(provider or "").strip().lower()
+    if not p or p in {"auto", "openrouter", "custom", "moa"}:
+        return True
+    if p.startswith("custom:"):
+        try:
+            from hermes_cli.runtime_provider import has_named_custom_provider
+
+            return has_named_custom_provider(p)
+        except Exception:
+            return True
+    try:
+        from hermes_cli.auth import is_runtime_provider_routable
+
+        return is_runtime_provider_routable(p)
+    except Exception:
+        return True
+
+
 def _stored_session_runtime_overrides(row: dict | None) -> dict:
     """Return runtime fields persisted with a stored session.
 
@@ -3656,6 +3688,27 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
                 "custom provider identity recovery failed", exc_info=True
             )
         provider = healed or ("" if not base_url else provider)
+
+    # A stored provider identity can outlive its config entry: a custom
+    # endpoint deleted from ``providers:`` / ``custom_providers:`` (or a
+    # built-in removed from the registry) leaves ``custom:<name>`` in the
+    # session row, and restoring it fails agent init with "Unknown provider
+    # '<name>'" — the Desktop/CLI divergence of GH #75128. When the identity
+    # is no longer routable, drop the model/provider overrides so resume
+    # falls back to the configured default, matching the working CLI path.
+    # The session row keeps the original identity (nothing is rewritten in
+    # place) and self-heals on the next persist.
+    if provider and not _provider_identity_routable(provider):
+        logger.warning(
+            "Stored provider %r for a resumed session is no longer "
+            "configured; falling back to the configured default model and "
+            "provider.",
+            provider,
+        )
+        model = ""
+        provider = ""
+        base_url = ""
+        api_mode = ""
 
     if model:
         # Use the same dict-shaped override that live /model switches use so a
@@ -6279,6 +6332,52 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+def _resolve_runtime_or_default(
+    resolve_kwargs: dict,
+    requested_provider: str | None,
+) -> _RuntimeFallbackResolution:
+    """Resolve an override runtime, degrading to the configured default when
+    the requested provider no longer exists.
+
+    Session/composer overrides carry the provider a chat was created with. A
+    ``custom:<name>`` endpoint deleted from config — GH #75128 — or a provider
+    removed from the registry makes that override unresolvable, and failing
+    the whole agent build on a stale identity is worse than the CLI's
+    behavior, which simply uses the configured default. Only the
+    ``invalid_provider`` AuthError triggers the fallback (the requested
+    provider is gone); credential/availability failures keep their existing
+    propagation so real auth problems stay loud. ``used_fallback`` is set so
+    the caller's stale base_url/api_mode/api_key overrides cannot leak into
+    the default runtime.
+    """
+    from hermes_cli.auth import AuthError
+
+    try:
+        return _resolve_runtime_with_fallback(resolve_kwargs)
+    except AuthError as exc:
+        if getattr(exc, "code", "") != "invalid_provider" or not requested_provider:
+            raise
+        logger.warning(
+            "Override provider %r is no longer configured (%s); falling back "
+            "to the configured default model and provider.",
+            requested_provider,
+            exc,
+        )
+        default_model, default_provider = _resolve_startup_runtime()
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(
+                requested=default_provider or None,
+                target_model=default_model or None,
+            )
+        except Exception:
+            # The configured default is broken too — surface the original,
+            # more actionable unknown-provider error.
+            raise exc
+        return _RuntimeFallbackResolution(runtime, default_model, True)
+
+
 def _make_agent(
     sid: str,
     key: str,
@@ -6385,7 +6484,7 @@ def _make_agent(
                 resolve_kwargs["explicit_base_url"] = override_base_url
         resolve_kwargs["requested"] = requested_provider
         resolve_kwargs["target_model"] = model or None
-        resolution = _resolve_runtime_with_fallback(resolve_kwargs)
+        resolution = _resolve_runtime_or_default(resolve_kwargs, requested_provider)
         runtime = resolution.runtime
         if resolution.used_fallback:
             if not resolution.selected_model:
@@ -6407,10 +6506,13 @@ def _make_agent(
             model = model_override
         if provider_override:
             requested_provider = provider_override
-        resolution = _resolve_runtime_with_fallback({
-            "requested": requested_provider,
-            "target_model": model or None,
-        })
+        resolution = _resolve_runtime_or_default(
+            {
+                "requested": requested_provider,
+                "target_model": model or None,
+            },
+            requested_provider,
+        )
         runtime = resolution.runtime
         if resolution.used_fallback:
             if not resolution.selected_model:


### PR DESCRIPTION
## Summary

Fixes #75128

Desktop resume restores a session's persisted provider identity from `state.db` (`sessions.model_config` JSON). When that provider no longer exists in config — a deleted `custom_providers:` / `providers:` entry (e.g. a retired HuggingFace inference endpoint), or a provider removed from the registry — the Desktop/TUI gateway fails agent init with:

```
agent init failed: Unknown provider 'custom:<name>'. Check 'hermes model' for available providers, or run 'hermes doctor' to diagnose config issues.
```

…while the CLI resumes the same session fine with the configured default model/provider, because the CLI never restores session-scoped runtime identity. This makes Desktop and CLI diverge after a config change, and `hermes doctor --fix` cannot help — the stale identity lives in the session row, not in config.

## Root Cause

`_stored_session_runtime_overrides()` (`tui_gateway/server.py`) deliberately restores the model/provider a chat actually used on `session.resume` — but it only healed the *bare* `"custom"` case. A `custom:<name>` slug (or a built-in provider) whose config entry has since been deleted was passed straight into `_make_agent` → `resolve_runtime_provider(requested="custom:<name>")` → `AuthError(code="invalid_provider")`, which the deferred agent build surfaced as "agent init failed: Unknown provider …".

## Fix

Two complementary layers, both in `tui_gateway/server.py`:

1. **Resume restore gate** — `_stored_session_runtime_overrides()` now validates the stored provider identity against the current config via the new `_provider_identity_routable()` helper. If the identity no longer resolves (deleted custom endpoint / removed provider), the model + provider overrides are dropped so resume falls back to the configured default — exactly the CLI path. Orthogonal preferences (reasoning effort, service tier) are preserved, and the session row is left untouched (it self-heals on the next persist).

2. **Agent-build safety net** — `_make_agent()` now resolves overrides through the new `_resolve_runtime_or_default()` helper, which degrades to the configured default *only* on `AuthError(code="invalid_provider")` and re-raises every other auth failure (missing credentials, provider down) so real problems stay loud. This covers sibling paths (a stale desktop composer pick, rows persisted before the fix) that bypass the restore gate.

## How to Verify

1. Create a session on a custom endpoint (`hermes model` → Custom provider, or a `custom_providers:` entry in config.yaml) and send at least one message.
2. Delete/retire that endpoint from config.yaml (or remove the entry) and set a different default model/provider.
3. Open the same session in the Desktop app. **Before this fix:** `agent init failed: Unknown provider 'custom:<name>'`. **After:** the session opens and the agent is built with the configured default (matching the CLI).
4. (Optional) Re-add the entry — the next resume restores the original session identity again, since the row was never rewritten.

## Test Plan

- [x] New regression tests in `tests/tui_gateway/test_custom_provider_session_persistence.py` covering both layers (restore gate + `_make_agent` fallback), plus non-regression guards for still-configured entries and built-in providers.
- [x] Updated `tests/test_tui_gateway_server.py::test_stored_session_runtime_overrides_skips_bare_billing_provider` to the new contract: an unresolvable explicit provider is dropped, a resolvable one is still restored.
- [x] Full hermetic suite via `scripts/run_tests.sh` (2,615 test files, ~23k tests) on the CI-exact dependency set (`uv sync --locked` with the full CI extra set) — **0 failures**.
- [x] Manual end-to-end reproduction against the reporter's exact session row + config: the agent now builds with the configured default (`nous` / `deepseek-v4-flash-0731`) with no stale-endpoint leakage.

## Risk Assessment

**Low.** The change only affects the *restore* step of `session.resume` and the override-resolution path of `_make_agent`:

- Valid, still-configured providers restore exactly as before (guarded by regression tests).
- Real auth failures (missing key, provider down) still propagate — only the "provider no longer exists" class degrades to the configured default.
- No session rows are rewritten and no config migration is required.

## Platforms Tested

- Linux (local dev environment, Python 3.12 test runner).
- The affected code path is platform-agnostic (SQLite session store + provider resolution); macOS/Windows behavior is unchanged from current main.


## Coverage vs. the surfaces listed in #75128

The report lists several places where a stale provider identity can live. Audited against current `main`:

| Surface | Status |
|---|---|
| `state.db` → `sessions.model_config` | **Fixed — the root cause.** This is the only surface the Desktop/TUI resume path reads for routing. The restore gate (layer 1) drops unresolvable identities so resume falls back to the configured default; the build safety net (layer 2) catches any stale override that still reaches agent build. |
| `webui/sessions/*.json`, `_index.json`, `_turn_journal/*.jsonl`, `webui/settings.json` (`default_model_provider`) | Does not exist on current `main` (verified at `36cb5ae553`): zero references in the codebase for `default_model_provider`, `webui/sessions`, or `_turn_journal`; the desktop app persists sessions to `state.db` via `preflightStateDb`, not to any `webui/` JSON; `webui` is only a session `source` tag in `state.db`. Nothing routes from it. |
| `auth.json` credential pools | Pools are consulted only *after* a provider identity resolves; a deleted entry fails the provider gate before any pool lookup, so a stale pool cannot cause this crash (the reporter's own repro confirms no `custom:ominiroute` pool entry existed). |
| `.env` `HERMES_CUSTOM_*` vars | These are the API-key env-var *names* (`key_env`) for entries defined in `custom_providers:` / `providers:` — not a separate provider mechanism. If the entry is gone the var is orphaned and irrelevant; the gate checks the config entry itself. |
| `config.yaml.bak.*` | Backups; never read for routing. |

This PR implements the report's alternative expected behavior — *"derive provider/model routing from the same authoritative config at runtime"* — rather than a cache-rewriting migration: session rows are never rewritten, so re-adding a provider restores the original session identity automatically, and no startup migration can touch user data.