### PR TITLE
fix(terminal): guard NUL bytes in remote script read fallback (#76762 follow-up)

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,43 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_binary_returned_by_read_remote_script_does_not_crash(self):
+        """#76762 follow-up: the guard is called from terminal_tool with a
+        read_remote_script fallback (local read miss -> cat via env). When a
+        referenced path is a binary (ELF), the fallback can return its raw
+        NUL-laden content; the recursive scan must not feed a NUL-embedded
+        path into os.open, which raises ValueError (not OSError) for such
+        paths.
+
+        Before this fix, the scan crashed with
+        ValueError: embedded null byte at _read_referenced_script's os.open.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        def fake_remote_script(path):
+            # Mimics terminal_tool._read_script_in_env's cat fallback on a
+            # large binary that exceeds the local read cap: raw bytes decoded
+            # with errors='replace' keep the NUL bytes. Content is harmless
+            # machine-code junk WITHOUT a lifecycle command — the point is
+            # that NUL-laden text must not crash the walk, not that it
+            # triggers a block.
+            return (b"\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                    b"\x01\x02\x03\x04\x05\x00\x00\x00\xff\xfe\xfd\xfc").decode(
+                "utf-8", errors="replace"
+            )
+
+        # Referenced path is a script (contains "/") so the walk reads it
+        # locally first (binary -> None), then falls back to the remote read
+        # which returns NUL-laden text -> recursion must not crash.
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "cd /tmp && ./venv/bin/tool --flag",
+            cwd="/tmp",
+            read_remote_script=fake_remote_script,
+        )
+        assert result is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2544,15 +2544,28 @@ def terminal_tool(
                         metadata = local_path.stat()
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
-                            if len(data) <= 1024 * 1024:
+                            if len(data) <= 1024 * 1024 and b"\x00" not in data:
                                 return data.decode("utf-8", errors="replace")
+                        # A NUL byte marks a binary (ELF/Mach-O/PE), not a
+                        # shell script — scanning its decoded text would
+                        # tokenize machine code and feed junk paths (with
+                        # embedded NULs) into the recursive guard walk
+                        # (#76762 follow-up). Local file that is binary or
+                        # oversized: nothing to scan; do not fall through to
+                        # `cat`, which would return the same bytes.
+                        return None
                 except Exception:
                     pass
                 # Remote / sandboxed backend: read via the environment's shell.
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        output = result.get("output", "")
+                        # A remote `cat` of a binary returns NUL-laden text;
+                        # treat it as nothing to scan rather than poisoning
+                        # the recursive walk (#76762 follow-up).
+                        if "\x00" not in output:
+                            return output
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## Problem

`_read_script_in_env`'s remote `cat` fallback returns raw binary content (NUL-laden text) when a referenced path is an ELF/Mach-O binary. The recursive lifecycle-guard walk then tokenizes machine code and feeds NUL-embedded junk paths into `os.open`, which raises `ValueError` (not `OSError`) and crashes the guard — a guarded path must never crash the guard.

Repro: any gateway-session terminal command referencing a path with `/` where the local read misses (binary >1MB or remote backend) → `ValueError: embedded null byte` in `_read_referenced_script`.

## Fix

- **Local read**: skip binaries (NUL byte present) and oversized files instead of falling through to `cat`, which would return the same bytes
- **Remote `cat` fallback**: drop NUL-laden output (binary) instead of poisoning the recursive walk

## Scope vs #76762

Upstream #76762 fixed the local-read path (NUL detection on local bytes) and the lifecycle_guard `resolve()` exception handling. This PR covers the remaining paths: local binary/oversized no longer falls through to `cat`, and remote cat output is NUL-checked.

## Test

Adds `test_binary_returned_by_read_remote_script_does_not_crash` — injects a fake remote script returning NUL-laden ELF junk and asserts the guard walk completes without crashing.

```
pytest tests/hermes_cli/test_gateway_restart_loop.py -q
83 passed
```