### PR TITLE
fix(slack): read alert content nested in attachment Block Kit blocks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -480,6 +480,40 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
     return "\n".join(parts)
 
 
+def _extract_text_from_block_kit_sections(blocks: list) -> list[str]:
+    """Extract readable lines from *structured* Block Kit blocks.
+
+    :func:`_extract_text_from_slack_blocks` only understands the ``rich_text``
+    blocks a human composer produces. Alert apps (Alertmanager, Grafana, CI,
+    in-house webhooks) instead post ``header``/``section``/``context``/
+    ``actions`` blocks nested inside a legacy attachment — with the message's
+    own ``text`` empty and ``fallback`` set to "[no preview available]", so
+    without this the alert body is invisible to the agent.
+    """
+    lines: list[str] = []
+
+    def _add(value: Any) -> None:
+        """Add a text value, unwrapping ``{"type": "mrkdwn", "text": ...}``."""
+        if isinstance(value, dict):
+            _add(value.get("text"))
+            return
+        text = str(value or "").strip()
+        if text and text not in lines:
+            lines.append(text)
+
+    for block in blocks or []:
+        if not isinstance(block, dict) or block.get("type") == "rich_text":
+            continue
+        _add(block.get("text"))
+        for item in (block.get("fields") or []) + (block.get("elements") or []):
+            _add(item)
+            # Keep a button's target, not just its label.
+            if isinstance(item, dict) and str(item.get("url", "")).startswith("http"):
+                _add(item["url"])
+
+    return lines
+
+
 def _extract_text_from_slack_attachments(attachments: list) -> str:
     """Extract readable text from legacy Slack message ``attachments``.
 
@@ -513,6 +547,7 @@ def _extract_text_from_slack_attachments(attachments: list) -> str:
             block_text = _extract_text_from_slack_blocks(nested)
             if block_text:
                 got.append(block_text)
+            got += _extract_text_from_block_kit_sections(nested)
         # Only use the (often duplicative) fallback when nothing structured exists.
         if not got and att.get("fallback"):
             got.append(str(att["fallback"]))

--- a/tests/gateway/test_slack_attachment_blocks.py
+++ b/tests/gateway/test_slack_attachment_blocks.py
@@ -1,0 +1,113 @@
+"""Alert content nested in ``message.attachments[0].blocks`` must be read.
+
+Alert apps post the message body as structured Block Kit blocks inside a
+legacy attachment: top-level ``text`` empty, no top-level ``blocks``, and
+``fallback`` set to "[no preview available]". Attachment-nested blocks were
+only read for ``rich_text``, so the fallback stood in as the body and the
+agent saw "[no preview available]" for the very alert it was asked to
+investigate.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+NO_PREVIEW = "[no preview available]"
+
+
+def _section(text):
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+# Structure of the reported message; every value is invented, standing in for
+# the internal service alert that surfaced the bug.
+ALERT_MESSAGE = {
+    "ts": "1700000000.000100",
+    "bot_id": "B_ALERT",
+    "subtype": "bot_message",
+    "text": "",
+    "blocks": None,
+    "attachments": [
+        {
+            "fallback": NO_PREVIEW,
+            "blocks": [
+                _section(":rotating_light: *EXAMPLE API(/v1/example) failure*"),
+                _section("environment: example-env"),
+                _section("servlet_path: /v1/example"),
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": "consumer_name: example-consumer"}
+                    ],
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {"type": "mrkdwn", "text": "exception_message: example failure"}
+                    ],
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Example Logs"},
+                            "url": "https://logs.example.com/q?id=X",
+                        }
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
+
+def test_alert_body_in_attachment_blocks_is_rendered():
+    rendered = SlackAdapter._render_message_text(ALERT_MESSAGE)
+
+    for expected in (
+        ":rotating_light: *EXAMPLE API(/v1/example) failure*",
+        "environment: example-env",
+        "servlet_path: /v1/example",
+        "consumer_name: example-consumer",
+        "exception_message: example failure",
+        "Example Logs",
+        "https://logs.example.com/q?id=X",
+    ):
+        assert expected in rendered
+    assert NO_PREVIEW not in rendered


### PR DESCRIPTION
Alert apps (Alertmanager/Grafana/CI and in-house webhooks) post their
body as structured Block Kit blocks wrapped in a legacy attachment: the
message's top-level `text` is empty, there are no top-level `blocks`,
and `fallback` is "[no preview available]".

`_extract_text_from_slack_attachments` handed nested blocks to
`_extract_text_from_slack_blocks`, which only walks `rich_text` blocks
(what a human composer produces) and skips every other block type. The
nested `section`/`header`/`context`/`actions` blocks therefore yielded
nothing, so the attachment's `fallback` stood in as the body —
the agent was asked to investigate an alert and could only see
"[no preview available]", then had to ask the human to re-paste it.

Add `_extract_text_from_block_kit_sections`, which reads one level of
structured blocks (`text.text`, `fields[*].text`, `elements[*].text`,
plus a button's `url` so a link keeps its target), and call it from the
attachment path alongside the existing rich-text extraction. Nothing
else changes: the rich-text renderer, the attachment field/fallback
precedence, and `_render_message_text` are untouched.

Given this attachment (contents mocked, real payload is an internal
service alert):

```
{
  "fallback": "[no preview available]",
  "blocks": [
    {"type": "section", "text": {"type": "mrkdwn",
      "text": ":rotating_light: *EXAMPLE API(/v1/example) failure*"}},
    {"type": "section", "text": {"type": "mrkdwn",
      "text": "environment: production"}},
    {"type": "section", "text": {"type": "mrkdwn",
      "text": "error_log_url: <https://logs.example.com/q?id=X>"}}
  ]
}
```

Before — the thread-root text the agent received:

```
[no preview available]
```

After:

```
:rotating_light: *EXAMPLE API(/v1/example) failure*
environment: production
error_log_url: <https://logs.example.com/q?id=X>
```

Scope: the `conversations.replies` / thread-context path, which is what
serves an @mention on an existing alert thread. The live-event branch in
`_handle_slack_message` renders attachments separately and still shows
the `fallback` placeholder for such a message; left alone deliberately
to keep this change narrow.

Assistant By Claude Opus 5