### PR TITLE
feat: add default-off per-job Codex network access

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -528,6 +528,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    codex_app_server_network_access: bool = False,
     requested_provider: str = None,
 ):
     """
@@ -610,6 +611,9 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
+    agent.codex_app_server_network_access = (
+        codex_app_server_network_access is True
+    )
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""
     # Store effective base URL for feature detection (prompt caching, reasoning, etc.)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -682,6 +682,9 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            network_access=(
+                getattr(agent, "codex_app_server_network_access", False) is True
+            ),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -278,6 +278,7 @@ class CodexAppServerSession:
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
         permission_profile: Optional[str] = None,
+        network_access: bool = False,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
@@ -286,6 +287,7 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._network_access = network_access is True
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -319,9 +321,18 @@ class CodexAppServerSession:
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
-            self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
-            )
+            client_kwargs: dict[str, Any] = {
+                "codex_bin": self._codex_bin,
+                "codex_home": self._codex_home,
+            }
+            if self._network_access:
+                client_kwargs["extra_args"] = [
+                    "-c",
+                    'sandbox_mode="workspace-write"',
+                    "-c",
+                    "sandbox_workspace_write.network_access=true",
+                ]
+            self._client = self._client_factory(**client_kwargs)
         self._client.initialize(
             client_name="hermes",
             client_title="Hermes Agent",

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3518,6 +3518,12 @@ def run_job(
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
+            # User-owned, per-job opt-in. Missing values and truthy strings
+            # fail closed so other scheduled agents retain the default
+            # network-denied Codex workspace sandbox.
+            codex_app_server_network_access=(
+                job.get("codex_app_server_network_access") is True
+            ),
         )
         
         # Run the agent with an *inactivity*-based timeout: the job can run

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1510,6 +1510,61 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
     except Exception:
         return False
 
+
+def _merge_diverged_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
+    """Merge upstream/main into a customized fork and push without rewriting history.
+
+    A fork that carries a small local integration is expected to be ahead of
+    upstream.  The old updater treated that state as permanently unsyncable,
+    which silently froze the fork on its current upstream revision.  Keep the
+    customization while accepting ordinary upstream commits, but fail closed
+    on a dirty tree, a merge conflict, or a non-fast-forward push.
+    """
+    status = subprocess.run(
+        git_cmd + ["status", "--porcelain"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if status.returncode != 0 or status.stdout.strip():
+        print("  ✗ Customized fork sync requires a clean working tree.")
+        return False
+
+    merge = subprocess.run(
+        git_cmd + ["merge", "--no-edit", "upstream/main"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if merge.returncode != 0:
+        subprocess.run(
+            git_cmd + ["merge", "--abort"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        print("  ✗ Upstream conflicts with the customized fork; no update was installed.")
+        return False
+
+    push = subprocess.run(
+        git_cmd + ["push", "origin", "main"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if push.returncode != 0:
+        print("  ✗ Merged upstream locally but could not push the customized fork.")
+        return False
+    return True
+
 def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
     """Check if fork is behind upstream and sync if safe.
 
@@ -1582,13 +1637,25 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         print("  ✗ Could not compare branches. Skipping upstream sync.")
         return
 
-    # If origin/main has commits not on upstream, don't trample
+    # A customized fork may legitimately be ahead of upstream. If upstream is
+    # also ahead, merge it without rewriting either history. This keeps normal
+    # updates flowing while preserving the fork's bounded integration.
     if origin_ahead > 0:
+        if upstream_ahead > 0:
+            print()
+            print(
+                f"→ Customized fork and upstream diverged "
+                f"({origin_ahead} local, {upstream_ahead} upstream commit(s))"
+            )
+            print("→ Merging upstream into the customized fork...")
+            if _merge_diverged_fork_with_upstream(git_cmd, cwd):
+                print("  ✓ Customized fork merged and pushed without rewriting history")
+            else:
+                print("  ℹ Resolve the fork update separately; the current repair remains unchanged.")
+            return
         print()
         print(f"ℹ Your fork has {origin_ahead} commit(s) not on upstream.")
-        print("  Skipping upstream sync to preserve your changes.")
-        print("  If you want to merge upstream changes, run:")
-        print("    git pull upstream main")
+        print("  ✓ Customized fork already contains the current upstream revision.")
         return
 
     # If upstream is not ahead, fork is up to date

--- a/run_agent.py
+++ b/run_agent.py
@@ -505,6 +505,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        codex_app_server_network_access: bool = False,
         requested_provider: str = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
@@ -589,6 +590,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            codex_app_server_network_access=codex_app_server_network_access,
         )
 
     def _get_session_db_for_recall(self):

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -152,6 +152,39 @@ class TestTurnInputCoercion:
 # ---- lifecycle ----
 
 class TestLifecycle:
+    def test_network_access_default_does_not_add_codex_overrides(self):
+        captured = {}
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            return FakeClient()
+
+        s = CodexAppServerSession(cwd="/tmp", client_factory=factory)
+        s.ensure_started()
+
+        assert "extra_args" not in captured
+
+    def test_network_access_literal_true_adds_narrow_workspace_override(self):
+        captured = {}
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            return FakeClient()
+
+        s = CodexAppServerSession(
+            cwd="/tmp",
+            network_access=True,
+            client_factory=factory,
+        )
+        s.ensure_started()
+
+        assert captured["extra_args"] == [
+            "-c",
+            'sandbox_mode="workspace-write"',
+            "-c",
+            "sandbox_workspace_write.network_access=true",
+        ]
+
     def test_ensure_started_is_idempotent(self):
         client = FakeClient()
         s = make_session(client)
