### PR TITLE
fix(terminal): sanitize binary lifecycle script reads

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -310,6 +310,110 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
 
+    def test_binary_reference_does_not_reenter_scanner_through_env_reader(
+        self, monkeypatch, tmp_path
+    ):
+        """A local binary leaf must not be decoded by the remote-read fallback.
+
+        The core scanner classifies NUL-containing files as binary leaves, but
+        terminal_tool's backend reader used to decode the same file as text and
+        feed it back into recursive path scanning, where an embedded NUL raised
+        ValueError before the command could execute.
+        """
+        import tools.approval as approval
+        import tools.terminal_tool as tt
+
+        monkeypatch.setattr(approval, "get_current_session_key", lambda default="": "test")
+
+        binary = tmp_path / "binary-tool"
+        binary_bytes = b"\x7fELF\x00/not-a-script"
+        binary.write_bytes(binary_bytes)
+        binary.chmod(0o755)
+
+        class _ExecutingEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                if command.startswith(("cat ", "base64 < ")):
+                    raise AssertionError("local binary must not use the remote reader")
+                return {"returncode": 0, "output": "binary ran", "cwd": str(tmp_path)}
+
+        self._patch_env(monkeypatch, _ExecutingEnv(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=str(binary), force=True))
+
+        assert result["exit_code"] == 0
+        assert result["output"] == "binary ran"
+
+    def test_remote_binary_reference_does_not_reenter_scanner(
+        self, monkeypatch, tmp_path
+    ):
+        """Remote binary bytes must survive transport for reliable classification."""
+        import tools.approval as approval
+        import tools.terminal_tool as tt
+
+        monkeypatch.setattr(approval, "get_current_session_key", lambda default="": "test")
+        binary_bytes = b"\x7fELF\x00/not-a-script"
+
+        class _ExecutingEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                if command.startswith("cat ") and "/remote/binary-tool" in command:
+                    return {
+                        "returncode": 0,
+                        "output": binary_bytes.decode("utf-8", errors="replace"),
+                    }
+                if command.startswith("cat "):
+                    return {"returncode": 1, "output": ""}
+                return {"returncode": 0, "output": "binary ran", "cwd": str(tmp_path)}
+
+        self._patch_env(monkeypatch, _ExecutingEnv(), inside_gateway=True)
+
+        result = json.loads(
+            tt.terminal_tool(command="/remote/binary-tool", force=True)
+        )
+
+        assert result["exit_code"] == 0
+        assert result["output"] == "binary ran"
+
+    def test_nul_containing_shell_script_remains_blocked(
+        self, monkeypatch, tmp_path
+    ):
+        """NUL bytes alone do not prove a file is a non-executable binary."""
+        import tools.approval as approval
+        import tools.terminal_tool as tt
+
+        monkeypatch.setattr(approval, "get_current_session_key", lambda default="": "test")
+
+        script = tmp_path / "unsafe.sh"
+        script_bytes = b"\x7fELF\n\x00hermes gateway restart\n"
+        script.write_bytes(script_bytes)
+        script.chmod(0o755)
+
+        class _ExecutingEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                if command.startswith("cat "):
+                    return {
+                        "returncode": 0,
+                        "output": script_bytes.decode("utf-8", errors="replace"),
+                    }
+                return {"returncode": 0, "output": "script ran", "cwd": str(tmp_path)}
+
+        self._patch_env(monkeypatch, _ExecutingEnv(), inside_gateway=True)
+
+        result = json.loads(
+            tt.terminal_tool(command=f"/bin/bash {script}", force=True)
+        )
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
     def test_blocks_launchctl_submit_inside_gateway(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt
 
@@ -800,7 +904,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         import tools.terminal_tool as tt
 
         # Path only exists on the remote backend; locally it is absent, so the
-        # guard must fall back to env.execute('cat ...') to scan it.
+        # guard must read it through the remote environment to scan it.
         script = "/remote/workspace/remote.sh"
         calls = []
 
@@ -809,8 +913,11 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
             cwd = str(tmp_path)
             def execute(self, command, **kwargs):
                 calls.append(command)
-                if "cat" in command and "/remote/workspace/remote.sh" in command:
-                    return {"output": "#!/bin/bash\\nhermes gateway restart\\n", "returncode": 0}
+                if command.startswith("cat ") and "/remote/workspace/remote.sh" in command:
+                    return {
+                        "output": "shell banner\n#!/bin/bash\nhermes gateway restart\n",
+                        "returncode": 0,
+                    }
                 return {"output": "", "returncode": 0}
 
         fake_env = _RemoteEnv()
@@ -821,7 +928,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
-        assert any("cat" in c for c in calls)
+        assert any(c.startswith("cat ") for c in calls)
 
 
 class TestCronCreateLifecycleBlockExtra:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2536,6 +2536,7 @@ def terminal_tool(
                 """
                 if env is None:
                     return None
+
                 try:
                     local_path = Path(script_path).expanduser()
                     if not local_path.is_absolute():
@@ -2545,14 +2546,18 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
-                                return data.decode("utf-8", errors="replace")
+                                return data.replace(b"\x00", b"").decode(
+                                    "utf-8", errors="replace"
+                                )
                 except Exception:
                     pass
                 # Remote / sandboxed backend: read via the environment's shell.
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        output = result.get("output", "")
+                        if len(output.encode("utf-8")) <= 1024 * 1024:
+                            return output.replace("\x00", "")
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## User-facing problem

When Hermes runs inside the gateway, it scans terminal commands and referenced scripts to prevent tools from restarting or stopping the gateway itself.

If a command referenced an executable binary—for example, when launching Python, Codex, or another CLI—the scanner could accidentally read that binary as script text. Embedded NUL bytes could then reach filesystem path handling and raise:

```
ValueError: embedded null byte
```

From the user's perspective, the terminal command never starts. The tool call may remain pending until the gateway's inactivity watchdog times out, making the conversation appear stalled and leaving background work incomplete.

## Summary

- prevent the terminal lifecycle guard callback from feeding NUL bytes back into recursive path scanning
- sanitize both local file bytes and remote `cat` output before scanning
- preserve detection of lifecycle commands hidden in NUL-containing content instead of treating NUL as proof that a file is safe

## Root cause and fix

The core lifecycle scanner already treats NUL-containing referenced files as binary leaves. `terminal_tool` then retried the same file through its environment reader, decoded the content with replacement, and returned embedded NUL characters to the recursive scanner. A resulting token could reach `os.open(...)` and raise `ValueError: embedded null byte`.

This PR removes NUL bytes before best-effort scanning, so referenced binaries no longer crash the guard.

Simply skipping NUL-containing content would introduce a lifecycle bypass: shells can execute commands after embedded NUL bytes, even when a file begins with an ELF- or PE-like prefix. The sanitized content therefore remains subject to normal lifecycle scanning, preserving the gateway self-protection.

## Tests

- regression: local executable binary content does not crash or hang the terminal guard
- regression: remote binary output does not reintroduce embedded NUL bytes
- regression: a NUL-containing script with a spoofed executable magic prefix remains blocked
- existing remote unsafe-script scan remains blocked even with banner text

Validation:

```
85 passed in tests/hermes_cli/test_gateway_restart_loop.py
ruff check: passed
git diff --check: passed
```
