### PR TITLE
fix(cli): resolve bare custom endpoint across providers (#79059)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1640,7 +1640,11 @@ def switch_model(
                 api_key = _ukey
                 base_url = _user_pdef.base_url
                 api_mode = ""
-        elif target_provider == "custom" and current_base_url:
+        elif (
+            target_provider == "custom"
+            and current_provider in {"custom", "local"}
+            and current_base_url
+        ):
             api_key = current_api_key
             base_url = current_base_url
             api_mode = determine_api_mode(target_provider, base_url)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -229,6 +229,60 @@ def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch)
     assert result.api_key == "sk-test"
 
 
+def test_switch_model_bare_custom_uses_configured_endpoint_across_providers(
+    monkeypatch,
+):
+    """A previous provider's endpoint must not leak into bare custom validation."""
+    configured_url = "http://localhost:8027/v1"
+    previous_url = "https://api.deepseek.com"
+    captured = {}
+
+    def resolve_runtime_provider(**kwargs):
+        captured["runtime"] = kwargs
+        return {
+            "api_key": "configured-key",
+            "base_url": configured_url,
+            "api_mode": "chat_completions",
+        }
+
+    def validate_requested_model(*args, **kwargs):
+        captured["validation"] = kwargs
+        return _MOCK_VALIDATION
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        resolve_runtime_provider,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        validate_requested_model,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_info", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities",
+        lambda *args, **kwargs: None,
+    )
+
+    result = switch_model(
+        raw_input="qwen3.6-27b",
+        current_provider="deepseek",
+        current_model="deepseek-v4-flash",
+        current_base_url=previous_url,
+        current_api_key="previous-key",
+        explicit_provider="custom",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert captured["runtime"]["requested"] == "custom"
+    assert captured["validation"]["base_url"] == configured_url
+    assert result.base_url == configured_url
+    assert result.api_key == "configured-key"
+
+
 def test_is_aggregator_recognizes_named_custom_provider():
     assert providers_mod.is_aggregator("custom:hpc-ai") is True
     assert providers_mod.is_aggregator("custom:litellm") is True


### PR DESCRIPTION
## What does this PR do?

Fixes #79059: switching from any non-custom provider to bare `custom` now
validates against the configured custom runtime instead of reusing the
previous session's URL and credentials.

The existing endpoint-reuse path remains unchanged when the active provider is
already `custom` or `local`, preserving live endpoint switching within a
custom session.

## Root cause

The bare-custom branch reused `current_base_url` whenever it was non-empty,
without checking `current_provider`. A switch from DeepSeek, OpenRouter, or a
virtual provider therefore validated the requested custom model against the
previous provider's catalog. Depending on that endpoint, users received a
misleading model warning or the switch was rejected.

## Changes

- Restrict current endpoint reuse to active `custom` / `local` sessions.
- Route cross-provider bare-custom switches through
  `resolve_runtime_provider("custom")`.
- Prove validation and the final switch result use the configured custom URL
  and key.

## Current-main reproduction

The same regression test was run with this PR's production change removed:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_model_switch_custom_providers.py \
  -k bare_custom_uses_configured_endpoint_across_providers -q

# current main: failed
# resolve_runtime_provider("custom") was never called
```

The test passes on this PR.

## Verification

```text
scripts/run_tests.sh <all 15 model-switch test files> -q
# 98 passed

uv run ruff check \
  hermes_cli/model_switch.py \
  tests/hermes_cli/test_model_switch_custom_providers.py
# All checks passed

scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
# passed
```

## Scope

- One production condition and one focused regression test.
- No persisted config values or provider aliases change.
- No behavior change for same-provider `custom` / `local` switches.
- No platform-specific behavior.

## CI status

The upstream Actions runs currently show `action_required`. GitHub reports
zero jobs for those runs: no test has started or failed. An upstream
maintainer must approve the fork workflow before CI can execute.
