### PR TITLE
fix(gateway): admit exactly one /update per profile

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -55,6 +55,14 @@ logger = logging.getLogger("gateway.run")
 # its worker thread. (#35994)
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
+# How long a /update reservation stays valid before another /update may take it
+# over (see _claim_update_slot). An updater that is killed without writing its
+# exit code — host reboot, OOM kill — leaves its marker behind forever, so the
+# reservation needs a ceiling or /update wedges for the lifetime of the profile.
+# Sized above _watch_update_progress's own 1800s watch timeout so a live update
+# that is still being watched is never stolen.
+_UPDATE_RESERVATION_TTL_S = 3600.0
+
 
 def _clean_str(value: Any) -> str:
     """Strip and return a non-empty string value, or empty string."""
@@ -121,6 +129,62 @@ def _home_thread_from_source(source) -> Optional[str]:
     ):
         return None
     return str(thread_id)
+
+
+def _claim_update_slot(pending_path: Path, ttl_seconds: float) -> bool:
+    """Atomically reserve the profile-wide ``/update`` slot.
+
+    ``/update`` is profile-global: it rewrites the checkout and the virtualenv
+    every session on the host shares, and the ``.update_*`` marker files are a
+    single-slot mailbox holding one requester's routing metadata. Two updaters
+    must therefore never run at once.
+
+    A ``if pending_path.exists(): return`` guard cannot provide that. Two
+    handlers can both observe the marker missing and both go on to create it,
+    so the second one's metadata silently replaces the first one's and a second
+    updater is spawned against the same checkout. ``os.open`` with
+    ``O_CREAT | O_EXCL`` collapses the observe-and-create into a single atomic
+    syscall, so exactly one caller can ever win.
+
+    Returns ``True`` when this caller now owns the slot (the marker exists and
+    is empty, ready for the caller to fill in with its routing metadata), and
+    ``False`` when another update already holds it.
+    """
+    def _create_exclusive() -> bool:
+        try:
+            fd = os.open(pending_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            return False
+        os.close(fd)
+        return True
+
+    if _create_exclusive():
+        return True
+
+    # The slot is held. Take it over only when it is provably abandoned: a host
+    # reboot or a SIGKILLed updater leaves a marker that nothing will ever
+    # clean up, and a permanently wedged /update would be a worse bug than the
+    # collision this guard exists to close.
+    try:
+        age = time.time() - pending_path.stat().st_mtime
+    except OSError:
+        # Vanished between the failed create and the stat — the previous update
+        # finished in that window. Retry once; if we lose again, the loser path
+        # is still correct.
+        return _create_exclusive()
+
+    if age < ttl_seconds:
+        return False
+
+    logger.warning(
+        "Reclaiming abandoned /update reservation %s (age %.0fs > %.0fs)",
+        pending_path, age, ttl_seconds,
+    )
+    try:
+        pending_path.unlink()
+    except OSError:
+        return False
+    return _create_exclusive()
 
 
 class GatewaySlashCommandsMixin:
@@ -5659,8 +5723,31 @@ class GatewaySlashCommandsMixin:
             return t("gateway.update.hermes_cmd_not_found")
 
         pending_path = _hermes_home / ".update_pending.json"
+        claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+
+        # Admission control. Reserve the profile-wide update slot BEFORE any
+        # routing metadata is written and BEFORE the updater is spawned, so two
+        # concurrent /update invocations (a double tap while the minutes-long
+        # update runs without an ack, or two platforms on one multiplexed
+        # gateway) cannot both start an updater against the same checkout and
+        # venv, with the second one's metadata clobbering the first requester's
+        # so they never learn their update finished.
+        #
+        # `.update_pending.claimed.json` is the notifier's transient rename of
+        # the marker (see _send_update_notification); while it exists an update
+        # is in flight, so reject. Checking it is not a check-then-create race:
+        # it can only ever produce an extra rejection, never an extra spawn,
+        # and the exclusive create below is what actually decides the winner.
+        if claimed_path.exists() or not _claim_update_slot(
+            pending_path, _UPDATE_RESERVATION_TTL_S
+        ):
+            # The loser still gets the outcome: the watcher is profile-wide and
+            # reports the result into the chat that started the update.
+            self._schedule_update_notification_watch()
+            return t("gateway.update.already_running")
+
         session_key = self._session_key_for_source(event.source)
         pending = {
             "platform": event.source.platform.value,
@@ -5674,10 +5761,6 @@ class GatewaySlashCommandsMixin:
             pending["thread_id"] = event.source.thread_id
         if event.message_id:
             pending["message_id"] = event.message_id
-        _tmp_pending = pending_path.with_suffix(".tmp")
-        _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
-        _tmp_pending.replace(pending_path)
-        exit_code_path.unlink(missing_ok=True)
 
         # Spawn `hermes update --gateway` detached so it survives gateway restart.
         # --gateway enables file-based IPC for interactive prompts (stash
@@ -5704,6 +5787,17 @@ class GatewaySlashCommandsMixin:
         # so the simplest correct thing is: launch an inline Python helper
         # that runs the command and writes both outputs.
         try:
+            # Fill the reservation in with this requester's routing metadata.
+            # Write-to-temp + rename keeps the marker a complete JSON document
+            # for the readers in gateway/run.py, which poll it concurrently.
+            # Everything from the claim onwards must release the slot on
+            # failure, or a /update that never actually started would block the
+            # next one until the reservation TTL expires.
+            _tmp_pending = pending_path.with_suffix(".tmp")
+            _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
+            _tmp_pending.replace(pending_path)
+            exit_code_path.unlink(missing_ok=True)
+
             if sys.platform == "win32":
                 import textwrap
                 from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
@@ -5764,6 +5858,8 @@ class GatewaySlashCommandsMixin:
                         start_new_session=True,
                     )
         except Exception as e:
+            # Release the reservation so the user can retry immediately.
+            pending_path.with_suffix(".tmp").unlink(missing_ok=True)
             pending_path.unlink(missing_ok=True)
             exit_code_path.unlink(missing_ok=True)
             return t("gateway.update.start_failed", error=e)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -187,6 +187,22 @@ def _claim_update_slot(pending_path: Path, ttl_seconds: float) -> bool:
     return _create_exclusive()
 
 
+def _release_update_slot(pending_path: Path) -> None:
+    """Give back a reservation taken by :func:`_claim_update_slot`.
+
+    Only removes the marker while it is still the empty file the claim created.
+    A non-empty marker means somebody else's routing metadata is now there —
+    the notifier restoring a live update's marker via
+    ``claimed_path.replace(pending_path)`` — and deleting that would lose their
+    completion notice.
+    """
+    try:
+        if pending_path.stat().st_size == 0:
+            pending_path.unlink()
+    except OSError:
+        pass
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -5737,12 +5753,18 @@ class GatewaySlashCommandsMixin:
         #
         # `.update_pending.claimed.json` is the notifier's transient rename of
         # the marker (see _send_update_notification); while it exists an update
-        # is in flight, so reject. Checking it is not a check-then-create race:
-        # it can only ever produce an extra rejection, never an extra spawn,
-        # and the exclusive create below is what actually decides the winner.
-        if claimed_path.exists() or not _claim_update_slot(
+        # is in flight. It is checked both BEFORE and AFTER the exclusive
+        # create, because the notifier can rename pending -> claimed between
+        # the two: that leaves pending momentarily absent, so the create would
+        # otherwise succeed and admit a second updater against a live one.
+        admitted = not claimed_path.exists() and _claim_update_slot(
             pending_path, _UPDATE_RESERVATION_TTL_S
-        ):
+        )
+        if admitted and claimed_path.exists():
+            _release_update_slot(pending_path)
+            admitted = False
+
+        if not admitted:
             # The loser still gets the outcome: the watcher is profile-wide and
             # reports the result into the chat that started the update.
             self._schedule_update_notification_watch()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -55,6 +55,14 @@ logger = logging.getLogger("gateway.run")
 # its worker thread. (#35994)
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
+# How long a /update reservation stays valid before another /update may take it
+# over (see _claim_update_slot). An updater that is killed without writing its
+# exit code — host reboot, OOM kill — leaves its marker behind forever, so the
+# reservation needs a ceiling or /update wedges for the lifetime of the profile.
+# Sized above _watch_update_progress's own 1800s watch timeout so a live update
+# that is still being watched is never stolen.
+_UPDATE_RESERVATION_TTL_S = 3600.0
+
 
 def _clean_str(value: Any) -> str:
     """Strip and return a non-empty string value, or empty string."""
@@ -96,6 +104,62 @@ def _model_switch_skew_guard() -> Optional[str]:
             f"crash — restart the gateway to load the new code: hermes gateway restart"
         ),
     )
