### PR TITLE
fix(dashboard): match non-directory public auth-gate entries exactly

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -75,13 +75,18 @@ def _path_is_public(path: str) -> bool:
       exactly (no prefix expansion) so adding ``/api/status`` doesn't
       accidentally expose ``/api/status/secret-extension``.
     * :data:`_GATE_PUBLIC_PREFIXES` — auth-bootstrap routes and static
-      mounts. Prefix-matched so ``/assets/foo.css`` lights up via
-      ``/assets/``.
+      mounts. An entry ending in ``/`` is a directory prefix
+      (``/assets/`` lights up ``/assets/foo.css``); every other entry
+      is an exact path. Without that split a bare ``startswith`` turns
+      each non-directory entry into a wildcard, so ``/login`` also
+      exempts ``/loginX`` and ``/favicon.ico`` also exempts
+      ``/favicon.icox`` — any path that merely *starts with* a public
+      entry bypasses the gate.
     """
     if path in PUBLIC_API_PATHS:
         return True
     return any(
-        path == prefix or path.startswith(prefix)
+        path.startswith(prefix) if prefix.endswith("/") else path == prefix
         for prefix in _GATE_PUBLIC_PREFIXES
     )
 

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -21,6 +21,7 @@ from fastapi.testclient import TestClient
 from hermes_cli import web_server
 from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.cookies import SESSION_AT_COOKIE
+from hermes_cli.dashboard_auth.middleware import _path_is_public
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
 
 
@@ -106,6 +107,68 @@ def test_other_public_api_paths_are_public_under_gate(gated_app, path):
             f"{path} redirected to {location} — should be public, "
             "not bounced to /login"
         )
+
+
+@pytest.mark.parametrize("path", [
+    "/auth/login",
+    "/auth/callback",
+    "/auth/password-login",
+    "/auth/logout",
+    "/login",
+    "/api/auth/providers",
+    "/favicon.ico",
+])
+def test_exact_public_entries_stay_public(path):
+    """Non-directory entries must still match themselves exactly.
+
+    Guards the fix below from over-correcting: tightening the matcher
+    must not lock operators out of the login page or the OAuth round
+    trip.
+    """
+    assert _path_is_public(path)
+
+
+@pytest.mark.parametrize("path", [
+    "/assets/index.css",
+    "/fonts/Collapse-Regular.woff2",
+    "/fonts-terminal/x.woff2",
+    "/ds-assets/icon.svg",
+    "/api/mcp/oauth/callback/abc123",
+])
+def test_directory_public_entries_still_match_children(path):
+    """Entries ending in ``/`` keep their prefix semantics."""
+    assert _path_is_public(path)
+
+
+@pytest.mark.parametrize("path", [
+    # Suffix extensions of exact entries must NOT inherit publicness.
+    "/loginX",
+    "/favicon.icox",
+    "/api/auth/providersX",
+    "/auth/loginX",
+    "/auth/logout-all",
+    # Directory entries were already safe (the trailing slash stops
+    # ``/assets/`` matching ``/assetsleak/``); pinned so the fix doesn't
+    # regress them.
+    "/assetsleak/secret.js",
+    "/fonts-terminalX/x.woff2",
+    # Genuinely gated routes stay gated.
+    "/api/config",
+    "/api/secrets",
+    "/sessions",
+    "/",
+])
+def test_public_entries_do_not_leak_prefixed_siblings(path):
+    """Regression pin for the ``startswith`` wildcard bug.
+
+    ``path == prefix or path.startswith(prefix)`` made every
+    non-directory entry a wildcard: ``/login`` exempted ``/loginX``,
+    ``/favicon.ico`` exempted ``/favicon.icox``. Any request whose path
+    merely started with such an entry bypassed the gate. Directory
+    entries were already safe — their trailing slash does the work —
+    and are pinned here so the fix doesn't regress them.
+    """
+    assert not _path_is_public(path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`_path_is_public` in `hermes_cli/dashboard_auth/middleware.py:77` tests `path == prefix or path.startswith(prefix)` against every `_GATE_PUBLIC_PREFIXES` entry. The `startswith` arm makes the `==` arm redundant and turns each non-directory entry into a wildcard:

| public entry | also exempts |
|---|---|
| `/login` | `/loginX` |
| `/favicon.ico` | `/favicon.icox` |
| `/api/auth/providers` | `/api/auth/providersX` |
| `/auth/logout` | `/auth/logout-all` |

Any request path that merely *starts with* a public entry bypasses the OAuth gate.

Directory entries were never affected — the trailing slash on `/assets/` already stops it matching `/assetsleak/`, as the list's own comment at line 46 notes. The bug is confined to entries without one.

The data already encodes the distinction, so this honours it in the matcher: prefix semantics for `/`-terminated entries, exact match for everything else. That mirrors how `PUBLIC_API_PATHS` is handled a few lines up, where the docstring calls out the identical hazard ("adding `/api/status` doesn't accidentally expose `/api/status/secret-extension`").

**Impact is hardening, not a live bypass.** Comparing the registered route table against the public entries, no route currently sits under one of those prefixes, so nothing sensitive is reachable on `main` today. This matters when someone later adds a route — or a static file under `web_dist` — whose name extends a public entry; the allowlist is the boundary and it should mean what it says.

Filing publicly rather than via GHSA per SECURITY.md §3.2 — no §3.1 outcome is reachable, so this is hardening, not a vulnerability report.

## Related Issue

No existing issue. Searched open/closed issues and PRs for `_path_is_public`, `GATE_PUBLIC_PREFIXES`, `auth gate prefix`, `startswith auth bypass` — closest hits are #61305, #35547, #27932, which touch this file but not this matcher.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — `_path_is_public` matches `/`-terminated entries by prefix, all others exactly; docstring updated
- `tests/hermes_cli/test_dashboard_auth_middleware.py` — 23 parametrised regression cases in three directions

## How to Test

Reproduce on `main`:

```python
from hermes_cli.dashboard_auth.middleware import _path_is_public
_path_is_public("/loginX")        # True  ← should be False
_path_is_public("/favicon.icox")  # True  ← should be False
```

With this branch both return `False`. The five sibling cases fail on the unfixed matcher and pass with it.

```
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_middleware.py -q
# 37 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suite via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: CachyOS (Linux 7.1.5), Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (docstring updated in place)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (pure string comparison, no path/OS semantics)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Full suite via `scripts/run_tests.sh -q`:

```
this branch:  2569 files, 24632 passed, 64 failed, 339.6s
clean main:   2569 files, 24706 passed, 61 failed, 334.1s
```

File-level diff of the failure sets: 22 files fail on `main`, 24 on this branch. The two extra — `tests/test_tui_gateway_server.py` and `tests/tools/test_transcription_tools.py` — **pass 563/563 when run in isolation on this branch**, and both failed on wall-clock timing under 32-way parallelism (`reader.join(timeout=0.5)` → `TimeoutExpired`; the tui file took 74.1s loaded vs 16.1s isolated). Nothing in the baseline set passed here in the other direction.

No dashboard/auth/web_server file appears in either failure set, and `test_dashboard_auth_middleware.py` passed (37✓) in the full run. The pre-existing failures are provider routing, media generation, sandbox backends, and doctor — all needing external services this environment lacks. Raw totals jitter between runs because of the timing-sensitive tests above, so the file-level diff is the meaningful comparison rather than the counts.

--EnA
