### PR TITLE
fix: polish Buzz coordinator transport

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -167,6 +167,11 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     # global ("all") defaults and compacted/narrated on nearly every turn.
     "photon":          _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
+    # Buzz DMs are permanent-message coordinator inboxes. Keep the timeline
+    # final-answer-first: the inbound reaction is the pickup signal, while
+    # tool traces, scratch commentary, heartbeat repeats, and iteration counts
+    # belong in logs unless the user explicitly opts in per platform.
+    "buzz":            {**_TIER_LOW, "busy_steer_ack_enabled": False},
     "weixin":          _TIER_LOW,
     "wecom":           _TIER_LOW,
     "wecom_callback":  _TIER_LOW,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -88,6 +88,13 @@ from gateway.config import Platform
 # returns housekeeping kinds (joins, canvas updates, …) — only kind 9 is
 # dispatched to the agent.
 _CHAT_KIND = 9
+
+# buzz-cli treats every prose ``@token`` as a member mention and rejects the
+# whole send when it cannot resolve one. Supplying one explicit identity tells
+# the CLI to permit unresolved at-sign text while leaving the content bytes
+# untouched. Avoid matching email addresses (the ``@`` is preceded by a word
+# character there).
+_AT_SIGN_TOKEN_RE = re.compile(r"(?<!\w)@[A-Za-z0-9_][A-Za-z0-9_.-]*")
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
@@ -609,9 +616,17 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        # A Buzz DM is already a single private timeline. Turning every
+        # assistant answer into a reply creates hidden one-message threads and
+        # makes the coordinator look silent in the main conversation.
+        state = self._channel_state.get(str(chat_id)) or {}
+        reply_target = None
+        if state.get("chat_type") != "dm":
+            reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
+        if self._self_pubkey and _AT_SIGN_TOKEN_RE.search(content):
+            args += ["--mention", self._self_pubkey]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -628,9 +643,11 @@ class BuzzAdapter(BasePlatformAdapter):
             # Belt-and-braces echo suppression: the poll loop already skips
             # our own pubkey, but marking the id seen makes de-dupe explicit.
             self._mark_seen(str(chat_id), str(event_id))
+        accepted = bool(data.get("accepted", True))
         return SendResult(
-            success=bool(data.get("accepted", True)),
+            success=accepted,
             message_id=str(event_id) if event_id else None,
+            error=None if accepted else str(data.get("message") or "Buzz rejected message"),
             raw_response=data,
         )
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -407,6 +407,73 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_allows_unresolved_at_sign_prose_without_rewriting_content(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-at", "message": ""})
+        adapter._run_cli = cli
+
+        content = "The @session token is documentation, not a Buzz member."
+        result = await adapter.send(CHANNEL, content)
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--mention") + 1] == SELF_PUBKEY
+        assert stdin_text == content
+
+    @pytest.mark.asyncio
+    async def test_send_preserves_real_multiline_text(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-lines", "message": ""})
+        adapter._run_cli = cli
+
+        content = "first line\nsecond line\n\nfinal paragraph"
+        result = await adapter.send(CHANNEL, content)
+
+        assert result.success is True
+        assert cli.calls[0][1] == content
+
+    @pytest.mark.asyncio
+    async def test_dm_send_stays_top_level_even_with_reply_metadata(self):
+        adapter = _make_adapter()
+        adapter._channel_state[DM_CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-flat", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            DM_CHANNEL,
+            "visible in the DM timeline",
+            reply_to="inbound-event",
+            metadata={"thread_id": "inbound-event"},
+        )
+
+        assert result.success is True
+        args, _ = cli.calls[0]
+        assert "--reply-to" not in args
+
+    @pytest.mark.asyncio
+    async def test_rejected_send_returns_cli_message_as_failure(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": False, "event_id": "", "message": "unrecognized member"},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is False
+        assert result.error == "unrecognized member"
+
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -168,6 +168,16 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "slack", "long_running_notifications") is False
         assert resolve_display_setting({}, "slack", "busy_ack_detail") is False
 
+    def test_buzz_private_coordinator_defaults_to_final_answer_only(self):
+        """Buzz is a permanent-message mobile inbox, not a debug console."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "buzz", "tool_progress") == "off"
+        assert resolve_display_setting({}, "buzz", "interim_assistant_messages") is False
+        assert resolve_display_setting({}, "buzz", "long_running_notifications") is False
+        assert resolve_display_setting({}, "buzz", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "buzz", "busy_steer_ack_enabled") is False
+
 
 # ---------------------------------------------------------------------------
 # Config migration: tool_progress_overrides → display.platforms


### PR DESCRIPTION
## Summary
- make Buzz coordinator conversations final-answer-first by default
- keep DM responses in the top-level timeline and preserve literal multiline payloads
- allow non-member `@token` prose without rewriting content and surface relay rejections

## Verification
- strict TDD: four regression tests observed red before implementation
- focused gateway suite: 74 passed
- ruff on changed files: passed
- independent frozen-diff review: passed
- full suite: 23k-test run completed with 124 unrelated optional/platform environment failures; no changed-file failures

## Runtime architecture
Native Hermes Buzz gateway is the sole intended automatic executor. Buzz Desktop ACP is an observer/manual surface and must not auto-publish a second Coordinator run. Local native gateway remains configured enabled; managed ACP cutover is tracked separately because it is owned by Buzz Desktop UI/runtime.