### PR TITLE
fix(security): gate profile config/env writes per-resource across file and terminal tools

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -355,6 +355,56 @@ class TestHermesConfigWriteProtection:
             assert dangerous is False, cmd
 
 
+class TestProfileConfigWriteProtection:
+    """Terminal-side pairing for the file_tools write_file/patch deny on
+    profile-mode configs (~/.hermes/profiles/<profile>/config.yaml, #79030).
+
+    In profile mode the active config realpath lives under
+    ``~/.hermes/profiles/<profile>/`` and patch/write_file already deny it,
+    but `sed -i` / `>` / `tee` / `cp` targeting the same file used to pass
+    the terminal guard unchecked — incident E16. Every write idiom must gate
+    the profiles/ tree exactly like the global ~/.hermes/config.yaml."""
+    def test_write_idioms_against_profile_config(self):
+        for command in (
+            "sed -i 's/provider: auto/provider: x/' ~/.hermes/profiles/prod/config.yaml",
+            "sed -i 's/provider: auto/provider: x/' $HOME/.hermes/profiles/prod/config.yaml",
+            "sed --in-place 's/provider: auto/provider: x/' ~/.hermes/profiles/prod/config.yaml",
+            "perl -i -pe 's/provider: auto/provider: x/' ~/.hermes/profiles/prod/config.yaml",
+            "echo 'approvals:' > ~/.hermes/profiles/prod/config.yaml",
+            "echo '  mode: off' >> ~/.hermes/profiles/prod/config.yaml",
+            "echo x | tee ~/.hermes/profiles/prod/config.yaml",
+            "cp /tmp/evil.yaml ~/.hermes/profiles/prod/config.yaml",
+            "mv /tmp/evil.yaml ~/.hermes/profiles/prod/config.yaml",
+        ):
+            dangerous, key, desc = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+
+    def test_write_idioms_against_profile_env(self):
+        for command in (
+            "sed -i 's/KEY=old/KEY=new/' ~/.hermes/profiles/prod/.env",
+            "echo 'KEY=new' > ~/.hermes/profiles/prod/.env",
+            "echo x | tee ~/.hermes/profiles/prod/.env",
+            "cp /tmp/evil.env ~/.hermes/profiles/prod/.env",
+        ):
+            dangerous, key, desc = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+
+    def test_profile_dir_non_security_writes_are_safe(self):
+        # Non-security files inside a profile dir (skills, memories, plugins)
+        # must stay writable, and config.yaml outside the Hermes tree is a
+        # project file, not Hermes policy.
+        for cmd in (
+            "sed -i 's/a/b/' ~/.hermes/profiles/prod/skills/foo.md",
+            "echo x > ~/.hermes/profiles/prod/memories/note.md",
+            "sed -i 's/a/b/' ~/.hermes/profiles/prod/skills/config.yaml",
+            "sed -i 's/a/b/' ~/notes/config.yaml",
+        ):
+            dangerous, key, desc = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
+
 class TestFindExecFullPathRm:
     """Detect find -exec with full-path rm bypasses."""
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -473,6 +473,51 @@ class TestSensitivePathCheck:
         # /etc (and its macOS /private/etc mirror) stay blocked.
         assert _check_sensitive_path("/private/etc/hosts") is not None
 
