### PR TITLE
investigate(cache): compression-rotation cache-scope gap -- needs maintainer design decision

### DIFF
--- a/tests/design/test_cache_scope_compression_rotation_gap.py
+++ b/tests/design/test_cache_scope_compression_rotation_gap.py
@@ -1,0 +1,51 @@
+"""Standalone design-gap reproduction for issue #79017.
+
+Not a fix, and not exercising production code -- #78959 (the PR that
+introduces the actual `_cache_scope_from_session_id` scoping concept this
+test is about) hasn't merged yet, so there is nothing in `main` to import.
+
+This file inlines a minimal reference copy of the scoping rule #78959
+proposes, purely to demonstrate -- self-contained, reviewable on `main`
+today, with zero dependency on that PR's merge state -- why "scope by
+physical session_id" alone is insufficient once you add context-compression
+rotation to the picture. See #79017 for the full design discussion.
+
+Once #78959 merges, this can be deleted or repointed at the real
+`agent.transports.codex._cache_scope_from_session_id` -- whichever
+maintainers prefer.
+"""
+
+import re
+
+import pytest
+
+_CRON_SESSION_ID_RE = re.compile(r"^(cron_.+)_\d{8}_\d{6}$")
+
+
+def _cache_scope_from_session_id(session_id: str) -> str:
+    """Mirrors the scoping rule proposed in #78959: pass non-cron session
+    ids through unchanged; strip only cron's per-fire timestamp."""
+    match = _CRON_SESSION_ID_RE.match(session_id or "")
+    return match.group(1) if match else (session_id or "")
+
+
+@pytest.mark.xfail(
+    reason="#79017: scoping by physical session_id alone has no concept of "
+    "a logical conversation identity distinct from the physical id, so a "
+    "context-compression rotation (which mints a new physical session_id "
+    "mid-conversation) always breaks cache-scope continuity. Needs a design "
+    "decision (a separate logical cache-scope), not a one-line fix.",
+    strict=True,
+)
+def test_compression_rotation_preserves_cache_scope():
+    root_session = "session-root-abc123"
+    # A compression rotation mints a new physical session_id for the same
+    # logical conversation (see agent/conversation_compression.py).
+    rotated_session = "session-rotated-def456"
+
+    root_scope = _cache_scope_from_session_id(root_session)
+    rotated_scope = _cache_scope_from_session_id(rotated_session)
+
+    # Desired behavior once #79017 lands: the rotated segment of the SAME
+    # conversation should keep the same cache scope as its root.
+    assert root_scope == rotated_scope


### PR DESCRIPTION
## Summary

Relates to #79017. Not a fix -- a standalone, self-contained reproduction for maintainer input on whether/how to pursue it. One file, no dependency on #78959's merge state (that PR introduces the actual scoping code this test is *about*; this file inlines a minimal reference copy purely so it's reviewable on `main` today).

`_cache_scope_from_session_id()` (proposed in #78959, closing #78941) scopes `prompt_cache_key` by the **physical** `session_id`. Correct for isolating unrelated sessions and for cron re-fires of the same job. But context-compression rotation mints a **new physical `session_id` mid-conversation** to segment the transcript, so the same logical conversation goes cache-cold at every rotation boundary.

## What this PR adds

One `xfail(strict=True)` test (`tests/design/test_cache_scope_compression_rotation_gap.py`) that documents the gap in runnable form and fails loudly if anyone tries to close it without a matching design.

## Why no fix is proposed here

A real fix needs a new concept -- a **logical cache-scope** (conversation identity) distinct from both the physical session id and provider sticky-routing keys:

| Identity | Role | Changes on |
|---|---|---|
| Physical session/transcript id | One execution/segment | `/new`, branch, compression rotation |
| Logical cache-scope (proposed) | Stable prompt-cache bucket | `/new`, branch, independent subagent -- **not** rotation |
| Provider sticky-routing (OpenRouter `session_id`, xAI `x-grok-conv-id`) | Pins requests to the warm backend | Per-provider contract |

Threading that scope through the compression/rotation/branch code paths (and NOT reusing `gateway_session_key` or a generic conversation-root walk, both of which outlive `/new` or cross branch boundaries incorrectly) is a design task, not a diff this PR wants to force through unreviewed.

## Ask

Maintainer call on:
1. Is this worth fixing, given it only costs one cold cache-prefix per rotation (relatively rare)?
2. If yes, does the logical-cache-scope shape above look right before someone implements it?

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Conversation Turn 1<br/>session-root] -->|Compression Threshold Hit| B[Rotation Event]
    B --> C[Conversation Turn 2<br/>session-rotated]

    A -->|scope = session-root| D[Cache Bucket: pck_root_hash]
    C -->|scope = session-rotated| E[Cache Bucket: pck_rotated_hash]

    D -. Same Logical Conversation .-> E
    D -->|Rotation Boundary| F[Cold Cache: Warm Prefix Lost]
    E --> F

    style F fill:#8b0000,stroke:#ff0038,color:#ffccd5
    style D fill:#3a0000,stroke:#ff0038,color:#ffccd5
    style E fill:#3a0000,stroke:#ff0038,color:#ffccd5
```

## Test plan

- [x] `pytest tests/design/test_cache_scope_compression_rotation_gap.py -v` -> 1 xfailed (expected; strict, will error if it starts passing without a matching design)
- [x] Zero dependency on other open PRs or unmerged code -- applies cleanly to `main` as-is

Relates to #79017 (design decision, not code fix).