### PR TITLE
fix(docker): skip gateway reconcile in serve containers (#78810)

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -350,16 +350,16 @@ def _is_legacy_gateway_run_request(argv: Sequence[str]) -> bool:
     return len(args) >= 2 and args[0] == "gateway" and args[1] == "run"
 
 
-def _is_dashboard_container(argv: Sequence[str]) -> bool:
-    """Return True when the container's command is the dashboard.
+def _is_web_server_container(argv: Sequence[str]) -> bool:
+    """Return True when the container runs ``dashboard`` or ``serve``.
 
-    A dashboard-only container (``hermes dashboard ...``) never spawns or
-    supervises per-profile gateways — that is the gateway container's job.
+    Web-server containers never spawn or supervise per-profile gateways —
+    that is the gateway container's job.
     Reconciling profile gateway s6 slots there is not just wasted work: when
-    the gateway and dashboard containers share a bind-mounted HERMES_HOME,
+    gateway and web-server containers share a bind-mounted HERMES_HOME,
     both race to ``flock()`` the same ``logs/gateways/<profile>/lock`` files,
     producing "Resource busy" failures and an s6-log restart storm. So the
-    dashboard container skips reconciliation entirely.
+    web-server container skips reconciliation entirely.
 
     Detected from PID 1 argv (``/proc/1/cmdline``) rather than an operator
     flag: the role is a fact about the container's command, not a tunable,
@@ -368,7 +368,7 @@ def _is_dashboard_container(argv: Sequence[str]) -> bool:
     in :func:`_is_legacy_gateway_run_request`.
     """
     args = _strip_container_argv_prefix(argv)
-    return bool(args) and args[0] == "dashboard"
+    return bool(args) and args[0] in {"dashboard", "serve"}
 
 
 def _read_desired_state(profile_dir: Path) -> str | None:
@@ -582,18 +582,18 @@ _LOG_ROTATE_BYTES = 256 * 1024
 
 def main() -> int:
     """Entry point invoked from /etc/cont-init.d/02-reconcile-profiles."""
-    # A dashboard-only container never spawns or supervises per-profile
+    # Web-server containers never spawn or supervise per-profile
     # gateways, so reconciling their s6 slots here is pure waste — and
-    # actively harmful: when the gateway and dashboard containers share a
+    # actively harmful: when gateway and web-server containers share a
     # bind-mounted HERMES_HOME, both race to flock() the same s6-log lock
     # files under logs/gateways/<profile>/lock, producing "Resource busy"
     # failures and a restart storm. Detect the role from PID 1 argv and
-    # skip reconciliation in the dashboard container. No operator flag:
+    # skip reconciliation in the web-server container. No operator flag:
     # the role is a fact about the container's command, and a flag can be
     # forgotten in a hand-written manifest, reintroducing the storm.
-    if _is_dashboard_container(_read_container_argv()):
+    if _is_web_server_container(_read_container_argv()):
         print(
-            "reconcile: skipping (dashboard container — does not need "
+            "reconcile: skipping (web server container — does not need "
             "per-profile gateways)"
         )
         return 0

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -230,7 +230,7 @@ def test_profiles_default_subdir_is_skipped_with_warning(
 
 
 # ---------------------------------------------------------------------------
-# Dashboard-container role detection (skip reconcile on the dashboard)
+# Web-server container role detection (skip reconcile on dashboard/serve)
 # ---------------------------------------------------------------------------
 
 
@@ -283,7 +283,43 @@ def test_main_skips_reconcile_in_dashboard_container_s6v3(
     assert rc == 0
     assert not (scandir / "gateway-worker").exists()
     assert not (scandir / "gateway-default").exists()
-    assert "skipping (dashboard container" in capsys.readouterr().out
+    assert "skipping (web server container" in capsys.readouterr().out
+
+
+def test_main_skips_reconcile_in_serve_container_s6v3(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A headless desktop backend must not supervise profile gateways."""
+    from hermes_cli import container_boot
+
+    scandir = tmp_path / "run-service"
+    scandir.mkdir()
+    _make_profile(tmp_path, "worker", state="running")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("S6_PROFILE_GATEWAY_SCANDIR", str(scandir))
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: (
+            "/bin/sh",
+            "-e",
+            "/run/s6/basedir/scripts/rc.init",
+            "top",
+            "/opt/hermes/docker/main-wrapper.sh",
+            "serve",
+            "--host",
+            "0.0.0.0",
+        ),
+    )
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    assert not (scandir / "gateway-worker").exists()
+    assert not (scandir / "gateway-default").exists()
+    assert "skipping (web server container" in capsys.readouterr().out
 
 
 
@@ -297,7 +333,5 @@ def _write_lifecycle_sentinel(profile_dir: Path, payload: dict) -> None:
     state_dir = profile_dir / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     (state_dir / "gateway.lifecycle.json").write_text(json.dumps(payload))
-
-
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents headless `hermes serve` containers from reconciling and auto-starting
per-profile s6 gateway services. A `serve` container sharing `HERMES_HOME`
with a dedicated gateway container now follows the same skip path as
`dashboard`, avoiding duplicate messaging gateways.

## Related Issue

Fixes #78810

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Generalize dashboard role detection to the two web-server commands:
  `dashboard` and `serve`.
- Keep ordinary CLI container commands unchanged.
- Add an s6-overlay v3 regression that asserts `serve` creates neither the
  default nor named profile gateway service slots.
- Preserve the existing dashboard regression.

## How to Test

1. Before the fix:
   `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_container_boot.py -k serve_container_s6v3 -q`
   fails after creating and starting `gateway-worker`.
2. After the fix:
   `scripts/run_tests.sh tests/hermes_cli/test_container_boot.py -q`
   reports 6 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed PRs for duplicate implementations.
- [x] My PR contains only changes related to this fix.
- [x] Focused tests pass.
- [x] I've added a regression test.
- [x] Tested on macOS 26.5.1 with a hermetic fake s6 service directory.

### Documentation & Housekeeping

- [x] Documentation update: N/A.
- [x] Config example update: N/A.
- [x] Architecture documentation update: N/A.
- [x] Cross-platform impact considered; this is container argv processing.
- [x] Tool schema update: N/A.
