### PR TITLE
feat(cron): support subject_template with {date} for email delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -318,6 +318,29 @@ def _is_cron_silence_response(text: str) -> bool:
 
     return is_autonomous_silence_response(text)
 
+
+def _render_subject_template(job: dict, metadata: dict) -> None:
+    """Render a cron job's ``subject_template`` into ``metadata['subject']``.
+
+    Supports ``{date}`` → today's date in YYYY/MM/DD format.
+    No-op when the job has no ``subject_template`` field.
+    """
+    template = job.get("subject_template")
+    if not template:
+        return
+    try:
+        from datetime import datetime as _dt
+        metadata["subject"] = template.format(date=_dt.now().strftime("%Y/%m/%d"))
+    except KeyError as e:
+        logger.warning(
+            "Job '%s': subject_template has unknown placeholder %s — "
+            "using raw template as subject",
+            job.get("name", job["id"]),
+            e,
+        )
+        metadata["subject"] = template
+
+
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
 # The tick function submits jobs here and returns immediately so the ticker
@@ -1765,6 +1788,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
                 }
+                _render_subject_template(job, route_metadata)
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
                 media_metadata = {"direct_messages_topic_id": str(thread_id)}
@@ -1781,6 +1805,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {"job_id": job["id"]}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
+                _render_subject_template(job, route_metadata)
                 media_metadata = {"thread_id": thread_id} if thread_id else None
 
             try:

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -942,11 +942,21 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        Subject resolution order:
+          1. ``metadata["subject"]`` (cron / scheduler override — used for
+             templated subjects like ``"Daily Report {date}"``).
+          2. Thread context's last subject, with ``Re:`` prefix if absent.
+          3. Default ``"Re: Hermes Agent"`` (legacy).
+        """
         try:
+            custom_subject = None
+            if metadata:
+                custom_subject = metadata.get("subject")
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, custom_subject
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -968,21 +978,37 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        custom_subject: Optional[str] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via SMTP. Runs in executor thread.
+
+        ``custom_subject`` (from ``metadata.subject``) wins over the thread
+        context's last subject. Used by cron deliveries that want a templated
+        subject independent of any inbound thread.
+        """
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        if custom_subject:
+            # Caller-supplied (cron / scheduler) — use as-is, no Re: prefix
+            subject = custom_subject
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        # Threading headers
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
+        # Threading headers — only when this is a thread reply (no custom_subject).
+        # cron / scheduler deliveries with a templated subject are new outbound
+        # messages, NOT replies to an inbound thread, so we don't reuse the
+        # thread's last message-id (would create a misleading In-Reply-To chain).
+        if custom_subject:
+            original_msg_id = reply_to_msg_id
+        else:
+            original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1901,3 +1901,48 @@ class TestSetCronSessionTitle:
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
 
 
+class TestRenderSubjectTemplate:
+    """_render_subject_template renders cron job subject templates into metadata."""
+
+    def test_renders_date_placeholder(self):
+        from cron.scheduler import _render_subject_template
+        job = {"id": "j1", "name": "daily", "subject_template": "Daily Report {date}"}
+        metadata = {}
+        _render_subject_template(job, metadata)
+        assert "subject" in metadata
+        # Format: YYYY/MM/DD
+        import re
+        assert re.match(r"Daily Report \d{4}/\d{2}/\d{2}", metadata["subject"])
+
+    def test_no_template_noop(self):
+        from cron.scheduler import _render_subject_template
+        job = {"id": "j1", "name": "no-template"}
+        metadata = {"job_id": "j1"}
+        _render_subject_template(job, metadata)
+        assert "subject" not in metadata
+
+    def test_empty_template_noop(self):
+        from cron.scheduler import _render_subject_template
+        job = {"id": "j1", "name": "empty", "subject_template": ""}
+        metadata = {}
+        _render_subject_template(job, metadata)
+        assert "subject" not in metadata
+
+    def test_unknown_placeholder_falls_back_to_raw(self):
+        from cron.scheduler import _render_subject_template
+        job = {"id": "j1", "name": "bad", "subject_template": "Report {unknown}"}
+        metadata = {}
+        _render_subject_template(job, metadata)
+        # Falls back to raw template instead of raising
+        assert metadata["subject"] == "Report {unknown}"
+
+    def test_preserves_existing_metadata_keys(self):
+        from cron.scheduler import _render_subject_template
+        job = {"id": "j1", "subject_template": "Report {date}"}
+        metadata = {"job_id": "j1", "thread_id": "t1"}
+        _render_subject_template(job, metadata)
+        assert metadata["job_id"] == "j1"
+        assert metadata["thread_id"] == "t1"
+        assert "subject" in metadata
+
+

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -907,5 +907,89 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestCustomSubject(unittest.TestCase):
+    """Email adapter honours metadata['subject'] as a custom subject."""
+
+    def _make_adapter(self):
+        from gateway.config import Platform, PlatformConfig, GatewayConfig, _apply_env_overrides
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            cfg = GatewayConfig()
+            _apply_env_overrides(cfg)
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(cfg.platforms[Platform.EMAIL])
+
+    def test_send_passes_metadata_subject_as_custom_subject(self):
+        adapter = self._make_adapter()
+        adapter._send_email = MagicMock(return_value="<msg-123@test.com>")
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send(
+                "user@example.com",
+                "Hello world",
+                metadata={"subject": "Daily Report 2026/08/05"},
+            )
+        )
+        self.assertTrue(result.success)
+        adapter._send_email.assert_called_once()
+        args = adapter._send_email.call_args
+        self.assertEqual(args[0][0], "user@example.com")
+        self.assertEqual(args[0][1], "Hello world")
+        # custom_subject is the 4th positional arg
+        self.assertEqual(args[0][3], "Daily Report 2026/08/05")
+
+    def test_send_email_custom_subject_used_as_is(self):
+        adapter = self._make_adapter()
+        # Set up thread context with a different subject
+        adapter._thread_context["user@example.com"] = {
+            "subject": "Old Thread",
+            "message_id": "<old@test.com>",
+        }
+        with patch("plugins.platforms.email.adapter.MIMEMultipart") as mock_mime_cls, \
+             patch.object(adapter, "_connect_smtp") as mock_connect:
+            mock_msg = MagicMock()
+            mock_mime_cls.return_value = mock_msg
+            mock_smtp = MagicMock()
+            mock_connect.return_value = mock_smtp
+
+            adapter._send_email("user@example.com", "body", custom_subject="Custom Subject")
+
+            # Subject should be the custom one, not the thread context one
+            self.assertEqual(mock_msg.__setitem__.call_args_list[2][0][1], "Custom Subject")
+
+    def test_send_email_no_custom_subject_falls_back_to_thread(self):
+        adapter = self._make_adapter()
+        adapter._thread_context["user@example.com"] = {
+            "subject": "Old Thread",
+            "message_id": "<old@test.com>",
+        }
+        with patch("plugins.platforms.email.adapter.MIMEMultipart") as mock_mime_cls, \
+             patch.object(adapter, "_connect_smtp") as mock_connect:
+            mock_msg = MagicMock()
+            mock_mime_cls.return_value = mock_msg
+            mock_smtp = MagicMock()
+            mock_connect.return_value = mock_smtp
+
+            adapter._send_email("user@example.com", "body")
+
+            # Subject should be Re: + thread context subject
+            self.assertEqual(mock_msg.__setitem__.call_args_list[2][0][1], "Re: Old Thread")
+
+    def test_no_metadata_does_not_crash(self):
+        adapter = self._make_adapter()
+        adapter._send_email = MagicMock(return_value="<msg@test.com>")
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send("user@example.com", "Hello")
+        )
+        self.assertTrue(result.success)
+        adapter._send_email.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a `subject_template` field to cron jobs. When set, the scheduler renders `{date}` (YYYY/MM/DD format) into `metadata['subject']` before delivery.

The email adapter honours `metadata.subject` as a custom outbound subject, letting cron reports have dated titles instead of the generic `Re: Hermes Agent`.

### Changes
- **cron/scheduler.py**: add `_render_subject_template` helper; call it from `_deliver_result` for both routing paths (DM-topic and regular)
- **plugins/platforms/email/adapter.py**: accept `custom_subject` via `metadata['subject']`; use as-is (no `Re:` prefix); skip thread `In-Reply-To` headers for templated subjects (they are new outbound messages, not replies)
- **tests**: 5 unit tests for template rendering, 4 tests for email subject routing

### Usage
Set `subject_template` on a cron job, e.g.:
```json
{
  "subject_template": "Daily Report {date}"
}
```
`{date}` is replaced with today's date in `YYYY/MM/DD` format.