### PR TITLE
fix: parse k/K-prefixed model versions in sort key

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -820,7 +820,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
 
     for ch in rest:
         if state == "start":
-            if ch in "vV":
+            if ch in "vVkK":
                 state = "in_version"
             elif ch.isdigit():
                 state = "in_version"
@@ -864,7 +864,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
             if ch.isdigit():
                 state = "in_version"
                 num_buf = ch
-            elif ch in "vV":
+            elif ch in "vVkK":
                 state = "in_version"
             elif ch in "-_.":
                 pass

--- a/tests/hermes_cli/test_gpt56_registration.py
+++ b/tests/hermes_cli/test_gpt56_registration.py
@@ -36,12 +36,22 @@ class TestGpt56SortInvariants:
         assert models[0] == "gpt-5.6-sol"
 
 
+
+
+class TestModelSortKPrefixVersions:
+    def test_k_prefix_versions_sort_numerically(self):
+        models = ["moonshotai/kimi-k2.6", "moonshotai/kimi-k3", "moonshotai/kimi-k3.5"]
+        models.sort(key=lambda m: _model_sort_key(m, "moonshotai/kimi"))
+        assert models[0] == "moonshotai/kimi-k3.5"
+
+
 class TestGpt56PricingRoute:
     def test_official_pricing_reachable_from_openai(self):
         route = resolve_billing_route("gpt-5.6-sol", provider="openai")
         entry = _lookup_official_docs_pricing(route)
         assert entry is not None
         assert entry.input_cost_per_million == Decimal("5.00")
+
 
 
     def test_cache_write_is_1_25x_input_for_56_series(self):


### PR DESCRIPTION
## Summary
- Extend `_model_sort_key` to recognize `k`/`K` version prefixes in model IDs (e.g., `kimi-k3` / `kimi-k2.6`) as version components.
- Keep existing version/suffix behavior unchanged for non-`k` models.

## Test Plan
- [x] `python3 -m py_compile hermes_cli/model_switch.py tests/hermes_cli/test_gpt56_registration.py`
- [x] `python3 -m pytest tests/hermes_cli/test_gpt56_registration.py -q`
- [x] `ruff check hermes_cli/model_switch.py tests/hermes_cli/test_gpt56_registration.py`

Closes #78886
