### PR TITLE
fix(security): redact current Mem0 API keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -104,6 +104,7 @@ _PREFIX_PATTERNS = [
     r"syt_[A-Za-z0-9]{10,}",            # Matrix access token
     r"retaindb_[A-Za-z0-9]{10,}",       # RetainDB API key
     r"hsk-[A-Za-z0-9]{10,}",            # Hindsight API key
+    r"m0-[A-Za-z0-9_-]{10,}",           # Mem0 Platform API key (current)
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -64,6 +64,12 @@ class TestKnownPrefixes:
         result = redact_sensitive_text(token)
         assert "a" * 14 not in result
 
+    def test_mem0_platform_key(self):
+        token = "m0-" + "A1b2C3d4" * 5
+        result = redact_sensitive_text(f"Mem0 key: {token}")
+        assert token not in result
+        assert "..." in result
+
 
 
 


### PR DESCRIPTION
## Summary

- recognize the current Mem0 Platform `m0-...` API-key prefix in the central redactor
- prevent bare Mem0 keys from leaking through logs, tool output, or other redacted text surfaces

## Root cause

The prefix registry covered the legacy `mem0_...` form, but Mem0's current hosted-platform examples use `m0-...`. A bare current-format key therefore passed through `redact_sensitive_text()` unchanged unless it happened to appear beside a separately recognized sensitive field name.

Mem0 documents the current prefix in its official CLI and platform examples: https://github.com/mem0ai/mem0/blob/main/cli/README.md

## Validation

- reproduced the leak on current `main` with a synthetic bare `m0-...` value
- added a focused behavior test for the current prefix
- `scripts/run_tests.sh tests/agent/test_redact.py -k mem0_platform_key -q` — 1 passed
- `python3 -m py_compile agent/redact.py tests/agent/test_redact.py`
- `git diff --check`
