### PR TITLE
feat(desktop): include messaging sessions in per-profile recents

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -248,4 +248,27 @@ describe('refreshSessions batches slices into one request', () => {
 
     expect(getCronJobs).toHaveBeenLastCalledWith('all')
   })
+
+  it('keeps messaging sources in the per-profile recents exclusion list', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    const { recentsExclude } = listSidebarSessions.mock.calls[0][0] as {
+      recentsExclude: string[]
+    }
+
+    // Cron/kanban/subagent/tool rows still get their own handling elsewhere.
+    expect(recentsExclude).toEqual(expect.arrayContaining(['cron', 'kanban', 'subagent', 'tool']))
+
+    // Messaging-platform sessions belong in the profile's Sessions list too —
+    // they are fetched separately for the global per-platform sections, but the
+    // profile recents must not filter them out.
+    for (const source of ['telegram', 'discord', 'slack']) {
+      expect(recentsExclude).not.toContain(source)
+    }
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -5,7 +5,6 @@ import { sameCronSignature } from '@/lib/session-signatures'
 import {
   isMessagingSource,
   LOCAL_SESSION_SOURCE_IDS,
-  MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '@/lib/session-source'
 import { setCronJobs } from '@/store/cron'
@@ -29,13 +28,14 @@ import {
 } from '@/store/session'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
-// The recents list is local-only: cron rows have their own section, kanban
-// dispatcher workers are read on the board, and each messaging platform
-// (telegram, discord, …) is fetched separately into its own self-managed
-// sidebar section (refreshMessagingSessions). Excluding them here keeps
-// "Load more" paging through interactive local chats instead of
-// interleaving gateway threads that bury them.
-const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'kanban', 'subagent', 'tool', ...MESSAGING_SESSION_SOURCE_IDS]
+// Per-profile recents keep cron/kanban/subagent/tool rows out — those have
+// their own sections or live on the board — but include messaging-platform
+// sessions (telegram, discord, …): a profile's Sessions list is complete
+// regardless of where the conversation originated. The per-platform sidebar
+// sections are fed by the separate messaging slice (refreshMessagingSessions)
+// and stay unchanged, so messaging rows appear both in their platform section
+// and in the active profile's recents.
+const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'kanban', 'subagent', 'tool']
 // The messaging slice is the inverse: drop cron + every local source so only
 // external-platform conversations remain, then split per platform in the UI.
 const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]


### PR DESCRIPTION
## Summary

Per-profile **Sessions** lists in the desktop sidebar currently exclude messaging-platform sessions (Telegram, Discord, Slack, …) — those only appear in the global per-platform sidebar sections introduced by #42537. This change includes them in the per-profile recents, so a profile's Sessions list is complete regardless of where a conversation originated.

**Before:** per-profile recents exclude `cron`, `kanban`, `subagent`, `tool`, **and every messaging source**.
**After:** per-profile recents exclude only `cron`, `kanban`, `subagent`, `tool`.

## Motivation

For users running messaging gateways against the same backend as desktop/CLI sessions (the standard single-profile setup), a conversation's location in the sidebar depends on its origin: Telegram chats live only in the global Telegram section, never in the profile's Sessions list. That split is confusing when:

- the profile's Sessions list is used as the canonical "what happened with this profile" view,
- handoffs move a Telegram conversation into a local session and the trail splits across two sections,
- a profile is messaging-heavy and the per-platform sections push chats far down the sidebar.

Including messaging rows in the profile recents makes the list a faithful view of the profile's activity while keeping the dedicated platform sections intact for platform-first browsing.

## Design note

This intentionally reverses part of the "local-only recents" intent from #42537 (which kept "Load more" paging through interactive local chats instead of interleaving gateway threads). The per-platform sections are **unchanged** — `refreshMessagingSessions` still fetches the same separate messaging slice — so messaging rows now appear in *both* the platform section and the active profile's recents. That duplication is the point (platform-first and profile-first browsing both work), and `recentsProfile` scoping already limits the extra rows to the active profile. Cron/kanban/subagent/tool rows stay excluded, as before.

If maintainers prefer this behind a config toggle rather than as the default, that's a reasonable follow-up — but a first pass as a plain behavior change keeps the surface minimal and matches how the rest of the sidebar sections are composed.

## Testing

- Added a behavior test asserting `recentsExclude` keeps `cron`/`kanban`/`subagent`/`tool` but no longer contains messaging sources.
- `npx vitest run src/app/session/hooks/use-session-list-actions.test.tsx` — 9/9 passing.
- `eslint` clean on both changed files.
