### PR TITLE
fix(gateway): do not resend a message the platform rate-limited

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5075,17 +5075,28 @@ class BasePlatformAdapter(ABC):
         if not is_network and self._is_timeout_error(error_str):
             return result
 
+        # Server-requested backoff (HTTP 429 / Telegram FloodWait) is
+        # delivery-ambiguous for the same reason a timeout is: the platform
+        # commonly ACCEPTS the message and rate-limits the acknowledgement, so
+        # re-sending puts a second full copy in the chat. The adapter already
+        # refuses its own internal resend on this error for that exact reason;
+        # retrying here just relocates the duplicate. Return the failure so the
+        # single copy the platform already holds stays the only one.
+        if result.retry_after is not None:
+            logger.warning(
+                "[%s] Send hit server rate limit (retry_after=%.1fs); not "
+                "resending — the message may already have been delivered: %s",
+                self.name, result.retry_after, error_str,
+            )
+            return result
+
         if is_network:
-            # Retry with exponential backoff for transient errors.
-            # Honor server-requested retry_after (e.g. Telegram FloodWait)
-            # when present — it is authoritative over our backoff schedule.
-            server_retry_after = result.retry_after
+            # Retry with exponential backoff for transient errors. A
+            # server-requested retry_after never reaches here — both the
+            # pre-loop check above and the in-loop check below return on it
+            # rather than resending, so there is no server schedule to honor.
             for attempt in range(1, max_retries + 1):
-                if server_retry_after is not None:
-                    delay = server_retry_after + random.uniform(0, 1)
-                    server_retry_after = None  # only honor once per send
-                else:
-                    delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
+                delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
                 logger.warning(
                     "[%s] Send failed (attempt %d/%d, retrying in %.1fs): %s",
                     self.name, attempt, max_retries, delay, error_str,
@@ -5102,7 +5113,14 @@ class BasePlatformAdapter(ABC):
                     return result
                 error_str = result.error or ""
                 if result.retry_after is not None:
-                    server_retry_after = result.retry_after
+                    # Same duplicate risk as the pre-loop check above: the
+                    # platform may already hold this message. Stop resending.
+                    logger.warning(
+                        "[%s] Send hit server rate limit on retry %d "
+                        "(retry_after=%.1fs); not resending: %s",
+                        self.name, attempt, result.retry_after, error_str,
+                    )
+                    return result
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -169,13 +169,23 @@ class TestSendWithRetryFallback:
 
 
 # ---------------------------------------------------------------------------
-# _send_with_retry — retry_after honor
+# _send_with_retry — server-requested backoff is NOT resent
 # ---------------------------------------------------------------------------
 
 class TestSendWithRetryAfter:
+    """A server-requested backoff (HTTP 429 / Telegram FloodWait) must not be
+    resent.
+
+    Contract change: these previously asserted that ``retry_after`` merely
+    *paced* a retry. In production that resent the whole message and delivered
+    two copies — Telegram accepts the message and rate-limits the ACK, so the
+    429 is not proof of non-delivery. ``retry_after`` is now treated as
+    delivery-ambiguous, exactly like a timeout.
+    """
+
     @pytest.mark.asyncio
-    async def test_retry_after_honored_on_first_retry(self):
-        """When the initial result has retry_after, the first retry waits that long."""
+    async def test_retry_after_is_not_resent(self):
+        """A 429 with retry_after sends exactly once — no duplicate copy."""
         adapter = _StubAdapter()
         adapter._send_results = [
             SendResult(success=False, error="Flood control exceeded. Retry in 37 seconds",
@@ -184,14 +194,13 @@ class TestSendWithRetryAfter:
         ]
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=2.0)
-        assert result.success
-        # First sleep should use retry_after (~37s + jitter), not base_delay (~2s)
-        first_sleep = mock_sleep.call_args_list[0][0][0]
-        assert first_sleep >= 36.0  # 37 - 1 (max jitter)
+        assert not result.success
+        assert len(adapter._send_calls) == 1, "flood control must not resend"
+        assert mock_sleep.call_count == 0
 
     @pytest.mark.asyncio
-    async def test_retry_after_from_subsequent_result(self):
-        """If a retry itself returns retry_after, the next retry honors it."""
+    async def test_retry_after_on_a_later_attempt_stops_resending(self):
+        """A retryable network error still retries, but a 429 on that retry stops it."""
         adapter = _StubAdapter()
         adapter._send_results = [
             SendResult(success=False, error="ConnectError", retryable=True),
@@ -199,10 +208,19 @@ class TestSendWithRetryAfter:
                        retryable=True, retry_after=30.0),
             SendResult(success=True, message_id="ok"),
         ]