+
+
+def _claim_update_slot(pending_path: Path, ttl_seconds: float) -> bool:
+    """Atomically reserve the profile-wide ``/update`` slot.
+
+    ``/update`` is profile-global: it rewrites the checkout and the virtualenv
+    every session on the host shares, and the ``.update_*`` marker files are a
+    single-slot mailbox holding one requester's routing metadata. Two updaters
+    must therefore never run at once.
+
+    A ``if pending_path.exists(): return`` guard cannot provide that. Two
+    handlers can both observe the marker missing and both go on to create it,
+    so the second one's metadata silently replaces the first one's and a second
+    updater is spawned against the same checkout. ``os.open`` with
+    ``O_CREAT | O_EXCL`` collapses the observe-and-create into a single atomic
+    syscall, so exactly one caller can ever win.
+
+    Returns ``True`` when this caller now owns the slot (the marker exists and
+    is empty, ready for the caller to fill in with its routing metadata), and
+    ``False`` when another update already holds it.
+    """
+    def _create_exclusive() -> bool:
+        try:
+            fd = os.open(pending_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            return False
+        os.close(fd)
+        return True
+
+    if _create_exclusive():
+        return True
+
+    # The slot is held. Take it over only when it is provably abandoned: a host
+    # reboot or a SIGKILLed updater leaves a marker that nothing will ever
+    # clean up, and a permanently wedged /update would be a worse bug than the
+    # collision this guard exists to close.
+    try:
+        age = time.time() - pending_path.stat().st_mtime
+    except OSError:
+        # Vanished between the failed create and the stat — the previous update
+        # finished in that window. Retry once; if we lose again, the loser path
+        # is still correct.
+        return _create_exclusive()
+
+    if age < ttl_seconds:
+        return False
+
+    logger.warning(
+        "Reclaiming abandoned /update reservation %s (age %.0fs > %.0fs)",
+        pending_path, age, ttl_seconds,
+    )
+    try:
+        pending_path.unlink()
+    except OSError:
+        return False
+    return _create_exclusive()
 
 
 class GatewaySlashCommandsMixin:
@@ -5432,8 +5496,31 @@ class GatewaySlashCommandsMixin:
             return t("gateway.update.hermes_cmd_not_found")
 
         pending_path = _hermes_home / ".update_pending.json"
+        claimed_path = _hermes_home / ".update_pending.claimed.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
+
+        # Admission control. Reserve the profile-wide update slot BEFORE any
+        # routing metadata is written and BEFORE the updater is spawned, so two
+        # concurrent /update invocations (a double tap while the minutes-long
+        # update runs without an ack, or two platforms on one multiplexed
+        # gateway) cannot both start an updater against the same checkout and
+        # venv, with the second one's metadata clobbering the first requester's
+        # so they never learn their update finished.
+        #
+        # `.update_pending.claimed.json` is the notifier's transient rename of
+        # the marker (see _send_update_notification); while it exists an update
+        # is in flight, so reject. Checking it is not a check-then-create race:
+        # it can only ever produce an extra rejection, never an extra spawn,
+        # and the exclusive create below is what actually decides the winner.
+        if claimed_path.exists() or not _claim_update_slot(
+            pending_path, _UPDATE_RESERVATION_TTL_S
+        ):
+            # The loser still gets the outcome: the watcher is profile-wide and
+            # reports the result into the chat that started the update.
+            self._schedule_update_notification_watch()
+            return t("gateway.update.already_running")
+
         session_key = self._session_key_for_source(event.source)
         pending = {
             "platform": event.source.platform.value,
@@ -5447,10 +5534,6 @@ class GatewaySlashCommandsMixin:
             pending["thread_id"] = event.source.thread_id
         if event.message_id:
             pending["message_id"] = event.message_id
-        _tmp_pending = pending_path.with_suffix(".tmp")
-        _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
-        _tmp_pending.replace(pending_path)
-        exit_code_path.unlink(missing_ok=True)
 
         # Spawn `hermes update --gateway` detached so it survives gateway restart.
         # --gateway enables file-based IPC for interactive prompts (stash
@@ -5477,6 +5560,17 @@ class GatewaySlashCommandsMixin:
         # so the simplest correct thing is: launch an inline Python helper
         # that runs the command and writes both outputs.
         try:
+            # Fill the reservation in with this requester's routing metadata.
+            # Write-to-temp + rename keeps the marker a complete JSON document
+            # for the readers in gateway/run.py, which poll it concurrently.
+            # Everything from the claim onwards must release the slot on
+            # failure, or a /update that never actually started would block the
+            # next one until the reservation TTL expires.
+            _tmp_pending = pending_path.with_suffix(".tmp")
+            _tmp_pending.write_text(json.dumps(pending), encoding="utf-8")
+            _tmp_pending.replace(pending_path)
+            exit_code_path.unlink(missing_ok=True)
+
             if sys.platform == "win32":
                 import textwrap
                 from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
@@ -5537,6 +5631,8 @@ class GatewaySlashCommandsMixin:
                         start_new_session=True,
                     )
         except Exception as e:
+            # Release the reservation so the user can retry immediately.
+            pending_path.with_suffix(".tmp").unlink(missing_ok=True)
             pending_path.unlink(missing_ok=True)
             exit_code_path.unlink(missing_ok=True)
             return t("gateway.update.start_failed", error=e)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -162,6 +162,22 @@ def _claim_update_slot(pending_path: Path, ttl_seconds: float) -> bool:
     return _create_exclusive()
 
 
+def _release_update_slot(pending_path: Path) -> None:
+    """Give back a reservation taken by :func:`_claim_update_slot`.
+
+    Only removes the marker while it is still the empty file the claim created.
+    A non-empty marker means somebody else's routing metadata is now there —
+    the notifier restoring a live update's marker via
+    ``claimed_path.replace(pending_path)`` — and deleting that would lose their
+    completion notice.
+    """
+    try:
+        if pending_path.stat().st_size == 0:
+            pending_path.unlink()
+    except OSError:
+        pass
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -5510,12 +5526,18 @@ class GatewaySlashCommandsMixin:
         #
         # `.update_pending.claimed.json` is the notifier's transient rename of
         # the marker (see _send_update_notification); while it exists an update
-        # is in flight, so reject. Checking it is not a check-then-create race:
-        # it can only ever produce an extra rejection, never an extra spawn,
-        # and the exclusive create below is what actually decides the winner.
-        if claimed_path.exists() or not _claim_update_slot(
+        # is in flight. It is checked both BEFORE and AFTER the exclusive
+        # create, because the notifier can rename pending -> claimed between
+        # the two: that leaves pending momentarily absent, so the create would
+        # otherwise succeed and admit a second updater against a live one.
+        admitted = not claimed_path.exists() and _claim_update_slot(
             pending_path, _UPDATE_RESERVATION_TTL_S
-        ):
+        )
+        if admitted and claimed_path.exists():
+            _release_update_slot(pending_path)
+            admitted = False
+
+        if not admitted:
             # The loser still gets the outcome: the watcher is profile-wide and
             # reports the result into the chat that started the update.
             self._schedule_update_notification_watch()

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Kon nie die `hermes`-opdrag vind nie. Hermes loop, maar die opdateeropdrag kon nie die uitvoerbare lêer op PATH of via die huidige Python-vertolker vind nie. Probeer `hermes update` met die hand in jou terminale uitvoer."
     start_failed:            "✗ Kon nie opdatering begin nie: {error}"
     starting:                "⚕ Begin Hermes-opdatering… Ek sal vordering hier stroom."
+    already_running:         "⚕ 'n Hermes-opdatering loop reeds vir hierdie profiel. Ek sal die resultaat rapporteer in die geselsie wat dit begin het."
 
   usage:
     rate_limits:              "⏱️ **Tariefperke:** {state}"

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Kon nie die `hermes`-opdrag vind nie. Hermes loop, maar die opdateeropdrag kon nie die uitvoerbare lêer op PATH of via die huidige Python-vertolker vind nie. Probeer `hermes update` met die hand in jou terminale uitvoer."
     start_failed:            "✗ Kon nie opdatering begin nie: {error}"
     starting:                "⚕ Begin Hermes-opdatering… Ek sal vordering hier stroom."
+    already_running:         "⚕ 'n Hermes-opdatering loop reeds vir hierdie profiel. Ek sal die resultaat rapporteer in die geselsie wat dit begin het."
 
   usage:
     rate_limits:              "⏱️ **Tariefperke:** {state}"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -370,6 +370,7 @@ gateway:
     hermes_cmd_not_found:    "✗ تعذّر تحديد موقع أمر `hermes`. Hermes يعمل، لكن أمر التحديث لم يجد الملف التنفيذي على PATH أو عبر مُفسّر Python الحالي. جرّب تشغيل `hermes update` يدويًا في طرفيتك."
     start_failed:            "✗ فشل بدء التحديث: {error}"
     starting:                "⚕ جارٍ بدء تحديث Hermes… سأبثّ التقدّم هنا."
+    already_running:         "⚕ يوجد بالفعل تحديث Hermes قيد التشغيل لهذا الملف الشخصي. سأبلّغ بالنتيجة في المحادثة التي بدأته."
 
   usage:
     rate_limits:              "⏱️ **حدود المعدّل:** {state}"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -368,6 +368,7 @@ gateway:
     hermes_cmd_not_found:    "✗ تعذّر تحديد موقع أمر `hermes`. Hermes يعمل، لكن أمر التحديث لم يجد الملف التنفيذي على PATH أو عبر مُفسّر Python الحالي. جرّب تشغيل `hermes update` يدويًا في طرفيتك."
     start_failed:            "✗ فشل بدء التحديث: {error}"
     starting:                "⚕ جارٍ بدء تحديث Hermes… سأبثّ التقدّم هنا."
+    already_running:         "⚕ يوجد بالفعل تحديث Hermes قيد التشغيل لهذا الملف الشخصي. سأبلّغ بالنتيجة في المحادثة التي بدأته."
 
   usage:
     rate_limits:              "⏱️ **حدود المعدّل:** {state}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Der Befehl `hermes` konnte nicht gefunden werden. Hermes läuft, aber der Update-Befehl konnte das ausführbare Programm weder im PATH noch über den aktuellen Python-Interpreter finden. Versuchen Sie, `hermes update` manuell im Terminal auszuführen."
     start_failed:            "✗ Update konnte nicht gestartet werden: {error}"
     starting:                "⚕ Hermes-Update wird gestartet… Ich streame den Fortschritt hier."
+    already_running:         "⚕ Für dieses Profil läuft bereits ein Hermes-Update. Ich melde das Ergebnis in dem Chat, der es gestartet hat."
 
   usage:
     rate_limits:              "⏱️ **Ratenlimits:** {state}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Der Befehl `hermes` konnte nicht gefunden werden. Hermes läuft, aber der Update-Befehl konnte das ausführbare Programm weder im PATH noch über den aktuellen Python-Interpreter finden. Versuchen Sie, `hermes update` manuell im Terminal auszuführen."
     start_failed:            "✗ Update konnte nicht gestartet werden: {error}"
     starting:                "⚕ Hermes-Update wird gestartet… Ich streame den Fortschritt hier."
+    already_running:         "⚕ Für dieses Profil läuft bereits ein Hermes-Update. Ich melde das Ergebnis in dem Chat, der es gestartet hat."
 
   usage:
     rate_limits:              "⏱️ **Ratenlimits:** {state}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -381,6 +381,7 @@ gateway:
     hermes_cmd_not_found:    "✗ Could not locate the `hermes` command. Hermes is running, but the update command could not find the executable on PATH or via the current Python interpreter. Try running `hermes update` manually in your terminal."
     start_failed:            "✗ Failed to start update: {error}"
     starting:                "⚕ Starting Hermes update… I'll stream progress here."
+    already_running:         "⚕ A Hermes update is already running for this profile. I'll report the result in the chat that started it."
 
   usage:
     rate_limits:              "⏱️ **Rate Limits:** {state}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -379,6 +379,7 @@ gateway:
     hermes_cmd_not_found:    "✗ Could not locate the `hermes` command. Hermes is running, but the update command could not find the executable on PATH or via the current Python interpreter. Try running `hermes update` manually in your terminal."
     start_failed:            "✗ Failed to start update: {error}"
     starting:                "⚕ Starting Hermes update… I'll stream progress here."
+    already_running:         "⚕ A Hermes update is already running for this profile. I'll report the result in the chat that started it."
 
   usage:
     rate_limits:              "⏱️ **Rate Limits:** {state}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -365,6 +365,7 @@ gateway:
     hermes_cmd_not_found:    "✗ No se pudo localizar el comando `hermes`. Hermes está en ejecución, pero el comando de actualización no encontró el ejecutable en PATH ni a través del intérprete de Python actual. Intenta ejecutar `hermes update` manualmente en tu terminal."
     start_failed:            "✗ No se pudo iniciar la actualización: {error}"
     starting:                "⚕ Iniciando la actualización de Hermes… Transmitiré el progreso aquí."
+    already_running:         "⚕ Ya hay una actualización de Hermes en curso para este perfil. Informaré del resultado en el chat que la inició."
 
   usage:
     rate_limits:              "⏱️ **Límites de tasa:** {state}"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -363,6 +363,7 @@ gateway:
     hermes_cmd_not_found:    "✗ No se pudo localizar el comando `hermes`. Hermes está en ejecución, pero el comando de actualización no encontró el ejecutable en PATH ni a través del intérprete de Python actual. Intenta ejecutar `hermes update` manualmente en tu terminal."
     start_failed:            "✗ No se pudo iniciar la actualización: {error}"
     starting:                "⚕ Iniciando la actualización de Hermes… Transmitiré el progreso aquí."
+    already_running:         "⚕ Ya hay una actualización de Hermes en curso para este perfil. Informaré del resultado en el chat que la inició."
 
   usage:
     rate_limits:              "⏱️ **Límites de tasa:** {state}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Impossible de localiser la commande `hermes`. Hermes est en cours d'exécution, mais la commande de mise à jour n'a pas pu trouver l'exécutable dans le PATH ni via l'interpréteur Python actuel. Essayez d'exécuter `hermes update` manuellement dans votre terminal."
     start_failed:            "✗ Échec du démarrage de la mise à jour : {error}"
     starting:                "⚕ Démarrage de la mise à jour Hermes… Je diffuserai la progression ici."
+    already_running:         "⚕ Une mise à jour Hermes est déjà en cours pour ce profil. Je signalerai le résultat dans la conversation qui l'a lancée."
 
   usage:
     rate_limits:              "⏱️ **Limites de débit :** {state}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Impossible de localiser la commande `hermes`. Hermes est en cours d'exécution, mais la commande de mise à jour n'a pas pu trouver l'exécutable dans le PATH ni via l'interpréteur Python actuel. Essayez d'exécuter `hermes update` manuellement dans votre terminal."
     start_failed:            "✗ Échec du démarrage de la mise à jour : {error}"
     starting:                "⚕ Démarrage de la mise à jour Hermes… Je diffuserai la progression ici."
+    already_running:         "⚕ Une mise à jour Hermes est déjà en cours pour ce profil. Je signalerai le résultat dans la conversation qui l'a lancée."
 
   usage:
     rate_limits:              "⏱️ **Limites de débit :** {state}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -372,6 +372,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Níorbh fhéidir an t-ordú `hermes` a aimsiú. Tá Hermes ag rith, ach níorbh fhéidir leis an ordú nuashonraithe an inrite a aimsiú ar PATH ná tríd an léirmhínitheoir Python reatha. Bain triail as `hermes update` a rith de láimh i do theirminéal."
     start_failed:            "✗ Theip ar nuashonrú a thosú: {error}"
     starting:                "⚕ Ag tosú nuashonrú Hermes… Cuirfidh mé an dul chun cinn ar shruth anseo."
+    already_running:         "⚕ Tá nuashonrú Hermes ar siúl cheana féin don phróifíl seo. Tuairisceoidh mé an toradh sa chomhrá a thosaigh é."
 
   usage:
     rate_limits:              "⏱️ **Teorainneacha Ráta:** {state}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -370,6 +370,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Níorbh fhéidir an t-ordú `hermes` a aimsiú. Tá Hermes ag rith, ach níorbh fhéidir leis an ordú nuashonraithe an inrite a aimsiú ar PATH ná tríd an léirmhínitheoir Python reatha. Bain triail as `hermes update` a rith de láimh i do theirminéal."
     start_failed:            "✗ Theip ar nuashonrú a thosú: {error}"
     starting:                "⚕ Ag tosú nuashonrú Hermes… Cuirfidh mé an dul chun cinn ar shruth anseo."
+    already_running:         "⚕ Tá nuashonrú Hermes ar siúl cheana féin don phróifíl seo. Tuairisceoidh mé an toradh sa chomhrá a thosaigh é."
 
   usage:
     rate_limits:              "⏱️ **Teorainneacha Ráta:** {state}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Nem sikerült megtalálni a `hermes` parancsot. A Hermes fut, de a frissítőparancs nem találta a futtatható fájlt a PATH-on vagy a jelenlegi Python interpreteren keresztül. Próbáld futtatni a `hermes update` parancsot manuálisan a terminálban."
     start_failed:            "✗ Nem sikerült elindítani a frissítést: {error}"
     starting:                "⚕ Hermes frissítés indítása… A folyamatot itt fogom közvetíteni."
+    already_running:         "⚕ Ehhez a profilhoz már fut egy Hermes frissítés. Az eredményt abban a beszélgetésben jelentem, amelyik elindította."
 
   usage:
     rate_limits:              "⏱️ **Sebességkorlátok:** {state}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Nem sikerült megtalálni a `hermes` parancsot. A Hermes fut, de a frissítőparancs nem találta a futtatható fájlt a PATH-on vagy a jelenlegi Python interpreteren keresztül. Próbáld futtatni a `hermes update` parancsot manuálisan a terminálban."
     start_failed:            "✗ Nem sikerült elindítani a frissítést: {error}"
     starting:                "⚕ Hermes frissítés indítása… A folyamatot itt fogom közvetíteni."
+    already_running:         "⚕ Ehhez a profilhoz már fut egy Hermes frissítés. Az eredményt abban a beszélgetésben jelentem, amelyik elindította."
 
   usage:
     rate_limits:              "⏱️ **Sebességkorlátok:** {state}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Impossibile localizzare il comando `hermes`. Hermes è in esecuzione, ma il comando di aggiornamento non ha trovato l'eseguibile nel PATH o tramite l'interprete Python attuale. Prova a eseguire `hermes update` manualmente nel terminale."
     start_failed:            "✗ Avvio dell'aggiornamento non riuscito: {error}"
     starting:                "⚕ Avvio dell'aggiornamento di Hermes… mostrerò qui i progressi in streaming."
+    already_running:         "⚕ Un aggiornamento di Hermes è già in corso per questo profilo. Riporterò il risultato nella chat che lo ha avviato."
 
   usage:
     rate_limits:              "⏱️ **Limiti di frequenza:** {state}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Impossibile localizzare il comando `hermes`. Hermes è in esecuzione, ma il comando di aggiornamento non ha trovato l'eseguibile nel PATH o tramite l'interprete Python attuale. Prova a eseguire `hermes update` manualmente nel terminale."
     start_failed:            "✗ Avvio dell'aggiornamento non riuscito: {error}"
     starting:                "⚕ Avvio dell'aggiornamento di Hermes… mostrerò qui i progressi in streaming."
+    already_running:         "⚕ Un aggiornamento di Hermes è già in corso per questo profilo. Riporterò il risultato nella chat che lo ha avviato."
 
   usage:
     rate_limits:              "⏱️ **Limiti di frequenza:** {state}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ `hermes` コマンドが見つかりません。Hermes は実行中ですが、更新コマンドは PATH 上にも現在の Python インタープリタ経由でも実行可能ファイルを見つけられませんでした。ターミナルで `hermes update` を手動で実行してみてください。"
     start_failed:            "✗ 更新の開始に失敗しました: {error}"
     starting:                "⚕ Hermes の更新を開始しています… 進捗をここにストリーミングします。"
+    already_running:         "⚕ このプロファイルでは Hermes の更新がすでに実行中です。結果は更新を開始したチャットに報告します。"
 
   usage:
     rate_limits:              "⏱️ **レート制限:** {state}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ `hermes` コマンドが見つかりません。Hermes は実行中ですが、更新コマンドは PATH 上にも現在の Python インタープリタ経由でも実行可能ファイルを見つけられませんでした。ターミナルで `hermes update` を手動で実行してみてください。"
     start_failed:            "✗ 更新の開始に失敗しました: {error}"
     starting:                "⚕ Hermes の更新を開始しています… 進捗をここにストリーミングします。"
+    already_running:         "⚕ このプロファイルでは Hermes の更新がすでに実行中です。結果は更新を開始したチャットに報告します。"
 
   usage:
     rate_limits:              "⏱️ **レート制限:** {state}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ `hermes` 명령을 찾을 수 없습니다. Hermes는 실행 중이지만 PATH나 현재 Python 인터프리터를 통해 실행 파일을 찾을 수 없습니다. 터미널에서 `hermes update`를 직접 실행해 보세요."
     start_failed:            "✗ 업데이트 시작 실패: {error}"
     starting:                "⚕ Hermes 업데이트를 시작합니다… 진행 상황을 여기에 스트리밍하겠습니다."
+    already_running:         "⚕ 이 프로필에서는 이미 Hermes 업데이트가 실행 중입니다. 결과는 업데이트를 시작한 채팅에 보고하겠습니다."
 
   usage:
     rate_limits:              "⏱️ **요청 제한:** {state}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ `hermes` 명령을 찾을 수 없습니다. Hermes는 실행 중이지만 PATH나 현재 Python 인터프리터를 통해 실행 파일을 찾을 수 없습니다. 터미널에서 `hermes update`를 직접 실행해 보세요."
     start_failed:            "✗ 업데이트 시작 실패: {error}"
     starting:                "⚕ Hermes 업데이트를 시작합니다… 진행 상황을 여기에 스트리밍하겠습니다."
+    already_running:         "⚕ 이 프로필에서는 이미 Hermes 업데이트가 실행 중입니다. 결과는 업데이트를 시작한 채팅에 보고하겠습니다."
 
   usage:
     rate_limits:              "⏱️ **요청 제한:** {state}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Não foi possível localizar o comando `hermes`. O Hermes está em execução, mas o comando de atualização não conseguiu encontrar o executável no PATH nem através do interpretador Python atual. Tenta executar `hermes update` manualmente no teu terminal."
     start_failed:            "✗ Falha ao iniciar a atualização: {error}"
     starting:                "⚕ A iniciar a atualização do Hermes… Vou transmitir o progresso aqui."
+    already_running:         "⚕ Já está em curso uma atualização do Hermes para este perfil. Vou comunicar o resultado na conversa que a iniciou."
 
   usage:
     rate_limits:              "⏱️ **Limites de taxa:** {state}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Não foi possível localizar o comando `hermes`. O Hermes está em execução, mas o comando de atualização não conseguiu encontrar o executável no PATH nem através do interpretador Python atual. Tenta executar `hermes update` manualmente no teu terminal."
     start_failed:            "✗ Falha ao iniciar a atualização: {error}"
     starting:                "⚕ A iniciar a atualização do Hermes… Vou transmitir o progresso aqui."
+    already_running:         "⚕ Já está em curso uma atualização do Hermes para este perfil. Vou comunicar o resultado na conversa que a iniciou."
 
   usage:
     rate_limits:              "⏱️ **Limites de taxa:** {state}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Не удалось найти команду `hermes`. Hermes запущен, но команда обновления не нашла исполняемый файл в PATH или через текущий интерпретатор Python. Попробуйте выполнить `hermes update` вручную в терминале."
     start_failed:            "✗ Не удалось запустить обновление: {error}"
     starting:                "⚕ Запуск обновления Hermes… Я буду транслировать прогресс сюда."
+    already_running:         "⚕ Для этого профиля уже выполняется обновление Hermes. Я сообщу результат в чат, из которого оно было запущено."
 
   usage:
     rate_limits:              "⏱️ **Ограничения скорости:** {state}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Не удалось найти команду `hermes`. Hermes запущен, но команда обновления не нашла исполняемый файл в PATH или через текущий интерпретатор Python. Попробуйте выполнить `hermes update` вручную в терминале."
     start_failed:            "✗ Не удалось запустить обновление: {error}"
     starting:                "⚕ Запуск обновления Hermes… Я буду транслировать прогресс сюда."
+    already_running:         "⚕ Для этого профиля уже выполняется обновление Hermes. Я сообщу результат в чат, из которого оно было запущено."
 
   usage:
     rate_limits:              "⏱️ **Ограничения скорости:** {state}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ `hermes` komutu bulunamadı. Hermes çalışıyor, ancak güncelleme komutu yürütülebilir dosyayı PATH'te veya mevcut Python yorumlayıcısı aracılığıyla bulamadı. Terminalde `hermes update` komutunu manuel olarak çalıştırmayı deneyin."
     start_failed:            "✗ Güncelleme başlatılamadı: {error}"
     starting:                "⚕ Hermes güncellemesi başlatılıyor… İlerlemeyi buraya akıtacağım."
+    already_running:         "⚕ Bu profil için zaten bir Hermes güncellemesi çalışıyor. Sonucu, güncellemeyi başlatan sohbette bildireceğim."
 
   usage:
     rate_limits:              "⏱️ **Hız Sınırları:** {state}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ `hermes` komutu bulunamadı. Hermes çalışıyor, ancak güncelleme komutu yürütülebilir dosyayı PATH'te veya mevcut Python yorumlayıcısı aracılığıyla bulamadı. Terminalde `hermes update` komutunu manuel olarak çalıştırmayı deneyin."
     start_failed:            "✗ Güncelleme başlatılamadı: {error}"
     starting:                "⚕ Hermes güncellemesi başlatılıyor… İlerlemeyi buraya akıtacağım."
+    already_running:         "⚕ Bu profil için zaten bir Hermes güncellemesi çalışıyor. Sonucu, güncellemeyi başlatan sohbette bildireceğim."
 
   usage:
     rate_limits:              "⏱️ **Hız Sınırları:** {state}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Не вдалося знайти команду `hermes`. Hermes запущено, але команда оновлення не знайшла виконуваний файл у PATH або через поточний інтерпретатор Python. Спробуйте виконати `hermes update` вручну у вашому терміналі."
     start_failed:            "✗ Не вдалося запустити оновлення: {error}"
     starting:                "⚕ Запуск оновлення Hermes… Я транслюватиму прогрес сюди."
+    already_running:         "⚕ Для цього профілю вже виконується оновлення Hermes. Я повідомлю результат у чат, з якого його було запущено."
 
   usage:
     rate_limits:              "⏱️ **Обмеження швидкості:** {state}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ Не вдалося знайти команду `hermes`. Hermes запущено, але команда оновлення не знайшла виконуваний файл у PATH або через поточний інтерпретатор Python. Спробуйте виконати `hermes update` вручну у вашому терміналі."
     start_failed:            "✗ Не вдалося запустити оновлення: {error}"
     starting:                "⚕ Запуск оновлення Hermes… Я транслюватиму прогрес сюди."
+    already_running:         "⚕ Для цього профілю вже виконується оновлення Hermes. Я повідомлю результат у чат, з якого його було запущено."
 
   usage:
     rate_limits:              "⏱️ **Обмеження швидкості:** {state}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ 找不到 `hermes` 指令。Hermes 正在執行，但更新指令無法在 PATH 上或透過目前的 Python 解譯器找到執行檔。請嘗試在終端機中手動執行 `hermes update`。"
     start_failed:            "✗ 啟動更新失敗：{error}"
     starting:                "⚕ 正在啟動 Hermes 更新…… 進度將在此處顯示。"
+    already_running:         "⚕ 此設定檔已有一個 Hermes 更新正在執行。我會在發起該更新的聊天中回報結果。"
 
   usage:
     rate_limits:              "⏱️ **速率限制：** {state}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ 找不到 `hermes` 指令。Hermes 正在執行，但更新指令無法在 PATH 上或透過目前的 Python 解譯器找到執行檔。請嘗試在終端機中手動執行 `hermes update`。"
     start_failed:            "✗ 啟動更新失敗：{error}"
     starting:                "⚕ 正在啟動 Hermes 更新…… 進度將在此處顯示。"
+    already_running:         "⚕ 此設定檔已有一個 Hermes 更新正在執行。我會在發起該更新的聊天中回報結果。"
 
   usage:
     rate_limits:              "⏱️ **速率限制：** {state}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -368,6 +368,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ 无法找到 `hermes` 命令。Hermes 正在运行，但更新命令无法在 PATH 上或通过当前 Python 解释器找到可执行文件。请尝试在终端中手动运行 `hermes update`。"
     start_failed:            "✗ 启动更新失败：{error}"
     starting:                "⚕ 正在启动 Hermes 更新…… 进度将在此处显示。"
+    already_running:         "⚕ 该配置文件已有一个 Hermes 更新正在运行。我会在发起该更新的聊天中报告结果。"
 
   usage:
     rate_limits:              "⏱️ **速率限制：** {state}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -366,6 +366,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     hermes_cmd_not_found:    "✗ 无法找到 `hermes` 命令。Hermes 正在运行，但更新命令无法在 PATH 上或通过当前 Python 解释器找到可执行文件。请尝试在终端中手动运行 `hermes update`。"
     start_failed:            "✗ 启动更新失败：{error}"
     starting:                "⚕ 正在启动 Hermes 更新…… 进度将在此处显示。"
+    already_running:         "⚕ 该配置文件已有一个 Hermes 更新正在运行。我会在发起该更新的聊天中报告结果。"
 
   usage:
     rate_limits:              "⏱️ **速率限制：** {state}"

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -389,6 +389,83 @@ class TestUpdateAdmissionControl:
         assert data["user_id"] == f"user-{data['chat_id']}"
 
     @pytest.mark.asyncio
+    async def test_rejects_when_notifier_claims_a_live_update_mid_admission(self, tmp_path):
+        """A marker renamed to `.claimed` mid-admission still blocks the caller.
+
+        ``_send_update_notification`` renames pending -> claimed while an update
+        is in flight. Landing that between the ``claimed`` check and the
+        exclusive create leaves ``pending`` momentarily absent, so the create
+        would succeed and admit a second updater against the live one — and the
+        notifier's later ``claimed.replace(pending)`` would clobber the new
+        reservation.
+
+        The claimed marker here is written from *inside* the admission window
+        to stand in for that concurrent notifier — it is not pre-seeded state
+        the guard is handed up front.
+        """
+        from gateway import slash_commands as slash_commands_module
+
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        claimed_path = hermes_home / ".update_pending.claimed.json"
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="second-chat")
+
+        real_claim = slash_commands_module._claim_update_slot
+
+        def _claim_after_notifier_rename(path, ttl_seconds):
+            # The notifier claims a live update's marker right here, after this
+            # handler already saw claimed_path missing.
+            claimed_path.write_text(
+                json.dumps({
+                    "platform": "telegram",
+                    "chat_id": "live-chat",
+                    "user_id": "live-user",
+                }),
+                encoding="utf-8",
+            )
+            return real_claim(path, ttl_seconds)
+
+        mock_watch = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(slash_commands_module, "_claim_update_slot",
+                          _claim_after_notifier_rename), \
+             patch.object(runner, "_schedule_update_notification_watch", mock_watch), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            reply = await runner._handle_update_command(event)
+
+        mock_popen.assert_not_called()
+        assert "already running" in reply.lower()
+        mock_watch.assert_called_once()
+
+        # The reservation was handed back, and the live update's claimed marker
+        # is untouched so its owner still gets the completion notice.
+        assert not pending_path.exists()
+        assert json.loads(claimed_path.read_text())["chat_id"] == "live-chat"
+
+    def test_release_update_slot_keeps_a_marker_that_holds_metadata(self, tmp_path):
+        """Releasing never deletes someone else's routing metadata.
+
+        If the notifier restores a live update's marker with
+        ``claimed_path.replace(pending_path)`` before the release runs, the
+        marker is no longer this caller's empty reservation and must survive.
+        """
+        from gateway.slash_commands import _claim_update_slot, _release_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+
+        assert _claim_update_slot(pending_path, 3600.0) is True
+        _release_update_slot(pending_path)
+        assert not pending_path.exists()
+
+        pending_path.write_text(json.dumps({"chat_id": "live-chat"}), encoding="utf-8")
+        _release_update_slot(pending_path)
+        assert pending_path.exists()
+        assert json.loads(pending_path.read_text())["chat_id"] == "live-chat"
+
+    @pytest.mark.asyncio
     async def test_failed_spawn_releases_the_update_slot(self, tmp_path):
         """A spawn that never started must not block the next /update.
 

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -4,7 +4,11 @@ Tests both the _handle_update_command handler (spawns update process) and
 the _send_update_notification startup hook (sends results after restart).
 """
 
