### PR TITLE
feat(codex): support DeepSeek Responses API server-side web search

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1182,6 +1182,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        is_deepseek_responses = agent._base_url_hostname == "api.deepseek.com"
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -1229,6 +1230,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
+            is_deepseek_responses=is_deepseek_responses,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -30,6 +30,7 @@ def _classify_responses_issuer(
     is_xai_responses: bool = False,
     is_github_responses: bool = False,
     is_codex_backend: bool = False,
+    is_deepseek_responses: bool = False,
     base_url: Optional[str] = None,
 ) -> str:
     """Stable identifier for the Responses endpoint that mints encrypted_content.
@@ -47,6 +48,8 @@ def _classify_responses_issuer(
         return "github_responses"
     if is_codex_backend:
         return "codex_backend"
+    if is_deepseek_responses:
+        return "deepseek_responses"
     if base_url:
         return f"other:{base_url}"
     return "other"

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -9,9 +9,20 @@ import hashlib
 import json
 import re
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
+
+
+def _hostname_of(url: Any) -> str:
+    """Lowercased hostname of a base URL ('' on any parse failure)."""
+    if not url:
+        return ""
+    try:
+        return (urlparse(str(url)).hostname or "").lower()
+    except Exception:
+        return ""
 
 
 def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
@@ -174,6 +185,11 @@ class ResponsesApiTransport(ProviderTransport):
             is_xai_responses=params.get("is_xai_responses") is True,
             is_github_responses=params.get("is_github_responses") is True,
             is_codex_backend=params.get("is_codex_backend") is True,
+            is_deepseek_responses=(
+                params.get("is_deepseek_responses") is True
+                or params.get("base_url_hostname") == "api.deepseek.com"
+                or _hostname_of(params.get("base_url")) == "api.deepseek.com"
+            ),
             base_url=params.get("base_url"),
         )
 
@@ -224,6 +240,7 @@ class ResponsesApiTransport(ProviderTransport):
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
+            is_deepseek_responses: bool — DeepSeek /responses backend
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -245,6 +262,10 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_deepseek_responses = params.get("is_deepseek_responses") is True or (
+            params.get("base_url_hostname") == "api.deepseek.com"
+            or _hostname_of(params.get("base_url")) == "api.deepseek.com"
+        )
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -274,6 +295,10 @@ class ResponsesApiTransport(ProviderTransport):
         if params.get("is_xai_responses", False):
             # xAI Responses tops out at high; keep generic stronger values usable.
             _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
+        elif is_deepseek_responses:
+            # DeepSeek Responses (deepseek-v4-flash) honors max; only the
+            # non-standard xhigh dial downgrades to high.
+            _effort_clamp.update({"xhigh": "high"})
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)
@@ -298,13 +323,26 @@ class ResponsesApiTransport(ProviderTransport):
         #    is honored, but rename the wire tool to
         #    ``hermes_web_search`` so Grok cannot hijack the name. The alias
         #    is mapped back to ``web_search`` in ``normalize_response``.
-        if is_xai_responses and response_tools:
+        if (is_xai_responses or is_deepseek_responses) and response_tools:
             has_client_web_search = any(
                 isinstance(t, dict) and t.get("name") == "web_search"
                 for t in response_tools
             )
             if has_client_web_search:
-                if _xai_prefers_native_web_search():
+                if is_deepseek_responses:
+                    # DeepSeek Responses (deepseek-v4-flash) ships a
+                    # server-executed ``web_search`` built-in on its /responses
+                    # surface (verified live 2026-08: the model streams
+                    # ``web_search_call`` items and returns a cited answer).
+                    # Swap the client function 1:1 so the search runs
+                    # server-side — same contract as the xAI native path.
+                    filtered = [
+                        t for t in response_tools
+                        if not (isinstance(t, dict) and t.get("name") == "web_search")
+                    ]
+                    filtered.append({"type": "web_search"})
+                    response_tools = filtered
+                elif _xai_prefers_native_web_search():
                     filtered = [
                         t for t in response_tools
                         if not (isinstance(t, dict) and t.get("name") == "web_search")
@@ -348,8 +386,16 @@ class ResponsesApiTransport(ProviderTransport):
         # there is no static content to hash.
         cache_key = _content_cache_key(instructions, response_tools) or session_id
         # xAI Responses takes prompt_cache_key in extra_body (set further
-        # down); GitHub Models opts out of cache-key routing entirely.
-        if not is_github_responses and not is_xai_responses and cache_key:
+        # down); GitHub Models opts out of cache-key routing entirely;
+        # DeepSeek's /responses surface has no prompt_cache_key parameter
+        # (unsupported params are silently ignored, but skip it anyway —
+        # DeepSeek's context-hard-disk caching is automatic).
+        if (
+            not is_github_responses
+            and not is_xai_responses
+            and not is_deepseek_responses
+            and cache_key
+        ):
             kwargs["prompt_cache_key"] = cache_key
 
         cache_retention = _default_prompt_cache_retention_for_request(

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -134,6 +134,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="DEEPSEEK_BASE_URL",
     ),
+    "deepseek-responses": HermesOverlay(
+        transport="codex_responses",
+        base_url_override="https://api.deepseek.com",
+        base_url_env_var="DEEPSEEK_RESPONSES_BASE_URL",
+    ),
     "alibaba": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="DASHSCOPE_BASE_URL",

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -303,6 +303,73 @@ class TestCodexBuildKwargs:
         assert "web_search" not in names
         assert "hermes_web_search" not in names
 
+    def test_deepseek_injects_native_web_search_when_client_web_search_present(self, transport):
+        """DeepSeek's /responses surface (deepseek-v4-flash) runs a
+        server-side ``web_search`` built-in. When the client web toolset is
+        enabled, swap the client ``web_search`` function 1:1 for the native
+        built-in so the search executes server-side (verified live 2026-08).
+        Non-conflicting client tools are preserved.
+        """
+        messages = [{"role": "user", "content": "Find current prices."}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash", messages=messages,
+            tools=[
+                {"type": "function", "function": {
+                    "name": "read_file", "description": "Read a file.",
+                    "parameters": {"type": "object",
+                                   "properties": {"path": {"type": "string"}}}}},
+                {"type": "function", "function": {
+                    "name": "web_search", "description": "Search the web.",
+                    "parameters": {"type": "object",
+                                   "properties": {"query": {"type": "string"}}}}},
+            ],
+            is_deepseek_responses=True,
+        )
+        tool_types = [t.get("type") for t in kw.get("tools", [])]
+        assert "web_search" in tool_types, kw.get("tools")
+        names = [t.get("name") for t in kw.get("tools", []) if t.get("type") == "function"]
+        assert "read_file" in names
+        assert "web_search" not in names
+        assert "hermes_web_search" not in names
+
+    def test_deepseek_hostname_detection_injects_native_web_search(self, transport):
+        """Hostname fallback: an api.deepseek.com base_url without an explicit
+        is_deepseek_responses flag still routes to the native web_search swap.
+        """
+        messages = [{"role": "user", "content": "Find current prices."}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash", messages=messages,
+            tools=[
+                {"type": "function", "function": {
+                    "name": "web_search", "description": "Search the web.",
+                    "parameters": {"type": "object",
+                                   "properties": {"query": {"type": "string"}}}}},
+            ],
+            base_url="https://api.deepseek.com",
+        )
+        tool_types = [t.get("type") for t in kw.get("tools", [])]
+        assert "web_search" in tool_types, kw.get("tools")
+        # DeepSeek's /responses surface has no prompt_cache_key; skip it so
+        # unsupported-param noise stays out of the request.
+        assert "prompt_cache_key" not in kw, kw.keys()
+
+    def test_deepseek_does_not_inject_native_web_search_without_client_web_search(self, transport):
+        """The native ``web_search`` built-in is a 1:1 swap for an
+        already-requested client ``web_search`` — NOT an additive grant.
+        """
+        messages = [{"role": "user", "content": "Say hi."}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash", messages=messages,
+            tools=[
+                {"type": "function", "function": {
+                    "name": "read_file", "description": "Read a file.",
+                    "parameters": {"type": "object",
+                                   "properties": {"path": {"type": "string"}}}}},
+            ],
+            is_deepseek_responses=True,
+        )
+        assert not any(t.get("type") == "web_search" for t in kw.get("tools", [])), kw.get("tools")
+
     def test_xai_renames_client_web_search_when_firecrawl_configured(self, transport, monkeypatch):
         """Configured Firecrawl (or any non-xai backend) must keep Hermes
         dispatch — rename the wire tool so Grok cannot hijack ``web_search``.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -302,6 +302,26 @@ hermes migrate xai --apply  # rewrite ~/.hermes/config.yaml in place
 
 **xAI Web Search backend.** When the [Web Search](../user-guide/features/web-search.md) toolset is enabled, `web.backend: xai` routes search through xAI's hosted search endpoint using the same `XAI_API_KEY` / OAuth credentials. No additional setup required if xAI is already configured as a provider.
 
