### PR TITLE
feat(discord): agent-facing add_reaction/remove_reaction (photon parity)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -61,6 +61,8 @@ _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
 # every slash command — not just the overflow ones. We keep the desired set
 # at or below this limit at registration time.
 _DISCORD_MAX_APP_COMMANDS = 100
+# How many agent-added reactions to remember for retraction (per gateway run).
+_AGENT_REACTION_MEMORY = 1024
 _DISCORD_SELECT_FIELD_LIMIT = 100
 _DISCORD_BUTTON_LABEL_LIMIT = 80
 _DISCORD_ELLIPSIS = "\u2026"
@@ -1003,6 +1005,16 @@ class DiscordAdapter(BasePlatformAdapter):
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
+        # Last inbound message ID per chat, recorded at processing start so
+        # agent-facing reactions can default to "the message that triggered
+        # this turn" instead of making the model thread ids through the tool
+        # call. Keyed by the chat the agent is in AND (for auto-threaded
+        # turns) the parent channel the trigger message actually lives in.
+        self._last_inbound_by_chat: Dict[str, str] = {}
+        # Emoji the agent reacted with, per (chat_id, message_id), so an
+        # unreact knows what to retract without stripping the lifecycle ack.
+        # Lost on restart — retraction is best-effort, as on photon.
+        self._agent_reactions: Dict[Tuple[str, str], str] = {}
         # Persistent set of bot-authored lifecycle/status message IDs that
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
@@ -2865,9 +2877,150 @@ class DiscordAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in {"false", "0", "no"}
 