+import asyncio
 import json
+import os
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -176,6 +180,247 @@ class TestHandleUpdateCommand:
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
         assert "Starting Hermes update" in result
+
+
+# ---------------------------------------------------------------------------
+# Concurrent /update admission control
+# ---------------------------------------------------------------------------
+
+
+def _fake_checkout(tmp_path):
+    """Build a fake checkout + profile home for the /update pre-flight.
+
+    ``_handle_update_command`` resolves ``project_root`` from
+    ``gateway/slash_commands.py``'s own ``__file__``, so the fake tree mirrors
+    that layout and carries a ``.git`` directory. Returns
+    ``(slash_commands_file, hermes_home)``.
+    """
+    root = tmp_path / "project"
+    (root / "gateway").mkdir(parents=True)
+    (root / ".git").mkdir()
+    slash_commands_file = root / "gateway" / "slash_commands.py"
+    slash_commands_file.touch()
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    return str(slash_commands_file), hermes_home
+
+
+class TestUpdateAdmissionControl:
+    """``/update`` must admit exactly one updater per profile.
+
+    ``hermes update`` rewrites the checkout and the virtualenv every session on
+    the host shares, and the ``.update_*`` markers are a single-slot mailbox
+    holding one requester's routing metadata. Two updaters racing the same
+    checkout is a real failure mode: the user double-taps ``/update`` because
+    the update takes minutes with no acknowledgement, or two platforms on one
+    multiplexed gateway both trigger it.
+
+    None of these tests pre-seed a marker file. A test that writes
+    ``.update_pending.json`` itself only proves the handler reads a file the
+    test created — it never exercises the window between observing the slot is
+    free and taking it, which is where the collision actually happens.
+    """
+
+    def test_claim_update_slot_admits_exactly_one_caller(self, tmp_path):
+        """The reservation primitive is exclusive, and creates its own marker."""
+        from gateway.slash_commands import _claim_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+        assert not pending_path.exists()
+
+        assert _claim_update_slot(pending_path, 3600.0) is True
+        assert pending_path.exists()
+        assert _claim_update_slot(pending_path, 3600.0) is False
+        assert _claim_update_slot(pending_path, 3600.0) is False
+
+    def test_claim_update_slot_is_exclusive_under_parallel_callers(self, tmp_path):
+        """16 threads released together still yield exactly one winner.
+
+        This is the check-to-create gap in isolation. A
+        ``if path.exists(): return`` guard fails here because every thread can
+        observe the marker missing before any of them creates it.
+        """
+        from gateway.slash_commands import _claim_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+        assert not pending_path.exists()
+
+        workers = 16
+        barrier = threading.Barrier(workers)
+        results = []
+        results_lock = threading.Lock()
+
+        def _claim():
+            barrier.wait(timeout=15)
+            won = _claim_update_slot(pending_path, 3600.0)
+            with results_lock:
+                results.append(won)
+
+        threads = [threading.Thread(target=_claim) for _ in range(workers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=20)
+
+        assert not any(thread.is_alive() for thread in threads)
+        assert len(results) == workers
+        assert results.count(True) == 1
+
+    def test_claim_update_slot_reclaims_an_abandoned_reservation(self, tmp_path):
+        """A reservation past its TTL is taken over, so /update never wedges.
+
+        An updater killed before it writes its exit code (host reboot, OOM
+        kill) leaves a marker nothing will clean up. Without the TTL the guard
+        would block /update for the lifetime of the profile.
+        """
+        from gateway.slash_commands import _claim_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+        assert _claim_update_slot(pending_path, 3600.0) is True
+        assert _claim_update_slot(pending_path, 3600.0) is False
+
+        abandoned = time.time() - 7200
+        os.utime(pending_path, (abandoned, abandoned))
+        assert _claim_update_slot(pending_path, 3600.0) is True
+
+    @pytest.mark.asyncio
+    async def test_second_update_is_rejected_without_preseeding_a_marker(self, tmp_path):
+        """The first /update creates the marker; the second is refused.
+
+        Nothing is written to the profile home before the first call, so the
+        reject path is driven entirely by state the handler itself produced.
+        """
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        assert not pending_path.exists()
+
+        first = _make_event(platform=Platform.TELEGRAM,
+                            chat_id="first-chat", user_id="first-user")
+        second = _make_event(platform=Platform.TELEGRAM,
+                             chat_id="second-chat", user_id="second-user")
+
+        mock_watch = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(runner, "_schedule_update_notification_watch", mock_watch), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            first_reply = await runner._handle_update_command(first)
+            second_reply = await runner._handle_update_command(second)
+
+        # Exactly one updater was launched.
+        assert mock_popen.call_count == 1
+        assert "Starting Hermes update" in first_reply
+        assert "already running" in second_reply.lower()
+
+        # The winner's routing metadata survived intact — the loser did not
+        # overwrite it, so the completion notice still reaches the first chat.
+        data = json.loads(pending_path.read_text())
+        assert data["chat_id"] == "first-chat"
+        assert data["user_id"] == "first-user"
+
+        # Both callers get the notification watcher, so the loser still learns
+        # how the update turned out.
+        assert mock_watch.call_count == 2
+
+    def test_concurrent_update_commands_spawn_exactly_one_updater(self, tmp_path):
+        """Two callers racing into the handler produce one updater, not two.
+
+        Both are released from a barrier inside ``_resolve_hermes_bin`` — the
+        last step before the slot is claimed — so they enter the claim window
+        together, in real threads, against the real filesystem, with no marker
+        pre-seeded.
+        """
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        assert not pending_path.exists()
+
+        callers = 2
+        barrier = threading.Barrier(callers)
+
+        def _resolve_hermes_bin_at_barrier():
+            barrier.wait(timeout=15)
+            return ["/usr/bin/hermes"]
+
+        spawns = []
+        spawn_lock = threading.Lock()
+
+        def _record_spawn(*args, **kwargs):
+            with spawn_lock:
+                spawns.append(args[0])
+            return MagicMock()
+
+        replies = []
+        replies_lock = threading.Lock()
+
+        def _invoke(chat_id):
+            event = _make_event(platform=Platform.TELEGRAM,
+                                chat_id=chat_id, user_id=f"user-{chat_id}")
+            reply = asyncio.run(runner._handle_update_command(event))
+            with replies_lock:
+                replies.append(reply)
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch("gateway.run._resolve_hermes_bin", _resolve_hermes_bin_at_barrier), \
+             patch.object(runner, "_schedule_update_notification_watch", MagicMock()), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen", side_effect=_record_spawn):
+            threads = [
+                threading.Thread(target=_invoke, args=(f"chat-{i}",))
+                for i in range(callers)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=20)
+            assert not any(thread.is_alive() for thread in threads)
+
+        assert len(spawns) == 1, f"expected one updater, got {len(spawns)}"
+        assert len(replies) == callers
+        assert sum("already running" in reply.lower() for reply in replies) == 1
+
+        # The surviving marker is one caller's complete, parseable metadata —
+        # not a half-written or interleaved document.
+        data = json.loads(pending_path.read_text())
+        assert data["chat_id"] in {"chat-0", "chat-1"}
+        assert data["user_id"] == f"user-{data['chat_id']}"
+
+    @pytest.mark.asyncio
+    async def test_failed_spawn_releases_the_update_slot(self, tmp_path):
+        """A spawn that never started must not block the next /update.
+
+        The slot is reserved before the spawn, so the failure path has to give
+        it back — otherwise one transient OSError would wedge /update until the
+        reservation TTL expired.
+        """
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="chat-1")
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(runner, "_schedule_update_notification_watch", MagicMock()), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen", side_effect=OSError("cannot fork")):
+            failed_reply = await runner._handle_update_command(event)
+
+        assert "Failed to start update" in failed_reply
+        assert not pending_path.exists()
+        assert not (hermes_home / ".update_pending.tmp").exists()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(runner, "_schedule_update_notification_watch", MagicMock()), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            retry_reply = await runner._handle_update_command(event)
+
+        assert mock_popen.call_count == 1
+        assert "Starting Hermes update" in retry_reply
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -388,6 +388,83 @@ class TestUpdateAdmissionControl:
         assert data["user_id"] == f"user-{data['chat_id']}"
 
     @pytest.mark.asyncio
