### PR TITLE
fix(serve): self-reap the desktop backend when its parent dies

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10172,6 +10172,72 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+# ── Parent-death watchdog for the desktop-spawned `serve` backend ─────────
+# Desktop Electron spawns this backend and tears it down in `before-quit`
+# (SIGTERM, then forceKillProcessTree over the primary and the pool). That
+# teardown is correct but structurally cannot cover a force-quit / SIGKILL /
+# fatal GPU abort — main.ts says so itself ("FATAL GPU aborts skip
+# before-quit"). macOS has no PR_SET_PDEATHSIG (documented in
+# tools/mcp_stdio_watchdog.py), so the kernel reparents us to pid 1 rather
+# than reaping us and we keep our 127.0.0.1 LISTEN socket and ~100 MB
+# forever. Three such orphans accumulated in one 3-minute restart burst.
+# No parent-side fix can close this — the parent's code is exactly what did
+# not run — so the child reaps itself, as tui_gateway/slash_worker.py does.
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env knob, falling back to *default* on absent/malformed
+    values. A bare ``float(os.environ.get(...))`` would raise ValueError at
+    import time on a typo (e.g. ``HERMES_SERVE_WATCHDOG_POLL_S=2s``) and take
+    down every `hermes` invocation, not just the watchdog."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+# Env-overridable so the integration test can drive sub-second timing.
+_SERVE_WATCHDOG_POLL_S = max(0.05, _env_float("HERMES_SERVE_WATCHDOG_POLL_S", 2.0))
+
+
+def _serve_is_orphaned(original_ppid, getppid=os.getppid) -> bool:
+    """Return whether this backend no longer has its original POSIX parent."""
+    return getppid() != original_ppid
+
+
+def _should_start_serve_watchdog(headless_backend, env, os_name) -> bool:
+    """Gate the watchdog to the one launch shape that can leak.
+
+    - ``headless_backend`` — cmd_dashboard backs BOTH `dashboard` and `serve`;
+      a human's foreground `hermes dashboard` must never self-reap.
+    - ``HERMES_DESKTOP=1`` — only the desktop's own backend is in scope. A
+      deliberate ``nohup hermes serve &`` legitimately reparents to pid 1 when
+      its shell exits, and killing that would be a regression, not a fix.
+    - POSIX — the named-profile re-exec below is ``os.execvpe`` here, which
+      preserves pid/ppid so the recorded value stays valid; on Windows it is
+      ``subprocess.Popen``, where it would not. Same gate tools/mcp_tool.py
+      uses for its watchdog wrap.
+    """
+    return bool(headless_backend) and env.get("HERMES_DESKTOP") == "1" and os_name == "posix"
+
+
+def _start_serve_parent_death_watchdog(original_ppid) -> None:
+    def _loop():
+        while not _serve_is_orphaned(original_ppid):
+            _time.sleep(_SERVE_WATCHDOG_POLL_S)
+        # os._exit, not sys.exit: uvicorn's loop owns the main thread and would
+        # swallow a SystemExit raised here. The kernel releases the LISTEN
+        # socket either way, and a backend whose parent is gone has no shutdown
+        # work worth flushing.
+        os._exit(0)
+
+    threading.Thread(
+        target=_loop, name="serve-parent-death-watchdog", daemon=True
+    ).start()
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -10322,6 +10388,12 @@ def cmd_dashboard(args):
             sys.exit(proc.wait())
         else:
             os.execvpe(sys.executable, reexec_argv, env)
+
+    # Past the re-exec, so the ppid we record is the one we will actually be
+    # orphaned from. os.execvpe above preserves pid/ppid; the Windows branch
+    # spawns a fresh process instead, which is why the gate is POSIX-only.
+    if _should_start_serve_watchdog(_headless_backend, os.environ, os.name):
+        _start_serve_parent_death_watchdog(os.getppid())
 
     if _token_file:
         _ssh_session_token = _read_ssh_session_token_file(_token_file)

