### PR TITLE
fix(desktop): support remote profile aliases

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -29,6 +29,7 @@ import {
   localProfileEntry,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
+  normalizeRemoteProfile,
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
@@ -104,6 +105,33 @@ test('profileRemoteOverride returns the per-profile remote with defaulted auth m
     authMode: 'token',
     token: { value: 'sek' }
   })
+})
+
+test('profileRemoteOverride preserves a valid URL remote-profile mapping', () => {
+  const config = {
+    profiles: {
+      work: {
+        mode: 'remote',
+        url: 'https://gateway.example.com/hermes',
+        remoteProfile: 'default'
+      }
+    }
+  }
+
+  assert.deepEqual(profileRemoteOverride(config, 'work'), {
+    url: 'https://gateway.example.com/hermes',
+    authMode: 'token',
+    token: undefined,
+    remoteProfile: 'default'
+  })
+})
+
+test('normalizeRemoteProfile accepts Hermes names and rejects unsafe or reserved values', () => {
+  assert.equal(normalizeRemoteProfile(' default '), 'default')
+  assert.equal(normalizeRemoteProfile('writer_2'), 'writer_2')
+  assert.equal(normalizeRemoteProfile('bad profile'), null)
+  assert.equal(normalizeRemoteProfile('root'), null)
+  assert.equal(normalizeRemoteProfile(''), null)
 })
 
 test('profileRemoteOverride preserves an explicit oauth auth mode', () => {
@@ -335,6 +363,28 @@ test('pathWithGlobalRemoteProfile skips local and per-profile remote override pa
       profileRemoteOverride: true
     }),
     '/api/model/info'
+  )
+})
+
+test('pathWithGlobalRemoteProfile removes a local alias for a mapped remote default', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/cron/jobs?profile=work', 'work', {
+      globalRemote: true,
+      profileRemoteOverride: true,
+      remoteProfile: 'default'
+    }),
+    '/api/cron/jobs'
+  )
+})
+
+test('pathWithGlobalRemoteProfile replaces the local alias with a named remote profile', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/config?profile=work&force=1', 'work', {
+      globalRemote: true,
+      profileRemoteOverride: true,
+      remoteProfile: 'writer'
+    }),
+    '/api/config?profile=writer&force=1'
   )
 })
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -216,6 +216,12 @@ function modeIsRemoteLike(mode) {
   return mode === 'remote' || mode === 'cloud'
 }
 
