### PR TITLE
fix(cache): scope prompt cache keys to conversation lineages

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3049,6 +3049,7 @@ def set_runtime_main(
     api_key: Any = "",
     api_mode: str = "",
     auth_mode: str = "",
+    cache_scope: Optional[str] = None,
 ) -> contextvars.Token:
     """Record the current context's live main runtime for auxiliary routing.
 
@@ -3058,6 +3059,8 @@ def set_runtime_main(
     global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
     global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
     global _RUNTIME_MAIN_AUTH_MODE, _RUNTIME_MAIN_COMPAT_SNAPSHOT
+    if cache_scope is None:
+        cache_scope = _runtime_main_value("cache_scope")
     runtime = {
         "provider": (provider or "").strip().lower(),
         "requested_provider": (requested_provider or "").strip().lower(),
@@ -3070,6 +3073,7 @@ def set_runtime_main(
         ),
         "api_mode": (api_mode or "").strip(),
         "auth_mode": (auth_mode or "").strip().lower(),
+        "cache_scope": (cache_scope or "").strip(),
     }
     # Publish authoritative context before updating locked compatibility
     # mirrors; concurrent sessions never read those mirrors at runtime.
@@ -3539,7 +3543,9 @@ _AUTO_PROVIDER_LABELS = {
 }
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider", "cache_scope",
+)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, scoped_runtime_main
 
 logger = logging.getLogger(__name__)
 
@@ -329,13 +329,14 @@ def _auto_title_session(
     # recorded against this session (task='title_generation', #23270).
     set_accounting_context(session_db, session_id)
 
-    title = generate_title(
-        user_message,
-        assistant_response,
-        failure_callback=failure_callback,
-        main_runtime=main_runtime,
-        runtime_validator=runtime_validator,
-    )
+    with scoped_runtime_main(main_runtime):
+        title = generate_title(
+            user_message,
+            assistant_response,
+            failure_callback=failure_callback,
+            main_runtime=main_runtime,
+            runtime_validator=runtime_validator,
+        )
     if not title:
         return
 
@@ -387,12 +388,18 @@ def maybe_auto_title(
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
 
+    from hermes_state import resolve_prompt_cache_scope
+
+    cache_scope = resolve_prompt_cache_scope(session_id, session_db)
+    title_runtime = dict(main_runtime) if isinstance(main_runtime, dict) else {}
+    title_runtime["cache_scope"] = cache_scope
+
     thread = threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message, assistant_response),
         kwargs={
             "failure_callback": failure_callback,
-            "main_runtime": main_runtime,
+            "main_runtime": title_runtime,
             "title_callback": title_callback,
             "runtime_validator": runtime_validator,
         },

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -118,19 +118,20 @@ def _default_prompt_cache_retention_for_request(
 
 
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
-    """Content-address the prompt cache key from the static request prefix.
+    """Content-address the prompt cache key within the logical session scope.
 
-    Returns ``pck_<sha256[:24]>`` of (instructions + sorted tool schemas), or
-    None when there is nothing static to key on. The cache key is a routing
-    hint only — never a correctness boundary — so two requests sharing a system
-    prompt and tool set intentionally resolve to the same warm prefix bucket.
+    Returns ``pck_<sha256[:24]>`` of (logical scope + instructions + sorted
+    tool schemas), or None when there is nothing static to key on. The cache
+    key is a routing hint only — never a correctness boundary. Calls outside
+    an agent runtime retain the legacy content-only key.
 
     The fix this exists for: recurring cron jobs build session_id as
     ``cron_<id>_<timestamp>``, so using session_id as the cache key made every
-    fire cache-cold. The static prefix (identity + tools) is identical across
-    fires, so hashing it gives a stable key that stays warm within the
-    provider's cache TTL. Sorting tools by name keeps the hash insertion-order
-    independent.
+    fire cache-cold. Agent runtime maps those ids to one stable per-job scope,
+    while ordinary conversations and branches remain isolated. A delegation
+    tree shares its parent's logical scope; the full instructions/tools hash
+    still separates child prompts whose static content differs. Sorting tools
+    by name keeps the hash insertion-order independent.
     """
     if not instructions and not tools:
         return None
