### PR TITLE
fix(tools): fail closed when the skill write-approval gate can't import

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -145,6 +145,43 @@ _SKILL = (
 )
 
 
+def _break_write_approval_import(monkeypatch):
+    """Simulate ``from tools import write_approval`` raising ImportError.
+
+    Poisoning ``sys.modules['tools.write_approval']`` alone is not enough:
+    once the real module has been imported anywhere in the process (e.g. by
+    an earlier test in this file), Python caches it as an attribute on the
+    parent ``tools`` package, and ``from tools import write_approval``
+    resolves straight from that attribute without re-touching
+    ``sys.modules`` at all. Both must be cleared to force a real (re-)import
+    attempt, which then hits the poisoned ``sys.modules`` entry and raises.
+    """
+    import sys
+    import tools as tools_pkg
+
+    monkeypatch.delattr(tools_pkg, "write_approval", raising=False)
+    monkeypatch.setitem(sys.modules, "tools.write_approval", None)
+
+
+def test_skill_gate_import_failure_fails_closed(hermes_home, tmp_path, monkeypatch):
+    """If ``tools.write_approval`` can't be imported, the skill write gate
+    must refuse the write (fail closed) rather than silently letting an
+    unattended create/edit/patch/delete through."""
+    from tools.skill_manager_tool import skill_manage
+
+    monkeypatch.setattr("tools.skill_manager_tool.SKILLS_DIR", tmp_path)
+    monkeypatch.setattr("agent.skill_utils.get_all_skills_dirs", lambda: [tmp_path])
+    _break_write_approval_import(monkeypatch)
+
+    r = json.loads(skill_manage(action="create", name="test-skill", content=_SKILL))
+
+    assert r["success"] is False
+    # tmp_path is not pristine (the autouse _hermetic_environment fixture in
+    # tests/conftest.py always pre-creates a hermes_test/ scaffold under it),
+    # so assert on the specific thing that must NOT exist: the refused skill.
+    assert not (tmp_path / "test-skill").exists()
+
+
 # ---------------------------------------------------------------------------
 # Pending store CRUD
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1412,7 +1412,16 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
     try:
         from tools import write_approval as wa
     except Exception:
-        return None  # fail open
+        # An unavailable gate module means we cannot determine whether write
+        # approval is required. Fail closed: refuse the write rather than
+        # silently granting an unattended skill write — create/edit/patch/
+        # delete/write_file/remove_file all mutate content a future turn may
+        # execute as trusted instructions.
+        return tool_error(
+            "skill write gate unavailable (write_approval module failed to "
+            "import); refusing write",
+            success=False,
+        )
 
     decision = wa.evaluate_gate(wa.SKILLS)
     if decision.allow:


### PR DESCRIPTION
## What does this PR do?

Fixes a fail-open bug in the skill write-approval gate. `tools/skill_manager_tool.py`'s
`_apply_skill_write_gate` — the function every `create`, `edit`, `patch`, `delete`,
`write_file`, and `remove_file` skill mutation goes through — tries to import
`tools.write_approval` to evaluate the configured `skills.write_approval` gate. On import
failure it currently does this:

```python
try:
    from tools import write_approval as wa
except Exception:
    return None  # fail open
```

`skill_manage()`'s call site treats a `None` return as "no verdict, perform the real write"
— so a broken or missing gate module means every skill mutation proceeds completely
unattended, an outcome the code itself already labels "fail open."

Skills are content a future agent turn reads and acts on as trusted instructions — arguably
higher stakes than a memory entry. The entire point of `skills.write_approval` is to let a
human review a skill create/edit/patch/delete before the agent starts following it
unsupervised. If `tools/write_approval.py` fails to import (bad edit, packaging issue, a
missing transitive dependency), that review step disappears with no error and no signal to
the user that protection is off.

This is a companion fix to the same fail-open pattern in the memory write-approval gate
(`tools/memory_tool.py`), filed as a separate PR since the two touch different subsystems.

## Related Issue

No existing issue found for this specific defect. I searched both open and merged PRs and
issues (`gh search prs`/`gh search issues`: "skill_manager write gate", "skill write
approval", "_apply_skill_write_gate", "skill_manage fail open", plus a broad "fail open"/
"fails open" sweep across the repo's issues). The closest related issue is #60440
("write_file and patch tools bypass skills.write_approval gate"), which is a **different**
root cause — other tools bypassing the gate entirely via a different code path — not this
gate's own ImportError fail-open. Not a duplicate.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`: `_apply_skill_write_gate`'s `except Exception:` branch now
  returns a `tool_error(..., success=False)` result instead of `None` — refusing the write,
  in the same response shape the function's own `decision.blocked` branch already uses a few
  lines below.
- `tests/tools/test_write_approval.py`: one new regression test,
  `test_skill_gate_import_failure_fails_closed`, plus a shared
  `_break_write_approval_import(monkeypatch)` helper.

## How to Test

1. Enable `skills.write_approval` in config.
2. Break the import of `tools.write_approval`.
3. Call `skill_manage(action="create", name="test-skill", content=<valid skill>)`.
4. Before this fix: the call succeeds (`success: true`) and the skill directory is written to
   disk.
5. After this fix: the call returns `success: false` with an explanatory error, and nothing
   is written.

Minimal repro used during development:

```python
import sys, tempfile
from pathlib import Path
import tools.skill_manager_tool as smt

tmp = Path(tempfile.mkdtemp())
smt.SKILLS_DIR = tmp
import agent.skill_utils as su
su.get_all_skills_dirs = lambda: [tmp]

import tools as tools_pkg
if hasattr(tools_pkg, "write_approval"):
    delattr(tools_pkg, "write_approval")
sys.modules["tools.write_approval"] = None

skill = "---\nname: test-skill\ndescription: A test skill\nversion: 1.0.0\n---\n# Test\nbody\n"
print(smt.skill_manage(action="create", name="test-skill", content=skill))
print("written:", (tmp / "test-skill").exists())
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I did **not** run the full suite. I ran the tests this change touches: `tests/tools/test_write_approval.py` (16 passed — 15 pre-existing plus the 1 new test this PR adds) and `tests/tools/test_skill_manager_tool.py` (45 passed, no regressions to creation, editing, patching, deletion, background-review guards, or curator consolidation guards).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control-flow change
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A, matches the existing `blocked` response contract

## Notes for reviewers

- I checked the one call site of `_apply_skill_write_gate` (`skill_manage()`) directly but
  did not exhaustively grep the whole tree for a second/reflective caller — it appears to be
  a private, narrowly-scoped helper based on its name and signature.
- Same judgment call as the companion memory-gate PR: the response shape matches this
  function's own existing `decision.blocked` precedent rather than inventing a distinct
  "gate broken" signal. Open to a different shape if you'd prefer one.
- Did not run upstream's full test suite or lint/type-check tooling — only the tests listed
  above.