+    def test_profile_security_files_blocked(self, tmp_path, monkeypatch):
+        # #79030: the deny must be per-resource, not per-tool. Every
+        # ~/.hermes/profiles/<name>/config.yaml / .env carries security
+        # policy (approvals.mode, yolo, model keys) — including profiles that
+        # are NOT the currently active one (the active one is already caught
+        # by the _hermes_config_resolved check above).
+        profiles_root = tmp_path / "profiles"
+        (profiles_root / "prod").mkdir(parents=True)
+        monkeypatch.setattr("tools.file_tools._profiles_root_resolved", str(profiles_root))
+        monkeypatch.setattr("tools.file_tools._profiles_root_resolved_loaded", True)
+
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(str(profiles_root / "prod" / "config.yaml")) is not None
+        assert _check_sensitive_path(str(profiles_root / "prod" / ".env")) is not None
+
+    def test_profile_config_blocked_for_write_file(self, tmp_path, monkeypatch):
+        profiles_root = tmp_path / "profiles"
+        (profiles_root / "prod").mkdir(parents=True)
+        monkeypatch.setattr("tools.file_tools._profiles_root_resolved", str(profiles_root))
+        monkeypatch.setattr("tools.file_tools._profiles_root_resolved_loaded", True)
+
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool(
+            str(profiles_root / "prod" / "config.yaml"), "approvals:\n  mode: off\n"
+        ))
+        assert "error" in result
+        assert "profile security file" in result["error"]
+
+    def test_profile_non_security_files_allowed(self, tmp_path, monkeypatch):
+        profiles_root = tmp_path / "profiles"
+        (profiles_root / "prod" / "skills").mkdir(parents=True)
+        monkeypatch.setattr("tools.file_tools._profiles_root_resolved", str(profiles_root))
+        monkeypatch.setattr("tools.file_tools._profiles_root_resolved_loaded", True)
+        # Active-config check must stay out of the way (unrelated path).
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(tmp_path / "other" / "config.yaml"))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+
+        from tools.file_tools import _check_sensitive_path
+        # Non-security files inside a profile dir stay writable.
+        assert _check_sensitive_path(str(profiles_root / "prod" / "skills" / "SKILL.md")) is None
+        assert _check_sensitive_path(str(profiles_root / "prod" / "memories" / "note.md")) is None
+        # config.yaml nested deeper (e.g. a service config under the profile)
+        # is out of scope for the Hermes-policy deny.
+        assert _check_sensitive_path(str(profiles_root / "prod" / "gateway" / "config.yaml")) is None
+
     @patch("tools.file_tools._get_file_ops")
     def test_normal_file_not_blocked(self, mock_get, monkeypatch):
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/home/user/.hermes/config.yaml")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -273,6 +273,7 @@ _HERMES_ENV_PATH = (
     r'(?:~\/\.hermes/|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
+    r'(?:profiles/[^/\s"\'`]+/)?'
     r'\.env\b'
 )
 # ~/.hermes/config.yaml IS the security policy: approvals.mode, yolo, and the
@@ -283,10 +284,20 @@ _HERMES_ENV_PATH = (
 # `cp`, etc. targeting it are gated too — otherwise the deny is unpaired
 # theater. Mirrors _HERMES_ENV_PATH; matches the HERMES_HOME override form as
 # well as ~/.hermes/.
+#
+# The optional ``profiles/<name>/`` segment covers profile-mode configs
+# (~/.hermes/profiles/<profile>/config.yaml): they carry the same security
+# policy as the global file, and in profile mode the active config realpath
+# (denied by file_tools) lives there. Before this segment, `sed -i` on the
+# profile config slipped past the terminal guard while patch/write_file were
+# denied — the per-tool bypass of incident E16 (#79030). Only ONE nesting
+# level is matched: ``config.yaml`` deeper inside a profile (e.g. a service's
+# own config under the profile dir) is out of scope.
 _HERMES_CONFIG_PATH = (
     r'(?:~\/\.hermes/|'
     r'(?:\$home|\$\{home\})/\.hermes/|'
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
+    r'(?:profiles/[^/\s"\'`]+/)?'
     r'config\.yaml\b'
 )
 _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -672,6 +672,38 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+_profiles_root_resolved: str | None = None
+_profiles_root_resolved_loaded = False
+
+
+def _get_profiles_root_resolved() -> str | None:
+    """Return the resolved absolute ``~/.hermes/profiles`` root (cached)."""
+    global _profiles_root_resolved, _profiles_root_resolved_loaded
+    if _profiles_root_resolved_loaded:
+        return _profiles_root_resolved
+    _profiles_root_resolved_loaded = True
+    try:
+        _profiles_root_resolved = str(Path(_expand_tilde("~/.hermes/profiles")).resolve())
+    except Exception:
+        _profiles_root_resolved = None
+    return _profiles_root_resolved
+
+
+def _is_profile_security_file(path: str) -> bool:
+    """Return True when *path* is a ``config.yaml`` / ``.env`` directly inside
+    a Hermes profile directory (``~/.hermes/profiles/<name>/``).
+
+    Every profile's config carries the same security policy as the global
+    config (approvals.mode, yolo, model keys), so the resource-class deny
+    must not depend on which profile happens to be active (#79030).
+    """
+    root = _get_profiles_root_resolved()
+    if not root or not path.startswith(root + os.sep):
+        return False
+    parts = path[len(root) + 1:].split(os.sep)
+    return len(parts) == 2 and parts[1] in ("config.yaml", ".env")
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -698,6 +730,16 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             f"Refusing to write to Hermes config file: {filepath}\n"
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
+        )
+    # Any profile's config.yaml / .env is the same security policy as the
+    # active profile's config, which is caught above via get_config_path().
+    # Deny the rest of the profiles/ tree too so the resource-class deny does
+    # not depend on which profile is active (#79030).
+    if _is_profile_security_file(resolved) or _is_profile_security_file(normalized):
+        return (
+            f"Refusing to write to Hermes profile security file: {filepath}\n"
+            "Agent cannot modify security-sensitive configuration. "
+            "Edit the profile's config.yaml directly or use 'hermes config' instead."
         )
     return None
 


