### PR TITLE
fix(gateway): stop leaking PYTHONPATH to subprocesses (regression fix)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -318,10 +318,6 @@ def _ensure_windows_gateway_venv_imports() -> None:
         sys.path.insert(insert_at, site_entry)
 
         os.environ["VIRTUAL_ENV"] = str(resolved_venv)
-        pythonpath = [project_entry, site_entry]
-        if os.environ.get("PYTHONPATH"):
-            pythonpath.append(os.environ["PYTHONPATH"])
-        os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
         return
 
 


### PR DESCRIPTION
## Problem

In `gateway/run.py`, `_ensure_windows_gateway_venv_imports()` mutates `os.environ["PYTHONPATH"]` by appending the project's venv site-packages. This leaks the gateway's venv into every subprocess the gateway spawns (including the bash terminals opened from chat sessions), breaking cross-version Python tools (`uvx`, `uv tool`, `honcho-cli`, `mcp-server-*`) that inherit cp311 site-packages under their own cp313 interpreters and crash with `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'`.

The fix is conceptually identical to upstream PR #57470 by `liuhao1024` (which I commented on with this analysis). However, #57470 was based on a fork where the bug had already been removed (`2d0447ca0` shows the post-fix state). Between that PR's base and current `upstream/main`, the bug was **re-introduced** at lines 321–324, which is why #57470 conflicted on rebase.

## Fix

Delete the 4-line block that mutates `os.environ["PYTHONPATH"]` in `gateway/run.py:321-324`:

```diff
         os.environ["VIRTUAL_ENV"] = str(resolved_venv)
-        pythonpath = [project_entry, site_entry]
-        if os.environ.get("PYTHONPATH"):
-            pythonpath.append(os.environ["PYTHONPATH"])
-        os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
         return
```

## What is preserved

- ✓ In-process `VIRTUAL_ENV` env var setting
- ✓ `sys.path.insert(0, project_root)` — so `import hermes_cli` etc. resolves in-process
- ✓ `site.addsitedir(site_entry)` — so pywin32's `.pth` processing exposes `pywintypes` for the MCP SDK on Windows
- ✓ The `if sys.platform != "win32": return` early-out
- ✓ The `seen` set de-dupe so multiple `VIRTUAL_ENV` candidates don't double-add

## Verification

- `ast.parse(gateway/run.py)` succeeds
- The 4 lines are an exact 1-for-1 match for the upstream `os.environ["PYTHONPATH"]` mutation that exists today
- No new tests added (the prior test in `tests/gateway/test_restart_drain.py` was deleted by an upstream refactor; the source-level fix is the durable piece)

## Relation to PR #57470

This is the **regression-corrected** version of the same fix. Once this lands, #57470 can be closed — the conflict the rebase subagent hit was a symptom of the re-introduced bug, which this PR resolves at the current base.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Hermes Agent](https://hermes-agent.nousresearch.com)
