### PR TITLE
feat(credential-pool): make the Anthropic credential resolution order configurable

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1354,16 +1354,86 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
+# Named credential sources for ``resolve_anthropic_token``, in the order they
+# are consulted by default. Users may reorder them via the
+# ``credential_resolve_order.anthropic`` config key.
+SOURCE_ENV_ANTHROPIC_TOKEN = "env_anthropic_token"
+SOURCE_ENV_CLAUDE_CODE_OAUTH_TOKEN = "env_claude_code_oauth_token"
+SOURCE_ENV_ANTHROPIC_API_KEY = "env_anthropic_api_key"
+SOURCE_CLAUDE_CODE_CREDENTIALS = "claude_code_credentials"
+SOURCE_CREDENTIAL_POOL = "credential_pool"
+
+DEFAULT_ANTHROPIC_RESOLVE_ORDER = (
+    SOURCE_ENV_ANTHROPIC_TOKEN,
+    SOURCE_ENV_CLAUDE_CODE_OAUTH_TOKEN,
+    SOURCE_ENV_ANTHROPIC_API_KEY,
+    SOURCE_CLAUDE_CODE_CREDENTIALS,
+    SOURCE_CREDENTIAL_POOL,
+)
+
+SUPPORTED_ANTHROPIC_RESOLVE_SOURCES = frozenset(DEFAULT_ANTHROPIC_RESOLVE_ORDER)
+
+
+def get_anthropic_resolve_order() -> tuple[str, ...]:
+    """Return the configured credential-source order for Anthropic.
+
+    Reads ``credential_resolve_order.anthropic`` from config.yaml. Any source
+    the user omits keeps its default relative position at the end, so a partial
+    list only *promotes* the sources it names and never silently drops a
+    fallback. Unknown entries are ignored.
+
+    Returns ``DEFAULT_ANTHROPIC_RESOLVE_ORDER`` when unset or unreadable, so
+    behaviour is unchanged for anyone who never touches the key.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+    except Exception:
+        return DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    if not isinstance(config, dict):
+        return DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    configured = config.get("credential_resolve_order")
+    if not isinstance(configured, dict):
+        return DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    requested = configured.get("anthropic")
+    if not isinstance(requested, (list, tuple)):
+        return DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    order: list[str] = []
+    for item in requested:
+        name = str(item or "").strip().lower()
+        if name in SUPPORTED_ANTHROPIC_RESOLVE_SOURCES and name not in order:
+            order.append(name)
+
+    if not order:
+        return DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    # Append any source the user did not mention, preserving default order.
+    for name in DEFAULT_ANTHROPIC_RESOLVE_ORDER:
+        if name not in order:
+            order.append(name)
+    return tuple(order)
+
+
 def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
-    Priority:
+    Default priority:
       1. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
       2. CLAUDE_CODE_OAUTH_TOKEN env var
       3. ANTHROPIC_API_KEY env var (explicit regular API key)
       4. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
          — with automatic refresh if expired and a refresh token is available
       5. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
+
+    The order is user-overridable via ``credential_resolve_order.anthropic`` in
+    config.yaml — see ``get_anthropic_resolve_order``. Multi-account pool users
+    typically promote ``credential_pool`` above ``claude_code_credentials`` so
+    that rotation, not a static file, decides which account is billed.
 
     Returns the token string or None.
     """
@@ -1377,37 +1447,40 @@ def resolve_anthropic_token() -> Optional[str]:
             creds_loaded = True
         return creds
 
-    # 1. Hermes-managed OAuth/setup token env var
-    token = _getenv("ANTHROPIC_TOKEN").strip()
-    if token:
-        preferred = _prefer_refreshable_claude_code_token(token, _read_creds())
-        if preferred:
-            return preferred
-        return token
+    def _from_env_anthropic_token() -> Optional[str]:
+        # Hermes-managed OAuth/setup token env var
+        token = _getenv("ANTHROPIC_TOKEN").strip()
+        if not token:
+            return None
+        return _prefer_refreshable_claude_code_token(token, _read_creds()) or token
 
