### PR TITLE
fix(cli): surface nested MCP tool failures

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1283,6 +1283,7 @@ class KawaiiSpinner:
 # =========================================================================
 
 _ERROR_SUFFIX_MAX_LEN = 48
+_MAX_STRUCTURED_RESULT_DEPTH = 4
 
 
 def _trim_error(msg: str) -> str:
@@ -1303,7 +1304,31 @@ def _trim_error(msg: str) -> str:
     return msg
 
 
-def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
+def _structured_failure_message(result: Any) -> str | None:
+    """Return a failure message from bounded nested MCP result envelopes."""
+    current = result
+    for _ in range(_MAX_STRUCTURED_RESULT_DEPTH):
+        if isinstance(current, str):
+            current = safe_json_loads(current)
+        if not isinstance(current, dict):
+            return None
+        if current.get("ok") is False:
+            return str(
+                current.get("error")
+                or current.get("message")
+                or current.get("status")
+                or "reported ok=false"
+            )
+        err = current.get("error") or current.get("message")
+        if err and (current.get("success") is False or "error" in current):
+            return str(err)
+        if "result" not in current:
+            return None
+        current = current["result"]
+    return None
+
+
+def _detect_tool_failure(tool_name: str, result: Any | None) -> tuple[bool, str]:
     """Inspect a tool result string for signs of failure.
 
     Returns ``(is_failure, suffix)`` where *suffix* is a short informational
@@ -1316,7 +1341,7 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     if file_mutation_result_landed(tool_name, result):
         return False, ""
 
-    data = safe_json_loads(result)
+    data = result if isinstance(result, dict) else safe_json_loads(result)
 
     # Terminal: non-zero exit code is the canonical failure signal.
     if tool_name == "terminal":
@@ -1335,11 +1360,12 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 
-    # Structured error in JSON result (any tool that surfaces {"error": ...}).
-    if isinstance(data, dict):
-        err = data.get("error") or data.get("message")
-        if err and (data.get("success") is False or "error" in data):
-            return True, f" [{_trim_error(str(err))}]"
+    # Structured errors may be wrapped by MCP as {"result": "<json>"} or
+    # {"result": {...}}. Only follow that explicit envelope, with a small
+    # depth cap, so arbitrary nested payload data is not treated as failure.
+    structured_error = _structured_failure_message(result)
+    if structured_error:
+        return True, f" [{_trim_error(structured_error)}]"
 
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
@@ -1354,7 +1380,7 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
 
 
 def _get_cute_tool_message(
-    tool_name: str, args: dict, duration: float, result: str | None = None,
+    tool_name: str, args: dict, duration: float, result: Any | None = None,
 ) -> str:
     """Generate a formatted tool completion line for CLI quiet mode.
 
