### PR TITLE
fix(update): restart the full gateway fleet on macOS after update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -146,33 +146,33 @@ def _get_service_pids() -> set:
 
     # --- launchd (macOS) ---
     if is_macos():
-        try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # Try plist format first (macOS 26+): "PID" = <N>;
-                pid = _parse_launchd_pid_from_list_output(result.stdout)
-                if pid is not None and pid > 0:
-                    pids.add(pid)
-                else:
-                    # Fall back to legacy tab-separated format:
-                    # "PID\tStatus\tLabel"
-                    for line in result.stdout.strip().splitlines():
-                        parts = line.split()
-                        if len(parts) >= 3 and parts[2] == label:
-                            try:
-                                pid = int(parts[0])
-                                if pid > 0:
-                                    pids.add(pid)
-                            except ValueError:
-                                pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        for label in list_launchd_gateway_labels():
+            try:
+                result = subprocess.run(
+                    ["launchctl", "list", label],
+                    capture_output=True,
+                    text=True, encoding='utf-8', errors='replace',
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    # Try plist format first (macOS 26+): "PID" = <N>;
+                    pid = _parse_launchd_pid_from_list_output(result.stdout)
+                    if pid is not None and pid > 0:
+                        pids.add(pid)
+                    else:
+                        # Fall back to legacy tab-separated format:
+                        # "PID\tStatus\tLabel"
+                        for line in result.stdout.strip().splitlines():
+                            parts = line.split()
+                            if len(parts) >= 3 and parts[2] == label:
+                                try:
+                                    pid = int(parts[0])
+                                    if pid > 0:
+                                        pids.add(pid)
+                                except ValueError:
+                                    pass
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
 
     return pids
 
@@ -336,6 +336,38 @@ def _append_unique_pid(
     if pid == os.getpid() or pid in exclude_pids or pid in pids:
         return
     pids.append(pid)
+
+
+def _run_ps_gateway_scan() -> str | None:
+    """Return ``ps -o pid=,command=`` output, or ``None`` when unusable.
+
+    The historical invocation ``ps -A eww -o pid=,command=`` uses the SysV
+    ``-A``/``eww`` flag combination, which macOS 26 removed (``ps: illegal
+    argument: eww`` — the BSD ``ps`` accepts ``a``/``x``/``w``, not ``e``).
+    On that platform the old command exits non-zero with no output, which
+    made every ``_scan_gateway_pids`` fall silent (no gateway PIDs found),
+    so ``hermes update`` could not restart the manual gateway fleet.
+
+    Try the historical form first for older systems, then fall back to the
+    BSD ``-axww`` form that works on both macOS and Linux.
+    """
+    candidates = (
+        ["ps", "-A", "eww", "-o", "pid=,command="],
+        ["ps", "-axww", "-o", "pid=,command="],
+    )
+    for cmd in candidates:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True, encoding='utf-8', errors='replace',
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+    return None
 
 
 def _scan_gateway_pids(
@@ -506,15 +538,10 @@ def _scan_gateway_pids(
                     pass
 
             if not _found_via_proc:
-                result = subprocess.run(
-                    ["ps", "-A", "eww", "-o", "pid=,command="],
-                    capture_output=True,
-                    text=True, encoding='utf-8', errors='replace',
-                    timeout=10,
-                )
-                if result.returncode != 0:
+                ps_stdout = _run_ps_gateway_scan()
+                if ps_stdout is None:
                     return []
-                for line in result.stdout.split("\n"):
+                for line in ps_stdout.split("\n"):
                     stripped = line.strip()
                     if not stripped or "grep" in stripped:
                         continue
@@ -2514,6 +2541,42 @@ def get_launchd_plist_path() -> Path:
     suffix = _profile_suffix()
     name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
     return _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
+
+
+def list_launchd_gateway_labels() -> list[str]:
+    """Return all loaded ``ai.hermes.gateway*`` launchd labels.
+
+    Enumerates the launchd job list (``launchctl list``) and returns every
+    label that belongs to a Hermes gateway service — the default
+    ``ai.hermes.gateway`` plus per-profile ``ai.hermes.gateway-<profile>``.
+    ``hermes update`` uses this to restart the whole gateway fleet after a
+    code update (mirroring the systemd ``hermes-gateway*`` unit sweep),
+    because a shared checkout update affects every profile's gateway.
+
+    Returns an empty list when launchctl is unavailable or nothing Hermes
+    manages is loaded.
+    """
+    labels: list[str] = []
+    try:
+        result = subprocess.run(
+            ["launchctl", "list"],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return labels
+    if result.returncode != 0:
+        return labels
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+        label = parts[-1]
+        if label == "ai.hermes.gateway" or label.startswith("ai.hermes.gateway-"):
+            if label not in labels:
+                labels.append(label)
+    return labels
 
 
 def _detect_venv_dir() -> Path | None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5190,24 +5190,43 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     from hermes_cli.gateway import (
                         launchd_restart,
                         get_launchd_label,
-                        get_launchd_plist_path,
+                        list_launchd_gateway_labels,
+                        _launchd_domain,
                     )
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
+                    # A shared-checkout code update affects every profile's
+                    # gateway, so restart the whole launchd-managed fleet —
+                    # the default label plus every loaded
+                    # ``ai.hermes.gateway-<profile>`` label. Mirrors the
+                    # systemd ``hermes-gateway*`` unit sweep above; previously
+                    # only the current profile's label was restarted, leaving
+                    # every other profile gateway running stale code.
+                    current_label = get_launchd_label()
+                    for label in list_launchd_gateway_labels():
+                        try:
+                            if label == current_label:
+                                # Current profile: graceful drain + kickstart
+                                # (also verifies the plist exists / is loaded).
                                 launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
+                            else:
+                                # Other profiles: kickstart -k stops the job
+                                # and launches it again against the freshly
+                                # updated checkout.  launchd's KeepAlive
+                                # respawns it with the new code.
+                                subprocess.run(
+                                    [
+                                        "launchctl",
+                                        "kickstart",
+                                        "-k",
+                                        f"{_launchd_domain()}/{label}",
+                                    ],
+                                    check=True,
+                                    timeout=90,
+                                )
+                            restarted_services.append(label)
+                        except subprocess.CalledProcessError as e:
+                            stderr = (getattr(e, "stderr", "") or "").strip()
+                            print(f"  ⚠ Gateway restart failed ({label}): {stderr}")
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 

--- a/tests/hermes_cli/test_gateway_fleet_restart.py
+++ b/tests/hermes_cli/test_gateway_fleet_restart.py
@@ -1,0 +1,193 @@
+"""Tests for the macOS 26 gateway-fleet restart fixes.
+
+Covers:
+1. ``_run_ps_gateway_scan`` — falls back from the removed ``ps -A eww``
+   form to ``ps -axww`` when the first invocation fails (macOS 26 dropped
+   the SysV ``e`` flag; ``ps: illegal argument: eww``).
+2. ``list_launchd_gateway_labels`` — enumerates the whole
+   ``ai.hermes.gateway*`` fleet (default + per-profile labels), not just
+   the current profile's label.
+3. ``_get_service_pids`` macOS branch — collects PIDs from every loaded
+   gateway label so the post-update manual sweep does not kill freshly
+   restarted launchd services.
+"""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+
+
+def _run_result(stdout: str = "", returncode: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(stdout=stdout, returncode=returncode)
+
+
+class TestRunPsGatewayScan:
+    def test_prefers_historical_eww_form_when_it_works(self, monkeypatch):
+        """On older systems ``ps -A eww`` still works — use it unchanged."""
+        good = _run_result(stdout="123 cmd-one\n456 cmd-two\n")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return good
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        out = gateway_cli._run_ps_gateway_scan()
+        assert out == "123 cmd-one\n456 cmd-two\n"
+        assert calls == [["ps", "-A", "eww", "-o", "pid=,command="]]
+
+    def test_falls_back_to_bsd_form_when_eww_fails(self, monkeypatch):
+        """macOS 26 drops ``eww`` (illegal argument) — retry with ``-axww``."""
+        eww_bad = _run_result(stdout="ps: illegal argument: eww\n", returncode=1)
+        axww_good = _run_result(stdout="123 cmd-one\n456 cmd-two\n")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ["ps", "-A", "eww", "-o", "pid=,command="]:
+                return eww_bad
+            return axww_good
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        out = gateway_cli._run_ps_gateway_scan()
+        assert out == "123 cmd-one\n456 cmd-two\n"
+        assert calls == [
+            ["ps", "-A", "eww", "-o", "pid=,command="],
+            ["ps", "-axww", "-o", "pid=,command="],
+        ]
+
+    def test_falls_back_when_eww_returns_empty_but_succeeds(self, monkeypatch):
+        """Guard against a platform where eww exits 0 but prints nothing."""
+        eww_empty = _run_result(stdout="")
+        axww_good = _run_result(stdout="123 cmd-one\n")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["ps", "-A", "eww", "-o", "pid=,command="]:
+                return eww_empty
+            return axww_good
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        assert gateway_cli._run_ps_gateway_scan() == "123 cmd-one\n"
+
+    def test_returns_none_when_both_forms_fail(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return _run_result(stdout="", returncode=2)
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        assert gateway_cli._run_ps_gateway_scan() is None
+
+    def test_scan_pids_uses_helper_and_finds_gateways(self, monkeypatch):
+        """``_scan_gateway_pids`` parses the fallback output for gateway procs."""
+        ps_out = (
+            "472 /venv/bin/python -m hermes_cli.main --profile orchestrator gateway run\n"
+            "484 /venv/bin/python -m hermes_cli.main --profile reviewer gateway run\n"
+            "999 /usr/bin/launchd\n"
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_run_ps_gateway_scan", lambda: ps_out
+        )
+        from gateway import status as gateway_status
+        monkeypatch.setattr(
+            gateway_status,
+            "looks_like_gateway_command_line",
+            lambda cmd: "gateway run" in cmd,
+        )
+        monkeypatch.setattr(
+            gateway_status,
+            "looks_like_gateway_runtime_command_line",
+            lambda cmd: "gateway run" in cmd,
+        )
+        pids = gateway_cli._scan_gateway_pids(set(), all_profiles=True)
+        assert pids == [472, 484]
+
+
+class TestListLaunchdGatewayLabels:
+    def test_enumerates_default_and_profile_labels(self, monkeypatch):
+        launchctl_out = (
+            "472\t0\tai.hermes.gateway-orchestrator\n"
+            "484\t0\tai.hermes.gateway-reviewer\n"
+            "895\t0\tai.hermes.gateway\n"
+            "485\t0\tai.hermes.gateway-coder\n"
+            "123\t0\tcom.apple.something\n"
+            "-   0\tcom.nousresearch.hermes-gateway\n"
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kw: _run_result(stdout=launchctl_out),
+        )
+        labels = gateway_cli.list_launchd_gateway_labels()
+        assert labels == [
+            "ai.hermes.gateway-orchestrator",
+            "ai.hermes.gateway-reviewer",
+            "ai.hermes.gateway",
+            "ai.hermes.gateway-coder",
+        ]
+
+    def test_returns_empty_on_launchctl_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kw: _run_result(stdout="", returncode=1),
+        )
+        assert gateway_cli.list_launchd_gateway_labels() == []
+
+    def test_returns_empty_on_file_not_found(self, monkeypatch):
+        def fake_run(cmd, **kw):
+            raise FileNotFoundError("no launchctl")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        assert gateway_cli.list_launchd_gateway_labels() == []
+
+    def test_dedupes_repeated_labels(self, monkeypatch):
+        launchctl_out = (
+            "895\t0\tai.hermes.gateway\n"
+            "896\t0\tai.hermes.gateway\n"
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kw: _run_result(stdout=launchctl_out),
+        )
+        labels = gateway_cli.list_launchd_gateway_labels()
+        assert labels == ["ai.hermes.gateway"]
+
+
+class TestGetServicePidsMacos:
+    def test_collects_pids_from_all_loaded_labels(self, monkeypatch):
+        """macOS branch must return every launchd gateway PID, not just the
+        current profile's, so the update's manual sweep excludes them."""
+        labels = [
+            "ai.hermes.gateway",
+            "ai.hermes.gateway-coder",
+            "ai.hermes.gateway-trader",
+        ]
+        monkeypatch.setattr(gateway_cli, "list_launchd_gateway_labels", lambda: labels)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+
+        def fake_run(cmd, **kw):
+            label = cmd[-1]
+            pid_by_label = {
+                "ai.hermes.gateway": '    "PID" = 895;\n',
+                "ai.hermes.gateway-coder": '    "PID" = 485;\n',
+                "ai.hermes.gateway-trader": "485\t0\tai.hermes.gateway-trader\n",
+            }
+            return _run_result(stdout=pid_by_label[label])
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        pids = gateway_cli._get_service_pids()
+        assert pids == {895, 485}
+
+    def test_no_labels_means_no_pids(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "list_launchd_gateway_labels", lambda: [])
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        assert gateway_cli._get_service_pids() == set()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

After `hermes update` on macOS, only the current profile's gateway restarts. Every other profile gateway keeps running the pre-update checkout, silently serving stale code until manually restarted.

Observed in `~/.hermes/logs/update.log`:

```
✓ Restarted ai.hermes.gateway
  Restart the dashboard when you're ready:
```

...with no `ai.hermes.gateway-<profile>` restarts at all.

## Root cause

Two independent defects combine on macOS:

**1. `_scan_gateway_pids` is blind on macOS 26**

`hermes_cli/gateway.py` runs `ps -A eww -o pid=,command=` to find gateway processes. macOS 26 removed the SysV `eww` flag:

```
$ ps -A eww -o pid=,command=
ps: illegal argument: eww
```

The command exits non-zero with no output, so `_scan_gateway_pids` silently returns `[]`. The post-update "manual (non-service) gateways" sweep therefore found nothing to restart on macOS.

**2. The launchd branch only restarts the current profile's label**

`_cmd_update_impl` restarts `get_launchd_label()` — exactly one label (`ai.hermes.gateway` when run from the default profile). The systemd branch already restarts the entire `hermes-gateway*` fleet; the macOS branch did not enumerate per-profile labels.

## Fix

**`gateway.py`:**
- Add `_run_ps_gateway_scan()`: tries the historical `ps -A eww` form first (older systems), then falls back to the BSD `-axww` form that works on macOS 26 and Linux.
- Add `list_launchd_gateway_labels()`: enumerates all loaded `ai.hermes.gateway*` labels via `launchctl list` (default + per-profile).
- `_get_service_pids()` macOS branch now collects PIDs from **every** loaded gateway label, so the post-update manual sweep excludes freshly-restarted launchd services instead of killing them.

**`update_cmd.py`:**
- The launchd restart branch now iterates `list_launchd_gateway_labels()`: graceful `launchd_restart()` for the current profile's label, `launchctl kickstart -k` for the others — mirroring the systemd fleet sweep.

## Testing

- New `tests/hermes_cli/test_gateway_fleet_restart.py` (11 tests): ps-scan fallback behavior (eww works / eww fails / eww empty / both fail / scan parses output), launchd label enumeration (multi-label, failure, dedupe), and `_get_service_pids` multi-label collection.
- Live-verified on macOS 26.6: `list_launchd_gateway_labels()` returns all 7 labels; `_get_service_pids()` returns all 7 PIDs; `find_gateway_pids(all_profiles=True, exclude=service)` correctly returns nothing (all gateways are launchd-managed).
- Related suites pass: `test_gateway_service.py`, `test_cmd_update.py`, `test_update_fleet_restart_timeout.py` (106 tests + the 11 new ones).

## Notes

- Tested on macOS 26.6 (Build 25G72). Linux/systemd path untouched.
- The `ps -A eww` fallback is conservative: it keeps the historical command for platforms where it still works, so no behavior change on older macOS or Linux.
