### PR TITLE
fix(context-compressor): max-iteration nudge no longer treated as human intent

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2081,6 +2081,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
+# Exact runtime nudge text appended by handle_max_iterations(). Exported so
+# compaction's synthetic-user-turn detection (agent/context_compressor.py)
+# can recognize this row by content after it survives SessionDB persistence,
+# which does not preserve underscore-prefixed in-memory provenance flags (#78580).
+MAX_ITERATION_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished so far, "
+    "without calling any more tools."
+)
+
+
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
@@ -2107,12 +2118,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             defer_logical_completion=True,
         )
 
-    summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+    messages.append(
+        {
+            "role": "user",
+            "content": MAX_ITERATION_SUMMARY_REQUEST,
+            "_max_iteration_synthetic": True,
+        }
     )
-    messages.append({"role": "user", "content": summary_request})
 
     try:
         # Build API messages, stripping internal-only fields

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -42,6 +42,7 @@ from agent.model_metadata import (
 from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
 from tools.todo_tool import TODO_INJECTION_HEADER
+from agent.chat_completion_helpers import MAX_ITERATION_SUMMARY_REQUEST
 
 logger = logging.getLogger(__name__)
 
@@ -4178,6 +4179,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
             _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
+            MAX_ITERATION_SUMMARY_REQUEST,
         } or text.startswith(
             TODO_INJECTION_HEADER + "\n"
         )

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -13,6 +13,7 @@ from agent.context_compressor import (
     _summarize_tool_result,
     _is_summary_access_or_quota_error,
 )
+from agent.chat_completion_helpers import MAX_ITERATION_SUMMARY_REQUEST
 from hermes_state import SessionDB
 
 
@@ -498,6 +499,33 @@ class TestNonStringContent:
             {"role": "user", "content": "[System: Your previous response was truncated ...]"},
         ]
         assert c._latest_user_task_snapshot(only_synthetic) is None
+
+    def test_max_iteration_nudge_not_treated_as_human_intent(self):
+        """Regression #78580: the max-iteration runtime nudge is appended with
+        role="user" so the LLM can respond after tool-calling budget is
+        exhausted. SessionDB round-trips drop underscore-prefixed provenance
+        flags, so detection must key off the nudge's exact text, not a flag.
+        The grounding snapshot must still anchor on the real human ask, and
+        the nudge itself must be classified as synthetic scaffolding.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        assert c._is_synthetic_compression_user_turn(
+            {"role": "user", "content": MAX_ITERATION_SUMMARY_REQUEST}
+        )
+
+        messages = [
+            {"role": "user", "content": "migrate the billing service to the new API"},
+            {"role": "assistant", "content": "starting migration"},
+            # Simulates a reloaded SessionDB row: no "_max_iteration_synthetic"
+            # flag survives persistence, only the literal nudge text does.
+            {"role": "user", "content": MAX_ITERATION_SUMMARY_REQUEST},
+        ]
+        snapshot = c._latest_user_task_snapshot(messages)
+        assert snapshot is not None
+        assert "migrate the billing service to the new API" in snapshot
+        assert "maximum number of tool-calling iterations" not in snapshot
 
     def test_grounding_preserves_following_sections_across_regrounding(self):
         """The snapshot rewrite must keep later headings intact — twice.


### PR DESCRIPTION
## Summary

- Fixes #78580: the max-iteration runtime nudge (`MAX_ITERATION_SUMMARY_REQUEST`, appended with `role="user"` so the LLM can produce a final response after exhausting tool-calling budget) was not recognized as synthetic scaffolding by `ContextCompressor._is_synthetic_compression_user_turn`.
- As a result, context compaction could anchor grounding/auto-focus on the nudge text instead of the real human ask whenever the nudge happened to be the newest `role="user"` message at compaction time.
- Detection is content-based (exact nudge text), not flag-based, because underscore-prefixed provenance flags (`_max_iteration_synthetic`) do not survive `SessionDB` persistence/reload — the same durability constraint already handled for todo-snapshot and truncation-notice scaffolding.
- `MAX_ITERATION_SUMMARY_REQUEST` is exported from `chat_completion_helpers.py` as the single source of truth and imported by `context_compressor.py`, so the literal nudge text is defined exactly once — no duplicated string.

## Root cause

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Tool-Calling Budget Exhausted] -->|handle_max_iterations| B[Max-Iteration Nudge Appended as role=user]
    B --> C{Context Compaction Triggered}
    C --> D[_is_synthetic_compression_user_turn]
    D -->|Before Fix: Nudge Text Unrecognized| E[Nudge Misread as Human Intent]
    E --> F[Grounding / Auto-Focus Anchored on Wrong Turn]
    D -->|After Fix: Nudge Text Matched| G[Nudge Classified as Synthetic Scaffolding]
    G --> H[Grounding Skips Nudge, Anchors on Real Human Ask]
    H --> I[Correct Auto-Focus Topic and Task Snapshot]

    style E fill:#ff007f,color:#fff
    style F fill:#ff007f,color:#fff
    style H fill:#00f0ff,color:#0a0a16
    style I fill:#00f0ff,color:#0a0a16
```

## Changes

- `agent/chat_completion_helpers.py`: extracted the max-iteration nudge string into an exported constant `MAX_ITERATION_SUMMARY_REQUEST`, tagged the appended message with `_max_iteration_synthetic` (best-effort, in-memory only), documented why content-based matching is required.
- `agent/context_compressor.py`: `_is_synthetic_compression_user_turn` now also matches `MAX_ITERATION_SUMMARY_REQUEST`. This is the single choke point consumed by `_transcript_has_real_user_turn`, `_derive_auto_focus_topic`, `_ensure_last_user_message_in_tail`, `_latest_user_task_snapshot`, and the `conversation_compression.py` synthetic-user-turn checks — all fixed transitively, no duplicated detection logic added.
- `tests/agent/test_context_compressor.py`: new regression test `test_max_iteration_nudge_not_treated_as_human_intent`, following the existing `test_task_snapshot_skips_synthetic_user_scaffolding` pattern — asserts the nudge is classified as synthetic and that grounding still anchors on the real human ask even when the nudge is the newest `role="user"` message (simulating a `SessionDB` reload where the in-memory flag is gone).

## Test plan

- [x] `pytest tests/agent/test_context_compressor.py -k "max_iteration_nudge or synthetic_user_scaffolding"` — 2 passed
- [x] `pytest tests/agent/test_context_compressor.py tests/agent/test_context_compressor_zero_user_provenance.py tests/agent/test_compressor_zero_user_guard.py` — 118 passed (no regressions)
- [x] `pytest tests/agent/test_turn_finalizer_final_response_persistence.py tests/run_agent/test_verification_continuation_budget.py tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/agent/test_turn_finalizer_cleanup_guard.py` — 19 passed (no regressions)
- [x] Confirmed no duplicate definition of the nudge string outside `chat_completion_helpers.py` (source of truth) and the new test