### PR TITLE
fix(feishu): use reply API instead of invalid receive_id_type="thread_id" on create fallback

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4814,34 +4814,46 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
+        # For topic/thread messages that fell back from reply→create, try to
+        # find a message in the thread to reply to.  Feishu's create API does
+        # not accept "thread_id" as a receive_id_type, so we cannot create
+        # directly in a thread — fall back to the main chat when no anchor is
+        # available.  (#78975)
         _thread_id = (metadata or {}).get("thread_id")
         if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+            anchor_msg = await self._fetch_last_message_in_thread(_thread_id)
+            if anchor_msg:
+                body = self._build_reply_message_body(
+                    content=payload,
+                    msg_type=msg_type,
+                    reply_in_thread=True,
+                    uuid_value=str(uuid.uuid4()),
+                )
+                request = self._build_reply_message_request(anchor_msg, body)
+                return await self._run_blocking(
+                    self._client.im.v1.message.reply, request,
+                )
+            logger.warning(
+                "[Feishu] thread_id=%s present but no reply anchor available; "
+                "falling back to main chat delivery",
+                _thread_id,
             )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+        # Default: send to the main chat.
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -107,18 +107,18 @@ class TestOverflowFirstMessage:
 
 
 class TestFeishuFallbackThreadRouting:
-    """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
+    """Verify FeishuAdapter._send_raw_message routes correctly on fallback."""
 
     @pytest.mark.asyncio
-    async def test_create_uses_thread_id_when_available(self):
-        """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+    async def test_thread_fallback_to_main_chat_when_no_anchor(self):
+        """When reply_to=None, metadata has thread_id, and the thread has no
+        messages to reply to, _send_raw_message should fall back to the main
+        chat (receive_id_type='chat_id') instead of using the invalid
+        'thread_id' receive_id_type that Feishu rejects.  (#78975)"""
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
-        # We test the _send_raw_message method directly by mocking the client
         adapter = MagicMock(spec=FeishuAdapter)
 
-        # Set up the real _send_raw_message logic manually
         mock_client = MagicMock()
         mock_create_response = SimpleNamespace(
             success=lambda: True,
@@ -126,18 +126,15 @@ class TestFeishuFallbackThreadRouting:
         )
         mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
 
-        # Use the real implementation path
         adapter._client = mock_client
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request
-        # _send_raw_message routes blocking SDK calls through _run_blocking
-        # (adapter-owned executor). On a MagicMock(spec=...) that method is
-        # auto-mocked and would swallow the real call, so wire a passthrough.
         async def _run_blocking_passthrough(func, *args):
             return func(*args)
         adapter._run_blocking = _run_blocking_passthrough
+        # No messages in the thread — anchor lookup returns None
+        adapter._fetch_last_message_in_thread = AsyncMock(return_value=None)
 
-        # Call _send_raw_message with reply_to=None and thread_id in metadata
         import json
         result = await FeishuAdapter._send_raw_message(
             adapter,
@@ -148,27 +145,58 @@ class TestFeishuFallbackThreadRouting:
             metadata={"thread_id": "omt_topic_abc"},
         )
 
-        # Verify message.create was called (not message.reply)
+        # Should have used message.create (not reply)
         mock_client.im.v1.message.create.assert_called_once()
-
-        # The request should have receive_id_type="thread_id"
         call_args = mock_client.im.v1.message.create.call_args[0][0]
-        # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
-        # The contributor's branch had the lark SDK installed, the test environment
-        # may not — handle both shapes.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
-            import json as _json
-            receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
+            receive_id = json.loads(body).get("receive_id")
+        # receive_id should be the main chat, not the thread_id
+        assert receive_id == "oc_main_chat", (
+            f"Expected receive_id='oc_main_chat' (main chat fallback), got '{receive_id}'"
         )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
         receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
+        assert receive_id_type == "chat_id", (
+            f"Expected receive_id_type='chat_id', got '{receive_id_type}'"
         )
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_when_anchor_available(self):
+        """When reply_to=None, metadata has thread_id, and the thread has a
+        message to reply to, _send_raw_message should use message.reply with
+        reply_in_thread=True."""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = MagicMock(spec=FeishuAdapter)
+
+        mock_client = MagicMock()
+        mock_reply_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="reply_msg_1"),
+        )
+        mock_client.im.v1.message.reply = MagicMock(return_value=mock_reply_response)
+
+        adapter._client = mock_client
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
+        async def _run_blocking_passthrough(func, *args):
+            return func(*args)
+        adapter._run_blocking = _run_blocking_passthrough
+        # Thread has a message — anchor lookup returns a message_id
+        adapter._fetch_last_message_in_thread = AsyncMock(return_value="om_msg_anchor_1")
+
+        import json
+        result = await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        # Should have used message.reply (not create)
+        mock_client.im.v1.message.reply.assert_called_once()
 


### PR DESCRIPTION
## Summary

Feishu's `im/v1/message/create` API only accepts `receive_id_type` values: `open_id`, `user_id`, `union_id`, `email`, `chat_id`. When `_send_raw_message` fell back from reply→create with a `thread_id` in metadata, it passed `"thread_id"` as `receive_id_type`, causing `[99992402] field validation failed` on every delivery.

## Root Cause

In `plugins/platforms/feishu/adapter.py:_send_raw_message()`, when `reply_to` is None but `metadata.thread_id` is set, the code attempted to create a message with `receive_id_type="thread_id"` — a value Feishu's API does not accept.

## Fix

When `thread_id` is present but no reply anchor exists:
1. Attempt to fetch the last message in the thread via `_fetch_last_message_in_thread()` as a reply anchor
2. If found, use `message.reply` with `reply_in_thread=True` (the correct Feishu API for thread messages)
3. If no anchor is available, log a warning and fall back to main chat delivery (`chat_id`)

This guarantees the message is always delivered rather than failing 100% of the time.

## Changes

- `plugins/platforms/feishu/adapter.py`: Replace invalid `receive_id_type="thread_id"` with thread reply-then-fallback logic
- `tests/gateway/test_stream_consumer_thread_routing.py`: Update test to verify new behavior (main chat fallback when no anchor, reply API when anchor available)

## Test Plan

- [x] `test_thread_fallback_to_main_chat_when_no_anchor` — verifies main chat fallback
- [x] `test_thread_reply_when_anchor_available` — verifies reply API with reply_in_thread
- [x] All existing Feishu tests pass (9/9)

Fixes #78975