@@ -145,7 +146,15 @@ def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]])
         )
     # \x00 separator so instructions ending in the tool JSON can't collide with
     # a request whose instructions contain that JSON and whose tools are empty.
+    try:
+        from agent.auxiliary_client import _runtime_main_value
+
+        cache_scope = str(_runtime_main_value("cache_scope") or "")
+    except Exception:
+        cache_scope = ""
     content = f"{instructions or ''}\x00{tools_part}"
+    if cache_scope:
+        content = f"{cache_scope}\x00{content}"
     digest = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()[:24]
     return f"pck_{digest}"
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15789,8 +15789,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
 
                     from agent.auxiliary_client import scoped_runtime_main
+                    from hermes_state import resolve_prompt_cache_scope
 
-                    with scoped_runtime_main(vision_runtime):
+                    try:
+                        peek_session_id = getattr(
+                            self.session_store, "peek_session_id", None
+                        )
+                        if callable(peek_session_id):
+                            scope_session_id = peek_session_id(session_key)
+                        else:
+                            entry = self.session_store._entries.get(session_key)
+                            scope_session_id = getattr(entry, "session_id", None)
+                    except Exception:
+                        scope_session_id = None
+                    scoped_vision_runtime = dict(vision_runtime or {})
+                    scoped_vision_runtime["cache_scope"] = resolve_prompt_cache_scope(
+                        scope_session_id or session_key or "",
+                        getattr(
+                            getattr(self, "_session_db", None),
+                            "_db",
+                            getattr(self, "_session_db", None),
+                        ),
+                    )
+
+                    with scoped_runtime_main(scoped_vision_runtime):
                         message_text = await self._enrich_message_with_vision(
                             message_text,
                             image_paths,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -76,6 +76,64 @@ from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
 from hermes_state_search import SessionSearchMixin
 
+
+_CRON_CACHE_SCOPE_RE = re.compile(r"cron_(.+)_\d{8}_\d{6}")
+
+
+def resolve_prompt_cache_scope(
+    session_id: str,
+    session_db=None,
+    *,
+    parent_session_id: str = None,
+) -> str:
+    """Return the stable prompt-cache namespace for a logical agent tree."""
+    session_id = str(session_id or "")
+    if not session_id:
+        return ""
+
+    current = session_id
+    if session_db is not None:
+        try:
+            if session_db.get_session(current) is None and parent_session_id:
+                current = str(parent_session_id)
+            seen = set()
+            for _ in range(100):
+                if not current or current in seen:
+                    break
+                seen.add(current)
+                lineage = session_db.get_compression_lineage(current)
+                if not isinstance(lineage, (list, tuple)):
+                    raise TypeError("compression lineage must be a sequence")
+                scope = lineage[0] if lineage else current
+                row = session_db.get_session(scope)
+                if row is None:
+                    current = scope
+                    break
+                if not isinstance(row, dict):
+                    raise TypeError("session row must be a mapping")
+                raw = row.get("model_config")
+                try:
+                    config = json.loads(raw) if isinstance(raw, str) else raw
+                except (TypeError, json.JSONDecodeError):
+                    config = None
+                delegate_from = (
+                    config.get("_delegate_from")
+                    if isinstance(config, dict)
+                    else None
+                )
+                if delegate_from is None:
+                    current = scope
+                    break
+                current = str(row.get("parent_session_id") or delegate_from)
+        except Exception:
+            current = str(parent_session_id or session_id)
+    elif parent_session_id:
+        current = str(parent_session_id)
+
+    match = _CRON_CACHE_SCOPE_RE.fullmatch(current)
+    return f"cron:{match.group(1)}" if match else current
+
+
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
     import psutil
 except ImportError:  # pragma: no cover - stripped/scaffold installs only
@@ -7831,7 +7889,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Export and cleanup
     # =========================================================================
 
-    def _is_branch_child_row(self, session: Dict[str, Any]) -> bool:
+    def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
+        if session.get("source") == "tool":
+            return True
         raw = session.get("model_config")
         if not raw:
             return False
@@ -7839,11 +7899,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cfg = json.loads(raw) if isinstance(raw, str) else raw
         except (TypeError, json.JSONDecodeError):
             return False
-        return isinstance(cfg, dict) and cfg.get("_branched_from") is not None
+        return isinstance(cfg, dict) and (
+            cfg.get("_branched_from") is not None
+            or cfg.get("_delegate_from") is not None
+        )
 
     def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
         parent_id = child.get("parent_session_id")
-        if not parent_id or self._is_branch_child_row(child):
+        if not parent_id or self._is_explicit_fork_child_row(child):
             return False
         parent = self.get_session(parent_id)
         return bool(parent and parent.get("end_reason") == "compression")
@@ -7851,7 +7914,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def get_compression_lineage(self, session_id: str) -> List[str]:
         """Return compression ancestors through tip in chronological order."""
         session = self.get_session(session_id)
-        if not session or self._is_branch_child_row(session):
+        if not session or self._is_explicit_fork_child_row(session):
             return [session_id] if session else []
 
         root = session
@@ -7879,7 +7942,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             next_child = None
             for row in rows:
                 candidate = dict(row)
-                if not self._is_branch_child_row(candidate):
+                if self._is_compression_child_row(candidate):
                     next_child = candidate
                     break
             if not next_child or next_child["id"] in seen:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7331,6 +7331,11 @@ class AIAgent:
             reset_conversation_context,
             set_conversation_context,
         )
