### PR TITLE
fix: harden cron retention and profile aliases

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -18,7 +18,8 @@ from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
-MAX_TERMINAL_EXECUTIONS = 1000
+_DEFAULT_MAX_TERMINAL_EXECUTIONS = 1000
+MAX_TERMINAL_EXECUTIONS = _DEFAULT_MAX_TERMINAL_EXECUTIONS
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
@@ -120,8 +121,72 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     return current is not None and current == started_at
 
 
+def _get_max_terminal_executions() -> Optional[int]:
+    """Resolve per-profile retention; return None when pruning is unsafe."""
+    if MAX_TERMINAL_EXECUTIONS != _DEFAULT_MAX_TERMINAL_EXECUTIONS:
+        return max(0, int(MAX_TERMINAL_EXECUTIONS))
+
+    try:
+        from hermes_cli import managed_scope
+        from hermes_cli.config import (
+            fast_safe_load,
+            load_config,
+            read_user_config_raw,
+        )
+
+        # Validate the raw files first. load_config() intentionally falls back
+        # to merged defaults on a fresh-process YAML parse failure, which is
+        # safe for ordinary runtime settings but unsafe for destructive
+        # retention pruning: the default 1,000 could erase a larger ledger.
+        read_user_config_raw()
+        managed_config = {}
+        managed_dir = managed_scope.get_managed_dir()
+        managed_path = managed_dir / "config.yaml" if managed_dir else None
+        if managed_path and managed_path.exists():
+            with open(managed_path, encoding="utf-8") as managed_file:
+                managed_config = fast_safe_load(managed_file) or {}
+            if not isinstance(managed_config, dict):
+                return None
+        config = load_config()
+    except Exception:
+        return None
+    if not isinstance(config, dict):
+        return None
+    cron_config = config.get("cron", {})
+    if not isinstance(cron_config, dict):
+        return None
+
+    # Administrator-managed leaf values win over process environment. Without
+    # this check, a service-level env override could silently defeat a pinned
+    # audit-retention policy. When the leaf is not managed, the documented env
+    # override remains higher priority than the user's profile config.
+    managed_cron = managed_config.get("cron", {})
+    is_managed = (
+        isinstance(managed_cron, dict)
+        and "max_terminal_executions" in managed_cron
+    )
+    raw = os.getenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "").strip()
+    if raw and not is_managed:
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            # A malformed temporary env override must not hide a valid
+            # profile setting or trigger destructive fallback pruning.
+            pass
+
+    configured = cron_config.get(
+        "max_terminal_executions", _DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )
+    try:
+        return max(0, int(configured))
+    except (TypeError, ValueError):
+        return None
+
+
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
-    limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
+    limit = _get_max_terminal_executions()
+    if limit is None:
+        return
     conn.execute(
         """DELETE FROM executions WHERE id IN (
              SELECT id FROM executions

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2158,6 +2158,10 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Maximum terminal execution attempts retained in each profile-local
+        # cron/executions.db. In-flight rows are always preserved. High-rate
+        # profiles can raise this without changing global scheduler behavior.
+        "max_terminal_executions": 1000,
         # Fail closed when an unpinned job's current global model/provider
         # differs from its creation-time snapshot. This prevents unattended
         # jobs from silently inheriting a paid default. Set to false only when

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,6 +5,7 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import shlex
 import sys
 import subprocess
 import shutil
@@ -103,6 +104,39 @@ def _safe_which(cmd: str) -> str | None:
         return shutil.which(cmd)
     except Exception:
         return None
+
+
+def _profile_alias_target_from_wrapper(content: str) -> str | None:
+    """Return the profile only for an exact Hermes-generated alias wrapper."""
+    lines = content.splitlines()
+    if len(lines) != 2:
+        return None
+
+    if lines[0].startswith("#!"):
+        try:
+            parts = shlex.split(lines[1])
+        except ValueError:
+            return None
+        if (
+            len(parts) == 5
+            and parts[0] == "exec"
+            and Path(parts[1]).name == "hermes"
+            and parts[2] == "-p"
+            and parts[4] == "$@"
+        ):
+            return parts[3]
+        return None
+
+    if lines[0].lower() == "@echo off":
+        parts = lines[1].split()
+        if (
+            len(parts) == 4
+            and parts[0].lower() == "hermes"
+            and parts[1] == "-p"
+            and parts[3] == "%*"
+        ):
+            return parts[2]
+    return None
 
 
 def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
@@ -2704,8 +2738,6 @@ def run_doctor(args):
 
     try:
         from hermes_cli.profiles import list_profiles, _get_wrapper_dir, profile_exists
-        import re as _re
-
         named_profiles = [p for p in list_profiles() if not p.is_default]
         if named_profiles:
             _section("Profiles")
@@ -2734,10 +2766,12 @@ def run_doctor(args):
                         continue
                     try:
                         content = wrapper.read_text(encoding="utf-8")
-                        if "hermes -p" in content:
-                            _m = _re.search(r"hermes -p (\S+)", content)
-                            if _m and not profile_exists(_m.group(1)):
-                                check_warn(f"Orphan alias: {wrapper.name} → profile '{_m.group(1)}' no longer exists")
+                        target = _profile_alias_target_from_wrapper(content)
+                        if target and not profile_exists(target):
+                            check_warn(
+                                f"Orphan alias: {wrapper.name} → profile "
+                                f"'{target}' no longer exists"
+                            )
                     except Exception:
                         pass
     except ImportError:

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -65,6 +65,113 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
     assert executions.latest_execution("live")["status"] == "running"
 
 
+def test_retention_limit_can_be_set_per_profile_config(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.delenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"cron": {"max_terminal_executions": 4321}},
+    )
+
+    assert executions._get_max_terminal_executions() == 4321
+
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["max_terminal_executions"] == 1000
+
+
+def test_retention_env_override_wins_and_invalid_value_uses_profile_config(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "7654")
+    assert executions._get_max_terminal_executions() == 7654
+
+    monkeypatch.setenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "not-a-number")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"cron": {"max_terminal_executions": 4321}},
+    )
+    assert executions._get_max_terminal_executions() == 4321
+
+
+def test_managed_retention_wins_over_environment(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    user_config = tmp_path / "user-config.yaml"
+    user_config.write_text(
+        "cron:\n  max_terminal_executions: 5000\n", encoding="utf-8"
+    )
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "cron:\n  max_terminal_executions: 9000\n", encoding="utf-8"
+    )
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: user_config)
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    monkeypatch.setenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "0")
+
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    assert executions._get_max_terminal_executions() == 9000
+
+
+def test_malformed_managed_retention_config_fails_closed(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    user_config = tmp_path / "user-config.yaml"
+    user_config.write_text(
+        "cron:\n  max_terminal_executions: 5000\n", encoding="utf-8"
+    )
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text("cron: [\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: user_config)
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    monkeypatch.setenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "0")
+
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
+    assert executions._get_max_terminal_executions() is None
+
+
+def test_retention_skips_pruning_when_config_is_unreadable(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.delenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", raising=False)
+
+    def fail_to_load():
+        raise OSError("temporary config read failure")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fail_to_load)
+    assert executions._get_max_terminal_executions() is None
+
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    with sqlite3.connect(executions.EXECUTIONS_FILE) as conn:
+        executions._initialize_schema(conn)
+        for index in range(3):
+            conn.execute(
+                """INSERT INTO executions
+                   (id, job_id, source, process_id, pid, status, claimed_at,
+                    finished_at)
+                   VALUES (?, 'job', 'test', 'process', 1, 'completed', ?, ?)""",
+                (f"row-{index}", f"2026-01-01T00:00:0{index}+00:00", f"2026-01-01T00:00:0{index}+00:00"),
+            )
+        executions._prune_unlocked(conn)
+        remaining = conn.execute("SELECT count(*) FROM executions").fetchone()[0]
+
+    assert remaining == 3
+
+
+def test_retention_skips_pruning_on_fresh_process_malformed_yaml(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.delenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", raising=False)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("cron: [\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+
+    assert executions._get_max_terminal_executions() is None
+
+
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     executions.EXECUTIONS_FILE.parent.mkdir(parents=True)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -51,6 +51,35 @@ class TestProviderEnvDetection:
         assert not _has_provider_env_config(content)
 
 
+class TestProfileAliasDetection:
+    def test_detects_generated_posix_and_windows_wrappers(self):
+        assert (
+            doctor._profile_alias_target_from_wrapper(
+                '#!/bin/sh\nexec /usr/local/bin/hermes -p papabank "$@"\n'
+            )
+            == "papabank"
+        )
+        assert (
+            doctor._profile_alias_target_from_wrapper(
+                "@echo off\r\nhermes -p papabank %*\r\n"
+            )
+            == "papabank"
+        )
+
+    def test_ignores_health_utilities_that_loop_over_profiles(self):
+        utility = """#!/bin/zsh
+profiles=(default eva doc)
+for p in $profiles; do
+  cmd=(hermes -p "$p")
+done
+"""
+        assert doctor._profile_alias_target_from_wrapper(utility) is None
+
+    def test_ignores_two_line_wrapper_for_an_unrelated_executable(self):
+        unrelated = '#!/bin/sh\nexec /usr/local/bin/tool -p archived "$@"\n'
+        assert doctor._profile_alias_target_from_wrapper(unrelated) is None
+
+
 class TestDoctorToolAvailabilitySummary:
     def test_missing_api_key_summary_ignores_disabled_toolsets(self, monkeypatch):
         unavailable = [


### PR DESCRIPTION
## Summary

- make cron execution-ledger retention configurable per profile
- fail closed on unreadable or malformed user/managed retention config
- preserve administrator-managed retention precedence over environment overrides
- stop `hermes doctor` from reporting generated profile aliases and unrelated wrappers as orphaned

## Verification

- `uv run pytest tests/cron/test_execution_ledger.py tests/hermes_cli/test_doctor.py` — 76 passed
- `git diff --check`
- independent reviewer re-review: no findings

## Scope

Draft for upstream review. The live deployment was validated separately; no unrelated Freddie worktree changes are included.