@@ -1530,7 +1556,7 @@ def _get_cute_tool_message(
 
 
 def get_cute_tool_message(
-    tool_name: str, args: dict, duration: float, result: str | None = None,
+    tool_name: str, args: dict, duration: float, result: Any | None = None,
 ) -> str:
     """Render a completion label without letting cosmetic failures escape."""
     try:

--- a/agent/display.py
+++ b/agent/display.py
@@ -890,6 +890,7 @@ class KawaiiSpinner:
 # ── Cute tool message (completion line that replaces the spinner) ─────────
 
 _ERROR_SUFFIX_MAX_LEN = 48
+_MAX_STRUCTURED_RESULT_DEPTH = 4
 
 
 def _trim_error(msg: str) -> str:
@@ -902,11 +903,43 @@ def _trim_error(msg: str) -> str:
     return _tail_trunc(msg, _ERROR_SUFFIX_MAX_LEN)
 
 
-def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
-    """Return ``(is_failure, suffix)`` for a tool result, e.g. ``(True, " [exit 1]")``."""
-    if result is None or file_mutation_result_landed(tool_name, result):
+def _structured_failure_message(result: Any) -> str | None:
+    """Return a failure message from bounded nested MCP result envelopes."""
+    current = result
+    for _ in range(_MAX_STRUCTURED_RESULT_DEPTH):
+        if isinstance(current, str):
+            current = safe_json_loads(current)
+        if not isinstance(current, dict):
+            return None
+        if current.get("ok") is False:
+            return str(
+                current.get("error")
+                or current.get("message")
+                or current.get("status")
+                or "reported ok=false"
+            )
+        err = current.get("error") or current.get("message")
+        if err and (current.get("success") is False or "error" in current):
+            return str(err)
+        if "result" not in current:
+            return None
+        current = current["result"]
+    return None
+
+
+def _detect_tool_failure(tool_name: str, result: Any | None) -> tuple[bool, str]:
+    """Inspect a tool result for signs of failure.
+
+    Returns ``(is_failure, suffix)`` where *suffix* is a short informational
+    tag like ``" [exit 1]"`` for terminal failures, ``" [full]"`` for memory
+    overflow, or a trimmed error message. On success returns ``(False, "")``.
+    """
+    if result is None:
         return False, ""
-    data = safe_json_loads(result)
+    if file_mutation_result_landed(tool_name, result):
+        return False, ""
+
+    data = result if isinstance(result, dict) else safe_json_loads(result)
 
     # Terminal: non-zero exit code is the canonical failure signal.
     if tool_name == "terminal":
@@ -916,18 +949,26 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         err_msg = data.get("error")
         return True, f" [{_trim_error(str(err_msg))}]" if err_msg else f" [exit {exit_code}]"
 
-    if isinstance(data, dict):
-        failed = data.get("success") is False
-        # Memory: distinguish "store full" from real errors.
-        if tool_name == "memory" and failed and "exceed the limit" in data.get("error", ""):
-            return True, " [full]"
-        err = data.get("error") or data.get("message")
-        if err and (failed or "error" in data):
-            return True, f" [{_trim_error(str(err))}]"
-    # Multimodal results (dicts) are successes; failures arrive as JSON-encoded strings.
-    if isinstance(result, str) and (
-        '"error"' in result[:500].lower() or '"failed"' in result[:500].lower() or result.startswith("Error")
-    ):
+    # Memory: distinguish "store full" from real errors.
+    if tool_name == "memory":
+        if isinstance(data, dict):
+            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+                return True, " [full]"
+
+    # Structured errors may be wrapped by MCP as {"result": "<json>"} or
+    # {"result": {...}}. Only follow that explicit envelope, with a small
+    # depth cap, so arbitrary nested payload data is not treated as failure.
+    structured_error = _structured_failure_message(result)
+    if structured_error:
+        return True, f" [{_trim_error(structured_error)}]"
+
+    # Generic heuristic for non-terminal tools. Multimodal tool results (dicts
+    # with _multimodal=True) are not strings — treat them as successes since
+    # failures would be JSON-encoded strings.
+    if not isinstance(result, str):
+        return False, ""
+    lower = result[:500].lower()
+    if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"
     return False, ""
 

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -57,6 +57,12 @@ class TestDetectToolFailureTerminal:
         assert suffix.startswith(" [")
         assert suffix.endswith("]")
 
+    def test_nested_mcp_failure_does_not_override_terminal_exit_rule(self):
+        result = json.dumps({
+            "result": json.dumps({"ok": False, "error": "remote failed"}),
+        })
+        assert _detect_tool_failure("terminal", result) == (False, "")
+
 
 
 
@@ -95,6 +101,32 @@ class TestDetectToolFailureStructured:
     def test_successful_result_not_flagged(self):
         result = json.dumps({"success": True, "data": "hello"})
         assert _detect_tool_failure("web_search", result) == (False, "")
+
+    def test_mcp_result_json_string_failure_is_surfaced(self):
+        result = json.dumps({
+            "result": json.dumps({
+                "ok": False,
+                "error": "upstream timeout",
+            }),
+        })
+        assert _detect_tool_failure(
+            "mcp__example__search",
+            result,
+        ) == (True, " [upstream timeout]")
+
+    def test_mcp_result_dict_failure_is_surfaced(self):
+        result = {"result": {"error": "provider unavailable"}}
+        assert _detect_tool_failure(
+            "mcp__example__search",
+            result,
+        ) == (True, " [provider unavailable]")
+
+    def test_mcp_result_nested_success_is_not_flagged(self):
+        result = {"result": json.dumps({"ok": True, "data": "hello"})}
+        assert _detect_tool_failure(
+            "mcp__example__search",
+            result,
+        ) == (False, "")
 
 
 


### PR DESCRIPTION
## Summary

- detect structured failures inside MCP `result` envelopes
- preserve the specific upstream error in CLI tool-completion status instead of showing success or a generic marker
- bound envelope traversal and preserve terminal's exit-code-only classification

## Root cause

`tools/mcp_tool.py` returns successful MCP transport payloads in a top-level `{"result": ...}` envelope. The enclosed model-facing text can itself be JSON such as `{"ok": false, "error": "upstream timeout"}`. The CLI failure classifier only inspected the top-level object, so this case was classified as successful even though the remote tool reported a failure.

The new helper follows only explicit `result` envelopes, stops after four levels, and retains the existing top-level `success: false` / `error` behavior.

## User impact

MCP failures now render with their actionable reason, for example `[upstream timeout]`, instead of a successful completion line.

## Validation

- reproduced current `main` returning `(False, "")` for a synthetic nested MCP failure
- added focused behavior coverage for nested JSON-string failure, nested-dict failure, nested success, and terminal precedence
- `scripts/run_tests.sh tests/agent/test_display_tool_failure.py -k 'nested_mcp or mcp_result' -q` — 4 passed
- `python3 -m py_compile agent/display.py tests/agent/test_display_tool_failure.py`
- `git diff --check`
