### PR TITLE
feat(optional-skills): add cafe24-aispace (web-development)

### DIFF
--- a/optional-skills/web-development/cafe24-aispace/SKILL.md
+++ b/optional-skills/web-development/cafe24-aispace/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cafe24-aispace
+description: Deploy and operate web apps on Cafe24 AI SPACE via MCP.
+version: 1.0.0
+author: Jiho Yoo (cafe24-jhyoo02), Cafe24 AI SPACE
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [cafe24, aispace, deploy, mcp, hosting, paas, korea, web-development]
+    category: web-development
+---
+
+# Cafe24 AI SPACE Skill
+
+Deploy and operate web apps on [Cafe24 AI SPACE](https://aispacedocs-docs.mycafe24.ai) — a Korean AI-native PaaS — through its remote MCP server. Runtime is auto-detected (Node.js 20 / Python 3.11 / PHP 8.2 / Static), databases (MySQL/PostgreSQL/SQLite/Redis) are injected automatically, and every deploy gets a live HTTPS URL at `https://{id}-{project}.mycafe24.ai`. Auth is a one-time Cafe24 account OAuth — no API keys.
+
+This skill does NOT cover plan changes, billing, project deletion, rollback, or power operations — those are intentionally excluded from the MCP surface and belong in the AI SPACE web console.
+
+## When to Use
+
+Load this skill when the user wants to:
+
+- **Ship agent-written code to a persistent live URL** with a database — "build this and put it online"
+- **Deploy an existing project** (Node/Python/PHP/static) to managed Korean infrastructure
+- **Operate a running AI SPACE app** — status, build/runtime logs, env vars, backups, IP/Geo access control
+- **Diagnose a failed AI SPACE build** from logs
+
+## When NOT to Use
+
+- **Throwaway previews with no persistence** → a temporary deploy service is simpler; AI SPACE targets apps that keep running (paid plans from KRW 4,900/month, 14-day free trial).
+- **Unsupported runtimes** (Go, Java, Rust) → not deployable; propose a supported-stack rewrite instead.
+- **Destructive or billing operations** → direct the user to the AI SPACE web console.
+
+## Prerequisites
+
+- A [Cafe24](https://www.cafe24.com) account with AI SPACE applied (14-day free trial available).
+- The AI SPACE MCP server registered in Hermes: `https://aih-proxy.cafe24.com/mcp` (`streamable-http`, `auth: oauth`).
+- **Headless OAuth completed once.** Servers have no browser; follow `references/headless-oauth.md` — present the auth URL, have the user complete Cafe24 login in their browser, then paste back the full redirected URL for the token exchange. Store tokens to the framework token path immediately.
+- **Refresh-token renewal configured.** Access tokens live ~15 minutes; schedule refresh via OS crontab/systemd (silent on success). This is the top cause of "it worked yesterday".
+- Network egress to `aih-proxy.cafe24.com` and `*.mycafe24.ai`.
+
+## How to Run
+
+Ask Hermes to deploy or operate an AI SPACE project. Typical flow:
+
+1. Confirm MCP connectivity by calling `list_my_projects` (run `scripts/verify_connection.py` first for an unauthenticated reachability check).
+2. Before deploying, run the pre-deploy checklist in the Procedure section — most build failures are prevented there.
+3. Deploy with `deploy_project` (new) or `update_project` (existing; check `source` via `get_project_status` first).
+4. Poll `get_project_status`, then verify reachability with `site_verify` — deployment success does not guarantee the site is serving.
+
+## Quick Reference
+
+- `list_my_projects` / `list_my_spaces` — inventory and free slots
+- `deploy_project` / `update_project` / `project_upload` — ship code
+- `get_project_status` / `get_project_logs` / `site_verify` — status, logs, reachability
+- `project_env` — env vars (get/set/delete; applies via light restart)
+- `backup_project` — source + `/app/user_data` + DB dump; download URL valid 7 days
+- `project_acl` — IP/CIDR and country-level access control
+- `external_repo` — GitHub-connected deploys
+
+## Procedure
+
+1. Identify intent: new build / bring existing code / operate.
+2. Pre-deploy checklist (violations are the top build-failure causes):
+   - No Dockerfile, docker-compose, or Nginx/Apache config files — the platform provides runtime images.
+   - Read DB credentials from auto-injected env vars (`DB_HOST` `DB_PORT` `DB_NAME` `DB_USER` `DB_PASSWORD`, `REDIS_*`); never set them. The variable is `DB_USER`, not `DB_USERNAME`.
+   - Persistent files only under `/app/user_data/` — other paths reset on redeploy.
+   - Node listens on port 3000, Python on 8000, host `0.0.0.0`.
+3. Deploy, then poll `get_project_status` and report progress honestly (only mark steps confirmed by status values).
+4. Verify with `site_verify` and report the live URL.
+5. On failure, fetch `get_project_logs` and diagnose against the checklist before any retry.
+
+## Pitfalls
+
+- **Auth errors are not deploy errors.** On 401, refresh or re-run the headless OAuth flow; never send the user to a login page, and never "fix" code in response to an auth failure.
+- **Stop after two identical failures.** Free-trial accounts have a 5-builds/day limit; retry loops burn it.
+- **`--temporary`-style anonymous use does not exist** — a Cafe24 account is always required.
+- Do not print tokens to conversation output; store them to the framework token path.
+- Do not cache or restate the full operating guide; load `references/headless-oauth.md` only when connecting.
+
+## Verification
+
+Run the connection check and confirm both gates:
+
+```
+python3 scripts/verify_connection.py
+```
+
+Expected: OAuth discovery reachable (HTTP 200 with `registration_endpoint`) and MCP endpoint responding. Then call `list_my_projects` through Hermes and confirm a (possibly empty) project list is returned.

--- a/optional-skills/web-development/cafe24-aispace/references/headless-oauth.md
+++ b/optional-skills/web-development/cafe24-aispace/references/headless-oauth.md
@@ -1,0 +1,39 @@
+# Headless OAuth for AI SPACE MCP (Hermes / server environments)
+
+Validated procedure (field-tested on Hermes Agent, July 2026, two runs). Korean original follows — the steps are framework-agnostic.
+
+Server URL: `https://aih-proxy.cafe24.com/mcp` (streamable-http, OAuth 2.0 DCR + PKCE; access token ~15 min, refresh required).
+
+---
+
+### 에이전트 프레임워크(OpenClaw·Hermes 등 헤드리스 서버)에서 쓸 때
+
+브라우저가 없는 서버 환경은 일반 도구와 인증 동작이 다르다. 최초 설치는 아래 순서가 정석이다.
+
+**최초 설치 4단계**
+
+1. **등록**: 원격 MCP를 `transport: streamable-http` + `auth: oauth`로 등록한다 (`https://aih-proxy.cafe24.com/mcp`).
+2. **최초 인증 — URL 붙여넣기 방식(기본)**: 인증 URL을 사용자에게 제시한다 → 사용자가 브라우저에서 열어 카페24 로그인·승인한다 → **승인 후 이동된 페이지가 연결 오류로 떠도 정상이다**(인증 코드는 주소창 URL에 있다) → 사용자에게 "주소창의 URL 전체를 복사해서 붙여넣어 달라"고 요청한다 → 받은 URL로 토큰 교환을 완료한다.
+   - **토큰 교환에 성공하면 출력하지 말고 즉시 프레임워크 토큰 경로에 파일로 저장한다.** 저장을 확인한 뒤에만 성공을 보고할 것 — 출력만 하면 토큰이 증발해 사용자에게 브라우저 재인증을 반복시키게 된다.
+   - 예외: 인증 URL을 여는 단계 자체가 거부되면(redirect_uri 불일치) 설정에서 redirect URL을 고정값으로 오버라이드하거나, 사전 등록 커넥터(고정 redirect + 서버측 토큰 주입)를 쓴다.
+3. **갱신 설정**: access 토큰 수명은 약 15분이다. refresh 토큰 자동 갱신을 반드시 켠다 — 없으면 15분 뒤부터 인증이 계속 끊긴다. "예전엔 됐는데 지금 안 된다"의 최다 원인. 갱신 잡 설계 규칙:
+   - **에이전트 잡(대화 루프 안 크론)으로 걸지 말 것.** 프레임워크의 에이전트 크론은 매 실행 결과를 채팅(Telegram 등)으로 배달해 사용자를 괴롭힌다. **OS crontab이나 systemd 타이머에서 독립 스크립트로** 실행한다.
+   - **성공 시 무출력** — 결과는 로그 파일에만 남긴다. 예: `*/10 * * * * /path/refresh-aispace.sh >> ~/aispace-refresh.log 2>&1`
+   - 실패 알림도 채팅으로 반복 발송하지 말 것 — 로그에 남기고, 다음 도구 호출이 401을 만나면 아래 "401 처리 순서"가 잡는다. 알리더라도 연속 실패가 지속될 때 1회만.
+   - 스크립트 내용: 토큰 파일에서 refresh_token을 읽어 토큰 엔드포인트(디스커버리로 확인)에 refresh grant 요청 → 응답 토큰을 **같은 파일에 원자적으로 덮어쓰기**.
+4. **스모크 테스트**: `list_my_projects`를 1회 호출해 성공을 확인하고 시작한다.
+
+**운영 중 401/인증 에러 처리 순서**: ① "Auth: none"으로 표시되면 토큰 문제가 아니라 **설정 문제**다(아래 함정 목록) → ② refresh 토큰으로 갱신 시도 → ③ 실패하면 2단계(URL 붙여넣기 재인증)를 다시 안내 → ④ **같은 인증 에러로 2회 연속 실패하면 재시도를 멈추고 보고한다.** 인증 에러를 배포 실패로 오진해 코드를 고치지 말 것.
+
+**알려진 함정 (Hermes 실측 2026-07, 2회 검증 — 버전에 따라 다를 수 있음)**
+
+- headless에서 `mcp add`가 인증 URL조차 출력하지 않고 실패할 수 있다(OAuthNonInteractiveError) → OAuth 플로우를 수동 수행: `.well-known/oauth-authorization-server` 디스커버리 → 동적 클라이언트 등록 → PKCE → 인증 URL을 사용자에게 제시 → 콜백 URL 붙여넣기로 토큰 교환.
+- **`mcp add --auth oauth`가 실패하면서 config를 `auth: none`으로 저장해 버릴 수 있다** → add 실행 후 config의 auth 필드를 반드시 확인하고, 틀려 있으면 config를 직접 수정한다(예: `config set mcp_servers.<서버명>.auth oauth`). 이게 "토큰은 멀쩡한데 401 + Auth: none"의 진짜 원인이다.
+- 수동 OAuth의 단계별 산출물(클라이언트 등록 정보·PKCE verifier·토큰)은 **생성 즉시 파일로 저장**한다. 메모리/출력에만 두면 중간 실패 시 처음부터(사용자 재인증 포함) 다시 해야 한다.
+- 동적 등록 전에 **실제 가용 포트를 먼저 할당**하고 그 포트로 redirect_uri를 등록할 것. 포트 0(`127.0.0.1:0/callback`)으로 등록하면 검증 400으로 실패한다.
+- config에는 `auth: oauth` 필드를 **명시**해야 OAuth 프로바이더가 생성된다. `oauth:` 자격증명 블록만 넣으면 "Auth: none"(토큰 미첨부) 상태로 401이 난다.
+- 수동 발급한 토큰은 프레임워크가 읽는 **정확한 경로와 JSON 키 이름**으로 저장할 것(예: `mcp-tokens/<서버명>.json`). 위치나 스키마가 다르면 조용히 무시된다.
+- config 변경은 **새 세션(또는 MCP 리로드)에서만 반영**된다. 수정 후 기존 세션에서 테스트하며 헤매지 말 것.
+- CLI가 안 잡히면 PATH부터 확인(예: `/opt/hermes/bin`).
+
+프레임워크의 LLM 라우팅이 경량 모델(기본값인 경우가 많다)로 잡혀 있으면 이 지침의 준수율이 떨어질 수 있다 — AI SPACE 작업 세션은 지침 준수율이 높은 모델로 라우팅하는 것을 권장한다.

--- a/optional-skills/web-development/cafe24-aispace/scripts/verify_connection.py
+++ b/optional-skills/web-development/cafe24-aispace/scripts/verify_connection.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Unauthenticated reachability check for the Cafe24 AI SPACE MCP server.
+
+Verifies (1) OAuth discovery responds with a registration endpoint and
+(2) the MCP endpoint itself answers. No credentials are sent or stored.
+"""
+import json
+import sys
+import urllib.request
+
+BASE = "https://aih-proxy.cafe24.com"
+OK = True
+
+def check(name, url, expect_json_key=None, accepted_codes=(200, 400, 401, 405, 406)):
+    global OK
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            body = r.read().decode("utf-8", "replace")
+            code = r.status
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace")
+        code = e.code
+    except Exception as e:
+        print(f"[FAIL] {name}: {e}")
+        OK = False
+        return
+    if code not in accepted_codes:
+        print(f"[FAIL] {name}: HTTP {code}")
+        OK = False
+        return
+    if expect_json_key:
+        try:
+            if expect_json_key not in json.loads(body):
+                print(f"[FAIL] {name}: missing '{expect_json_key}'")
+                OK = False
+                return
+        except ValueError:
+            print(f"[FAIL] {name}: non-JSON response")
+            OK = False
+            return
+    print(f"[PASS] {name}: HTTP {code}")
+
+check("OAuth discovery", f"{BASE}/.well-known/oauth-authorization-server",
+      expect_json_key="registration_endpoint", accepted_codes=(200,))
+check("MCP endpoint", f"{BASE}/mcp")
+
+print("RESULT:", "OK - proceed to OAuth (see references/headless-oauth.md)" if OK else "NOT REACHABLE")
+sys.exit(0 if OK else 1)


### PR DESCRIPTION
## What

Adds `optional-skills/web-development/cafe24-aispace` — deploy and operate web apps on **Cafe24 AI SPACE**, a Korean AI-native PaaS, via its remote MCP server (`https://aih-proxy.cafe24.com/mcp`, streamable-http + OAuth 2.0/PKCE). Runtime auto-detection (Node/Python/PHP/Static), auto-injected databases, automatic SSL on `*.mycafe24.ai`.

## Why optional-skills

Per CONTRIBUTING, paid-service integrations that are official and useful but not universally needed belong here: AI SPACE is a paid PaaS (14-day free trial), and we — the Cafe24 AI SPACE team — maintain the skill. [Cafe24](https://www.cafe24.com) is a KRX-listed Korean e-commerce & hosting platform company, and **we also ship a Hermes Agent VPS product line to Korean customers**, so Hermes users are a first-class audience for this integration.

## Duplicate check

Searched open and merged PRs/issues for `aispace` / `cafe24` — no existing coverage.

## What's included

- `SKILL.md` — strict format: When to Use / When NOT to Use / Prerequisites / How to Run / Quick Reference / Procedure / Pitfalls / Verification. The Procedure encodes the platform's real failure modes (no Dockerfile, auto-injected `DB_USER` env vars, `/app/user_data` persistence, fixed ports, two-strikes retry stop under the free-trial build limit).
- `references/headless-oauth.md` — the headless (no-browser) OAuth procedure for server environments: auth-URL paste-back token exchange, immediate token persistence, and OS-crontab refresh (~15-min access tokens). **Field-tested on Hermes Agent in July 2026 (two validation runs)**, including the known failure modes we hit (auth:none config trap, port-0 redirect registration, token file path/schema).
- `scripts/verify_connection.py` — unauthenticated reachability check (OAuth discovery + MCP endpoint). Run today against the live server: both gates PASS.

## Dependencies & data scope

- External dependency: the AI SPACE MCP server (public endpoint above). No API keys — Cafe24 account OAuth only; tokens are stored to the framework token path, never printed.
- Data scope: MCP tool calls operate solely on the signed-in user's own Cafe24 projects. **Destructive operations (delete / rollback / power / billing) are excluded from the MCP surface by design** — the skill directs users to the web console for those.
- License: MIT (skill), service docs at https://aispacedocs-docs.mycafe24.ai (privacy/terms linked there). Support: the docs site and Cafe24 CS.

## Testing

- `python3 scripts/verify_connection.py` → OAuth discovery HTTP 200 with `registration_endpoint`, MCP endpoint responding (run 2026-08-05).
- End-to-end MCP flow (connect → headless OAuth → `list_my_projects` → deploy → `site_verify`) validated on Hermes Agent server environments in July 2026; the reference doc is distilled from those runs.
- No destructive commands anywhere in the skill.