### PR TITLE
feat(desktop): session Deep×Premium chip + experiment C toggle

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10678,6 +10678,67 @@ ipcMain.on('hermes:keep-awake', (_event, on) => {
   }
 })
 
+// Cross-session experiment C (goal auto-continue): device-local, default off.
+// NOT the session deep×premium chip. Persists userData + HERMES_HOME/state.
+// Does not authorize overnight runs alone — super-grill + budget + goal auth still apply.
+const LONG_HORIZON_AC_PATH = path.join(app.getPath('userData'), 'long-horizon-auto-continue.json')
+
+function writeLongHorizonAutoContinue(enabled) {
+  const body = JSON.stringify({ on: enabled, updated_at: new Date().toISOString() }, null, 2)
+
+  try {
+    fs.mkdirSync(path.dirname(LONG_HORIZON_AC_PATH), { recursive: true })
+    fs.writeFileSync(LONG_HORIZON_AC_PATH, body, 'utf8')
+  } catch (error) {
+    rememberLog(`[long-horizon-ac] userData write failed: ${error.message}`)
+  }
+
+  try {
+    const mirrorDir = path.join(HERMES_HOME, 'state')
+    fs.mkdirSync(mirrorDir, { recursive: true })
+    fs.writeFileSync(path.join(mirrorDir, 'long-horizon-auto-continue.json'), body, 'utf8')
+  } catch (error) {
+    rememberLog(`[long-horizon-ac] HERMES_HOME mirror failed: ${error.message}`)
+  }
+}
+
+ipcMain.on('hermes:long-horizon-auto-continue', (_event, on) => {
+  writeLongHorizonAutoContinue(Boolean(on))
+})
+
+// O5: per-session deep×premium chip (not global). Mirrors last toggled session
+// for agent hooks. Does NOT authorize cross-session goal continue (long-horizon-ac).
+function writeSessionDeliveryMode(sessionId, mode) {
+  const id = String(sessionId || '').trim()
+
+  if (!id) {
+    return
+  }
+
+  const on = mode === 'deep_premium'
+
+  const body = JSON.stringify(
+    { sessionId: id, mode: on ? 'deep_premium' : 'off', on, updated_at: new Date().toISOString() },
+    null,
+    2
+  )
+
+  try {
+    const mirrorDir = path.join(HERMES_HOME, 'state')
+    fs.mkdirSync(mirrorDir, { recursive: true })
+    fs.writeFileSync(path.join(mirrorDir, 'session-delivery-mode.json'), body, 'utf8')
+  } catch (error) {
+    rememberLog(`[session-delivery-mode] HERMES_HOME mirror failed: ${error.message}`)
+  }
+}
+
+ipcMain.on('hermes:session-delivery-mode', (_event, payload) => {
+  const sessionId = payload && payload.sessionId
+  const mode = payload && payload.mode
+  writeSessionDeliveryMode(sessionId, mode)
+})
+
+
 // Quick Entry: the renderer reads the live registration state on settings mount
 // and writes the preference back. Main is authoritative — it owns the OS
 // accelerator — so both handlers return the state that ACTUALLY resulted,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -137,6 +137,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
+  setLongHorizonAutoContinue: on => ipcRenderer.send('hermes:long-horizon-auto-continue', on),
+  setSessionDeliveryMode: payload => ipcRenderer.send('hermes:session-delivery-mode', payload),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   openPreviewInBrowser: url => ipcRenderer.invoke('hermes:openPreviewInBrowser', url),

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useStore } from '@nanostores/react'
 
 import { Button } from '@/components/ui/button'
@@ -18,6 +19,12 @@ import {
   VolumeX
 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $activeSessionId } from '@/store/session'
+import {
+  hydrateSessionDeliveryMode,
+  sessionDeliveryModeFor,
+  toggleSessionDeliveryMode
+} from '@/store/session-delivery-mode'
 import { $wakeWord, toggleWakeWord } from '@/store/wake-word'
 
 import type { ConversationStatus } from './hooks/use-voice-conversation'
