### PR TITLE
feat(honcho): consolidate memory at session end instead of by hand

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1399,6 +1399,14 @@ class HonchoMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.debug("Honcho session-end flush failed: %s", e)
 
+        # Consolidate after the flush so the dream sees this session's messages.
+        # Opt-in (autoDream), throttled, dispatched on a daemon thread — it must
+        # never delay shutdown or surface an error into the user's session.
+        try:
+            self._manager.maybe_schedule_dream()
+        except Exception as e:
+            logger.debug("Honcho auto-dream skipped: %s", e)
+
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return tool schemas, respecting recall_mode.
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -396,6 +396,14 @@ class HonchoClientConfig:
     # Dialectic (peer.chat) settings
     # reasoning_level: "minimal" | "low" | "medium" | "high" | "max"
     dialectic_reasoning_level: str = "low"
+    # When true, ask Honcho to consolidate memory (dream) at session end.
+    # Server-side auto-dream requires a stretch of idle time that an actively
+    # used install rarely reaches, so conclusions otherwise accumulate raw
+    # until someone remembers to run ``hermes honcho dream``.
+    auto_dream: bool = False
+    # Minimum seconds between auto-dreams. Dreaming is heavy server-side work;
+    # the default matches Honcho's own elapsed-time threshold.
+    auto_dream_min_interval_seconds: int = 28800  # 8h
     # When true, the model can override reasoning_level per-call via the
     # honcho_reasoning tool param (agentic). When false, always uses
     # dialecticReasoningLevel and ignores model-provided overrides.
@@ -630,6 +638,16 @@ class HonchoClientConfig:
                 host_block.get("dialecticReasoningLevel")
                 or raw.get("dialecticReasoningLevel")
                 or "low"
+            ),
+            auto_dream=_resolve_bool(
+                host_block.get("autoDream"),
+                raw.get("autoDream"),
+                default=False,
+            ),
+            auto_dream_min_interval_seconds=_parse_int_config(
+                host_block.get("autoDreamMinIntervalSeconds"),
+                raw.get("autoDreamMinIntervalSeconds"),
+                default=28800,
             ),
             dialectic_dynamic=_resolve_bool(
                 host_block.get("dialecticDynamic"),

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -7,6 +7,8 @@ import queue
 import re
 import logging
 import threading
+import time
+from pathlib import Path
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, TYPE_CHECKING
@@ -544,6 +546,89 @@ class HonchoSessionManager:
                         self._flush_session(item)
                 except queue.Empty:
                     break
+
+    def maybe_schedule_dream(self) -> bool:
+        """Ask Honcho to consolidate memory, at most once per interval.
+
+        Dreaming is what turns raw conclusions into a deduplicated,
+        contradiction-resolved representation and refreshes the peer card.
+        Server-side auto-dream only fires when ALL of these hold: enough new
+        conclusions, enough elapsed time, AND a stretch of idle time. On an
+        actively used install the idle condition rarely holds, so conclusions
+        accumulate unconsolidated and the only remedy is remembering to run
+        ``hermes honcho dream`` by hand.
+
+        Best-effort and deliberately quiet: never raises, never blocks shutdown
+        (dispatched on a daemon thread), and throttled by a stamp file so a burst
+        of short sessions cannot queue a burst of dreams.
+
+        Returns:
+            True if a dream was dispatched, False if skipped (disabled,
+            throttled, or no client available).
+        """
+        cfg = self._config
+        if cfg is None or not getattr(cfg, "auto_dream", False):
+            return False
+
+        # Prefer the already-resolved client: this runs at shutdown, where
+        # re-resolving the singleton can fail on a missing key and is not worth
+        # raising over for a best-effort consolidation.
+        client = self._honcho
+        if client is None:
+            try:
+                client = self.honcho
+            except Exception as e:
+                logger.debug("Honcho auto-dream: client unavailable: %s", e)
+                return False
+        if client is None:
+            return False
+
+        interval = max(0, int(getattr(cfg, "auto_dream_min_interval_seconds", 28800)))
+        stamp = self._auto_dream_stamp_path()
+        now = time.time()
+        if interval > 0 and stamp is not None:
+            try:
+                if (now - float(stamp.read_text().strip())) < interval:
+                    return False
+            except (OSError, ValueError):
+                # No stamp yet, or unreadable: treat as due rather than never
+                # dreaming at all.
+                pass
+
+        observer = getattr(cfg, "peer_name", None) or "user"
+        observed = getattr(cfg, "ai_peer", None) or None
+
+        def _dream() -> None:
+            try:
+                client.schedule_dream(observer=observer)
+                if observed and observed != observer:
+                    client.schedule_dream(observer=observer, observed=observed)
+                logger.info(
+                    "Honcho auto-dream scheduled (observer=%s, observed=%s)",
+                    observer, observed,
+                )
+            except Exception as e:
+                logger.debug("Honcho auto-dream failed to schedule: %s", e)
+
+        # Stamp BEFORE dispatch: sessions ending in quick succession must not
+        # each queue a dream while the first request is still in flight.
+        if stamp is not None:
+            try:
+                stamp.parent.mkdir(parents=True, exist_ok=True)
+                stamp.write_text(str(now))
+            except OSError as e:
+                logger.debug("Honcho auto-dream stamp write failed: %s", e)
+
+        threading.Thread(target=_dream, name="honcho-auto-dream", daemon=True).start()
+        return True
+
+    def _auto_dream_stamp_path(self) -> Path | None:
+        try:
+            from hermes_constants import get_hermes_home
+
+            return Path(get_hermes_home()) / "honcho-auto-dream.stamp"
+        except Exception:
+            return None
 
     def _ensure_async_writer(self) -> None:
         """Start the async writer on first enqueue (idempotent, thread-safe)."""

--- a/tests/plugins/memory/test_honcho_auto_dream.py
+++ b/tests/plugins/memory/test_honcho_auto_dream.py
@@ -154,3 +154,58 @@ def test_single_peer_setup_does_not_dream_against_itself(tmp_path, monkeypatch):
     )
     m.maybe_schedule_dream()
     assert client.calls == [{"observer": "kai"}], "no self-targeted second dream"
