### PR TITLE
fix(terminal): feed SUDO_PASSWORD to background local processes (#78608)

### DIFF
--- a/tests/tools/test_local_background_sudo_stdin.py
+++ b/tests/tools/test_local_background_sudo_stdin.py
@@ -1,0 +1,254 @@
+"""Regression tests for issue #78608.
+
+``SUDO_PASSWORD`` is honoured by the *foreground* terminal path
+(``BaseEnvironment._prepare_command`` -> ``_transform_sudo_command``), but the
+*background local* path used to hand the raw command straight to
+``process_registry.spawn_local()`` — which spawns with ``stdin=DEVNULL`` — so a
+background ``sudo`` invocation could never receive its password and failed with
+"sudo: a terminal is required to read the password".
+
+The fix:
+  1. The background local branch now calls ``_transform_sudo_command`` and
+     forwards the resulting ``sudo_stdin`` to ``spawn_local``.
+  2. ``spawn_local`` gained an optional ``stdin_data`` parameter that, when set,
+     spawns with ``stdin=PIPE`` (Popen path) / writes to the pty handle (PTY
+     path) so the password reaches ``sudo -S``.
+
+These tests exercise the *real* ``spawn_local`` subprocess machinery (not a
+re-computation of the fix) plus a wiring guard that proves the terminal_tool
+background branch actually performs the transform + hand-off.
+"""
+
+import os
+import shlex
+import sys
+
+import pytest
+
+from tools.process_registry import process_registry
+
+_IS_WINDOWS = sys.platform.startswith("win")
+_HAS_PTYPROCESS = True
+try:  # pragma: no cover - import probe
+    import ptyprocess  # noqa: F401
+except Exception:  # pragma: no cover
+    _HAS_PTYPROCESS = False
+
+
+def _wait(session, timeout=12.0):
+    """Block until the background process finishes (or timeout)."""
+    session._completion_event.wait(timeout=timeout)
+    return session.exited
+
+
+def _cleanup(session):
+    if not getattr(session, "exited", False):
+        try:
+            process_registry.kill_process(session.id, source="test_cleanup")
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# spawn_local — Popen path: stdin_data must reach the real subprocess
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_local_pipes_stdin_data_to_subprocess(tmp_path):
+    """A background local process must receive spawn-time stdin.
+
+    ``cat`` copies its stdin to the redirect target and exits on EOF; if
+    ``stdin_data`` is never piped in, the capture file is never written.
+    """
+    outfile = tmp_path / "stdin_capture.txt"
+    session = process_registry.spawn_local(
+        command=f"cat > {shlex.quote(str(outfile))}",
+        cwd=str(tmp_path),
+        task_id="t-78608-pipe",
+        stdin_data="hermes_secret_pw\n",
+        use_pty=False,
+    )
+    try:
+        assert _wait(session), "background `cat` did not finish in time"
+        assert outfile.exists(), (
+            "stdin_data was never piped to the subprocess — spawn_local is "
+            "still spawning with stdin=DEVNULL (#78608)"
+        )
+        assert outfile.read_text() == "hermes_secret_pw\n", (
+            "piped stdin content mismatch — password did not arrive intact"
+        )
+    finally:
+        _cleanup(session)
+
+
+def test_spawn_local_without_stdin_data_is_unchanged(tmp_path):
+    """No sudo / no stdin_data -> spawn_local keeps stdin=DEVNULL and the
+    common (non-sudo) background command runs exactly as before."""
+    session = process_registry.spawn_local(
+        command="echo nomarker78608",
+        cwd=str(tmp_path),
+        task_id="t-78608-nostdin",
+        use_pty=False,
+    )
+    try:
+        assert _wait(session), "background `echo` did not finish in time"
+        assert session.exit_code == 0, (
+            f"plain background command failed (rc={session.exit_code}) — "
+            "the default stdin=DEVNULL path regressed"
+        )
+        assert "nomarker78608" in (session.output_buffer or ""), (
+            "background output was not captured for the no-stdin case"
+        )
+    finally:
+        _cleanup(session)
+
+
+# ---------------------------------------------------------------------------
+# spawn_local — PTY path: stdin_data must reach the pty handle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    _IS_WINDOWS or not _HAS_PTYPROCESS,
+    reason="PTY stdin write tested only on POSIX with ptyprocess installed",
+)
+def test_spawn_local_pty_writes_stdin_data(tmp_path):
+    """In PTY mode the spawn-time stdin must be written to the pty handle so an
+    interactive ``sudo -S`` under a pty also receives its password."""
+    outfile = tmp_path / "pty_capture.txt"
+    session = process_registry.spawn_local(
+        command=f"read line; printf '%s' \"$line\" > {shlex.quote(str(outfile))}",
+        cwd=str(tmp_path),
+        task_id="t-78608-pty",
+        stdin_data="ptysecret\n",
+        use_pty=True,
+    )
+    try:
+        # PTY path must actually have been taken.
+        assert getattr(session, "_pty", None) is not None, (
+            "spawn_local fell back to Popen — PTY path was not exercised"
+        )
+        assert _wait(session, timeout=15), "PTY `read` did not finish in time"
+        assert outfile.exists(), (
+            "stdin_data was never written to the pty handle — the PTY spawn "
+            "path does not feed spawn-time stdin (#78608)"
+        )
+        assert outfile.read_text() == "ptysecret"
+    finally:
+        _cleanup(session)
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool — background local branch must transform + hand off password
+# ---------------------------------------------------------------------------
+
+
+def _bg_sudo_base_config(tmp_path):
+    return {
+        "env_type": "local",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+        "cwd": str(tmp_path),
+        "timeout": 30,
+    }
+
+
+def _bg_harness(monkeypatch, tmp_path, captured):
+    """Patch terminal_tool enough to reach the background local branch and
+    record what ``spawn_local`` is called with."""
+    import tools.terminal_tool as terminal_tool_module
+    from tools import process_registry as process_registry_module
+    from types import SimpleNamespace
+
+    config = _bg_sudo_base_config(tmp_path)
+
+    def fake_spawn_local(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            id="proc_78608_wire",
+            pid=4242,
+            notify_on_complete=False,
+            watcher_platform="",
+            watcher_chat_id="",
+            watcher_user_id="",
+            watcher_user_name="",
+            watcher_thread_id="",
+            watcher_message_id="",
+            watcher_interval=0,
+        )
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_a, **_k: {"approved": True},
+    )
+    monkeypatch.setattr(
+        process_registry_module.process_registry, "spawn_local", fake_spawn_local
+    )
+    monkeypatch.setitem(
+        terminal_tool_module._active_environments, "default", SimpleNamespace(env={})
+    )
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+    return terminal_tool_module
+
+
+def test_background_local_applies_sudo_transform_and_pipes_password(
+    monkeypatch, tmp_path
+):
+    """The background local branch must rewrite ``sudo`` -> ``sudo -S`` and pass
+    the password through as ``stdin_data`` to ``spawn_local`` (#78608)."""
+    import tools.terminal_tool as terminal_tool_module
+
+    monkeypatch.setenv("SUDO_PASSWORD", "bgpw-test")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    terminal_tool_module._reset_cached_sudo_passwords()
+
+    captured = {}
+    tt = _bg_harness(monkeypatch, tmp_path, captured)
+    try:
+        tt.terminal_tool(command="sudo id", background=True)
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+        terminal_tool_module._reset_cached_sudo_passwords()
+
+    assert "sudo -S" in captured.get("command", ""), (
+        "background local command was not sudo-transformed — the branch is "
+        "still handing the raw command to spawn_local (#78608)"
+    )
+    assert captured.get("stdin_data") == "bgpw-test\n", (
+        "sudo password was not forwarded as stdin_data — spawn_local received "
+        f"stdin_data={captured.get('stdin_data')!r}"
+    )
+
+
+def test_background_local_without_sudo_passes_no_stdin_data(monkeypatch, tmp_path):
+    """A non-sudo background command must NOT inject stdin_data (no spurious
+    password piping / no behaviour change for the common case)."""
+    import tools.terminal_tool as terminal_tool_module
+
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    terminal_tool_module._reset_cached_sudo_passwords()
+
+    captured = {}
+    tt = _bg_harness(monkeypatch, tmp_path, captured)
+    try:
+        tt.terminal_tool(
+            command="echo plainbg78608", background=True, notify_on_complete=True
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+        terminal_tool_module._reset_cached_sudo_passwords()
+
+    assert captured.get("stdin_data") in (None, ""), (
+        "non-sudo background command must not carry stdin_data"
+    )
+    assert "sudo -S" not in captured.get("command", ""), (
+        "non-sudo command should not be rewritten"
+    )

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -170,6 +170,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "stdin_data": None,
     }]
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -695,6 +695,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        stdin_data: str | None = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -705,6 +706,12 @@ class ProcessRegistry:
             use_pty: If True, use a pseudo-terminal via ptyprocess for interactive
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
+            stdin_data: Optional spawn-time stdin to feed the process. This is
+                     used to pipe a ``sudo -S`` password (produced by
+                     ``_transform_sudo_command``) so background local sudo
+                     commands can authenticate (#78608). On the Popen path the
+                     data is written and stdin closed (matching the foreground
+                     path); on the PTY path it is written to the pty handle.
         """
         # Guard against the `A && B &` subshell-wait trap (issue #68915).
         # Bash parses ``A && B &`` as ``(A && B) &`` — a subshell that holds
@@ -744,6 +751,18 @@ class ProcessRegistry:
                 session.host_start_time = self._safe_host_start_time(session.pid)
                 # Store the pty handle on the session for read/write
                 session._pty = pty_proc
+
+                # Feed spawn-time stdin (e.g. the sudo -S password) to the pty
+                # so a background sudo under a pty can authenticate (#78608).
+                # The kernel pty buffer holds the bytes until the slave reads.
+                if stdin_data:
+                    try:
+                        if _IS_WINDOWS:
+                            session._pty.write(str(stdin_data))
+                        else:
+                            session._pty.write(stdin_data.encode("utf-8"))
+                    except (BrokenPipeError, OSError):
+                        pass
 
                 # PTY reader thread
                 reader = threading.Thread(
@@ -787,7 +806,7 @@ class ProcessRegistry:
             errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             start_new_session=True,
             **_popen_kwargs,
         )
@@ -795,6 +814,15 @@ class ProcessRegistry:
         session.process = proc
         session.pid = proc.pid
         session.host_start_time = self._safe_host_start_time(session.pid)
+
+        # Feed spawn-time stdin (e.g. the sudo -S password) on a daemon thread
+        # to avoid pipe-buffer deadlocks, matching the foreground path. The
+        # data is written and stdin closed so sudo -S reads exactly one line
+        # then sees EOF (#78608).
+        if stdin_data is not None:
+            from tools.environments.base import _pipe_stdin
+
+            _pipe_stdin(proc, stdin_data)
 
         try:
             # Start output reader thread

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2663,13 +2663,20 @@ def terminal_tool(
             )
             try:
                 if env_type == "local":
+                    # Apply the sudo transform so background local commands can
+                    # also use SUDO_PASSWORD (#78608). The foreground path does
+                    # this via BaseEnvironment._prepare_command(); the local
+                    # background path used to skip it entirely and spawn with
+                    # stdin=DEVNULL, so sudo could never read its password.
+                    bg_command, bg_sudo_stdin = _transform_sudo_command(command)
                     proc_session = process_registry.spawn_local(
-                        command=command,
+                        command=bg_command if bg_command is not None else command,
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        stdin_data=bg_sudo_stdin,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(


### PR DESCRIPTION
## Problem

A background terminal command (`background=true`) using sudo fails on the local backend with:

```
sudo: a terminal is required to read the password; either use the -S
option to read from standard input or configure an askpass helper
sudo: a password is required
```

`SUDO_PASSWORD` works for foreground calls but not background ones. Reported in #78608.

## Root cause

The foreground local path flows through `BaseEnvironment.execute()` -> `_prepare_command()` -> `_transform_sudo_command()`, which rewrites bare sudo to read its password from stdin and returns that password as a stdin string that gets piped to the process.

The **background local** path (`terminal_tool(background=True, env_type=="local")`) handed the raw command straight to `process_registry.spawn_local()`, skipping `_transform_sudo_command()` entirely. `spawn_local()` also spawned with `stdin=DEVNULL`, so even if the rewrite had been applied there, sudo would have had nowhere to read the password.

The **non-local** background path (`spawn_via_env` -> `env.execute()` -> `_prepare_command()`) was already correct and is untouched.

## Fix

1. **`tools/terminal_tool.py`** — the background local branch now calls `_transform_sudo_command(command)` and forwards the resulting `sudo_stdin` to `spawn_local` as `stdin_data`.
2. **`tools/process_registry.py`** — `spawn_local` gained an optional `stdin_data` parameter:
   - **Popen path**: spawns with `stdin=PIPE` (instead of `DEVNULL`) when `stdin_data` is set and feeds it via the existing `_pipe_stdin` helper (write + close, matching the foreground path so the password is read then sees EOF).
   - **PTY path**: writes the data to the pty master handle so an interactive sudo under a PTY also receives its password.

When `stdin_data is None` (no sudo, or `SUDO_PASSWORD` unset), behavior is unchanged — Popen stays `stdin=DEVNULL`, PTY path untouched.

## Verification

**Fail-without-fix (RED, run on `upstream/main` before the fix):**
- 3 of 5 new tests fail:
  - `test_spawn_local_pipes_stdin_data_to_subprocess` — `spawn_local()` got unexpected `stdin_data` kwarg
  - `test_spawn_local_pty_writes_stdin_data` — same
  - `test_background_local_applies_sudo_transform_and_pipes_password` — background local command not transformed

**With the fix (GREEN):**
- New suite `tests/tools/test_local_background_sudo_stdin.py`: **5/5 pass**
- `tests/tools/test_terminal_task_cwd.py` (updated kwargs assertion): **5/5 pass**
- Broader run (7 process/terminal/stdin files): **92 pass**
- `ruff check`: clean · `git diff --check`: clean

Tests exercise the real `spawn_local` subprocess machinery (a background `cat`/`read` round-trips the password to a file — not a boolean re-computation of the fix) plus a wiring guard that proves the `terminal_tool` background branch performs the transform + hand-off.

## Scope

One focused commit. Reuses existing helpers (`_transform_sudo_command`, `_pipe_stdin`) — no new dependencies, no new abstractions.

Auto-published by Moonsong via Path B automated pipeline.