+    # -- Agent-facing reactions (send_message action="react") ---------------
+    #
+    # Unlike the lifecycle hooks below, these are deliberate agent intents,
+    # so they are NOT gated by DISCORD_REACTIONS (that env var exists to mute
+    # the automatic 👀/✅ ack, not explicit requests).
+
+    def _record_inbound_reaction_target(self, event: MessageEvent) -> None:
+        """Remember the message that triggered this turn, per chat."""
+        source = getattr(event, "source", None)
+        message_id = str(
+            getattr(event, "message_id", "")
+            or getattr(getattr(event, "raw_message", None), "id", "")
+            or ""
+        )
+        if not message_id:
+            return
+        # An auto-threaded turn runs with chat_id set to the new thread while
+        # the trigger message sits in the parent channel; record both so the
+        # agent can target either.
+        for key in (
+            getattr(source, "chat_id", None),
+            getattr(source, "parent_chat_id", None),
+        ):
+            if key:
+                self._last_inbound_by_chat[str(key)] = message_id
+
+    async def _fetch_reaction_target(self, chat_id: str, message_id: str) -> Optional[Any]:
+        """Fetch a message to react to, falling back to a thread's parent.
+
+        Auto-threaded turns address the thread, but the message that started
+        them belongs to the parent channel, so both are tried.
+        """
+        if not self._client:
+            return None
+        try:
+            channel_key = int(chat_id)
+            target_id = int(message_id)
+        except (TypeError, ValueError):
+            return None
+        channel = self._client.get_channel(channel_key)
+        if not channel:
+            try:
+                channel = await self._client.fetch_channel(channel_key)
+            except Exception as e:
+                logger.debug("[%s] reaction channel fetch failed: %s", self.name, e)
+                return None
+        if not channel:
+            return None
+        candidates = [channel]
+        parent = self._thread_parent_channel(channel)
+        if parent is not None and parent is not channel:
+            candidates.append(parent)
+        for candidate in candidates:
+            fetch = getattr(candidate, "fetch_message", None)
+            if not callable(fetch):
+                continue
+            try:
+                message = await fetch(target_id)
+            except Exception as e:
+                logger.debug("[%s] reaction message fetch failed: %s", self.name, e)
+                continue
+            if message:
+                return message
+        return None
+
+    def _resolve_reaction_target_id(
+        self, chat_id: str, message_id: Optional[str]
+    ) -> Optional[str]:
+        target = message_id or self._last_inbound_by_chat.get(str(chat_id))
+        return str(target) if target else None
+
+    async def add_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """React with ``emoji`` to a message in ``chat_id``.
+
+        Without ``message_id``, targets the message that triggered this turn
+        (the one the agent is responding to).
+        """
+        target = self._resolve_reaction_target_id(chat_id, message_id)
+        if not target:
+            return {
+                "success": False,
+                "error": "no message to react to — pass message_id (no inbound "
+                "message seen in this chat since the gateway started)",
+            }
+        message = await self._fetch_reaction_target(chat_id, target)
+        if message is None:
+            return {
+                "success": False,
+                "error": f"message {target} not found in chat {chat_id}",
+            }
+        if not await self._add_reaction(message, emoji):
+            return {
+                "success": False,
+                "error": "reaction failed (see gateway debug log)",
+            }
+        self._remember_agent_reaction(chat_id, target, emoji)
+        return {"success": True, "message_id": target}
+
+    async def remove_reaction(
+        self, chat_id: str, message_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Retract the reaction the agent added to a message."""
+        target = self._resolve_reaction_target_id(chat_id, message_id)
+        if not target:
+            return {
+                "success": False,
+                "error": "no message to unreact — pass message_id",
+            }
+        emoji = self._agent_reactions.get((str(chat_id), target))
+        if not emoji:
+            return {
+                "success": False,
+                "error": f"no reaction of ours to retract on message {target} "
+                "(only reactions added since the gateway started are tracked)",
+            }
+        message = await self._fetch_reaction_target(chat_id, target)
+        if message is None:
+            return {
+                "success": False,
+                "error": f"message {target} not found in chat {chat_id}",
+            }
+        if not await self._remove_reaction(message, emoji):
+            return {
+                "success": False,
+                "error": "unreact failed (see gateway debug log)",
+            }
+        self._agent_reactions.pop((str(chat_id), target), None)
+        return {"success": True, "message_id": target}
+
+    def _remember_agent_reaction(self, chat_id: str, message_id: str, emoji: str) -> None:
+        """Track an agent reaction so unreact knows what to retract."""
+        self._agent_reactions[(str(chat_id), str(message_id))] = emoji
+        while len(self._agent_reactions) > _AGENT_REACTION_MEMORY:
+            self._agent_reactions.pop(next(iter(self._agent_reactions)))
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction and record durable handling state."""
         message = event.raw_message
+        self._record_inbound_reaction_target(event)
         acked = False
         if self._reactions_enabled() and hasattr(message, "add_reaction"):
             acked = await self._add_reaction(message, "👀")

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -278,4 +278,3 @@ async def test_remove_reaction_without_a_tracked_emoji_reports_why(adapter):
 
     assert result["success"] is False
     message.remove_reaction.assert_not_awaited()
-

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -140,3 +140,142 @@ async def test_reactions_disabled_via_env(adapter, monkeypatch):
     adapter.send.assert_awaited_once()
 
 
+# --- Agent-facing reactions (send_message action="react") -------------------
+
+
+class FakeChannel:
+    """Minimal channel double: fetch_message succeeds only for known ids."""
+
+    def __init__(self, channel_id, messages=None, parent=None):
+        self.id = int(channel_id)
+        self._messages = messages or {}
+        self.parent = parent
+
+    async def fetch_message(self, message_id):
+        message = self._messages.get(int(message_id))
+        if message is None:
+            raise RuntimeError("404 Not Found (error code: 10008): Unknown Message")
+        return message
+
+
+def _fake_message(message_id):
+    return SimpleNamespace(
+        id=int(message_id),
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+
+
+def _wire_channels(adapter, *channels):
+    by_id = {channel.id: channel for channel in channels}
+    adapter._client.get_channel = lambda cid: by_id.get(int(cid))
+
+
+async def _run_turn(adapter, event):
+    """Drive one full inbound turn so lifecycle state is recorded."""
+
+    async def handler(_event):
+        await asyncio.sleep(0)
+        return "ack"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="999"))
+    adapter._keep_typing = hold_typing
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_targets_explicit_message_id(adapter):
+    message = _fake_message(555)
+    _wire_channels(adapter, FakeChannel(123, {555: message}))
+
+    result = await adapter.add_reaction(chat_id="123", emoji="🟢", message_id="555")
+
+    assert result == {"success": True, "message_id": "555"}
+    message.add_reaction.assert_awaited_once_with("🟢")
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_defaults_to_the_triggering_message(adapter):
+    """No message_id: react to whatever started this turn (photon precedent)."""
+    message = _fake_message(777)
+    _wire_channels(adapter, FakeChannel(123, {777: message}))
+    await _run_turn(adapter, _make_event("777", _fake_message(777)))
+
+    result = await adapter.add_reaction(chat_id="123", emoji="🟡")
+
+    assert result == {"success": True, "message_id": "777"}
+    message.add_reaction.assert_awaited_once_with("🟡")
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_falls_back_to_the_thread_parent(adapter):
+    """An auto-threaded turn runs in the thread; its trigger is in the parent."""
+    message = _fake_message(777)
+    parent = FakeChannel(123, {777: message})
+    _wire_channels(adapter, parent, FakeChannel(888, {}, parent=parent))
+
+    result = await adapter.add_reaction(chat_id="888", emoji="🔴", message_id="777")
+
+    assert result == {"success": True, "message_id": "777"}
+    message.add_reaction.assert_awaited_once_with("🔴")
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_is_not_gated_by_the_lifecycle_env(adapter, monkeypatch):
+    """DISCORD_REACTIONS mutes the automatic ack, not deliberate agent intent."""
+    monkeypatch.setenv("DISCORD_REACTIONS", "false")
+    message = _fake_message(555)
+    _wire_channels(adapter, FakeChannel(123, {555: message}))
+
+    result = await adapter.add_reaction(chat_id="123", emoji="🟢", message_id="555")
+
+    assert result["success"] is True
+    message.add_reaction.assert_awaited_once_with("🟢")
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_without_a_target_reports_why(adapter):
+    _wire_channels(adapter, FakeChannel(123, {}))
+
+    result = await adapter.add_reaction(chat_id="123", emoji="🟢")
+
+    assert result["success"] is False
+    assert "message_id" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_add_reaction_reports_an_unknown_message(adapter):
+    _wire_channels(adapter, FakeChannel(123, {}))
+
+    result = await adapter.add_reaction(chat_id="123", emoji="🟢", message_id="555")
+
+    assert result["success"] is False
+    assert "555" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_remove_reaction_retracts_the_emoji_we_added(adapter):
+    message = _fake_message(555)
+    _wire_channels(adapter, FakeChannel(123, {555: message}))
+    await adapter.add_reaction(chat_id="123", emoji="🟢", message_id="555")
+
+    result = await adapter.remove_reaction(chat_id="123", message_id="555")
+
+    assert result == {"success": True, "message_id": "555"}
+    message.remove_reaction.assert_awaited_once_with("🟢", adapter._client.user)
+
+
+@pytest.mark.asyncio
+async def test_remove_reaction_without_a_tracked_emoji_reports_why(adapter):
+    message = _fake_message(555)
+    _wire_channels(adapter, FakeChannel(123, {555: message}))
+
+    result = await adapter.remove_reaction(chat_id="123", message_id="555")
+
+    assert result["success"] is False
+    message.remove_reaction.assert_not_awaited()
+

