### PR TITLE
fix: never crash lifecycle guard on NUL-byte paths from binaries

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: missing/unreadable. ValueError: embedded NUL byte — a
+        # path tokenized out of decoded binary content (see #76762); such
+        # a path can never name a real file. Both mean "nothing to scan".
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -275,11 +278,15 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
     # PE), not a shell script — scanning its decoded contents would
     # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
+    # (including a `ValueError: embedded null byte` from Path.resolve /
+    # os.open, #76762). Treat it as "nothing to scan" rather than unsafe:
+    # a binary executed by the user is not a referenced *shell script*.
     if b"\x00" in data:
-        return None, False
+        # Return "" rather than None: the caller's `script_text is None`
+        # branch would otherwise fall back to read_remote_script() and
+        # re-fetch the raw bytes as text, tokenizing machine code into
+        # NUL-byte paths that crash the guard (#76762).
+        return "", False
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
     return data.decode("utf-8", errors="replace"), False

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -9,6 +9,7 @@ Covers:
 import json
 import os
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
@@ -387,6 +388,79 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
+
+    def test_nul_byte_path_read_skipped(self):
+        """#76762: a path with an embedded NUL byte (tokenized out of decoded
+        binary content) must be treated as nothing-to-scan, not crash."""
+        from cron.lifecycle_guard import _read_referenced_script
+
+        text, unsafe = _read_referenced_script(Path("bad\x00path"))
+
+        assert text is None
+        assert unsafe is False
+
+    def test_binary_read_returns_empty_not_none(self, tmp_path):
+        """A binary referenced by a command must be skipped by the local scan
+        (returns "" rather than None) so the caller's remote-read fallback is
+        not triggered for it (#76762)."""
+        from cron.lifecycle_guard import _read_referenced_script
+
+        binary = tmp_path / "tool.bin"
+        binary.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 64)
+
+        text, unsafe = _read_referenced_script(binary)
+
+        assert text == ""
+        assert unsafe is False
+
+    def test_binary_referenced_script_passes_guard(self, monkeypatch, tmp_path):
+        """A command referencing a local ELF binary passes the guard (no
+        remote re-fetch of the binary as text) and executes normally."""
+        import tools.terminal_tool as tt
+
+        binary = tmp_path / "tool.bin"
+        binary.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 64)
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {binary}"))
+
+        assert result["exit_code"] == 0
+        assert calls == [f"/bin/bash {binary}"]
+
+    def test_binary_remote_content_does_not_crash_guard(self, monkeypatch):
+        """A script missing locally is fetched through the env's shell; when
+        that content is raw binary, NUL-byte paths tokenized from it must be
+        skipped, not crash the guard (#76762)."""
+        import tools.terminal_tool as tt
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                if "remote-tool.bin" in command:
+                    return {
+                        "output": "#!/bin/sh\nrestart the app\n\x00\x01\x02/usr/bin/tool\x00",
+                        "returncode": 0,
+                    }
+                return {"output": "", "returncode": 1}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(
+            command="/bin/bash /nonexistent/remote-tool.bin"
+        ))
+
+        assert result["exit_code"] == 0
 
     def test_relative_script_uses_live_session_cwd(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt


### PR DESCRIPTION
## Summary

`cron/lifecycle_guard.py` — the gateway lifecycle guard — crashes with `ValueError: embedded null byte` when a terminal command references a binary executable (any executable whose path contains a slash). Inside a gateway process this takes down every guarded terminal call, e.g. `uv pip install ...` or `python -c ...`, with the raw traceback surfaced as the tool error.

## Root cause

1. `_iter_referenced_shell_scripts` treats any executable containing a `/` as a script to scan.
2. `_read_referenced_script` reads the first chunk and deliberately skips binaries (NUL bytes) by returning `(None, False)`.
3. `_contains_unsafe_gateway_action` interprets `script_text is None` as "file missing" and calls `read_remote_script` — which re-fetches the file's raw bytes as text (via the `cat` fallback in `_read_script_in_env`).
4. The decoded binary content is tokenized as shell; a token containing a NUL byte becomes a `Path`, and `_read_referenced_script`'s `os.open(path)` raises `ValueError: embedded null byte` — uncaught, because the existing #76762 guard only wrapped `Path.resolve()`.

## Fix

- **Safety net:** `os.open` now catches `(OSError, ValueError)` and returns `(None, False)` — a guarded path must never crash the guard.
- **Root cause:** the binary skip now returns `("", False)` instead of `(None, False)`, so the remote-read fallback (keyed on `script_text is None`) is never triggered for content that was deliberately skipped as non-script.

## Verification

- 86/86 tests pass in `tests/hermes_cli/test_gateway_restart_loop.py`, including 4 new regression tests:
  - a NUL-byte path is skipped by the read, not crashed on
  - a binary referenced script returns `""` (not `None`)
  - a command referencing a local binary passes the guard and executes normally
  - binary content returned by the remote-read fallback does not crash the guard
- Live on a gateway process: `python -c "print(1)"` and `uv pip list` previously crashed with the ValueError; after the fix they execute normally, while blocking of `hermes gateway restart` / `launchctl submit` still holds.

Related: #76762 (a guarded path must never crash the guard), #30719 (original restart-loop defense).
