### PR TITLE
fix(tools): degrade tool-defs cache instead of full bypass on unresolved multiplex scope (#79047)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -275,6 +275,11 @@ _LEGACY_TOOLSET_MAP = {
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
+# Set once when get_tool_definitions() first falls back to the process-wide
+# cache because the multiplex profile scope was unresolvable, so the warning
+# is emitted once per process, not once per request (#79047).
+_warned_tool_defs_scope_bypass: bool = False
+
 # Hard cap on memoized get_tool_definitions() results. A long-lived Gateway
 # process sees many distinct toolset/config fingerprints over its lifetime
 # (per-session toolset sets, config edits, kanban-task toggles); without a
@@ -297,10 +302,7 @@ def get_tool_definitions(
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
 ) -> List[Dict[str, Any]]:
-    """
-    Get tool definitions for model API calls with toolset-based filtering.
-
-    All tools must be part of a toolset to be accessible.
+    """Get tool definitions for model API calls with toolset-based filtering.
 
     Args:
         enabled_toolsets: Only include tools from these toolsets.
@@ -315,6 +317,7 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    global _warned_tool_defs_scope_bypass
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -333,17 +336,33 @@ def get_tool_definitions(
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
         profile_scope = check_fn_cache_scope()
-        if profile_scope != CHECK_FN_CACHE_BYPASS:
-            cache_key = (
-                frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
-                frozenset(disabled_toolsets) if disabled_toolsets else None,
-                registry._generation,
-                cfg_fp,
-                bool(os.environ.get("HERMES_KANBAN_TASK")),
-                bool(skip_tool_search_assembly),
-                _is_delegated_child_context(),
-                profile_scope,
-            )
+        if profile_scope == CHECK_FN_CACHE_BYPASS:
+            # Profile identity could not be resolved (multiplex gateway,
+            # no home override in this context — e.g. api_server worker
+            # threads that run outside _profile_runtime_scope). Failing
+            # closed here would disable the cache ENTIRELY: every request
+            # would recompute tool definitions and re-run live check_fn
+            # probes (~3.3s per api_server call, #79047). Degrade to the
+            # process-wide cache key instead — identical to single-profile
+            # behavior — and log the reason so operators can see this path.
+            if not _warned_tool_defs_scope_bypass:
+                logger.warning(
+                    "get_tool_definitions: profile cache scope unresolved "
+                    "(multiplex without home override); falling back to "
+                    "process-wide tool-definitions cache (#79047)"
+                )
+                _warned_tool_defs_scope_bypass = True
+            profile_scope = None
+        cache_key = (
+            frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
+            frozenset(disabled_toolsets) if disabled_toolsets else None,
+            registry._generation,
+            cfg_fp,
+            bool(os.environ.get("HERMES_KANBAN_TASK")),
+            bool(skip_tool_search_assembly),
+            _is_delegated_child_context(),
+            profile_scope,
+        )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see

--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -205,8 +205,18 @@ class TestCheckFnTransientFailureSuppression:
             reg.invalidate_check_fn_cache()
             _clear_tool_defs_cache()
 
-    def test_unscoped_multiplex_request_bypasses_cache(self, monkeypatch):
-        """An unknown profile must never share another request's cache entry."""
+    def test_unscoped_multiplex_request_degrades_to_process_wide_cache(self, monkeypatch):
+        """An unresolved profile scope must degrade to the process-wide cache,
+        not disable caching entirely.
+
+        Failing closed (disabling both the check_fn TTL cache and the
+        tool-definitions memo) made every api_server request in a multiplex
+        gateway recompute tool definitions and re-run live probes — ~3.3s per
+        request (#79047). Unresolvable scopes now share the process-wide
+        (scope=None) cache key, which is safe: resolvable profiles still use
+        their own scope key, so cross-profile isolation is preserved (see
+        test_profile_scoped_availability_does_not_cross_multiplex_profiles).
+        """
         import model_tools
         import tools.registry as reg
         from agent.secret_scope import set_multiplex_active
@@ -224,14 +234,18 @@ class TestCheckFnTransientFailureSuppression:
         set_multiplex_active(True)
         monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute_definitions)
         try:
+            # First probe result is TTL-cached under the process-wide key...
             assert reg._check_fn_cached(probe) is True
-            assert reg._check_fn_cached(probe) is False
-            assert not reg._check_fn_cache
+            # ...so the second call hits the cache and never re-runs the probe.
+            assert reg._check_fn_cached(probe) is True
+            assert reg._check_fn_cache
 
+            # Tool-definitions memo degrades the same way: repeated unscoped
+            # calls reuse the process-wide entry instead of recomputing.
             model_tools.get_tool_definitions(quiet_mode=True)
             model_tools.get_tool_definitions(quiet_mode=True)
-            assert definition_calls["n"] == 2
-            assert not model_tools._tool_defs_cache
+            assert definition_calls["n"] == 1
+            assert model_tools._tool_defs_cache
         finally:
             set_multiplex_active(False)
             reg.invalidate_check_fn_cache()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -280,16 +280,13 @@ def _check_fn_cached(fn: Callable) -> bool:
     now = time.monotonic()
     scope = check_fn_cache_scope()
     if scope == CHECK_FN_CACHE_BYPASS:
-        try:
-            return bool(fn())
-        except Exception:
-            logger.warning(
-                "check_fn %s raised while profile cache scope was unresolved; "
-                "dependent tools will be unavailable this turn",
-                getattr(fn, "__qualname__", fn),
-                exc_info=True,
-            )
-            return False
+        # Profile identity could not be resolved (multiplex gateway, no
+        # home override in this context). Failing closed here would run the
+        # probe LIVE on every call — with 8+ tools that is seconds per
+        # request (api_server #79047). Degrade to the process-wide TTL
+        # cache (scope=None) instead, matching pre-multiplex behavior; the
+        # 30s TTL still bounds staleness and the lock still serializes.
+        scope = None
     cache_key = (fn, scope)
     with _check_fn_cache_lock:
         _prune_check_fn_caches(now)
@@ -357,9 +354,11 @@ def get_cached_check_fn_result(fn: Callable) -> Optional[bool]:
     now = time.monotonic()
     scope = check_fn_cache_scope()
     if scope == CHECK_FN_CACHE_BYPASS:
-        # Unresolved profile identity bypasses the cache entirely; there is no
-        # trustworthy cached verdict to report.
-        return None
+        # Unresolved profile identity: report the process-wide cached verdict
+        # (scope=None) when one is fresh. Matches _check_fn_cached's
+        # degradation — a full bypass here would starve read-only surfaces
+        # of every verdict in multiplex api_server paths (#79047).
+        scope = None
     with _check_fn_cache_lock:
         cached = _check_fn_cache.get((fn, scope))
         if cached is None:


### PR DESCRIPTION
## Summary

Fixes #79047: `api_server` requests add ~3.3s to agent creation because the tool-definitions cache is fully disabled on every request.

## Root cause

Commit `76cf19fee` ("fix(tools): isolate model tools by multiplex profile") made `get_tool_definitions()` **fail closed** when the multiplex profile cache scope cannot be resolved (`check_fn_cache_scope()` returns `CHECK_FN_CACHE_BYPASS` — i.e. multiplex is active but no `HERMES_HOME` override is installed in the calling context, such as api_server worker threads running outside `_profile_runtime_scope`).

When that happens, the code set `cache_key = None`, which disabled **both** cache layers:
- the top-level tool-definitions memo (`_tool_defs_cache`), and
- the per-probe `check_fn` TTL cache in `tools/registry.py` (`_check_fn_cached` ran the probe **live** on every call).

For an api_server request with ~8 tools, that is ~3.3s of live availability probes per request, before the agent is even created.

## Fix

Degrade to the **process-wide cache key** (`scope=None`) instead of bypassing caching entirely, in three places:

1. `model_tools.get_tool_definitions()` — when `check_fn_cache_scope()` returns `CHECK_FN_CACHE_BYPASS`, fall back to `profile_scope=None` so the memo still caches/returns, and log the reason once per process.
2. `tools.registry._check_fn_cached()` — when the scope is unresolved, TTL-cache probe results under the process-wide key (`(fn, None)`) instead of re-probing on every call.
3. `tools.registry.get_cached_check_fn_result()` — read the process-wide verdict when the scope is unresolved, matching the degradation.

Resolvable profiles keep their own scope key, so cross-profile isolation is unchanged (verified by the existing multiplex isolation test `test_profile_scoped_availability_does_not_cross_multiplex_profiles` and `tests/gateway/test_64674_multiplex_primary_token_scope.py`).

## Tests

- Updated `test_unscoped_multiplex_request_bypasses_cache` → `test_unscoped_multiplex_request_degrades_to_process_wide_cache` to assert the new degrade semantics (probe TTL-cached; memo reused on repeat calls).
- Ran: `tests/tools/test_terminal_tool_requirements.py`, `tests/hermes_cli/test_tools_config.py`, `tests/gateway/test_64674_multiplex_primary_token_scope.py`, `tests/test_get_tool_definitions_cache_isolation.py`, `tests/test_model_tools.py`, `tests/tools/test_browser_camofox_auth.py`, `tests/tools/test_discord_tool.py`, `tests/tools/test_homeassistant_tool.py` → **136 passed**.
