### PR TITLE
feat(plugins): warn when a probe cannot produce the opposite result

### DIFF
--- a/plugins/discrimination-guard/README.md
+++ b/plugins/discrimination-guard/README.md
@@ -1,0 +1,62 @@
+# discrimination-guard
+
+Warns when a probe or test the agent is writing **cannot produce the opposite
+result**.
+
+## The problem
+
+An agent that writes its own verification code has a specific way of being
+confidently wrong: it produces a measurement that looks like evidence but that
+would have come out the same way whether or not the claim were true. The
+output then reads exactly like a discovery.
+
+Real examples, all from one session:
+
+| what was observed | what it actually meant |
+|---|---|
+| `pytest` reported `0 failed` | collection **errored**; zero tests ran |
+| `tf.format == 2` (PAX) | `format` on a *read* handle is the reader default |
+| `hasattr(mod, name)` is `False` | the function is **nested**, not module-level |
+| `19 FAILED` in someone's suite | 14 were `ModuleNotFoundError` from an incomplete venv |
+| `(rc == 0) == (on == wanted)` held | a tautology — true whichever way the tool behaves |
+| `git checkout -B` "worked" | it printed `Aborting`; the next patch hit the old branch |
+
+Every one of those is the same defect: a measurement accepted without first
+establishing that it can **distinguish** the claimed outcome from its opposite.
+
+## What it checks
+
+Structural properties, not a list of known-bad snippets — so it fires on shapes
+it has never seen:
+
+1. a verdict is emitted with **no negative control** anywhere in the probe
+2. an assertion compares **two of the probe's own observations** (tautology)
+3. a `subprocess` result is consumed **without inspecting `returncode`**
+4. a *"no failures"* conclusion with **no evidence anything ran**
+5. **text presence** (`"x" in src`, `grep -c`) used as proof a code path behaves
+
+Only files that look like probes/tests are considered, and only writes over
+~120 characters.
+
+## Behaviour
+
+Non-blocking by default: the write proceeds and the warning rides back to the
+model in the next turn so it can self-correct. Set
+`DISCRIMINATION_GUARD_BLOCK=1` to refuse the write instead.
+
+## False positives
+
+The guard is quiet on probes that already discriminate — one that drives the
+real function and asserts a control case, one that checks `returncode`, one
+that mutation-verifies its own fix, and on ordinary source files. Those four
+shapes are covered as negative cases in the test suite, because a guard that
+flags everything gets ignored within a day.
+
+## Testing
+
+```
+pytest tests/plugins/test_discrimination_guard_plugin.py
+```
+
+8 cases: 4 real wrong-verdict probes that must be flagged, 4 sound probes that
+must stay quiet.

