### PR TITLE
fix(copilot): create the JWT store at 0o600 and preserve a symlinked store

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -22,12 +22,15 @@ import json
 import logging
 import os
 import shutil
+import stat
 import subprocess
 import time
+import uuid
 from pathlib import Path
 from typing import Optional
 
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -372,6 +375,54 @@ def _read_jwt_store(path: Path) -> Optional[dict]:
         return None
 
 
+def _write_jwt_store_atomically(path: Path, store: dict) -> None:
+    """Persist ``store`` to ``path`` as an owner-only file, preserving symlinks.
+
+    Single chokepoint for every write of the persisted store (save + eviction),
+    mirroring ``_read_jwt_store`` on the read side. The store holds live Copilot
+    API tokens, so two properties matter and both were previously missing:
+
+    * The temp file is created with ``os.open(O_EXCL, 0o600)`` instead of
+      ``Path.write_text`` + a post-write ``chmod``, so it never exists at the
+      process umask (typically ``0o644``). Mirrors ``hermes_cli.auth``,
+      ``agent/google_oauth.py`` (#19673) and ``tools/mcp_oauth.py`` (#21148).
+    * ``utils.atomic_replace`` resolves a symlinked target before renaming, so a
+      ``.copilot_jwt.json`` symlinked into a managed profile package survives the
+      write instead of being replaced by a regular file (#16743). It also falls
+      back to copy/fsync/unlink on ``EXDEV``/``EBUSY`` for bind-mount and
+      cross-device deployments, and returns the resolved real path so the final
+      ``chmod`` targets the real inode explicitly rather than the link.
+
+    The temp name carries pid + uuid so two processes writing the store
+    concurrently cannot collide on a single fixed ``.tmp`` name.
+
+    Raises on failure; both callers log at debug and continue, since the disk
+    store is only a restart-survivability cache for the in-process one.
+    """
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    try:
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(store))
+            handle.flush()
+            os.fsync(handle.fileno())
+        real_path = atomic_replace(tmp_path, path)
+        try:
+            os.chmod(real_path, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+
+
 def evict_cached_exchanged_token(raw_token: str) -> None:
     """Drop any cached exchanged JWT for ``raw_token`` (in-process + on-disk).
 
@@ -397,13 +448,7 @@ def evict_cached_exchanged_token(raw_token: str) -> None:
         store = _read_jwt_store(path)
         if store is not None and fp in store:
             del store[fp]
-            tmp = path.with_suffix(path.suffix + ".tmp")
-            tmp.write_text(json.dumps(store), encoding="utf-8")
-            try:
-                os.chmod(tmp, 0o600)
-            except Exception:
-                pass
-            os.replace(tmp, path)
+            _write_jwt_store_atomically(path, store)
     except Exception as exc:
         logger.debug("Failed to evict cached Copilot JWT: %s", exc)
 
@@ -462,17 +507,7 @@ def _save_jwt_to_disk(
             "expires_at": expires_at,
             "base_url": base_url,
         }
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(store), encoding="utf-8")
-        try:
-            os.chmod(tmp, 0o600)
-        except Exception:
-            pass
-        os.replace(tmp, path)
-        try:
-            os.chmod(path, 0o600)
-        except Exception:
-            pass
+        _write_jwt_store_atomically(path, store)
     except Exception as exc:
         logger.debug("Failed to persist Copilot JWT: %s", exc)
 

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -30,7 +30,6 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
-from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -399,6 +398,14 @@ def _write_jwt_store_atomically(path: Path, store: dict) -> None:
     Raises on failure; both callers log at debug and continue, since the disk
     store is only a restart-survivability cache for the in-process one.
     """
+    # Imported lazily, matching this module's convention for its other
+    # cross-package dependencies (``get_hermes_home`` in ``_jwt_disk_path``,
+    # ``urllib.request`` in ``exchange_copilot_token``). ``utils`` pulls in
+    # PyYAML, which costs ~10ms of import time this module does not otherwise
+    # pay — and ``copilot_auth`` sits on the credential-resolution path that
+    # ``tests/tui_gateway/test_cold_start_gil_stall.py`` guards.
+    from utils import atomic_replace
+
     tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
     try:
         fd = os.open(

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,5 +1,11 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
+import json
+import os
+import stat
+import sys
+import time
+
 import pytest
 from unittest.mock import patch
 
@@ -136,4 +142,178 @@ class TestEnvVarOrder:
         assert "COPILOT_GITHUB_TOKEN" in copilot.api_key_env_vars
         # COPILOT_GITHUB_TOKEN should be first
         assert copilot.api_key_env_vars[0] == "COPILOT_GITHUB_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# On-disk exchanged-JWT store writers (<HERMES_HOME>/.copilot_jwt.json)
+# ---------------------------------------------------------------------------
+
+_OWNER_ONLY = stat.S_IRUSR | stat.S_IWUSR
+
+
+def _seed_store(path, entries):
+    """Write an existing JWT store at 0o600 so the writer takes its merge path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+    os.chmod(path, _OWNER_ONLY)
+
+
+def _spying_os_open(observed):
+    """Record every ``os.open`` call so the creation mode can be asserted."""
+    real_os_open = os.open
+
+    def spy(path, flags, mode=0o777, *args, **kwargs):
+        observed.append((str(path), flags, mode))
+        return real_os_open(path, flags, mode, *args, **kwargs)
+
+    return spy
+
+
+def _assert_temp_created_owner_only(observed):
+    tmp_opens = [
+        entry for entry in observed if ".copilot_jwt.json.tmp" in entry[0]
+    ]
+    assert tmp_opens, (
+        "os.open was never called for the JWT store temp file — the writer still "
+        f"creates it at the process umask; observed={observed!r}"
+    )
+    for path, flags, mode in tmp_opens:
+        assert flags & os.O_CREAT, f"temp open missing O_CREAT: {path}"
+        assert flags & os.O_EXCL, (
+            f"temp open missing O_EXCL — a concurrent writer could be clobbered: {path}"
+        )
+        assert mode == _OWNER_ONLY, (
+            f"temp open mode 0o{mode:o} != 0o600 — umask applies and the live "
+            f"Copilot JWT is briefly world-readable: {path}"
+        )
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits and symlinks are not enforced on Windows",
+)
+class TestJwtStoreDiskWrites:
+    """``.copilot_jwt.json`` holds a live Copilot API token.
+
+    Both writers — ``_save_jwt_to_disk`` and ``evict_cached_exchanged_token`` —
+    used to create the temp file with ``Path.write_text`` and only ``chmod`` it
+    to 0o600 afterward (world-readable at the process umask in between), then
+    finish with a bare ``os.replace`` that detaches a symlinked store. They now
+    share ``_write_jwt_store_atomically``: ``os.open(O_EXCL, 0o600)`` + ``fsync``
+    + ``utils.atomic_replace``. Mirrors #19673 / #21148 and
+    ``tests/hermes_cli/test_auth_toctou_file_modes.py``.
+    """
+
+    def test_save_creates_store_owner_only(self, tmp_path, monkeypatch):
+        """``_save_jwt_to_disk`` must create the store at 0o600, never 0o644."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli import copilot_auth
+
+        observed: list = []
+        old_umask = os.umask(0o022)  # make the race observable if it regresses
+        try:
+            with patch.object(os, "open", _spying_os_open(observed)):
+                copilot_auth._save_jwt_to_disk(
+                    "fp-save", "tid=abc;exp=1", time.time() + 600, None
+                )
+        finally:
+            os.umask(old_umask)
+
+        store_path = tmp_path / ".copilot_jwt.json"
+        assert store_path.exists(), "JWT store was not written"
+        mode = stat.S_IMODE(store_path.stat().st_mode)
+        assert mode == 0o600, f"JWT store mode 0o{mode:o} != 0o600"
+        assert json.loads(store_path.read_text())["fp-save"]["api_token"] == "tid=abc;exp=1"
+        _assert_temp_created_owner_only(observed)
+
+    def test_save_preserves_symlinked_store(self, tmp_path, monkeypatch):
+        """A ``.copilot_jwt.json`` symlinked into a managed profile must survive."""
+        home = tmp_path / "home"
+        home.mkdir()
+        real = tmp_path / "tracked" / "copilot_jwt.json"
+        _seed_store(real, {})
+        link = home / ".copilot_jwt.json"
+        link.symlink_to(real)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        from hermes_cli import copilot_auth
+
+        copilot_auth._save_jwt_to_disk(
+            "fp-save", "tid=abc;exp=1", time.time() + 600, None
+        )
+
+        assert link.is_symlink(), (
+            "the symlinked JWT store was replaced by a regular file — managed "
+            "profile packages silently detach (#16743)"
+        )
+        assert os.path.realpath(link) == os.path.realpath(real)
+        assert json.loads(real.read_text())["fp-save"]["api_token"] == "tid=abc;exp=1"
+        real_mode = stat.S_IMODE(real.stat().st_mode)
+        assert real_mode == 0o600, f"symlink target mode 0o{real_mode:o} != 0o600"
+
+    def test_evict_creates_store_owner_only(self, tmp_path, monkeypatch):
+        """``evict_cached_exchanged_token`` must rewrite the store at 0o600."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli import copilot_auth
+
+        drop_raw, keep_raw = "gho_drop_me", "gho_keep_me"
+        drop_fp = copilot_auth._token_fingerprint(drop_raw)
+        keep_fp = copilot_auth._token_fingerprint(keep_raw)
+        expires_at = time.time() + 600
+        store_path = tmp_path / ".copilot_jwt.json"
+        _seed_store(
+            store_path,
+            {
+                drop_fp: {"api_token": "stale", "expires_at": expires_at, "base_url": None},
+                keep_fp: {"api_token": "fresh", "expires_at": expires_at, "base_url": None},
+            },
+        )
+
+        observed: list = []
+        old_umask = os.umask(0o022)
+        try:
+            with patch.object(os, "open", _spying_os_open(observed)):
+                copilot_auth.evict_cached_exchanged_token(drop_raw)
+        finally:
+            os.umask(old_umask)
+
+        data = json.loads(store_path.read_text())
+        assert drop_fp not in data, "evicted fingerprint survived the rewrite"
+        assert data[keep_fp]["api_token"] == "fresh", "eviction dropped an unrelated entry"
+        mode = stat.S_IMODE(store_path.stat().st_mode)
+        assert mode == 0o600, f"JWT store mode 0o{mode:o} != 0o600"
+        _assert_temp_created_owner_only(observed)
+
+    def test_evict_preserves_symlinked_store(self, tmp_path, monkeypatch):
+        """Eviction must not detach a symlinked store either."""
+        home = tmp_path / "home"
+        home.mkdir()
+        real = tmp_path / "tracked" / "copilot_jwt.json"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        from hermes_cli import copilot_auth
+
+        drop_raw, keep_raw = "gho_drop_me", "gho_keep_me"
+        drop_fp = copilot_auth._token_fingerprint(drop_raw)
+        keep_fp = copilot_auth._token_fingerprint(keep_raw)
+        expires_at = time.time() + 600
+        _seed_store(
+            real,
+            {
+                drop_fp: {"api_token": "stale", "expires_at": expires_at, "base_url": None},
+                keep_fp: {"api_token": "fresh", "expires_at": expires_at, "base_url": None},
+            },
+        )
+        link = home / ".copilot_jwt.json"
+        link.symlink_to(real)
+
+        copilot_auth.evict_cached_exchanged_token(drop_raw)
+
+        assert link.is_symlink(), (
+            "eviction replaced the symlinked JWT store with a regular file (#16743)"
+        )
+        assert os.path.realpath(link) == os.path.realpath(real)
+        data = json.loads(real.read_text())
+        assert drop_fp not in data
+        assert data[keep_fp]["api_token"] == "fresh"
+        real_mode = stat.S_IMODE(real.stat().st_mode)
+        assert real_mode == 0o600, f"symlink target mode 0o{real_mode:o} != 0o600"
 


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/copilot_auth.py` persists a live GitHub Copilot API JWT to `<HERMES_HOME>/.copilot_jwt.json` so a gateway restart during a network blip reuses the still-valid ~30-minute token instead of degrading to the raw GitHub token. Both writers of that store — `_save_jwt_to_disk()` and the on-disk half of `evict_cached_exchanged_token()` — do it two unsafe ways:

1. **The token is world-readable for a window.** Both create the temp with `tmp.write_text(...)` and only `os.chmod(tmp, 0o600)` afterward, so on a multi-user host the file exists at the process umask (typically `0o644`) between create and chmod. This is the exact pattern already fixed for `agent/google_oauth.py` (#19673), `tools/mcp_oauth.py` (#21148), and the `hermes_cli/auth.py` writers — `tests/hermes_cli/test_auth_toctou_file_modes.py` documents that sweep. `copilot_auth.py` was missed.
2. **A symlinked store gets detached.** Both finish with a bare `os.replace(tmp, path)`, which replaces a symlinked `.copilot_jwt.json` with a regular file (#16743) — silently detaching managed profile packages that link `HERMES_HOME` files into a tracked repo. `utils.atomic_replace` resolves the link for exactly this reason, and it is already the convention in this package; `copilot_auth.py` imported neither helper. `_save_jwt_to_disk` additionally chmod'd *after* the replace, which would have targeted the link rather than the real inode once the replace was corrected.

Both writers are now routed through one shared `_write_jwt_store_atomically()` helper — the duplication is how the second site was missed in the first place, so the fix is a single chokepoint mirroring `_read_jwt_store` on the read side. The fixed `.tmp` suffix is also replaced with a pid+uuid name (mirroring `hermes_cli/auth.py`), so two processes writing the store concurrently no longer collide on the same temp. Failure handling is deliberately unchanged: both callers still swallow into `logger.debug`, since the disk store is only a restart-survivability cache for the in-process one.

### Sibling-site sweep — every `os.replace` in Channel A

Enumerated with `git grep -n 'os\.replace(' origin/main -- '*.py' | grep -v '/tests/\|test_'` and filtered to CLI / gateway / TUI-gateway / `cli.py`. Both `copilot_auth.py` sites are fixed here; the rest are listed so the coverage is checkable without reading the diff.

| Site | Verdict |
|---|---|
| `hermes_cli/copilot_auth.py:406` (`evict_cached_exchanged_token`) | **fixed here** — credential store, umask temp + bare replace |
| `hermes_cli/copilot_auth.py:471` (`_save_jwt_to_disk`) | **fixed here** — same, plus a post-replace chmod on the link |
| `hermes_cli/auth.py:5370` (`_write_shared_nous_state`) | **excluded — @Tranquil-Flow's #68780 owns this line.** It already creates the temp via `os.open(O_EXCL, 0o600)`, so only the symlink half is missing, and #68780's hunks (`-5350,10` and `-5367,20`) land on exactly that `os.replace`. Not touched here. |
| `gateway/status.py:1467` | excluded — `os.replace` is used *as* the atomic lock-claim primitive (`# exactly one racer claims the stale…`); resolving symlinks there would change locking semantics, not harden them |
| `cli.py:1890` | excluded — worktree merge-verdict cache, derived and regenerable |
| `hermes_cli/models.py:944` | excluded — Nous recommended-models disk cache, derived |
| `hermes_cli/active_sessions.py:202` | excluded — session registry, no credential material |
| `hermes_cli/backup.py:211`, `:1337` | excluded — `.partial` staging file and staging-directory publish, not a live file being rewritten |
| `hermes_cli/web_server.py:2525`, `:2683`, `:12923` | excluded — user-managed file/archive uploads and editor writes; the target is arbitrary user content, and forcing 0o600 there would be wrong |
| `hermes_cli/web_server.py:17338` (`_write_dashboard_ready_file`) | excluded — a port announcement for the Electron launcher, no credential material |
| `gateway/sticker_cache.py:50`, `gateway/rich_sent_store.py:66`, `gateway/status.py:116` | excluded — sticker cache, sent-message dedup store, restart-timestamp ring buffer; all derived caches |
| `tui_gateway/turn_marker.py:88` | excluded — turn markers, derived |

`utils.py:115` is `atomic_replace`'s own implementation — the helper this PR routes into.

## Related Issue

Relates to #16743 (`atomic writes to HERMES_HOME files replace symlinked targets`). That issue was closed once `utils.atomic_replace` shipped — its docstring names #16743 directly — but this call site was never routed through the helper, so the bug is still live for `.copilot_jwt.json`. No separate issue is filed for the Copilot JWT store; found by sweeping `os.replace` against `atomic_replace`'s stated invariant.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/copilot_auth.py`: add `_write_jwt_store_atomically()` — `os.open(O_CREAT|O_EXCL, 0o600)` + `os.fdopen` + `fsync`, then `utils.atomic_replace`, then chmod the **resolved real path** that `atomic_replace` returns. Temp name carries pid + uuid; the temp is unlinked on any failure.
- `hermes_cli/copilot_auth.py`: `_save_jwt_to_disk()` and `evict_cached_exchanged_token()` both call the new helper; the dead post-replace `os.chmod(path, 0o600)` is removed.
- `hermes_cli/copilot_auth.py`: adds `stat` and `uuid` at module scope; `atomic_replace` is imported **lazily inside the helper** (the module previously imported neither `utils` nor `atomic_replace`). `utils` pulls in PyYAML — ~10.6ms on top of this module's own ~19.8ms import, which it does not otherwise pay — and `copilot_auth` sits on the credential-resolution path that `tests/tui_gateway/test_cold_start_gil_stall.py` guards, so the module-scope form would have made every import heavier. The lazy form matches this module's existing convention (`get_hermes_home` in `_jwt_disk_path`, `urllib.request` in `exchange_copilot_token`).
- `tests/hermes_cli/test_copilot_auth.py`: `TestJwtStoreDiskWrites` — four regression tests (creation-mode and symlink survival, for each writer).

## How to Test

1. `umask 022`, then symlink the store: `ln -s /tmp/real_jwt.json ~/.hermes/.copilot_jwt.json` (seed `/tmp/real_jwt.json` with `{}`).
2. Trigger a Copilot token exchange. **Before:** `~/.hermes/.copilot_jwt.json` is now a regular file and the symlink is gone. **After:** the symlink survives and `/tmp/real_jwt.json` holds the payload at `0o600`.
3. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_auth_toctou_file_modes.py -v`

**Regression guard, both directions.** With only the production hunk reverted to `main` and the new tests kept, all four fail:

```
FAILED TestJwtStoreDiskWrites::test_save_creates_store_owner_only
FAILED TestJwtStoreDiskWrites::test_save_preserves_symlinked_store
FAILED TestJwtStoreDiskWrites::test_evict_creates_store_owner_only
FAILED TestJwtStoreDiskWrites::test_evict_preserves_symlinked_store
4 failed, 12 deselected in 0.19s
```

with e.g. `AssertionError: eviction replaced the symlinked JWT store with a regular file (#16743)` and `os.open was never called for the JWT store temp file — the writer still creates it at the process umask`. With the fix restored, the touched and adjacent Copilot/auth suites are green: **168 passed in 8.59s** across `test_copilot_auth.py`, `test_auth_toctou_file_modes.py`, `test_copilot_token_exchange.py`, `test_copilot_catalog_oauth_fallback.py`, `test_copilot_context.py`, `test_copilot_in_model_list.py`, `test_copilot_model_api_mode.py`, `test_copilot_runtime_api_mode.py`, `test_model_switch_copilot_api_mode.py`, `test_api_key_providers.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — by changed path and by symbol. #78378 also touches `copilot_auth.py`, but its hunks are at lines 150/180/195/315/528 and do not reach the 396–477 store-writer region; #68780 owns the `hermes_cli/auth.py` half of this class and is deliberately left alone.
- [x] My PR contains **only** changes related to this fix (2 files, no unrelated commits)
- [x] I've run the touched and adjacent suites and all tests pass (168 passed; full `pytest tests/ -q` not run locally)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (POSIX mode-bit and symlink assertions skip on Windows)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper) — no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact — the new test class is skipped on Windows (POSIX mode bits and symlinks are not enforced there), matching `test_auth_toctou_file_modes.py`; the production path is unchanged in behaviour on Windows beyond routing through `atomic_replace`, which already carries the Windows-safe fallbacks
- [x] I've updated tool descriptions/schemas — N/A, no tool behaviour changed

