### PR TITLE
fix(gateway): bound initial channel directory build with 30s timeout (#79044)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11263,12 +11263,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
         
-        # Build initial channel directory for send_message name resolution
+        # Build initial channel directory for send_message name resolution.
+        # Bounded by a timeout so that slow directory discovery (e.g. Slack
+        # API name resolution) cannot block inbound message handling
+        # indefinitely.  On timeout the previous cache is retained and
+        # housekeeping will retry later.
         try:
             from gateway.channel_directory import build_channel_directory
-            directory = await build_channel_directory(self.adapters)
+            directory = await asyncio.wait_for(
+                build_channel_directory(self.adapters),
+                timeout=30.0,
+            )
             ch_count = sum(len(chs) for chs in directory.get("platforms", {}).values())
             logger.info("Channel directory built: %d target(s)", ch_count)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Channel directory build timed out after 30s; "
+                "previous cache retained, will retry during housekeeping"
+            )
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
         
@@ -12379,8 +12391,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # Rebuild channel directory with the new adapter
                         try:
                             from gateway.channel_directory import build_channel_directory
-                            await build_channel_directory(self.adapters)
-                        except Exception:
+                            await asyncio.wait_for(
+                                build_channel_directory(self.adapters),
+                                timeout=30.0,
+                            )
+                        except (asyncio.TimeoutError, Exception):
                             pass
 
                         # A platform that was offline at gateway startup never


### PR DESCRIPTION
## Summary

Wraps the initial `build_channel_directory()` call at Gateway startup with `asyncio.wait_for(..., timeout=30.0)` so that slow directory discovery cannot block inbound message handling indefinitely.

## Problem

During Gateway startup, `build_channel_directory()` is awaited without a time bound. Slow directory discovery (sequential Slack API name resolution, rate-limited workspace queries, or inaccessible conversations) blocks the startup-restore gate indefinitely. Inbound messages are queued with no response even though outbound delivery and platform connections are healthy.

The channel directory is a non-critical cache — the previous cache is already atomically written to disk, and the housekeeping loop refreshes it every 5 minutes with its own 30s timeout.

## Changes

- **Startup path** (line ~11269): wrap `build_channel_directory()` with `asyncio.wait_for(..., timeout=30.0)`. On `TimeoutError`, log a warning, retain the previous cache, and continue startup.
- **Reconnect path** (line ~12382): same timeout for the adapter-reconnect rebuild.
- Housekeeping path already has a 30s timeout via `safe_schedule_threadsafe` + `fut.result(timeout=30)` — no change needed.

## Test Plan

- [ ] Verify Gateway starts successfully with a healthy Slack connection
- [ ] Simulate slow directory discovery (e.g. mock Slack API with 60s delay) and verify startup completes within 30s
- [ ] Verify channel directory is refreshed during the next housekeeping cycle after a timeout
- [ ] Verify existing channel_directory.json is preserved on timeout

Fixes #79044