-    # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
-    cc_token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
-    if cc_token:
-        preferred = _prefer_refreshable_claude_code_token(cc_token, _read_creds())
-        if preferred:
-            return preferred
-        return cc_token
+    def _from_env_claude_code_oauth_token() -> Optional[str]:
+        # CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
+        token = _getenv("CLAUDE_CODE_OAUTH_TOKEN").strip()
+        if not token:
+            return None
+        return _prefer_refreshable_claude_code_token(token, _read_creds()) or token
 
-    # 3. Regular API key. An explicit user-configured key must not be shadowed
-    # by auto-discovered Claude Code or credential-pool OAuth credentials.
-    api_key = _getenv("ANTHROPIC_API_KEY").strip()
-    if api_key:
-        return api_key
+    def _from_env_anthropic_api_key() -> Optional[str]:
+        # Regular API key. An explicit user-configured key must not be shadowed
+        # by auto-discovered Claude Code or credential-pool OAuth credentials.
+        return _getenv("ANTHROPIC_API_KEY").strip() or None
 
-    # 4. Claude Code credential file
-    resolved_claude_token = _resolve_claude_code_token_from_credentials(_read_creds())
-    if resolved_claude_token:
-        return resolved_claude_token
+    def _from_claude_code_credentials() -> Optional[str]:
+        return _resolve_claude_code_token_from_credentials(_read_creds())
 
-    # 5. Hermes credential_pool OAuth entry.
-    resolved_pool_token = _resolve_anthropic_pool_token()
-    if resolved_pool_token:
-        return resolved_pool_token
+    resolvers = {
+        SOURCE_ENV_ANTHROPIC_TOKEN: _from_env_anthropic_token,
+        SOURCE_ENV_CLAUDE_CODE_OAUTH_TOKEN: _from_env_claude_code_oauth_token,
+        SOURCE_ENV_ANTHROPIC_API_KEY: _from_env_anthropic_api_key,
+        SOURCE_CLAUDE_CODE_CREDENTIALS: _from_claude_code_credentials,
+        SOURCE_CREDENTIAL_POOL: _resolve_anthropic_pool_token,
+    }
+
+    for source in get_anthropic_resolve_order():
+        resolved = resolvers[source]()
+        if resolved:
+            return resolved
 
     return None
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4654,6 +4654,7 @@ def _default_value_for_key(dotted_key: str):
 _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "providers",
     "credential_pool_strategies",
+    "credential_resolve_order",
     "mcp_servers",
     "hooks",
     "quick_commands",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,10 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    # Optional per-provider override of the credential-source resolution order.