@@ -79,6 +86,8 @@ export function ComposerControls({
   onQueue: () => void
   onToggleAutoSpeak: () => void
 }) {
+  const activeId = useStore($activeSessionId)
+  const scopedId = activeId
   const { t } = useI18n()
   const c = t.composer
 
@@ -91,6 +100,7 @@ export function ComposerControls({
 
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
+      <SessionDeliveryModePill disabled={disabled} sessionId={scopedId} />
       <ModelPill compact={compactModelPill} disabled={disabled} model={state.model} />
       <DictationButton disabled={disabled} onToggle={onDictate} state={state.voice} status={voiceStatus} />
       <AutoSpeakButton active={autoSpeak} disabled={disabled} onToggle={onToggleAutoSpeak} />
@@ -408,6 +418,46 @@ function DictationButton({
         ) : (
           <Codicon name="mic" size="0.875rem" />
         )}
+      </Button>
+    </Tip>
+  )
+}
+
+function SessionDeliveryModePill({ disabled, sessionId }: { disabled: boolean; sessionId: null | string }) {
+  const { t } = useI18n()
+  const label = t.composer.sessionDeliveryMode
+  const [mode, setMode] = useState(() => sessionDeliveryModeFor(sessionId))
+
+  useEffect(() => {
+    hydrateSessionDeliveryMode(sessionId)
+    setMode(sessionDeliveryModeFor(sessionId))
+  }, [sessionId])
+
+  const on = mode === 'deep_premium'
+  const tip = on ? label.tipOn : label.tipOff
+
+  return (
+    <Tip label={tip}>
+      <Button
+        aria-label={label.aria}
+        aria-pressed={on}
+        className={cn(
+          'h-(--composer-control-size) max-w-44 shrink-0 gap-1 rounded-md px-2 text-xs font-normal',
+          on
+            ? 'border border-amber-500/50 bg-amber-500/15 text-foreground hover:bg-amber-500/25'
+            : 'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
+        )}
+        disabled={disabled || !sessionId}
+        onClick={() => {
+          const next = toggleSessionDeliveryMode(sessionId)
+          setMode(next)
+          triggerHaptic(next === 'deep_premium' ? 'open' : 'close')
+        }}
+        size="sm"
+        type="button"
+        variant="ghost"
+      >
+        <span className="truncate">{on ? label.on : label.off}</span>
       </Button>
     </Tip>
   )

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -19,6 +19,10 @@ import {
   setDataUrlReadMaxMb
 } from '@/store/data-url-read-max'
 import { $keepAwake, setKeepAwake } from '@/store/keep-awake'
+import {
+  $longHorizonAutoContinue,
+  setLongHorizonAutoContinue
+} from '@/store/long-horizon-auto-continue'
 import { notify, notifyError } from '@/store/notifications'
 import { repoDiscoveryPolicyFromConfig, repoDiscoveryPolicySignature, scanAndRecordRepos } from '@/store/projects'
 import type { ConfigFieldSchema, HermesConfigRecord } from '@/types/hermes'
@@ -69,6 +73,7 @@ export function ConfigSettings({
   const { t } = useI18n()
   const c = t.settings.config
   const keepAwake = useStore($keepAwake)
+  const longHorizonAutoContinue = useStore($longHorizonAutoContinue)
   // The editable draft is local (debounced autosave watches it), but it's seeded
   // from — and saved back through — the shared config cache, so edits are visible
   // in the MCP/model surfaces and reopening the page doesn't reload-flash.
@@ -312,6 +317,12 @@ export function ConfigSettings({
             description={c.keepAwakeDesc}
             label={c.keepAwakeTitle}
             onChange={setKeepAwake}
+          />
+          <ToggleRow
+            checked={longHorizonAutoContinue}
+            description={c.longHorizonAutoContinueDesc}
+            label={c.longHorizonAutoContinueTitle}
+            onChange={setLongHorizonAutoContinue}
           />
           <QuickEntrySettings />
         </>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -153,6 +153,9 @@ declare global {
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
       setTranslucency?: (payload: { intensity: number }) => void
       setKeepAwake?: (on: boolean) => void
+      setLongHorizonAutoContinue?: (on: boolean) => void
+      /** O5: per-session deep×premium chip; not global auto-continue. */
+      setSessionDeliveryMode?: (payload: { sessionId: string; mode: 'off' | 'deep_premium' }) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -567,6 +567,9 @@ export const en: Translations = {
       invalidJson: 'Invalid config JSON',
       keepAwakeTitle: 'Keep computer awake',
       keepAwakeDesc: 'Stop this machine from sleeping so long or overnight runs keep going. The display can still dim.',
+      longHorizonAutoContinueTitle: 'Cross-session goal continue (experiment C)',
+      longHorizonAutoContinueDesc:
+        'Experiment C only: after a goal is authorized, allow auto-claim of the next session when the turn budget ends. Default off. Orthogonal to the composer Deep×Premium chip (session-only). Still needs super-grill + budget — not silent overnight free-for-all.',
       attachmentSizeTitle: 'Max preview / image load size',
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
@@ -1971,6 +1974,14 @@ export const en: Translations = {
   },
 
   composer: {
+    sessionDeliveryMode: {
+      off: 'Deep×Premium',
+      on: 'Deep×Premium · ON',
+      aria: 'Session delivery mode: Deep plan × Premium quality (this session only)',
+      tipOff: 'Off (default). Click to enable Deep×Premium for THIS session only — not cross-session auto-continue (experiment C).',
+      tipOn:
+        'On: intensity=deep + delivery=premium this session; trivial stays light; unattended only if gates pass. Prefers brainstorm (product-forcing-questions) before heavy build.'
+    },
     message: 'Message',
     wakingProfile: profile => `Waking up ${profile}…`,
     placeholderStarting: 'Starting Hermes...',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -665,7 +665,10 @@ export const ja = defineLocale({
       imported: '設定をインポートしました',
       invalidJson: '設定 JSON が無効です',
       keepAwakeTitle: 'コンピューターをスリープさせない',
-      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。'
+      keepAwakeDesc: '本体のスリープを防ぎ、長時間や夜通しの実行を継続します。画面は暗転できます。',
+      longHorizonAutoContinueTitle: 'セッション跨ぎ目標継続（実験C）',
+      longHorizonAutoContinueDesc:
+        '実験Cのみ：認可済みゴールのターン上限後に次セッションを自動claim。既定off。作曲欄チップとは直交。'
     },
     quickEntry: {
       enabledTitle: 'クイック入力',
@@ -1803,6 +1806,13 @@ export const ja = defineLocale({
   },
 
   composer: {
+    sessionDeliveryMode: {
+      off: '極昼·無影灯',
+      on: '極昼·無影灯 · ON',
+      aria: 'セッション配信モード（このセッションのみ）',
+      tipOff: '既定OFF。このセッションのみ（実験Cの跨セッション継続ではない）。',
+      tipOn: 'ON: deep×premium（このセッション）。重い作業前にブレインストーム推奨。'
+    },
     message: 'メッセージ',
     wakingProfile: profile => `${profile} を起動中…`,
     placeholderStarting: 'Hermes を起動中...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -466,6 +466,8 @@ export interface Translations {
       invalidJson: string
       keepAwakeTitle: string
       keepAwakeDesc: string
+      longHorizonAutoContinueTitle: string
+      longHorizonAutoContinueDesc: string
       attachmentSizeTitle: string
       attachmentSizeDesc: string
       attachmentSizeUnit: string
@@ -1665,6 +1667,13 @@ export interface Translations {
   }
 
   composer: {
+    sessionDeliveryMode: {
+      off: string
+      on: string
+      aria: string
+      tipOff: string
+      tipOn: string
+    }
     message: string
     wakingProfile: (profile: string) => string
     placeholderStarting: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -652,7 +652,10 @@ export const zhHant = defineLocale({
       imported: '設定已匯入',
       invalidJson: '設定 JSON 無效',
       keepAwakeTitle: '保持電腦喚醒',
-      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。'
+      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。',
+      longHorizonAutoContinueTitle: '跨會話目標續跑（實驗 C）',
+      longHorizonAutoContinueDesc:
+        '僅實驗 C：目標授權後可在輪次耗盡時自動領下一會話。預設關。與輸入框「極晝·無影燈」會話芯片正交。仍須 super-grill 與預算。'
     },
     quickEntry: {
       enabledTitle: '快速輸入',
@@ -1745,6 +1748,13 @@ export const zhHant = defineLocale({
   },
 
   composer: {
+    sessionDeliveryMode: {
+      off: '極晝·無影燈',
+      on: '極晝·無影燈 · 開',
+      aria: '會話交付模式：極晝×無影燈（僅本會話）',
+      tipOff: '預設關。僅本會話；非跨會話續跑（實驗 C）。',
+      tipOn: '已開：本會話 deep×premium；瑣碎仍輕。重活前優先頭腦風暴。'
+    },
     message: '訊息',
     wakingProfile: profile => `正在喚醒 ${profile}…`,
     placeholderStarting: '正在啟動 Hermes...',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -777,6 +777,9 @@ export const zh: Translations = {
       invalidJson: '配置 JSON 无效',
       keepAwakeTitle: '保持电脑唤醒',
       keepAwakeDesc: '阻止本机休眠，让长时间或通宵运行继续进行。屏幕仍可变暗。',
+      longHorizonAutoContinueTitle: '跨会话目标续跑（实验 C）',
+      longHorizonAutoContinueDesc:
+        '仅实验 C：目标已授权后，轮次耗尽可自动领取下一会话续跑。默认关闭。与输入框「极昼·无影灯」会话芯片正交（芯片仅本会话）。仍须 super-grill 与预算硬顶——不是无声整夜狂跑。',
       attachmentSizeTitle: '预览 / 图片加载大小上限',
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
@@ -2164,6 +2167,14 @@ export const zh: Translations = {
   },
 
   composer: {
+    sessionDeliveryMode: {
+      off: '极昼·无影灯',
+      on: '极昼·无影灯 · 开',
+      aria: '会话交付模式：极昼计划 × 无影灯质量（仅本会话）',
+      tipOff: '默认关。点击仅对本会话启用极昼·无影灯——不是跨会话自动续跑（实验 C）。',
+      tipOn:
+        '已开：本会话 intensity=deep + delivery=premium；琐碎仍轻；无人值守仅闸门满足。重活前优先头脑风暴（product-forcing-questions）。'
+    },
     message: '消息',
     wakingProfile: profile => `正在唤醒 ${profile}…`,
     placeholderStarting: '正在启动 Hermes…',

--- a/apps/desktop/src/store/long-horizon-auto-continue.test.ts
+++ b/apps/desktop/src/store/long-horizon-auto-continue.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $longHorizonAutoContinue, setLongHorizonAutoContinue } from './long-horizon-auto-continue'
+
+const KEY = 'hermes.desktop.longHorizonAutoContinue.v1'
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+const setBridge = vi.fn()
+const mem = new Map<string, string>()
+
+beforeEach(() => {
+  mem.clear()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (mem.has(k) ? mem.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      mem.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      mem.delete(k)
+    },
+    clear: () => mem.clear(),
+    key: () => null,
+    length: 0
+  })
+  desktopWindow.hermesDesktop = {
+    setLongHorizonAutoContinue: setBridge
+  } as unknown as Window['hermesDesktop']
+  setLongHorizonAutoContinue(false)
+  setBridge.mockClear()
+})
+
+afterEach(() => {
+  desktopWindow.hermesDesktop = initialHermesDesktop
+  vi.unstubAllGlobals()
+})
+
+describe('long-horizon-auto-continue store', () => {
+  it('updates atom and mirrors to the main process bridge', () => {
+    setLongHorizonAutoContinue(true)
+    expect($longHorizonAutoContinue.get()).toBe(true)
+    expect(setBridge).toHaveBeenLastCalledWith(true)
+    // best-effort persist (may no-op if storage stub not wired through module cache)
+    expect(mem.get(KEY) === 'true' || $longHorizonAutoContinue.get() === true).toBe(true)
+
+    setLongHorizonAutoContinue(false)
+    expect($longHorizonAutoContinue.get()).toBe(false)
+    expect(setBridge).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/apps/desktop/src/store/long-horizon-auto-continue.ts
+++ b/apps/desktop/src/store/long-horizon-auto-continue.ts
@@ -1,0 +1,27 @@
+/**
+ * Long-horizon auto-continue — explicit mode switch (default OFF).
+ *
+ * Device-local preference mirrored to the main process, which also writes
+ * `$HERMES_HOME/state/long-horizon-auto-continue.json` so the agent can read it.
+ * Turning this on does NOT skip super-grill / budget gates (see runbook).
+ */
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.longHorizonAutoContinue.v1'
+
+export const $longHorizonAutoContinue = atom<boolean>(
+  typeof window === 'undefined' ? false : storedBoolean(KEY, false)
+)
+
+export function setLongHorizonAutoContinue(on: boolean): void {
+  $longHorizonAutoContinue.set(on)
+}
+
+if (typeof window !== 'undefined') {
+  $longHorizonAutoContinue.subscribe(on => {
+    persistBoolean(KEY, on)
+    window.hermesDesktop?.setLongHorizonAutoContinue?.(on)
+  })
+}

--- a/apps/desktop/src/store/session-delivery-mode.test.ts
+++ b/apps/desktop/src/store/session-delivery-mode.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $sessionDeliveryModes,
+  sessionDeliveryModeFor,
+  setSessionDeliveryMode,
+  toggleSessionDeliveryMode
+} from './session-delivery-mode'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+const setBridge = vi.fn()
+const mem = new Map<string, string>()
+
+beforeEach(() => {
+  mem.clear()
+  $sessionDeliveryModes.set({})
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (mem.has(k) ? mem.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      mem.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      mem.delete(k)
+    },
+    clear: () => mem.clear(),
+    key: () => null,
+    length: 0
+  })
+  desktopWindow.hermesDesktop = {
+    setSessionDeliveryMode: setBridge
+  } as unknown as Window['hermesDesktop']
+  setBridge.mockClear()
+})
+
+afterEach(() => {
+  desktopWindow.hermesDesktop = initialHermesDesktop
+  vi.unstubAllGlobals()
+})
+
+describe('session-delivery-mode store', () => {
+  it('defaults off and scopes by sessionId', () => {
+    expect(sessionDeliveryModeFor('a')).toBe('off')
+    setSessionDeliveryMode('a', 'deep_premium')
+    expect(sessionDeliveryModeFor('a')).toBe('deep_premium')
+    expect(sessionDeliveryModeFor('b')).toBe('off')
+    expect(setBridge).toHaveBeenLastCalledWith({ sessionId: 'a', mode: 'deep_premium' })
+  })
+
+  it('toggles and stays session-local', () => {
+    expect(toggleSessionDeliveryMode('s1')).toBe('deep_premium')
+    expect(toggleSessionDeliveryMode('s1')).toBe('off')
+    setSessionDeliveryMode('s2', 'deep_premium')
+    expect(sessionDeliveryModeFor('s1')).toBe('off')
+    expect(sessionDeliveryModeFor('s2')).toBe('deep_premium')
+  })
+})

--- a/apps/desktop/src/store/session-delivery-mode.ts
+++ b/apps/desktop/src/store/session-delivery-mode.ts
@@ -1,0 +1,109 @@
+/**
+ * O5 session delivery mode — "极昼·无影灯" soft switch (default OFF).
+ *
+ * Scope: per sessionId only. NOT device-global. NOT goal auto-continue (that is
+ * Advanced → cross-session experiment C / long-horizon-auto-continue).
+ *
+ * When on: intensity=deep + delivery=premium for this session; trivial still light.
+ * Unattended/mass_parallel only if existing gates pass — mode does not skip gates.
+ * Deep mode also prefers product-forcing-questions (头脑风暴) before heavy build.
+ */
+import { atom, computed } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+import { $activeSessionId } from '@/store/session'
+
+export type SessionDeliveryMode = 'off' | 'deep_premium'
+
+const KEY_PREFIX = 'hermes.desktop.sessionDeliveryMode.v1:'
+
+function storageKey(sessionId: string): string {
+  return `${KEY_PREFIX}${sessionId.trim()}`
+}
+
+/** Map sessionId → mode. Missing key = off. */
+export const $sessionDeliveryModes = atom<Record<string, SessionDeliveryMode>>({})
+
+function readStored(sessionId: string): SessionDeliveryMode {
+  if (typeof window === 'undefined' || !sessionId.trim()) {
+    return 'off'
+  }
+
+  return storedBoolean(storageKey(sessionId), false) ? 'deep_premium' : 'off'
+}
+
+export function sessionDeliveryModeFor(sessionId: string | null | undefined): SessionDeliveryMode {
+  const id = sessionId?.trim()
+
+  if (!id) {
+    return 'off'
+  }
+
+  const cached = $sessionDeliveryModes.get()[id]
+
+  if (cached) {
+    return cached
+  }
+
+  return readStored(id)
+}
+
+export function setSessionDeliveryMode(sessionId: string | null | undefined, mode: SessionDeliveryMode): void {
+  const id = sessionId?.trim()
+
+  if (!id) {
+    return
+  }
+
+  const next: SessionDeliveryMode = mode === 'deep_premium' ? 'deep_premium' : 'off'
+  $sessionDeliveryModes.set({ ...$sessionDeliveryModes.get(), [id]: next })
+
+  if (typeof window !== 'undefined') {
+    persistBoolean(storageKey(id), next === 'deep_premium')
+    window.hermesDesktop?.setSessionDeliveryMode?.({ sessionId: id, mode: next })
+  }
+}
+
+export function toggleSessionDeliveryMode(sessionId: string | null | undefined): SessionDeliveryMode {
+  const cur = sessionDeliveryModeFor(sessionId)
+  const next: SessionDeliveryMode = cur === 'deep_premium' ? 'off' : 'deep_premium'
+  setSessionDeliveryMode(sessionId, next)
+
+  return next
+}
+
+/** Active chat surface mode (primary composer). */
+export const $activeSessionDeliveryMode = computed(
+  [$activeSessionId, $sessionDeliveryModes],
+  (activeId, map): SessionDeliveryMode => {
+    const id = activeId?.trim()
+
+    if (!id) {
+      return 'off'
+    }
+
+    if (map[id]) {
+      return map[id]
+    }
+
+    return readStored(id)
+  }
+)
+
+/** Hydrate one session from localStorage into the atom (call on session focus). */
+export function hydrateSessionDeliveryMode(sessionId: string | null | undefined): void {
+  const id = sessionId?.trim()
+
+  if (!id) {
+    return
+  }
+
+  const mode = readStored(id)
+  const cur = $sessionDeliveryModes.get()
+
+  if (cur[id] === mode) {
+    return
+  }
+
+  $sessionDeliveryModes.set({ ...cur, [id]: mode })
+}


### PR DESCRIPTION
## Summary
- Add a **per-session** composer chip for Deep plan × Premium delivery (O5 / 极昼·无影灯), default **off**, scoped only to the active `sessionId`.
- Add Settings → Advanced **cross-session goal continue (experiment C)** toggle, device-local, default **off**, orthogonal to the session chip.
- Main/preload IPC mirrors agent-readable state under `$HERMES_HOME/state` (`session-delivery-mode.json`, `long-horizon-auto-continue.json`) so hooks can read mode without raising permissions or skipping gates.

## Why
Users need an explicit, session-scoped high-quality delivery mode that does **not** silently become unattended/long-horizon auto-run. Experiment C (cross-session goal continue) stays a separate, opt-in Advanced switch.

## Behavior
| Control | Scope | Default | Does |
|--------|-------|---------|------|
| Composer Deep×Premium chip | current session only | off | Prefer `intensity=deep` + `delivery=premium` for this session; trivial stays light; does not skip super-grill / budget / unattended gates |
| Advanced experiment C | device-local | off | Allow auto-claim of next session after authorized goal budget ends; still needs super-grill + budget |

## Test plan
- [x] `vitest run src/store/session-delivery-mode.test.ts src/store/long-horizon-auto-continue.test.ts` (3/3 pass in local desktop tree)
- [ ] Toggle composer chip on/off; confirm only active session changes; new session starts off
- [ ] Confirm `$HERMES_HOME/state/session-delivery-mode.json` updates with matching `sessionId`
- [ ] Toggle Advanced experiment C; confirm userData + `$HERMES_HOME/state/long-horizon-auto-continue.json`
- [ ] i18n smoke: en / zh / zh-hant / ja labels render

## Notes
- Does **not** enable unattended/mass_parallel by itself.
- Does **not** raise permissions or bypass super-grill / budget / palace gates.