### PR TITLE
docs(portal): clarify subscription requirement in quickstart

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3110,7 +3110,7 @@ def run_setup_wizard(args):
         setup_mode = prompt_choice(
             "How would you like to set up Hermes?",
             [
-                "Quick Setup (Nous Portal) — free OAuth login, no API keys, model + tools (recommended)",
+                "Quick Setup (Nous Portal) — no API keys; sign in with a Nous Portal subscription; model + tools (recommended)",
                 "Full setup — configure every provider, tool & option yourself (bring your own keys)",
                 "Blank Slate — everything off except the bare minimum; opt in to each capability",
             ],

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -98,7 +98,7 @@ That logs you in, sets Nous as your provider, and turns on the Tool Gateway in o
 :::info Setup modes
 On a fresh install, `hermes setup` offers three modes:
 
-- **Quick Setup (Nous Portal)** — free OAuth login, no API keys; sets up a model plus the Tool Gateway tools. The recommended fast path.
+- **Quick Setup (Nous Portal)** — no API keys to manage; sign in with a Nous Portal subscription; sets up a model plus the Tool Gateway tools. The recommended fast path.
 - **Full Setup** — walk through every provider, tool, and option yourself (bring your own keys).
 - **Blank Slate** — everything starts **off** except the bare minimum needed to run an agent: **provider & model, the File Operations toolset, and the Terminal toolset**. No web, browser, code execution, vision, memory, delegation, cron, skills, plugins, or MCP servers — and compression, checkpoints, smart routing, and memory capture are all disabled. After the minimal baseline is applied, you choose one of two paths: **start with everything disabled** (finish now with the minimal agent), or **walk through all configurations** (opt in to tools, skills, plugins, MCP, and messaging). Pick this when you want a minimal, fully-controlled agent and intend to enable only exactly what you need.
 


### PR DESCRIPTION
## Summary
- Reword the quickstart Setup modes line so Nous Portal is not described as a free OAuth path
- Apply the same clarification to the matching `hermes setup` prompt in `hermes_cli/setup.py`
- Preserve the existing tip that one subscription covers models + Tool Gateway

Fixes #78254

## Test plan
- [ ] Confirm `website/docs/getting-started/quickstart.md` no longer says “free OAuth login”
- [ ] Confirm the Quick Setup choice in `hermes setup` mentions a Nous Portal subscription
- [ ] Confirm the tip above Setup modes still reads as subscription-based
- [ ] Spot-check that unrelated “free” Portal model-tier language is unchanged