### PR TITLE
fix(tui): close profile-owned SessionDB handles on teardown

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11398,6 +11398,1097 @@ def test_teardown_ends_session_in_profile_db(monkeypatch, tmp_path):
     assert str(seen.get("db_path")).endswith("state.db")
 
 
+def test_teardown_closes_profile_session_db_owned_by_agent_build(monkeypatch, tmp_path):
+    """A profile DB handed to an agent build must be closed at teardown."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+
+    class ProfileDB:
+        def __init__(self, db_path=None):
+            self.db_path = db_path
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    class FakeAgent:
+        model = "test-model"
+
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    def fake_make_agent(_sid, _key, session_db=None, **_kwargs):
+        captured["db"] = session_db
+        captured["agent"] = FakeAgent()
+        return captured["agent"]
+
+    monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_probe_config_health", lambda *_a: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+
+    sid = "profile-build-sid"
+    session = {
+        "agent": None,
+        "agent_ready": threading.Event(),
+        "session_key": "profile-session",
+        "profile_home": str(profile_home),
+    }
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert session["agent_ready"].wait(timeout=3), "agent build did not finish"
+        assert captured["db"].db_path == profile_home / "state.db"
+        assert captured["db"].close_calls == 0
+
+        server._teardown_session(session)
+
+        assert captured["agent"].close_calls == 1
+        assert captured["db"].close_calls == 1
+    finally:
+        server._sessions.pop(sid, None)
+
+
+class _CountingDB:
+    """Minimal SessionDB stand-in that counts close() calls per instance."""
+
+    instances: list = []
+
+    def __init__(self, db_path=None):
+        self.db_path = db_path
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    def get_session(self, _key):
+        return {"id": _key, "cwd": None}
+
+    def update_session_cwd(self, *_a, **_k):
+        return None
+
+    def end_session(self, *_a, **_k):
+        return None
+
+    def close(self):
+        self.close_calls += 1
+
+
+class _CountingAgent:
+    model = "test-model"
+
+    def __init__(self, db=None):
+        self.close_calls = 0
+        self.db_close_calls_when_agent_closed = None
+        self._db = db
+
+    def close(self):
+        self.close_calls += 1
+        if self._db is not None and self.db_close_calls_when_agent_closed is None:
+            self.db_close_calls_when_agent_closed = self._db.close_calls
+
+
+def _stub_build_machinery(monkeypatch):
+    """Silence the side machinery _start_agent_build touches around the build."""
+    monkeypatch.setattr(server, "_set_session_context", lambda _t: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _t: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_probe_config_health", lambda *_a: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+
+
+def _deferred_profile_session(profile_home=None):
+    session = {
+        "agent": None,
+        "agent_ready": threading.Event(),
+        "session_key": "owned-db-session",
+    }
+    if profile_home is not None:
+        session["profile_home"] = str(profile_home)
+    return session
+
+
+def test_teardown_does_not_close_shared_db_for_launch_sessions(monkeypatch):
+    """A launch-profile session borrows _get_db(); teardown must leave it open."""
+    _CountingDB.instances = []
+    shared = _CountingDB()
+    agent = _CountingAgent(db=shared)
+
+    def fake_make_agent(_sid, _key, session_db=None, **_kw):
+        # Mirror _make_agent's fallback: no dedicated handle -> shared _get_db().
+        assert session_db is None
+        return agent
+
+    _stub_build_machinery(monkeypatch)
+    monkeypatch.setattr(server, "_get_db", lambda: shared)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+
+    sid = "launch-shared-sid"
+    session = _deferred_profile_session()
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert session["agent_ready"].wait(timeout=3)
+        assert "_owned_session_db" not in session
+
+        server._teardown_session(session)
+
+        assert agent.close_calls == 1
+        assert shared.close_calls == 0
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_profile_db_closed_when_agent_build_fails(monkeypatch, tmp_path):
+    """A profile DB built for a failed _make_agent must not outlive the build."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+
+    def failing_make_agent(*_a, **_k):
+        raise RuntimeError("boom")
+
+    _stub_build_machinery(monkeypatch)
+    monkeypatch.setattr("hermes_state.SessionDB", _CountingDB)
+    monkeypatch.setattr(server, "_make_agent", failing_make_agent)
+
+    sid = "failed-build-sid"
+    session = _deferred_profile_session(profile_home)
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert session["agent_ready"].wait(timeout=3)
+
+        assert session.get("agent_error")
+        assert "_owned_session_db" not in session
+        assert len(_CountingDB.instances) == 1
+        assert _CountingDB.instances[0].close_calls == 1
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_close_during_deferred_build_closes_agent_and_db(monkeypatch, tmp_path):
+    """If session.close wins before publication, the build disposes of both."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    entered = threading.Event()
+    release = threading.Event()
+    agent_box: dict = {}
+
+    def gated_make_agent(_sid, _key, session_db=None, **_kw):
+        entered.set()
+        assert release.wait(timeout=5), "test gate never released"
+        agent_box["agent"] = _CountingAgent(db=session_db)
+        return agent_box["agent"]
+
+    _stub_build_machinery(monkeypatch)
+    monkeypatch.setattr("hermes_state.SessionDB", _CountingDB)
+    monkeypatch.setattr(server, "_make_agent", gated_make_agent)
+
+    sid = "close-mid-build-sid"
+    session = _deferred_profile_session(profile_home)
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert entered.wait(timeout=5)
+        # Concurrent close claims the registry entry while the build is inside
+        # _make_agent; the build must then dispose of what it constructed.
+        popped = server._sessions.pop(sid)
+        server._teardown_session(popped)
+        release.set()
+        assert session["agent_ready"].wait(timeout=5)
+
+        assert agent_box["agent"].close_calls == 1
+        assert _CountingDB.instances[0].close_calls == 1
+        assert "_owned_session_db" not in session
+        # The discarded build must release resources WITHOUT finalizing the
+        # durable row (a deferred resume's row belongs to the conversation).
+        assert getattr(agent_box["agent"], "_end_session_on_close", True) is False
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_session_close_after_publish_does_not_double_close(monkeypatch, tmp_path):
+    """A close landing between publication and build completion closes once."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    entered = threading.Event()
+    release = threading.Event()
+    agent_box: dict = {}
+
+    def fake_make_agent(_sid, _key, session_db=None, **_kw):
+        agent_box["agent"] = _CountingAgent(db=session_db)
+        return agent_box["agent"]
+
+    def gated_wire_callbacks(_sid):
+        # Runs after the atomic publish; hold the build here while the close
+        # side claims and closes the published resources.
+        entered.set()
+        assert release.wait(timeout=5), "test gate never released"
+
+    _stub_build_machinery(monkeypatch)
+    monkeypatch.setattr("hermes_state.SessionDB", _CountingDB)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_wire_callbacks", gated_wire_callbacks)
+
+    sid = "close-post-publish-sid"
+    session = _deferred_profile_session(profile_home)
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert entered.wait(timeout=5)
+        popped = server._sessions.pop(sid)
+        server._teardown_session(popped)
+        release.set()
+        assert session["agent_ready"].wait(timeout=5)
+
+        assert agent_box["agent"].close_calls == 1
+        assert _CountingDB.instances[0].close_calls == 1
+    finally:
+        release.set()
+        server._sessions.pop(sid, None)
+
+
+def test_repeated_teardown_closes_resources_once(monkeypatch, tmp_path):
+    """Teardown is idempotent, and the agent closes while its DB is still open."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    agent_box: dict = {}
+
+    def fake_make_agent(_sid, _key, session_db=None, **_kw):
+        agent_box["agent"] = _CountingAgent(db=session_db)
+        return agent_box["agent"]
+
+    _stub_build_machinery(monkeypatch)
+    monkeypatch.setattr("hermes_state.SessionDB", _CountingDB)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+
+    sid = "repeat-teardown-sid"
+    session = _deferred_profile_session(profile_home)
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert session["agent_ready"].wait(timeout=3)
+
+        server._teardown_session(session)
+        server._teardown_session(session)
+
+        agent = agent_box["agent"]
+        assert agent.close_calls == 1
+        assert _CountingDB.instances[0].close_calls == 1
+        # AIAgent.close finalizes the session row through the db as its last
+        # step, so the owned handle must still be open when the agent closes.
+        assert agent.db_close_calls_when_agent_closed == 0
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_init_session_records_owned_profile_db(monkeypatch, tmp_path):
+    """_init_session must record a caller-owned profile DB for teardown."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    db = _CountingDB(db_path=profile_home / "state.db")
+    agent = _CountingAgent(db=db)
+
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+
+    sid = "init-owned-sid"
+    try:
+        server._init_session(
+            sid,
+            "init-owned-key",
+            agent,
+            [],
+            session_db=db,
+            owned_session_db=db,
+            profile_home=str(profile_home),
+        )
+        assert server._sessions[sid]["_owned_session_db"] is db
+
+        server._teardown_session(server._sessions.pop(sid))
+
+        assert agent.close_calls == 1
+        assert db.close_calls == 1
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_init_session_failure_unregisters_and_returns_ownership(monkeypatch, tmp_path):
+    """A post-registration _init_session failure with no concurrent closer leaves the record unregistered and resources untouched."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    db = _CountingDB(db_path=profile_home / "state.db")
+    agent = _CountingAgent(db=db)
+
+    def raise_wire_callbacks(_sid):
+        raise RuntimeError("wire boom")
+
+    monkeypatch.setattr(server, "_wire_callbacks", raise_wire_callbacks)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+
+    sid = "init-fail-sid"
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            server._init_session(
+                sid,
+                "init-fail-key",
+                agent,
+                [],
+                session_db=db,
+                owned_session_db=db,
+                profile_home=str(profile_home),
+            )
+        assert sid not in server._sessions
+        assert not getattr(excinfo.value, "_resources_claimed_by_closer", False)
+        assert db.close_calls == 0
+        assert agent.close_calls == 0
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_init_session_failure_after_concurrent_close_marks_claimed(monkeypatch, tmp_path):
+    """A concurrent closer that claims the record before the raise marks the exception as claimed and closes resources exactly once."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    db = _CountingDB(db_path=profile_home / "state.db")
+    agent = _CountingAgent(db=db)
+
+    sid = "init-claimed-sid"
+
+    def wire_callbacks_with_concurrent_close(_sid):
+        popped = server._sessions.pop(sid)
+        server._teardown_session(popped)
+        raise RuntimeError("wire boom")
+
+    monkeypatch.setattr(server, "_wire_callbacks", wire_callbacks_with_concurrent_close)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            server._init_session(
+                sid,
+                "init-claimed-key",
+                agent,
+                [],
+                session_db=db,
+                owned_session_db=db,
+                profile_home=str(profile_home),
+            )
+        assert getattr(excinfo.value, "_resources_claimed_by_closer", False) is True
+        assert agent.close_calls == 1
+        assert db.close_calls == 1
+        assert sid not in server._sessions
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_init_session_refuses_to_displace_registered_sid(monkeypatch, tmp_path):
+    """Two initializers racing one sid: the loser fails fast, the winner survives."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    _CountingDB.instances = []
+    winner = {"session_key": "winner-key"}
+    loser_db = _CountingDB(db_path=profile_home / "state.db")
+    loser_agent = _CountingAgent(db=loser_db)
+
+    sid = "contested-sid"
+    server._sessions[sid] = winner
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            server._init_session(
+                sid,
+                "loser-key",
+                loser_agent,
+                [],
+                session_db=loser_db,
+                owned_session_db=loser_db,
+                profile_home=str(profile_home),
+            )
+        assert not getattr(excinfo.value, "_resources_claimed_by_closer", False)
+        assert server._sessions[sid] is winner
+        # The loser's resources revert to its caller — nothing auto-closed.
+        assert loser_agent.close_calls == 0
+        assert loser_db.close_calls == 0
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_eager_resume_init_failure_closes_locals_no_ghost(monkeypatch, tmp_path):
+    """An unclaimed _init_session failure during eager resume closes the local agent+db and leaves no ghost session."""
+    target = "stored-profile-session-initfail"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+
+    class ResumeProfileDB(_CountingDB):
+        def get_session(self, _target):
+            return {"id": target, "cwd": str(tmp_path)}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            return None
+
+        def get_resume_conversations(self, _sid):
+            return ([{"role": "user", "content": "hello"}], [])
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(self, *_a, **_k):
+            return [{"role": "user", "content": "hello"}]
+
+        def resolve_resume_session_id(self, sid_):
+            return sid_
+
+    class LaunchDB:
+        def close(self):
+            raise AssertionError("shared launch db must never be closed")
+
+    ResumeProfileDB.instances = []
+
+    def fake_make_agent(_sid, _key, session_id=None, session_db=None, **_kw):
+        captured["agent_db"] = session_db
+        captured["agent"] = _CountingAgent(db=session_db)
+        return captured["agent"]
+
+    class FakeWorker:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def close(self):
+            pass
+
+    def raise_wire_callbacks(_sid):
+        raise RuntimeError("wire boom")
+
+    monkeypatch.setattr(server, "_profile_home", lambda _p: profile_home)
+    monkeypatch.setattr("hermes_state.SessionDB", ResumeProfileDB)
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+    monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _t: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _t: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_wire_callbacks", raise_wire_callbacks)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": target, "profile": "worker", "eager_build": True},
+            }
+        )
+        assert "error" in resp, resp
+        assert captured["agent_db"].close_calls == 1
+        assert captured["agent"].close_calls == 1
+        # The existing conversation stays resumable: the discarded agent must
+        # not end_session the durable target row.
+        assert getattr(captured["agent"], "_end_session_on_close", True) is False
+        assert all(s.get("session_key") != target for s in server._sessions.values())
+    finally:
+        server._sessions.clear()
+
+
+def test_branch_init_failure_closes_locals_no_ghost(monkeypatch, tmp_path):
+    """An unclaimed _init_session failure during branch closes the local agent+db and leaves no ghost session."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+
+    class BranchProfileDB(_CountingDB):
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} (branch)"
+
+        def create_session(self, *_a, **_k):
+            return None
+
+        def append_messages_batch(self, _sid, messages, **_k):
+            return list(range(1, len(messages) + 1))
+
+        def set_session_title(self, *_a, **_k):
+            return True
+
+    BranchProfileDB.instances = []
+
+    def fake_make_agent(*_a, **kw):
+        captured["agent_db"] = kw.get("session_db")
+        captured["agent"] = _CountingAgent(db=kw.get("session_db"))
+        return captured["agent"]
+
+    def raise_wire_callbacks(_sid):
+        raise RuntimeError("wire boom")
+
+    parent = {
+        "session_key": "parent-key",
+        "history": [{"role": "user", "content": "hi"}],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cols": 80,
+        "profile_home": str(profile_home),
+        "source": "tui",
+        "agent": _CountingAgent(),
+        "created_at": 1.0,
+        "last_active": 1.0,
+        "cwd": str(tmp_path),
+    }
+    server._sessions["parent"] = parent
+    monkeypatch.setattr("hermes_state.SessionDB", BranchProfileDB)
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_wire_callbacks", raise_wire_callbacks)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.branch",
+                "params": {"session_id": "parent", "name": "forked"},
+            }
+        )
+        assert "error" in resp, resp
+        assert captured["agent_db"].close_calls == 1
+        assert captured["agent"].close_calls == 1
+        assert set(server._sessions.keys()) == {"parent"}
+    finally:
+        server._sessions.clear()
+
+
+def test_eager_resume_init_failure_claimed_skips_local_close(monkeypatch, tmp_path):
+    """A concurrent closer that reclaims the eager-resume session before the raise closes resources exactly once, not doubled by the RPC handler."""
+    target = "stored-profile-session-claimed"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+
+    class ResumeProfileDB(_CountingDB):
+        def get_session(self, _target):
+            return {"id": target, "cwd": str(tmp_path)}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            return None
+
+        def get_resume_conversations(self, _sid):
+            return ([{"role": "user", "content": "hello"}], [])
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(self, *_a, **_k):
+            return [{"role": "user", "content": "hello"}]
+
+        def resolve_resume_session_id(self, sid_):
+            return sid_
+
+    class LaunchDB:
+        def close(self):
+            raise AssertionError("shared launch db must never be closed")
+
+    ResumeProfileDB.instances = []
+
+    def fake_make_agent(_sid, _key, session_id=None, session_db=None, **_kw):
+        captured["agent_db"] = session_db
+        captured["agent"] = _CountingAgent(db=session_db)
+        return captured["agent"]
+
+    class FakeWorker:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def close(self):
+            pass
+
+    def wire_callbacks_with_concurrent_close(_sid):
+        claimed_sid = next(
+            sid_ for sid_, sess in server._sessions.items() if sess.get("session_key") == target
+        )
+        popped = server._sessions.pop(claimed_sid)
+        server._teardown_session(popped)
+        raise RuntimeError("wire boom")
+
+    monkeypatch.setattr(server, "_profile_home", lambda _p: profile_home)
+    monkeypatch.setattr("hermes_state.SessionDB", ResumeProfileDB)
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+    monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _t: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _t: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_wire_callbacks", wire_callbacks_with_concurrent_close)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": target, "profile": "worker", "eager_build": True},
+            }
+        )
+        assert "error" in resp, resp
+        assert captured["agent"].close_calls == 1
+        assert captured["agent_db"].close_calls == 1
+        assert all(s.get("session_key") != target for s in server._sessions.values())
+    finally:
+        server._sessions.clear()
+
+
+def test_eager_resume_records_and_closes_profile_db(monkeypatch, tmp_path):
+    """An eager profile resume hands its dedicated DB to teardown, exactly once."""
+    target = "stored-profile-session"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+
+    class ResumeProfileDB(_CountingDB):
+        def get_session(self, _target):
+            return {"id": target, "cwd": str(tmp_path)}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            return None
+
+        def get_resume_conversations(self, _sid):
+            return ([{"role": "user", "content": "hello"}], [])
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(self, *_a, **_k):
+            return [{"role": "user", "content": "hello"}]
+
+        def resolve_resume_session_id(self, sid_):
+            return sid_
+
+    class LaunchDB:
+        def close(self):
+            raise AssertionError("shared launch db must never be closed")
+
+    ResumeProfileDB.instances = []
+
+    def fake_make_agent(_sid, _key, session_id=None, session_db=None, **_kw):
+        captured["agent_db"] = session_db
+        captured["agent"] = _CountingAgent(db=session_db)
+        return captured["agent"]
+
+    class FakeWorker:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "_profile_home", lambda _p: profile_home)
+    monkeypatch.setattr("hermes_state.SessionDB", ResumeProfileDB)
+    monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
+    monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _t: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _t: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": target, "profile": "worker", "eager_build": True},
+            }
+        )
+        assert "error" not in resp, resp
+        sid = resp["result"]["session_id"]
+        assert server._sessions[sid]["_owned_session_db"] is captured["agent_db"]
+        assert captured["agent_db"].close_calls == 0
+
+        assert server._close_session_by_id(sid)
+
+        assert captured["agent"].close_calls == 1
+        assert captured["agent_db"].close_calls == 1
+    finally:
+        server._sessions.clear()
+
+
+def test_eager_resume_race_loser_closes_profile_db(monkeypatch, tmp_path):
+    """The losing side of the resume race closes its agent AND its profile DB."""
+    target = "raced-profile-session"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+    winner = ("winner-sid", {"session_key": target})
+
+    class ResumeProfileDB(_CountingDB):
+        def get_session(self, _target):
+            return {"id": target, "cwd": str(tmp_path)}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            return None
+
+        def get_resume_conversations(self, _sid):
+            return ([{"role": "user", "content": "hello"}], [])
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(self, *_a, **_k):
+            return [{"role": "user", "content": "hello"}]
+
+        def resolve_resume_session_id(self, sid_):
+            return sid_
+
+    ResumeProfileDB.instances = []
+    find_calls = {"n": 0}
+
+    def fake_find_live(_key):
+        # First probe is the pre-build fast path (no live session yet); the
+        # post-build double-check then finds the concurrent winner.
+        find_calls["n"] += 1
+        return None if find_calls["n"] == 1 else winner
+
+    def fake_make_agent(_sid, _key, session_id=None, session_db=None, **_kw):
+        captured["agent_db"] = session_db
+        captured["agent"] = _CountingAgent(db=session_db)
+        return captured["agent"]
+
+    monkeypatch.setattr(server, "_profile_home", lambda _p: profile_home)
+    monkeypatch.setattr("hermes_state.SessionDB", ResumeProfileDB)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _t: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _t: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_find_live_session_by_key", fake_find_live)
+    monkeypatch.setattr(server, "_live_session_payload", lambda *a, **k: {})
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": target, "profile": "worker", "eager_build": True},
+            }
+        )
+        assert "error" not in resp, resp
+        assert resp["result"]["resumed"] == target
+        assert captured["agent"].close_calls == 1
+        assert captured["agent_db"].close_calls == 1
+        # The winner owns the durable session row: the discarded duplicate
+        # must be released without finalizing (end_session-ing) that row.
+        assert getattr(captured["agent"], "_end_session_on_close", True) is False
+    finally:
+        server._sessions.clear()
+
+
+def test_deferred_profile_resume_closes_transient_read_handle(monkeypatch, tmp_path):
+    """The default deferred resume must close its read-only profile handle."""
+    target = "stored-profile-session-deferred"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+
+    class ResumeProfileDB(_CountingDB):
+        def get_session(self, _target):
+            return {"id": target, "cwd": str(tmp_path)}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            return None
+
+        def get_resume_conversations(self, _sid):
+            return ([{"role": "user", "content": "hello"}], [])
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(self, *_a, **_k):
+            return [{"role": "user", "content": "hello"}]
+
+        def resolve_resume_session_id(self, sid_):
+            return sid_
+
+    ResumeProfileDB.instances = []
+
+    monkeypatch.setattr(server, "_profile_home", lambda _p: profile_home)
+    monkeypatch.setattr("hermes_state.SessionDB", ResumeProfileDB)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.resume",
+                "params": {"session_id": target, "profile": "worker"},
+            }
+        )
+        assert "error" not in resp, resp
+        # Exactly one dedicated handle was opened for the reads, and the
+        # handler closed it (TrackedConnection only untracks on close(), so
+        # dropping it for GC would poison the byte-probe registry).
+        assert len(ResumeProfileDB.instances) == 1
+        assert ResumeProfileDB.instances[0].close_calls == 1
+    finally:
+        server._sessions.clear()
+
+
+def test_profile_resume_read_exception_closes_transient_handle(monkeypatch, tmp_path):
+    """A db read raising mid-resume must still close the transient profile handle."""
+    target = "stored-profile-session-raises"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+
+    class ExplodingProfileDB(_CountingDB):
+        def get_session(self, _target):
+            raise RuntimeError("read boom")
+
+    ExplodingProfileDB.instances = []
+
+    monkeypatch.setattr(server, "_profile_home", lambda _p: profile_home)
+    monkeypatch.setattr("hermes_state.SessionDB", ExplodingProfileDB)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+
+    try:
+        with pytest.raises(RuntimeError, match="read boom"):
+            server.handle_request(
+                {
+                    "id": "1",
+                    "method": "session.resume",
+                    "params": {"session_id": target, "profile": "worker"},
+                }
+            )
+        assert len(ExplodingProfileDB.instances) == 1
+        assert ExplodingProfileDB.instances[0].close_calls == 1
+    finally:
+        server._sessions.clear()
+
+
+def test_branch_records_and_closes_profile_db(monkeypatch, tmp_path):
+    """A branched agent's dedicated profile DB is owned and closed at teardown."""
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    captured: dict = {}
+
+    class BranchProfileDB(_CountingDB):
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} (branch)"
+
+        def create_session(self, *_a, **_k):
+            return None
+
+        def append_messages_batch(self, _sid, messages, **_k):
+            return list(range(1, len(messages) + 1))
+
+        def set_session_title(self, *_a, **_k):
+            return True
+
+    BranchProfileDB.instances = []
+
+    def fake_make_agent(*_a, **kw):
+        captured["agent_db"] = kw.get("session_db")
+        captured["agent"] = _CountingAgent(db=kw.get("session_db"))
+        return captured["agent"]
+
+    parent = {
+        "session_key": "parent-key",
+        "history": [{"role": "user", "content": "hi"}],
+        "history_lock": threading.Lock(),
+        "running": False,
+        "cols": 80,
+        "profile_home": str(profile_home),
+        "source": "tui",
+        "agent": _CountingAgent(),
+        "created_at": 1.0,
+        "last_active": 1.0,
+        "cwd": str(tmp_path),
+    }
+    server._sessions["parent"] = parent
+    monkeypatch.setattr("hermes_state.SessionDB", BranchProfileDB)
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *a, **k: None)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.branch",
+                "params": {"session_id": "parent", "name": "forked"},
+            }
+        )
+        assert "result" in resp, resp
+        child_sid = resp["result"]["session_id"]
+        assert captured["agent_db"] is not None
+        assert server._sessions[child_sid]["_owned_session_db"] is captured["agent_db"]
+        assert captured["agent_db"].close_calls == 0
+
+        assert server._close_session_by_id(child_sid)
+
+        assert captured["agent"].close_calls == 1
+        assert captured["agent_db"].close_calls == 1
+    finally:
+        server._sessions.clear()
+
+
+def test_profile_session_churn_keeps_fd_count_stable(monkeypatch, tmp_path):
+    """Create/close churn with REAL profile SessionDBs must not grow the FD table.
+
+    This is the incident regression: every profile chat leaked ~3 SQLite fds
+    (db + WAL + SHM) until the launchd 256 soft limit killed the dashboard.
+    """
+    import gc
+
+    try:
+        fd_dir = os.listdir("/dev/fd")
+    except OSError:
+        pytest.skip("/dev/fd unavailable on this platform")
+
+    profile_home = tmp_path / "profiles" / "mlperf"
+    profile_home.mkdir(parents=True)
+    agents: list = []
+
+    def fake_make_agent(_sid, _key, session_db=None, **_kw):
+        agents.append(_CountingAgent(db=session_db))
+        return agents[-1]
+
+    _stub_build_machinery(monkeypatch)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+
+    import tools.approval as approval
+
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(approval, "load_permanent_allowlist", lambda: None)
+
+    def churn_once(i: int) -> None:
+        sid = f"fd-churn-{i}"
+        session = _deferred_profile_session(profile_home)
+        session["session_key"] = f"fd-churn-key-{i}"
+        server._sessions[sid] = session
+        try:
+            server._start_agent_build(sid, session)
+            assert session["agent_ready"].wait(timeout=10), "build did not finish"
+            assert session.get("agent_error") is None, session.get("agent_error")
+            assert "_owned_session_db" in session
+        finally:
+            server._close_session_by_id(sid, end_reason="tui_close")
+
+    # Warm-up pass so one-time imports/caches don't count as growth.
+    churn_once(0)
+    gc.collect()
+    before = len(os.listdir("/dev/fd"))
+    for i in range(1, 13):
+        churn_once(i)
+    gc.collect()
+    after = len(os.listdir("/dev/fd"))
+
+    assert all(a.close_calls == 1 for a in agents)
+    assert after - before <= 3, f"fd count grew {before} -> {after}"
+
+
 def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     """session.branch must copy history into the parent's profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -561,6 +561,15 @@ class ComputeHost:
                 platform_override=frame.get("source"),
                 session_db=session_db,
             )
+        except Exception:
+            # The dedicated profile handle never reached an agent/session that
+            # could own it — close it before the build error propagates.
+            if session_db is not None:
+                try:
+                    session_db.close()
+                except Exception:
+                    pass
+            raise
         finally:
             if home_token is not None:
                 try:
@@ -571,12 +580,13 @@ class ComputeHost:
                     reset_secret_scope(secret_token)
                 except Exception:
                     pass
+        record = None
         try:
             from tui_gateway.transport import bind_transport, reset_transport
 
             token = bind_transport(self._transport)
             try:
-                server._init_session(
+                record = server._init_session(
                     sid,
                     key,
                     agent,
@@ -585,14 +595,27 @@ class ComputeHost:
                     cwd=str(frame.get("cwd") or "") or None,
                     session_db=session_db,
                     source=frame.get("source"),
+                    # Dedicated profile handle (never the shared launch db):
+                    # the session record owns it so teardown closes it.
+                    owned_session_db=session_db,
                 )
             finally:
                 reset_transport(token)
-        except Exception:
+        except Exception as exc:
+            if getattr(exc, "_resources_claimed_by_closer", False):
+                # A concurrent close claimed the just-registered session and
+                # closed the agent + profile handle. Installing the fallback
+                # would resurrect closed resources; fail the turn instead.
+                raise
             # If _init_session's side machinery (slash worker, approval notify) is
-            # unavailable, keep a minimal host-owned session rather than failing
-            # the turn after the expensive agent build succeeded.
-            server._sessions[sid] = {
+            # unavailable, it unregistered its record and returned the live agent
+            # + profile handle to us — keep a minimal host-owned session rather
+            # than failing the turn after the expensive agent build succeeded.
+            # Built completely (ownership included) BEFORE publication, and
+            # published under the lock only into an empty slot, so a closer
+            # can never observe a record missing its owned handle and a
+            # concurrent initializer's live session is never displaced.
+            fallback = {
                 "agent": agent,
                 "session_key": key,
                 "history": list(history),
@@ -615,7 +638,41 @@ class ComputeHost:
                 "source": server._sanitize_client_source(frame.get("source")),
                 "transport": self._transport,
             }
-        session = server._sessions[sid]
+            if session_db is not None:
+                fallback["_owned_session_db"] = session_db
+            with server._sessions_lock:
+                existing = server._sessions.get(sid)
+                if existing is None:
+                    server._sessions[sid] = fallback
+            if existing is not None:
+                # A concurrent initializer won the sid (registration refuses
+                # to displace a live record) — its session serves this turn;
+                # our just-built resources lose and must be disposed of.
+                try:
+                    # Resource release only: the winner owns the durable
+                    # session row, so this discarded duplicate must not
+                    # end_session it.
+                    agent._end_session_on_close = False
+                except Exception:
+                    pass
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                if session_db is not None:
+                    try:
+                        session_db.close()
+                    except Exception:
+                        pass
+                record = existing
+            else:
+                record = fallback
+        if record is None:
+            # Older _init_session seams (tests) return nothing; fall back to
+            # the registry so their stubs keep working.
+            record = server._sessions.get(sid) or {}
+        session = record
         session["transport"] = self._transport
         session["profile_home"] = profile_home or session.get("profile_home")
         if isinstance(frame.get("attached_images"), list):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -321,8 +321,14 @@ def _(rid, params: dict) -> dict:
     # the caller explicitly requests it; other clients keep upstream behavior.
     omit_messages = is_truthy_value(params.get("omit_messages", False))
 
-    # In a profile scope, the agent OWNS a long-lived db handle bound to that
-    # profile (do NOT auto-close it here). Otherwise reuse the shared launch db.
+    # In a profile scope this is a dedicated handle bound to that profile. The
+    # eager path hands it to the agent for the session's lifetime and records
+    # it as the session's ``_owned_session_db`` (closed exactly once at
+    # teardown); every other path only reads through it and must close it
+    # explicitly before returning — TrackedConnection untracks a path only on
+    # close(), so a handle dropped for GC would permanently inflate
+    # _live_connections and disable byte-probe recovery for that state.db.
+    # Launch/own profile → the shared launch db, left open.
     if profile_home is not None:
         from hermes_state import SessionDB
 
@@ -332,238 +338,254 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _db_unavailable_error(rid, code=5000)
 
-    found = db.get_session(target)
-    if not found:
-        found = db.get_session_by_title(target)
-        if found:
-            target = found["id"]
-        elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
-            # Race: a watch window opened on a freshly-spawned subagent. The
-            # child relays `subagent.start` (which carries child_session_id and
-            # triggers the window) BEFORE its first run_conversation() flushes
-            # the DB row via _ensure_db_session, so db.get_session(target) is
-            # momentarily empty. On slower hosts (notably WSL2, where SQLite +
-            # process scheduling widen the gap) the window's resume consistently
-            # lands inside this window and used to hard-fail "session not found"
-            # — the frontend then 404'd on the REST messages fallback and the
-            # window spun forever. The child is provably live (_child_run_active),
-            # so proceed into the lazy branch with empty history; the live mirror
-            # streams the whole turn anyway and the row exists by upgrade time.
-            found = {}
-        else:
-            return _err(rid, 4007, "session not found")
+    handed_off = False
+    try:
+        found = db.get_session(target)
+        if not found:
+            found = db.get_session_by_title(target)
+            if found:
+                target = found["id"]
+            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
+                # Race: a watch window opened on a freshly-spawned subagent. The
+                # child relays `subagent.start` (which carries child_session_id and
+                # triggers the window) BEFORE its first run_conversation() flushes
+                # the DB row via _ensure_db_session, so db.get_session(target) is
+                # momentarily empty. On slower hosts (notably WSL2, where SQLite +
+                # process scheduling widen the gap) the window's resume consistently
+                # lands inside this window and used to hard-fail "session not found"
+                # — the frontend then 404'd on the REST messages fallback and the
+                # window spun forever. The child is provably live (_child_run_active),
+                # so proceed into the lazy branch with empty history; the live mirror
+                # streams the whole turn anyway and the row exists by upgrade time.
+                found = {}
+            else:
+                return _err(rid, 4007, "session not found")
 
-    # Follow the compression-continuation chain to the live tip so a resume on
-    # a rotated-out parent id binds to the descendant that actually holds the
-    # post-compression turns. Auto-compression ends the session and forks a
-    # continuation child; without this, resuming the original id (the desktop's
-    # routed id when the chat was opened before it rotated) reloads the parent
-    # transcript and the response generated after compression is missing — the
-    # "I came back and the reply isn't there" bug on large sessions. Resolving
-    # here also re-anchors the fast path below so a still-live rotated session
-    # is reused (by its new key) instead of rebuilding a duplicate agent on the
-    # stale parent. Skipped for lazy watch windows, which intentionally attach
-    # to the exact child branch they were opened on.
-    if found and not is_truthy_value(params.get("lazy", False)):
-        try:
-            tip = db.resolve_resume_session_id(target)
-        except Exception:
-            tip = target
-        if tip and tip != target:
-            target = tip
-            found = db.get_session(target) or found
+        # Follow the compression-continuation chain to the live tip so a resume on
+        # a rotated-out parent id binds to the descendant that actually holds the
+        # post-compression turns. Auto-compression ends the session and forks a
+        # continuation child; without this, resuming the original id (the desktop's
+        # routed id when the chat was opened before it rotated) reloads the parent
+        # transcript and the response generated after compression is missing — the
+        # "I came back and the reply isn't there" bug on large sessions. Resolving
+        # here also re-anchors the fast path below so a still-live rotated session
+        # is reused (by its new key) instead of rebuilding a duplicate agent on the
+        # stale parent. Skipped for lazy watch windows, which intentionally attach
+        # to the exact child branch they were opened on.
+        if found and not is_truthy_value(params.get("lazy", False)):
+            try:
+                tip = db.resolve_resume_session_id(target)
+            except Exception:
+                tip = target
+            if tip and tip != target:
+                target = tip
+                found = db.get_session(target) or found
 
-    profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
-        profile_home
-    )
-
-    def _reuse_live_payload(sid: str, session: dict) -> dict:
-        payload = _live_session_payload(
-            sid,
-            session,
-            cols=cols,
-            touch=True,
-            transport=current_transport() or _stdio_transport,
-            omit_messages=omit_messages,
+        profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
+            profile_home
         )
-        payload["resumed"] = target
-        # A lazy watch session never owns a run loop, so its payload's running
-        # flag is always False — overlay the child-run registry so a reconnecting
-        # watch window keeps its busy indicator while the child is still mid-run.
-        if session.get("agent") is None and _child_run_active(target):
-            payload["running"] = True
-            payload["status"] = "streaming"
-        return payload
 
-    # Fast path: if the session is already live, reuse it under the lock.
-    with _session_resume_lock:
-        live = _find_live_session_by_key(target)
-        if live is not None:
-            return _ok(rid, _reuse_live_payload(*live))
-
-    # Lazy/watch resume: register the live session WITHOUT building an agent.
-    # Used by the desktop's subagent windows — the child runs inside the
-    # parent's turn, so its window only needs the stored history plus a
-    # transport for the child-mirror's live events. Skipping _make_agent here
-    # is what keeps the window cheap while the backend is busy running the
-    # delegation. A later prompt.submit upgrades it via _start_agent_build
-    # (resume_session_id keeps the upgrade on the stored conversation).
-    if is_truthy_value(params.get("lazy", False)):
-        sid = uuid.uuid4().hex[:8]
-        source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-        lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
-        try:
-            db.reopen_session(target)
-            # The child's OWN conversation only — include_ancestors would prepend
-            # the parent's transcript onto the subagent's branch.
-            # repair_alternation: this resume feeds LIVE REPLAY (the loaded
-            # history becomes the resumed session record's working conversation),
-            # so heal a durable ``user;user`` violation once here instead of
-            # re-firing the pre-request repair on every subsequent turn.
-            history = db.get_messages_as_conversation(target, repair_alternation=True)
-        except Exception as e:
-            if lease is not None:
-                lease.release()
-            return _err(rid, 5000, f"resume failed: {e}")
-        cwd = profile_resume_cwd or _default_session_cwd()
-        record = _deferred_session_record(
-            target,
-            cols=cols,
-            cwd=cwd,
-            history=history,
-            lease=lease,
-            source=source,
-            close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
-            profile_home=profile_home,
-            lazy=True,
-        )
-        if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-            return _ok(rid, _reuse_live_payload(*live))
-        # A delegated child mid-run emits no session events of its own — report
-        # its liveness from the relay registry so the window shows a busy turn.
-        child_running = _child_run_active(target)
-        # User-visible messages use the VERBATIM display projection (child-only,
-        # no ancestors — matching the repaired read above), so model-invisible
-        # rows persisted by #65919 (verification candidates collapsed by
-        # repair_message_sequence) survive in the watch window just as they do
-        # on the eager resume + REST paths. The repaired ``history`` above still
-        # feeds live replay. Fall back to it if the display read fails.
-        try:
-            display_history = db.get_messages_as_conversation(
-                target, repair_alternation=False, include_row_ids=True
+        def _reuse_live_payload(sid: str, session: dict) -> dict:
+            payload = _live_session_payload(
+                sid,
+                session,
+                cols=cols,
+                touch=True,
+                transport=current_transport() or _stdio_transport,
+                omit_messages=omit_messages,
             )
-        except Exception:
-            logger.debug("child-watch display projection read failed", exc_info=True)
-            display_history = history
-        messages = [] if omit_messages else _history_to_messages(display_history)
-        return _ok(
-            rid,
-            {
+            payload["resumed"] = target
+            # A lazy watch session never owns a run loop, so its payload's running
+            # flag is always False — overlay the child-run registry so a reconnecting
+            # watch window keeps its busy indicator while the child is still mid-run.
+            if session.get("agent") is None and _child_run_active(target):
+                payload["running"] = True
+                payload["status"] = "streaming"
+            return payload
+
+        # Fast path: if the session is already live, reuse it under the lock.
+        with _session_resume_lock:
+            live = _find_live_session_by_key(target)
+            if live is not None:
+                return _ok(rid, _reuse_live_payload(*live))
+
+        # Lazy/watch resume: register the live session WITHOUT building an agent.
+        # Used by the desktop's subagent windows — the child runs inside the
+        # parent's turn, so its window only needs the stored history plus a
+        # transport for the child-mirror's live events. Skipping _make_agent here
+        # is what keeps the window cheap while the backend is busy running the
+        # delegation. A later prompt.submit upgrades it via _start_agent_build
+        # (resume_session_id keeps the upgrade on the stored conversation).
+        if is_truthy_value(params.get("lazy", False)):
+            sid = uuid.uuid4().hex[:8]
+            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            try:
+                db.reopen_session(target)
+                # The child's OWN conversation only — include_ancestors would prepend
+                # the parent's transcript onto the subagent's branch.
+                # repair_alternation: this resume feeds LIVE REPLAY (the loaded
+                # history becomes the resumed session record's working conversation),
+                # so heal a durable ``user;user`` violation once here instead of
+                # re-firing the pre-request repair on every subsequent turn.
+                history = db.get_messages_as_conversation(target, repair_alternation=True)
+            except Exception as e:
+                if lease is not None:
+                    lease.release()
+                return _err(rid, 5000, f"resume failed: {e}")
+            cwd = profile_resume_cwd or _default_session_cwd()
+            record = _deferred_session_record(
+                target,
+                cols=cols,
+                cwd=cwd,
+                history=history,
+                lease=lease,
+                source=source,
+                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                profile_home=profile_home,
+                lazy=True,
+            )
+            if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
+                return _ok(rid, _reuse_live_payload(*live))
+            # A delegated child mid-run emits no session events of its own — report
+            # its liveness from the relay registry so the window shows a busy turn.
+            child_running = _child_run_active(target)
+            # User-visible messages use the VERBATIM display projection (child-only,
+            # no ancestors — matching the repaired read above), so model-invisible
+            # rows persisted by #65919 (verification candidates collapsed by
+            # repair_message_sequence) survive in the watch window just as they do
+            # on the eager resume + REST paths. The repaired ``history`` above still
+            # feeds live replay. Fall back to it if the display read fails.
+            try:
+                display_history = db.get_messages_as_conversation(
+                    target, repair_alternation=False, include_row_ids=True
+                )
+            except Exception:
+                logger.debug("child-watch display projection read failed", exc_info=True)
+                display_history = history
+            messages = [] if omit_messages else _history_to_messages(display_history)
+            return _ok(
+                rid,
+                {
+                    "session_id": sid,
+                    "resumed": target,
+                    "message_count": len(display_history) if omit_messages else len(messages),
+                    "messages": messages,
+                    "messages_omitted": omit_messages,
+                    "info": _lazy_resume_info(cwd, profile=profile),
+                    "inflight": None,
+                    "running": child_running,
+                    "session_key": target,
+                    "started_at": record["created_at"],
+                    "status": "streaming" if child_running else "idle",
+                },
+            )
+
+        # Cold resume default: register the live session and read its stored
+        # transcript, but build the agent OFF the response path. _make_agent can
+        # block for seconds (MCP discovery, prompt/skill build, AIAgent
+        # construction), and every resume caller (desktop + Ink TUI) awaits this RPC
+        # before it paints — so building eagerly is the bulk of the multi-second
+        # "switching sessions is frozen" latency. Return the full display transcript
+        # immediately and pre-warm the agent on a short timer (the same deferred-
+        # build contract session.create uses); _sess() also builds on demand if the
+        # first prompt beats the timer. A caller that needs the agent built
+        # synchronously (e.g. tests of the build race) passes ``eager_build: true``
+        # to fall through to the eager path below. Distinct from the lazy/watch
+        # branch above: a normal resume restores the full ancestor history and the
+        # session's persisted runtime identity, and is a real (upgradable) session.
+        if not is_truthy_value(params.get("eager_build", False)):
+            sid = uuid.uuid4().hex[:8]
+            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            # Interactive resume routes approvals/clarify through gateway prompts;
+            # the deferred build wires the remaining per-session callbacks.
+            _enable_gateway_prompts()
+            try:
+                db.reopen_session(target)
+                # One lineage SELECT feeds both projections (#67142-adjacent perf,
+                # from the desktop audit): the model-fed copy is alternation-repaired
+                # (raw_history → sanitize_replay_history → the resumed session's
+                # working conversation) and the display copy stays verbatim —
+                # inspection/export must show what is actually stored.
+                if omit_messages:
+                    raw_history = db.get_messages_as_conversation(
+                        target, repair_alternation=True
+                    )
+                    display_history = []
+                else:
+                    raw_history, display_history = db.get_resume_conversations(target)
+            except Exception as e:
+                if lease is not None:
+                    lease.release()
+                return _err(rid, 5000, f"resume failed: {e}")
+            # Display keeps the full transcript; the model-fed history drops a
+            # dangling/interrupted tool-call tail so a session killed mid-loop does
+            # not replay the unanswered call forever (#29086).
+            prefix = [] if omit_messages else db.get_ancestor_display_prefix(target)
+            history = sanitize_replay_history(raw_history)
+            # Restore the model/provider/reasoning/tier this chat last used so the
+            # deferred build (and the info below) match the eager path — without them
+            # the build drops the provider ("No LLM provider configured").
+            overrides = _stored_session_runtime_overrides(found) or {}
+            model_override = overrides.get("model_override") or {}
+            cwd = profile_resume_cwd or _default_session_cwd()
+            record = _deferred_session_record(
+                target,
+                cols=cols,
+                cwd=cwd,
+                history=history,
+                lease=lease,
+                source=source,
+                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                display_history_prefix=prefix,
+                profile_home=profile_home,
+                model_override=overrides.get("model_override"),
+                resume_runtime_overrides=overrides or None,
+            )
+            if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
+                return _ok(rid, _reuse_live_payload(*live))
+
+            _schedule_agent_build(sid)
+            _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
+            auto_continue = _maybe_schedule_auto_continue(sid, record, target)
+
+            messages = [] if omit_messages else _history_to_messages(display_history)
+            payload = {
                 "session_id": sid,
                 "resumed": target,
-                "message_count": len(display_history) if omit_messages else len(messages),
+                "message_count": len(raw_history) if omit_messages else len(messages),
                 "messages": messages,
                 "messages_omitted": omit_messages,
-                "info": _lazy_resume_info(cwd, profile=profile),
+                "info": _lazy_resume_info(
+                    cwd,
+                    model=model_override.get("model") or "",
+                    provider=overrides.get("provider_override") or "",
+                    profile=profile,
+                ),
                 "inflight": None,
-                "running": child_running,
+                "running": False,
                 "session_key": target,
                 "started_at": record["created_at"],
-                "status": "streaming" if child_running else "idle",
-            },
-        )
+                "status": "idle",
+            }
+            if auto_continue is not None:
+                payload["auto_continue"] = auto_continue
+            return _ok(rid, payload)
+        # Reaching here means no non-eager branch returned: the request
+        # falls through to the eager build, which hands the handle to the
+        # agent (ownership recorded via _init_session) — leave it open.
+        handed_off = True
+    finally:
+        # Every non-eager exit — return OR raise — must close the dedicated
+        # profile read handle. TrackedConnection only untracks a path on
+        # close(), so a handle dropped for GC would permanently inflate
+        # _live_connections and disable byte-probe recovery for that
+        # state.db. The shared launch handle is never closed.
+        if not handed_off and profile_home is not None:
+            with contextlib.suppress(Exception):
+                db.close()
 
-    # Cold resume default: register the live session and read its stored
-    # transcript, but build the agent OFF the response path. _make_agent can
-    # block for seconds (MCP discovery, prompt/skill build, AIAgent
-    # construction), and every resume caller (desktop + Ink TUI) awaits this RPC
-    # before it paints — so building eagerly is the bulk of the multi-second
-    # "switching sessions is frozen" latency. Return the full display transcript
-    # immediately and pre-warm the agent on a short timer (the same deferred-
-    # build contract session.create uses); _sess() also builds on demand if the
-    # first prompt beats the timer. A caller that needs the agent built
-    # synchronously (e.g. tests of the build race) passes ``eager_build: true``
-    # to fall through to the eager path below. Distinct from the lazy/watch
-    # branch above: a normal resume restores the full ancestor history and the
-    # session's persisted runtime identity, and is a real (upgradable) session.
-    if not is_truthy_value(params.get("eager_build", False)):
-        sid = uuid.uuid4().hex[:8]
-        source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-        lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
-        # Interactive resume routes approvals/clarify through gateway prompts;
-        # the deferred build wires the remaining per-session callbacks.
-        _enable_gateway_prompts()
-        try:
-            db.reopen_session(target)
-            # One lineage SELECT feeds both projections (#67142-adjacent perf,
-            # from the desktop audit): the model-fed copy is alternation-repaired
-            # (raw_history → sanitize_replay_history → the resumed session's
-            # working conversation) and the display copy stays verbatim —
-            # inspection/export must show what is actually stored.
-            if omit_messages:
-                raw_history = db.get_messages_as_conversation(
-                    target, repair_alternation=True
-                )
-                display_history = []
-            else:
-                raw_history, display_history = db.get_resume_conversations(target)
-        except Exception as e:
-            if lease is not None:
-                lease.release()
-            return _err(rid, 5000, f"resume failed: {e}")
-        # Display keeps the full transcript; the model-fed history drops a
-        # dangling/interrupted tool-call tail so a session killed mid-loop does
-        # not replay the unanswered call forever (#29086).
-        prefix = [] if omit_messages else db.get_ancestor_display_prefix(target)
-        history = sanitize_replay_history(raw_history)
-        # Restore the model/provider/reasoning/tier this chat last used so the
-        # deferred build (and the info below) match the eager path — without them
-        # the build drops the provider ("No LLM provider configured").
-        overrides = _stored_session_runtime_overrides(found) or {}
-        model_override = overrides.get("model_override") or {}
-        cwd = profile_resume_cwd or _default_session_cwd()
-        record = _deferred_session_record(
-            target,
-            cols=cols,
-            cwd=cwd,
-            history=history,
-            lease=lease,
-            source=source,
-            close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
-            display_history_prefix=prefix,
-            profile_home=profile_home,
-            model_override=overrides.get("model_override"),
-            resume_runtime_overrides=overrides or None,
-        )
-        if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-            return _ok(rid, _reuse_live_payload(*live))
-
-        _schedule_agent_build(sid)
-        _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
-        auto_continue = _maybe_schedule_auto_continue(sid, record, target)
-
-        messages = [] if omit_messages else _history_to_messages(display_history)
-        payload = {
-            "session_id": sid,
-            "resumed": target,
-            "message_count": len(raw_history) if omit_messages else len(messages),
-            "messages": messages,
-            "messages_omitted": omit_messages,
-            "info": _lazy_resume_info(
-                cwd,
-                model=model_override.get("model") or "",
-                provider=overrides.get("provider_override") or "",
-                profile=profile,
-            ),
-            "inflight": None,
-            "running": False,
-            "session_key": target,
-            "started_at": record["created_at"],
-            "status": "idle",
-        }
-        if auto_continue is not None:
-            payload["auto_continue"] = auto_continue
-        return _ok(rid, payload)
 
     # Build the agent OUTSIDE the lock — _make_agent can block for seconds
     # (MCP discovery, prompt/skill build, AIAgent construction). Holding
@@ -626,6 +648,11 @@ def _(rid, params: dict) -> dict:
     except Exception as e:
         if lease is not None:
             lease.release()
+        # The dedicated profile handle never reached an owner (the shared
+        # launch handle stays open — see _get_db()).
+        if profile_home is not None:
+            with contextlib.suppress(Exception):
+                db.close()
         return _err(rid, 5000, f"resume failed: {e}")
     finally:
         if home_token is not None:
@@ -640,10 +667,23 @@ def _(rid, params: dict) -> dict:
         live = _find_live_session_by_key(target)
         if live is not None:
             try:
+                # Resource release only: the WINNER owns the durable session
+                # row, so this discarded duplicate must not end_session it
+                # (run_agent honors this seam for helpers that hand session
+                # ownership forward).
+                agent._end_session_on_close = False
+            except Exception:
+                pass
+            try:
                 if hasattr(agent, "close"):
                     agent.close()
             except Exception:
                 pass
+            # Close AFTER the agent, and only the dedicated profile handle;
+            # the winner holds its own.
+            if profile_home is not None:
+                with contextlib.suppress(Exception):
+                    db.close()
             if lease is not None:
                 lease.release()
             other_sid, other_session = live
@@ -669,7 +709,7 @@ def _(rid, params: dict) -> dict:
                 else None
             )
             try:
-                _init_session(
+                record = _init_session(
                     sid,
                     target,
                     agent,
@@ -678,27 +718,52 @@ def _(rid, params: dict) -> dict:
                     cwd=profile_resume_cwd,
                     session_db=db,
                     source=source,
+                    # A dedicated profile handle lives as long as the agent;
+                    # the session record owns it so teardown closes it.
+                    owned_session_db=db if profile_home is not None else None,
                 )
             finally:
                 if init_home_token is not None:
                     reset_hermes_home_override(init_home_token)
                 if init_secret_token is not None:
                     reset_secret_scope(init_secret_token)
-            if sid in _sessions:
-                if stored_runtime_overrides.get("model_override") is not None:
-                    _sessions[sid]["model_override"] = stored_runtime_overrides[
-                        "model_override"
-                    ]
-                _sessions[sid]["display_history_prefix"] = display_history_prefix
-                # Remember the profile home so each turn re-binds HERMES_HOME (the
-                # agent persists to its own db, but mid-turn home reads — memory,
-                # skills — must resolve to the resumed profile too).
-                if profile_home is not None:
-                    _sessions[sid]["profile_home"] = str(profile_home)
-                _sessions[sid]["active_session_lease"] = lease
+            if record is None:
+                # Older _init_session seams (tests) return nothing; fall back
+                # to the registry so their stubs keep working.
+                record = _sessions.get(sid) or {}
+            if stored_runtime_overrides.get("model_override") is not None:
+                record["model_override"] = stored_runtime_overrides["model_override"]
+            record["display_history_prefix"] = display_history_prefix
+            # Remember the profile home so each turn re-binds HERMES_HOME (the
+            # agent persists to its own db, but mid-turn home reads — memory,
+            # skills — must resolve to the resumed profile too).
+            if profile_home is not None:
+                record["profile_home"] = str(profile_home)
+            record["active_session_lease"] = lease
         except Exception as e:
             if lease is not None:
                 lease.release()
+            # A failed _init_session unregisters the record it created before
+            # re-raising. Unmarked, the agent + profile handle reverted to
+            # these locals; marked, a concurrent closer claimed the record
+            # and closes both itself — closing here would double-close.
+            if not getattr(e, "_resources_claimed_by_closer", False):
+                try:
+                    # Resource release only: this agent is bound to the
+                    # EXISTING conversation (target), which stays resumable —
+                    # a failed poller/callback init must not end_session the
+                    # durable row.
+                    agent._end_session_on_close = False
+                except Exception:
+                    pass
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                if profile_home is not None:
+                    with contextlib.suppress(Exception):
+                        db.close()
             return _err(rid, 5000, f"resume failed: {e}")
         session = _sessions.get(sid) or {}
     auto_continue = (
@@ -2745,6 +2810,8 @@ def _(rid, params: dict) -> dict:
             if lease is not None:
                 lease.release()
             return _err(rid, 5008, f"branch failed: {e}")
+    branch_db = None
+    agent = None
     try:
         # Bind the branched AGENT to the parent's profile, mirroring
         # session.create/resume: home override so config/skills/memory resolve
@@ -2754,7 +2821,6 @@ def _(rid, params: dict) -> dict:
         # parent's db while the agent stayed on the launch handle would
         # recreate the cross-profile split one turn later.
         parent_home = session.get("profile_home")
-        branch_db = None
         if parent_home:
             from hermes_state import SessionDB
 
@@ -2784,7 +2850,7 @@ def _(rid, params: dict) -> dict:
                 )
             finally:
                 _clear_session_context(tokens)
-            _init_session(
+            branch_record = _init_session(
                 new_sid,
                 new_key,
                 agent,
@@ -2794,17 +2860,40 @@ def _(rid, params: dict) -> dict:
                 session_db=branch_db,
                 source=source,
                 profile_home=parent_home,
+                # The branched agent keeps this dedicated handle for its whole
+                # life; the session record owns it so teardown closes it.
+                owned_session_db=branch_db,
             )
         finally:
             if secret_token is not None:
                 reset_secret_scope(secret_token)
             if home_token is not None:
                 reset_hermes_home_override(home_token)
-        if new_sid in _sessions:
-            _sessions[new_sid]["active_session_lease"] = lease
+        if branch_record is None:
+            # Older _init_session seams (tests) return nothing; fall back to
+            # the registry so their stubs keep working.
+            branch_record = _sessions.get(new_sid) or {}
+        # Once _init_session succeeded, ownership lives in the registered
+        # record — mutate our local reference (a registry re-lookup here
+        # could raise on a concurrent pop and trip the local-close path on
+        # resources a closer already claimed).
+        branch_record["active_session_lease"] = lease
     except Exception as e:
         if lease is not None:
             lease.release()
+        # A failed _init_session unregisters the record it created before
+        # re-raising. Unmarked (or failed before init), the branched agent +
+        # dedicated profile handle are these locals to dispose of; marked, a
+        # concurrent closer claimed the record and closes both itself.
+        if not getattr(e, "_resources_claimed_by_closer", False):
+            try:
+                if agent is not None and hasattr(agent, "close"):
+                    agent.close()
+            except Exception:
+                pass
+            if branch_db is not None:
+                with contextlib.suppress(Exception):
+                    branch_db.close()
         return _err(rid, 5000, f"agent init failed on branch: {e}")
     branched_session = _sessions.get(new_sid)
     return _ok(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -852,16 +852,37 @@ def _teardown_session(session: dict | None, *, end_reason: str = "tui_close") ->
             unregister_gateway_notify(key)
     except Exception:
         pass
-    try:
-        agent = session.get("agent")
-        if agent is not None and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
+    _close_session_agent_and_owned_db(session)
     # NOTE: the slash-worker is closed inside _finalize_session (the single
     # _finalized-guarded chokepoint that main folded it into), exactly once.
     # We deliberately do NOT re-close it here — _teardown_session's job beyond
     # finalize is unregistering the notifier and closing the in-process agent.
+
+
+def _close_session_agent_and_owned_db(session: dict) -> None:
+    """Close resources created exclusively for one gateway session.
+
+    Popping each resource is the idempotent ownership claim, so repeated
+    teardown closes each resource exactly once; both pops happen under one
+    lock so a concurrent claimant takes both resources or neither — the db
+    can never be closed out from under ``agent.close()``'s final
+    ``end_session`` write.  Only dedicated profile handles are recorded under
+    ``_owned_session_db``; the process-wide ``_get_db()`` handle is never put
+    here and must remain open.
+    """
+    with _sessions_lock:
+        agent = session.pop("agent", None)
+        session_db = session.pop("_owned_session_db", None)
+    try:
+        if agent is not None and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
+        if session_db is not None and hasattr(session_db, "close"):
+            session_db.close()
+    except Exception:
+        pass
 
 
 def _attach_worker(sid: str, session: dict, worker) -> None:
@@ -2108,13 +2129,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
         notify_registered = False
         home_token = None
         secret_token = None
+        session_db = None
         profile_home = current.get("profile_home")
         try:
             tokens = _set_session_context(key)
             # Build against the session's profile (global-remote): bind its
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
-            session_db = None
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
                 try:
@@ -2169,7 +2190,34 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
-            current["agent"] = agent
+            # Transfer both resources to the live session atomically. If a
+            # concurrent close already detached it, this build still owns them
+            # and must dispose of them instead of publishing into an orphaned
+            # dict. The profile DB is exclusive to this build; shared launch
+            # DBs arrive through _make_agent's fallback and are never stored.
+            with _sessions_lock:
+                published = _sessions.get(sid) is current
+                if published:
+                    current["agent"] = agent
+                    if session_db is not None:
+                        current["_owned_session_db"] = session_db
+                        session_db = None
+            if not published:
+                try:
+                    # Resource release only: this agent never became the
+                    # session's owner, and on a deferred RESUME its
+                    # session_id is the durable conversation row the user
+                    # may reopen — ending it as agent_close here would fight
+                    # the gateway's own finalize policy for reaped sessions.
+                    agent._end_session_on_close = False
+                except Exception:
+                    pass
+                try:
+                    if hasattr(agent, "close"):
+                        agent.close()
+                except Exception:
+                    pass
+                return
             # Baseline for the per-turn config sync; the profile home
             # override is still active here.
             current["config_model_seen"] = _config_model_target()
@@ -2241,6 +2289,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
+            # A DB created before _make_agent failed (or before a concurrent
+            # close won the publish race) never transferred to the session.
+            if session_db is not None:
+                try:
+                    session_db.close()
+                except Exception:
+                    pass
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             if secret_token is not None:
@@ -2255,6 +2310,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # leak (session.close unregistered before _build registered it).
             with _sessions_lock:
                 replaced = _sessions.get(sid) is not current
+            # No resource cleanup here even when replaced: publish and pop are
+            # totally ordered by _sessions_lock, so a session detached AFTER
+            # publication is always torn down by its closer (pop ->
+            # _teardown_session -> _close_session_agent_and_owned_db), which
+            # finalizes BEFORE closing. Closing from this thread too would
+            # race that finalize (persist/end_session through a just-closed
+            # agent/db). A build that never published disposed of its own
+            # locals above.
             if replaced and notify_registered:
                 try:
                     from tools.approval import unregister_gateway_notify
@@ -6476,114 +6539,163 @@ def _init_session(
     session_db=None,
     source: str | None = None,
     profile_home: str | None = None,
+    owned_session_db=None,
 ):
+    # ``owned_session_db``: a dedicated (non-launch-profile) SessionDB the
+    # caller built for this session's agent. Recording it here transfers
+    # ownership to the session record so _teardown_session closes it exactly
+    # once. Callers must NEVER pass the shared _get_db() handle.
     now = time.time()
+    record = {
+        "agent": agent,
+        "session_key": key,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "created_at": now,
+        "last_active": now,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cwd": cwd or _completion_cwd(),
+        "cols": cols,
+        "slash_worker": None,
+        "show_reasoning": _load_show_reasoning(),
+        "source": _resolve_session_source(source),
+        "tool_progress_mode": _load_tool_progress_mode(),
+        "edit_snapshots": {},
+        "tool_started_at": {},
+        # Profile-scoped HERMES_HOME for app-global remote mode; None =
+        # launch profile. SessionBranch copies the parent's value so the
+        # child stays on the same state.db.
+        "profile_home": profile_home,
+        # Per-session model override set by an in-session /model switch.
+        # Honored on rebuild (/new, resume) so a switch in THIS session
+        # never leaks into siblings via process-global env vars.
+        "model_override": None,
+        # Pin async event emissions to whichever transport created the
+        # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
+        "transport": current_transport() or _stdio_transport,
+    }
+    if owned_session_db is not None:
+        # Recorded in the same dict that gets registered, so a concurrent
+        # close that pops this session always finds the handle it is
+        # expected to close.
+        record["_owned_session_db"] = owned_session_db
     with _sessions_lock:
-        _sessions[sid] = {
-            "agent": agent,
-            "session_key": key,
-            "history": history,
-            "history_lock": threading.Lock(),
-            "history_version": 0,
-            "inflight_turn": None,
-            "created_at": now,
-            "last_active": now,
-            "running": False,
-            "attached_images": [],
-            "image_counter": 0,
-            "cwd": cwd or _completion_cwd(),
-            "cols": cols,
-            "slash_worker": None,
-            "show_reasoning": _load_show_reasoning(),
-            "source": _resolve_session_source(source),
-            "tool_progress_mode": _load_tool_progress_mode(),
-            "edit_snapshots": {},
-            "tool_started_at": {},
-            # Profile-scoped HERMES_HOME for app-global remote mode; None =
-            # launch profile. SessionBranch copies the parent's value so the
-            # child stays on the same state.db.
-            "profile_home": profile_home,
-            # Per-session model override set by an in-session /model switch.
-            # Honored on rebuild (/new, resume) so a switch in THIS session
-            # never leaks into siblings via process-global env vars.
-            "model_override": None,
-            # Pin async event emissions to whichever transport created the
-            # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
-            "transport": current_transport() or _stdio_transport,
-        }
-    _init_owns_db = False
-    if session_db is not None:
-        db = session_db
-    elif profile_home:
-        try:
-            from hermes_state import SessionDB
-
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-            _init_owns_db = True
-        except Exception:
-            db = _get_db()
-    else:
-        db = _get_db()
+        if _sessions.get(sid) is not None:
+            # Refusing to displace a live record keeps the failure-path pop
+            # below unambiguous: once OUR record is registered, the slot can
+            # only change by a closer's pop-claim, never by silent
+            # replacement (two compute-host turns racing the same sid would
+            # otherwise strand the loser's agent + profile db unowned).
+            raise RuntimeError(f"session {sid} is already registered")
+        _sessions[sid] = record
     try:
-        if db is not None:
-            row = db.get_session(key) if hasattr(db, "get_session") else None
-            if row and row.get("cwd"):
-                with _sessions_lock:
-                    if sid in _sessions:
-                        _sessions[sid]["cwd"] = row["cwd"]
-            else:
-                try:
-                    _cwd = _sessions[sid]["cwd"]
-                    if hasattr(db, "update_session_cwd"):
-                        db.update_session_cwd(key, _cwd)
-                    # git branch/root probes run off the hot path (see _set_session_cwd).
-                    _persist_session_git_meta(_sessions[sid], _cwd)
-                except Exception:
-                    logger.debug(
-                        "failed to persist resumed session cwd", exc_info=True
-                    )
-    finally:
-        if _init_owns_db and db is not None:
+        _init_owns_db = False
+        if session_db is not None:
+            db = session_db
+        elif profile_home:
             try:
-                db.close()
+                from hermes_state import SessionDB
+
+                db = SessionDB(db_path=Path(profile_home) / "state.db")
+                _init_owns_db = True
+            except Exception:
+                db = _get_db()
+        else:
+            db = _get_db()
+        try:
+            if db is not None:
+                row = db.get_session(key) if hasattr(db, "get_session") else None
+                if row and row.get("cwd"):
+                    record["cwd"] = row["cwd"]
+                else:
+                    try:
+                        _cwd = record["cwd"]
+                        if hasattr(db, "update_session_cwd"):
+                            db.update_session_cwd(key, _cwd)
+                        # git branch/root probes run off the hot path (see _set_session_cwd).
+                        _persist_session_git_meta(record, _cwd)
+                    except Exception:
+                        logger.debug(
+                            "failed to persist resumed session cwd", exc_info=True
+                        )
+        finally:
+            if _init_owns_db and db is not None:
+                try:
+                    db.close()
+                except Exception:
+                    pass
+        _register_session_cwd(record)
+        # No eager slash-worker pre-warm — the session dict already carries
+        # slash_worker=None and slash.exec builds one on demand. See the
+        # deferred-build path in _start_agent_build for the full rationale
+        # (per-worker MCP fleets accumulating across retained sessions).
+        try:
+            from tools.approval import register_gateway_notify, load_permanent_allowlist
+
+            register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
+            load_permanent_allowlist()
+        except Exception:
+            pass
+        # Surface the self-improvement background review's "💾 …" summary as a
+        # review.summary event so Ink can render it as a persistent system line
+        # in the transcript. In the CLI path this message is printed via
+        # prompt_toolkit; the TUI has no equivalent print surface, so without
+        # this callback the review would write the skill/memory change silently.
+        try:
+            agent.background_review_callback = lambda message, _sid=sid: _emit(
+                "review.summary", _sid, {"text": str(message)}
+            )
+            # Honor display.memory_notifications (off | on | verbose) like the
+            # messaging gateway and CLI do — otherwise the review always behaved as
+            # "on" on the TUI/desktop and a user who set "off" was ignored.
+            agent.memory_notifications = _load_memory_notifications()
+        except Exception:
+            # Bare AIAgents that don't expose the attribute (unlikely, but keep
+            # session startup resilient).
+            pass
+        _wire_callbacks(sid)
+        with _sessions_lock:
+            if sid in _sessions:
+                _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+        _notify_session_boundary("on_session_reset", key, _session_source(record))
+        _emit("session.info", sid, _session_info(agent, record))
+        _schedule_mcp_late_refresh(sid, agent)
+    except Exception as e:
+        # A half-initialized session must not stay registered: nobody ever
+        # receives its sid, so no close/reap could reach its agent or owned
+        # profile db for hours. Reclaim the record with the same atomic pop
+        # teardown uses. Winning the pop proves no concurrent closer touched
+        # it — the agent and owned db revert to the caller's locals, and
+        # nothing here closes them. Losing the pop means a closer already
+        # claimed the record and closes both resources itself (registration
+        # refuses to displace a live record, so a closer's pop is the ONLY
+        # way our record can leave the slot); the marker tells the caller
+        # not to close (or resurrect) them again.
+        with _sessions_lock:
+            still_ours = _sessions.get(sid) is record
+            if still_ours:
+                _sessions.pop(sid, None)
+        if still_ours:
+            stop_event = record.get("_notif_stop")
+            if stop_event is not None:
+                stop_event.set()
+            try:
+                from tools.approval import unregister_gateway_notify
+
+                unregister_gateway_notify(key)
             except Exception:
                 pass
-    _register_session_cwd(_sessions[sid])
-    # No eager slash-worker pre-warm — the session dict already carries
-    # slash_worker=None and slash.exec builds one on demand. See the
-    # deferred-build path in _start_agent_build for the full rationale
-    # (per-worker MCP fleets accumulating across retained sessions).
-    try:
-        from tools.approval import register_gateway_notify, load_permanent_allowlist
-
-        register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
-        load_permanent_allowlist()
-    except Exception:
-        pass
-    # Surface the self-improvement background review's "💾 …" summary as a
-    # review.summary event so Ink can render it as a persistent system line
-    # in the transcript. In the CLI path this message is printed via
-    # prompt_toolkit; the TUI has no equivalent print surface, so without
-    # this callback the review would write the skill/memory change silently.
-    try:
-        agent.background_review_callback = lambda message, _sid=sid: _emit(
-            "review.summary", _sid, {"text": str(message)}
-        )
-        # Honor display.memory_notifications (off | on | verbose) like the
-        # messaging gateway and CLI do — otherwise the review always behaved as
-        # "on" on the TUI/desktop and a user who set "off" was ignored.
-        agent.memory_notifications = _load_memory_notifications()
-    except Exception:
-        # Bare AIAgents that don't expose the attribute (unlikely, but keep
-        # session startup resilient).
-        pass
-    _wire_callbacks(sid)
-    with _sessions_lock:
-        if sid in _sessions:
-            _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
-    _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
-    _schedule_mcp_late_refresh(sid, agent)
+        else:
+            try:
+                e._resources_claimed_by_closer = True
+            except Exception:
+                pass
+        raise
+    return record
 
 
 def _new_session_key() -> str:


### PR DESCRIPTION
## What does this PR do?

Fixes a file-descriptor leak in the dashboard/TUI gateway: every session scoped to a **non-launch profile** builds a dedicated `SessionDB` for that profile's `state.db` and hands it to its `AIAgent` — but nothing ever closed it. `AIAgent.close()` intentionally leaves `_session_db` open (its last step is `end_session()` *through* that handle, and on ordinary sessions the handle is the process-shared `_get_db()` that must stay open), so the dedicated profile handles had no owner. Each one holds ~5 fds (db + WAL + SHM + read conn), pinned by the token-writer `atexit` registration, so session churn (desktop chat switching + the TTL/LRU reapers) grows the fd table monotonically. A long-lived dashboard under app-global remote mode exhausts the macOS launchd 256-fd soft limit and dies in an EMFILE storm (auth reads, cron jobs, skills, log writes, `socket.accept`). Observed in production: 255/256 fds, ~224 SQLite-related, repeated handles on the same profile `state.db` files.

This is the same leak class as #69678 (fixed for the delivery/delegation/verification ledgers) on a surface that fix didn't cover. It's also distinct from the WAL-reader-per-thread work in #75269/#75546/#74304 (read-pool internals) and from #78500 (notification-poller profile scoping): those bound *other* fd sources; this one gives the agent-held profile handle an owner.

**The ownership contract**: the shared `_get_db()` launch handle is *borrowed* and never closed; a dedicated profile handle is *owned by exactly one session record* (under `_owned_session_db`) and closed exactly once at teardown, strictly after `agent.close()` (which still writes `end_session` through it). This extends the `(db, owns_handle)` idiom the file already uses for scoped handles (`_db_for_profile` / `_profile_db` / `_session_db`) across time instead of scope.

Origin: the leak arrived with 6f6eb871 (#39993, deferred builds), and the same unowned pattern was repeated by the eager resume path (02d6bf1c), `session.branch` (29dd621498), and the compute host (7d27a31ce7). The teardown fix in 6da970f1 predates profile DBs and closed only the agent.

## Related Issue

Related: #69678 (same fd-leak class; closed — its fix covered the ledgers but not this tui_gateway surface). No open issue tracks this specific leak.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Review tip: `git diff -w` — the `session.resume` non-eager phase was mechanically reindented into a `try/finally`, which inflates the raw line count.

## Changes Made

- `tui_gateway/server.py`
  - New `_close_session_agent_and_owned_db()`: single teardown disposal helper. Claims the agent and the owned db **atomically under `_sessions_lock`** (a concurrent claimant takes both resources or neither, so the db can never be closed out from under `agent.close()`'s final `end_session` write), then closes agent first, db second. `_teardown_session` routes through it.
  - `_start_agent_build`: publishes agent + profile db to the live session atomically iff the sid still maps to this record; a build that lost the publish race disposes of its own locals with `_end_session_on_close=False` (a deferred resume's row belongs to the still-resumable conversation, not the discarded agent); a `_make_agent` failure closes the db in the `finally`. The build thread deliberately does **not** also close published resources when it later finds the session detached — publish and pop are totally ordered by `_sessions_lock`, so the closer that popped the session always tears it down itself, and a second closer would race `_finalize_session`'s unflushed-message persist and `end_session` writes.
  - `_init_session` grows `owned_session_db=` so eager construction sites can record ownership at registration time (same lock as registration, so a concurrent close always finds the handle it must close). Registration refuses to displace a live record, so a closer's pop-claim is the only way a registered record leaves the slot (two compute-host turns racing one sid can no longer strand the loser's resources). A failed `_init_session` no longer strands a half-initialized registered session (nobody ever receives its sid, so nothing could close it until the idle reaper hours later): it reclaims its record with the same atomic identity-checked pop teardown uses and re-raises — unmarked when the pop proves no concurrent closer touched the record (agent/db revert to the caller's locals, which every caller disposes of), marked `_resources_claimed_by_closer` when a concurrent close won the pop (that closer closes both resources; callers must not double-close). Callers mutate the record `_init_session` returns instead of re-looking up the registry, so a concurrent pop can't divert them into the local-close path.
- `tui_gateway/methods_session.py`
  - Eager `session.resume` (`eager_build`): ownership transferred via `_init_session`; the double-checked-locking race loser is released with `_end_session_on_close=False` (it must not `end_session` the durable row the winner owns) and closes its profile db after its agent; build/init failures close the local agent + db unless the exception is marked claimed-by-closer. The stale "the agent OWNS a long-lived db handle" comment now documents the actual contract.
  - `session.resume`'s whole non-eager phase runs under one `try/finally`, closing its **transient** profile read handle on every exit — not-found, fast live reuse, lazy watch, deferred, and any mid-read exception. `TrackedConnection` untracks a path only on `close()`, so dropping the handle for GC frees the fds but permanently inflates `_live_connections` and disables byte-probe recovery for that `state.db`.
  - `session.branch`: `branch_db` ownership transferred via `_init_session`; the failure path disposes of the built agent + db under the same claimed-by-closer guard.
- `tui_gateway/compute_host.py`
  - `_ensure_server_session`: closes the profile db if `_make_agent` raises; transfers ownership via `_init_session`; the minimal fallback record is built complete (ownership included) and published atomically under `_sessions_lock` only into an empty slot; a claimed failure re-raises instead of resurrecting closed handles, and losing the slot to a concurrent initializer disposes of the losing build's resources with `_end_session_on_close=False` so the winner's durable row is never finalized by the loser.
- `tests/test_tui_gateway_server.py` — 20 regression tests (see below).

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py` — 536 passed (517 existing + 19 new, plus two strengthened). New coverage: owned profile db closed exactly once at teardown (deferred build, eager resume, branch); shared launch handle never closed; `_make_agent` failure closes the db; close-during-build and close-after-publish races close each resource exactly once; repeated teardown is idempotent; the agent closes while its db is still open (so `end_session` still lands); init-failure unregisters the record and returns ownership to the caller (no ghost session); init-failure with a concurrent close marks the exception and nothing double-closes or resurrects; registration refuses to displace a live record; every discarded duplicate agent (resume loser, compute-host slot loser, detached deferred build, failed eager-resume init) releases without `end_session`; the transient read handle closes on every non-eager exit including mid-read exceptions; and `test_profile_session_churn_keeps_fd_count_stable`, which churns 13 sessions with **real** `SessionDB` instances and asserts the process fd table stays flat (the incident regression — it fails by ~40+ fds without the fix). All were written red-first against the unfixed code.
   Note: while validating, `test_write_json_serializes_concurrent_writes` was observed to flake (~1 in 4 under heavy machine load) on the **unmodified base** as well — an extra event line lands in its patched stdout from a thread leaked by an earlier test in the file. Pre-existing, unrelated to this change; happy to file it separately.
2. `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/test_hermes_state.py tests/test_session_db_read_path_split.py tests/hermes_state tests/state` — 801 passed, 0 failed.
3. Full suite (controlled comparison, same machine + venv): 25,211 passed on this branch vs 25,200 on a pristine base checkout — byte-identical failing set of 72 (all pre-existing environment-dependent tests: missing optional extras like `anthropic`/`daytona`/`fal`), delta exactly the new tests. Re-run on the final commit posted as a PR comment.
4. Live validation on the affected deployment: before the fix the dashboard sat at 255/256 fds and EMFILE'd twice; after cutover fd count settled at 38 and stayed flat under health-check load, with no further EMFILE.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings/comments updated in the touched functions
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fd-count regression test skips where `/dev/fd` is unavailable
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Second-incident evidence (before fix): dashboard process at 255 open fds against the 256 launchd soft limit, ~224 SQLite-related, repeated open handles on the same profile `state.db`/WAL/SHM paths, EMFILE spreading from platform probes to auth reads, cron, skills, log writes, and `socket.accept`. After fix: fd count stable at 38 across session churn and sustained health checks.
