### PR TITLE
fix(aux): don't send primary model to a different custom endpoint (#78948)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5777,6 +5777,11 @@ def resolve_provider_client(
     # cannot accept one and the Portal 404s. Leave ``model`` unset and let the
     # Portal slot through; only an explicit caller model may override it.
     _nous_portal_vision = provider == "nous" and is_vision
+    # Capture the caller's original model before the universal fallback
+    # below fills it with _read_main_model_for_aux().  The explicit-custom
+    # endpoint branch must not send the *primary* provider's model to a
+    # *different* endpoint when the caller left the model unset (#78948).
+    _caller_model = (model or "").strip() or None
     if not model and provider != "auto" and not _nous_portal_vision:
         model = _get_aux_model_for_provider(provider) or _read_main_model_for_aux() or model
 
@@ -5974,8 +5979,21 @@ def resolve_provider_client(
                 custom_base = _main_base
                 custom_key = _main_key
         if custom_base and custom_key:
+            # Only borrow main_runtime's model when it targets the SAME
+            # endpoint as ``custom_base``; otherwise the model belongs to a
+            # different provider and sending it here 404s (#78948).  Use the
+            # caller's original model (``_caller_model``) rather than the
+            # universal-fallback value, which may be the primary provider's
+            # slug leaked from config via _read_main_model_for_aux().
+            _same_endpoint_model = None
+            if main_runtime:
+                _rt_base = str(main_runtime.get("base_url") or "").strip()
+                _cb_host = base_url_hostname(custom_base)
+                _rt_host = base_url_hostname(_rt_base)
+                if _cb_host and _rt_host and _cb_host == _rt_host:
+                    _same_endpoint_model = main_runtime.get("model")
             final_model = _normalize_resolved_model(
-                model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
+                _caller_model or _same_endpoint_model or "gpt-4o-mini",
                 provider,
             )
             extra = {}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -860,6 +860,148 @@ class TestResolveProviderClientUniversalModelFallback:
         assert mock_build.call_args.args[0] == "grok-4.20-multi-agent"
 
 
+class TestExplicitCustomEndpointModelScope:
+    """resolve_provider_client() must not send the *primary* provider's model
+    to a *different* explicit custom endpoint (#78948).
+
+    The explicit-custom-endpoint branch (``provider == "custom"`` +
+    ``explicit_base_url``) historically fell back to ``main_runtime.model``
+    when the caller left the model unset.  When ``explicit_base_url`` targets
+    a different backend than ``main_runtime`` (e.g. a ``fallback_providers``
+    entry pointing at a local server), the primary model slug is sent to the
+    wrong endpoint and 404s.
+
+    The sibling named-custom-provider branch avoids this by consulting the
+    entry's own ``model`` first; this branch has no entry, so it must instead
+    refuse to borrow a model from a mismatched endpoint.
+    """
+
+    _PRIMARY = {
+        "model": "gpt-5.5",
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "sk-primary",
+        "api_mode": "codex_responses",
+    }
+    _FALLBACK_URL = "http://127.0.0.1:11434/v1"
+
+    def test_mismatched_endpoint_does_not_borrow_primary_model(self):
+        """No caller model + primary main_runtime → must NOT return gpt-5.5."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model_for_aux",
+                return_value="gpt-5.5",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "custom",
+                "",
+                explicit_base_url=self._FALLBACK_URL,
+                explicit_api_key="no-key-required",
+                main_runtime=dict(self._PRIMARY),
+            )
+
+        assert client is not None
+        # The resolved model must NOT be the primary provider's slug.
+        assert model != "gpt-5.5", (
+            "explicit custom endpoint must not borrow the primary model across "
+            "a mismatched endpoint (#78948)"
+        )
+        # It should be the neutral default, never None.
+        assert model == "gpt-4o-mini"
+
+    def test_same_endpoint_runtime_model_is_used(self):
+        """When main_runtime targets the SAME endpoint, its model is safe."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        consistent_runtime = {
+            "model": "qwen3:4b",
+            "provider": "custom",
+            "base_url": self._FALLBACK_URL,
+            "api_key": "no-key-required",
+            "api_mode": "",
+        }
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model_for_aux",
+                return_value="gpt-5.5",  # config still says primary
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "custom",
+                "",
+                explicit_base_url=self._FALLBACK_URL,
+                explicit_api_key="no-key-required",
+                main_runtime=consistent_runtime,
+            )
+
+        assert client is not None
+        assert model == "qwen3:4b", (
+            "when main_runtime and explicit_base_url agree on the endpoint, "
+            "the runtime model should be used"
+        )
+
+    def test_caller_supplied_model_wins(self):
+        """An explicit caller model is always honoured."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model_for_aux",
+                return_value="gpt-5.5",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "custom",
+                "llama3.2:3b",
+                explicit_base_url=self._FALLBACK_URL,
+                explicit_api_key="no-key-required",
+                main_runtime=dict(self._PRIMARY),
+            )
+
+        assert client is not None
+        assert model == "llama3.2:3b"
+
+    def test_no_runtime_uses_neutral_default(self):
+        """No caller model + no main_runtime → neutral default, not primary."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_model_for_aux",
+                return_value="gpt-5.5",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "custom",
+                "",
+                explicit_base_url=self._FALLBACK_URL,
+                explicit_api_key="no-key-required",
+                main_runtime=None,
+            )
+
+        assert client is not None
+        assert model == "gpt-4o-mini"
+
+
 class TestExpiredCodexFallback:
     """Test that expired Codex tokens don't block the auto chain."""
 


