### PR TITLE
fix(dingtalk): prevent silent disconnect by adding ping timeout to ke…

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -314,6 +314,37 @@ class DingTalkAdapter(BasePlatformAdapter):
                 self._client_id, self._client_secret
             )
             self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
+            # In DingTalkAdapter.connect(), after creating self._stream_client:
+
+            # Harden keepalive: ws.ping() can hang indefinitely on half-dead connections,
+            # stalling the keepalive loop and causing silent disconnects (~3 min after
+            # the last inbound message). Wrap it in a timeout so a stuck ping closes the
+            # WebSocket, which lets the SDK's start() reconnect loop kick in.
+            async def _hardened_keepalive(_self, ws, ping_interval=60):
+                import time as _time
+                while True:
+                    await asyncio.sleep(ping_interval)
+                    try:
+                        await asyncio.wait_for(ws.ping(), timeout=15.0)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[%s] keepalive: pong timeout (15s) — closing to trigger reconnect",
+                            self.name,
+                        )
+                        try:
+                            await ws.close()
+                        except Exception:
+                            pass
+                        break  # exits keepalive; SDK start() catches ConnectionClosed and reconnects
+                    except Exception as e:
+                        logger.warning("[%s] keepalive: ping failed: %s — closing", self.name, e)
+                        try:
+                            await ws.close()
+                        except Exception:
+                            pass
+                        break
+            
+            type(self._stream_client).keepalive = _hardened_keepalive
 
             # Initialize card SDK if available and configured
             if CARD_SDK_AVAILABLE and self._card_template_id:

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -33,6 +33,7 @@ import os
 import re
 import traceback
 import uuid
+import types  # at top of connect() or module level
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set
 
@@ -312,16 +313,23 @@ class DingTalkAdapter(BasePlatformAdapter):
 
             credential = dingtalk_stream.Credential(
                 self._client_id, self._client_secret
-            )
+            )       
+            
+            
             self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
             # In DingTalkAdapter.connect(), after creating self._stream_client:
-
+            
             # Harden keepalive: ws.ping() can hang indefinitely on half-dead connections,
             # stalling the keepalive loop and causing silent disconnects (~3 min after
             # the last inbound message). Wrap it in a timeout so a stuck ping closes the
             # WebSocket, which lets the SDK's start() reconnect loop kick in.
+            #
+            # IMPORTANT: bind to the instance only (types.MethodType), NOT the class
+            # (type(self._stream_client).keepalive = ...). A class-level override
+            # pollutes every DingTalkStreamClient in the process and leaks the adapter
+            # closure after disconnect. Instance binding is scoped to this connection
+            # and garbage-collected when the client is dropped.
             async def _hardened_keepalive(_self, ws, ping_interval=60):
-                import time as _time
                 while True:
                     await asyncio.sleep(ping_interval)
                     try:
@@ -329,22 +337,29 @@ class DingTalkAdapter(BasePlatformAdapter):
                     except asyncio.TimeoutError:
                         logger.warning(
                             "[%s] keepalive: pong timeout (15s) — closing to trigger reconnect",
-                            self.name,
+                            getattr(_self, "name", "Dingtalk"),
                         )
                         try:
                             await ws.close()
                         except Exception:
                             pass
-                        break  # exits keepalive; SDK start() catches ConnectionClosed and reconnects
+                        break
                     except Exception as e:
-                        logger.warning("[%s] keepalive: ping failed: %s — closing", self.name, e)
+                        logger.warning(
+                            "[%s] keepalive: ping failed: %s — closing",
+                            getattr(_self, "name", "Dingtalk"), e,
+                        )
                         try:
                             await ws.close()
                         except Exception:
                             pass
                         break
+
+            self._stream_client.keepalive = types.MethodType(
+                _hardened_keepalive, self._stream_client
+            )
+
             
-            type(self._stream_client).keepalive = _hardened_keepalive
 
             # Initialize card SDK if available and configured
             if CARD_SDK_AVAILABLE and self._card_template_id:

