### PR TITLE
fix(cron): degrade lifecycle_guard when HOME is unresolvable

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -171,7 +171,15 @@ def contains_launchctl_submit_command(command: str) -> bool:
 
 
 def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+    try:
+        path = Path(candidate).expanduser()
+    except RuntimeError:
+        # HOME unresolvable (unset/empty + no passwd entry): keep the
+        # literal path — a guarded path must never crash the guard
+        # (#76762). expanduser raises RuntimeError (not OSError/ValueError)
+        # in that case, so it must be caught here, not at the resolve()
+        # call site (#78974).
+        path = Path(candidate)
     if not path.is_absolute():
         path = Path(cwd or Path.cwd()) / path
     return path
@@ -310,7 +318,14 @@ def _contains_unsafe_gateway_action(
         ):
             return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    try:
+        script_paths = list(_iter_referenced_shell_scripts(command, cwd=cwd))
+    except (OSError, ValueError, RuntimeError):
+        # Any tokenizer/expansion surprise (unresolvable HOME, NUL bytes,
+        # unreadable paths) must degrade the scan, never crash the
+        # terminal tool (#78974, #76762).
+        script_paths = []
+    for script_path in script_paths:
         try:
             resolved = script_path.resolve(strict=False)
         except (OSError, ValueError):

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -9,6 +9,7 @@ Covers:
 import json
 import os
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
@@ -704,6 +705,29 @@ class TestLifecycleGuardModule:
         (tmp_path / "deploy.sh").write_text("#!/bin/bash\nhermes gateway stop\n")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
+
+    def test_unresolvable_home_does_not_crash_guard(self, monkeypatch):
+        """#78974: expanduser raising RuntimeError (HOME unset + no passwd
+        entry) must degrade the scan, not crash the terminal tool.
+
+        Before the fix, _resolve_terminal_script_path called expanduser()
+        unguarded; the RuntimeError escaped the generator before the
+        resolve() try/except could catch it.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        def _boom(self):
+            raise RuntimeError("Could not determine home directory.")
+
+        monkeypatch.setattr(Path, "expanduser", _boom)
+        # A ~-prefixed path forces the expanduser() call; the guard must
+        # degrade to the literal path and complete the scan.
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash ~/x.sh"
+        )
+        assert result is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #78974. The `lifecycle_guard` pre-command scan crashed with `RuntimeError: Could not determine home directory.` when `HOME` was unset/empty, **taking down the entire terminal tool** — every command failed pre-execution until `HOME` was restored.

## Root Cause

`cron/lifecycle_guard.py:174` — `_resolve_terminal_script_path` called `Path(candidate).expanduser()` **unguarded**. `pathlib.Path.expanduser()` raises `RuntimeError` (not `OSError`/`ValueError`) when home cannot be determined, and the exception escaped the generator `_iter_referenced_shell_scripts` *before* the existing `try/except (OSError, ValueError)` around `resolve()` (line 315) could catch it. The guard runs on **every** terminal call pre-execution, so the failure was total and persistent.

## Fix

1. **`_resolve_terminal_script_path`**: wrap `expanduser()` in `try/except RuntimeError`, falling back to the literal path — a guarded path must never crash the guard (#76762).
2. **`_contains_unsafe_gateway_action`**: materialize the referenced-script generator inside `try/except (OSError, ValueError, RuntimeError)` → degrade to no referenced scripts, so any future tokenizer/expansion surprise degrades the scan instead of nuking the terminal tool.

The direct command patterns (`contains_gateway_lifecycle_command`, launchctl) and `-c` payload recursion still run — only the referenced-script-file scan degrades (environment-level failure path, not attacker-controlled input).

## Testing

- New regression test `test_unresolvable_home_does_not_crash_guard`: verified **RED** on unfixed code (exact issue RuntimeError) and **GREEN** with the fix.
- `tests/hermes_cli/test_gateway_restart_loop.py`: 83/83 pass (incl. full `TestLifecycleGuardModule`).
- `tests/cron/`: 390/390 pass.
- Verified via `scripts/run_tests.sh` (CI parity).