### PR TITLE
feat(events): emit memory.changed broadcast on memory mutations

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -26,10 +26,12 @@ import { $gateway } from '@/store/gateway'
 import { applyGoalStatusText } from '@/store/goals'
 import {
   notifyCronChanged,
+  notifyMemoryChanged,
   notifyPairingChanged,
   notifyPetChanged,
   notifyPlatformsChanged,
   notifySessionsChanged,
+  type MemoryChangeMeta,
   type PetChangeMeta,
   setChangeEventsAvailable
 } from '@/store/live-sync'
@@ -309,7 +311,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         event.type === 'cron.changed' ||
         event.type === 'sessions.changed' ||
         event.type === 'platforms.changed' ||
-        event.type === 'pairing.changed'
+        event.type === 'pairing.changed' ||
+        event.type === 'memory.changed'
       ) {
         // Change-watcher broadcasts (server._broadcast_watched_changes): the
         // backend's on-disk signature moved. Route to the live-sync ticks the
@@ -327,6 +330,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             notifyPlatformsChanged()
           } else if (event.type === 'pairing.changed') {
             notifyPairingChanged()
+          } else if (event.type === 'memory.changed') {
+            notifyMemoryChanged(payload as MemoryChangeMeta | undefined)
           } else {
             notifySessionsChanged()
           }

--- a/apps/desktop/src/store/live-sync.test.ts
+++ b/apps/desktop/src/store/live-sync.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { $memoryChange, MemoryChangeMeta, notifyMemoryChanged } from './live-sync'
+
+describe('notifyMemoryChanged', () => {
+  it('increments tick and stores meta payload', () => {
+    const before = $memoryChange.get()
+
+    const meta: MemoryChangeMeta = { profile: "coder", target: "memory", source: "memory_tool" }
+    notifyMemoryChanged(meta)
+
+    const after = $memoryChange.get()
+    expect(after.tick).toBe(before.tick + 1)
+    expect(after.meta).toEqual(meta)
+  })
+
+  it('works without meta (broad refresh)', () => {
+    const before = $memoryChange.get()
+
+    notifyMemoryChanged()
+
+    const after = $memoryChange.get()
+    expect(after.tick).toBe(before.tick + 1)
+    expect(after.meta).toBeUndefined()
+  })
+
+  it('preserves meta across multiple ticks', () => {
+    notifyMemoryChanged({ profile: 'default', target: 'user', source: 'memory_tool' })
+    const first = $memoryChange.get()
+
+    notifyMemoryChanged({ profile: "coder", target: "memory", source: 'reset' })
+    const second = $memoryChange.get()
+
+    expect(second.tick).toBe(first.tick + 1)
+    expect(second.meta).toEqual({ profile: 'coder', target: 'memory', source: 'reset' })
+    // First meta is gone — only the latest is kept
+    expect($memoryChange.get().meta).not.toEqual({ profile: 'default', target: 'user', source: 'memory_tool' })
+  })
+})

--- a/apps/desktop/src/store/live-sync.ts
+++ b/apps/desktop/src/store/live-sync.ts
@@ -21,6 +21,16 @@ export const $sessionsChangeTick = atom(0)
 export const $platformsChangeTick = atom(0)
 export const $pairingChangeTick = atom(0)
 