+
+
+
+def test_provider_session_end_triggers_the_dream(tmp_path, monkeypatch):
+    """The unit tests call maybe_schedule_dream() directly; this proves the
+    PROVIDER actually reaches it from on_session_end, which is the only path
+    that runs in production.
+    """
+    import plugins.memory.honcho as honcho_pkg
+
+    provider_cls = honcho_pkg.HonchoMemoryProvider
+
+    client = _FakeClient()
+    mgr = HonchoSessionManager(honcho=client, config=_config())
+    monkeypatch.setattr(mgr, "_auto_dream_stamp_path", lambda: tmp_path / "s")
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session.threading.Thread",
+        lambda target, name=None, daemon=None: _InlineThread(target),
+    )
+
+    p = provider_cls.__new__(provider_cls)
+    p._cron_skipped = False
+    p._manager = mgr
+    p._session_initialized = True
+    p._init_thread = None
+    p._sync_thread = None
+
+    p.on_session_end([{"role": "user", "content": "x"}] * 20)
+
+    assert client.calls == [
+        {"observer": "kai"},
+        {"observer": "kai", "observed": "hermes"},
+    ], "on_session_end must reach schedule_dream"
+
+
+def test_provider_session_end_respects_the_off_switch(tmp_path, monkeypatch):
+    """Negative control for the test above: same path, autoDream off, silence."""
+    import plugins.memory.honcho as honcho_pkg
+
+    provider_cls = honcho_pkg.HonchoMemoryProvider
+
+    client = _FakeClient()
+    mgr = HonchoSessionManager(honcho=client, config=_config(auto_dream=False))
+    monkeypatch.setattr(mgr, "_auto_dream_stamp_path", lambda: tmp_path / "s")
+
+    p = provider_cls.__new__(provider_cls)
+    p._cron_skipped = False
+    p._manager = mgr
+    p._session_initialized = True
+    p._init_thread = None
+    p._sync_thread = None
+
+    p.on_session_end([{"role": "user", "content": "x"}] * 20)
+
+    assert client.calls == [], "autoDream=False must keep the session-end path silent"