+    async def test_rejects_when_notifier_claims_a_live_update_mid_admission(self, tmp_path):
+        """A marker renamed to `.claimed` mid-admission still blocks the caller.
+
+        ``_send_update_notification`` renames pending -> claimed while an update
+        is in flight. Landing that between the ``claimed`` check and the
+        exclusive create leaves ``pending`` momentarily absent, so the create
+        would succeed and admit a second updater against the live one — and the
+        notifier's later ``claimed.replace(pending)`` would clobber the new
+        reservation.
+
+        The claimed marker here is written from *inside* the admission window
+        to stand in for that concurrent notifier — it is not pre-seeded state
+        the guard is handed up front.
+        """
+        from gateway import slash_commands as slash_commands_module
+
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        claimed_path = hermes_home / ".update_pending.claimed.json"
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="second-chat")
+
+        real_claim = slash_commands_module._claim_update_slot
+
+        def _claim_after_notifier_rename(path, ttl_seconds):
+            # The notifier claims a live update's marker right here, after this
+            # handler already saw claimed_path missing.
+            claimed_path.write_text(
+                json.dumps({
+                    "platform": "telegram",
+                    "chat_id": "live-chat",
+                    "user_id": "live-user",
+                }),
+                encoding="utf-8",
+            )
+            return real_claim(path, ttl_seconds)
+
+        mock_watch = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(slash_commands_module, "_claim_update_slot",
+                          _claim_after_notifier_rename), \
+             patch.object(runner, "_schedule_update_notification_watch", mock_watch), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            reply = await runner._handle_update_command(event)
+
+        mock_popen.assert_not_called()
+        assert "already running" in reply.lower()
+        mock_watch.assert_called_once()
+
+        # The reservation was handed back, and the live update's claimed marker
+        # is untouched so its owner still gets the completion notice.
+        assert not pending_path.exists()
+        assert json.loads(claimed_path.read_text())["chat_id"] == "live-chat"
+
+    def test_release_update_slot_keeps_a_marker_that_holds_metadata(self, tmp_path):
+        """Releasing never deletes someone else's routing metadata.
+
+        If the notifier restores a live update's marker with
+        ``claimed_path.replace(pending_path)`` before the release runs, the
+        marker is no longer this caller's empty reservation and must survive.
+        """
+        from gateway.slash_commands import _claim_update_slot, _release_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+
+        assert _claim_update_slot(pending_path, 3600.0) is True
+        _release_update_slot(pending_path)
+        assert not pending_path.exists()
+
+        pending_path.write_text(json.dumps({"chat_id": "live-chat"}), encoding="utf-8")
+        _release_update_slot(pending_path)
+        assert pending_path.exists()
+        assert json.loads(pending_path.read_text())["chat_id"] == "live-chat"
+
+    @pytest.mark.asyncio
     async def test_failed_spawn_releases_the_update_slot(self, tmp_path):
         """A spawn that never started must not block the next /update.
 

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -4,7 +4,11 @@ Tests both the _handle_update_command handler (spawns update process) and
 the _send_update_notification startup hook (sends results after restart).
 """
 
