### PR TITLE
fix(gateway): treat virtual model alias as unset in API server sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3312,7 +3312,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if len(session_id) > self._MAX_SESSION_HEADER_LEN:
             return web.json_response(_openai_error("Session ID too long", code="invalid_session_id"), status=400)
 
-        model = body.get("model") or self._model_name
+        raw_model = _clean_request_string(body.get("model"))
+        # The advertised virtual model name (e.g. "hermes-agent") is an alias
+        # for "use the gateway default"; don't persist it as a real model.
+        model = raw_model if raw_model and raw_model != self._model_name else None
         system_prompt = body.get("system_prompt")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_prompt must be a string", code="invalid_system_prompt"), status=400)
@@ -3322,13 +3325,18 @@ class APIServerAdapter(BasePlatformAdapter):
         if lock_error is not None:
             return lock_error
         requested = runtime_request.get("requested") or {}
-        model_name = self._clean_runtime_id(requested.get("model")) or (str(model) if model else None)
+        requested_model = self._clean_runtime_id(requested.get("model"))
+        # The advertised virtual model is an alias for the gateway default;
+        # don't persist it as a real model or runtime lock target.
+        if requested_model == self._model_name:
+            requested_model = ""
+        model_name = requested_model or model
         model_config = None
-        if requested.get("model") or requested.get("provider"):
+        if requested_model or requested.get("provider"):
             model_config = {
                 "browser_model_lock": {
                     "provider": requested.get("provider") or "",
-                    "model": requested.get("model") or "",
+                    "model": requested_model or "",
                     "model_options": runtime_request.get("model_options") or {},
                     "route_source": runtime_request.get("route_source") or "",
                     "confirmed": bool(runtime_request.get("require_model_lock")),
@@ -3568,6 +3576,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
             stored_model = session.get("model") if isinstance(session, dict) else None
+            # The advertised virtual model is an alias for the gateway default;
+            # don't let it override the real default model.
+            if stored_model == self._model_name:
+                stored_model = None
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None
@@ -3678,6 +3690,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
             stored_model = session.get("model") if isinstance(session, dict) else None
+            # The advertised virtual model is an alias for the gateway default;
+            # don't let it override the real default model.
+            if stored_model == self._model_name:
+                stored_model = None
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -608,3 +608,67 @@ async def test_require_model_lock_hard_fails_when_global_default_would_be_used(a
     mock_run.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_create_session_without_model_persists_none(adapter, session_db):
+    """A session created without an explicit model should not inherit the
+    advertised virtual model name (e.g. 'hermes-agent') as its persisted model."""
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/sessions", json={})
+        assert resp.status == 201, await resp.text()
+        payload = await resp.json()
+
+    assert payload["session"]["model"] is None
+    row = session_db.get_session(payload["session"]["id"])
+    assert row["model"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_session_with_virtual_model_alias_persists_none(adapter, session_db):
+    """Sending the advertised virtual model as the session model is an alias
+    for 'use the gateway default' and must not be persisted as a real model."""
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/sessions", json={"model": adapter._model_name})
+        assert resp.status == 201, await resp.text()
+        payload = await resp.json()
+
+    assert payload["session"]["model"] is None
+    row = session_db.get_session(payload["session"]["id"])
+    assert row["model"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_chat_with_virtual_model_alias_uses_gateway_default(adapter, session_db):
+    """A session that was persisted with the virtual model alias must fall
+    back to the gateway's default model instead of passing the alias through
+    as a real model ID."""
+    session_id = session_db.create_session(
+        "virtual-alias-session", "api_server", model=adapter._model_name
+    )
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, **kwargs):
+            self.session_id = kwargs["session_id"]
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            return {"final_response": "default", "session_id": self.session_id}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_create_agent", side_effect=FakeAgent) as mock_create:
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi"},
+            )
+            assert resp.status == 200, await resp.text()
+
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("session_model") is None
+    assert kwargs.get("route") is None
+
+


### PR DESCRIPTION
## What
When a client creates an API server session without an explicit `model`, or sends the advertised virtual model alias (e.g. `"hermes-agent"`), the session is now created with `model = NULL` and subsequent chat turns fall back to the gateway's configured default model.

## Why
The advertised model name is a virtual alias that `_request_agent_overrides` already treats as "use gateway default" for `/v1/chat/completions`. The `/api/sessions` endpoints were persisting that alias as a real model ID and then passing it to `_create_agent`, overriding the global default and causing provider errors.

This regression was introduced when session model persistence was added (commit `f7527b0fdb`).

## How
- In `_handle_create_session`, normalize both the raw body `model` and the parsed runtime-request `model` to `None` when they equal `self._model_name`.
- In `_handle_session_chat` and `_handle_session_chat_stream`, treat a stored session model that matches the virtual alias as unset.
- Added tests covering session creation without a model, with the virtual alias, and chat routing back to the gateway default.

## Tests
```bash
scripts/run_tests.sh tests/gateway/test_session_api.py
```

## Related
- Commit `f7527b0fdb` — feat: add API server session controls
- Fixes #79101
