### PR TITLE
fix(agent): omit unsupported metadata on Relay scope.pop (#78993)

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -880,7 +880,8 @@ def _complete_logical(
                     output["response_model"] = response_model_name
             lease.host.run_in_session(
                 lease.session,
-                lease.host.relay.scope.pop,
+                relay_runtime.pop_relay_scope,
+                lease.host.relay,
                 handle,
                 output=output,
                 metadata={

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -26,6 +26,40 @@ RUNTIME_INSTANCE_KEY = "hermes.relay.runtime_instance"
 _PROFILE_KEY_CACHE: dict[str, str] = {}
 
 
+def pop_relay_scope(
+    relay: Any,
+    handle: Any,
+    *,
+    output: Any = None,
+    metadata: Any = None,
+    timestamp: Any = None,
+) -> Any:
+    """Pop a Relay scope without passing kwargs the binding rejects.
+
+    NeMo Relay ``scope.pop`` gained ``metadata`` in 0.4+. Older wheels (e.g.
+    0.3.x) raise ``TypeError: pop() got an unexpected keyword argument
+    'metadata'`` when Hermes finalization forwards runtime metadata. Filter to
+    parameters the live binding accepts so turn/session close can complete.
+    """
+    pop = relay.scope.pop
+    kwargs: dict[str, Any] = {}
+    if output is not None:
+        kwargs["output"] = output
+    if metadata is not None:
+        kwargs["metadata"] = metadata
+    if timestamp is not None:
+        kwargs["timestamp"] = timestamp
+    try:
+        params = inspect.signature(pop).parameters
+    except (TypeError, ValueError):
+        params = {}
+    if params and not any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()
+    ):
+        kwargs = {key: value for key, value in kwargs.items() if key in params}
+    return pop(handle, **kwargs)
+
+
 @dataclass
 class RelaySession:
     """One isolated Relay scope stack owned by a Hermes session."""
@@ -315,7 +349,8 @@ class RelayRuntime:
                 try:
                     self.run_in_session(
                         session,
-                        self.relay.scope.pop,
+                        pop_relay_scope,
+                        self.relay,
                         session.handle,
                         output={},
                         metadata={
@@ -659,7 +694,8 @@ class RelaySessionCoordinator:
                         try:
                             lease.host.run_in_session(
                                 lease.session,
-                                lease.host.relay.scope.pop,
+                                pop_relay_scope,
+                                lease.host.relay,
                                 turn.handle,
                                 output={"outcome": outcome},
                                 metadata={
@@ -743,7 +779,8 @@ class RelaySessionCoordinator:
             try:
                 lease.host.run_in_session(
                     lease.session,
-                    lease.host.relay.scope.pop,
+                    pop_relay_scope,
+                    lease.host.relay,
                     logical_handle,
                     output={"outcome": outcome},
                     metadata={

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -935,7 +935,8 @@ class _Runtime:
         try:
             self._run_in_task(
                 task,
-                self.relay.scope.pop,
+                relay_runtime.pop_relay_scope,
+                self.relay,
                 task.handle,
                 output=fields,
                 metadata=self._event_metadata(),

--- a/tests/agent/test_relay_scope_pop_metadata.py
+++ b/tests/agent/test_relay_scope_pop_metadata.py
@@ -1,0 +1,121 @@
+"""Regression for #78993: scope.pop metadata kwarg on older NeMo Relay."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+from agent import relay_runtime
+
+
+def test_pop_relay_scope_omits_unsupported_metadata_kwarg():
+    calls: list[tuple[object, dict]] = []
+
+    def pop_without_metadata(handle, *, output=None):
+        calls.append((handle, {"output": output}))
+
+    relay = SimpleNamespace(scope=SimpleNamespace(pop=pop_without_metadata))
+    handle = ("scope", "hermes.turn", 1)
+
+    relay_runtime.pop_relay_scope(
+        relay,
+        handle,
+        output={"outcome": "success"},
+        metadata={"hermes.relay.schema_version": "hermes.relay.runtime.v1"},
+    )
+
+    assert calls == [(handle, {"output": {"outcome": "success"}})]
+
+
+def test_pop_relay_scope_forwards_metadata_when_supported():
+    calls: list[tuple[object, dict]] = []
+
+    def pop_with_metadata(handle, *, output=None, metadata=None, timestamp=None):
+        calls.append(
+            (
+                handle,
+                {
+                    "output": output,
+                    "metadata": metadata,
+                    "timestamp": timestamp,
+                },
+            )
+        )
+
+    relay = SimpleNamespace(scope=SimpleNamespace(pop=pop_with_metadata))
+    handle = ("scope", "hermes.turn", 2)
+    metadata = {"hermes.relay.runtime_instance": "abc"}
+
+    relay_runtime.pop_relay_scope(
+        relay,
+        handle,
+        output={"outcome": "error"},
+        metadata=metadata,
+    )
+
+    assert calls == [
+        (
+            handle,
+            {
+                "output": {"outcome": "error"},
+                "metadata": metadata,
+                "timestamp": None,
+            },
+        )
+    ]
+
+
+def test_end_turn_finalization_survives_pop_without_metadata(monkeypatch, caplog):
+    """Mirror #78993: nemo-relay 0.3.x rejects metadata= on scope.pop."""
+    pytest.importorskip("nemo_relay")
+
+    monkeypatch.setenv("HERMES_HOME", tempfile.mkdtemp())
+    relay_runtime._reset_for_tests()
+    lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
+        profile_key=relay_runtime.current_profile_key(),
+        session_id="session-78993",
+        platform="cli",
+    )
+    turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
+        lease,
+        turn_id="turn-1",
+        task_id="task-1",
+    )
+    lease.host.retain_managed_execution("test.relay_scope_pop")
+
+    original_pop = lease.host.relay.scope.pop
+    assert "metadata" in inspect.signature(original_pop).parameters
+
+    def pop_without_metadata(handle, *, output=None, timestamp=None):
+        return original_pop(handle, output=output, timestamp=timestamp)
+
+    monkeypatch.setattr(lease.host.relay.scope, "pop", pop_without_metadata)
+
+    logical = lease.host.run_in_session(
+        lease.session,
+        lease.host.relay.scope.push,
+        "logical-llm",
+        lease.host.relay.ScopeType.Custom,
+        handle=turn.handle,
+        input={},
+        metadata={"hermes.test": True},
+    )
+    turn.logical_llm_calls["api-1"] = logical
+
+    with caplog.at_level(logging.WARNING, logger="agent.relay_runtime"):
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "unexpected keyword argument 'metadata'" not in joined
+    assert "turn finalization failed" not in joined
+    assert "logical LLM finalization failed" not in joined
+    assert turn.logical_llm_calls == {}
+    assert turn.closed is True
+
+    lease.host.release_managed_execution("test.relay_scope_pop")
+    relay_runtime.SESSION_COORDINATOR.release_conversation(lease)
+    relay_runtime._reset_for_tests()


### PR DESCRIPTION
## What does this PR do?

Fixes a Gateway finalization crash where Hermes called `relay.scope.pop(..., metadata=...)` and older NeMo Relay bindings (e.g. 0.3.x) raised `TypeError: pop() got an unexpected keyword argument 'metadata'`. That failure left scopes unclosed and produced the repeated `relay finalization failed` / event-loop stall symptoms reported in #78993.

Adds `pop_relay_scope()`, which inspects the live `scope.pop` signature and only forwards kwargs the binding accepts. On 0.4+ / 0.6.x, `metadata` is still passed; on 0.3.x it is omitted so turn/session/logical/shared-metrics close can complete.

## Related Issue

Fixes #78993

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/relay_runtime.py` — add `pop_relay_scope()`; use it for session close, turn finalization, and logical-LLM finalization
- `agent/relay_llm.py` — route logical LLM completion through `pop_relay_scope()`
- `hermes_cli/observability/relay_shared_metrics.py` — route task-scope close through `pop_relay_scope()`
- `tests/agent/test_relay_scope_pop_metadata.py` — unit coverage for omit/forward behavior + end-turn regression matching #78993

## How to Test

1. With a `scope.pop` that rejects `metadata` (nemo-relay 0.3.x, or a monkeypatched pop without that kwarg), open a turn + logical LLM scope and call `SESSION_COORDINATOR.end_turn(...)`.
2. **Before:** `TypeError: pop() got an unexpected keyword argument 'metadata'` at `run_in_session` → `invoke`, with `logical LLM finalization failed` / `turn finalization failed` warnings.
3. **After:** no metadata TypeError; logical handles clear; turn closes cleanly.
4. Run: `pytest tests/agent/test_relay_scope_pop_metadata.py -v`
5. Optional smoke: `pytest tests/agent/test_relay_llm.py::test_non_stream_result_survives_logical_scope_close_failure -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduced against nemo-relay **0.3.0** before the fix:

```
TypeError: pop() got an unexpected keyword argument 'metadata'
  File "agent/relay_runtime.py", line 217, in run_in_session
    return context.run(invoke)
  File "agent/relay_runtime.py", line 213, in invoke
    return callback(*args, **kwargs)
```

Followed by `Hermes Relay logical LLM finalization failed` and `Hermes Relay turn finalization failed`.

After the fix (same 0.3.0 path): no metadata TypeError; turn finalization completes.

Made with [Cursor](https://cursor.com)