-        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-            result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=2.0)
+        result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=0.0)
+        assert not result.success
+        assert len(adapter._send_calls) == 2, "must stop at the 429, not send a third copy"
+
+    @pytest.mark.asyncio
+    async def test_plain_network_error_still_retries(self):
+        """The guard is scoped to retry_after — ordinary transient errors still retry."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="ConnectError", retryable=True),
+            SendResult(success=True, message_id="ok"),
+        ]
+        result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0.0)
         assert result.success
-        # Second sleep should use the retry_after from the second result
-        second_sleep = mock_sleep.call_args_list[1][0][0]
-        assert second_sleep >= 29.0  # 30 - 1 (max jitter)
+        assert len(adapter._send_calls) == 2
 


### PR DESCRIPTION
A `429` with a server-requested `retry_after` is not proof of non-delivery. Telegram commonly ACCEPTS the message and rate-limits the acknowledgement, so `_send_with_retry` re-sending the whole payload puts a second full copy in the chat.

Observed in a live gateway log, one user turn:

```
sendRichMessage transient failure (no legacy resend): Flood control exceeded. Retry in 13 seconds
Send failed (attempt 1/2, retrying in 13.7s)
Send succeeded on retry 1
```

One `Sending response (1700 chars)`, two identical messages delivered to the chat.

## Cause

The Telegram adapter already refuses its own internal legacy-resend on this exact error, for this exact reason:

```python
# Transient / network / unknown: the request may have reached
# Telegram. Do NOT legacy-resend (duplicate risk)
```

It then returns `retryable=True` with the parsed `retry_after`, which hands the same duplicate risk to the shared retry layer in `gateway/platforms/base.py` — which re-sends the whole message. The adapter closed the door and the base layer opened it again.

## Change

Treat `retry_after` as delivery-ambiguous, the way a timeout already is. `_send_with_retry` returns the failure instead of resending, in both the pre-loop check and the in-loop check (a 429 can arrive on a later attempt after a genuine `ConnectError`).

That makes the first-send `server_retry_after` pacing branch unreachable, so it is removed rather than left as dead code.

Fixed in the shared base adapter rather than in Telegram: every platform that reports `retry_after` routes through this one path.

Ordinary transient errors (`ConnectError` and friends) retry exactly as before — the guard is scoped to a server-requested backoff.

## Tests

`TestSendWithRetryAfter` previously asserted that `retry_after` merely *paced* a retry, which is the bug encoded as a contract, so those two cases are rewritten to assert send-count instead:

- `test_retry_after_is_not_resent` — 429 sends exactly once
- `test_retry_after_on_a_later_attempt_stops_resending` — `ConnectError` still retries, the 429 on that retry stops it (no third copy)
- `test_plain_network_error_still_retries` — new, pins that the guard did not disable ordinary retries

Both rewritten tests were confirmed to **fail on unpatched code** before the fix was trusted, reproducing the duplicate (`assert not result.success` / `AssertionError: assert not True`).

```
tests/gateway/test_send_retry.py                 13 passed
+ 21 sibling _send_with_retry tests (slack, ephemeral, photon overflow)  24 passed
```

The suite also drops 32.13s → 1.16s, because the old tests were really sleeping through the flood waits they asserted on.

Not run: the full `tests/gateway` suite is red at baseline in this environment (213 failed / 1389 errors on an unmodified checkout), so its totals carry no signal. Three `test_telegram_thread_fallback` cases fail when the `_send_with_retry` files are run as one batch — they fail identically on unpatched code and pass in isolation, so that is a pre-existing cross-test state leak, not this change.