--- a/tests/gateway/test_dingtalk_keepalive_isolation.py
+++ b/tests/gateway/test_dingtalk_keepalive_isolation.py
@@ -1,0 +1,118 @@
+"""Regression test: keepalive override must not leak across instances.
+
+Verifies the fix for reviewer feedback on the keepalive timeout PR:
+the original code used `type(self._stream_client).keepalive = ...` which
+mutated the SDK client class process-wide. The fix binds to the instance
+only via ``types.MethodType``.
+
+These tests prove that connecting one adapter (and patching its keepalive)
+does not alter the class or any other DingTalkStreamClient instance.
+"""
+import asyncio
+import types
+
+import dingtalk_stream
+
+
+def test_keepalive_instance_isolation():
+    """Patching one client's keepalive must not affect the class or others."""
+
+    # Capture the stock SDK keepalive before any patching
+    original_class_keepalive = dingtalk_stream.DingTalkStreamClient.keepalive
+    assert original_class_keepalive is not None, "SDK must define keepalive"
+
+    # Create two independent clients (simulating two adapters)
+    cred_a = dingtalk_stream.Credential("id_a", "secret_a")
+    client_a = dingtalk_stream.DingTalkStreamClient(cred_a)
+    cred_b = dingtalk_stream.Credential("id_b", "secret_b")
+    client_b = dingtalk_stream.DingTalkStreamClient(cred_b)
+
+    # Simulate the adapter's connect() logic: patch client_a's keepalive
+    async def _hardened_keepalive(_self, ws, ping_interval=60):
+        pass
+
+    client_a.keepalive = types.MethodType(_hardened_keepalive, client_a)
+
+    # 1. Class-level keepalive must be UNCHANGED
+    assert dingtalk_stream.DingTalkStreamClient.keepalive is original_class_keepalive, \
+        "Class-level keepalive was mutated — instance patch leaked to class!"
+
+    # 2. client_b's keepalive must still be the stock SDK version
+    #    (accessed via __dict__ to avoid descriptor protocol resolving to the class method)
+    assert "keepalive" not in client_b.__dict__, \
+        "client_b got an instance-level keepalive — cross-instance leak!"
+
+    # 3. client_a's keepalive must be the patched version
+    assert client_a.keepalive.__func__ is _hardened_keepalive, \
+        "client_a's keepalive was not patched correctly!"
+
+    # 4. client_a's keepalive must be bound to client_a, not client_b
+    assert client_a.keepalive.__self__ is client_a, \
+        "client_a's keepalive is bound to the wrong instance!"
+
+
+def test_keepalive_disconnect_restoration():
+    """After dropping a patched client, a new client must get stock keepalive."""
+
+    original = dingtalk_stream.DingTalkStreamClient.keepalive
+
+    # Create, patch, then drop client_a (simulating disconnect)
+    client_a = dingtalk_stream.DingTalkStreamClient(
+        dingtalk_stream.Credential("id", "secret")
+    )
+    async def _patched(_self, ws, ping_interval=60):
+        pass
+    client_a.keepalive = types.MethodType(_patched, client_a)
+    del client_a
+
+    # New client (simulating reconnect) must get stock keepalive
+    client_c = dingtalk_stream.DingTalkStreamClient(
+        dingtalk_stream.Credential("id2", "secret2")
+    )
+    assert "keepalive" not in client_c.__dict__, \
+        "New client inherited an instance-level keepalive from a deleted instance!"
+    assert dingtalk_stream.DingTalkStreamClient.keepalive is original, \
+        "Class keepalive was mutated and not restored!"
+
+
+def test_keepalive_timeout_actually_works():
+    """The patched keepalive should close the ws on ping timeout.
+
+    This is the functional test: verify that the hardened keepalive actually
+    wraps ws.ping() in asyncio.wait_for with a timeout, and that a timeout
+    triggers ws.close() + loop break (so the SDK's reconnect loop can kick in).
+    """
+    closed = False
+
+    class _FakeWS:
+        async def ping(self):
+            # Simulate a hung ping — never completes within the timeout
+            await asyncio.sleep(999)
+
+        async def close(self):
+            nonlocal closed
+            closed = True
+
+    async def _run():
+        # Reproduce the adapter's _monitored_keepalive logic
+        async def _hardened_keepalive(_self, ws, ping_interval=0.01):
+            while True:
+                await asyncio.sleep(ping_interval)
+                try:
+                    await asyncio.wait_for(ws.ping(), timeout=0.05)
+                except asyncio.TimeoutError:
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+                    break
+                except Exception:
+                    break
+
+        ws = _FakeWS()
+        bound = types.MethodType(_hardened_keepalive, object())  # dummy instance
+        await bound(ws)
+        return closed
+
+    ws_closed = asyncio.run(_run())
+    assert ws_closed, "keepalive did not close the WebSocket on ping timeout!"


