### PR TITLE
fix(gateway): respect _enabled_explicit for email platform env arming (#78823)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2096,7 +2096,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if all([email_addr, email_pwd, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
-        config.platforms[Platform.EMAIL].enabled = True
+        if not config.platforms[Platform.EMAIL].extra.get("_enabled_explicit", False):
+            config.platforms[Platform.EMAIL].enabled = True
         config.platforms[Platform.EMAIL].extra.update({
             "address": email_addr,
             "imap_host": email_imap,


### PR DESCRIPTION
## Summary

The email platform env-arming block sets `enabled = True` unconditionally when `EMAIL_*` env vars are present, overriding an explicit `enabled: false` in `config.yaml`.

Other platforms (Telegram, Slack, WhatsApp, Signal, Matrix, etc.) already guard this with the `_enabled_explicit` flag set during YAML parsing. The email block was missed in the #41112 fix.

## Root Cause

In `gateway/config.py` line ~2100, the email env-arming block:
```python
config.platforms[Platform.EMAIL].enabled = True
```
has no `_enabled_explicit` guard, unlike every other platform.

## Fix

Add the same `_enabled_explicit` guard used by Telegram, Slack, WhatsApp, and others:
```python
if not config.platforms[Platform.EMAIL].extra.get("_enabled_explicit", False):
    config.platforms[Platform.EMAIL].enabled = True
```

The `extra.update()` for credentials still runs unconditionally — only the `enabled = True` is guarded.

## Reproduction

Run the Python repro from the issue body: with `enabled: false` in config and `EMAIL_*` env vars set, email should stay `enabled=False` (currently shows `enabled=True`).

Fixes #78823
