### PR TITLE
fix(windows): avoid pipe deadlock in Git Bash capability probe

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -907,21 +907,38 @@ def _bash_starts(bash: str) -> bool:
     if cached is not None:
         return cached
 
+    combined = ""
     try:
-        result = subprocess.run(
-            [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-            timeout=15,
-            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
-        )
+        # Do not use PIPE-backed capture here. During ACP startup, MCP and
+        # plugin subprocesses launch concurrently; on Windows one can inherit
+        # a probe pipe handle and prevent subprocess.run().communicate() from
+        # ever observing EOF, even after its timeout kills bash. A temporary
+        # file keeps the diagnostic output without a reader thread or EOF wait.
+        with tempfile.TemporaryFile() as capture:
+            try:
+                result = subprocess.run(
+                    [
+                        bash,
+                        "--noprofile",
+                        "--norc",
+                        "-c",
+                        _BASH_EXTERNAL_PROGRAM_PROBE,
+                    ],
+                    stdout=capture,
+                    stderr=subprocess.STDOUT,
+                    timeout=15,
+                    creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
+                )
+            finally:
+                capture.seek(0)
+                combined = capture.read().decode("utf-8", errors="replace")
         ok = result.returncode == 0
         if not ok:
-            combined = f"{result.stdout or ''}{result.stderr or ''}"
             _bash_probe_details_cache[bash] = combined.strip()[:2000]
             logger.debug("bash probe failed for %s: %s", bash, combined.strip()[:200])
     except Exception as exc:
-        _bash_probe_details_cache[bash] = str(exc)[:2000]
+        details = combined.strip() or str(exc)
+        _bash_probe_details_cache[bash] = details[:2000]
         logger.debug("bash probe error for %s: %s", bash, exc)
         ok = False
 


### PR DESCRIPTION
# fix(windows): avoid pipe deadlock in Git Bash capability probe

## Problem

On Windows, `_bash_starts()` in `tools/environments/local.py` probes Git Bash with
`subprocess.run(..., capture_output=True, timeout=15)`. During ACP startup, MCP and
plugin subprocesses launch concurrently, and one can inherit the probe's pipe write
handle. When that happens, `communicate()` never observes EOF on the child's pipes —
**even after the timeout kills bash** — because CPython joins the reader threads
unconditionally after killing the child. The probe thread blocks forever.

Captured worker stack from a wedged agent process:

```
LocalEnvironment.__init__
  BaseEnvironment.init_session
    LocalEnvironment._run_bash
      _find_bash
        _bash_starts
          subprocess.run(..., capture_output=True, timeout=15)
            Windows communicate() waiting in stdout reader thread join
```

## Impact

When the probe hangs or times out, Git Bash is rejected and the environment falls
back to `C:\Windows\System32\bash.exe` (the WSL launcher), where `/c/` does not
exist and no Windows PATH tools are reachable. Every cold agent process pays one or
two 15s probe timeouts — or hangs permanently:

```
ready in 30.9s   <- two probe timeouts
ready in 15.2s   <- one probe timeout
never completed  <- permanent hang
ready in 0.68s   <- healthy (long-lived process, cached probe)
```

Short-lived / per-conversation agent processes (e.g. ACP hosting) hit this on every
spawn; long-lived gateway processes only at startup, which is why the failure is
intermittent and hard to attribute.

## Fix

Redirect probe output to a `tempfile.TemporaryFile()` with stderr merged into
stdout, then read it after process completion. No reader threads, no EOF wait, no
inheritable pipe handles. Diagnostic output (`_bash_probe_details_cache`) is
preserved.

After the fix the same probe completes in ~0.09s and passes.

## Notes

- The `combined` capture moves outside the `try` so probe output is still available
  in the exception path.
- Behavior is unchanged on POSIX platforms; the tempfile path is used everywhere
  for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