+function normalizeRemoteProfile(value) {
+  const profile = String(value || '').trim()
+
+  return /^[a-z0-9][a-z0-9_-]{0,63}$/.test(profile) && !RESERVED_REMOTE_PROFILES.has(profile) ? profile : null
+}
+
 function normalizeSshConfig(entry) {
   if (!entry || typeof entry !== 'object' || entry.mode !== 'ssh') {
     return null
@@ -288,9 +294,9 @@ function normalizeSshConfig(entry) {
   // name used by the remote Hermes installation. Preserve an explicit mapping
   // when it is a valid Hermes profile identifier; otherwise fall back to the
   // historical same-name behavior in the caller.
-  const remoteProfile = String(entry.remoteProfile || '').trim()
+  const remoteProfile = normalizeRemoteProfile(entry.remoteProfile)
 
-  if (/^[a-z0-9][a-z0-9_-]{0,63}$/.test(remoteProfile) && !RESERVED_REMOTE_PROFILES.has(remoteProfile)) {
+  if (remoteProfile) {
     out.remoteProfile = remoteProfile
   }
 
@@ -370,13 +376,26 @@ function profileRemoteOverride(config, profile) {
     return null
   }
 
-  return { url, authMode: normAuthMode(entry.authMode), token: entry.token }
+  const override: any = {
+    url,
+    authMode: normAuthMode(entry.authMode),
+    token: entry.token
+  }
+
+  const remoteProfile = normalizeRemoteProfile(entry.remoteProfile)
+
+  if (remoteProfile) {
+    override.remoteProfile = remoteProfile
+  }
+
+  return override
 }
 
 export interface ProfileRouteOptions {
   globalRemote?: boolean
   primaryProfile?: null | string
   profileRemoteOverride?: boolean
+  remoteProfile?: null | string
 }
 
 export interface ProfileBackendRoute {
@@ -433,8 +452,9 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
  */
 function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = {}) {
   const scopedProfile = connectionScopeKey(profile)
+  const remoteProfile = normalizeRemoteProfile(opts.remoteProfile)
 
-  if (!resolveProfileBackendRoute(profile, opts).scopePath) {
+  if (!remoteProfile && !resolveProfileBackendRoute(profile, opts).scopePath) {
     return path
   }
 
@@ -452,7 +472,17 @@ function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = 
     return path
   }
 
-  if (parsed.searchParams.has('profile')) {
+  if (remoteProfile) {
+    if (remoteProfile === 'default') {
+      parsed.searchParams.delete('profile')
+    } else {
+      parsed.searchParams.set('profile', remoteProfile)
+    }
+
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  }
+
+  if (!scopedProfile || parsed.searchParams.has('profile')) {
     return path
   }
 
@@ -573,6 +603,7 @@ export {
   localProfileEntry,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
+  normalizeRemoteProfile,
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -64,6 +64,7 @@ import {
   localProfileEntry,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
+  normalizeRemoteProfile,
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
@@ -6835,6 +6836,7 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
       authMode?: string
       token?: object
       org?: string
+      remoteProfile?: string
       savedSsh?: object
     } = {
       mode: modeIsRemoteLike(entry.mode) ? entry.mode : 'local'
@@ -6858,6 +6860,12 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
 
     if ((entry as any).token && typeof entry.token === 'object') {
       cleaned.token = entry.token
+    }
+
+    const remoteProfile = normalizeRemoteProfile(entry.remoteProfile)
+
+    if (remoteProfile) {
+      cleaned.remoteProfile = remoteProfile
     }
 
     // Preserve the Hermes Cloud org tag on cloud-mode entries so Settings can
@@ -7010,6 +7018,7 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
     cloudOrg: mode === 'cloud' ? String(block.org || '') : '',
     remoteTokenPreview: tokenPreview(remoteToken),
     remoteTokenSet: Boolean(remoteToken),
+    remoteProfile: modeIsRemoteLike(mode) ? normalizeRemoteProfile(block.remoteProfile) || '' : '',
     sshHost: (ssh || savedSsh)?.host || '',
     sshUser: (ssh || savedSsh)?.user || '',
     sshPort: (ssh || savedSsh)?.port || null,
@@ -7028,12 +7037,12 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
 // `org` (optional) is the Hermes Cloud org slug/id the instance was discovered
 // under — persisted so Settings can reopen into the same org; omitted from the
 // block when empty so plain remote connections stay unchanged.
-function buildRemoteBlock(remoteUrl, authMode, token, org?: string) {
+function buildRemoteBlock(remoteUrl, authMode, token, org?: string, remoteProfile?: string) {
   if (authMode !== 'oauth' && !decryptDesktopSecret(token)) {
     throw new Error('Remote gateway session token is required.')
   }
 
-  const block: { url: string; authMode: string; token: object; org?: string } = {
+  const block: { url: string; authMode: string; token: object; org?: string; remoteProfile?: string } = {
     url: normalizeRemoteBaseUrl(remoteUrl),
     authMode,
     token
@@ -7043,6 +7052,12 @@ function buildRemoteBlock(remoteUrl, authMode, token, org?: string) {
 
   if (orgValue) {
     block.org = orgValue
+  }
+
+  const remoteProfileValue = normalizeRemoteProfile(remoteProfile)
+
+  if (remoteProfileValue) {
+    block.remoteProfile = remoteProfileValue
   }
 
   return block
@@ -7077,6 +7092,7 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
   // (switching cloud→remote drops it), so it stays unset unless mode is cloud.
   const cloudOrg = mode === 'cloud' ? String(input.cloudOrg ?? existingBlock.org ?? '').trim() : ''
   const incomingToken = typeof input.remoteToken === 'string' ? input.remoteToken.trim() : ''
+  const remoteProfile = input.remoteProfile ?? existingBlock.remoteProfile
 
   const nextToken = incomingToken
     ? persistToken
@@ -7107,7 +7123,7 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
     const profiles = { ...(existing.profiles || {}) }
 
     if (remoteLike) {
-      profiles[key] = { mode, ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg) }
+      profiles[key] = { mode, ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg, remoteProfile) }
     } else {
       const localEntry = localProfileEntry(rawExistingBlock)
 
@@ -7177,7 +7193,8 @@ async function buildRemoteConnection(
   source,
   remoteHost?,
   remoteKind = 'url',
-  remoteIdentity?
+  remoteIdentity?,
+  remoteProfile?
 ) {
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
   // For token/oauth remotes the meaningful host is the real backend URL; for
@@ -7234,6 +7251,7 @@ async function buildRemoteConnection(
       remoteHost: host || undefined,
       remoteIdentity,
       remoteKind,
+      remoteProfile: normalizeRemoteProfile(remoteProfile) || undefined,
       // No static token in OAuth mode; REST is cookie-authed via the partition.
       token: null,
       wsUrl: buildGatewayWsUrlWithTicket(baseUrl, ticket)
@@ -7255,6 +7273,7 @@ async function buildRemoteConnection(
     remoteHost: host || undefined,
     remoteIdentity,
     remoteKind,
+    remoteProfile: normalizeRemoteProfile(remoteProfile) || undefined,
     token,
     wsUrl: buildGatewayWsUrl(baseUrl, token)
   }
@@ -7566,7 +7585,9 @@ async function resolveRemoteBackend(profile) {
       token,
       'profile',
       undefined,
-      config.profiles?.[connectionScopeKey(profile)]?.mode === 'cloud' ? 'cloud' : 'url'
+      config.profiles?.[connectionScopeKey(profile)]?.mode === 'cloud' ? 'cloud' : 'url',
+      undefined,
+      override.remoteProfile
     )
   }
 
@@ -8005,10 +8026,13 @@ function primaryProfileKey() {
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
 function profileRouteOptions(profile) {
+  const override = profileRemoteOverride(readDesktopConnectionConfig(), profile)
+
   return {
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
-    profileRemoteOverride: Boolean(profileHasRemoteOverride(profile))
+    profileRemoteOverride: Boolean(profileHasRemoteOverride(profile)),
+    remoteProfile: override?.remoteProfile
   }
 }
 
@@ -8418,6 +8442,8 @@ async function startHermes() {
         remoteHost: remote.remoteHost,
         remoteKind: remote.remoteKind,
         remoteHermesVersion: remote.remoteHermesVersion,
+        profile: primaryProfileKey(),
+        remoteProfile: remote.remoteProfile,
         token: remote.token,
         wsUrl: remote.wsUrl,
         logs: hermesLog.slice(-80),

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -166,6 +166,7 @@ export function useGatewayBoot({
           return
         }
 
+        gateway.setProfileRoute(conn.profile, conn.remoteProfile)
         publish(conn)
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
         // with a short TTL, so the ticket baked into the cached conn.wsUrl is
@@ -304,6 +305,7 @@ export function useGatewayBoot({
           return
         }
 
+        gateway.setProfileRoute(conn.profile, conn.remoteProfile)
         publish(conn)
         const wsUrl = await resolveGatewayWsUrl(desktop, conn)
         await gateway.connect(wsUrl)
@@ -499,6 +501,7 @@ export function useGatewayBoot({
           message: translateNow('boot.steps.connectingGateway'),
           progress: 95
         })
+        gateway.setProfileRoute(conn.profile, conn.remoteProfile)
         publish(conn)
         // Mint a fresh WS URL right before connecting. For OAuth gateways the
         // ticket is single-use with a short TTL, so the ticket baked into

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -118,4 +118,41 @@ describe('GatewaySettings', () => {
       )
     )
   })
+
+  it('shows and saves a URL remote-profile mapping for a named Desktop profile', async () => {
+    getConnectionConfig.mockImplementation(async profile =>
+      profile === 'work'
+        ? {
+            ...localConnection,
+            mode: 'remote',
+            profile: 'work',
+            remoteUrl: 'https://gateway.example.com/hermes',
+            remoteProfile: 'default',
+            remoteTokenSet: true
+          }
+        : localConnection
+    )
+    saveConnectionConfig.mockReturnValue(new Promise(() => {}))
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: 'work' }))
+
+    await waitFor(() => expect(getConnectionConfig).toHaveBeenLastCalledWith('work'))
+    const inputs = await screen.findAllByPlaceholderText('work')
+    const remoteProfileInput = inputs.find(input => (input as HTMLInputElement).value === 'default')
+
+    expect(remoteProfileInput).toBeTruthy()
+    fireEvent.change(remoteProfileInput!, { target: { value: 'writer' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save for next restart' }))
+
+    await waitFor(() =>
+      expect(saveConnectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profile: 'work',
+          remoteProfile: 'writer'
+        })
+      )
+    )
+  })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -5,7 +5,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tip } from '@/components/ui/tooltip'
-import type { DesktopAuthProvider, DesktopCloudAgent, DesktopCloudOrg, DesktopConnectionProbeResult } from '@/global'
+import type {
+  DesktopAuthProvider,
+  DesktopCloudAgent,
+  DesktopCloudOrg,
+  DesktopConnectionConfig,
+  DesktopConnectionProbeResult
+} from '@/global'
 import { useI18n } from '@/i18n'
 import { ExternalLink } from '@/lib/external-link'
 import {
@@ -44,6 +50,7 @@ interface GatewaySettingsState {
   remoteOauthConnected: boolean
   remoteTokenPreview: string | null
   remoteTokenSet: boolean
+  remoteProfile: string
   remoteUrl: string
   cloudOrg: string
   sshHost: string
@@ -63,6 +70,7 @@ const EMPTY_STATE: GatewaySettingsState = {
   remoteOauthConnected: false,
   remoteTokenPreview: null,
   remoteTokenSet: false,
+  remoteProfile: '',
   remoteUrl: '',
   cloudOrg: '',
   sshHost: '',
@@ -167,8 +175,8 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   const contextSeq = useRef(0)
   const [connectedCloudUrl, setConnectedCloudUrl] = useState('')
 
-  const acceptSavedConfig = (config: GatewaySettingsState) => {
-    setState(config)
+  const acceptSavedConfig = (config: DesktopConnectionConfig) => {
+    setState({ ...EMPTY_STATE, ...config })
     setConnectedCloudUrl(savedCloudConnectionUrl(config))
   }
 
@@ -423,7 +431,8 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     state.sshPort,
     state.sshKeyPath,
     state.sshRemoteHermesPath,
-    state.sshRemoteProfile
+    state.sshRemoteProfile,
+    state.remoteProfile
   ])
 
   const oauthConnected = state.remoteOauthConnected
@@ -445,6 +454,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
     profile: scope ?? undefined,
     remoteAuthMode: authMode,
     remoteToken: authMode === 'token' ? remoteToken.trim() || undefined : undefined,
+    remoteProfile: state.remoteProfile.trim(),
     remoteUrl: trimmedUrl,
     sshHost: state.sshHost.trim(),
     sshUser: state.sshUser.trim() || undefined,
@@ -1264,6 +1274,21 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
             description={g.remoteUrlDesc}
             title={g.remoteUrlTitle}
           />
+
+          {scope !== null ? (
+            <ListRow
+              action={
+                <Input
+                  className={cn('h-8 font-mono', CONTROL_TEXT)}
+                  onChange={event => setState(current => ({ ...current, remoteProfile: event.target.value }))}
+                  placeholder={scope}
+                  value={state.remoteProfile}
+                />
+              }
+              description={g.sshRemoteProfileDesc}
+              title={g.sshRemoteProfileTitle}
+            />
+          ) : null}
 
           {state.mode === 'remote' && probeStatus === 'probing' ? (
             <div className="flex items-center gap-2 py-3 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -476,6 +476,8 @@ export interface HermesConnection {
   remoteIdentity?: string
   remoteKind?: 'cloud' | 'ssh' | 'url'
   remoteHermesVersion?: string
+  // Remote backend profile id when it differs from the Desktop display profile.
+  remoteProfile?: string
   nativeOverlayWidth: number
   source?: 'env' | 'local' | 'settings'
   token: string
@@ -527,6 +529,9 @@ export interface DesktopConnectionConfig {
   remoteOauthConnected: boolean
   remoteTokenPreview: string | null
   remoteTokenSet: boolean
+  // Optional profile id on a named remote backend. Blank keeps the historical
+  // same-name mapping from the Desktop profile.
+  remoteProfile?: string
   remoteUrl: string
   // For a 'cloud' connection: the persisted Hermes Cloud org (slug or id) the
   // connected instance was discovered under, so Settings → Gateway can reopen
@@ -547,6 +552,7 @@ export interface DesktopConnectionConfigInput {
   profile?: null | string
   remoteAuthMode?: 'oauth' | 'token'
   remoteToken?: string
+  remoteProfile?: string
   remoteUrl?: string
   // For a 'cloud' connection: the selected Hermes Cloud org (slug or id) to
   // persist so Settings can reopen into it. Ignored for remote/local modes.

--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -6,6 +6,7 @@ import {
   getElevenLabsVoices,
   getMemoryProviderConfig,
   getStatus,
+  mapGatewayProfileParams,
   restartGateway,
   saveMemoryProviderConfig,
   setApiRequestProfile,
@@ -13,6 +14,27 @@ import {
   transcribeAudio,
   updateHermes
 } from './hermes'
+
+describe('remote gateway profile aliases', () => {
+  it('removes the Desktop alias when the remote target is default', () => {
+    expect(mapGatewayProfileParams({ profile: 'work', session_id: 's1' }, 'work', 'default')).toEqual({
+      session_id: 's1'
+    })
+  })
+
+  it('injects a named remote profile when a request omits the Desktop alias', () => {
+    expect(mapGatewayProfileParams({ key: 'model' }, 'research', 'writer')).toEqual({
+      key: 'model',
+      profile: 'writer'
+    })
+  })
+
+  it('preserves unrelated explicit profile scopes', () => {
+    expect(mapGatewayProfileParams({ profile: 'reviewer' }, 'research', 'writer')).toEqual({
+      profile: 'reviewer'
+    })
+  })
+})
 
 // Contract: every backend-targeted action helper must carry the active gateway
 // profile, so a multi-profile / global-remote user's restart, status poll, and

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -226,7 +226,39 @@ export type {
   WebhooksResponse
 } from '@/types/hermes'
 
+export function mapGatewayProfileParams(
+  params: Record<string, unknown>,
+  localProfile?: null | string,
+  remoteProfile?: null | string
+): Record<string, unknown> {
+  const local = (localProfile ?? '').trim()
+  const remote = (remoteProfile ?? '').trim()
+
+  if (!local || !remote || local === remote) {
+    return params
+  }
+
+  const requested = typeof params.profile === 'string' ? params.profile.trim() : ''
+
+  if (requested && requested !== local) {
+    return params
+  }
+
+  const mapped = { ...params }
+
+  if (remote === 'default') {
+    delete mapped.profile
+  } else {
+    mapped.profile = remote
+  }
+
+  return mapped
+}
+
 export class HermesGateway extends JsonRpcGatewayClient {
+  private localProfile: null | string = null
+  private remoteProfile: null | string = null
+
   constructor() {
     super({
       closedErrorMessage: 'Hermes gateway connection closed',
@@ -235,6 +267,20 @@ export class HermesGateway extends JsonRpcGatewayClient {
       notConnectedErrorMessage: 'Hermes gateway is not connected',
       requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
     })
+  }
+
+  setProfileRoute(localProfile?: null | string, remoteProfile?: null | string): void {
+    this.localProfile = localProfile || null
+    this.remoteProfile = remoteProfile || null
+  }
+
+  override request<T>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ): Promise<T> {
+    return super.request(method, mapGatewayProfileParams(params, this.localProfile, this.remoteProfile), timeoutMs, signal)
   }
 }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -175,6 +175,7 @@ async function openSecondary(entry: Secondary): Promise<void> {
   }
 
   const conn = await desktop.getConnection(entry.profile)
+  entry.gateway.setProfileRoute(entry.profile, conn.remoteProfile)
   const wsUrl = await resolveGatewayWsUrl(desktop, conn)
   await entry.gateway.connect(wsUrl)
   void desktop.touchBackend?.(entry.profile).catch(() => undefined)


### PR DESCRIPTION
## Summary

- add an optional remote profile id for named URL gateway connections
- apply the mapping consistently to REST query parameters and WebSocket JSON-RPC calls
- preserve the existing same-name behavior when no mapping is configured

## Why

A Desktop profile can be a local display and routing label while the connected Hermes backend uses a different physical profile name. SSH connections already model that distinction. Named URL remotes currently send the local Desktop profile id, which can scope sessions, settings, and cron data to the wrong backend profile.

## Testing

- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test:desktop:platforms` (939 passed, 2 skipped)
- `npm run test:ui`
- targeted Electron connection-config tests (79 passed)
- targeted Gateway Settings and RPC profile-routing tests (10 passed)

Platform tested: macOS arm64