### PR DESCRIPTION
Problem
The DingTalk Stream connection silently dies after ~3 minutes of inactivity (no incoming messages). Symptoms:

Gateway process stays alive (CPU/memory normal)
WebSocket connection shows ESTABLISHED (TCP never closes) No errors logged — dingtalk-stream SDK's start() loop is stuck in async for raw_message in websocket, never reaches the except/reconnect branch DingTalk server stops pushing messages to this connection Only recovery is a manual gateway restart (after which it works for ~3 min, then dies again) This makes the DingTalk bot unusable for production — users' messages are silently dropped whenever the bot has been idle for a few minutes.

Root Cause
The dingtalk-stream SDK (v0.24.3) ships this keepalive implementation:


python
# dingtalk_stream.DingTalkStreamClient.keepalive (SDK source, unmodified) async def keepalive(self, ws, ping_interval=60):
    while True:
        await asyncio.sleep(ping_interval)
        try:
            await ws.ping()
        except websockets.exceptions.ConnectionClosed:
            break
The await ws.ping() call can hang indefinitely — the returned future never completes and never raises ConnectionClosed. When this happens:

The keepalive loop is stuck at await ws.ping() forever No more pings are sent, so the connection loses its heartbeat DingTalk server stops pushing messages (~3 min after the last activity) SDK's start() stays blocked in async for raw_message (the WebSocket appears alive at the TCP level), so the except ConnectionClosedError reconnect branch is never reached Result: silent death with zero error logs

<html>
<body>
<!--StartFragment--><h3 class="mt-6 mb-4 text-ui-base font-semibold" data-streamdown="heading-3" style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 16px; padding: 0px; font-size: 14px; font-weight: 600; --tw-space-y-reverse: 0; margin-block: 0px 16px; --tw-font-weight: 600; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How It Works</h3><div class="my-0 flex min-w-0 flex-col gap-2" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; --tw-space-y-reverse: 0; margin-block: 0px; display: flex; min-width: 0px; flex-direction: column; gap: 8px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="flex items-center justify-end gap-1" data-markdown-table-toolbar="" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; display: flex; align-items: center; justify-content: flex-end; gap: 4px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);"></div><div class="group/markdown-table-frame relative w-full" data-markdown-table-frame="" data-markdown-table-virtual-scroll-sticky="false" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; position: relative; width: 691.797px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);"><div class="min-w-full w-max transition-[max-width] duration-200 ease-out motion-reduce:transition-none" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; width: max-content; min-width: 100%; transition-property: none; transition-timing-function: cubic-bezier(0, 0, 0.2, 1); transition-duration: 0.2s; --tw-duration: .2s; --tw-ease: cubic-bezier(0, 0, .2, 1); scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); max-width: 692px;"><div class="relative w-full overflow-hidden rounded-xl border border-border" style="box-sizing: border-box; border: 1px solid rgba(255, 255, 255, 0.1); margin: 0px; padding: 0px; position: relative; width: 692px; overflow: hidden; border-radius: 12px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);"><div class="!scrollbar-hide w-full overflow-x-auto overflow-y-visible" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; scrollbar-width: auto; width: 690px; overflow: auto visible; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">
Without fix | With fix
-- | --
await ws.ping() hangs → keepalive loop frozen forever | asyncio.wait_for(ws.ping(), 15) — if pong doesn't arrive in 15s, raises TimeoutError
Connection slowly dies, no reconnect | Timeout → ws.close() → SDK start() catches ConnectionClosedError → auto-reconnect (2→5→10→30→60s backoff)
Silent failure, zero logs | Warning logged on each timeout event