--- a/plugins/discrimination-guard/__init__.py
+++ b/plugins/discrimination-guard/__init__.py
@@ -1,0 +1,151 @@
+"""discrimination-guard — refuse a verdict whose measurement cannot be wrong.
+
+WHY THIS EXISTS
+---------------
+16 wrong verdicts in one session, and all 16 are one defect:
+
+    a measurement was accepted without first establishing that it can
+    DISTINGUISH the claimed outcome from its opposite.
+
+Four disguises, all the same thing:
+
+  indicator      read a signal without checking what it can mean
+                 (`tf.format` on a read handle reports the READER default;
+                  `hasattr` cannot see a nested function)
+  environment    the probe ran in a world unlike production
+                 (an incomplete venv turns ModuleNotFoundError into "19 bugs")
+  discrimination the check passes under BOTH outcomes
+                 (`(rc == 0) == (on == wanted)` is a tautology)
+  silent-failure the command failed and said so somewhere unread
+                 (`git checkout -B` prints "Aborting" and exits non-zero)
+
+The existing contract-guard matches TEXT PATTERNS of past mistakes, so it
+scored 0/8 against this session's new shapes. Pattern matching on last week's
+errors cannot catch next week's. This guard asks a structural question instead:
+
+    does this probe contain anything that could have come out the other way?
+
+WHAT IT CHECKS (all structural, none tied to a specific past bug)
+  1. a verdict is being emitted with no negative control in the same probe
+  2. an assertion compares two of the probe's own observations (tautology)
+  3. a subprocess/shell result is consumed without inspecting returncode
+  4. "zero failures" style conclusions with no proof anything ran
+  5. presence-of-text (grep/`in`) used as evidence a code path is guarded
+
+Default is warn. DISCRIMINATION_GUARD_BLOCK=1 makes it refuse.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, List
+
+# --- structural signals ---------------------------------------------------
+
+# a probe that prints a verdict
+_VERDICT = re.compile(
+    r"\b(ok|pass(?:ed)?|fail(?:ed|s)?|clean|safe|leak|vulnerable|broken|"
+    r"present|missing|correct|wrong|verdict|confirmed|reproduce[sd]?)\b",
+    re.I)
+
+# a negative control: something asserted NOT to happen, or a control fixture
+_NEGATIVE_CONTROL = re.compile(
+    r"(negative[ _]control|control\b|counterexample|must not|should not|"
+    r"assert not|!=|is False|== False|unchanged|untouched|baseline)", re.I)
+
+# comparing two observations the probe itself produced
+_TAUTOLOGY = re.compile(
+    r"\(\s*\w+\s*==\s*[^)]+\)\s*==\s*\(\s*\w+\s*==\s*[^)]+\)"
+    r"|assert\s+\w+\s*==\s*\w+\s*$")
+
+# subprocess use
+_SUBPROCESS = re.compile(r"subprocess\.(run|call|Popen)|check_output|os\.system")
+_RC_CHECKED = re.compile(
+    r"returncode|\.check_returncode|check=True|rc\s*[!=]=|exit_code|"
+    r"\$\?|CalledProcessError")
+
+# "nothing failed" conclusions
+_ZERO_FAIL = re.compile(
+    r"(0|zero|no)\s+(fail(?:ure|ed)?s?|error(?:s)?|leak(?:s)?|regression(?:s)?)",
+    re.I)
+_RAN_PROOF = re.compile(
+    r"(collected|passed|\btotal\b|len\(|count|assert\s+\w+\s*>\s*0|"
+    r"\bran\b|executed)", re.I)
+
+# text presence used as proof of behaviour
+_GREP_AS_PROOF = re.compile(
+    r"(\"[^\"]+\"\s+in\s+(src|source|text|body|content|block|code)\w*"
+    r"|grep\s+-c\b)")
+_DRIVES_CODE = re.compile(
+    r"(import(?:lib)?|spec_from_file_location|__import__|"
+    r"getattr\(|\bcall\(|\(\)\s*$)", re.M)
+
+_PROBE_HINT = re.compile(
+    r"(audits?/|probe|verify|check|hunt|prove|reach|test_|_test\b)", re.I)
+
+
+def _looks_like_a_probe(path: str, content: str) -> bool:
+    if _PROBE_HINT.search(path or ""):
+        return True
+    return bool(_VERDICT.search(content) and
+                ("print(" in content or "assert " in content))
+
+
+def analyse(content: str) -> List[str]:
+    """Return structural objections. Empty list == nothing to say."""
+    out: List[str] = []
+
+    if _VERDICT.search(content) and not _NEGATIVE_CONTROL.search(content):
+        out.append(
+            "emits a verdict but contains NO negative control — add a case that "
+            "must come out the other way, or the probe cannot fail")
+
+    if _TAUTOLOGY.search(content):
+        out.append(
+            "an assertion compares two of the probe's own observations; that is "
+            "true whichever way the system behaves — assert the contract instead")
+
+    if _SUBPROCESS.search(content) and not _RC_CHECKED.search(content):
+        out.append(
+            "consumes a subprocess result without inspecting returncode — a "
+            "command that refused to run reads as a clean result")
+
+    if _ZERO_FAIL.search(content) and not _RAN_PROOF.search(content):
+        out.append(
+            "concludes 'no failures' without evidence anything RAN — zero "
+            "failures and zero executions look identical")
+
+    if _GREP_AS_PROOF.search(content) and not _DRIVES_CODE.search(content):
+        out.append(
+            "uses text presence as proof a code path behaves — grep finds the "
+            "symbol, not the branch that executes; drive the real function")
+
+    return out
+
+
+def _on_pre_tool_call(tool_name: str = "", args: Any = None, **_: Any):
+    if tool_name not in ("write_file", "patch", "execute_code"):
+        return None
+    if not isinstance(args, dict):
+        return None
+    content = args.get("content") or args.get("code") or args.get("new_string") or ""
+    path = args.get("path") or ""
+    if not isinstance(content, str) or len(content) < 120:
+        return None
+    if not _looks_like_a_probe(str(path), content):
+        return None
+
+    problems = analyse(content)
+    if not problems:
+        return None
+
+    msg = ("discrimination-guard: this probe may not be able to produce the "
+           "opposite result.\n" + "\n".join(f"  - {p}" for p in problems))
+    if os.environ.get("DISCRIMINATION_GUARD_BLOCK") == "1":
+        return {"action": "block",
+                "message": msg + "\n\n(unset DISCRIMINATION_GUARD_BLOCK to warn only)"}
+    return {"action": "warn", "message": msg}
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)

--- a/plugins/discrimination-guard/plugin.yaml
+++ b/plugins/discrimination-guard/plugin.yaml
@@ -1,0 +1,6 @@
+name: discrimination-guard
+version: "0.1.0"
+description: "Warn when a probe or test the agent is writing cannot produce the opposite result — no negative control, a tautological assertion, a subprocess result consumed without checking returncode, a 'no failures' conclusion with no proof anything ran, or text presence used as evidence a code path behaves. Structural checks only, so it catches shapes it has never seen. Non-blocking by default; DISCRIMINATION_GUARD_BLOCK=1 refuses the write."
+author: "NousResearch"
+hooks:
+  - pre_tool_call

--- a/tests/plugins/test_discrimination_guard_plugin.py
+++ b/tests/plugins/test_discrimination_guard_plugin.py
@@ -1,0 +1,134 @@
+"""discrimination-guard must catch probes that cannot fail, and stay quiet
+on probes that can.
+
+The second half carries the weight: a guard that flags sound work is noise,
+and noise gets muted within a day.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+PLUGIN = (Path(__file__).resolve().parents[2]
+          / "plugins" / "discrimination-guard" / "__init__.py")
+
+
+@pytest.fixture(scope="module")
+def guard():
+    spec = importlib.util.spec_from_file_location("discrimination_guard", PLUGIN)
+    assert spec is not None and spec.loader is not None, f"cannot load {PLUGIN}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def flagged(guard, content, path="/tmp/audits/probe.py"):
+    out = guard._on_pre_tool_call(tool_name="write_file",
+                                  args={"path": path, "content": content})
+    return bool(out and out.get("action") in ("warn", "block"))
+
+
+# --------------------------------------------------------------- must flag
+
+TAUTOLOGY = '''
+"""Verify the guard refuses a dirty tree."""
+rc = cmd_branch("feature2", "master", d)
+on = current_branch(d)
+check("dirty tree: reported honestly", True, (rc == 0) == (on == "feature2"))
+print("verdict: guard ok")
+'''
+
+UNCHECKED_SUBPROCESS = '''
+"""Probe whether the branch switch worked."""
+import subprocess
+subprocess.run("git checkout -B fix/new upstream/main", shell=True)
+subprocess.run("git apply /tmp/x.patch", shell=True)
+print("branch switched: ok")
+'''
+
+ZERO_FAILURES = '''
+"""Baseline the suite before judging the patch."""
+import subprocess
+out = subprocess.run("pytest tests/ -q", shell=True, capture_output=True,
+                     text=True).stdout
+fails = [l for l in out.splitlines() if l.startswith("FAILED")]
+print("baseline: no failures, patch is clean" if not fails else fails)
+'''
+
+GREP_AS_PROOF = '''
+"""Check collect_files rejects non-regular files."""
+src = open("graphify/extract.py").read()
+block = src[src.find("def collect_files"):][:3000]
+has_guard = "is_file" in block
+print("guard present:", has_guard, "-> verdict: safe")
+'''
+
+
+@pytest.mark.parametrize("label,content", [
+    ("tautological assertion", TAUTOLOGY),
+    ("unchecked subprocess", UNCHECKED_SUBPROCESS),
+    ("zero failures, nothing ran", ZERO_FAILURES),
+    ("grep as proof of behaviour", GREP_AS_PROOF),
+])
+def test_a_probe_that_cannot_fail_is_flagged(guard, label, content):
+    assert flagged(guard, content), f"{label} should have been flagged"
+
+
+# -------------------------------------------------------------- must be quiet
+
+WIRE_PROBE_WITH_CONTROL = '''
+"""Does the webhook leak the key on the wire?"""
+import secrets
+key = "sk-" + secrets.token_hex(24)
+body = wh._serialize_payload("pre_tool_call", {"args": {"cmd": key}}, "id").decode()
+print("key present:", key in body)
+control = "see file.txt for details"
+assert control in wh._serialize_payload(
+    "pre_tool_call", {"args": {"cmd": control}}, "id").decode(), "prose untouched"
+'''
+
+RETURNCODE_CHECKED = '''
+"""Measure the failure rate on a pristine worktree."""
+import subprocess
+r = subprocess.run(["pytest", "tests/x.py", "-q"], capture_output=True, text=True)
+if r.returncode not in (0, 1):
+    raise SystemExit(f"UNKNOWN: pytest could not run (rc={r.returncode})")
+print("failed:", "FAILED" in r.stdout, "| baseline unchanged:", r.returncode == 0)
+'''
+
+MUTATION_VERIFIED = '''
+"""Prove the fix is not vacuous by reverting it."""
+mod = load_real_module()
+before = mod.file_hash(f, root)
+f.write_text("different")
+after = mod.file_hash(f, root)
+print("digest changed:", before != after)
+print("control, untouched file stable:", mod.file_hash(g, root) == g_digest)
+'''
+
+ORDINARY_SOURCE = '''
+def render_summary(rows):
+    """Format a table for the CLI."""
+    width = max(len(r.name) for r in rows)
+    return "\\n".join(f"{r.name:<{width}}  {r.value}" for r in rows)
+'''
+
+
+@pytest.mark.parametrize("label,content,path", [
+    ("wire probe with a control", WIRE_PROBE_WITH_CONTROL, "/tmp/audits/p.py"),
+    ("returncode checked", RETURNCODE_CHECKED, "/tmp/audits/p.py"),
+    ("mutation verified", MUTATION_VERIFIED, "/tmp/audits/p.py"),
+    ("ordinary source file", ORDINARY_SOURCE, "/tmp/project/render.py"),
+])
+def test_a_sound_probe_is_left_alone(guard, label, content, path):
+    assert not flagged(guard, content, path), f"{label} should not be flagged"
+
+
+def test_short_writes_are_ignored(guard):
+    assert not flagged(guard, "print('ok')")
+
+
+def test_non_write_tools_are_ignored(guard):
+    out = guard._on_pre_tool_call(tool_name="terminal",
+                                  args={"command": "echo ok, verdict clean"})
+    assert out is None