### PR DESCRIPTION
## What

`resolve_provider_client()` paired the **primary** provider's model slug with a **caller-supplied** custom endpoint. When a `fallback_providers` entry points at a local OpenAI-compatible server (e.g. `http://127.0.0.1:11434/v1`), auxiliary tasks (title generation, etc.) sent the primary model (e.g. `gpt-5.5`) to that server and got a 404. Every session started during a fallback window ended up untitled.

## Root cause

Two leaks in the explicit-custom-endpoint branch (`provider == "custom"` + `explicit_base_url`):

1. **Universal fallback** (`~line 5781`): `_read_main_model_for_aux()` fills `model` with the configured primary model *before* the custom branch runs. By the time the branch checks `model or main_runtime.get("model")`, `model` is already the primary slug.
2. **Explicit borrow** (`~line 5978`): `model or (main_runtime.get("model") if main_runtime else None)` borrows `main_runtime`'s model even when `explicit_base_url` targets a *different* backend than `main_runtime`.

The sibling named-custom-provider branch (`~line 6063`) does not have this bug — it consults the entry's own model first. This branch has no entry, so it must refuse to borrow a model from a mismatched endpoint.

## Fix

- Capture `_caller_model` **before** the universal fallback clobbers `model`.
- In the explicit-custom branch, only borrow `main_runtime.model` when its `base_url` hostname matches `custom_base`'s hostname (same endpoint). Otherwise fall through to `_caller_model` or the neutral default `gpt-4o-mini`.

## Verification

- **Bug confirmed on `main`** at `36cb5ae55` — the leaky `model or main_runtime.get("model")` line is unchanged.
- **Fail-without-fix**: 3/4 new tests fail with the production fix reverted (primary model leaks as `gpt-5.5` in all no-caller-model cases).
- **With fix**: all 4 new tests pass.
- **Full suite**: `tests/agent/test_auxiliary_client.py` 173/173 pass.
- **Related aux suites** (named_custom, azure_foundry, user_default_headers): 31/31 pass.
- `ruff`: clean.

### New tests (`TestExplicitCustomEndpointModelScope`)

| Test | Scenario |
|------|----------|
| `test_mismatched_endpoint_does_not_borrow_primary_model` | No caller model + primary runtime → neutral default, NOT `gpt-5.5` |
| `test_same_endpoint_runtime_model_is_used` | Runtime targets same endpoint → runtime model preserved |
| `test_caller_supplied_model_wins` | Explicit caller model always honoured |
| `test_no_runtime_uses_neutral_default` | No caller model + no runtime → `gpt-4o-mini` |

## Competitor analysis

No competing open PRs found (issue-number + topic-overlap + same-author search).

---
Auto-published by Moonsong via Path B automated pipeline.