### PR TITLE
fix(dashboard): recover black chat viewport

### DIFF
--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -11,15 +11,28 @@ class FakeFitAddon {
 }
 
 class FakeWebglAddon {
-  onContextLoss() {
+  static instances: FakeWebglAddon[] = [];
+
+  contextLossHandler: (() => void) | null = null;
+  dispose = vi.fn();
+
+  constructor() {
+    FakeWebglAddon.instances.push(this);
+  }
+
+  onContextLoss(handler: () => void) {
+    this.contextLossHandler = handler;
     return { dispose() {} };
   }
 }
 
 class FakeTerminal {
+  static instances: FakeTerminal[] = [];
+
   options: Record<string, unknown>;
   rows = 24;
   cols = 80;
+  scrollToBottom = vi.fn();
   parser = {
     registerOscHandler: vi.fn(),
   };
@@ -27,6 +40,7 @@ class FakeTerminal {
 
   constructor(options: Record<string, unknown>) {
     this.options = options;
+    FakeTerminal.instances.push(this);
   }
 
   attachCustomKeyEventHandler() {
@@ -61,7 +75,7 @@ class FakeTerminal {
 
   paste() {}
 
-  refresh() {}
+  refresh = vi.fn();
 
   write() {}
 }
@@ -154,6 +168,8 @@ async function render(ui: ReactNode) {
 }
 
 beforeEach(() => {
+  FakeTerminal.instances = [];
+  FakeWebglAddon.instances = [];
   FakeWebSocket.instances = [];
   maybeReloadForLoopbackWsAuthFailure.mockClear();
   apiMocks.buildWsUrl.mockReset();
@@ -190,6 +206,10 @@ beforeEach(() => {
     configurable: true,
     value: { addEventListener() {}, removeEventListener() {}, width: 1280 },
   });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
   Object.defineProperty(window, "__HERMES_SESSION_TOKEN__", {
     configurable: true,
     value: "stale-token",
@@ -217,6 +237,73 @@ afterEach(async () => {
 });
 
 describe("ChatPage", () => {
+  it("restores the live terminal viewport when returning to Chat", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+    const page = (isActive: boolean) => (
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive={isActive} />
+      </MemoryRouter>
+    );
+
+    await render(page(true));
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    terminal.scrollToBottom.mockClear();
+
+    await act(async () => root.render(page(false)));
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+
+    await act(async () => root.render(page(true)));
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the live terminal viewport when the browser tab becomes visible", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    terminal.scrollToBottom.mockClear();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("repaints with the fallback renderer after WebGL context loss", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeWebglAddon.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    const webgl = FakeWebglAddon.instances[0];
+    terminal.refresh.mockClear();
+
+    webgl.contextLossHandler?.();
+
+    expect(webgl.dispose).toHaveBeenCalledTimes(1);
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+
   it("treats loopback 4401 closes as stale-token reload candidates", async () => {
     const { default: ChatPage } = await import("./ChatPage");
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -786,7 +786,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
+        webgl.onContextLoss(() => {
+          // Disposing returns xterm to its built-in renderer, but that renderer
+          // does not necessarily repaint the existing buffer until another
+          // dirty region arrives. Force a full repaint so a suspended tab or
+          // GPU reset cannot leave the fallback showing a black pane.
+          webgl.dispose();
+          try {
+            term.refresh(0, term.rows - 1);
+          } catch {
+            /* terminal teardown raced the context-loss callback */
+          }
+        });
         term.loadAddon(webgl);
       } catch (err) {
         console.warn(
@@ -1349,6 +1360,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       raf2 = requestAnimationFrame(() => {
         raf2 = 0;
         syncMetricsRef.current?.();
+        // Inline-mode output lives in xterm's primary-buffer scrollback. After
+        // Chat was display:none, xterm can resume with the viewport parked
+        // above the live tail, presenting an entirely black pane even though
+        // new input/output is being rendered correctly. Re-anchor only on the
+        // explicit inactive → active path so ordinary resizes preserve a
+        // user's intentional history position.
+        termRef.current?.scrollToBottom();
         const host = hostRef.current;
         const active = typeof document !== "undefined"
           ? document.activeElement
@@ -1405,14 +1423,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
 
     const onResume = () => maybeReconnectOnPageResume();
+    const onVisibilityChange = () => {
+      maybeReconnectOnPageResume();
+      if (document.visibilityState !== "visible") return;
+      // Browser tab suspension can leave xterm's primary-buffer viewport
+      // above the live tail even while the PTY keeps rendering. Restore the
+      // viewport only on a real visible-resume event; focus/pageshow/online
+      // still handle transport recovery without disturbing scroll history.
+      syncMetricsRef.current?.();
+      termRef.current?.scrollToBottom();
+    };
 
-    document.addEventListener("visibilitychange", onResume);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     window.addEventListener("pageshow", onResume);
     window.addEventListener("focus", onResume);
     window.addEventListener("online", onResume);
 
     return () => {
-      document.removeEventListener("visibilitychange", onResume);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pageshow", onResume);
       window.removeEventListener("focus", onResume);
       window.removeEventListener("online", onResume);


### PR DESCRIPTION
## Summary

- restore xterm's live viewport after returning to the Chat route
- restore metrics and the live viewport when a suspended browser tab becomes visible
- force a full terminal repaint after WebGL context loss so the fallback renderer does not remain black
- preserve scroll history during ordinary resize, focus, pageshow, and online events

## Problem

The dashboard chat can display an entirely black terminal after the Chat page was hidden, a browser tab resumed, or the WebGL context was lost. The PTY and terminal buffer can still be live, but xterm's viewport may remain above the live tail or its fallback renderer may not repaint the existing buffer.

Fixes #27740.

## Testing

- `npm test -- src/pages/ChatPage.test.tsx` — 7 tests passed
- `npm run typecheck` — passed
- `npx eslint src/pages/ChatPage.tsx src/pages/ChatPage.test.tsx` — no errors; 3 pre-existing warnings in `ChatPage.tsx`

Regression tests cover:

- no viewport jump while Chat is inactive, followed by restoration on inactive-to-active transition
- no viewport jump on a hidden visibility event, followed by restoration when visible
- WebGL disposal and full fallback-renderer repaint after context loss