### PR TITLE
fix: harden lifecycle guard against NUL-encoded script paths (#78942)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,7 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -318,6 +318,13 @@ def _contains_unsafe_gateway_action(
             # from a binary's decoded contents tokenized as a path — a
             # guarded path must never crash the guard (#76762).
             resolved = script_path
+
+        # NUL-bearing path tokens are not valid filesystem paths and cannot
+        # reference a real script file. Skip them so a malformed token cannot
+        # crash the recursion path.
+        if "\x00" in str(script_path):
+            continue
+
         if resolved in visited:
             continue
         visited.add(resolved)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -9,6 +9,7 @@ Covers:
 import json
 import os
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
@@ -627,6 +628,19 @@ class TestLifecycleGuardModule:
         script.write_bytes(b"\xfehermes gateway restart\xff")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("", str(script))
+
+    def test_shell_reference_with_nul_path_does_not_crash(self):
+        """Embedded NUL bytes in referenced script paths should be treated as
+        non-executable junk and skipped, not as a guard crash."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        assert contains_gateway_lifecycle_command_or_referenced_script("sh foo\x00bar.sh") is False
+
+    def test_read_referenced_script_handles_nul_path_without_exception(self):
+        """A NUL byte in a candidate path should fail-safe to "nothing to scan"."""
+        from cron.lifecycle_guard import _read_referenced_script
+
+        assert _read_referenced_script(Path("foo\x00bar")) == (None, False)
 
 
     def test_relative_script_resolved_under_scripts_dir(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Make gateway lifecycle guard resilient to NUL-byte script references.
- Skip invalid NUL-encoded script path tokens before recursive scan.
- Catch NUL-related path-open failures in _read_referenced_script.
- Add regression tests for both malformed script references and malformed paths.

## Test Plan
- [x] python3 -m py_compile cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py
- [x] python3 -m pytest -q tests/hermes_cli/test_gateway_restart_loop.py -k "nul_path or read_referenced_script"
- [x] ruff check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py
- [ ] python3 -m pytest -q tests/hermes_cli/test_gateway_restart_loop.py

Closes #78942