### PR DESCRIPTION
An agent that writes its own verification code has a specific way of being
confidently wrong: it produces a measurement that looks like evidence but that
would have come out the same way whether or not the claim were true. The output
then reads exactly like a discovery.

Six real examples, all from one session of hunting bugs in this repo and one
other project:

| what was observed | what it actually meant |
|---|---|
| `pytest` reported `0 failed` | collection **errored**; zero tests ran |
| `tf.format == 2` (PAX) | `format` on a *read* handle is the reader default, not the file's format |
| `hasattr(mod, name)` is `False` | the function is **nested**, not module-level |
| `19 FAILED` in another project | 14 were `ModuleNotFoundError` from an incomplete venv, not their bugs |
| `(rc == 0) == (on == wanted)` held | a tautology — true whichever way `git` behaves |
| `git checkout -B` "worked" | it printed `Aborting`; the next patch landed on the branch we were already on |

Every one is the same defect: **a measurement accepted without first
establishing that it can distinguish the claimed outcome from its opposite.**

Three of those six produced a confident wrong verdict that reached a human
before it was caught. The remaining three were caught only because something
else contradicted them later.

## Why a structural check

The obvious fix — a list of known-bad snippets — does not work. I tried it: a
pattern-matching guard built from an earlier set of mistakes scored **0/8**
against this session's new ones, because each new mistake had a shape it had
never seen. Pattern matching on last week's errors cannot catch next week's.