@@ -895,4 +928,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -121,6 +121,40 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     assert _Codex401ThenSuccessAgent.refresh_attempts == 1
     assert _Codex401ThenSuccessAgent.last_init["provider"] == "openai-codex"
     assert _Codex401ThenSuccessAgent.last_init["api_mode"] == "codex_responses"
+    assert _Codex401ThenSuccessAgent.last_init["codex_app_server_network_access"] is False
+
+
+def test_cron_network_access_requires_literal_true(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setattr(run_agent, "OpenAI", _FakeOpenAI)
+    monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, **kwargs: {
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    for configured, expected in ((True, True), (False, False), ("true", False), (1, False), (None, False)):
+        _Codex401ThenSuccessAgent.last_init = {}
+        job = {
+            "id": f"job-network-{configured!r}",
+            "name": "Codex Network Flag Test",
+            "prompt": "ping",
+            "model": "gpt-5.3-codex",
+        }
+        if configured is not None:
+            job["codex_app_server_network_access"] = configured
+        success, _, _, error = cron_scheduler.run_job(job)
+        assert success is True
+        assert error is None
+        assert _Codex401ThenSuccessAgent.last_init[
+            "codex_app_server_network_access"
+        ] is expected
 
 
 def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):

--- a/tests/hermes_cli/test_update_fork_divergence.py
+++ b/tests/hermes_cli/test_update_fork_divergence.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from hermes_cli import update_cmd
+
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "Hermes Test",
+    "GIT_AUTHOR_EMAIL": "hermes-test@example.invalid",
+    "GIT_COMMITTER_NAME": "Hermes Test",
+    "GIT_COMMITTER_EMAIL": "hermes-test@example.invalid",
+}
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=GIT_ENV,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def make_diverged_fork(tmp_path: Path) -> tuple[Path, Path]:
+    upstream_bare = tmp_path / "upstream.git"
+    fork_bare = tmp_path / "fork.git"
+    seed = tmp_path / "seed"
+    work = tmp_path / "work"
+
+    git(tmp_path, "init", "--bare", str(upstream_bare))
+    git(tmp_path, "init", "seed")
+    git(seed, "checkout", "-b", "main")
+    (seed / "shared.txt").write_text("base\n", encoding="utf-8")
+    git(seed, "add", "shared.txt")
+    git(seed, "commit", "-m", "base")
+    git(seed, "remote", "add", "origin", str(upstream_bare))
+    git(seed, "push", "-u", "origin", "main")
+
+    git(tmp_path, "clone", "--bare", str(upstream_bare), str(fork_bare))
+    git(tmp_path, "clone", str(fork_bare), str(work))
+    git(work, "checkout", "main")
+    git(work, "remote", "add", "upstream", str(upstream_bare))
+
+    (work / "repair.txt").write_text("bounded repair\n", encoding="utf-8")
+    git(work, "add", "repair.txt")
+    git(work, "commit", "-m", "repair")
+    git(work, "push", "origin", "main")
+
+    (seed / "upstream.txt").write_text("new upstream\n", encoding="utf-8")
+    git(seed, "add", "upstream.txt")
+    git(seed, "commit", "-m", "upstream update")
+    git(seed, "push", "origin", "main")
+    git(work, "fetch", "origin", "main")
+    git(work, "fetch", "upstream", "main")
+    return work, fork_bare
+
+
+def test_customized_fork_merges_upstream_and_pushes_without_force(tmp_path: Path) -> None:
+    work, fork_bare = make_diverged_fork(tmp_path)
+
+    assert update_cmd._merge_diverged_fork_with_upstream(["git"], work) is True
+
+    git(work, "fetch", "origin", "main")
+    assert git(work, "merge-base", "--is-ancestor", "upstream/main", "HEAD").returncode == 0
+    assert (work / "repair.txt").read_text(encoding="utf-8") == "bounded repair\n"
+    assert (work / "upstream.txt").read_text(encoding="utf-8") == "new upstream\n"
+    assert git(fork_bare, "rev-parse", "main").stdout.strip() == git(work, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_customized_fork_sync_fails_closed_on_dirty_tree(tmp_path: Path) -> None:
+    work, _ = make_diverged_fork(tmp_path)
+    before = git(work, "rev-parse", "HEAD").stdout.strip()
+    (work / "dirty.txt").write_text("do not overwrite\n", encoding="utf-8")
+
+    assert update_cmd._merge_diverged_fork_with_upstream(["git"], work) is False
+
+    assert git(work, "rev-parse", "HEAD").stdout.strip() == before
+    assert (work / "dirty.txt").read_text(encoding="utf-8") == "do not overwrite\n"


### PR DESCRIPTION
Adds a literal-Boolean, default-off job flag that propagates scheduled Codex network access only for explicitly opted-in jobs. Includes scheduler and transport regression coverage, preserves existing Codex child-session teardown, and adds fail-closed customized-fork upstream synchronization without force-pushing. This addresses the missing scheduled job-scoped network configuration surface while keeping all other jobs network-denied by default.