--- a/tests/hermes_cli/test_serve_parent_death_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_death_watchdog.py
@@ -1,0 +1,211 @@
+"""Contract for the parent-death watchdog on the headless ``hermes serve`` backend.
+
+The desktop Electron app spawns its backend as ``hermes serve --host 127.0.0.1
+--port 0`` and tears it down in ``before-quit``.  That teardown is correct but
+structurally cannot cover a force-quit / SIGKILL / fatal GPU abort, because the
+parent's code never runs.  macOS has no ``PR_SET_PDEATHSIG``, so the kernel
+reparents the backend to pid 1 instead of reaping it and it keeps its LISTEN
+socket and its ~100 MB forever.  Three such orphans were recovered from one
+3-minute restart burst.
+
+No parent-side fix can close this, so the backend reaps itself: it records its
+ppid at startup and exits once that ppid changes.  These tests pin the
+predicate, the three gates that keep it off every other launch shape, its
+placement after the re-exec, and — end to end — that a real serve-shaped child
+actually dies when its parent is SIGKILLed.
+
+Mirrors ``tests/test_slash_worker_watchdog.py``, whose watchdog this copies.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import main as main_mod
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ── the orphan predicate ──────────────────────────────────────────────────
+
+
+def test_is_orphaned_true_when_ppid_changes():
+    # Our parent went away and we were reparented to init/a subreaper.
+    assert main_mod._serve_is_orphaned(1234, getppid=lambda: 1) is True
+
+
+def test_is_orphaned_false_when_direct_parent_is_unchanged():
+    original_ppid = 1234
+    assert main_mod._serve_is_orphaned(original_ppid, getppid=lambda: original_ppid) is False
+
+
+# ── the three gates ───────────────────────────────────────────────────────
+
+
+def test_watchdog_runs_for_a_desktop_spawned_serve_on_posix():
+    assert main_mod._should_start_serve_watchdog(
+        headless_backend=True, env={"HERMES_DESKTOP": "1"}, os_name="posix"
+    ) is True
+
+
+def test_watchdog_skips_the_interactive_dashboard():
+    # cmd_dashboard backs BOTH `dashboard` and `serve`. A human's foreground
+    # `hermes dashboard` must never self-reap.
+    assert main_mod._should_start_serve_watchdog(
+        headless_backend=False, env={"HERMES_DESKTOP": "1"}, os_name="posix"
+    ) is False
+
+
+def test_watchdog_skips_a_standalone_serve():
+    # `nohup hermes serve &` legitimately reparents to pid 1 when the launching
+    # shell exits — that is a deliberate daemon, not an orphan. Only the
+    # desktop's own backend (HERMES_DESKTOP=1) is in scope.
+    assert main_mod._should_start_serve_watchdog(
+        headless_backend=True, env={}, os_name="posix"
+    ) is False
+
+
+def test_watchdog_skips_windows():
+    # The profile re-exec is os.execvpe on POSIX (pid/ppid preserved, so the
+    # recorded ppid stays valid) but subprocess.Popen on Windows, where it
+    # would not be. Same gate tools/mcp_tool.py uses.
+    assert main_mod._should_start_serve_watchdog(
+        headless_backend=True, env={"HERMES_DESKTOP": "1"}, os_name="nt"
+    ) is False
+
+
+# ── contract + placement ──────────────────────────────────────────────────
+
+
+def test_watchdog_contract_has_no_create_time_plumbing():
+    assert list(inspect.signature(main_mod._serve_is_orphaned).parameters) == [
+        "original_ppid",
+        "getppid",
+    ]
+    assert list(
+        inspect.signature(main_mod._start_serve_parent_death_watchdog).parameters
+    ) == ["original_ppid"]
+
+
+def test_cmd_dashboard_starts_the_watchdog_after_the_reexec():
+    # The ppid must be recorded on the far side of the named-profile re-exec.
+    # Recorded before it, the value would be the pre-exec parent's — and on the
+    # Windows branch (subprocess.Popen, not execvpe) a whole different process.
+    src = inspect.getsource(main_mod.cmd_dashboard)
+    assert "_start_serve_parent_death_watchdog" in src, (
+        "cmd_dashboard never starts the watchdog — the helper is dead code"
+    )
+    assert src.index("os.execvpe") < src.index("_start_serve_parent_death_watchdog"), (
+        "watchdog must be started AFTER the re-exec block, not before"
+    )
+
+
+# ── end to end: a real orphan reaps itself ────────────────────────────────
+
+
+def _child_source(pidfile: Path) -> str:
+    """A serve-shaped child: holds a LISTEN socket, runs the real watchdog."""
+    return (
+        "import os, socket, sys, time\n"
+        f"sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+        "from hermes_cli.main import _start_serve_parent_death_watchdog\n"
+        # The orphans each held a live 127.0.0.1 LISTEN socket; keep one so the
+        # test exercises the same shape rather than a bare sleeper.
+        "s = socket.socket(); s.bind(('127.0.0.1', 0)); s.listen(8)\n"
+        "_start_serve_parent_death_watchdog(os.getppid())\n"
+        f"open({str(pidfile)!r}, 'w').write(str(os.getpid()))\n"
+        "while True: time.sleep(0.05)\n"
+    )
+
+
+def _parent_source(child_script: Path) -> str:
+    # Exit if the child dies, so a child that fails to start surfaces as an
+    # immediate "parent died before the child came up" instead of a timeout.
+    return (
+        "import subprocess, sys\n"
+        f"sys.exit(subprocess.Popen([sys.executable, {str(child_script)!r}]).wait())\n"
+    )
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
+
+
+def _read_pid(pidfile: Path) -> int | None:
+    try:
+        return int(pidfile.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _reap(pid: int | None) -> None:
+    if pid is None:
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except Exception:
+        # Cleanup must never raise: it runs in `finally`, and an exception
+        # here would replace the AssertionError that names the real failure.
+        pass
+
+
+# Real SIGKILL delivery is the whole point — a mocked signal cannot orphan a
+# process. Both PIDs are spawned by this test; the child is deliberately
+# reparented to init, which is exactly what the subtree guard refuses.
+@pytest.mark.live_system_guard_bypass
+def test_serve_child_self_reaps_when_its_parent_is_sigkilled(tmp_path):
+    pidfile = tmp_path / "child.pid"
+    child_script = tmp_path / "child.py"
+    parent_script = tmp_path / "parent.py"
+    child_script.write_text(_child_source(pidfile))
+    parent_script.write_text(_parent_source(child_script))
+
+    env = dict(os.environ)
+    env["HERMES_DESKTOP"] = "1"
+    env["HERMES_SERVE_WATCHDOG_POLL_S"] = "0.1"  # read at import; keeps this fast
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+
+    parent = subprocess.Popen([sys.executable, str(parent_script)], env=env)
+    child_pid = None
+    try:
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            child_pid = _read_pid(pidfile)
+            if child_pid is not None:
+                break
+            if parent.poll() is not None:
+                raise AssertionError("parent died before the child came up")
+            time.sleep(0.05)
+        assert child_pid is not None, "child never started"
+        assert _alive(child_pid), "child exited before the parent was killed"
+
+        # Force-quit / fatal abort: the parent's teardown code never runs.
+        os.kill(parent.pid, signal.SIGKILL)
+        parent.wait(timeout=10)
+
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if not _alive(child_pid):
+                return  # self-reaped
+            time.sleep(0.05)
+        raise AssertionError(
+            f"orphaned serve child {child_pid} survived its parent's SIGKILL — "
+            "this is the leak the watchdog exists to prevent"
+        )
+    finally:
+        _reap(parent.pid)
+        _reap(child_pid if child_pid is not None else _read_pid(pidfile))


### PR DESCRIPTION
## What does this PR do?

Makes the headless `hermes serve` backend reap itself when its parent dies, closing the one orphan path that no parent-side fix can reach.

The desktop app spawns its backend as `hermes serve --host 127.0.0.1 --port 0` and tears it down in `before-quit`. That teardown is correct, and #76245 / #76244 make it more reliable still. But all three live on the **parent** path, and there is a case where the parent's code never runs at all: force-quit, `SIGKILL`, or a fatal GPU abort. `main.ts` already acknowledges this in a comment — *"FATAL GPU aborts skip before-quit"*.

When that happens on macOS there is no `PR_SET_PDEATHSIG` (this repo documents the constraint verbatim in `tools/mcp_stdio_watchdog.py`), so the kernel reparents the backend to pid 1 instead of reaping it. It keeps its `127.0.0.1` LISTEN socket and its resident memory forever. That is the `PPID=1` accumulation in #61349.

Since the parent's code is exactly what did not run, the fix has to be child-side.

**This is not a new mechanism for this repo.** `tui_gateway/slash_worker.py` already solves precisely this with a parent-death watchdog, and `tests/test_slash_worker_watchdog.py` pins it. #61349 reports orphans from *both* `serve` and `slash_worker` — `slash_worker` is already covered by this idiom; `serve` never was. This PR extends the proven pattern to `serve`, deliberately mirroring the existing code and tests rather than inventing anything.

### Relationship to the other open orphan issues

This is a complement, not a replacement:

| Issue | Path it fixes | Covers force-quit / SIGKILL? |
|---|---|---|
| #76245 — before-quit doesn't wait for SIGTERM | parent | No |
| #76244 — uvicorn graceful shutdown unbounded | child, but only once SIGTERM arrives | No |
| **this PR** — backend self-reaps on parent death | child, needs no signal at all | **Yes** |

## Related Issue

Addresses the force-quit / abort path of #61349, and reduces the pile-up behind #78872 and #78821.

To be precise about scope: #61349 likely has more than one cause, and the graceful-quit paths belong to #76245 / #76244. This PR does not supersede those — it covers the case where no teardown code runs at all. I've deliberately written "addresses" rather than "fixes" for that reason.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` (+72, purely additive — no existing lines changed):
  - `_serve_is_orphaned(original_ppid, getppid=os.getppid)` — same predicate/signature as `slash_worker._is_orphaned`.
  - `_should_start_serve_watchdog(headless_backend, env, os_name)` — the gate, as a pure function so it is directly testable.
  - `_start_serve_parent_death_watchdog(original_ppid)` — daemon thread; `os._exit(0)` once orphaned.
  - `_env_float(...)` + `_SERVE_WATCHDOG_POLL_S` (`HERMES_SERVE_WATCHDOG_POLL_S`, default 2.0s), mirroring the `slash_worker` helper so a typo'd env var can't raise at import.
  - One call site in `cmd_dashboard`.
- `tests/hermes_cli/test_serve_parent_death_watchdog.py` (new, 9 tests).

### The gate

`cmd_dashboard` backs **both** `dashboard` and `serve`, so the watchdog is gated on all three of:

1. **`_headless_backend`** — `serve` only. A human's foreground `hermes dashboard` must never self-reap.
2. **`HERMES_DESKTOP=1`** — the desktop's own backend only. A deliberate `nohup hermes serve &` legitimately reparents to pid 1 when its shell exits; killing that would be a regression, not a fix. This env var is already load-bearing here — `cmd_dashboard` branches on it a few lines below.
3. **POSIX** — same gate `tools/mcp_tool.py` uses.

### Why the call sits after the re-exec

The named-profile re-exec is `os.execvpe` on POSIX, which preserves pid/ppid, so a ppid recorded after it stays valid. On Windows that same branch is `subprocess.Popen`, where it would not — hence both the placement and the POSIX gate. A test asserts the ordering so a future refactor can't silently move it above the re-exec.

## How to Test

Both arms, against a real backend (not a mock). Substitute any Python with the repo importable:

**1. Treatment — desktop-shaped launch self-reaps:**

```bash
cat > /tmp/parent.py <<'PY'
import subprocess, sys, os
p = subprocess.Popen([sys.executable, "-m", "hermes_cli.main",
                      "serve", "--host", "127.0.0.1", "--port", "0"])
open(os.environ["PIDFILE"], "w").write(str(p.pid)); sys.exit(p.wait())
PY
PIDFILE=/tmp/child.pid HERMES_HOME=/tmp/isolated-home HERMES_DESKTOP=1 \
  HERMES_SERVE_WATCHDOG_POLL_S=0.2 python /tmp/parent.py &
sleep 25
CHILD=$(cat /tmp/child.pid); PARENT=$(ps -p $CHILD -o ppid= | tr -d ' ')
lsof -nP -p $CHILD | grep LISTEN     # backend is up and listening
kill -9 $PARENT                       # force-quit: no teardown code runs
sleep 3; ps -p $CHILD || echo "self-reaped"
```

**2. Control — a standalone daemon is left alone.** Same script with `HERMES_DESKTOP` unset: the child survives at `PPID=1`. This both reproduces the original bug and demonstrates the gate protects a deliberate `nohup hermes serve &`.

**3. Unit + integration tests:**

```bash
bash scripts/run_tests.sh --files "tests/hermes_cli/test_serve_parent_death_watchdog.py:tests/hermes_cli/test_serve_command.py:tests/test_slash_worker_watchdog.py"
```

### Results on my machine (macOS 15 / Darwin 25.5.0, Python 3.11.14)

- Treatment: backend **self-reaped 1s** after the parent's SIGKILL; LISTEN socket released.
- Control: backend **survived at PPID=1** — the bug reproduced.
- No spurious firing: under a live parent the backend ran 25s+ without self-reaping.
- Mutation check: with the watchdog loop neutered, the integration test fails with the real "orphan survived" message — confirming the test actually discriminates rather than passing vacuously.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, no unrelated changes)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially; see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0, ARM64), Python 3.11.14

> **Note on the full-suite checkbox, stated plainly rather than ticked:** I ran the change's blast radius — `test_serve_parent_death_watchdog.py`, `test_serve_command.py`, `test_slash_worker_watchdog.py`, `test_dashboard_param_clamps.py`, `test_apply_profile_override.py`, `test_web_server_cron_profiles.py`, `test_argparse_flag_propagation.py`, `tests/dashboard/` — **46 tests, 0 failures** under `scripts/run_tests.sh`. I did not complete a clean full-suite run: running `scripts/run_tests.sh tests/hermes_cli` rebuilt my checkout's `.venv` and removed `pytest` from it, breaking the runner on the next invocation. That looks like the hazard `tests/hermes_cli/test_managed_uv.py:45-46` mocks (the SQLite-repair path probing the real checkout's venv) being reached unmocked somewhere else in that directory. It is unrelated to this change — it reproduced before it — and I'm happy to file it separately if it isn't already known.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior is internal; the rationale is in the code comments and commit message)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys; the one env knob is test-only tuning with a safe default)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — yes, explicitly: the watchdog is POSIX-gated because the Windows re-exec branch invalidates the recorded ppid. Windows behavior is unchanged.
- [x] I've updated tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
