### PR TITLE
fix(cron): prevent lifecycle guard crash on binary remote-read paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -114,7 +114,11 @@ _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
-    normalized = command.replace("\\\n", "")
+    # NUL bytes can leak into tokens when a scanned script's binary contents
+    # are decoded and tokenized as paths (see #76762). They are never valid
+    # shell characters; stripping them here keeps every downstream Path()
+    # construction crash-free (`ValueError: embedded null byte`).
+    normalized = command.replace("\\\n", "").replace("\x00", "")
     for line in normalized.splitlines() or [normalized]:
         try:
             lexer = shlex.shlex(
@@ -258,7 +262,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: embedded NUL byte in path when decoded binary content
+        # is tokenized as a command line. A guarded path must never crash
+        # the guard (#76762).
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -325,8 +332,18 @@ def _contains_unsafe_gateway_action(
         if unsafe:
             return True
         if script_text is None and read_remote_script is not None:
-            # Local path missing; try the remote backend if one is available.
+            # Local path missing or deliberately skipped as binary; try the
+            # remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+            # The callback has no binary detection: it reads via `cat` and
+            # decodes with errors="replace". NUL bytes survive decoding, so
+            # without this check the remote branch undoes the protection
+            # _read_referenced_script established above — machine code gets
+            # tokenized, linker paths yield NUL-bearing candidates, and
+            # os.open raises. Same rule as the local read (#76762): a binary
+            # is "nothing to scan", not a suspicion.
+            if script_text and "\x00" in script_text[:_MAX_REFERENCED_SCRIPT_BYTES]:
+                script_text = None
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's
@@ -374,7 +391,7 @@ def _resolve_script_path(script_path: str) -> Path:
     """
     from hermes_constants import get_hermes_home
 
-    raw = Path(script_path).expanduser()
+    raw = Path(script_path.replace("\x00", "")).expanduser()
     if raw.is_absolute():
         return raw
     return get_hermes_home() / "scripts" / raw

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -823,6 +823,69 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         assert "referenced script" in result["error"]
         assert any("cat" in c for c in calls)
 
+    def test_remote_read_of_binary_does_not_crash_the_guard(self, tmp_path):
+        """A binary read through the remote callback is 'nothing to scan'.
+
+        _read_referenced_script skips binaries locally (NUL byte in the first
+        chunk) and returns None. That None falls through to the remote
+        callback, which reads via ``cat`` and decodes with errors="replace" —
+        NUL bytes survive. The decoded machine code is then tokenized as a
+        command line, linker paths produce NUL-bearing candidates, and os.open
+        raises ValueError: embedded null byte. The guard must not crash (#76762).
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script as guard,
+        )
+
+        binary = tmp_path / "chrome"
+        binary.write_bytes(
+            b"\x7fELF\x02\x01\x01\x00"
+            + b"\x00" * 32
+            + b"/lib64/ld-linux-x86-64.so.2\x00libc.so.6\x00"
+        )
+        binary.chmod(0o755)
+
+        def read_remote(path):
+            try:
+                with open(path, "rb") as handle:
+                    return handle.read(200_000).decode("utf-8", errors="replace")
+            except OSError:
+                return None
+
+        assert guard(f"{binary} --version", read_remote_script=read_remote) is False
+
+    def test_shell_script_referencing_system_binary_does_not_crash_guard(
+        self, tmp_path
+    ):
+        """Regression for godmode-bus scripts that invoke /usr/bin/flock etc.
+
+        A shell script referencing a system binary must not crash the gateway
+        lifecycle guard when the remote-read callback is active (the path
+        terminal_tool.py uses inside _HERMES_GATEWAY sessions).
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script as guard,
+        )
+
+        script = tmp_path / "watchdog.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            "exec 9>\"$LOCK\"\n"
+            "/usr/bin/flock -n 9 || exit 0\n"
+        )
+        script.chmod(0o755)
+
+        def read_remote(path):
+            try:
+                with open(path, "rb") as handle:
+                    return handle.read(200_000).decode("utf-8", errors="replace")
+            except OSError:
+                return None
+
+        assert (
+            guard(f"bash {script}", read_remote_script=read_remote) is False
+        )
+
 
 class TestCronCreateLifecycleBlockExtra:
     """Additional cron create lifecycle guard coverage."""


### PR DESCRIPTION
## Summary

- Fixes `ValueError: embedded null byte` crash in `cron/lifecycle_guard.py` when the gateway terminal tool scans shell scripts that reference system binaries (e.g. `/usr/bin/flock` in `godmode-bus/bin/disk-watchdog.sh`)
- Root cause: `_read_referenced_script` correctly skips local binary reads, but the `read_remote_script` callback (used by `terminal_tool.py` in `_HERMES_GATEWAY` sessions) decodes ELF contents with NUL bytes intact; tokenizing that machine code produced paths with embedded NULs, crashing `os.open`
- Workaround before fix: copy script to `/tmp` first (bypasses the recursive binary scan path)

## Fix (3 defensive layers, same class as #76762)

| Site | Change |
|---|---|
| `_iter_command_segments()` | Strip `\x00` before tokenization |
| `_read_referenced_script()` | `except (OSError, ValueError)` at `os.open` |
| `_contains_unsafe_gateway_action()` | Skip remote-read content containing NUL bytes |
| `_resolve_script_path()` | NUL-strip before `Path()` construction |

## Test plan

- [x] `tests/hermes_cli/test_gateway_restart_loop.py` — **84 passed**
- [x] New regression: `test_remote_read_of_binary_does_not_crash_the_guard` (ELF via remote callback)
- [x] New regression: `test_shell_script_referencing_system_binary_does_not_crash_guard` (flock-shaped godmode-bus script)
- [x] Manual repro: `bash ~/godmode-bus/bin/disk-watchdog.sh` with `read_remote_script` callback → no crash


Made with [Cursor](https://cursor.com)