### PR TITLE
fix(tools): fail closed when the memory write-approval gate can't import

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -78,6 +78,57 @@ def test_memory_gate_off_allows_write(hermes_home):
     assert wa.pending_count("memory") == 0
 
 
+def _break_write_approval_import(monkeypatch):
+    """Simulate ``from tools import write_approval`` raising ImportError.
+
+    Poisoning ``sys.modules['tools.write_approval']`` alone is not enough:
+    once the real module has been imported anywhere in the process (e.g. by
+    an earlier test in this file), Python caches it as an attribute on the
+    parent ``tools`` package, and ``from tools import write_approval``
+    resolves straight from that attribute without re-touching
+    ``sys.modules`` at all. Both must be cleared to force a real (re-)import
+    attempt, which then hits the poisoned ``sys.modules`` entry and raises.
+    """
+    import sys
+    import tools as tools_pkg
+
+    monkeypatch.delattr(tools_pkg, "write_approval", raising=False)
+    monkeypatch.setitem(sys.modules, "tools.write_approval", None)
+
+
+def test_memory_gate_import_failure_fails_closed(hermes_home, monkeypatch):
+    """If ``tools.write_approval`` can't be imported, the single-op gate must
+    refuse the write (fail closed) rather than silently letting an unattended
+    write through, regardless of the configured write_approval setting."""
+    from tools.memory_tool import memory_tool, MemoryStore
+
+    _break_write_approval_import(monkeypatch)
+
+    store = MemoryStore(); store.load_from_disk()
+    r = json.loads(memory_tool("add", "user", "should not be written", store=store))
+
+    assert r["success"] is False
+    assert store.user_entries == []
+
+
+def test_memory_batch_gate_import_failure_fails_closed(hermes_home, monkeypatch):
+    """Same fail-closed requirement for the batch ('operations=[...]') path,
+    which has its own independent gate (_apply_batch_write_gate)."""
+    from tools.memory_tool import memory_tool, MemoryStore
+
+    _break_write_approval_import(monkeypatch)
+
+    store = MemoryStore(); store.load_from_disk()
+    r = json.loads(memory_tool(
+        target="user",
+        operations=[{"action": "add", "content": "should not be written"}],
+        store=store,
+    ))
+
+    assert r["success"] is False
+    assert store.user_entries == []
+
+
 def test_cli_memory_approve_without_live_agent_uses_fresh_store(hermes_home, capsys):
     """#46783: ``/memory approve`` from a context with no live agent (e.g. the
     Desktop GUI) passed ``memory_store=None`` into the shared handler, which

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -922,9 +922,15 @@ def _apply_write_gate(action: str, target: str, content: Optional[str],
     try:
         from tools import write_approval as wa
     except Exception:
-        # If the gate module can't load, fail open (current behaviour) rather
-        # than blocking all memory writes.
-        return None
+        # If the gate module can't load, we cannot know whether write
+        # approval is required, so refuse the write (fail closed) rather
+        # than assuming the gate is off. A broken/missing gate module must
+        # never silently grant an unattended memory write.
+        return tool_error(
+            "memory write gate unavailable (write_approval module failed to "
+            "import); refusing write",
+            success=False,
+        )
 
     # Build a small inline summary/detail for the foreground approval prompt.
     label = "user profile" if target == "user" else "memory"
@@ -975,7 +981,13 @@ def _apply_batch_write_gate(target: str, operations: List[Dict[str, Any]]) -> Op
     try:
         from tools import write_approval as wa
     except Exception:
-        return None
+        # Same fail-closed rationale as _apply_write_gate: an unavailable
+        # gate module must not silently let the whole batch through.
+        return tool_error(
+            "memory write gate unavailable (write_approval module failed to "
+            "import); refusing batch",
+            success=False,
+        )
 
     label = "user profile" if target == "user" else "memory"
     summary = f"apply {len(operations)} op(s) to {label}"


### PR DESCRIPTION
## What does this PR do?

Fixes a fail-open bug in the memory write-approval gate. `tools/memory_tool.py` has two
functions that gate memory writes behind the configured `memory.write_approval` setting:
`_apply_write_gate` (single `add`/`replace`/`remove` calls) and `_apply_batch_write_gate`
(the `operations=[...]` batch path). Both try to import `tools.write_approval` to evaluate
the gate, and both currently return `None` on import failure:

```python
try:
    from tools import write_approval as wa
except Exception:
    # If the gate module can't load, fail open (current behaviour) rather
    # than blocking all memory writes.
    return None
```

Both call sites in `memory_tool()` treat a `None` return as "no gate verdict, perform the
real write" — so if `tools/write_approval.py` fails to import for any reason (a bad edit, a
packaging regression, a missing transitive dependency), every memory write silently bypasses
approval regardless of what the user configured. A user who explicitly turned
`write_approval` on gets no indication whatsoever that the gate stopped functioning; writes
just start going through. A broken enforcement mechanism should deny, not allow.

Two independent fail-open sites had to be fixed, not one — `_apply_batch_write_gate` (the
batch path) has the exact same pattern with no comment at all, and would remain an unguarded
hole even after fixing only the single-op path.

## Related Issue

No existing issue found. I searched both open and merged PRs and issues (`gh search prs`/
`gh search issues`, several term variants: "write_approval fail open", "memory write gate",
"approval gate ImportError", "memory write approval bypass") before opening this — nothing
matched this specific defect.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/memory_tool.py`: `_apply_write_gate` and `_apply_batch_write_gate` now return a
  `tool_error(..., success=False)` result instead of `None` when `tools.write_approval`
  fails to import — refusing the write instead of silently allowing it. This matches the
  response shape the existing `decision.blocked` branch in the same functions already uses,
  so no caller needs new handling.
- `tests/tools/test_write_approval.py`: two new regression tests,
  `test_memory_gate_import_failure_fails_closed` (single-op path) and
  `test_memory_batch_gate_import_failure_fails_closed` (batch path), plus a shared
  `_break_write_approval_import(monkeypatch)` helper.

## How to Test

1. Enable `memory.write_approval` in config (or leave it default — the bug fires regardless,
   since the gate never gets far enough to check the setting).
2. Break the import of `tools.write_approval` (e.g. simulate a packaging/dependency failure).
3. Call `memory_tool("add", "user", "some content", store=store)` (or the batch form via
   `operations=[...]`).
4. Before this fix: the write succeeds (`success: true`) and the content lands in the store —
   the gate silently did nothing.
5. After this fix: the call returns `success: false` with an explanatory error, and nothing
   is written.

Minimal repro used during development:

```python
import sys
import tools as tools_pkg
if hasattr(tools_pkg, "write_approval"):
    delattr(tools_pkg, "write_approval")
sys.modules["tools.write_approval"] = None  # forces the next import to raise

from tools.memory_tool import memory_tool, MemoryStore
store = MemoryStore(); store.load_from_disk()
print(memory_tool("add", "user", "should not be written", store=store))
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I did **not** run the full suite (out of scope of what I could do without upstream's CI). I ran the specific tests this change touches: `tests/tools/test_write_approval.py` (17 passed — the file's 15 pre-existing tests plus the 2 new ones this PR adds) and `tests/tools/test_memory_tool.py` + `test_memory_tool_schema.py` + `test_memory_tool_import_fallback.py` (37 passed, no regressions, including the default-off happy path).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing behavior change to document beyond the fixed error path
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control-flow change, no platform-specific code touched
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A, the tool's success/failure contract already covers this response shape (matches the existing `blocked` case)

## Notes for reviewers

- The response shape (`success: false` + `error` string, matching the existing `blocked`
  gate outcome) is a judgment call following existing precedent in the file, not something a
  test can validate as "the right" shape — happy to change it if you'd prefer a distinct
  signal for "gate broken" vs. "gate blocked the write on purpose."
- I did not run upstream's full test suite or any lint/type-check tooling — only the tests
  directly touched by this change, listed above.
