### PR TITLE
fix(mattermost): tune aiohttp connector keepalive (parity with #18451 hardening)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -86,6 +86,34 @@ def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
     return payload
 
 
+def _make_connector() -> Any:
+    """Return an ``aiohttp.TCPConnector`` tuned to drain idle keep-alive sockets promptly.
+
+    aiohttp's default ``keepalive_timeout`` is 15s. Behind a reverse proxy
+    or load balancer with a shorter idle timeout, the peer can close a
+    pooled connection before aiohttp reaps it, so the next request reuses
+    an already-dead socket and fails instead of transparently reconnecting.
+
+    This is the same class of issue as #18451 (CLOSE_WAIT accumulation
+    from idle pooled connections), whose fix was rolled out to the
+    httpx-based platform adapters via ``gateway/platforms/_http_client_limits.py``
+    and to Weixin's aiohttp connector (``gateway/platforms/weixin.py::_make_ssl_connector``,
+    #69089) — but never to Mattermost, which builds a bare
+    ``aiohttp.ClientSession()`` with no connector tuning at all.
+
+    ``keepalive_timeout=2`` mirrors the Weixin fix. ``enable_cleanup_closed=True``
+    helps the connector clean up sockets the remote side has already closed.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return None
+    return aiohttp.TCPConnector(
+        keepalive_timeout=2,
+        enable_cleanup_closed=True,
+    )
+
+
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter runtime dependency is available."""
     try:
@@ -316,7 +344,8 @@ class MattermostAdapter(BasePlatformAdapter):
             return False
 
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            connector=_make_connector(),
         )
         self._closing = False
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -78,6 +78,34 @@ def _url_and_token(config) -> Tuple[str, str]:
             getattr(config, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", ""))
 
 
+def _make_connector() -> Any:
+    """Return an ``aiohttp.TCPConnector`` tuned to drain idle keep-alive sockets promptly.
+
+    aiohttp's default ``keepalive_timeout`` is 15s. Behind a reverse proxy
+    or load balancer with a shorter idle timeout, the peer can close a
+    pooled connection before aiohttp reaps it, so the next request reuses
+    an already-dead socket and fails instead of transparently reconnecting.
+
+    This is the same class of issue as #18451 (CLOSE_WAIT accumulation
+    from idle pooled connections), whose fix was rolled out to the
+    httpx-based platform adapters via ``gateway/platforms/_http_client_limits.py``
+    and to Weixin's aiohttp connector (``gateway/platforms/weixin.py::_make_ssl_connector``,
+    #69089) — but never to Mattermost, which builds a bare
+    ``aiohttp.ClientSession()`` with no connector tuning at all.
+
+    ``keepalive_timeout=2`` mirrors the Weixin fix. ``enable_cleanup_closed=True``
+    helps the connector clean up sockets the remote side has already closed.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return None
+    return aiohttp.TCPConnector(
+        keepalive_timeout=2,
+        enable_cleanup_closed=True,
+    )
+
+
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter runtime dependency is available."""
     try:
@@ -233,7 +261,11 @@ class MattermostAdapter(BasePlatformAdapter):
         if not self._base_url or not self._token:
             logger.error("Mattermost: URL or token not configured")
             return False
-        self._session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), trust_env=gateway_trust_env())
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=gateway_trust_env(),
+            connector=_make_connector(),
+        )
         self._closing = False
         me = await self._api_get("users/me")
         if not me or "id" not in me:

--- a/tests/gateway/test_mattermost_connector.py
+++ b/tests/gateway/test_mattermost_connector.py
@@ -1,0 +1,28 @@
+"""Regression: Mattermost's aiohttp session must use a keepalive-tuned
+connector, not aiohttp's bare default.
+
+Same class of issue as #18451 (CLOSE_WAIT accumulation from idle pooled
+connections whose peer already closed them). That fix landed for the
+httpx-based platform adapters (``gateway/platforms/_http_client_limits.py``)
+and for Weixin's aiohttp connector (``gateway/platforms/weixin.py::_make_ssl_connector``,
+#69089), but Mattermost was building a bare ``aiohttp.ClientSession()`` with
+no connector tuning at all.
+"""
+import aiohttp
+import pytest
+
+from plugins.platforms.mattermost.adapter import _make_connector
+
+
+@pytest.mark.asyncio
+async def test_make_connector_tunes_keepalive_timeout():
+    connector = _make_connector()
+    try:
+        assert isinstance(connector, aiohttp.TCPConnector)
+        # aiohttp's own default is 15s -- too long for peers with a shorter
+        # idle timeout. Mirrors the Weixin fix's keepalive_timeout=2.
+        assert connector._keepalive_timeout == 2
+        # enable_cleanup_closed=True -- default is disabled.
+        assert connector._cleanup_closed_disabled is False
+    finally:
+        await connector.close()


### PR DESCRIPTION
Fixes #79094

## Summary

Mattermost's adapter builds a bare `aiohttp.ClientSession()` (`plugins/platforms/mattermost/adapter.py`, `connect()`) with **no connector tuning at all** — unlike every other platform adapter.

- The 8 httpx-based platform adapters (DingTalk, WeCom, WeCom-callback, Telegram, WhatsApp-Cloud, Signal, BlueBubbles, QQBot) got a shared, tightened `httpx.Limits(keepalive_expiry=2.0)` via `gateway/platforms/_http_client_limits.py` after #18451 (CLOSE_WAIT accumulation from idle pooled connections whose peer had already closed them).
- Weixin's aiohttp connector got the equivalent treatment in #69089 (`gateway/platforms/weixin.py::_make_ssl_connector`: `keepalive_timeout=2`, `enable_cleanup_closed=True`).
- Mattermost was never included in either pass. It's exposed to the same class of failure: aiohttp's default `keepalive_timeout` is 15s, so behind any reverse proxy / load balancer whose own idle keep-alive timeout is shorter than that, a pooled connection can be closed by the peer while sitting idle, and the next request reuses the now-dead socket instead of transparently reconnecting.

See #79094 for the full bug report.

## Fix

Mirrors the Weixin fix exactly: a `TCPConnector(keepalive_timeout=2, enable_cleanup_closed=True)`, passed into the adapter's `ClientSession` construction. Added a small regression test asserting the connector is actually tuned (`tests/gateway/test_mattermost_connector.py`).

## Testing

- `pytest tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py tests/gateway/test_mattermost_connector.py` — 25 passed
- `ruff check` on both changed files — clean
- `ty check plugins/platforms/mattermost/adapter.py` — 6 diagnostics, identical to the pre-existing baseline on `main` (confirmed via `git stash` before/after diff); this PR introduces no new type diagnostics

## Scope note

This same gap (no connector/pool tuning) likely exists in the other aiohttp-based adapters that never went through either hardening pass (Discord, Slack, Matrix, Teams, LINE, WhatsApp, Home Assistant, Google Chat, SMS) — deliberately out of scope here to keep this PR small and reviewable; happy to follow up if that's wanted.