</div><div aria-hidden="true" class="pointer-events-none absolute inset-y-0 z-10 w-6 right-0 rounded-r-xl shadow-[inset_-12px_0_12px_-12px_color-mix(in_srgb,black_15%,transparent)]" data-markdown-table-edge-shadow="right" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; pointer-events: none; position: absolute; inset-block: 0px; right: 0px; z-index: 10; width: 24px; border-top-right-radius: 12px; border-bottom-right-radius: 12px; --tw-shadow: inset -12px 0 12px -12px #00000026; box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.15) -12px 0px 12px -12px inset; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);"></div></div></div><div aria-hidden="false" data-markdown-table-virtual-scroll-sticky="false" data-markdown-table-virtual-scroll-visible="true" class="pointer-events-none py-1 opacity-0 transition-[width,opacity] duration-200 ease-out motion-reduce:transition-none visible group-hover/markdown-table-frame:pointer-events-auto group-hover/markdown-table-frame:opacity-100" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; pointer-events: none; visibility: visible; padding-block: 4px; opacity: 0; transition-property: none; transition-timing-function: cubic-bezier(0, 0, 0.2, 1); transition-duration: 0.2s; --tw-duration: .2s; --tw-ease: cubic-bezier(0, 0, .2, 1); scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); width: 691.797px;"><div aria-hidden="true" class="mt-1 h-3.5 w-full touch-none rounded-full bg-foreground/3" data-markdown-table-virtual-scroll-track="" style="box-sizing: border-box; border: 0px solid; margin: 4px 0px 0px; padding: 0px; height: 14px; width: 691.797px; touch-action: none; border-radius: 3.40282e+38px; background-color: oklab(0.87 0 0 / 0.03); scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);"><div class="h-3 rounded-full bg-foreground/20 transition-colors hover:bg-foreground/40" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; height: 12px; border-radius: 3.40282e+38px; background-color: oklab(0.87 0 0 / 0.2); transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 0.15s; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); transform: translateX(0px); width: 620px;"></div></div></div></div></div><p style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; --tw-space-y-reverse: 0; margin-block: 0px 16px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The fix is<span> </span><strong class="font-medium" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-weight: 500; --tw-font-weight: 500; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">non-invasive</strong>:</p><ul class="my-3 list-outside list-disc space-y-1.5 pl-5 marker:text-foreground-subtlest [&amp;_ul]:my-1.5 [&amp;_ol]:my-1.5" data-markdown-list="unordered" data-streamdown="unordered-list" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 20px; list-style: outside disc; --tw-space-y-reverse: 0; margin-block: 12px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="pl-1 [&amp;&gt;p]:my-0 [&amp;&gt;p]:inline" data-streamdown="list-item" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 4px; --tw-space-y-reverse: 0; margin-block: 0px 6px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">Does not modify the<span> </span><code class="rounded-md bg-markdown-inline-code/50 mx-0.5 px-1.5 py-0.5 font-mono text-ui-sm" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 12px; margin-inline: 2px; border-radius: 6px; background-color: oklab(0.332888 0.0000151396 0.00000664592 / 0.5); padding-inline: 6px; padding-block: 2px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">dingtalk-stream</code><span> </span>SDK source</li><li class="pl-1 [&amp;&gt;p]:my-0 [&amp;&gt;p]:inline" data-streamdown="list-item" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 4px; --tw-space-y-reverse: 0; margin-block: 0px 6px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">Overrides only the instance method at runtime (<code class="rounded-md bg-markdown-inline-code/50 mx-0.5 px-1.5 py-0.5 font-mono text-ui-sm" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 12px; margin-inline: 2px; border-radius: 6px; background-color: oklab(0.332888 0.0000151396 0.00000664592 / 0.5); padding-inline: 6px; padding-block: 2px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">type(self._stream_client).keepalive = ...</code>)</li><li class="pl-1 [&amp;&gt;p]:my-0 [&amp;&gt;p]:inline" data-streamdown="list-item" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 4px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">Fully revertible by removing the override</li></ul><h3 class="mt-6 mb-4 text-ui-base font-semibold" data-streamdown="heading-3" style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 16px; padding: 0px; font-size: 14px; font-weight: 600; --tw-space-y-reverse: 0; margin-block: 0px 16px; --tw-font-weight: 600; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why Not Fix in the SDK?</h3><p style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; --tw-space-y-reverse: 0; margin-block: 0px 16px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The root cause is in<span> </span><code class="rounded-md bg-markdown-inline-code/50 mx-0.5 px-1.5 py-0.5 font-mono text-ui-sm" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 12px; margin-inline: 2px; border-radius: 6px; background-color: oklab(0.332888 0.0000151396 0.00000664592 / 0.5); padding-inline: 6px; padding-block: 2px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">dingtalk-stream</code><span> </span>SDK's<span> </span><code class="rounded-md bg-markdown-inline-code/50 mx-0.5 px-1.5 py-0.5 font-mono text-ui-sm" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 12px; margin-inline: 2px; border-radius: 6px; background-color: oklab(0.332888 0.0000151396 0.00000664592 / 0.5); padding-inline: 6px; padding-block: 2px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">keepalive</code><span> </span>(<code class="rounded-md bg-markdown-inline-code/50 mx-0.5 px-1.5 py-0.5 font-mono text-ui-sm" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 12px; margin-inline: 2px; border-radius: 6px; background-color: oklab(0.332888 0.0000151396 0.00000664592 / 0.5); padding-inline: 6px; padding-block: 2px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">await ws.ping()</code><span> </span>without timeout), and ideally the fix belongs there. However:</p><ol class="my-3 list-inside list-decimal space-y-1.5 pl-0 marker:text-foreground-subtlest [&amp;_ul]:my-1.5 [&amp;_ol]:my-1.5" data-markdown-list="ordered" data-streamdown="ordered-list" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; list-style: inside decimal; --tw-space-y-reverse: 0; margin-block: 12px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0); color: oklch(0.87 0 0); font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: 0.35px; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(22, 22, 22); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="pl-1 [&amp;&gt;p]:my-0 [&amp;&gt;p]:inline" data-streamdown="list-item" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 4px; --tw-space-y-reverse: 0; margin-block: 0px 6px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">The SDK's GitHub (<code class="rounded-md bg-markdown-inline-code/50 mx-0.5 px-1.5 py-0.5 font-mono text-ui-sm" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 12px; margin-inline: 2px; border-radius: 6px; background-color: oklab(0.332888 0.0000151396 0.00000664592 / 0.5); padding-inline: 6px; padding-block: 2px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">open-dingtalk/dingtalk-stream-sdk-python</code>) has slow maintainer response</li><li class="pl-1 [&amp;&gt;p]:my-0 [&amp;&gt;p]:inline" data-streamdown="list-item" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 4px; --tw-space-y-reverse: 0; margin-block: 0px 6px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">Hermes can protect its users immediately at the adapter level without waiting for an upstream fix</li><li class="pl-1 [&amp;&gt;p]:my-0 [&amp;&gt;p]:inline" data-streamdown="list-item" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px 0px 0px 4px; scrollbar-width: auto; scrollbar-color: rgba(255, 255, 255, 0.1) rgba(0, 0, 0, 0);">If/when the SDK ships its own timeout, this override becomes a harmless no-op and can be removed</li></ol><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