+/** Payload carried on `memory.changed` — profile and target when a agent memory or user memory
+ * is updated. Source identifies the emitter (e.g. "memory_tool", "reset", or a custom provider). */
+export interface MemoryChangeMeta {
+  profile?: string
+  target?: string
+  source?: string
+}
+
+export const $memoryChange = atom<{ meta?: MemoryChangeMeta; tick: number }>({ tick: 0 })
+
 /** `pet.info.meta`-shaped payload carried on `pet.changed` — lets the pet skip
  *  the heavy sprite refetch when the broadcast already says enabled=false. */
 export interface PetChangeMeta {
@@ -55,6 +65,10 @@ export function notifyPlatformsChanged(): void {
 
 export function notifyPairingChanged(): void {
   $pairingChangeTick.set($pairingChangeTick.get() + 1)
+}
+
+export function notifyMemoryChanged(meta?: MemoryChangeMeta): void {
+  $memoryChange.set({ meta, tick: $memoryChange.get().tick + 1 })
 }
 
 /** Reset on gateway wipe/reconnect — a new backend re-advertises capability on

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -99,6 +99,7 @@ from gateway.status import (
     resolve_gateway_liveness,
 )
 from utils import env_var_enabled
+from hermes_cli.profiles import get_active_profile_name
 
 try:
     from fastapi import (
@@ -12691,6 +12692,14 @@ async def reset_memory(body: MemoryReset):
                 deleted.append(fname)
             except OSError as exc:
                 raise HTTPException(status_code=500, detail=f"Could not delete {fname}: {exc}")
+    try:
+        from tui_gateway.server import _broadcast_global_event
+        profile = get_active_profile_name()
+        payload = {"profile": profile, "target": target, "source": "default_memory_tool_reset"}
+        _broadcast_global_event("memory.changed", payload)
+        _log.info("memory.changed emitted (reset): %s", payload)
+    except Exception:
+        pass
     return {"ok": True, "deleted": deleted}
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15967,3 +15967,27 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         assert cleanup_order == ["trim", "reset_home"]
     finally:
         server._sessions.pop("sid_trim", None)
+
+
+def test_memory_tool_broadcasts_on_save(monkeypatch, tmp_path):
+    """MemoryStore.save_to_disk emits memory.changed via _broadcast_global_event."""
+    import tools.memory_tool as memory_tool
+
+    memory_dir = tmp_path / ".hermes" / "memories"
+    memory_dir.mkdir(parents=True)
+    monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memory_dir)
+
+    broadcasts = []
+    def _capture(event, payload=None):
+        broadcasts.append((event, payload))
+    monkeypatch.setattr("tui_gateway.server._broadcast_global_event", _capture)
+
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "default")
+
+    store = memory_tool.MemoryStore()
+    result = store.add("memory", "test entry")
+    assert result["success"] is True
+    assert len(broadcasts) == 1
+    assert broadcasts[0][0] == "memory.changed"
+    assert broadcasts[0][1] == {"profile": "default", "target": "memory", "source": "default_memory_tool"}
+

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -364,6 +364,16 @@ class MemoryStore:
         """Persist entries to the appropriate file. Called after every mutation."""
         get_memory_dir().mkdir(parents=True, exist_ok=True)
         self._write_file(self._path_for(target), self._entries_for(target))
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            from tui_gateway.server import _broadcast_global_event
+
+            profile = get_active_profile_name()
+            payload = {"profile": profile, "target": target, "source": "default_memory_tool"}
+            _broadcast_global_event("memory.changed", payload)
+            logger.info("memory.changed emitted: %s", payload)
+        except Exception:
+            pass
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":


### PR DESCRIPTION
## What does this PR do?

Allows detecting memory changes with a direct `memory.changed` broadcast event emitted from write paths. Instead of polling for file changes, the desktop and web dashboard now receive an immediate event when the default memory is changed, enabling instant UI refreshes.

The event fires from two write paths:
1. `memory_tool.save_to_disk()` — emits on every memory file write
2. `web_server.reset_memory()` — emits after memory file deletion

The broadcast payload includes `{ profile, target, source }` so the receiver can filter by profile and know which subsystem triggered the change.

**Part 2 in Memory & Context settings revamp** (follows #77082 which adds the desktop Memory settings UI). 

## Related Issue

Part of the Memory & Context settings revamp initiative. Links to #77082.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **`tools/memory_tool.py`** — Added `_broadcast_global_event()` call in `save_to_disk()` with lazy imports of `hermes_cli.profiles` and `tui_gateway.server`. Payload: `{ profile, target, source: "default_memory_tool" }`.
- **`hermes_cli/web_server.py`** — Added `_broadcast_global_event()` call in `reset_memory()` after file deletion. Payload: `{ profile, target, source: "default_memory_tool_reset" }`.
- **`apps/desktop/src/store/live-sync.ts`** — Added `MemoryChangeMeta` interface, `$memoryChange` atom, and `notifyMemoryChanged()` function for desktop-side event consumption.
- **`apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts`** — Added routing for `memory.changed` → `notifyMemoryChanged()`.
- **`tests/test_tui_gateway_server.py`** — Added `test_memory_tool_broadcasts_on_save` verifying the Python emitter.
- **`apps/desktop/src/store/live-sync.test.ts`** — Added 3 TypeScript tests for `notifyMemoryChanged`.

