### PR TITLE
fix(cli): sort Kimi k-prefixed versions numerically (#78886)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -820,7 +820,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
 
     for ch in rest:
         if state == "start":
-            if ch in "vV":
+            if ch in "vVkK":
                 state = "in_version"
             elif ch.isdigit():
                 state = "in_version"

--- a/tests/hermes_cli/test_model_sort_key.py
+++ b/tests/hermes_cli/test_model_sort_key.py
@@ -1,0 +1,26 @@
+"""Behavior tests for model-family version sorting."""
+
+import pytest
+
+from hermes_cli.model_switch import _model_sort_key
+
+
+@pytest.mark.parametrize("version_prefix", ["k", "K"])
+def test_letter_prefixed_versions_sort_numerically(version_prefix):
+    prefix = "moonshotai/kimi"
+    older = f"{prefix}-{version_prefix}2.6"
+    newer = f"{prefix}-{version_prefix}3"
+
+    assert sorted(
+        [older, newer],
+        key=lambda model: _model_sort_key(model, prefix),
+    ) == [newer, older]
+
+
+def test_v_prefixed_version_sorting_is_preserved():
+    prefix = "mimo"
+
+    assert sorted(
+        ["mimo-v2.5", "mimo-v3"],
+        key=lambda model: _model_sort_key(model, prefix),
+    ) == ["mimo-v3", "mimo-v2.5"]


### PR DESCRIPTION
## What does this PR do?

Fixes model-family sorting for Kimi IDs whose numeric version is prefixed by
`k` or `K`. These versions now use the same numeric ordering as existing
`v`-prefixed versions, so `k3` sorts ahead of `k2.6`.

## Related Issue

Fixes #78886

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Recognize `k` and `K` in the version parser's initial state.
- Add behavior tests for lowercase and uppercase prefixes.
- Preserve and test existing `v`-prefixed ordering.

## How to Test

1. Before the fix:
   `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_model_sort_key.py -q`
   reports two failures because `k2.6` sorts before `k3`.
2. After the fix:
   `scripts/run_tests.sh tests/hermes_cli/test_model_sort_key.py tests/hermes_cli/test_gpt56_registration.py -q`
   reports 10 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed PRs for duplicate implementations.
- [x] My PR contains only changes related to this fix.
- [x] Focused tests pass.
- [x] I've added tests for the regression.
- [x] Tested on macOS 26.5.1.

### Documentation & Housekeeping

- [x] Documentation update: N/A.
- [x] Config example update: N/A.
- [x] Architecture documentation update: N/A.
- [x] Cross-platform impact considered; the parser is platform-neutral.
- [x] Tool schema update: N/A.
