### PR TITLE
Wait for owned delegations before goal verdict

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18659,6 +18659,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not mgr.is_active():
             return
 
+        # A background delegation belongs to this goal turn even though it is
+        # not represented in the process registry. Judging the goal before the
+        # result re-enters the parent session can falsely mark the goal done and
+        # lets the parent publish a synthesis that never integrated the work it
+        # commissioned.
+        try:
+            from tools.async_delegation import list_async_delegations
+
+            pending_delegations = [
+                record
+                for record in list_async_delegations()
+                if record.get("status") in {"running", "stalling", "finalizing"}
+                and str(record.get("parent_session_id") or "") == sid
+            ]
+        except Exception:
+            logger.debug(
+                "goal continuation: async-delegation check failed",
+                exc_info=True,
+            )
+            pending_delegations = []
+
+        if pending_delegations:
+            pending_tasks = sum(
+                len(record.get("goals") or [])
+                if record.get("is_batch") and record.get("goals")
+                else 1
+                for record in pending_delegations
+            )
+            if source is not None:
+                noun = "task" if pending_tasks == 1 else "tasks"
+                await self._defer_goal_status_notice_after_delivery(
+                    source,
+                    f"⏳ Goal waiting — {pending_tasks} delegated {noun} still running.",
+                )
+            return
+
         try:
             from hermes_cli.goals import gather_background_processes as _gather_bg
             _bg_procs = _gather_bg()

--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -199,3 +199,56 @@ async def test_runner_goal_hook_enqueues_into_the_key_the_adapter_drains(hermes_
     assert adapter._pending_messages[adapter_key].text.startswith(
         "[Continuing toward your standing goal]"
     )
+
+
+@pytest.mark.asyncio
+async def test_goal_judge_waits_for_own_async_delegations(hermes_home):
+    """A parent goal cannot complete before its commissioned work returns."""
+    from datetime import datetime
+    from unittest.mock import AsyncMock, MagicMock, patch
+    import uuid
+
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionEntry
+    from hermes_cli.goals import GoalManager
+
+    src = _slack_thread_source()
+    session_entry = SessionEntry(
+        session_key=build_session_key(src),
+        session_id=f"goal-sess-{uuid.uuid4().hex[:8]}",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="channel",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._defer_goal_status_notice_after_delivery = AsyncMock()
+    GoalManager(session_entry.session_id).set("integrate the delegated analysis")
+
+    records = [
+        {
+            "status": "running",
+            "parent_session_id": session_entry.session_id,
+            "is_batch": True,
+            "goals": ["portal", "business", "field operations"],
+        },
+        {
+            "status": "running",
+            "parent_session_id": "another-session",
+        },
+    ]
+    with patch(
+        "tools.async_delegation.list_async_delegations",
+        return_value=records,
+    ), patch("hermes_cli.goals.judge_goal") as judge:
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="preliminary synthesis",
+        )
+
+    judge.assert_not_called()
+    runner._defer_goal_status_notice_after_delivery.assert_awaited_once_with(
+        src,
+        "⏳ Goal waiting — 3 delegated tasks still running.",
+    )


### PR DESCRIPTION
## Summary

Hold `/goal` evaluation while async delegations owned by the same durable session are still running, stalling, or finalizing.

## Root cause

The goal continuation hook passed process-registry background work to the judge but did not account for `delegate_task(background=true)`. A parent turn could therefore emit a success verdict and publish a final synthesis before its commissioned results returned.

## Behavior

- same-session delegations defer the goal judge
- unrelated sessions do not block the goal
- batch records report their actual child-task count
- the deferred status is delivered after the visible parent response
- the completion event remains responsible for re-entering the parent session

## Checks

- `python3 -m pytest -q tests/gateway/test_goal_continuation_drain.py` — 3 passed
- live Imago dependency-free smoke — judge not called for a three-task owned batch
- live gateway private generation — `IMAGO_RELIABILITY_OK`

## Impact

This prevents false goal completion and incomplete synthesis for background delegation on gateway sessions. It does not alter synchronous delegation or unrelated-session scheduling.