So this asks a structural question instead: *does this probe contain anything
that could have come out the other way?*

1. a verdict emitted with **no negative control** anywhere in the probe
2. an assertion comparing **two of the probe's own observations** (tautology)
3. a `subprocess` result consumed **without inspecting `returncode`**
4. a *"no failures"* conclusion with **no evidence anything ran**
5. **text presence** (`"x" in src`, `grep -c`) used as proof a code path behaves

## Behaviour

Non-blocking by default, matching `security-guidance`: the file is written and
the warning rides back to the model in the next turn so it can self-correct.
`DISCRIMINATION_GUARD_BLOCK=1` refuses the write instead.

Scope is narrow on purpose — only probe/test-shaped files, only writes over
~120 characters, and only through `write_file` / `patch` / `execute_code`.

## False positives are the real risk

A guard that flags sound work is noise, and noise gets muted within a day. Four
sound-probe shapes are covered as negative cases and must stay quiet:

- a wire-level probe that drives the real function **and** asserts a control
- a subprocess probe that checks `returncode` and reports UNKNOWN
- a mutation-verified check that reverts its own fix
- an ordinary source file that happens to contain the word "ok"

## Testing

```
pytest tests/plugins/test_discrimination_guard_plugin.py    # 10 passed
pytest tests/plugins/                                       # 1315 passed
```

10 cases: 4 wrong-verdict probes that must be flagged, 4 sound probes that must
stay quiet, plus short-write and non-write-tool exclusions. Removing the plugin
directory turns all 10 into collection errors, so they are not vacuous.

## Fit

No core files are touched — it lives entirely in `plugins/` and uses the
existing `pre_tool_call` hook, alongside `security-guidance` which warns about
dangerous *content*. This one warns about verification that cannot fail.

Not a third-party integration: no external service, no vendor SDK, nothing to
keep working against someone else's API.