+        from agent.auxiliary_client import (
+            _normalize_main_runtime,
+            scoped_runtime_main,
+        )
+        from contextlib import ExitStack
         # Out-of-turn compaction entry points — ``/compact`` (cli.py), the
         # gateway ``/compress`` command and its hygiene sweep (both of which
         # build a throwaway agent), and partial head compression — call this
@@ -7366,7 +7371,14 @@ class AIAgent:
                 "_active_compression_commit_fence", missing_fence
             )
             self._active_compression_commit_fence = active_fence
+        runtime_scope = ExitStack()
         try:
+            compression_runtime = _normalize_main_runtime(None)
+            compression_runtime["cache_scope"] = (
+                AIAgent._prompt_cache_scope_id(self) or ""
+            )
+            runtime_scope.enter_context(scoped_runtime_main(compression_runtime))
+
             def _run(fence=None, target_messages=None):
                 return compress_context(
                     self,
@@ -7541,8 +7553,11 @@ class AIAgent:
                     self._active_compression_commit_fence = previous_fence
             # Restore whatever the caller had, so a compaction never leaks its
             # tag into the surrounding scope.
-            if token is not None:
-                reset_conversation_context(token)
+            try:
+                if token is not None:
+                    reset_conversation_context(token)
+            finally:
+                runtime_scope.close()
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:
         """Record the first guardrail decision that should stop this turn."""
@@ -7719,6 +7734,26 @@ class AIAgent:
         from agent.chat_completion_helpers import handle_max_iterations
         return handle_max_iterations(self, messages, api_call_count)
 
+    def _prompt_cache_scope_id(self) -> Optional[str]:
+        """Return a stable cache namespace for this logical session."""
+        sid = str(getattr(self, "session_id", None) or "")
+        if not sid:
+            return None
+        from hermes_state import resolve_prompt_cache_scope
+
+        return resolve_prompt_cache_scope(
+            sid,
+            getattr(self, "_session_db", None),
+            # Native delegates create their DB row lazily, so their first call
+            # needs the parent hint.  Branch/tool children must keep their own
+            # namespace and are resolved from their persisted marker instead.
+            parent_session_id=(
+                getattr(self, "_parent_session_id", None)
+                if getattr(self, "platform", None) == "subagent"
+                else None
+            ),
+        )
+
     def _conversation_root_id(self) -> Optional[str]:
         """Resolve the stable conversation id for Portal usage attribution.
 
@@ -7841,7 +7876,9 @@ class AIAgent:
             # replaces the value with the live runtime after fallback restoration.
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}):
+            with bind_subagent_parent(self), scoped_runtime_main({
+                "cache_scope": AIAgent._prompt_cache_scope_id(self) or "",
+            }):
                 result = run_conversation(
                     self,
                     user_message,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2946,6 +2946,21 @@ class TestCodexAdapterPromptCacheKey:
         ])
         assert "prompt_cache_retention" not in captured
 
+    def test_prompt_cache_key_isolated_by_logical_scope(self):
+        from agent.auxiliary_client import scoped_runtime_main
+
+        def key(scope):
+            adapter, captured = self._build_adapter()
+            with scoped_runtime_main({"cache_scope": scope}):
+                adapter.create(messages=[
+                    {"role": "system", "content": "SYS"},
+                    {"role": "user", "content": "hi"},
+                ])
+            return captured["prompt_cache_key"]
+
+        assert key("conversation-a") == key("conversation-a")
+        assert key("conversation-a") != key("conversation-b")
+
     @pytest.mark.parametrize("base_url", [
         "https://api.openai.com/v1",
         "https://example.services.ai.azure.com/openai/v1",

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -231,10 +231,110 @@ class TestMaybeAutoTitle:
                 "hello",
                 "hi there",
                 failure_callback=None,
-                main_runtime=None,
+                main_runtime={"cache_scope": "sess-1"},
                 title_callback=None,
                 runtime_validator=None,
             )
+
+    def test_bare_threads_bind_logical_cache_scope_without_leaking(self, tmp_path):
+        import threading
+
+        from agent.auxiliary_client import _runtime_main_value, scoped_runtime_main
+
+        db = SessionDB(tmp_path / "state.db")
+        for session_id in (
+            "session-a",
+            "session-b",
+            "root",
+            "cron_nightly_20260804_151339",
+        ):
+            db.create_session(session_id=session_id, source="cli")
+        db.end_session("root", "compression")
+        db.create_session(
+            session_id="continuation",
+            source="cli",
+            parent_session_id="root",
+        )
+        db.end_session("cron_nightly_20260804_151339", "compression")
+        db.create_session(
+            session_id="cron-continuation",
+            source="cron",
+            parent_session_id="cron_nightly_20260804_151339",
+        )
+
+        observed = {}
+        worker_scope_after_return = {}
+        threads = []
+        real_thread = threading.Thread
+        real_auto_title_session = auto_title_session
+
+        def capture_thread(*args, **kwargs):
+            thread = real_thread(*args, **kwargs)
+            threads.append(thread)
+            return thread
+
+        def capture_scope(user_message, *_args, **_kwargs):
+            observed[user_message] = _runtime_main_value("cache_scope")
+            return None
+
+        def run_worker(*args, **kwargs):
+            real_auto_title_session(*args, **kwargs)
+            worker_scope_after_return[args[2]] = _runtime_main_value("cache_scope")
+
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        runtime = {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "api_mode": "codex_responses",
+        }
+        with (
+            patch("agent.title_generator._auto_title_enabled", return_value=True),
+            patch("agent.title_generator.threading.Thread", side_effect=capture_thread),
+            patch("agent.title_generator.auto_title_session", side_effect=run_worker),
+            patch("agent.title_generator.generate_title", side_effect=capture_scope),
+            scoped_runtime_main({"cache_scope": "caller"}),
+        ):
+            for session_id in (
+                "session-a",
+                "session-b",
+                "root",
+                "continuation",
+                "cron_nightly_20260804_151339",
+                "cron-continuation",
+            ):
+                maybe_auto_title(
+                    db,
+                    session_id,
+                    session_id,
+                    "response",
+                    history,
+                    main_runtime=runtime,
+                )
+            for thread in threads:
+                thread.join(timeout=10)
+                assert not thread.is_alive()
+            assert _runtime_main_value("cache_scope") == "caller"
+
+        assert observed == {
+            "session-a": "session-a",
+            "session-b": "session-b",
+            "root": "root",
+            "continuation": "root",
+            "cron_nightly_20260804_151339": "cron:nightly",
+            "cron-continuation": "cron:nightly",
+        }
+        assert worker_scope_after_return == {
+            "session-a": "",
+            "session-b": "",
+            "root": "",
+            "continuation": "",
+            "cron_nightly_20260804_151339": "",
+            "cron-continuation": "",
+        }
+        assert _runtime_main_value("cache_scope") == ""
 
 
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -731,3 +731,19 @@ class TestPromptCacheKeyCapability:
         assert first == second
         assert first != key("cron_job_2026-07-15T10:05:00Z", instructions="You are different.")
         assert first != key("cron_job_2026-07-15T10:05:00Z", tool_name="search")
+
+    def test_cache_key_isolated_by_logical_scope(self, transport):
+        from agent.auxiliary_client import scoped_runtime_main
+
+        def key(scope):
+            with scoped_runtime_main({"cache_scope": scope}):
+                return transport.build_kwargs(
+                    model="cache-model",
+                    messages=self._messages(),
+                    tools=self._tools(),
+                    session_id=f"segment-{scope}",
+                    supports_prompt_cache_key=True,
+                )["prompt_cache_key"]
+
+        assert key("conversation-a") == key("conversation-a")
+        assert key("conversation-a") != key("conversation-b")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -74,6 +74,61 @@ class TestCodexBuildKwargs:
         )
         assert kw1["prompt_cache_key"] == kw2["prompt_cache_key"]
 
+    def test_cache_key_isolated_by_logical_scope(self, transport):
+        from agent.auxiliary_client import scoped_runtime_main
+
+        messages = [{"role": "user", "content": "Hi"}]
+        with scoped_runtime_main({"cache_scope": "conversation-a"}):
+            first = transport.build_kwargs(
+                model="gpt-5.4", messages=messages, tools=[], session_id="segment-a",
+            )
+            continuation = transport.build_kwargs(
+                model="gpt-5.4", messages=messages, tools=[], session_id="segment-a2",
+            )
+        with scoped_runtime_main({"cache_scope": "conversation-b"}):
+            other = transport.build_kwargs(
+                model="gpt-5.4", messages=messages, tools=[], session_id="segment-b",
+            )
+
+        assert first["prompt_cache_key"] == continuation["prompt_cache_key"]
+        assert first["prompt_cache_key"] != other["prompt_cache_key"]
+
+    def test_same_scope_still_hashes_child_prompt_and_tools(self, transport):
+        from agent.auxiliary_client import scoped_runtime_main
+
+        messages_a = [
+            {"role": "system", "content": "child goal A"},
+            {"role": "user", "content": "work"},
+        ]
+        messages_b = [
+            {"role": "system", "content": "child goal B"},
+            {"role": "user", "content": "work"},
+        ]
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        with scoped_runtime_main({"cache_scope": "parent"}):
+            goal_a = transport.build_kwargs(
+                model="gpt-5.4", messages=messages_a, tools=[], session_id="child-a"
+            )
+            goal_b = transport.build_kwargs(
+                model="gpt-5.4", messages=messages_b, tools=[], session_id="child-b"
+            )
+            with_tool = transport.build_kwargs(
+                model="gpt-5.4",
+                messages=messages_a,
+                tools=[tool],
+                session_id="child-c",
+            )
+
+        assert goal_a["prompt_cache_key"] != goal_b["prompt_cache_key"]
+        assert goal_a["prompt_cache_key"] != with_tool["prompt_cache_key"]
+
 
     def test_github_responses_drops_message_item_id_end_to_end(self, transport):
         # #32716: Copilot binds codex_message_items ids to a backend

--- a/tests/gateway/test_image_input_routing_runtime.py
+++ b/tests/gateway/test_image_input_routing_runtime.py
@@ -167,3 +167,65 @@ async def test_prepare_route_identity_check_keeps_event_loop_responsive(monkeypa
     assert result == "inspect @AGENTS.md"
     assert seen["event_loop_progressed"] is True
     assert seen["thread"] is not main_thread
+
+
+@pytest.mark.asyncio
+async def test_pre_turn_vision_uses_logical_scope_without_leaking(
+    tmp_path, monkeypatch
+):
+    from types import SimpleNamespace
+
+    from agent.auxiliary_client import _runtime_main_value, scoped_runtime_main
+    from hermes_state import SessionDB
+
+    runner = _make_runner()
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session("root", source="gateway")
+        db.end_session("root", "compression")
+        db.create_session(
+            "continuation",
+            source="gateway",
+            parent_session_id="root",
+        )
+        runner._session_db = SimpleNamespace(_db=db)
+        runner.session_store = SimpleNamespace(
+            peek_session_id=lambda session_key: (
+                "continuation" if session_key == "routing-key" else None
+            )
+        )
+        monkeypatch.setattr(
+            runner,
+            "_decide_image_input_mode",
+            lambda **_kwargs: "text",
+        )
+        monkeypatch.setattr(
+            runner,
+            "_resolve_session_agent_runtime",
+            lambda **_kwargs: (
+                "gpt-5.4",
+                {"provider": "openai-codex", "api_mode": "codex_responses"},
+            ),
+        )
+        observed = []
+
+        async def fake_enrich(message_text, _image_paths):
+            observed.append(_runtime_main_value("cache_scope"))
+            return f"vision: {message_text}"
+
+        monkeypatch.setattr(runner, "_enrich_message_with_vision", fake_enrich)
+
+        with scoped_runtime_main({"cache_scope": "caller"}):
+            result = await runner._prepare_inbound_message_text(
+                event=_image_event(),
+                source=_source(),
+                history=[],
+                session_key="routing-key",
+            )
+            assert _runtime_main_value("cache_scope") == "caller"
+
+        assert result == "vision: look"
+        assert observed == ["root"]
+        assert _runtime_main_value("cache_scope") == ""
+    finally:
+        db.close()

--- a/tests/hermes_state/test_session_md_export.py
+++ b/tests/hermes_state/test_session_md_export.py
@@ -40,10 +40,13 @@ def test_get_compression_lineage_returns_only_compression_chain(tmp_path):
         db.end_session("child", "compression")
         db.create_session("tip", source="cli", parent_session_id="child")
         db.create_session("branch", source="cli", parent_session_id="root", model_config={"_branched_from": "root"})
+        db.create_session("delegate", source="delegate", parent_session_id="child", model_config={"_delegate_from": "child"})
+        db.create_session("tool", source="tool", parent_session_id="child")
 
         assert db.get_compression_lineage("tip") == ["root", "child", "tip"]
         assert db.get_compression_lineage("branch") == ["branch"]
+        assert db.get_compression_lineage("delegate") == ["delegate"]
+        assert db.get_compression_lineage("tool") == ["tool"]
     finally:
         db.close()
-
 

--- a/tests/run_agent/test_prompt_cache_scope.py
+++ b/tests/run_agent/test_prompt_cache_scope.py
@@ -1,0 +1,253 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _scope(session_id, *, platform="cli", db=None, parent_session_id=None):
+    agent = SimpleNamespace(
+        session_id=session_id,
+        platform=platform,
+        _session_db=db,
+        _parent_session_id=parent_session_id,
+    )
+    return AIAgent._prompt_cache_scope_id(agent)
+
+
+def test_prompt_cache_scope_preserves_only_compression_lineage(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="cli")
+        db.create_session("other-root", source="cli")
+        db.create_session(
+            "delegate-a",
+            source="delegate",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+        db.create_session(
+            "delegate-b",
+            source="delegate",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+        db.create_session(
+            "delegate-other",
+            source="delegate",
+            parent_session_id="other-root",
+            model_config={"_delegate_from": "other-root"},
+        )
+        db.create_session("tool", source="tool", parent_session_id="root")
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="root",
+            model_config={"_branched_from": "root"},
+        )
+        db.end_session("root", "compression")
+        db.create_session("continuation", source="cli", parent_session_id="root")
+
+        db.end_session("delegate-a", "compression")
+        db.create_session(
+            "delegate-tip",
+            source="delegate",
+            parent_session_id="delegate-a",
+        )
+
+        assert db.get_compression_lineage("root") == ["root", "continuation"]
+        assert _scope("root", db=db) == "root"
+        assert _scope("continuation", db=db) == "root"
+        assert _scope("branch", db=db) == "branch"
+        assert _scope("tool", db=db) == "tool"
+        assert _scope("delegate-a", db=db) == "root"
+        assert _scope("delegate-b", db=db) == "root"
+        assert _scope("delegate-tip", db=db) == "root"
+        assert _scope("delegate-other", db=db) == "other-root"
+        # A first-turn native delegate has not created its row yet. Its parent
+        # hint still resolves through a nested delegate to the top-level root.
+        assert (
+            _scope(
+                "not-created-yet",
+                platform="subagent",
+                db=db,
+                parent_session_id="delegate-a",
+            )
+            == "root"
+        )
+        # Non-delegate children never inherit merely because they have a
+        # parent hint; their explicit branch/tool namespace remains isolated.
+        assert (
+            _scope(
+                "not-created-branch",
+                platform="cli",
+                db=db,
+                parent_session_id="root",
+            )
+            == "not-created-branch"
+        )
+    finally:
+        db.close()
+
+
+def test_cron_prompt_cache_scope_is_stable_per_job():
+    first = _scope("cron_my_job_20260804_151339", platform="cron")
+    second = _scope("cron_my_job_20260804_161339", platform="cron")
+
+    assert first == second == "cron:my_job"
+    assert first != _scope("cron_other_job_20260804_151339", platform="cron")
+
+
+def test_cron_continuation_uses_job_scope(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        root = "cron_my_job_20260804_151339"
+        db.create_session(root, source="cron")
+        db.end_session(root, "compression")
+        db.create_session(
+            "cron-continuation",
+            source="cron",
+            parent_session_id=root,
+        )
+
+        assert _scope(root, platform="cron", db=db) == "cron:my_job"
+        assert _scope("cron-continuation", platform="cron", db=db) == "cron:my_job"
+    finally:
+        db.close()
+
+
+def test_main_runtime_refresh_preserves_scoped_cache_namespace():
+    from agent.auxiliary_client import (
+        _runtime_main_value,
+        reset_runtime_main,
+        scoped_runtime_main,
+        set_runtime_main,
+    )
+
+    with scoped_runtime_main({"cache_scope": "conversation-a"}):
+        token = set_runtime_main("custom", "model")
+        try:
+            assert _runtime_main_value("cache_scope") == "conversation-a"
+        finally:
+            reset_runtime_main(token)
+        assert _runtime_main_value("cache_scope") == "conversation-a"
+
+    assert _runtime_main_value("cache_scope") == ""
+
+
+def test_direct_compression_binds_scope_in_sync_and_bare_executor(
+    tmp_path, monkeypatch
+):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from agent.auxiliary_client import _runtime_main_value, scoped_runtime_main
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+        db.create_session("continuation", source="cli", parent_session_id="root")
+        agent = AIAgent.__new__(AIAgent)
+        agent.session_id = "continuation"
+        agent.platform = "cli"
+        agent._session_db = db
+        agent._parent_session_id = None
+        agent._conversation_root_id = lambda: None
+        observed = []
+
+        def fake_compress(_agent, messages, system_message, **_kwargs):
+            observed.append(_runtime_main_value("cache_scope"))
+            return messages, system_message
+
+        monkeypatch.setattr(
+            "agent.conversation_compression.compress_context", fake_compress
+        )
+
+        with scoped_runtime_main({"cache_scope": "caller"}):
+            assert agent._compress_context([], "system", commit_fence=object()) == (
+                [],
+                "system",
+            )
+            assert _runtime_main_value("cache_scope") == "caller"
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            assert executor.submit(
+                agent._compress_context,
+                [],
+                "system",
+                commit_fence=object(),
+            ).result(timeout=10) == ([], "system")
+            assert (
+                executor.submit(_runtime_main_value, "cache_scope").result(timeout=10)
+                == ""
+            )
+
+        assert observed == ["root", "root"]
+        assert _runtime_main_value("cache_scope") == ""
+    finally:
+        db.close()
+
+
+def test_direct_compression_restores_runtime_scope_after_exception(
+    tmp_path, monkeypatch
+):
+    from agent.auxiliary_client import _runtime_main_value, scoped_runtime_main
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="cli")
+        agent = AIAgent.__new__(AIAgent)
+        agent.session_id = "root"
+        agent.platform = "cli"
+        agent._session_db = db
+        agent._parent_session_id = None
+        agent._conversation_root_id = lambda: None
+        observed = []
+
+        def fail_compress(*_args, **_kwargs):
+            observed.append(
+                {
+                    field: _runtime_main_value(field)
+                    for field in (
+                        "provider",
+                        "model",
+                        "base_url",
+                        "api_mode",
+                        "cache_scope",
+                    )
+                }
+            )
+            raise RuntimeError("compression failed")
+
+        monkeypatch.setattr(
+            "agent.conversation_compression.compress_context", fail_compress
+        )
+
+        caller_runtime = {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "base_url": "https://example.invalid/openai/v1",
+            "api_mode": "codex_responses",
+            "cache_scope": "caller",
+        }
+        with scoped_runtime_main(caller_runtime):
+            with pytest.raises(RuntimeError, match="compression failed"):
+                agent._compress_context([], "system", commit_fence=object())
+            assert {
+                field: _runtime_main_value(field) for field in caller_runtime
+            } == caller_runtime
+
+        assert observed == [
+            {
+                "provider": "openai-codex",
+                "model": "gpt-5.4",
+                "base_url": "https://example.invalid/openai/v1",
+                "api_mode": "codex_responses",
+                "cache_scope": "root",
+            }
+        ]
+        assert _runtime_main_value("cache_scope") == ""
+        assert "_active_compression_commit_fence" not in vars(agent)
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

- Add the logical conversation lineage to generated prompt cache routing keys.
- Keep compression continuations and native delegates in the parent scope.
- Keep branches, tool sessions, different roots, and different cron jobs isolated.
- Propagate the same scope through main, auxiliary, title, compression, and vision calls.
- Preserve explicit prompt cache key overrides and existing official Codex headers.

## Reason

A content-only routing key can map independent conversations with the same static prefix to one upstream routing bucket. This change removes that client-side collision risk while preserving reuse inside one logical conversation.

This is a client-side cache-routing hardening change. It does not claim to explain every historical provider cache miss. Official Codex session headers are unchanged. The tested PM-compatible route does not send those official Codex headers.

## Validation

- Focused upstream-main tests: 140 passed.
- Focused auxiliary cache test: 1 passed.
- Independent final review: approved with no correctness or security blocker.
- Ruff and git diff checks: passed.
- Standalone bounded PM-route validation:
  - main repeat: 98.48% cached input
  - auxiliary repeat: 97.22% cached input
  - fresh native delegate with the same parent: 98.46% cached input
  - fresh delegate with a different parent: cold, as required

Fixes #78941