### PR TITLE
fix(gateway): launchd 服务不再注入 --replace，修复共享 Token 配置文件的互相驱逐死循环

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4720,10 +4720,22 @@ def _timestamped_stderr_gateway_command(
     ``hermes update`` sees the flag on the live grandchild argv and hands
     the process back to launchd instead of starting a detached watcher
     (#86893 / #87005). The detached nohup fallback stays unmarked.
+
+    Supervised starts also drop ``--replace`` (issue #79048): a launchd
+    service is respawned by KeepAlive, so takeover authority would be
+    re-armed on every respawn — two profiles legitimately sharing one
+    platform token would each terminate the sibling, and launchd would
+    revive the victim forever. Bounded replacement is the lifecycle
+    commands' job (``launchctl kickstart -k``, drain in
+    ``launchd_restart()``, bootout+bootstrap in install/refresh), which
+    run before supervision resumes. Mirrors ``generate_systemd_unit``,
+    whose ExecStart also runs ``gateway run`` without ``--replace``.
     """
     inner = _gateway_run_command()
     if external_supervisor and "--external-supervisor" not in inner:
         inner = [*inner, "--external-supervisor"]
+    if external_supervisor and "--replace" in inner:
+        inner = [part for part in inner if part != "--replace"]
     return [
         get_python_path(),
         "-m",

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -10,6 +10,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
+    SendResult,
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
@@ -1254,6 +1255,7 @@ class TestMediaFallbackDoesNotLeakHostPath:
         assert self.SENSITIVE_PATH not in sent_text
 
 
+
 class TestDockerProfileSandboxMediaTranslation:
     """MEDIA from persistent Docker sandboxes must resolve to the host
     directory the profile's container actually bind-mounts (#93950).
@@ -1386,3 +1388,101 @@ class TestDockerProfileSandboxMediaTranslation:
             "did not resolve" in r.message and f"session_key={self.SESSION_KEY}" in r.message
             for r in caplog.records
         )
+
+class _LockGovernanceProbeAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter for platform-lock takeover governance tests."""
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send(self, *args, **kwargs) -> SendResult:
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {"name": "probe", "type": "dm"}
+
+
+class TestPlatformLockTakeoverGovernance:
+    """A supervised (non-``--replace``) gateway must never evict a live holder.
+
+    Regression for #79048: launchd services with ``KeepAlive=true`` used to be
+    generated with ``--replace``, re-arming takeover authority on every
+    respawn. Two profiles sharing one platform token (e.g. the same Discord
+    bot) would then terminate each other in an endless mutual-eviction loop.
+    The runtime guard is the adapter's ``_platform_lock_takeover_allowed``
+    bit — only an explicit ``gateway run --replace`` startup arms it. Without
+    that authority a live cross-home holder must be left alone and reported
+    as a retryable failure, never terminated.
+    """
+
+    def _make_adapter(self, *, takeover_allowed: bool):
+        from gateway.config import Platform, PlatformConfig
+
+        adapter = _LockGovernanceProbeAdapter(
+            config=PlatformConfig(), platform=Platform.DISCORD
+        )
+        adapter._platform_lock_takeover_allowed = takeover_allowed
+        return adapter
+
+    def test_no_takeover_without_replace_authority(self, tmp_path, monkeypatch):
+        from gateway import status
+
+        existing = {
+            "pid": 4242,
+            "start_time": 123,
+            "home": str(tmp_path / "other-profile-home"),
+        }
+        monkeypatch.setattr(
+            status,
+            "acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (False, existing),
+        )
+        takeover_calls = []
+        monkeypatch.setattr(
+            status,
+            "take_over_scoped_lock_holder",
+            lambda existing: takeover_calls.append(existing) or 4242,
+        )
+        monkeypatch.setattr(status, "write_runtime_status", lambda **kw: None)
+
+        adapter = self._make_adapter(takeover_allowed=False)
+        # Ordinary (supervised) start: the live cross-home holder must be
+        # left untouched — the gateway fails retryably instead of killing it.
+        assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
+        assert takeover_calls == []
+        assert adapter.fatal_error_retryable is True
+        assert adapter._fatal_error_code == "discord-token_lock"
+
+    def test_takeover_authority_consumed_once(self, tmp_path, monkeypatch):
+        from gateway import status
+
+        existing = {
+            "pid": 4242,
+            "start_time": 123,
+            "home": str(tmp_path / "other-profile-home"),
+        }
+        monkeypatch.setattr(
+            status,
+            "acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (False, existing),
+        )
+        takeover_calls = []
+        monkeypatch.setattr(
+            status,
+            "take_over_scoped_lock_holder",
+            lambda existing: takeover_calls.append(existing) or 4242,
+        )
+        monkeypatch.setattr(status, "write_runtime_status", lambda **kw: None)
+
+        adapter = self._make_adapter(takeover_allowed=True)
+        # An explicit --replace start may attempt exactly one takeover...
+        assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
+        assert len(takeover_calls) == 1
+        # ...but the authority is consumed, so a reconnect can never evict a
+        # healthy holder (this is what stops the supervised respawn loop).
+        assert adapter._acquire_platform_lock("discord-token", "tok", "Discord") is False
+        assert len(takeover_calls) == 1
+        assert adapter._platform_lock_takeover_attempted is True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1490,7 +1490,6 @@ class TestProfileArg:
             "mybot",
             "gateway",
             "run",
-            "--replace",
             "--external-supervisor",
         ]
 
@@ -2147,6 +2146,44 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+
+class TestServiceTakeoverGovernance:
+    """Supervised service definitions must never arm ``--replace`` takeover.
+
+    Regression for #79048: two launchd-supervised profile gateways sharing
+    one platform token (e.g. the same Discord bot) entered an endless
+    mutual-eviction loop because the generated plist armed ``--replace`` on
+    every KeepAlive respawn: each revived process was authorized to terminate
+    the sibling holding the shared token, and launchd immediately revived the
+    victim. The systemd unit already runs ``gateway run`` without
+    ``--replace``; the launchd plist must match so a supervised restart can
+    never evict a legitimate cross-profile lock holder. Bounded replacement
+    stays the lifecycle commands' job (kickstart -k / drain / bootout).
+    """
+
+    def test_launchd_plist_does_not_arm_takeover(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        plist = gateway_cli.generate_launchd_plist()
+        # The whole bug class: no --replace anywhere in the supervised argv.
+        assert "--replace" not in plist
+        # It still runs the plain gateway command under KeepAlive.
+        assert "<string>gateway</string>" in plist
+        assert "<string>run</string>" in plist
+        assert "<key>KeepAlive</key>" in plist
+        assert "<true/>" in plist
+
+    def test_systemd_unit_does_not_arm_takeover(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        exec_starts = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
+        assert exec_starts, "unit has no ExecStart line"
+        # The safe service posture the launchd plist now mirrors.
+        assert "--replace" not in exec_starts[0]
 
 
 class TestLaunchctlBootstrapEioRetry:


### PR DESCRIPTION
## 背景

修复 #79048: macOS 上两个 launchd 监管的 profile gateway 若合法共享同一个平台 Token（例如同一个 Discord Bot），在 `hermes update` 重新生成 plist 后会陷入无休止的互相驱逐循环。

## 根因分析

生成的 launchd 服务定义同时包含三个要素：

1. `generate_launchd_plist()` 无条件生成 `gateway run --replace`（ProgramArguments）
2. 无条件 `KeepAlive=true`
3. 基于 Token 的跨 `HERMES_HOME` 平台锁接管逻辑（`take_over_scoped_lock_holder()`）

由于 KeepAlive 每次重启都会重新武装 `--replace` 的接管权限，每个被唤醒的进程都有权终止持有共享 Token 的兄弟进程，而 launchd 又会立刻复活被终止的一方——形成监管器层面的死循环。per-process 的 takeover marker 只能让单次退出显得"干净"，无法终止 supervisor 级别的循环。

另外，`generate_systemd_unit()` 的 ExecStart 一直是 `gateway run`（不带 `--replace`），本就不存在此问题；launchd 生成器与 systemd 的安全姿势不一致。

## 修复方式

- `generate_launchd_plist()` 改为生成普通的 `gateway run`，不再注入 `--replace`，与 systemd unit 保持一致。
- 有界替换（bounded replacement）仍由生命周期命令负责：`launchctl kickstart -k`、`launchd_restart()` 中的 drain、install/refresh 流程的 bootout+bootstrap 都在监管恢复前完成替换。
- 受监管服务重启后无法再驱逐合法的跨 profile 锁持有者；失去锁的一方以 retryable 失败保持运行（Discord adapter 进入 retrying），而不是杀死兄弟进程——这正是 issue 中生产环境验证过的 workaround（移除命名 profile 的 `--replace`）的持久化版本。
- 非监管的一次性路径（`_gateway_run_command()` 后台启动、`_gateway_run_args_for_profile()` 更新期重启）保留 `--replace`：那里没有 supervisor 复活目标进程，一次性有界替换是正确的。

## Who should enable this

macOS 上使用 **多 profile gateway** 且多个 profile 共享同一平台 Token（Discord Bot / Telegram Bot / Slack App 等）的用户：

- 升级后两个 gateway 进程陷入互相 kill-重启循环，CPU 飙升、日志刷屏
- 共享 Token 的 profile 频繁掉线/重连

修复仅影响 **launchd 监管的服务**；普通 CLI 启动的一次性 `--replace` 行为不变。

## Platform compatibility

| 平台 | 兼容性 |
|---|---|
| macOS | ✅ 修复目标平台（launchd 监管） |
| Linux | ✅ 无影响（systemd unit 本就不带 `--replace`，行为已一致） |
| Windows | ✅ 无影响（不使用 launchd/systemd 监管） |

## Quick-start guide

1. `hermes update`（或拉取本 PR 分支）
2. 重新生成受影响的 launchd 服务（`hermes gateway install` 或 `hermes update` 自动刷新）
3. `launchctl bootout` 旧服务 → `launchctl bootstrap` 重新加载（或直接 `launchctl kickstart -k` 触发有界替换）
4. 验证：`launchctl print gui/$(id -u)/<service>` 中 ProgramArguments 不再包含 `--replace`；多 profile 共享 Token 不再互相驱逐

## Troubleshooting

| 症状 | 原因 | 修复 |
|---|---|---|
| 多 profile 共享 Token 互相驱逐 | launchd 服务带 `--replace` + KeepAlive | 升级后重新生成 plist；确认无 `--replace` |
| 升级后服务未更新 | plist 未刷新 | `hermes gateway install` 重新生成，或手动 bootout+bootstrap |
| 一次性 CLI 启动行为变化 | — | 无变化（非监管路径保留 `--replace`，有界替换正确） |
| Discord adapter 进入 retrying | 失去共享锁 | 正常行为：以 retryable 失败保持运行，不杀死兄弟进程；等待锁释放后自动恢复 |

## 回归测试

- launchd plist 不得包含 `--replace`（且 KeepAlive 仍为 true）
- systemd unit ExecStart 不得包含 `--replace`（固化安全姿势）
- 无接管权限时 `_acquire_platform_lock()` 不得终止存活的跨 home 锁持有者（改为 retryable 失败）
- 接管权限在一次尝试后被消耗，重连无法驱逐健康持有者

## 验证

- [x] 代码变更已在本地验证（plist 可被 plistlib 解析，ProgramArguments 无 `--replace`）
- [x] 新增 4 个回归测试全部通过；相关测试套件 202 passed, 1 skipped（test_gateway_service.py + test_platform_base.py + test_status.py）
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更（一次性 `--replace` 路径保持不变）

Closes #79048
