### PR TITLE
fix(desktop): derive --ui-bg-input from the editor surface instead of hardcoding #fcfcfc

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -244,7 +244,12 @@
       var(--theme-neutral-card)
     );
     --ui-bg-card: color-mix(in srgb, var(--ui-accent) 4%, color-mix(in srgb, var(--ui-base) 4%, transparent));
-    --ui-bg-input: #fcfcfc;
+    /* Input-field fill. Derived from the editor surface (itself card-seed +
+       neutral-card, both opaque and theme-driven) so the field flips with the
+       skin's dark palette — the old hardcoded `#fcfcfc` painted a white input
+       in every dark theme. Plugins use this for inset text fields; core
+       inputs take `.desktop-input-chrome` instead. */
+    --ui-bg-input: var(--ui-bg-editor);
     --ui-bg-primary: color-mix(
       in srgb,
       var(--ui-accent) var(--theme-fill-primary-accent-mix),


### PR DESCRIPTION
## What does this PR do?

Fixes `--ui-bg-input` being hardcoded to `#fcfcfc` with no `:root.dark` override, so any plugin or core surface using the token renders a white input field on every dark skin (midnight, ember, dark).

### Reproduction on current main
1. Load the desktop app with any dark skin.
2. Open a plugin surface that fills an inset text field from `--ui-bg-input` (found via the annotation-batch plugin v2.1 — its comment field rendered as a white box).
3. Observe: the field is `#fcfcfc` white, ignoring the active dark palette.

Root cause: `apps/desktop/src/styles.css` declared `--ui-bg-input: #fcfcfc` as a raw literal with no dark-mode flip.

### Why this approach?
- Derives `--ui-bg-input` from `--ui-bg-editor`, which mixes the per-skin card seed with the mode-flipping `--theme-neutral-card` (`#fcfcfc` light / `#161618` dark) — the field fill now follows the active skin and dark mode.
- Removes a raw literal in favour of a token (per `DESIGN.md`: tokens over literals).
- Adapter/theme-local: one CSS token line, no core or plugin changes.

## Related Issue

No issue filed — small theme-token fix. Duplicate search (`gh search prs "ui-bg-input"` open + closed, repo NousResearch/hermes-agent): no prior owner, novel.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/styles.css` — `--ui-bg-input: var(--ui-bg-editor);` (+ comment), 1 file, +6/-1.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/themes` → 8 files / 66 tests pass.
2. Full UI project suite: `npx vitest run --project ui` → all pass.
3. `git diff --check origin/main...HEAD` → clean.
4. Resolved-value check (color-mix in browser/DevTools):
   - nous dark → `#142345` · midnight → `#13131e` · ember → `#191310` (all dark ✓)
   - nous light → `#fdfdfd` (imperceptible from the old `#fcfcfc`)

Platform: macOS 26.5.1 · desktop renderer (Chromium).

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (desktop UI change; repo's UI vitest suite run instead)
- [ ] I've added tests for my changes — N/A (token derivation covered by existing theme tests; resolved-value verification done manually)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (CSS token only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (renderer CSS, platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## AI assistance

Prepared with assistance from an AI coding agent (Red / Hermes Agent). The change was authored and verified locally; no private session data or credentials are included.