--- a/tests/plugins/memory/test_honcho_auto_dream.py
+++ b/tests/plugins/memory/test_honcho_auto_dream.py
@@ -1,0 +1,156 @@
+"""Tests for Honcho session-end auto-dream.
+
+Every positive case is paired with a negative control: a hook that always fires
+is indistinguishable from one that fires for the wrong reason.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+class _InlineThread:
+    """Run the thread body inline so assertions are deterministic."""
+
+    def __init__(self, target):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import HonchoSessionManager
+
+
+class _FakeClient:
+    def __init__(self, fail: bool = False):
+        self.calls: list[dict] = []
+        self.fail = fail
+
+    def schedule_dream(self, **kwargs):
+        if self.fail:
+            raise RuntimeError("honcho unreachable")
+        self.calls.append(kwargs)
+
+
+def _config(
+    *,
+    auto_dream: bool = True,
+    auto_dream_min_interval_seconds: int = 28800,
+    peer_name: str = "kai",
+    ai_peer: str = "hermes",
+) -> HonchoClientConfig:
+    """Real config object, so a field rename breaks these tests loudly."""
+    return HonchoClientConfig(
+        auto_dream=auto_dream,
+        auto_dream_min_interval_seconds=auto_dream_min_interval_seconds,
+        peer_name=peer_name,
+        ai_peer=ai_peer,
+    )
+
+
+@pytest.fixture()
+def mgr(tmp_path, monkeypatch):
+    """Manager wired to a fake client, with the stamp isolated to tmp_path."""
+    client = _FakeClient()
+    m = HonchoSessionManager(honcho=client, config=_config())
+    monkeypatch.setattr(
+        m, "_auto_dream_stamp_path",
+        lambda: tmp_path / "honcho-auto-dream.stamp",
+    )
+    # Run the dispatch thread body inline so assertions are deterministic.
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session.threading.Thread",
+        lambda target, name=None, daemon=None: _InlineThread(target),
+    )
+    return m, client
+
+
+# --- it fires when it should ------------------------------------------------
+
+def test_dispatches_a_dream_for_both_directions(mgr):
+    m, client = mgr
+    assert m.maybe_schedule_dream() is True
+    assert client.calls == [
+        {"observer": "kai"},
+        {"observer": "kai", "observed": "hermes"},
+    ]
+
+
+def test_fires_again_once_the_interval_has_elapsed(mgr, tmp_path):
+    m, client = mgr
+    assert m.maybe_schedule_dream() is True
+    (tmp_path / "honcho-auto-dream.stamp").write_text(str(time.time() - 30000))
+    assert m.maybe_schedule_dream() is True
+    assert len(client.calls) == 4
+
+
+# --- negative controls: it must DECLINE -------------------------------------
+
+def test_declines_when_auto_dream_is_off(tmp_path, monkeypatch):
+    client = _FakeClient()
+    m = HonchoSessionManager(honcho=client, config=_config(auto_dream=False))
+    monkeypatch.setattr(m, "_auto_dream_stamp_path",
+                        lambda: tmp_path / "s.stamp")
+    assert m.maybe_schedule_dream() is False
+    assert client.calls == []
+
+
+def test_declines_while_throttled(mgr):
+    m, client = mgr
+    assert m.maybe_schedule_dream() is True
+    assert m.maybe_schedule_dream() is False, "second call inside the interval"
+    assert len(client.calls) == 2, "no extra dream was dispatched"
+
+
+def test_declines_without_a_config(tmp_path, monkeypatch):
+    m = HonchoSessionManager(honcho=_FakeClient(), config=None)
+    monkeypatch.setattr(m, "_auto_dream_stamp_path", lambda: tmp_path / "s")
+    assert m.maybe_schedule_dream() is False
+
+
+# --- robustness -------------------------------------------------------------
+
+def test_a_failing_dream_never_raises(tmp_path, monkeypatch):
+    """A dead Honcho must not surface into session shutdown."""
+    client = _FakeClient(fail=True)
+    m = HonchoSessionManager(honcho=client, config=_config())
+    monkeypatch.setattr(m, "_auto_dream_stamp_path", lambda: tmp_path / "s")
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session.threading.Thread",
+        lambda target, name=None, daemon=None: _InlineThread(target),
+    )
+    assert m.maybe_schedule_dream() is True   # dispatched; the failure is swallowed
+
+
+def test_stamp_is_written_before_dispatch(tmp_path, monkeypatch):
+    """A burst of session ends must not queue a burst of dreams.
+
+    The stamp has to land even if the request itself is slow or fails, otherwise
+    concurrent shutdowns each see "no stamp" and all dispatch.
+    """
+    client = _FakeClient(fail=True)
+    m = HonchoSessionManager(honcho=client, config=_config())
+    stamp = tmp_path / "s.stamp"
+    monkeypatch.setattr(m, "_auto_dream_stamp_path", lambda: stamp)
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session.threading.Thread",
+        lambda target, name=None, daemon=None: _InlineThread(target),
+    )
+    m.maybe_schedule_dream()
+    assert stamp.exists(), "stamp must be written even when the dream fails"
+
+
+def test_single_peer_setup_does_not_dream_against_itself(tmp_path, monkeypatch):
+    client = _FakeClient()
+    m = HonchoSessionManager(honcho=client, config=_config(ai_peer="kai"))
+    monkeypatch.setattr(m, "_auto_dream_stamp_path", lambda: tmp_path / "s")
+    monkeypatch.setattr(
+        "plugins.memory.honcho.session.threading.Thread",
+        lambda target, name=None, daemon=None: _InlineThread(target),
+    )
+    m.maybe_schedule_dream()
+    assert client.calls == [{"observer": "kai"}], "no self-targeted second dream"


### PR DESCRIPTION
## Problem

Honcho only deduplicates conclusions, resolves contradictions and refreshes the peer card when a **dream** runs. Server-side auto-dream needs a stretch of idle time on top of its volume and elapsed-time thresholds — and an actively used install rarely goes idle long enough to qualify.

The plumbing for the fix is already here, just not connected:

```python
# plugins/memory/honcho/__init__.py — on_session_end, before this PR
def on_session_end(self, messages):
    """Flush all pending messages to Honcho on session end."""
    self._manager.flush_all()          # raw message sync, nothing else
```

`schedule_dream` exists, but only on the `hermes honcho dream` path. So consolidation depends on a human remembering to run a command, and conclusions accumulate raw until they do.

Measured on one install after ~7 weeks: **89,498 conclusions** across peers (40,663 own + 20,016 + 28,819 cross-peer), and a 60-item sample of the most recent ones was **65% raw auto-observation records** (`kai's command ...`, `kai is asking ...`) rather than durable facts. The peer card was full at 40 entries, so the card itself is fine — it is the conclusion layer underneath that never gets compacted.

## Change

Adds `HonchoSessionManager.maybe_schedule_dream()` and calls it from `on_session_end` **after** the flush, so the dream sees the session it is consolidating.

Opt-in and quiet by construction:

| Property | Behaviour |
|---|---|
| Default | **off** — requires `autoDream: true` in `honcho.json` |
| Throttle | `autoDreamMinIntervalSeconds`, default 8h, via a stamp file |
| Stamp timing | written **before** dispatch, so sessions ending in quick succession cannot each queue a dream while the first is in flight |
| Threading | daemon thread — dreaming is heavy server-side work and must never delay shutdown |
| Client | prefers the already-resolved client; re-resolving the singleton at shutdown can raise on a missing key, and a best-effort consolidation is not worth failing a shutdown over |
| Failure | every path logs at debug and returns; nothing surfaces to the user |

```yaml
# honcho.json
autoDream: true
autoDreamMinIntervalSeconds: 28800   # 8h
```

## Why in the plugin rather than a separate plugin

I built this as a standalone plugin first. It works, but it duplicates state the Honcho plugin already owns — the resolved client, the peer names, the config block — and it has to re-read `honcho.json` and `.env` itself to get them. The manager already holds all of it, and `flush_all()` is right there as the sibling operation. A separate plugin is the wrong seam.

## Tests

`tests/plugins/memory/test_honcho_auto_dream.py`, 8 cases. Every positive is paired with a negative control, since a hook that always fires is indistinguishable from one that fires for the wrong reason:

- dispatches for both peer directions (`observer`, then `observer`+`observed`)
- re-fires once the interval has elapsed
- declines when `autoDream` is off / while throttled / with no config
- no self-targeted second dream when `ai_peer == peer_name`
- a failing dream does not raise
- the stamp lands even when the request fails (otherwise concurrent shutdowns all see "no stamp" and all dispatch)

Mutation-checked — disabling the `autoDream` guard, the throttle, the second dream, or the stamp write each turns the suite red (4/4 caught), so the assertions are load-bearing rather than incidentally green.

```
tests/plugins/memory: 293 passed
```

## Scope

+267 / −0 across 4 files. No behaviour change for anyone who does not set `autoDream`.

Related but distinct: #58669 covers *extraction* of durable facts from short sessions (what gets written); this covers *consolidation* of what has already been written. Searched the tracker for `schedule_dream` — zero prior art.

Verified against a live Honcho workspace: triggering a dream moves the deriver queue (`total 1 → 2`, `in-progress 0 → 1`) and drains back to idle when done, so the scheduling call does real work rather than no-oping.