+import asyncio
 import json
+import os
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -175,6 +179,247 @@ class TestHandleUpdateCommand:
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
         assert "Starting Hermes update" in result
+
+
+# ---------------------------------------------------------------------------
+# Concurrent /update admission control
+# ---------------------------------------------------------------------------
+
+
+def _fake_checkout(tmp_path):
+    """Build a fake checkout + profile home for the /update pre-flight.
+
+    ``_handle_update_command`` resolves ``project_root`` from
+    ``gateway/slash_commands.py``'s own ``__file__``, so the fake tree mirrors
+    that layout and carries a ``.git`` directory. Returns
+    ``(slash_commands_file, hermes_home)``.
+    """
+    root = tmp_path / "project"
+    (root / "gateway").mkdir(parents=True)
+    (root / ".git").mkdir()
+    slash_commands_file = root / "gateway" / "slash_commands.py"
+    slash_commands_file.touch()
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    return str(slash_commands_file), hermes_home
+
+
+class TestUpdateAdmissionControl:
+    """``/update`` must admit exactly one updater per profile.
+
+    ``hermes update`` rewrites the checkout and the virtualenv every session on
+    the host shares, and the ``.update_*`` markers are a single-slot mailbox
+    holding one requester's routing metadata. Two updaters racing the same
+    checkout is a real failure mode: the user double-taps ``/update`` because
+    the update takes minutes with no acknowledgement, or two platforms on one
+    multiplexed gateway both trigger it.
+
+    None of these tests pre-seed a marker file. A test that writes
+    ``.update_pending.json`` itself only proves the handler reads a file the
+    test created — it never exercises the window between observing the slot is
+    free and taking it, which is where the collision actually happens.
+    """
+
+    def test_claim_update_slot_admits_exactly_one_caller(self, tmp_path):
+        """The reservation primitive is exclusive, and creates its own marker."""
+        from gateway.slash_commands import _claim_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+        assert not pending_path.exists()
+
+        assert _claim_update_slot(pending_path, 3600.0) is True
+        assert pending_path.exists()
+        assert _claim_update_slot(pending_path, 3600.0) is False
+        assert _claim_update_slot(pending_path, 3600.0) is False
+
+    def test_claim_update_slot_is_exclusive_under_parallel_callers(self, tmp_path):
+        """16 threads released together still yield exactly one winner.
+
+        This is the check-to-create gap in isolation. A
+        ``if path.exists(): return`` guard fails here because every thread can
+        observe the marker missing before any of them creates it.
+        """
+        from gateway.slash_commands import _claim_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+        assert not pending_path.exists()
+
+        workers = 16
+        barrier = threading.Barrier(workers)
+        results = []
+        results_lock = threading.Lock()
+
+        def _claim():
+            barrier.wait(timeout=15)
+            won = _claim_update_slot(pending_path, 3600.0)
+            with results_lock:
+                results.append(won)
+
+        threads = [threading.Thread(target=_claim) for _ in range(workers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=20)
+
+        assert not any(thread.is_alive() for thread in threads)
+        assert len(results) == workers
+        assert results.count(True) == 1
+
+    def test_claim_update_slot_reclaims_an_abandoned_reservation(self, tmp_path):
+        """A reservation past its TTL is taken over, so /update never wedges.
+
+        An updater killed before it writes its exit code (host reboot, OOM
+        kill) leaves a marker nothing will clean up. Without the TTL the guard
+        would block /update for the lifetime of the profile.
+        """
+        from gateway.slash_commands import _claim_update_slot
+
+        pending_path = tmp_path / ".update_pending.json"
+        assert _claim_update_slot(pending_path, 3600.0) is True
+        assert _claim_update_slot(pending_path, 3600.0) is False
+
+        abandoned = time.time() - 7200
+        os.utime(pending_path, (abandoned, abandoned))
+        assert _claim_update_slot(pending_path, 3600.0) is True
+
+    @pytest.mark.asyncio
+    async def test_second_update_is_rejected_without_preseeding_a_marker(self, tmp_path):
+        """The first /update creates the marker; the second is refused.
+
+        Nothing is written to the profile home before the first call, so the
+        reject path is driven entirely by state the handler itself produced.
+        """
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        assert not pending_path.exists()
+
+        first = _make_event(platform=Platform.TELEGRAM,
+                            chat_id="first-chat", user_id="first-user")
+        second = _make_event(platform=Platform.TELEGRAM,
+                             chat_id="second-chat", user_id="second-user")
+
+        mock_watch = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(runner, "_schedule_update_notification_watch", mock_watch), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            first_reply = await runner._handle_update_command(first)
+            second_reply = await runner._handle_update_command(second)
+
+        # Exactly one updater was launched.
+        assert mock_popen.call_count == 1
+        assert "Starting Hermes update" in first_reply
+        assert "already running" in second_reply.lower()
+
+        # The winner's routing metadata survived intact — the loser did not
+        # overwrite it, so the completion notice still reaches the first chat.
+        data = json.loads(pending_path.read_text())
+        assert data["chat_id"] == "first-chat"
+        assert data["user_id"] == "first-user"
+
+        # Both callers get the notification watcher, so the loser still learns
+        # how the update turned out.
+        assert mock_watch.call_count == 2
+
+    def test_concurrent_update_commands_spawn_exactly_one_updater(self, tmp_path):
+        """Two callers racing into the handler produce one updater, not two.
+
+        Both are released from a barrier inside ``_resolve_hermes_bin`` — the
+        last step before the slot is claimed — so they enter the claim window
+        together, in real threads, against the real filesystem, with no marker
+        pre-seeded.
+        """
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        assert not pending_path.exists()
+
+        callers = 2
+        barrier = threading.Barrier(callers)
+
+        def _resolve_hermes_bin_at_barrier():
+            barrier.wait(timeout=15)
+            return ["/usr/bin/hermes"]
+
+        spawns = []
+        spawn_lock = threading.Lock()
+
+        def _record_spawn(*args, **kwargs):
+            with spawn_lock:
+                spawns.append(args[0])
+            return MagicMock()
+
+        replies = []
+        replies_lock = threading.Lock()
+
+        def _invoke(chat_id):
+            event = _make_event(platform=Platform.TELEGRAM,
+                                chat_id=chat_id, user_id=f"user-{chat_id}")
+            reply = asyncio.run(runner._handle_update_command(event))
+            with replies_lock:
+                replies.append(reply)
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch("gateway.run._resolve_hermes_bin", _resolve_hermes_bin_at_barrier), \
+             patch.object(runner, "_schedule_update_notification_watch", MagicMock()), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen", side_effect=_record_spawn):
+            threads = [
+                threading.Thread(target=_invoke, args=(f"chat-{i}",))
+                for i in range(callers)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=20)
+            assert not any(thread.is_alive() for thread in threads)
+
+        assert len(spawns) == 1, f"expected one updater, got {len(spawns)}"
+        assert len(replies) == callers
+        assert sum("already running" in reply.lower() for reply in replies) == 1
+
+        # The surviving marker is one caller's complete, parseable metadata —
+        # not a half-written or interleaved document.
+        data = json.loads(pending_path.read_text())
+        assert data["chat_id"] in {"chat-0", "chat-1"}
+        assert data["user_id"] == f"user-{data['chat_id']}"
+
+    @pytest.mark.asyncio
+    async def test_failed_spawn_releases_the_update_slot(self, tmp_path):
+        """A spawn that never started must not block the next /update.
+
+        The slot is reserved before the spawn, so the failure path has to give
+        it back — otherwise one transient OSError would wedge /update until the
+        reservation TTL expired.
+        """
+        runner = _make_runner()
+        slash_commands_file, hermes_home = _fake_checkout(tmp_path)
+        pending_path = hermes_home / ".update_pending.json"
+        event = _make_event(platform=Platform.TELEGRAM, chat_id="chat-1")
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(runner, "_schedule_update_notification_watch", MagicMock()), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen", side_effect=OSError("cannot fork")):
+            failed_reply = await runner._handle_update_command(event)
+
+        assert "Failed to start update" in failed_reply
+        assert not pending_path.exists()
+        assert not (hermes_home / ".update_pending.tmp").exists()
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.slash_commands.__file__", slash_commands_file), \
+             patch.object(runner, "_schedule_update_notification_watch", MagicMock()), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            retry_reply = await runner._handle_update_command(event)
+
+        assert mock_popen.call_count == 1
+        assert "Starting Hermes update" in retry_reply
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Supersedes #15539

@hharry11's #15539 identified this collision correctly and the underlying overwrite path is still live on `main`. This PR re-does that fix against the code as it exists today, and closes the three specific deficiencies called out in review.

- **What #15539 covered:** the diagnosis — two `/update` invocations clobber the shared `.update_pending.json` IPC state, and a second updater is spawned.
- **What #15539 did not do:** it patched `gateway/run.py:7821`, but the handler moved to `gateway/slash_commands.py` in `619bd7827`, so its guard never executes on HEAD (that PR is also `CONFLICTING`/`DIRTY` today). Its guard was `if pending_path.exists() or claimed_path.exists(): return`, a check-then-write that both callers can pass. Its two tests pre-seeded the marker, so they never reached the check-to-create gap.
- **What this adds:** the guard in the file the handler actually lives in, an *atomic* reservation instead of check-then-write, a TTL so a crashed updater cannot wedge `/update` forever, and a synchronized two-caller regression that pre-seeds nothing.

## What does this PR do?

`_handle_update_command` in `gateway/slash_commands.py` writes `.update_pending.json` and spawns a detached `hermes update --gateway` with **no admission control of any kind**. A `grep -niE "claimed|lock|already|in_progress|is_running|O_EXCL"` over the whole handler body on `main` returns nothing.

`/update` is profile-global: it rewrites the checkout and the virtualenv every session on the host shares, and the `.update_*` markers are a single-slot mailbox holding one requester's routing metadata. Two concurrent invocations — a user double-tapping because the update runs for minutes with no acknowledgement, or two platforms on one multiplexed gateway both triggering it — each write the marker and each spawn an updater against the same checkout and venv. The second write replaces the first requester's routing metadata, so that user never learns their update finished.

There is a second, louder symptom: both handlers stage through the same `.update_pending.tmp` path, so the losing `Path.replace()` raises `FileNotFoundError` straight out of the handler. That is reproduced by the new concurrency test against unpatched `main` — see *How to Test*.

The fix reserves the profile-wide slot with `os.open(..., O_CREAT | O_EXCL)` **before** any routing metadata is written and **before** the updater is spawned, collapsing observe-and-claim into a single atomic syscall so exactly one caller can ever win. `O_EXCL` is the same primitive on Windows (CPython raises `FileExistsError` there too), so the win32 spawn branch needs no separate handling.

## Related Issue

No separate issue — this supersedes PR #15539, whose review states the acceptance criteria. Deliberately **not** using a closing keyword, so #15539 stays open for its author to close.

## Acceptance checklist from the #15539 review

> "`gateway/run.py:7829` checks for a marker before the later write at PR lines 7843-7845. **Two simultaneous handlers can both pass that check and both spawn an update process**, so the reported race remains."

Answered by `_claim_update_slot`, which uses `os.open(O_CREAT | O_EXCL)`. There is no window between observing the slot is free and taking it — it is one syscall, and the kernel picks the winner. `test_claim_update_slot_is_exclusive_under_parallel_callers` releases 16 threads from a barrier onto one path and asserts exactly one `True`.

> "The handler **moved to `gateway/slash_commands.py` in `619bd7827`**; current main still overwrites `.update_pending.json` at `gateway/slash_commands.py:4531-4549`."

The guard is in `gateway/slash_commands.py`, in `_handle_update_command`. The cited lines have drifted since the review — the handler now starts at `:5393` and the unguarded write is at `:5450-5453` on `36cb5ae55`. Nothing is changed in `gateway/run.py`.

> "The new tests at PR `tests/gateway/test_update_command.py:218` and `:257` pre-seed a marker, so they **do not exercise the concurrent check-to-create gap**."

**No test in this PR pre-seeds a marker to stand in for the race.** Every marker the guard is handed is created by the handler or by the primitive under test. `test_concurrent_update_commands_spawn_exactly_one_updater` runs two callers in real threads against the real filesystem, released together from a barrier placed at the last step before the claim, and asserts exactly one spawn plus one "already running" reply. `test_second_update_is_rejected_without_preseeding_a_marker` drives the reject path purely from state the first call produced, and asserts the winner's routing metadata survived byte-for-byte.

The one test that does write a marker, `test_rejects_when_notifier_claims_a_live_update_mid_admission`, writes it from *inside* the admission window to stand in for the concurrent notifier — that is the event being simulated, not state handed to the guard up front. See *Follow-up* below.

## Sibling-site sweep

`git grep -n "update_pending" origin/main -- '*.py'` (non-test), every site classified:

| Site | Role | Changed? |
|---|---|---|
| `gateway/slash_commands.py:5450-5453` | **the only writer + spawner, unguarded** | **yes** |
| `gateway/run.py:11281-11282` | startup re-arms the notification watch if either marker exists | no — reader |
| `gateway/run.py:20564-20565` | `_watch_update_progress` reads claimed→pending for routing | no — reader |
| `gateway/run.py:20806-20824` | `_send_update_notification` — **already claims atomically** via `pending_path.replace(claimed_path)` | no — reader, and already correct |

The three `run.py` sites only ever consume the marker; none of them creates one, so none of them can produce a second updater. The reservation deliberately mirrors the claim idiom the reader at `gateway/run.py:20819` already uses, so the two halves of the protocol match. `tests/gateway/test_update_streaming.py` exercises the watcher (a reader) and needed no change; it still passes unmodified.

## Changes Made

- `gateway/slash_commands.py`
  - New module-level `_claim_update_slot(pending_path, ttl_seconds)` — atomic `O_CREAT | O_EXCL` reservation, with takeover of a reservation older than the TTL.
  - New `_UPDATE_RESERVATION_TTL_S = 3600.0`. An updater killed before it writes its exit code (host reboot, OOM kill) leaves a marker nothing will clean up; without a ceiling the new guard would wedge `/update` for the lifetime of the profile — a worse bug than the one being fixed. Sized above `_watch_update_progress`'s own 1800s watch timeout so a live, still-watched update is never stolen.
  - `_handle_update_command` claims the slot before writing routing metadata and before spawning. The loser gets `t("gateway.update.already_running")` **and** `_schedule_update_notification_watch()`, so it still learns how the running update turned out.
  - The metadata write moved inside the existing `try`, and the failure path releases the reservation (and any orphaned `.update_pending.tmp`), so a spawn that never started does not block the next `/update`.
- `locales/*.yaml` (all 17) — new `gateway.update.already_running` key. `tests/agent/test_i18n.py` asserts catalog parity, so the key has to land in every locale in the same commit.
- `tests/gateway/test_update_command.py` — new `TestUpdateAdmissionControl` with 6 tests.

## How to Test

1. Focused suites, all green:
   ```
   pytest tests/gateway/test_update_command.py tests/gateway/test_update_streaming.py \
          tests/agent/test_i18n.py tests/gateway/test_startup_restart_race.py -q
   # 64 passed
   ```
2. **Fails before / passes after.** Restore only `gateway/slash_commands.py` to `origin/main` and re-run the new class:
   ```
   git checkout origin/main -- gateway/slash_commands.py
   pytest tests/gateway/test_update_command.py::TestUpdateAdmissionControl -q
   # 5 failed, 1 passed
   ```
   The concurrency test additionally surfaces the unhandled crash on unpatched `main`:
   ```
   FileNotFoundError: [Errno 2] No such file or directory:
     '.../hermes/.update_pending.tmp' -> '.../hermes/.update_pending.json'
     at gateway/slash_commands.py:5452 in _handle_update_command
   ```
   With the fix restored, all 6 pass. (`test_failed_spawn_releases_the_update_slot` is the one that passes both ways by design — it guards the *new* release path, i.e. that this PR cannot itself wedge `/update`, so it has nothing to fail against on `main`.)
3. Full `tests/gateway/` suite, run serially on this branch and on clean `origin/main` for comparison: **the identical 7 failures on both**, in `test_discord_send.py`, `test_send_multiple_images.py`, `test_session_store_prune.py`, `test_shutdown_forensics.py`, `test_systemd_notify.py`. All are pre-existing and order-dependent (they pass in isolation), none is in touched code, and the set does not change with this PR applied.
4. Manual: from a messaging platform, send `/update` twice in quick succession. Before, two `hermes update` processes appear (`pgrep -fa "hermes update"`) and only the second chat is notified. After, the second call answers "A Hermes update is already running for this profile" and one updater runs.

## Follow-up: second-updater window closed in `d15ce760e`

Copilot's review caught a real defect in the first commit, and it is worth recording because it is the same class of bug as the one this PR fixes. The `claimed_path.exists()` pre-check was not synchronized with the exclusive create. `_send_update_notification` renames `.update_pending.json` → `.update_pending.claimed.json` while an update is in flight; landing that rename between the check and the create leaves `pending` momentarily absent, so the claim succeeded and admitted a second updater against the live one — and the notifier's later `claimed.replace(pending)` clobbered the new reservation. Reproduced, not theoretical:

```
AssertionError: Expected 'Popen' to not have been called. Called 1 times.
Calls: [call(['/usr/bin/setsid', 'bash', '-c',
        'PYTHONUNBUFFERED=1 /usr/bin/hermes update --gateway > .../.update_output.txt ...'])]
```

`d15ce760e` re-checks the claimed marker immediately after a successful claim and hands the reservation back if it is present. The release itself is narrowed: `_release_update_slot` only removes the marker while it is still zero-length — the state the exclusive create leaves it in — because if the notifier restored a live update's metadata in between, deleting it would lose that user's completion notice.

Both new tests (`test_rejects_when_notifier_claims_a_live_update_mid_admission`, `test_release_update_slot_keeps_a_marker_that_holds_metadata`) fail against `58ac06ac6` and pass on `d15ce760e`. 8 tests in `TestUpdateAdmissionControl`, 20 in the file.

## Related / Positioning

Both dedup nets were run; stating what was checked rather than claiming the field is empty.

- **By changed file** (`gh pr list --json files`, newest 300 open PRs, spanning #78440–#78871 — roughly the last day, so this net sees recent rivals only): 6 open PRs touch `gateway/slash_commands.py`, none on the update path.
- **By symbol, corpus-wide** (`gh search prs` on `_handle_update_command`, `update_pending`, `slash_commands.py`, `15539`): the two adjacent PRs worth naming are
  - **#33282** (@Yellowfish23) adds an `.update_in_progress` sentinel, but in `gateway/run.py` where the handler no longer lives, and the sentinel is read with the same check-then-write pattern the #15539 review rejected. It is bundled with five unrelated concerns (transcript logging, UTF-8 env, Windows helper streaming) across 6 files. Overlapping intent, but it does not make concurrent admission safe and does not execute on HEAD.
  - **#64519** (@jcjc81) adds a *confirmation prompt* to `/update` and extracts the spawn into `_execute_update`. Different concern — a UX gate, not admission control; two callers who both confirm still both spawn. If it lands first this PR rebases onto `_execute_update` cleanly, since the claim belongs at the top of the spawn path either way.

  Neither is a superset of this change on the atomicity dimension. Happy to defer or rebase if a maintainer reads it differently.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see *Related / Positioning*
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests: the full `tests/gateway/` package (which contains every test this PR touches) plus `tests/agent/test_i18n.py` for catalog parity, run serially against both this branch and clean `origin/main` — identical results, zero new failures. Details in *How to Test* item 3.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper and the TTL constant carry docstrings/comments explaining the invariant; no user docs describe `/update` concurrency
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — `O_CREAT | O_EXCL` raises `FileExistsError` on Windows as on POSIX, so the win32 spawn branch needs no separate guard; only the metadata write moved inside the existing `try`, which is platform-agnostic. Tested on macOS.
- [x] N/A — no tool descriptions or schemas changed