+    # Empty = each provider's built-in default order. See
+    # agent.anthropic_adapter.get_anthropic_resolve_order for the source names.
+    "credential_resolve_order": {},
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/tests/agent/test_anthropic_resolve_order.py
+++ b/tests/agent/test_anthropic_resolve_order.py
@@ -1,0 +1,212 @@
+"""Configurable credential resolution order for Anthropic.
+
+``resolve_anthropic_token()`` consults credential sources in a fixed order, with
+the Claude Code credentials file ranked above the Hermes credential pool. For a
+multi-account pool that is the wrong precedence: the pool rotates, but every
+call site that falls back to a bare resolve bills whichever account the static
+file happens to hold.
+
+These tests pin the default order (unchanged) and the config override that lets
+a user promote ``credential_pool``.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from agent.anthropic_adapter import (
+    DEFAULT_ANTHROPIC_RESOLVE_ORDER,
+    SOURCE_CLAUDE_CODE_CREDENTIALS,
+    SOURCE_CREDENTIAL_POOL,
+    SOURCE_ENV_ANTHROPIC_TOKEN,
+    get_anthropic_resolve_order,
+    resolve_anthropic_token,
+)
+
+CLAUDE_TOKEN = "sk-ant-oat01-from-claude-code-file"
+POOL_TOKEN = "sk-ant-oat01-from-credential-pool"
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """A temp HERMES_HOME with a real config.yaml and auth.json pool entry."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    (home / "auth.json").write_text(
+        json.dumps(
+            {
+                "credential_pool": {
+                    "anthropic": [
+                        {
+                            "id": "pool1",
+                            "label": "anthropic-pooled",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual",
+                            "access_token": POOL_TOKEN,
+                            "base_url": "https://api.anthropic.com",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    # No Anthropic env vars should leak in from the developer's shell.
+    for var in ("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    return home
+
+
+def write_config(home: Path, config: dict) -> None:
+    (home / "config.yaml").write_text(yaml.safe_dump(config))
+
+
+class TestResolveOrderConfig:
+    def test_default_order_when_unset(self, hermes_home):
+        write_config(hermes_home, {})
+        assert get_anthropic_resolve_order() == DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    def test_default_order_when_config_missing(self, hermes_home):
+        assert get_anthropic_resolve_order() == DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    def test_pool_can_be_promoted(self, hermes_home):
+        write_config(
+            hermes_home,
+            {"credential_resolve_order": {"anthropic": [SOURCE_CREDENTIAL_POOL]}},
+        )
+        order = get_anthropic_resolve_order()
+        assert order[0] == SOURCE_CREDENTIAL_POOL
+        # Unmentioned sources are retained, in default relative order.
+        assert set(order) == set(DEFAULT_ANTHROPIC_RESOLVE_ORDER)
+        assert order.index(SOURCE_CREDENTIAL_POOL) < order.index(
+            SOURCE_CLAUDE_CODE_CREDENTIALS
+        )
+
+    def test_unknown_sources_ignored(self, hermes_home):
+        write_config(
+            hermes_home,
+            {
+                "credential_resolve_order": {
+                    "anthropic": ["not_a_source", SOURCE_CREDENTIAL_POOL]
+                }
+            },
+        )
+        order = get_anthropic_resolve_order()
+        assert "not_a_source" not in order
+        assert order[0] == SOURCE_CREDENTIAL_POOL
+
+    def test_all_invalid_falls_back_to_default(self, hermes_home):
+        write_config(
+            hermes_home, {"credential_resolve_order": {"anthropic": ["nonsense"]}}
+        )
+        assert get_anthropic_resolve_order() == DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    def test_non_list_value_falls_back_to_default(self, hermes_home):
+        write_config(
+            hermes_home,
+            {"credential_resolve_order": {"anthropic": SOURCE_CREDENTIAL_POOL}},
+        )
+        assert get_anthropic_resolve_order() == DEFAULT_ANTHROPIC_RESOLVE_ORDER
+
+    def test_duplicates_collapse(self, hermes_home):
+        write_config(
+            hermes_home,
+            {
+                "credential_resolve_order": {
+                    "anthropic": [SOURCE_CREDENTIAL_POOL, SOURCE_CREDENTIAL_POOL]
+                }
+            },
+        )
+        order = get_anthropic_resolve_order()
+        assert len(order) == len(set(order)) == len(DEFAULT_ANTHROPIC_RESOLVE_ORDER)
+
+
+class TestResolveTokenHonoursOrder:
+    """End-to-end: the resolved token follows the configured order."""
+
+    def _patch_claude_file(self):
+        return patch(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            return_value={"accessToken": CLAUDE_TOKEN},
+        )
+
+    def test_default_prefers_claude_code_file(self, hermes_home):
+        write_config(hermes_home, {})
+        with self._patch_claude_file():
+            assert resolve_anthropic_token() == CLAUDE_TOKEN
+
+    def test_promoted_pool_wins_over_claude_code_file(self, hermes_home):
+        write_config(
+            hermes_home,
+            {"credential_resolve_order": {"anthropic": [SOURCE_CREDENTIAL_POOL]}},
+        )
+        with self._patch_claude_file():
+            assert resolve_anthropic_token() == POOL_TOKEN
+
+    def test_promoted_pool_still_falls_back_when_pool_empty(self, hermes_home):
+        (hermes_home / "auth.json").write_text(
+            json.dumps({"credential_pool": {"anthropic": []}})
+        )
+        write_config(
+            hermes_home,
+            {"credential_resolve_order": {"anthropic": [SOURCE_CREDENTIAL_POOL]}},
+        )
+        with self._patch_claude_file():
+            # Pool yields nothing, so the next source in order still answers.
+            assert resolve_anthropic_token() == CLAUDE_TOKEN
+
+    def test_explicit_env_token_still_wins_when_listed_first(
+        self, hermes_home, monkeypatch
+    ):
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-explicit-env")
+        write_config(
+            hermes_home,
+            {
+                "credential_resolve_order": {
+                    "anthropic": [SOURCE_ENV_ANTHROPIC_TOKEN, SOURCE_CREDENTIAL_POOL]
+                }
+            },
+        )
+        with patch(
+            "agent.anthropic_adapter.read_claude_code_credentials", return_value=None
+        ):
+            assert resolve_anthropic_token() == "sk-ant-oat01-explicit-env"
+
+    def test_env_token_can_be_deprioritised_below_pool(self, hermes_home, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-explicit-env")
+        write_config(
+            hermes_home,
+            {"credential_resolve_order": {"anthropic": [SOURCE_CREDENTIAL_POOL]}},
+        )
+        with patch(
+            "agent.anthropic_adapter.read_claude_code_credentials", return_value=None
+        ):
+            assert resolve_anthropic_token() == POOL_TOKEN
+
+    def test_returns_none_when_no_source_answers(self, hermes_home):
+        (hermes_home / "auth.json").write_text(
+            json.dumps({"credential_pool": {"anthropic": []}})
+        )
+        write_config(hermes_home, {})
+        with patch(
+            "agent.anthropic_adapter.read_claude_code_credentials", return_value=None
+        ):
+            assert resolve_anthropic_token() is None
+
+
+class TestConfigSchemaAcceptsKey:
+    def test_key_is_open_dict_so_arbitrary_providers_validate(self):
+        from hermes_cli.config import _OPEN_DICT_TOP_LEVEL_KEYS
+
+        assert "credential_resolve_order" in _OPEN_DICT_TOP_LEVEL_KEYS
+
+    def test_default_config_declares_the_key(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["credential_resolve_order"] == {}

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -134,6 +134,41 @@ credential_pool_strategies:
 | `least_used` | Always pick the key with the lowest request count |
 | `random` | Random selection among healthy keys |
 
+## Credential Resolution Order
+
+Rotation decides *which pool entry* is selected. A separate question is *whether
+the pool is consulted at all* — Hermes resolves a provider token from several
+sources, and for Anthropic the Claude Code credentials file
+(`~/.claude/.credentials.json`) is checked **before** the credential pool by
+default.
+
+That default is right for single-account setups, but it surprises multi-account
+pool users: any code path that falls back to a bare token resolve (rather than
+being handed an explicit key) bills whichever account that static file holds,
+regardless of which entry the pool just rotated to. The pool's *selections* stay
+perfectly balanced while the *traffic* lands on one account.
+
+Override the order in `config.yaml`:
+
+```yaml
+credential_resolve_order:
+  anthropic:
+    - credential_pool          # consult the rotating pool first
+```
+
+| Source | Reads |
+|--------|-------|
+| `env_anthropic_token` | `ANTHROPIC_TOKEN` |
+| `env_claude_code_oauth_token` | `CLAUDE_CODE_OAUTH_TOKEN` |
+| `env_anthropic_api_key` | `ANTHROPIC_API_KEY` |
+| `claude_code_credentials` | `~/.claude.json`, `~/.claude/.credentials.json` |
+| `credential_pool` | `~/.hermes/auth.json` |
+
+Sources you omit keep their default relative position at the end of the list, so
+a one-line override only *promotes* what it names and never drops a fallback.
+Unknown names are ignored, and an absent or unusable key leaves the default
+order untouched.
+
 ## Error Recovery
 
 The pool handles different errors differently:


### PR DESCRIPTION
## The problem

`resolve_anthropic_token()` consults credential sources in a hardcoded order, with the Claude Code credentials file ranked **above** the Hermes credential pool:

```
1. ANTHROPIC_TOKEN env
2. CLAUDE_CODE_OAUTH_TOKEN env
3. ANTHROPIC_API_KEY env
4. ~/.claude/.credentials.json   ← static, single account
5. credential_pool               ← the rotation lives down here
```

For a single-account setup that's correct. For a **multi-account pool it's backwards**, and it fails in a way that's genuinely hard to see.

Roughly eight call sites resolve a bare token instead of receiving an explicit `api_key` — `agent_init` when the key is empty, `agent_runtime_helpers`, `auxiliary_client`, the `chat_completion_helpers` fallback, `account_usage`, plus title-generation, vision/STT enrichment, and retry paths. Every one of them bills whichever account that static file holds, regardless of which entry the pool just rotated to.

The result: the pool's selection log is textbook-balanced, and 100% of the actual usage lands on one account.

```
selections:  account-a 91 / account-b 88 / account-c 88   ← perfect rotation
meters:      account-a 48% / account-b 77% / account-c 0%  ← one account never served a request
```

`account-c` above had `resets_at: null` — it had never served a single request despite being selected 88 times. The symptom reads as "rotation is broken", but rotation is fine; the traffic simply never asked the pool.

Compounding it, `_resolve_anthropic_pool_token()` returns `entries[0]` — a fixed entry, not the rotating selection — so even reaching source 5 doesn't follow rotation.

## The change

Adds `credential_resolve_order.anthropic` to `config.yaml`, mirroring the existing `credential_pool_strategies` shape and using the same open-dict schema registration:

```yaml
credential_resolve_order:
  anthropic:
    - credential_pool
```

| Source | Reads |
|--------|-------|
| `env_anthropic_token` | `ANTHROPIC_TOKEN` |
| `env_claude_code_oauth_token` | `CLAUDE_CODE_OAUTH_TOKEN` |
| `env_anthropic_api_key` | `ANTHROPIC_API_KEY` |
| `claude_code_credentials` | `~/.claude.json`, `~/.claude/.credentials.json` |
| `credential_pool` | `~/.hermes/auth.json` |

Sources omitted from the list keep their default relative position at the end, so a one-line override only *promotes* what it names and never silently drops a fallback. Unknown names are ignored; an absent, malformed, or all-invalid value returns the default order.

`resolve_anthropic_token` is refactored from a straight-line chain into named per-source resolvers driven by that order. The lazy `_read_creds` memo is preserved, as is each source's semantics — including "an explicit user-configured API key must not be shadowed by auto-discovered credentials".

**Default behaviour is unchanged.** With no config key present, the order is byte-identical to today.

## Why config rather than changing the default

Flipping the default would be a behaviour change for every single-account user who relies on the Claude Code file winning, so the safe move is to make it expressible. Users who don't touch the key see nothing new.

Deliberately kept to the Anthropic resolver — that's where the concrete reported problem is. The config key is per-provider (`credential_resolve_order.<provider>`) so other providers can adopt the same shape if the need shows up, without this PR speculating on their behalf.

## Verification

New: `tests/agent/test_anthropic_resolve_order.py` — 15 cases run against a **real temp `HERMES_HOME`** with a real `config.yaml` and `auth.json` (no mocked config layer), per the E2E guidance in AGENTS.md:

- default order when the key is unset / config file missing
- pool promoted above the credentials file, end-to-end through `resolve_anthropic_token()`
- promoted-but-empty pool still falls through to the next source
- unknown names ignored, duplicates collapsed, non-list and all-invalid values fall back to default
- env-var precedence honoured in **both** directions (listed first wins; deliberately deprioritised below the pool loses)
- `None` when no source answers
- schema registration in `_OPEN_DICT_TOP_LEVEL_KEYS` and `DEFAULT_CONFIG`

```
tests/agent/test_anthropic_resolve_order.py                 15 passed
tests/agent/test_anthropic_adapter.py
  + tests/agent/test_anthropic_token_scope_isolation.py     100 passed  (untouched)
ruff check                                                  All checks passed
```

Broader `tests/agent/ -k "config or credential or anthropic or resolve"` shows 4 failures — all 4 reproduce identically on a clean `origin/main` worktree (pre-existing cross-test pollution: `test_anthropic_mcp_prefix_strip` ×2, `test_credential_pool_oat_authtype`, `test_credential_pool_routing`), and `test_credential_pool_oat_authtype` passes in isolation on this branch.

Docs: new "Credential Resolution Order" section in `website/docs/user-guide/features/credential-pools.md`.
