### PR TITLE
fix(cron): guard false-positive on non-.py Python scripts with ~/ paths (#78980)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -412,7 +412,13 @@ def check_gateway_lifecycle(
     combined = prompt or ""
     python_script = False
     if script:
-        python_script = _resolve_script_path(script).suffix == ".py"
+        # Match the scheduler's interpreter selection (cron/scheduler.py:2275):
+        # .sh/.bash → bash, everything else → Python.  The shell-script
+        # reference walk produces false positives on Python source (pathlib's
+        # "/" operator, ~/… literals) — skip it for all non-shell scripts,
+        # not just those with a .py extension (#78980).
+        _script_suffix = _resolve_script_path(script).suffix.lower()
+        python_script = _script_suffix not in (".sh", ".bash")
         script_text = _read_script_for_scanning(script)
         if script_text:
             combined = f"{combined}\n{script_text}"

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -664,6 +664,26 @@ class TestLifecycleGuardModule:
         )
         check_gateway_lifecycle("clean prompt", str(script))
 
+    def test_non_py_extension_python_script_with_tilde_not_blocked(
+        self, tmp_path
+    ):
+        """#78980: a cron script without a .py extension (but executed as
+        Python per the scheduler) containing a ~/... path literal must NOT
+        be blocked.
+
+        The scheduler treats .sh/.bash as bash and everything else as
+        Python.  The guard must match this policy: non-shell scripts skip
+        the shell-script reference walk, not just .py files.
+        """
+        from cron.lifecycle_guard import check_gateway_lifecycle
+        script = tmp_path / "watchdog"
+        script.write_text(
+            "import os\n"
+            'root = os.path.expanduser("~/.hermes/skills")\n'
+            'print(f"scanning {root}")\n'
+        )
+        check_gateway_lifecycle("", str(script))
+
     def test_python_script_with_literal_lifecycle_command_still_blocked(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

The lifecycle guard's `python_script` check only matched `.py` extensions, but the scheduler runs ALL non-`.sh`/`.bash` scripts via Python. A cron script without a `.py` extension containing `~/...` path literals (e.g. `os.path.expanduser("~/.hermes/skills")`) was shell-tokenized by `_iter_referenced_shell_scripts`, which resolved the path as a referenced script, found a directory instead of a regular file, and failed closed with `unsafe=True`.

## Root cause

`check_gateway_lifecycle` in `cron/lifecycle_guard.py` used `.suffix == ".py"` to decide whether to skip the shell-script reference walk. But the scheduler (`cron/scheduler.py:2275`) runs `.sh`/`.bash` via bash and **everything else** via Python. Scripts without a `.py` extension (e.g. `watchdog`, `skills-check`) were treated as shell, causing false positives on `~/...` path literals in Python source.

## Fix

Match the scheduler's interpreter selection: `.sh`/`.bash` triggers the shell-script reference walk, everything else gets regex-only check. The direct command regex still catches literal lifecycle commands in non-shell scripts.

## Test plan

- [x] New test: `test_non_py_extension_python_script_with_tilde_not_blocked` -- no-extension script with `~/` path is NOT blocked
- [x] All 83 existing tests pass (78 lifecycle + 5 other)
- [x] Literal lifecycle command in non-`.py` script still blocked (existing test)

Fixes #78980