### PR TITLE
fix(desktop): fall back for read-only attachment workspaces

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Iterable
 
 from agent.model_metadata import estimate_tokens_rough
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
@@ -126,6 +126,7 @@ def preprocess_context_references(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
+    additional_allowed_roots: Iterable[str | Path] | None = None,
 ) -> ContextReferenceResult:
     coro = preprocess_context_references_async(
         message,
@@ -133,6 +134,7 @@ def preprocess_context_references(
         context_length=context_length,
         url_fetcher=url_fetcher,
         allowed_root=allowed_root,
+        additional_allowed_roots=additional_allowed_roots,
     )
     # Safe for both CLI (no loop) and gateway (loop already running).
     try:
@@ -153,6 +155,7 @@ async def preprocess_context_references_async(
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: str | Path | None = None,
+    additional_allowed_roots: Iterable[str | Path] | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
@@ -163,6 +166,9 @@ async def preprocess_context_references_async(
     # the active workspace unless a caller explicitly widens the root.
     allowed_root_path = (
         Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
+    )
+    additional_allowed_root_paths = tuple(
+        Path(root).expanduser().resolve() for root in (additional_allowed_roots or ())
     )
     warnings: list[str] = []
     blocks: list[str] = []
@@ -181,6 +187,7 @@ async def preprocess_context_references_async(
                 cwd_path,
                 url_fetcher=url_fetcher,
                 allowed_root=allowed_root_path,
+                additional_allowed_roots=additional_allowed_root_paths,
             )
             for ref in refs
         )
@@ -241,12 +248,23 @@ async def _expand_reference(
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: Path | None = None,
+    additional_allowed_roots: tuple[Path, ...] = (),
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_file_reference(
+                ref,
+                cwd,
+                allowed_root=allowed_root,
+                additional_allowed_roots=additional_allowed_roots,
+            )
         if ref.kind == "folder":
-            return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_folder_reference(
+                ref,
+                cwd,
+                allowed_root=allowed_root,
+                additional_allowed_roots=additional_allowed_roots,
+            )
         if ref.kind == "diff":
             return _expand_git_reference(ref, cwd, ["diff"], "git diff")
         if ref.kind == "staged":
@@ -270,8 +288,14 @@ def _expand_file_reference(
     cwd: Path,
     *,
     allowed_root: Path | None = None,
+    additional_allowed_roots: tuple[Path, ...] = (),
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
+    path = _resolve_path(
+        cwd,
+        ref.target,
+        allowed_root=allowed_root,
+        additional_allowed_roots=additional_allowed_roots,
+    )
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: file not found", None
@@ -304,8 +328,14 @@ def _expand_folder_reference(
     cwd: Path,
     *,
     allowed_root: Path | None = None,
+    additional_allowed_roots: tuple[Path, ...] = (),
 ) -> tuple[str | None, str | None]:
-    path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
+    path = _resolve_path(
+        cwd,
+        ref.target,
+        allowed_root=allowed_root,
+        additional_allowed_roots=additional_allowed_roots,
+    )
     _ensure_reference_path_allowed(path)
     if not path.exists():
         return f"{ref.raw}: folder not found", None
@@ -368,16 +398,29 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
+def _resolve_path(
+    cwd: Path,
+    target: str,
+    *,
+    allowed_root: Path | None = None,
+    additional_allowed_roots: tuple[Path, ...] = (),
+) -> Path:
     path = Path(os.path.expanduser(target))
     if not path.is_absolute():
         path = cwd / path
     resolved = path.resolve()
-    if allowed_root is not None:
-        try:
-            resolved.relative_to(allowed_root)
-        except ValueError as exc:
-            raise ValueError("path is outside the allowed workspace") from exc
+    allowed_roots = tuple(
+        root for root in (allowed_root, *additional_allowed_roots) if root is not None
+    )
+    if allowed_roots:
+        for root in allowed_roots:
+            try:
+                resolved.relative_to(root)
+                break
+            except ValueError:
+                continue
+        else:
+            raise ValueError("path is outside the allowed workspace")
     return resolved
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -136,6 +136,33 @@ def test_missing_file_becomes_warning(sample_repo: Path):
 
 
 @pytest.mark.asyncio
+async def test_additional_allowed_root_is_narrow_and_keeps_sibling_blocked(tmp_path: Path):
+    from agent.context_references import preprocess_context_references_async
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session_root = tmp_path / "profile" / "cache" / "desktop-attachments" / "session-a"
+    session_root.mkdir(parents=True)
+    staged = session_root / "report.txt"
+    staged.write_text("session-a report", encoding="utf-8")
+    sibling = session_root.parent / "session-b" / "secret.txt"
+    sibling.parent.mkdir()
+    sibling.write_text("session-b secret", encoding="utf-8")
+
+    result = await preprocess_context_references_async(
+        f"inspect @file:{staged} and @file:{sibling}",
+        cwd=workspace,
+        allowed_root=workspace,
+        additional_allowed_roots=(session_root,),
+        context_length=100_000,
+    )
+
+    assert "session-a report" in result.message
+    assert "session-b secret" not in result.message
+    assert any("outside the allowed workspace" in warning for warning in result.warnings)
+
+
+@pytest.mark.asyncio
 async def test_blocks_canonical_read_denylist_credential_stores(tmp_path: Path, monkeypatch):
     """@file expansion must honour the canonical read deny-list.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import subprocess
@@ -7807,7 +7808,7 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     assert captured["session_key"] == "session-key"
 
 
-def test_prompt_submit_expands_context_refs(monkeypatch):
+def test_prompt_submit_expands_context_refs(monkeypatch, tmp_path):
     captured = {}
 
     class _Agent:
@@ -7830,19 +7831,23 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
             self._target()
 
     fake_ctx = types.ModuleType("agent.context_references")
-    fake_ctx.preprocess_context_references = (
-        lambda message, **kwargs: types.SimpleNamespace(
+
+    def preprocess_context_references(message, **kwargs):
+        captured["context_kwargs"] = kwargs
+        return types.SimpleNamespace(
             blocked=False,
             message="expanded prompt",
             warnings=[],
             references=[],
             injected_tokens=0,
         )
-    )
+
+    fake_ctx.preprocess_context_references = preprocess_context_references
     fake_meta = types.ModuleType("agent.model_metadata")
     fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
 
-    server._sessions["sid"] = _session(agent=_Agent())
+    session = _session(agent=_Agent(), profile_home=str(tmp_path / "profile-home"))
+    server._sessions["sid"] = session
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
@@ -7859,6 +7864,9 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     )
 
     assert captured["prompt"] == "expanded prompt"
+    assert captured["context_kwargs"]["additional_allowed_roots"] == (
+        server._profile_desktop_attachment_dir(session, create=False),
+    )
 
 
 def test_image_attach_appends_local_image(monkeypatch):
@@ -7952,6 +7960,111 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         assert resp["result"]["path"] == str(stored)
         assert resp["result"]["ref_text"] == "@file:.hermes/desktop-attachments/report.txt"
         assert stored.read_text(encoding="utf-8") == "hello world"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+@pytest.mark.parametrize(
+    "staging_error",
+    [
+        pytest.param(PermissionError("workspace staging denied"), id="permission-denied"),
+        pytest.param(OSError(errno.EROFS, "read-only filesystem"), id="read-only-filesystem"),
+    ],
+)
+def test_file_attach_falls_back_to_profile_home_when_workspace_staging_is_unwritable(
+    monkeypatch, tmp_path, staging_error
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "profile-home"
+    profile_home.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    def fail_workspace_staging(_session):
+        raise staging_error
+
+    monkeypatch.setattr(server, "_desktop_attachment_dir", fail_workspace_staging)
+    session = _session(cwd=str(workspace), profile_home=str(profile_home))
+    server._sessions["sid"] = session
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+
+        fallback_root = server._profile_desktop_attachment_dir(session, create=False)
+        stored = fallback_root / "report.txt"
+        assert resp["result"]["attached"] is True
+        assert resp["result"]["uploaded"] is True
+        assert resp["result"]["path"] == str(stored)
+        assert resp["result"]["ref_text"] == f"@file:{stored}"
+        assert stored.read_text(encoding="utf-8") == "hello world"
+        assert not (workspace / ".hermes" / "desktop-attachments").exists()
+
+        from agent.context_references import preprocess_context_references
+
+        expanded = preprocess_context_references(
+            resp["result"]["ref_text"],
+            cwd=workspace,
+            allowed_root=workspace,
+            additional_allowed_roots=(fallback_root,),
+            context_length=100_000,
+        )
+        assert not expanded.blocked
+        assert "hello world" in expanded.message
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_does_not_fallback_for_unrelated_staging_os_error(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "profile-home"
+    profile_home.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    def fail_workspace_staging(_session):
+        raise OSError(errno.ENOSPC, "no space left on device")
+
+    monkeypatch.setattr(server, "_desktop_attachment_dir", fail_workspace_staging)
+    server._sessions["sid"] = _session(
+        cwd=str(workspace), profile_home=str(profile_home)
+    )
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+
+        assert "error" in resp
+        assert resp["error"]["message"] == "[Errno 28] no space left on device"
+        assert not (profile_home / "cache" / "desktop-attachments").exists()
     finally:
         server._sessions.pop("sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -274,19 +274,28 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
 
 
 def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch):
+    captured = {}
+
     class _Supervisor:
-        def submit_turn(self, _frame, *, on_complete=None):
+        def submit_turn(self, frame, *, on_complete=None):
+            captured["frame"] = frame
             session["attached_images"].append("/tmp/c.png")
 
     session = _session(attached_images=[])
     monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor())
 
     response = server._submit_prompt_to_compute_host(
-        "r1", "sid", session, "B", image_paths=["/tmp/b.png"]
+        "r1",
+        "sid",
+        session,
+        "B",
+        image_paths=["/tmp/b.png"],
+        attachment_session_keys=["pre-compression-key"],
     )
 
     assert response["result"]["status"] == "streaming"
     assert session["attached_images"] == ["/tmp/c.png"]
+    assert captured["frame"]["attachment_session_keys"] == ["pre-compression-key"]
 
 
 def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monkeypatch):
@@ -7864,9 +7873,113 @@ def test_prompt_submit_expands_context_refs(monkeypatch, tmp_path):
     )
 
     assert captured["prompt"] == "expanded prompt"
-    assert captured["context_kwargs"]["additional_allowed_roots"] == (
-        server._profile_desktop_attachment_dir(session, create=False),
+    current_root = server._profile_desktop_attachment_dir(session, create=False)
+    assert captured["context_kwargs"]["additional_allowed_roots"] == (current_root,)
+
+    server._run_prompt_submit(
+        "2",
+        "sid",
+        session,
+        "@file:/queued/attachment.txt",
+        attachment_session_keys=["pre-compression-key"],
     )
+
+    assert captured["context_kwargs"]["additional_allowed_roots"] == (
+        current_root,
+        server._profile_desktop_attachment_dir(
+            session, create=False, session_key="pre-compression-key"
+        ),
+    )
+
+
+def test_queued_file_ref_expands_after_session_key_rotation(monkeypatch, tmp_path):
+    captured = {}
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+        provider = ""
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "profile-home"
+    session = _session(
+        agent=_Agent(),
+        cwd=str(workspace),
+        profile_home=str(profile_home),
+        session_key="after-compression",
+    )
+    old_root = server._profile_desktop_attachment_dir(
+        session, create=True, session_key="before-compression"
+    )
+    attached = old_root / "queued.txt"
+    attached.write_text("queued attachment survived compression", encoding="utf-8")
+
+    from agent import model_metadata
+
+    monkeypatch.setattr(
+        model_metadata, "get_model_context_length", lambda *args, **kwargs: 100000
+    )
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    server._run_prompt_submit(
+        "1",
+        "sid",
+        session,
+        f"@file:{attached}",
+        attachment_session_keys=["before-compression"],
+    )
+
+    assert "queued attachment survived compression" in captured["prompt"]
+
+
+def test_queued_file_refs_retain_pre_compression_session_keys(monkeypatch):
+    session = _session(running=True, session_key="before-compression")
+    transport = object()
+    server._enqueue_prompt(session, "@file:/old/one.txt", transport)
+    session["session_key"] = "during-compression"
+    server._enqueue_prompt(session, "@file:/old/two.txt", transport)
+
+    queued = session["queued_prompt"]
+    assert queued["attachment_session_keys"] == [
+        "before-compression",
+        "during-compression",
+    ]
+
+    captured = {}
+
+    def capture_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    session["session_key"] = "after-compression"
+    session["running"] = False
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: False)
+    monkeypatch.setattr(server, "_run_prompt_submit", capture_run)
+
+    assert server._drain_queued_prompt("1", "sid", session)
+    assert captured["kwargs"]["attachment_session_keys"] == [
+        "before-compression",
+        "during-compression",
+    ]
 
 
 def test_image_attach_appends_local_image(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7967,7 +7967,13 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
 @pytest.mark.parametrize(
     "staging_error",
     [
-        pytest.param(PermissionError("workspace staging denied"), id="permission-denied"),
+        pytest.param(PermissionError("workspace staging denied"), id="permission-no-errno"),
+        pytest.param(
+            PermissionError(errno.EACCES, "permission denied"), id="permission-eacces"
+        ),
+        pytest.param(
+            PermissionError(errno.EPERM, "operation not permitted"), id="permission-eperm"
+        ),
         pytest.param(OSError(errno.EROFS, "read-only filesystem"), id="read-only-filesystem"),
     ],
 )
@@ -8013,6 +8019,9 @@ def test_file_attach_falls_back_to_profile_home_when_workspace_staging_is_unwrit
         assert resp["result"]["ref_text"] == f"@file:{stored}"
         assert stored.read_text(encoding="utf-8") == "hello world"
         assert not (workspace / ".hermes" / "desktop-attachments").exists()
+        if os.name != "nt":
+            assert stored.stat().st_mode & 0o777 == 0o600
+            assert fallback_root.stat().st_mode & 0o777 == 0o700
 
         from agent.context_references import preprocess_context_references
 
@@ -8029,18 +8038,27 @@ def test_file_attach_falls_back_to_profile_home_when_workspace_staging_is_unwrit
         server._sessions.pop("sid", None)
 
 
-def test_file_attach_does_not_fallback_for_unrelated_staging_os_error(monkeypatch, tmp_path):
+def test_file_attach_rejects_profile_cache_symlink_escape(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     profile_home = tmp_path / "profile-home"
-    profile_home.mkdir()
+    cache_root = profile_home / "cache"
+    cache_root.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    attachment_link = cache_root / "desktop-attachments"
+    try:
+        attachment_link.symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
     fake_cli = types.ModuleType("cli")
     fake_cli._detect_file_drop = lambda raw: None
     fake_cli._split_path_input = lambda raw: (raw, "")
     fake_cli._resolve_attachment_path = lambda raw: None
 
     def fail_workspace_staging(_session):
-        raise OSError(errno.ENOSPC, "no space left on device")
+        raise PermissionError("workspace staging denied")
 
     monkeypatch.setattr(server, "_desktop_attachment_dir", fail_workspace_staging)
     server._sessions["sid"] = _session(
@@ -8063,7 +8081,109 @@ def test_file_attach_does_not_fallback_for_unrelated_staging_os_error(monkeypatc
         )
 
         assert "error" in resp
-        assert resp["error"]["message"] == "[Errno 28] no space left on device"
+        assert "escaped the active profile home" in resp["error"]["message"]
+        assert list(outside.rglob("*")) == []
+    finally:
+        server._sessions.pop("sid", None)
+
+
+@pytest.mark.parametrize(
+    "staging_error",
+    [
+        pytest.param(OSError(errno.ENOSPC, "no space left on device"), id="disk-full"),
+        pytest.param(OSError(errno.EIO, "input/output error"), id="io-error"),
+        pytest.param(OSError(errno.ENOTDIR, "not a directory"), id="not-a-directory"),
+    ],
+)
+def test_file_attach_does_not_fallback_for_unrelated_staging_os_error(
+    monkeypatch, tmp_path, staging_error
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "profile-home"
+    profile_home.mkdir()
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    def fail_workspace_staging(_session):
+        raise staging_error
+
+    monkeypatch.setattr(server, "_desktop_attachment_dir", fail_workspace_staging)
+    server._sessions["sid"] = _session(
+        cwd=str(workspace), profile_home=str(profile_home)
+    )
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+
+        assert "error" in resp
+        assert resp["error"]["message"] == str(staging_error)
+        assert not (profile_home / "cache" / "desktop-attachments").exists()
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_does_not_fallback_for_source_read_permission_error(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / "profile-home"
+    profile_home.mkdir()
+    source = tmp_path / "outside.txt"
+    source.write_text("unreadable source", encoding="utf-8")
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: source
+
+    original_read_bytes = Path.read_bytes
+
+    def deny_source_read(path):
+        if path.resolve() == source.resolve():
+            raise PermissionError(errno.EACCES, "source read denied")
+        return original_read_bytes(path)
+
+    fallback_calls = []
+    original_fallback_dir = server._profile_desktop_attachment_dir
+
+    def track_fallback(*args, **kwargs):
+        fallback_calls.append(True)
+        return original_fallback_dir(*args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_bytes", deny_source_read)
+    monkeypatch.setattr(server, "_profile_desktop_attachment_dir", track_fallback)
+    server._sessions["sid"] = _session(
+        cwd=str(workspace), profile_home=str(profile_home)
+    )
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {"session_id": "sid", "path": str(source)},
+            }
+        )
+
+        assert "error" in resp
+        assert "source read denied" in resp["error"]["message"]
+        assert fallback_calls == []
         assert not (profile_home / "cache" / "desktop-attachments").exists()
     finally:
         server._sessions.pop("sid", None)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -483,7 +483,13 @@ class ComputeHost:
             except Exception:
                 pass
             text = frame.get("text") if "text" in frame else frame.get("prompt", "")
-            server._run_prompt_submit(request_id, sid, session, text)
+            server._run_prompt_submit(
+                request_id,
+                sid,
+                session,
+                text,
+                attachment_session_keys=frame.get("attachment_session_keys"),
+            )
             run_thread = session.get("_run_thread")
             if run_thread is not None and hasattr(run_thread, "join"):
                 run_thread.join()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -608,8 +608,10 @@ def _(rid, params: dict) -> dict:
     """Stage a non-image file attachment into the session workspace.
 
     The image/PDF path renders to vision tiles; this one keeps the file as a
-    readable artifact and returns a workspace-relative ``@file:`` ref so the
-    agent's file tools (and ``agent.context_references``) can read it. Solves the
+    readable artifact and returns an ``@file:`` ref that the agent's file tools
+    (and ``agent.context_references``) can read. Writable workspaces use the
+    existing relative ref; a read-only workspace falls back to a session-scoped
+    profile cache and an explicitly authorized absolute ref. This solves the
     remote-gateway case where the desktop passes a path that only exists on the
     CLIENT's disk: the client uploads ``data_url`` bytes and we materialize the
     file on the gateway.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1635,6 +1635,7 @@ def _compute_host_turn_frame(
     text: Any,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    attachment_session_keys: list[str] | None = None,
 ) -> dict:
     with session["history_lock"]:
         history = list(session.get("history", []))
@@ -1661,6 +1662,7 @@ def _compute_host_turn_frame(
         "source": _session_source(session),
         "attached_images": attached_images,
         "queued_prompt_generation": queued_prompt_generation,
+        "attachment_session_keys": list(attachment_session_keys or []),
     }
 
 
@@ -1738,6 +1740,7 @@ def _submit_prompt_to_compute_host(
     text: Any,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    attachment_session_keys: list[str] | None = None,
 ) -> dict:
     cfg = _load_dashboard_process_isolation_config()
     frame = _compute_host_turn_frame(
@@ -1747,6 +1750,7 @@ def _submit_prompt_to_compute_host(
         text,
         image_paths=image_paths,
         queued_prompt_generation=queued_prompt_generation,
+        attachment_session_keys=attachment_session_keys,
     )
 
     def _complete(done: dict) -> None:
@@ -7327,6 +7331,10 @@ def _enqueue_prompt(
     """
     image_paths = list(image_paths or [])
     queued = {"text": text, "transport": transport}
+    if isinstance(text, str) and "@file:" in text:
+        attachment_session_key = str(session.get("session_key") or "").strip()
+        if attachment_session_key:
+            queued["attachment_session_keys"] = [attachment_session_key]
     if image_paths:
         queued["image_paths"] = image_paths
     existing = session.get("queued_prompt")
@@ -7340,6 +7348,10 @@ def _enqueue_prompt(
     ):
         prev = existing["text"]
         existing["text"] = f"{prev}\n\n{text}" if prev and text else (prev or text)
+        existing_keys = existing.setdefault("attachment_session_keys", [])
+        for attachment_session_key in queued.get("attachment_session_keys", []):
+            if attachment_session_key not in existing_keys:
+                existing_keys.append(attachment_session_key)
         return
     if existing:
         session.setdefault("queued_prompts", []).append(queued)
@@ -7501,10 +7513,16 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     queued["text"],
                     image_paths=queued["image_paths"],
                     queued_prompt_generation=queue_generation,
+                    attachment_session_keys=queued.get("attachment_session_keys"),
                 )
             else:
                 resp = _submit_prompt_to_compute_host(
-                    rid, sid, session, queued["text"], queued_prompt_generation=queue_generation
+                    rid,
+                    sid,
+                    session,
+                    queued["text"],
+                    queued_prompt_generation=queue_generation,
+                    attachment_session_keys=queued.get("attachment_session_keys"),
                 )
             if resp.get("error"):
                 message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
@@ -7522,6 +7540,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     queued["text"],
                     image_paths=queued["image_paths"],
                     queued_prompt_generation=queue_generation,
+                    attachment_session_keys=queued.get("attachment_session_keys"),
                 )
             else:
                 _run_prompt_submit(
@@ -7530,6 +7549,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     session,
                     queued["text"],
                     queued_prompt_generation=queue_generation,
+                    attachment_session_keys=queued.get("attachment_session_keys"),
                 )
     except Exception as exc:
         print(
@@ -9349,6 +9369,7 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    attachment_session_keys: list[str] | None = None,
 ) -> None:
     with session["history_lock"]:
         if (
@@ -9460,13 +9481,22 @@ def _run_prompt_submit(
                         agent, "_config_context_length", None
                     ),
                 )
+                attachment_roots = [
+                    _profile_desktop_attachment_dir(session, create=False)
+                ]
+                for attachment_session_key in attachment_session_keys or []:
+                    queued_root = _profile_desktop_attachment_dir(
+                        session,
+                        create=False,
+                        session_key=attachment_session_key,
+                    )
+                    if queued_root not in attachment_roots:
+                        attachment_roots.append(queued_root)
                 ctx = preprocess_context_references(
                     prompt,
                     cwd=cwd,
                     allowed_root=cwd,
-                    additional_allowed_roots=(
-                        _profile_desktop_attachment_dir(session, create=False),
-                    ),
+                    additional_allowed_roots=tuple(attachment_roots),
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -10346,11 +10376,18 @@ def _desktop_attachment_dir(session: dict) -> Path:
     return root
 
 
-def _profile_desktop_attachment_dir(session: dict, *, create: bool = True) -> Path:
-    """Return this session's profile-owned attachment fallback directory."""
+def _profile_desktop_attachment_dir(
+    session: dict,
+    *,
+    create: bool = True,
+    session_key: str | None = None,
+) -> Path:
+    """Return a profile-owned attachment fallback directory for a session key."""
     profile_home = session.get("profile_home")
     base = Path(profile_home) if profile_home else Path(_hermes_home)
-    session_key = str(session.get("session_key") or session.get("_sid") or "").strip()
+    session_key = str(
+        session_key if session_key is not None else session.get("session_key") or ""
+    ).strip()
     if not session_key:
         raise ValueError("session identity unavailable for attachment staging")
     profile_root = base.resolve()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7502,6 +7502,9 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:
             session["running"] = False
             return True
+    attachment_kwargs = {}
+    if queued.get("attachment_session_keys"):
+        attachment_kwargs["attachment_session_keys"] = queued["attachment_session_keys"]
     dispatch_failed = False
     try:
         if use_compute_host:
@@ -7513,7 +7516,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     queued["text"],
                     image_paths=queued["image_paths"],
                     queued_prompt_generation=queue_generation,
-                    attachment_session_keys=queued.get("attachment_session_keys"),
+                    **attachment_kwargs,
                 )
             else:
                 resp = _submit_prompt_to_compute_host(
@@ -7522,7 +7525,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     session,
                     queued["text"],
                     queued_prompt_generation=queue_generation,
-                    attachment_session_keys=queued.get("attachment_session_keys"),
+                    **attachment_kwargs,
                 )
             if resp.get("error"):
                 message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
@@ -7540,7 +7543,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     queued["text"],
                     image_paths=queued["image_paths"],
                     queued_prompt_generation=queue_generation,
-                    attachment_session_keys=queued.get("attachment_session_keys"),
+                    **attachment_kwargs,
                 )
             else:
                 _run_prompt_submit(
@@ -7549,7 +7552,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     session,
                     queued["text"],
                     queued_prompt_generation=queue_generation,
-                    attachment_session_keys=queued.get("attachment_session_keys"),
+                    **attachment_kwargs,
                 )
     except Exception as exc:
         print(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10353,11 +10353,24 @@ def _profile_desktop_attachment_dir(session: dict, *, create: bool = True) -> Pa
     session_key = str(session.get("session_key") or session.get("_sid") or "").strip()
     if not session_key:
         raise ValueError("session identity unavailable for attachment staging")
+    profile_root = base.resolve()
     scope = hashlib.sha256(session_key.encode("utf-8")).hexdigest()
-    root = base.resolve() / "cache" / "desktop-attachments" / scope
+    root = profile_root / "cache" / "desktop-attachments" / scope
+    resolved_root = root.resolve()
+    try:
+        resolved_root.relative_to(profile_root)
+    except ValueError as exc:
+        raise PermissionError("attachment fallback escaped the active profile home") from exc
     if create:
-        root.mkdir(parents=True, exist_ok=True)
-    return root
+        resolved_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        resolved_root = resolved_root.resolve()
+        try:
+            resolved_root.relative_to(profile_root)
+        except ValueError as exc:
+            raise PermissionError("attachment fallback escaped the active profile home") from exc
+    if create and os.name != "nt":
+        resolved_root.chmod(0o700)
+    return resolved_root
 
 
 def _is_readonly_attachment_staging_error(exc: OSError) -> bool:
@@ -10374,18 +10387,29 @@ def _sanitize_attachment_name(name: str) -> str:
     return candidate or "attachment"
 
 
-def _unique_attachment_path(root: Path, filename: str) -> Path:
-    candidate = root / filename
-    if not candidate.exists():
-        return candidate
+def _write_unique_attachment(
+    root: Path, filename: str, payload: bytes, *, mode: int = 0o600
+) -> Path:
+    """Create an attachment without following or replacing a raced path."""
     stem = Path(filename).stem or "attachment"
     suffix = Path(filename).suffix
-    counter = 2
+    counter = 1
     while True:
-        next_candidate = root / f"{stem}-{counter}{suffix}"
-        if not next_candidate.exists():
-            return next_candidate
-        counter += 1
+        candidate = root / (filename if counter == 1 else f"{stem}-{counter}{suffix}")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(candidate, flags, mode)
+        except FileExistsError:
+            counter += 1
+            continue
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+        except Exception:
+            with contextlib.suppress(OSError):
+                candidate.unlink()
+            raise
+        return candidate
 
 
 def _resolve_gateway_attachment_path(raw: str) -> Path | None:
@@ -10470,14 +10494,14 @@ def _stage_session_file_attachment(
     safe_filename = _sanitize_attachment_name(filename)
     try:
         upload_dir = _desktop_attachment_dir(session)
-        target = _unique_attachment_path(upload_dir, safe_filename)
-        target.write_bytes(payload)
+        target = _write_unique_attachment(
+            upload_dir, safe_filename, payload, mode=0o666
+        )
     except OSError as exc:
         if not _is_readonly_attachment_staging_error(exc):
             raise
         upload_dir = _profile_desktop_attachment_dir(session)
-        target = _unique_attachment_path(upload_dir, safe_filename)
-        target.write_bytes(payload)
+        target = _write_unique_attachment(upload_dir, safe_filename, payload)
     return target.resolve(), True
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import copy
+import errno
 import hashlib
 import inspect
 import json
@@ -9463,6 +9464,9 @@ def _run_prompt_submit(
                     prompt,
                     cwd=cwd,
                     allowed_root=cwd,
+                    additional_allowed_roots=(
+                        _profile_desktop_attachment_dir(session, create=False),
+                    ),
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -10342,6 +10346,25 @@ def _desktop_attachment_dir(session: dict) -> Path:
     return root
 
 
+def _profile_desktop_attachment_dir(session: dict, *, create: bool = True) -> Path:
+    """Return this session's profile-owned attachment fallback directory."""
+    profile_home = session.get("profile_home")
+    base = Path(profile_home) if profile_home else Path(_hermes_home)
+    session_key = str(session.get("session_key") or session.get("_sid") or "").strip()
+    if not session_key:
+        raise ValueError("session identity unavailable for attachment staging")
+    scope = hashlib.sha256(session_key.encode("utf-8")).hexdigest()
+    root = base.resolve() / "cache" / "desktop-attachments" / scope
+    if create:
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _is_readonly_attachment_staging_error(exc: OSError) -> bool:
+    """Classify only permission/read-only errors as workspace fallback triggers."""
+    return isinstance(exc, PermissionError) or exc.errno == errno.EROFS
+
+
 def _sanitize_attachment_name(name: str) -> str:
     import re as _re
 
@@ -10422,6 +10445,11 @@ def _stage_session_file_attachment(
          path on the CLIENT's disk) — decode the uploaded ``data_url`` bytes and
          write them into ``.hermes/desktop-attachments/``.
 
+    If workspace-local staging is denied or the filesystem is read-only, the
+    attachment is instead written under the active profile's HERMES_HOME. The
+    resulting reference is absolute so it remains resolvable outside the
+    workspace.
+
     Returns ``(stored_path, uploaded)``.
     """
     workspace = Path(_session_cwd(session)).resolve()
@@ -10439,9 +10467,17 @@ def _stage_session_file_attachment(
         payload = _decode_attachment_data_url(data_url)
         filename = _sanitize_attachment_name(name or Path(str(raw_path or "")).name)
 
-    upload_dir = _desktop_attachment_dir(session)
-    target = _unique_attachment_path(upload_dir, _sanitize_attachment_name(filename))
-    target.write_bytes(payload)
+    safe_filename = _sanitize_attachment_name(filename)
+    try:
+        upload_dir = _desktop_attachment_dir(session)
+        target = _unique_attachment_path(upload_dir, safe_filename)
+        target.write_bytes(payload)
+    except OSError as exc:
+        if not _is_readonly_attachment_staging_error(exc):
+            raise
+        upload_dir = _profile_desktop_attachment_dir(session)
+        target = _unique_attachment_path(upload_dir, safe_filename)
+        target.write_bytes(payload)
     return target.resolve(), True
 
 


### PR DESCRIPTION
## What does this PR do?

Makes Desktop `file.attach` robust when a session's workspace exists but cannot host `.hermes/desktop-attachments`.

Hermes still stages into the workspace first, preserving current relative `@file:` behavior. If that write fails specifically with a permission denial or read-only filesystem, the gateway falls back to a profile-owned, session-scoped cache directory:

```text
<HERMES_HOME>/cache/desktop-attachments/<session-scope>/
```

The returned absolute reference is authorized only for that session during prompt context expansion. Sibling session caches and arbitrary paths outside the workspace remain blocked, and the existing credential deny-list still applies.

Fallback directories and files are private (`0700`/`0600` on POSIX), writes use exclusive creation without following a raced final symlink, and the fallback fails closed if any cache-path symlink would escape the active profile home.

If a prompt is queued while another turn is running, the queue envelope retains the attachment's durable session key. A compression continuation can therefore authorize that exact pre-compression attachment root without widening access to sibling sessions; the association is also forwarded through compute-host turn isolation.

This fixes remote Desktop sessions that inherited a read-only cwd such as `/Volumes`, where uploads failed with `[Errno 13] Permission denied: '/Volumes/.hermes'` even though the active profile home was writable.

## Related Issue

Fixes #79065

Related workspace-placement UX: #53004 and #68621. This PR deliberately does not duplicate that work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - classify only `PermissionError` and `EROFS` as fallback-worthy workspace failures;
  - stage fallback files under a profile- and session-scoped cache root;
  - authorize only the current session's cache root when expanding prompt references;
  - reject profile-cache symlink escapes and create fallback files privately and atomically;
  - retain exact attachment-session associations across queued prompts and compression rotation;
  - preserve unrelated filesystem errors such as `ENOSPC`.
- `tui_gateway/compute_host.py`
  - preserve queued attachment-session associations through isolated turn frames.
- `tui_gateway/methods_prompt.py`
  - document workspace-relative and profile-cache attachment reference behavior.
- `agent/context_references.py`
  - add an optional additive allowed-root list while retaining the workspace root and canonical credential guard.
- `tests/test_tui_gateway_server.py`
  - cover `EACCES`/`EPERM`/`EROFS` fallback, profile routing, private modes, symlink-escape rejection, source-read errors, queued compression rotation, compute-host forwarding, returned-reference expansion, prompt wiring, writable-workspace compatibility, and non-fallback errors.
- `tests/agent/test_context_references.py`
  - prove the current session's staged root is readable while a sibling session root remains blocked.

## How to Test

1. Run the focused gateway and context-reference tests:

   ```bash
   pytest -q tests/test_tui_gateway_server.py
   pytest -q tests/agent/test_context_references.py
   ```

2. Run static checks:

   ```bash
   python -m ruff check agent/context_references.py tui_gateway/server.py tests/test_tui_gateway_server.py tests/agent/test_context_references.py
   python -m compileall -q agent/context_references.py tui_gateway/server.py tui_gateway/methods_prompt.py tests/test_tui_gateway_server.py tests/agent/test_context_references.py
   git diff --check
   ```

3. In Desktop remote mode, attach a text file from a session whose cwd is read-only. The upload should succeed from the profile cache and the `@file:` reference should expand normally.

Verified locally:

```text
528 gateway tests passed across split verification
  527 passed, 1 deselected  # suite excluding an intermittent pre-existing concurrency test
  1 passed                  # concurrency test run in isolation
12 passed in 0.62s          # tests/agent/test_context_references.py
12 passed                   # compute-host suites
15 passed                   # queue-on-busy compatibility suite
All checks passed!          # ruff
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused affected suites pass; full suite delegated to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and docstrings are updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-tool schema change

## Screenshots / Logs

The regression is gateway-side and covered by deterministic filesystem-error injection. No UI changes.