### PR DESCRIPTION
## Summary

Fixes the guardrail bypass where `patch` / `write_file` refused to edit a Hermes profile's sensitive config (`~/.hermes/profiles/<profile>/config.yaml`) while the same file could still be modified through the terminal tool (`sed -i`, `>`, `tee`, `cp`, …). The runtime guard was enforced **per tool** instead of **per resource** — the exact scenario behind incident E16 (2026-07-07).

## Root Cause

Two separate guard layers existed for Hermes config files:

- **File tools** (`tools/file_tools.py::_check_sensitive_path`) already deny writes to the active profile's `config.yaml` (resolved via `get_config_path()`).
- **Terminal tool** (`tools/approval.py`) gates shell write idioms (`sed -i`, `tee`, `>`, `cp`/`mv`/`install`, `perl`/`ruby -i`) against `~/.hermes/config.yaml` / `~/.hermes/.env` via the `_HERMES_CONFIG_PATH` / `_HERMES_ENV_PATH` patterns.

Those patterns required `config.yaml` / `.env` to sit **directly** under `~/.hermes/`, so the profile-mode path `~/.hermes/profiles/<profile>/config.yaml` (and `.env`) matched neither the file-side active-config deny nor the terminal-side patterns. A `sed -i` on the profile config sailed through with auto-approve while `patch` on the same file was denied — inconsistent protection and false failure reports.

## Change

**`tools/approval.py`** — extend `_HERMES_CONFIG_PATH` and `_HERMES_ENV_PATH` with an optional single-segment `profiles/<name>/` nesting, so every terminal write idiom now gates `~/.hermes/profiles/<profile>/config.yaml` and `.env` exactly like the global config. `$HOME/…`, `~/.hermes/…`, `$HERMES_HOME/…`, and (via the existing home folds) resolved-absolute forms are all covered. Only one nesting level is matched — non-security files inside a profile dir (skills, memories, plugins) and deeper service configs stay writable.

**`tools/file_tools.py`** — `_check_sensitive_path` additionally denies `config.yaml` / `.env` directly inside **any** profile directory (`~/.hermes/profiles/<name>/…`), not just the active profile's, so the file-side resource-class deny no longer depends on which profile is active.

No change to approval semantics: terminal-side findings still go through the standard approval flow (same as the existing `~/.hermes/config.yaml` gate), and file-side denials remain hard errors.

## Verification

- `pytest tests/tools/test_approval.py -k "HermesConfig or ProfileConfig or TeePattern or SensitiveCopyMove or SensitiveInPlace or IFSWhitespace" -q` → **15 passed**
- `pytest tests/tools/test_file_tools.py -k "SensitivePathCheck" -q` → **8 passed**
- Full changed files: `pytest tests/tools/test_approval.py tests/tools/test_file_tools.py -q` → **148 passed, 1 failed** (pre-existing, environment-dependent: `TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` fails on clean `main` too when the user home is a single-segment path like `/root`, because the resolved-absolute `authorized_keys` fold requires ≥2 home components; unrelated to this change, passes on CI-style multi-segment homes)
- Empirical pre/post probe of `detect_dangerous_command`:
  - `sed -i … ~/.hermes/profiles/prod/config.yaml` → **allowed → dangerous** ("in-place edit of Hermes config/env")
  - `sed -i … $HOME/.hermes/profiles/prod/config.yaml` → **allowed → dangerous**
  - `sed -i … ~/.hermes/profiles/prod/.env` → **allowed → dangerous**
  - E16 shape (`sed -i … /home/hermes/.hermes/profiles/prod/config.yaml`) → **dangerous**
  - Legit paths unchanged: `~/.hermes/profiles/prod/skills/foo.md`, `~/notes/config.yaml` → still allowed

New regression tests: `TestProfileConfigWriteProtection` (approval) and three `_check_sensitive_path` tests (file_tools) covering the bypass, the `.env` variant, the write_file end-to-end deny, and negative cases.

Closes #79030
