### PR TITLE
fix(cron)+fix(memory): NUL-byte guard and MEMORY_GUIDANCE doctrine

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -163,8 +163,12 @@ HERMES_AGENT_HELP_GUIDANCE = (
 )
 
 MEMORY_GUIDANCE = (
-    "You have persistent memory across sessions. Save durable facts using the memory "
-    "tool: user preferences, environment details, tool quirks, and stable conventions. "
+    "You have persistent memory across sessions. Save pointers and operating facts. "
+    "Not all durable facts are memory-worthy: if a fact has a home in a file, a board, "
+    "a calendar, or a contact record, save the pointer, not the fact. Prefer saving "
+    "user preferences, corrections, and stable conventions you must hold in future "
+    "turns; personal details belong in structured stores — memory holds at most a "
+    "pointer to where they live. "
     "Memory is injected into every turn, so keep it compact and focused on facts that "
     "will still matter later.\n"
     "Prioritize what reduces future user steering — the most valuable memory is one "

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -255,10 +255,19 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
 
 def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+    # A path containing an embedded NUL byte can never be a real script on
+    # disk (POSIX filenames are NUL-terminated), and os.open / Path.resolve
+    # raise `ValueError: embedded null byte` for such paths. A guarded path
+    # must never crash the guard (#76762), so skip it as "nothing to scan"
+    # up front rather than relying on an exception handler below.
+    if "\x00" in str(path):
+        return None, False
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long/missing paths. ValueError: embedded NUL
+        # byte from a NUL-bearing path (defence-in-depth, #76762).
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -50,6 +50,28 @@ class TestGuidanceConstants:
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
 
+    def test_memory_guidance_is_doctrine_aligned_pointer_not_fact(self):
+        """Regression: MEMORY_GUIDANCE must follow the skill-based memory
+        doctrine (pointer-not-fact framing): when a fact has a permanent
+        home in a file/board/calendar/contact, the agent should save the
+        pointer, not duplicate the fact into memory."""
+        assert "save the pointer, not the fact" in MEMORY_GUIDANCE
+        assert "if a fact has a home" in MEMORY_GUIDANCE
+        assert "memory-worthy" in MEMORY_GUIDANCE
+        assert "pointer to where they live" in MEMORY_GUIDANCE
+        # The doctrine still allows compact durable facts (lowercase) — the
+        # surrounding text must not have regressed.
+        assert "durable facts" in MEMORY_GUIDANCE
+
+    def test_memory_guidance_lacks_conflicting_instruction(self):
+        """Regression: the pre-doctrine wording told the agent to blanket
+        'save durable facts using the memory tool' including environment
+        details and tool quirks — which conflicts with the pointer-not-fact
+        doctrine. That conflicting instruction must not be present."""
+        assert "using the memory tool" not in MEMORY_GUIDANCE
+        assert "environment details" not in MEMORY_GUIDANCE
+        assert "tool quirks" not in MEMORY_GUIDANCE
+
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,51 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_binary_with_embedded_nul_path_token_never_crashes(self, tmp_path):
+        """#76762 deterministic regression: a real on-disk binary whose
+        decoded bytes contain a NUL-bearing path token must never crash the
+        guard.
+
+        This is the exact panic frame from the dump: the walk reads the
+        binary's bytes, the decoded text yields a path with an embedded NUL,
+        and _read_referenced_script/os.open used to raise
+        ValueError: embedded null byte. The guard must treat it as
+        "nothing to scan" and return False without raising.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        binary = tmp_path / "mock-binary"
+        # Premixed shebang + NUL-bearing path token + NUL padding, exactly
+        # matching the reported crash binary's shape.
+        binary.write_bytes(
+            b"#!/bin/sh\n"
+            b"echo ok\n"
+            b"/tmp/fake\x00bin\n"
+            b"\x00" * 16
+        )
+        # Contains a slash -> the referenced-script walk picks the binary up.
+        command = f"{binary} --version"
+        result = contains_gateway_lifecycle_command_or_referenced_script(command)
+        assert result is False
+
+    def test_command_with_embedded_nul_path_never_crashes(self):
+        """#76762: a command whose text itself contains an embedded NUL byte
+        in a path token must never crash the guard.
+
+        Before the complete fix, this NUL-bearing path reached
+        _read_referenced_script's os.open(), which only caught OSError, so
+        ValueError: embedded null byte escaped and took down the guard (and
+        every guarded terminal call in the gateway process).
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        # A NUL byte directly embedded in the command text.
+        command = "/tmp/fake\x00bin --version"
+        result = contains_gateway_lifecycle_command_or_referenced_script(command)
+        assert result is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Summary

Two independent bug fixes from the Hermes self-maintenance fleet, split into separate commits:

**1. fix(cron): lifecycle guard total against NUL-byte paths (#76762)**
- `cron/lifecycle_guard.py`: short-circuit any path containing an embedded NUL byte (POSIX filenames are NUL-terminated, so such a path is never real). `os.open`/`Path.resolve` raise `ValueError: embedded null byte`; the guard must never crash on a guarded path.
- Also widen the OSError handler to `(OSError, ValueError)` for defence-in-depth.
- Test: `tests/hermes_cli/test_gateway_restart_loop.py` (+45)

**2. fix(memory): align MEMORY_GUIDANCE with skill-based pointer-not-fact doctrine (#79034)**
- `agent/prompt_builder.py`: rewrite the MEMORY_GUIDANCE system-prompt text to save pointers and operating facts instead of duplicating every durable fact into memory; personal details belong in structured stores, memory holds at most a pointer.
- Test: `tests/agent/test_prompt_builder.py` (+22)

## Test plan
- `tests/hermes_cli/test_gateway_restart_loop.py` - lifecycle guard regression
- `tests/agent/test_prompt_builder.py` - MEMORY_GUIDANCE doctrine regression
