### PR TITLE
fix(voice): filter CJK hallucination tokens from local STT on noise

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -557,6 +557,30 @@ class TestWhisperHallucinationFilter:
         assert is_whisper_hallucination("Thank you for your help with the project.") is False
         assert is_whisper_hallucination("Can you explain this code?") is False
 
+    def test_cjk_hallucinations(self):
+        """Local CJK STT (SenseVoice) emits single ideographic tokens on
+        noise-only clips — those must be filtered like the English set."""
+        from tools.voice_mode import is_whisper_hallucination
+
+        assert is_whisper_hallucination("我。") is True
+        assert is_whisper_hallucination("嗯。") is True
+        assert is_whisper_hallucination("嗯") is True
+        assert is_whisper_hallucination("그") is True
+        assert is_whisper_hallucination("그.") is True
+        assert is_whisper_hallucination("ち？") is True
+        assert is_whisper_hallucination("。") is True
+        assert is_whisper_hallucination("。。") is True
+        assert is_whisper_hallucination("。。。") is True
+        assert is_whisper_hallucination("....") is True
+        assert is_whisper_hallucination("……") is True
+
+    def test_cjk_real_speech_not_filtered(self):
+        from tools.voice_mode import is_whisper_hallucination
+
+        assert is_whisper_hallucination("今天天气不错，我们出去走走吧。") is False
+        assert is_whisper_hallucination("ありがとうございました") is False
+        assert is_whisper_hallucination("안녕하세요") is False
+
 
 # ============================================================================
 # play_audio_file

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1236,11 +1236,26 @@ WHISPER_HALLUCINATIONS = {
     "amara.org",
     "www.mooji.org",
     "ご視聴ありがとうございました",
+    # CJK/ideographic hallucinations SenseVoice emits on noise-only clips
+    # (seen with local SenseVoice: "我。", "嗯。", "그", "ち？", "....")
+    "我。",
+    "嗯。",
+    "嗯",
+    "그",
+    "그.",
+    "그...",
+    "ち？",
+    "ち?",
+    "。",
+    "。。",
+    "。。。",
+    "....",
+    "……",
 }
 
 # Regex patterns for repetitive hallucinations (e.g. "Thank you. Thank you. Thank you.")
 _HALLUCINATION_REPEAT_RE = re.compile(
-    r'^(?:thank you|thanks|bye|you|ok|okay|the end|\.|\s|,|!)+$',
+    r'^(?:thank you|thanks|bye|you|ok|okay|the end|\.|。|、|…|,|，|!|！|\?|？|\s)+$',
     flags=re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Problem

Local STT (e.g. SenseVoice) on a noise-only clip can emit a single CJK/ideographic token (我。 嗯。 그 ち？), which sailed through `WHISPER_HALLUCINATIONS` (English-only) and the repeat regex (ASCII punctuation only) and spuriously triggered voice replies — part of the runaway-synthesis theme in local TTS/STT pipelines.

## Fix

- Add observed CJK/ideographic tokens to the exact-match hallucination set
- Widen the repeat regex to CJK punctuation (。、…，！？)
- Real CJK speech is untouched (tokens only filtered when they are the entire utterance)

## Relationship to #78489 / #78491

This is a **different bug on the opposite side of the pipeline**: #78489/#78491 fix the TTS *output* sentence cutter (`tools/tts_streaming.py`) so long Chinese replies split on 。！？. This PR fixes the STT *input* side (`tools/voice_mode.py`) so a noise-only clip recognized as a lone CJK token does not spuriously trigger a voice reply. No file overlap; complementary.

Refs #78477 (runaway-synthesis theme)