### PR TITLE
feat(skills): add 2chat-whatsapp optional skill

### DIFF
--- a/optional-skills/communication/2chat-whatsapp/SKILL.md
+++ b/optional-skills/communication/2chat-whatsapp/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: 2chat-whatsapp
+description: WhatsApp, SMS, and contacts via the 2Chat MCP server.
+version: 1.0.0
+author: Carlos Ruiz-Díaz (@2ChatCo), 2Chat
+license: MIT
+homepage: https://2chat.co
+platforms: [macos, linux, windows]
+metadata:
+  hermes:
+    category: communication
+    tags: [whatsapp, sms, 2chat, waba, messaging, mcp, contacts]
+---
+
+# 2Chat — WhatsApp, SMS & Voice
+
+Connects Hermes to **2Chat's official remote MCP server** so the agent can send and read WhatsApp
+messages (WhatsApp Web *and* the WhatsApp Business API), send SMS, manage WABA templates, work with
+contacts and groups, publish WhatsApp statuses, browse catalogs, and pull call records — through the
+user's existing 2Chat account.
+
+- **Server:** `https://mcp.2chat.io/mcp`
+- **Transport:** Streamable HTTP (Hermes default for remote servers)
+- **Auth:** OAuth 2.1 (browser sign-in, PKCE). No API key. Hermes stores tokens at `~/.hermes/mcp-tokens/2chat.json` and refreshes them automatically.
+
+## When to Use
+
+Use this skill whenever the user wants to:
+
+- Send a WhatsApp or SMS message, or check whether a number is on WhatsApp.
+- Send WhatsApp **Business API** messages with approved templates, or list/sync/price WABA templates.
+- Read conversations, group messages, or group participant lists.
+- Publish a WhatsApp text/image/video **status** (story).
+- Create, search, update, or delete **contacts**.
+- Inspect connected channels (WhatsApp Web, WABA, virtual numbers) or pull **call records**.
+
+## Prerequisites
+
+- A [2Chat](https://2chat.co) account with at least one connected channel.
+- The `2chat` MCP server configured in Hermes (see Quick Reference). No API key is required.
+
+## Quick Reference — one-time setup
+
+Add the 2Chat server to your Hermes config (`~/.hermes/config.yaml`) under `mcp_servers` — or use the
+dashboard **Profile Builder → MCP Servers** with the same URL and OAuth:
+
+```yaml
+mcp_servers:
+  2chat:
+    url: "https://mcp.2chat.io/mcp"
+    auth: oauth
+```
+
+A copy is in `references/mcp-server.yaml`. On first connection Hermes opens the 2Chat sign-in page in
+your browser and persists the tokens. Confirm with: *"List my connected 2Chat WhatsApp channels."*
+
+## Procedure
+
+1. Ensure the `2chat` MCP server is connected. If its tools aren't available, it isn't configured
+   yet — add it per Quick Reference and complete the browser sign-in.
+2. Identify the sending channel. If multiple numbers exist, call `get_whatsapp_numbers` /
+   `get_waba_numbers` and confirm which one to use.
+3. For a first-time WhatsApp recipient, verify reachability with `check_if_number_is_on_whatsapp`.
+4. Compose the message, **echo recipient + exact body back to the user for confirmation**, then send
+   with `send_whatsapp_message`, `send_waba_message`, or `send_sms`.
+5. Report the resulting message id / status to the user.
+
+## Tools
+
+Full descriptions are in `references/tools.md`. Summary by area:
+
+- **Account:** `get_who_am_i`, `get_billing_info`
+- **WhatsApp Web:** `send_whatsapp_message`, `check_if_number_is_on_whatsapp`, `get_whatsapp_messages`
+- **WABA:** `send_waba_message`, `get_waba_templates`, `sync_waba_templates`, `calculate_waba_template_cost`
+- **SMS:** `send_sms`
+- **Channels:** `get_whatsapp_numbers`, `get_whatsapp_number`, `execute_whatsapp_channel_command`, `get_waba_numbers`, `get_waba_number`
+- **Conversations & groups:** `list_whatsapp_conversations`, `list_whatsapp_groups`, `list_whatsapp_group_participants`, `get_whatsapp_group_messages`
+- **Status:** `set_whatsapp_text_status`, `set_whatsapp_image_status`, `set_whatsapp_video_status`
+- **Catalog:** `list_whatsapp_catalog_products`
+- **Contacts:** `create_contact`, `get_contact`, `list_contacts`, `search_contacts`, `update_contact`, `delete_contact`
+- **Calls:** `list_virtual_numbers`, `get_call_history`, `get_call_details`, `get_call_price`
+
+## Pitfalls
+
+- **Sending costs money and reaches real people.** Always confirm recipient and exact body before any
+  `send_*` call. Never batch-send without explicit confirmation.
+- **WABA needs an approved template** outside the 24-hour service window; use `get_waba_templates`
+  (and `calculate_waba_template_cost` if cost matters) first.
+- **`delete_contact` is permanent** — confirm the contact UUID first.
+- **No channels connected?** Read tools return empty; connect a number in the 2Chat dashboard first.
+- **Auth expired?** Re-trigger the OAuth sign-in; Hermes refreshes tokens automatically, but a revoked
+  grant needs a fresh browser login.
+
+## Verification
+
+- `get_who_am_i` returns the authenticated 2Chat account → server connected and authorized.
+- `get_whatsapp_numbers` lists at least one channel → ready to send.
+- A test `send_whatsapp_message` to your own number returns a message id → end-to-end working.

--- a/optional-skills/communication/2chat-whatsapp/references/mcp-server.yaml
+++ b/optional-skills/communication/2chat-whatsapp/references/mcp-server.yaml
@@ -1,0 +1,12 @@
+# 2Chat MCP server for Hermes Agent.
+# Add this block to your Hermes config (e.g. ~/.hermes/config.yaml).
+# On first connection Hermes opens a browser for 2Chat OAuth sign-in and
+# stores tokens at ~/.hermes/mcp-tokens/2chat.json (auto-refreshed).
+#
+# No API key is required.
+
+mcp_servers:
+  2chat:
+    url: "https://mcp.2chat.io/mcp"
+    auth: oauth
+    # transport defaults to Streamable HTTP; set `transport: "sse"` only if instructed.

--- a/optional-skills/communication/2chat-whatsapp/references/tools.md
+++ b/optional-skills/communication/2chat-whatsapp/references/tools.md
@@ -1,0 +1,61 @@
+# 2Chat MCP — Tool Reference
+
+All tools become available once the `2chat` MCP server is connected (see SKILL.md → Quick Reference).
+
+## Account
+- **get_who_am_i** — Return information about the authenticated 2Chat account.
+- **get_billing_info** — Current billing status, plan limits, and API usage metrics.
+
+## Messaging — WhatsApp Web
+- **send_whatsapp_message** — Send a text or media message via a connected WhatsApp Web channel.
+- **check_if_number_is_on_whatsapp** — Verify whether a phone number has an active WhatsApp account.
+- **get_whatsapp_messages** — Retrieve WhatsApp messages exchanged through a connected number.
+
+## Messaging — WhatsApp Business API (WABA)
+- **send_waba_message** — Send a WABA message using an approved template or free-form text.
+- **get_waba_templates** — List WABA message templates (optional filtering).
+- **sync_waba_templates** — Trigger a background sync of WABA templates from Meta.
+- **calculate_waba_template_cost** — Estimate messaging cost by plan, country, and template type.
+
+## Messaging — SMS
+- **send_sms** — Send an SMS through a 2Chat SMS channel.
+
+## Channels — WhatsApp Web
+- **get_whatsapp_numbers** — List WhatsApp Web numbers connected via QR code.
+- **get_whatsapp_number** — Full details for a single WhatsApp Web channel.
+- **execute_whatsapp_channel_command** — Connect/disconnect operations on a WhatsApp channel.
+
+## Channels — WABA
+- **get_waba_numbers** — List WABA numbers connected to the account.
+- **get_waba_number** — Full details of a single WABA number.
+
+## Conversations & Groups
+- **list_whatsapp_conversations** — List WhatsApp conversations ordered by recent activity.
+- **list_whatsapp_groups** — List WhatsApp groups visible to a connected number.
+- **list_whatsapp_group_participants** — List participants of a WhatsApp group.
+- **get_whatsapp_group_messages** — Retrieve messages from a WhatsApp group.
+
+## Status (Stories)
+- **set_whatsapp_text_status** — Publish an ephemeral text status.
+- **set_whatsapp_image_status** — Publish an ephemeral image status.
+- **set_whatsapp_video_status** — Publish an ephemeral video status.
+
+## Catalog
+- **list_whatsapp_catalog_products** — List products from WhatsApp Business catalogs.
+
+## Contacts
+- **create_contact** — Create a new contact.
+- **get_contact** — Retrieve a single contact by UUID.
+- **list_contacts** — List contacts (optional channel filtering).
+- **search_contacts** — Find contacts by name or phone number.
+- **update_contact** — Modify an existing contact.
+- **delete_contact** — Permanently remove a contact (irreversible).
+
+## Calls & Virtual Numbers
+- **list_virtual_numbers** — List VoIP numbers connected to the account.
+- **get_call_history** — Get call detail records (CDRs).
+- **get_call_details** — Full details for a specific call.
+- **get_call_price** — Estimate per-minute outbound call cost to a destination.
+
+---
+Docs: https://developers.2chat.co/docs/MCP/setup

--- a/tests/skills/test_2chat_whatsapp_skill.py
+++ b/tests/skills/test_2chat_whatsapp_skill.py
@@ -1,0 +1,45 @@
+"""Metadata sanity tests for the 2chat-whatsapp optional skill.
+
+Uses only the standard library + pytest. No live network calls.
+"""
+import re
+from pathlib import Path
+
+SKILL = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "communication"
+    / "2chat-whatsapp"
+    / "SKILL.md"
+)
+
+
+def _frontmatter() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), "SKILL.md must start with YAML frontmatter"
+    return text.split("---\n", 2)[1]
+
+
+def test_skill_file_exists():
+    assert SKILL.is_file(), f"missing skill file: {SKILL}"
+
+
+def test_required_frontmatter_fields():
+    fm = _frontmatter()
+    for field in ("name:", "description:", "version:", "author:", "license:"):
+        assert field in fm, f"frontmatter missing {field!r}"
+
+
+def test_description_is_short_single_sentence():
+    fm = _frontmatter()
+    m = re.search(r"^description:\s*(.+)$", fm, re.MULTILINE)
+    assert m, "no description field found"
+    desc = m.group(1).strip()
+    assert len(desc) <= 60, f"description must be <= 60 chars, got {len(desc)}"
+    assert desc.endswith("."), "description must end with a period"
+
+
+def test_references_present():
+    ref_dir = SKILL.parent / "references"
+    assert (ref_dir / "mcp-server.yaml").is_file()
+    assert (ref_dir / "tools.md").is_file()


