### PR TITLE
fix(desktop): fall back to HERMES_HOME cache when session workspace is read-only

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -125,7 +125,7 @@ def preprocess_context_references(
     cwd: str | Path,
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: str | Path | None = None,
+    allowed_root: str | Path | tuple[Path, ...] | None = None,
 ) -> ContextReferenceResult:
     coro = preprocess_context_references_async(
         message,
@@ -152,7 +152,7 @@ async def preprocess_context_references_async(
     cwd: str | Path,
     context_length: int,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: str | Path | None = None,
+    allowed_root: str | Path | tuple[Path, ...] | None = None,
 ) -> ContextReferenceResult:
     refs = parse_context_references(message)
     if not refs:
@@ -160,10 +160,17 @@ async def preprocess_context_references_async(
 
     cwd_path = Path(cwd).expanduser().resolve()
     # Default to the current working directory so @ references cannot escape
-    # the active workspace unless a caller explicitly widens the root.
-    allowed_root_path = (
-        Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
-    )
+    # the active workspace unless a caller explicitly widens the root. A
+    # single root or a tuple of roots is accepted (e.g. a session cwd plus a
+    # fallback desktop-attachment cache dir staged outside the workspace).
+    if allowed_root is None:
+        allowed_root_paths: tuple[Path, ...] = (cwd_path,)
+    elif isinstance(allowed_root, tuple):
+        allowed_root_paths = tuple(
+            Path(r).expanduser().resolve() for r in allowed_root
+        )
+    else:
+        allowed_root_paths = (Path(allowed_root).expanduser().resolve(),)
     warnings: list[str] = []
     blocks: list[str] = []
     injected_tokens = 0
@@ -180,7 +187,7 @@ async def preprocess_context_references_async(
                 ref,
                 cwd_path,
                 url_fetcher=url_fetcher,
-                allowed_root=allowed_root_path,
+                allowed_root=allowed_root_paths,
             )
             for ref in refs
         )
@@ -240,7 +247,7 @@ async def _expand_reference(
     cwd: Path,
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
-    allowed_root: Path | None = None,
+    allowed_root: Path | tuple[Path, ...] | None = None,
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
@@ -269,7 +276,7 @@ def _expand_file_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_root: Path | None = None,
+    allowed_root: Path | tuple[Path, ...] | None = None,
 ) -> tuple[str | None, str | None]:
     path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     _ensure_reference_path_allowed(path)
@@ -303,7 +310,7 @@ def _expand_folder_reference(
     ref: ContextReference,
     cwd: Path,
     *,
-    allowed_root: Path | None = None,
+    allowed_root: Path | tuple[Path, ...] | None = None,
 ) -> tuple[str | None, str | None]:
     path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     _ensure_reference_path_allowed(path)
@@ -368,17 +375,35 @@ async def _default_url_fetcher(url: str) -> str:
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 
-def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
+def _path_within_root(resolved: Path, root: Path) -> bool:
+    """Return True when *resolved* lives at or below *root*."""
+    try:
+        resolved.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_path(
+    cwd: Path,
+    target: str,
+    *,
+    allowed_root: Path | tuple[Path, ...] | None = None,
+) -> Path:
     path = Path(os.path.expanduser(target))
     if not path.is_absolute():
         path = cwd / path
     resolved = path.resolve()
-    if allowed_root is not None:
-        try:
-            resolved.relative_to(allowed_root)
-        except ValueError as exc:
-            raise ValueError("path is outside the allowed workspace") from exc
-    return resolved
+    # ``allowed_root`` may be a single root or a tuple of roots (e.g. a session
+    # cwd plus a fallback desktop-attachment cache dir that lives outside the
+    # workspace). A ref resolves iff it is within ANY of the allowed roots.
+    roots = (cwd,) if allowed_root is None else (
+        allowed_root if isinstance(allowed_root, tuple) else (allowed_root,)
+    )
+    for root in roots:
+        if _path_within_root(resolved, root):
+            return resolved
+    raise ValueError("path is outside the allowed workspace")
 
 
 def _ensure_reference_path_allowed(path: Path) -> None:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7956,6 +7956,99 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         server._sessions.pop("sid", None)
 
 
+def test_file_attach_readonly_workspace_falls_back_to_hermes_home(
+    monkeypatch, tmp_path
+):
+    """Read-only session cwd must not break non-image desktop uploads.
+
+    Regression for #79065: ``_desktop_attachment_dir`` unconditionally mkdir'd
+    under the session cwd, so a read-only/inherited remote cwd (e.g. /Volumes)
+    raised PermissionError → RPC 5028. It must fall back to the profile-owned
+    ``HERMES_HOME/cache/desktop-attachments`` root, record that root on the
+    session, and return a ref that ``preprocess_context_references`` can expand.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+    # Existing writable test confirms the same reshape doesn't break the
+    # in-workspace path; here the session cwd is deliberately read-only.
+    workspace = tmp_path / "Volumes-RO"
+    workspace.mkdir()
+    os.chmod(workspace, 0o555)
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(workspace))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        # 1) Staging must fall back to HERMES_HOME cache, not fail.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+        # No RPC error (5028) and the file landed in the cache fallback root.
+        assert "error" not in resp, resp
+        assert resp["result"]["attached"] is True
+        assert resp["result"]["uploaded"] is True
+        fallback_dir = (home / "cache" / "desktop-attachments").resolve()
+        assert Path(resp["result"]["path"]).parent == fallback_dir
+        assert (fallback_dir / "report.txt").read_text(encoding="utf-8") == "hello world"
+        # The reachable ref is the absolute cache path (outside the read-only cwd).
+        assert resp["result"]["ref_text"] == f"@file:{fallback_dir / 'report.txt'}"
+
+        # 2) The session recorded the fallback so prompt.submit can allow it.
+        assert (
+            server._sessions["sid"].get(server._DESKTOP_ATTACHMENT_FALLBACK_KEY)
+            == str(fallback_dir)
+        )
+        allowed_roots = server._desktop_attachment_allowed_roots(
+            server._sessions["sid"], str(workspace)
+        )
+        assert str(fallback_dir) in allowed_roots
+
+        # 3) The staged @file: ref must EXPAND (not be blocked) when prompt.submit
+        #    preprocesses it with the widened allowed roots — the second-order
+        #    constraint from the original diagnosis.
+        from agent.context_references import preprocess_context_references_async
+
+        import asyncio
+
+        ref = resp["result"]["ref_text"]
+        # Without widening (allowed_root=cwd only) it would be refused:
+        alone = asyncio.run(
+            preprocess_context_references_async(
+                ref, cwd=str(workspace), context_length=100000, allowed_root=str(workspace)
+            )
+        )
+        assert "outside the allowed workspace" in (alone.message or "")
+        # With the widened roots it expands to the uploaded bytes:
+        widened = asyncio.run(
+            preprocess_context_references_async(
+                ref,
+                cwd=str(workspace),
+                context_length=100000,
+                allowed_root=allowed_roots,
+            )
+        )
+        assert widened.blocked is False
+        assert "hello world" in (widened.message or "")
+    finally:
+        os.chmod(workspace, 0o755)
+        server._sessions.pop("sid", None)
+        reset_hermes_home_override(token)
+
+
 def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, tmp_path):
     """Local case: gateway can see the file but it's outside the workspace → copy in."""
     workspace = tmp_path / "workspace"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9462,7 +9462,7 @@ def _run_prompt_submit(
                 ctx = preprocess_context_references(
                     prompt,
                     cwd=cwd,
-                    allowed_root=cwd,
+                    allowed_root=_desktop_attachment_allowed_roots(session, cwd),
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -10336,10 +10336,55 @@ def _attachment_ref_path(session: dict, target: Path) -> str:
         return str(target.resolve())
 
 
+_DESKTOP_ATTACHMENT_FALLBACK_KEY = "desktop_attachment_fallback_dir"
+
+
+def _desktop_attachment_allowed_roots(session: dict, cwd: str) -> tuple:
+    """Allowed roots for @file: expansion during prompt.submit.
+
+    Normally just the session cwd. When a desktop attachment was staged to the
+    profile-owned fallback cache root (read-only workspace), its absolute path
+    is outside the cwd, so that root MUST also be allowed or the staged
+    ``@file:`` ref would be rejected by ``preprocess_context_references``.
+    """
+    roots = (cwd,)
+    if session is not None:
+        fallback = session.get(_DESKTOP_ATTACHMENT_FALLBACK_KEY)
+        if fallback:
+            roots = roots + (fallback,)
+    return roots
+
+
+def _desktop_attachment_fallback_dir() -> Path:
+    """Writable profile-owned staging root for desktop attachments.
+
+    Used when the session workspace itself is not writable (e.g. a read-only
+    or stale inherited remote ``cwd`` such as ``/Volumes``). Anchored under
+    ``HERMES_HOME/cache`` so it is profile-owned and independent of the
+    session cwd, and explicitly resolved so the returned path matches the
+    ``@file:`` refs produced against it. The directory is created lazily by
+    the caller.
+    """
+    from hermes_constants import get_hermes_home
+
+    return (get_hermes_home() / "cache" / "desktop-attachments").resolve()
+
+
 def _desktop_attachment_dir(session: dict) -> Path:
     root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
-    root.mkdir(parents=True, exist_ok=True)
-    return root
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+    except OSError:
+        # Session workspace is not writable. Fall back to a profile-owned
+        # cache root so non-image desktop uploads still work, and record the
+        # fallback on the session so prompt.submit can widen its allowed_root
+        # (preprocess_context_references) to accept the staged @file: ref.
+        fallback = _desktop_attachment_fallback_dir()
+        fallback.mkdir(parents=True, exist_ok=True)
+        if session is not None:
+            session[_DESKTOP_ATTACHMENT_FALLBACK_KEY] = str(fallback)
+        return fallback
 
 
 def _sanitize_attachment_name(name: str) -> str:


### PR DESCRIPTION
Fixes #79065

## Problem

Non-image desktop uploads (the `file.attach` RPC) unconditionally stage bytes under `<session cwd>/.hermes/desktop-attachments` and call `mkdir(parents=True, exist_ok=True)`. When a session's stored cwd is read-only or an inherited remote workspace (e.g. `/Volumes` on macOS), the mkdir raises `[Errno 13] Permission denied`, returned to the desktop as RPC error `5028` — blocking every non-image upload for the lifetime of the session.

## Fix

- `_desktop_attachment_dir()` now falls back to the profile-owned `HERMES_HOME/cache/desktop-attachments` root when the workspace-local mkdir raises `OSError`, and records the chosen root on the session.
- Because the fallback root lives outside the session cwd, `preprocess_context_references` could no longer expand the resulting `@file:` ref ("path is outside the allowed workspace"). `allowed_root` now accepts a tuple of roots (session cwd + recorded fallback cache dir), preserving the default single-root (cwd-only) behavior when no fallback is recorded.
- Regression test `test_file_attach_readonly_workspace_falls_back_to_hermes_home` covers the full chain: staging fallback → session recording → allowed-roots widening → `@file:` ref expansion on submit.

## Verification

- New regression test + existing positive upload test pass.
- Full `tests/test_tui_gateway_server.py` (518) and `tests/agent/test_context_references.py` (11) pass; extra edge-case suite (6 MiB binary, 5 file types, duplicate/unsafe filenames, multi-session fallback reuse, end-to-end ref expansion) passes.
- Security: fallback anchors under `HERMES_HOME/cache/desktop-attachments`, not in the file-safety deny-lists; single-root default behavior preserved; outside-workspace refs still rejected; `Path.relative_to` component-aware check prevents path escapes.