--- a/tests/tools/test_send_message_react.py
+++ b/tests/tools/test_send_message_react.py
@@ -50,6 +50,35 @@ def test_react_dispatches_to_add_reaction():
     assert adapter.calls == [("add", "+15551234567", "❤️", None)]
 
 
+def test_react_without_a_chat_uses_the_current_turn(monkeypatch):
+    """A bare platform target means "here", not the home channel."""
+    adapter = _FakePhotonAdapter()
+    monkeypatch.setattr("gateway.session_context.get_session_env", lambda k, d="": {
+        "HERMES_SESSION_PLATFORM": "photon",
+        "HERMES_SESSION_CHAT_ID": "+15559998888",
+    }.get(k, d))
+    with patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)):
+        result = _call({"action": "react", "target": "photon", "emoji": "🟢"})
+    assert result["success"] is True
+    assert adapter.calls == [("add", "+15559998888", "🟢", None)]
+
+
+def test_react_without_a_chat_ignores_a_different_platforms_turn(monkeypatch):
+    """The current chat only applies to the platform the turn is running on."""
+    adapter = _FakePhotonAdapter()
+    monkeypatch.setattr("gateway.session_context.get_session_env", lambda k, d="": {
+        "HERMES_SESSION_PLATFORM": "discord",
+        "HERMES_SESSION_CHAT_ID": "999",
+    }.get(k, d))
+    home = SimpleNamespace(chat_id="+15551110000")
+    config = SimpleNamespace(get_home_channel=lambda _p: home)
+    with patch("gateway.run._gateway_runner_ref", lambda: _runner_with(adapter)), \
+            patch("gateway.config.load_gateway_config", lambda: config):
+        result = _call({"action": "react", "target": "photon", "emoji": "🟢"})
+    assert result["success"] is True
+    assert adapter.calls == [("add", "+15551110000", "🟢", None)]
+
+
 def test_react_without_live_gateway():
     with patch("gateway.run._gateway_runner_ref", lambda: None):
         result = _call(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -214,7 +214,7 @@ SEND_MESSAGE_SCHEMA = {
             "action": {
                 "type": "string",
                 "enum": ["send", "list", "react", "unreact"],
-                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it, e.g. photon/iMessage tapbacks). 'unreact' retracts a previously-added reaction."
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it: Discord, photon/iMessage tapbacks). 'unreact' retracts a previously-added reaction. For 'react'/'unreact', a bare 'platform' target means the chat you are currently in, not the home channel."
             },
             "target": {
                 "type": "string",
@@ -263,6 +263,22 @@ def _handle_list():
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
 
 
+def _current_turn_chat_id(platform_name):
+    """Return the chat this turn is running in, if it's on ``platform_name``.
+
+    A react with no chat means "this conversation" — the home-channel
+    fallback used for sends would land the reaction on an unrelated
+    message in a different channel.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+    if get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower() != platform_name:
+        return None
+    return get_session_env("HERMES_SESSION_CHAT_ID", "").strip() or None
+
+
 def _handle_react(args, remove=False):
     """Attach (or with ``remove=True`` retract) an emoji reaction on a message
     via a live gateway adapter.
@@ -306,6 +322,8 @@ def _handle_react(args, remove=False):
     except (ValueError, KeyError):
         return tool_error(f"Unknown platform: {platform_name}")
 
+    if not chat_id:
+        chat_id = _current_turn_chat_id(platform_name)
     if not chat_id:
         try:
             config = load_gateway_config()


### PR DESCRIPTION
## What does this PR do?

`send_message(action="react")` resolves reactions by duck-typing public `add_reaction`/`remove_reaction` coroutines on the live adapter (`tools/send_message_tool.py`). Photon ships the pair; the Discord adapter has only the private `_add_reaction`/`_remove_reaction` helpers it uses for the 👀/✅ lifecycle ack. So reacting on Discord fails with `Platform 'discord' does not support message reactions`, even though the adapter is already reacting to messages several times per turn.

This exposes the pair on photon's contract, and fixes the target resolution that made it unusable in practice.

Same shape as #77994 (Matrix), which is the sibling half of this gap.

**1. Discord adapter gets the public pair.**

- Same return shapes as photon (`{"success", "message_id"}` / `{"success", "error"}`).
- Deliberately **not** gated by `DISCORD_REACTIONS` — that env var exists to mute the automatic per-message ack, not explicit agent intent. Same policy photon documents for `PHOTON_REACTIONS`.
- Default target is the message that triggered this turn, recorded per chat in `on_processing_start` (before the env gate, for the same reason).
- Auto-threading needs one extra step that photon doesn't: the turn runs with `chat_id` set to the *new thread*, while the message that triggered it lives in the *parent channel*. Both are recorded as keys, and both channels are tried on fetch, so a react from inside an auto-thread lands on the message that started it.
- `remove_reaction` retracts only the emoji this process placed, tracked per `(chat, message)` and bounded. Without that, an unreact would have to guess, and stripping the lifecycle ✅ is the wrong guess. Lost on restart, which matches photon's documented best-effort retraction.

**2. `react`/`unreact` with no chat now mean "here".**

A bare `platform` target fell through to `get_home_channel()`. That is right for a send and wrong for a reaction: the agent means *this conversation*, and the home channel would put the emoji on an unrelated message in a different channel. The current turn's chat (`HERMES_SESSION_CHAT_ID`) now wins when it is on the same platform, with the home-channel fallback intact for every other case.

This matters more than it looks: the system prompt tells the agent `Platform: discord` but never its channel id, so *without* this, the only reliably correct call is one the agent has no way to construct.

## Related Issue

Partially addresses #29026 — that request covers both directions (the agent reading reactions as input, and placing them). This is the outbound half only; inbound Discord reaction events are #46855.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/discord/adapter.py` — public `add_reaction`/`remove_reaction`, `_fetch_reaction_target` (thread → parent fallback), `_last_inbound_by_chat` recorded in `on_processing_start`, bounded `_agent_reactions` tracking for retraction.
- `tools/send_message_tool.py` — `_current_turn_chat_id()` preferred over the home channel for `react`/`unreact`; `action` schema description updated to say Discord is supported and that a bare platform target means the current chat.
- `tests/gateway/test_discord_reactions.py` — 8 tests: explicit id, turn default, thread-parent fallback, env not gating agent intent, both error paths, retract-what-we-added, retract-with-nothing-tracked.
- `tests/tools/test_send_message_react.py` — 2 tests: bare target resolves to the current turn; a turn on a *different* platform does not leak into it (home fallback still wins).

## How to Test

1. `pytest tests/gateway/test_discord_reactions.py tests/tools/test_send_message_react.py -q`
2. In a Discord channel, mention the bot so a turn starts, then have it call `send_message(action="react", target="discord", emoji="🟢")`. The 🟢 lands on the message that mentioned it, alongside the lifecycle ✅ — including when auto-threading moved the turn into a new thread.
3. `send_message(action="unreact", target="discord")` retracts the 🟢 and leaves the ✅.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#77994 is the Matrix half of the same gap; #22100/#31167/#22365 are about making the *lifecycle* emojis configurable, which is a different axis)
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: the two suites above pass (14 passed). The full run in my environment has ~136 pre-existing failures from optional deps I don't have installed (`aiohttp`, browser/slack extras); I verified the Discord/tools files I touch have an identical pass/fail set before and after this change.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), running against a live Discord guild

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings on the new methods; no user-facing docs describe reaction platform support
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure Python, no OS-specific paths
- [x] I've updated tool descriptions/schemas (the `action` description now names Discord and the current-chat default)
