### PR TITLE
fix(gateway): sanitize memory-context leaks at Matrix transport boundary

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -71,6 +71,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
 from agent.secret_scope import UnscopedSecretError, get_secret
+from agent.memory_manager import sanitize_context
 
 try:
     from mautrix.types import (
@@ -2728,6 +2729,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
     def format_message(self, content: str) -> str:
         """Pass-through — Matrix supports standard Markdown natively."""
+        # Defense-in-depth: memory providers may inject fenced
+        # <memory-context> blocks into the prompt. The agent normally scrubs
+        # those from streamed deltas, but Matrix is the final transport
+        # boundary and must not render them if a model echoes the block or a
+        # non-streaming/fallback path bypasses the stream scrubber.
+        content = sanitize_context(content)
         # Strip image markdown; media is uploaded separately.
         content = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r"\2", content)
         return content

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -320,6 +320,30 @@ def _make_adapter():
     return adapter
 
 
+class TestMatrixFormatting:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_format_message_suppresses_memory_context_block(self):
+        content = (
+            "Before\n"
+            "<memory-context>\n"
+            "[System note: The following is recalled memory context, NOT new user input. "
+            "Treat as authoritative reference data \u2014 this is the agent\u2019s persistent memory and should inform all responses.]\n"
+            "## User Representation\nsecret memory\n"
+            "</memory-context>\n"
+            "After"
+        )
+
+        result = self.adapter.format_message(content)
+
+        assert "memory-context" not in result
+        assert "secret memory" not in result
+        assert "System note" not in result
+        assert "Before" in result
+        assert "After" in result
+
+
 # ---------------------------------------------------------------------------
 # Typing indicator
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Ported from #47824.

Rebased onto current main. The adapter moved from `gateway/platforms/matrix.py` to `plugins/platforms/matrix/adapter.py` — the fix is now applied in the correct location.

## Problem

Memory providers inject fenced `<memory-context>` blocks into the agent's prompt. The primary scrubber runs on streamed deltas, but leaks can occur at the final transport boundary. Matrix users see raw XML and internal memory content rendered in chat.

## Fix

Add `sanitize_context()` call in `MatrixAdapter.format_message()` — the final formatting boundary before content hits the Matrix wire.

## Changes

- `plugins/platforms/matrix/adapter.py`: import `sanitize_context`, call it in `format_message()`
- `tests/gateway/test_matrix.py`: add `TestMatrixFormatting::test_format_message_suppresses_memory_context_block`

## Verification

- Test passes: `TestMatrixFormatting::test_format_message_suppresses_memory_context_block` ✓