### PR DESCRIPTION
## What

Adds an official optional skill, `2chat-whatsapp`, under `optional-skills/communication/`. It connects
Hermes to 2Chat's official remote MCP server (`https://mcp.2chat.io/mcp`, Streamable HTTP, OAuth 2.1)
so the agent can send/read WhatsApp (Web + Business API) and SMS, manage WABA templates, contacts,
groups, statuses, catalogs, and call records — all through the user's existing 2Chat account.

Install target once merged: `hermes skills install official/communication/2chat-whatsapp`.

## Why

2Chat is a widely used WhatsApp/SMS platform and publishes an official MCP server. This makes it a
first-class, trusted install for Hermes users doing messaging workflows.

## How it works

- Skill declares no scripts and stores no secrets. It documents a one-time config step adding the
  `2chat` server under `mcp_servers` (or via Profile Builder), then Hermes handles the OAuth flow and
  token storage (`~/.hermes/mcp-tokens/2chat.json`).
- All tools are provided by the remote 2Chat MCP server; the skill provides usage guidance and safety
  rules (confirm before sending, WABA template rules, permanent deletes).

## Testing

- `tests/skills/test_2chat_whatsapp_skill.py` validates frontmatter, the ≤60-char description rule,
  and that reference files exist. stdlib + pytest only, no network.
- Ran `python -m pytest tests/skills/test_2chat_whatsapp_skill.py -q` → 4 passed.
- Manually verified on macOS: added the server, completed OAuth, and confirmed
  `get_who_am_i` / `get_whatsapp_numbers` return the connected account and channels.

## Checklist

- [x] Description ≤ 60 chars, one sentence, ends with a period
- [x] Author credit with GitHub handle
- [x] MIT-licensed contribution
- [x] Conventional Commit
- [x] Focused, single-skill PR