+### DeepSeek — Responses API + Server-Side Web Search
+
+DeepSeek exposes an OpenAI-compatible **Responses API** at `https://api.deepseek.com` (no `/v1` suffix) for `deepseek-v4-flash`. The Responses surface ships a **server-executed `web_search` built-in**: when the [Web Search](../user-guide/features/web-search.md) toolset is enabled, Hermes replaces the client-side `web_search` function with DeepSeek's native `{"type": "web_search"}` tool, so the model decides when to search and DeepSeek executes the search server-side (multi-query, page-open, cited answers — verified live against `deepseek-v4-flash`).
+
+To use it, point the provider at the Responses surface:
+
+```yaml
+providers:
+  deepseek:
+    api: https://api.deepseek.com   # Responses API base — no /v1
+    transport: codex_responses      # enables Responses + native web_search
+```
+
+Requires `DEEPSEEK_API_KEY` in `~/.hermes/.env`. Notes:
+
+- The Responses API currently supports **only `deepseek-v4-flash`** (pro support was announced for August 2026). Chat-completions usage is unaffected.
+- Reasoning effort is honored (`low` / `high` / `max`); `max` is a valid dial for DeepSeek, unlike xAI where it clamps to `high`.
+- `prompt_cache_key` is skipped on this surface — DeepSeek's context hard-disk caching is automatic.
+- Unsupported Responses parameters are silently ignored by DeepSeek, so existing clients connect without changes.
+
 ### NovitaAI
 
 [NovitaAI](https://novita.ai) is the AI-native cloud for builders and agents. Its three product lines are Model API for 200+ models, Agent Sandbox for building and running AI agents, and GPU Cloud for scalable compute, all available from one platform.


### PR DESCRIPTION
## Summary

DeepSeek's OpenAI-compatible **Responses API** (`https://api.deepseek.com`, no `/v1`) ships a **server-executed `web_search` built-in** on `deepseek-v4-flash`. This PR wires it into Hermes's existing `codex_responses` transport so that when the user enables the web toolset, the client-side `web_search` function is swapped 1:1 for DeepSeek's native `{"type": "web_search"}` tool — the model decides when to search, DeepSeek executes multi-query + page-open searches server-side, and answers come back cited. Same contract as the existing xAI native-search path (#48108).

## Changes

- **`hermes_cli/providers.py`** — new `deepseek-responses` overlay (`codex_responses` transport, base URL `https://api.deepseek.com`).
- **`agent/transports/codex.py`**
  - Detect DeepSeek via explicit `is_deepseek_responses` flag **or** `api.deepseek.com` hostname (from `base_url_hostname` or parsed `base_url`).
  - Swap client `web_search` → native `{"type": "web_search"}` when present (never an additive grant).
  - Skip `prompt_cache_key` on this surface (DeepSeek's context hard-disk caching is automatic).
  - Keep `max` reasoning effort (DeepSeek honors it; only non-standard `xhigh` clamps to `high`).
- **`agent/codex_responses_adapter.py`** — classify `deepseek_responses` issuer so reasoning replay never mixes encrypted blobs across endpoints (avoids HTTP 400 `invalid_encrypted_content`).
- **`agent/chat_completion_helpers.py`** — detect `api.deepseek.com` hostname on the codex path and thread the flag through.
- **`website/docs/integrations/providers.md`** — DeepSeek Responses + web-search section.

## Verified

- 3 new unit tests + full `test_codex_transport.py` (69) + `test_codex_responses_adapter.py` (16) pass.
- **Live E2E against `deepseek-v4-flash`**: transport `build_kwargs` produces `tools=[..., {"type": "web_search"}]`, the API streams `web_search_call` items, and the final answer is a cited, current-news response. (Multi-language queries + page-open actions observed.)

## Notes

- The Responses API currently supports **only `deepseek-v4-flash`** (pro announced for Aug 2026); chat-completions usage is unaffected.
- DeepSeek silently ignores unsupported Responses parameters, so existing clients connect without changes.
- DeepSeek's web search results arrive baked into the model's answer (bypass Hermes tool-trace/citation plumbing) — same trade-off as the xAI native path.