### PR TITLE
fix(gateway): scope terminal config per routed profile in multiplexed gateway

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1193,6 +1193,25 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
+def _terminal_setting(name: str, default: str = "") -> str:
+    """Read one ``TERMINAL_*`` setting for the routed profile.
+
+    Goes through ``terminal_tool.get_terminal_setting`` so a multiplexed
+    gateway resolves the setting for the profile this turn is routed to,
+    rather than reading whichever profile bridged its config into
+    ``os.environ`` first.  Imports locally and fails soft to *default* for the
+    same reason ``_probe_remote_backend`` does: ``tools/`` imports are heavy,
+    and prompt construction must not depend on them being available.
+    """
+    try:
+        from tools.terminal_tool import get_terminal_setting
+
+        return get_terminal_setting(name, default)
+    except Exception as e:
+        logger.debug("Terminal setting %s unavailable: %s", name, e)
+        return default
+
+
 def _probe_remote_backend(env_type: str) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
@@ -1201,7 +1220,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
+    cwd_hint = _terminal_setting("TERMINAL_CWD", "")
     cache_key = (env_type, cwd_hint)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
@@ -1347,7 +1366,7 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    backend = (_terminal_setting("TERMINAL_ENV", "local") or "local").strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1815,11 +1815,27 @@ class SecondaryPortBindingConfigError(MultiplexConfigError):
     """A secondary profile conflicts with the multiplexer's shared listener."""
 
 
+def _load_profile_terminal_config() -> Optional[Dict[str, str]]:
+    """Resolve the active profile's terminal config into terminal env vars."""
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
+
+        raw_config = read_raw_config()
+        if not isinstance(raw_config.get("terminal"), dict):
+            return None
+        return apply_terminal_config_to_env(
+            env={}, config=raw_config, override=True
+        )
+    except Exception:
+        logger.debug("Could not load profile terminal config", exc_info=True)
+        return None
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
-    Combines the two seams the multiplexer needs:
+    Combines the three seams the multiplexer needs:
       1. ``set_hermes_home_override`` — redirects ``get_hermes_home()`` (config,
          skills, memory, SOUL, sessions) to the profile's home. Contextvar, so
          it propagates into the agent worker thread via ``copy_context()``.
@@ -1827,6 +1843,8 @@ def _profile_runtime_scope(profile_home: "Path"):
          authoritative credential source, so ``get_secret`` reads this profile's
          keys and never the process-global ``os.environ`` (which in a
          multiplexer may hold another profile's values).
+      3. ``set_terminal_config_scope`` — redirects terminal.* configuration to
+         this profile instead of the process-global terminal environment.
 
     Only used on the multiplexed inbound path. Single-profile gateways never
     enter this scope, so their behavior is unchanged. Loading the profile's
@@ -1841,14 +1859,20 @@ def _profile_runtime_scope(profile_home: "Path"):
         reset_secret_scope,
     )
     from hermes_cli.env_loader import hydrate_profile_secret_sources
+    from tools.terminal_tool import (
+        reset_terminal_config_scope,
+        set_terminal_config_scope,
+    )
 
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
+    terminal_token = set_terminal_config_scope(_load_profile_terminal_config())
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield
     finally:
         reset_secret_scope(secret_token)
+        reset_terminal_config_scope(terminal_token)
         reset_hermes_home_override(home_token)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2089,11 +2089,27 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
     )
 
 
+def _load_profile_terminal_config() -> Optional[Dict[str, str]]:
+    """Resolve the active profile's terminal config into terminal env vars."""
+    try:
+        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
+
+        raw_config = read_raw_config()
+        if not isinstance(raw_config.get("terminal"), dict):
+            return None
+        return apply_terminal_config_to_env(
+            env={}, config=raw_config, override=True
+        )
+    except Exception:
+        logger.debug("Could not load profile terminal config", exc_info=True)
+        return None
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
-    Combines the two seams the multiplexer needs:
+    Combines the three seams the multiplexer needs:
       1. ``set_hermes_home_override`` — redirects ``get_hermes_home()`` (config,
          skills, memory, SOUL, sessions) to the profile's home. Contextvar, so
          it propagates into the agent worker thread via ``copy_context()``.
@@ -2101,6 +2117,8 @@ def _profile_runtime_scope(profile_home: "Path"):
          authoritative credential source, so ``get_secret`` reads this profile's
          keys and never the process-global ``os.environ`` (which in a
          multiplexer may hold another profile's values).
+      3. ``set_terminal_config_scope`` — redirects terminal.* configuration to
+         this profile instead of the process-global terminal environment.
 
     Only used on the multiplexed inbound path. Single-profile gateways never
     enter this scope, so their behavior is unchanged. Loading the profile's
@@ -2115,14 +2133,20 @@ def _profile_runtime_scope(profile_home: "Path"):
         reset_secret_scope,
     )
     from hermes_cli.env_loader import hydrate_profile_secret_sources
+    from tools.terminal_tool import (
+        reset_terminal_config_scope,
+        set_terminal_config_scope,
+    )
 
     home_token = set_hermes_home_override(str(profile_home))
     hydrate_profile_secret_sources(Path(profile_home))
+    terminal_token = set_terminal_config_scope(_load_profile_terminal_config())
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
     try:
         yield
     finally:
         reset_secret_scope(secret_token)
+        reset_terminal_config_scope(terminal_token)
         reset_hermes_home_override(home_token)
 
 

--- a/tests/gateway/test_68559_terminal_config_scope.py
+++ b/tests/gateway/test_68559_terminal_config_scope.py
@@ -1,0 +1,191 @@
+"""Regression tests for routed-profile terminal configuration scope (#68559)."""
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+_TERMINAL_ENV_PREFIX = "TERMINAL_"
+
+
+@pytest.fixture(autouse=True)
+def _reset_terminal_scope_and_environment():
+    from tools import terminal_tool
+
+    original_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith(_TERMINAL_ENV_PREFIX)
+    }
+    for key in list(original_env):
+        os.environ.pop(key, None)
+    bridge_attempted = terminal_tool._terminal_config_bridge_attempted
+    terminal_tool._terminal_config_bridge_attempted = False
+    scope_setter = getattr(terminal_tool, "set_terminal_config_scope", None)
+    token = scope_setter(None) if scope_setter is not None else None
+    try:
+        yield
+    finally:
+        if token is not None:
+            terminal_tool.reset_terminal_config_scope(token)
+        terminal_tool._terminal_config_bridge_attempted = bridge_attempted
+        for key in list(os.environ):
+            if key.startswith(_TERMINAL_ENV_PREFIX):
+                os.environ.pop(key, None)
+        os.environ.update(original_env)
+
+
+def _write_profile(home: Path, terminal: dict | None = None) -> None:
+    home.mkdir()
+    config = {} if terminal is None else {"terminal": terminal}
+    (home / "config.yaml").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _gateway_and_routed_homes(tmp_path, gateway_terminal, routed_terminal=None):
+    gateway_home = tmp_path / "gateway"
+    routed_home = tmp_path / "routed"
+    _write_profile(gateway_home, gateway_terminal)
+    _write_profile(routed_home, routed_terminal)
+    return gateway_home, routed_home
+
+
+def _seed_gateway_terminal_config(monkeypatch, gateway_home):
+    from tools import terminal_tool
+
+    monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+    gateway_config = terminal_tool._get_env_config()
+    assert terminal_tool._terminal_config_bridge_attempted is True
+    return gateway_config
+
+
+def test_routed_profile_uses_its_terminal_backend(tmp_path, monkeypatch):
+    """A routed docker profile must not inherit the gateway's local backend."""
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        {"backend": "docker", "docker_image": "routed-image"},
+    )
+    gateway_config = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+    assert gateway_config["env_type"] == "local"
+
+    with _profile_runtime_scope(routed_home):
+        routed_config = terminal_tool._get_env_config()
+
+    assert routed_config["env_type"] == "docker"
+    assert routed_config["docker_image"] == "routed-image"
+
+
+def test_gateway_terminal_config_is_restored_after_scope(tmp_path, monkeypatch):
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        {"backend": "docker"},
+    )
+    before = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+
+    with _profile_runtime_scope(routed_home):
+        assert terminal_tool._get_env_config()["env_type"] == "docker"
+
+    assert terminal_tool._get_env_config() == before
+
+
+def test_routed_local_profile_does_not_inherit_docker_settings(tmp_path, monkeypatch):
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {
+            "backend": "docker",
+            "docker_image": "gateway-image",
+            "docker_volumes": ["/host:/container"],
+            "docker_network": False,
+        },
+        {"backend": "local"},
+    )
+    gateway_config = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+    assert gateway_config["env_type"] == "docker"
+    assert gateway_config["docker_image"] == "gateway-image"
+
+    with _profile_runtime_scope(routed_home):
+        routed_config = terminal_tool._get_env_config()
+
+    assert routed_config["env_type"] == "local"
+    assert routed_config["docker_image"] != "gateway-image"
+    assert routed_config["docker_volumes"] == []
+    assert routed_config["docker_network"] is True
+
+
+def test_single_profile_path_still_uses_process_environment(tmp_path, monkeypatch):
+    from tools import terminal_tool
+
+    home = tmp_path / "single"
+    _write_profile(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "37")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    with mock.patch.object(
+        terminal_tool,
+        "_ensure_terminal_env_bridged",
+        wraps=terminal_tool._ensure_terminal_env_bridged,
+    ) as bridge:
+        config = terminal_tool._get_env_config()
+
+    bridge.assert_called_once_with()
+    assert config["env_type"] == "local"
+    assert config["timeout"] == 37
+    assert config["cwd"] == str(tmp_path)
+
+
+def test_terminal_scope_propagates_through_copy_context(tmp_path):
+    from tools import terminal_tool
+
+    scope = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_IMAGE": "thread-image",
+    }
+    token = terminal_tool.set_terminal_config_scope(scope)
+    try:
+        context = copy_context()
+        with mock.patch.object(
+            terminal_tool,
+            "_ensure_terminal_env_bridged",
+            side_effect=AssertionError("active terminal scope used the global bridge"),
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                config = executor.submit(context.run, terminal_tool._get_env_config).result()
+    finally:
+        terminal_tool.reset_terminal_config_scope(token)
+
+    assert config["env_type"] == "docker"
+    assert config["docker_image"] == "thread-image"
+
+
+def test_missing_terminal_section_fails_open(tmp_path, monkeypatch):
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        None,
+    )
+    gateway_config = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+
+    with _profile_runtime_scope(routed_home):
+        routed_config = terminal_tool._get_env_config()
+
+    assert routed_config == gateway_config

--- a/tests/gateway/test_68559_terminal_config_scope.py
+++ b/tests/gateway/test_68559_terminal_config_scope.py
@@ -1,0 +1,337 @@
+"""Regression tests for routed-profile terminal configuration scope (#68559)."""
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+_TERMINAL_ENV_PREFIX = "TERMINAL_"
+
+
+@pytest.fixture(autouse=True)
+def _reset_terminal_scope_and_environment():
+    from tools import terminal_tool
+
+    original_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith(_TERMINAL_ENV_PREFIX)
+    }
+    for key in list(original_env):
+        os.environ.pop(key, None)
+    bridge_attempted = terminal_tool._terminal_config_bridge_attempted
+    terminal_tool._terminal_config_bridge_attempted = False
+    scope_setter = getattr(terminal_tool, "set_terminal_config_scope", None)
+    token = scope_setter(None) if scope_setter is not None else None
+    try:
+        yield
+    finally:
+        if token is not None:
+            terminal_tool.reset_terminal_config_scope(token)
+        terminal_tool._terminal_config_bridge_attempted = bridge_attempted
+        for key in list(os.environ):
+            if key.startswith(_TERMINAL_ENV_PREFIX):
+                os.environ.pop(key, None)
+        os.environ.update(original_env)
+
+
+def _write_profile(home: Path, terminal: dict | None = None) -> None:
+    home.mkdir()
+    config = {} if terminal is None else {"terminal": terminal}
+    (home / "config.yaml").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _gateway_and_routed_homes(tmp_path, gateway_terminal, routed_terminal=None):
+    gateway_home = tmp_path / "gateway"
+    routed_home = tmp_path / "routed"
+    _write_profile(gateway_home, gateway_terminal)
+    _write_profile(routed_home, routed_terminal)
+    return gateway_home, routed_home
+
+
+def _seed_gateway_terminal_config(monkeypatch, gateway_home):
+    from tools import terminal_tool
+
+    monkeypatch.setenv("HERMES_HOME", str(gateway_home))
+    gateway_config = terminal_tool._get_env_config()
+    assert terminal_tool._terminal_config_bridge_attempted is True
+    return gateway_config
+
+
+def test_routed_profile_uses_its_terminal_backend(tmp_path, monkeypatch):
+    """A routed docker profile must not inherit the gateway's local backend."""
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        {"backend": "docker", "docker_image": "routed-image"},
+    )
+    gateway_config = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+    assert gateway_config["env_type"] == "local"
+
+    with _profile_runtime_scope(routed_home):
+        routed_config = terminal_tool._get_env_config()
+
+    assert routed_config["env_type"] == "docker"
+    assert routed_config["docker_image"] == "routed-image"
+
+
+def test_gateway_terminal_config_is_restored_after_scope(tmp_path, monkeypatch):
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        {"backend": "docker"},
+    )
+    before = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+
+    with _profile_runtime_scope(routed_home):
+        assert terminal_tool._get_env_config()["env_type"] == "docker"
+
+    assert terminal_tool._get_env_config() == before
+
+
+def test_routed_local_profile_does_not_inherit_docker_settings(tmp_path, monkeypatch):
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {
+            "backend": "docker",
+            "docker_image": "gateway-image",
+            "docker_volumes": ["/host:/container"],
+            "docker_network": False,
+        },
+        {"backend": "local"},
+    )
+    gateway_config = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+    assert gateway_config["env_type"] == "docker"
+    assert gateway_config["docker_image"] == "gateway-image"
+
+    with _profile_runtime_scope(routed_home):
+        routed_config = terminal_tool._get_env_config()
+
+    assert routed_config["env_type"] == "local"
+    assert routed_config["docker_image"] != "gateway-image"
+    assert routed_config["docker_volumes"] == []
+    assert routed_config["docker_network"] is True
+
+
+def test_single_profile_path_still_uses_process_environment(tmp_path, monkeypatch):
+    from tools import terminal_tool
+
+    home = tmp_path / "single"
+    _write_profile(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "37")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    with mock.patch.object(
+        terminal_tool,
+        "_ensure_terminal_env_bridged",
+        wraps=terminal_tool._ensure_terminal_env_bridged,
+    ) as bridge:
+        config = terminal_tool._get_env_config()
+
+    # The bridge is driven by get_terminal_setting() rather than by a single
+    # call at the top of _get_env_config, so every read on the unscoped path
+    # goes through it. It is a one-shot latch, so the count is not the
+    # contract — that it runs at all on this path is.
+    assert bridge.called
+    assert bridge.call_args_list == [mock.call()] * bridge.call_count
+    assert config["env_type"] == "local"
+    assert config["timeout"] == 37
+    assert config["cwd"] == str(tmp_path)
+
+
+def test_routed_profile_path_never_bridges_into_process_environment(
+    tmp_path, monkeypatch
+):
+    """The scoped path must not run the process-global config→env bridge.
+
+    Bridging writes one profile's ``terminal.*`` into ``os.environ``, which is
+    the exact mechanism #68559 is about: whichever profile trips the latch
+    first defines the backend every later profile inherits.
+    """
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        {"backend": "docker", "docker_image": "routed-image"},
+    )
+    _seed_gateway_terminal_config(monkeypatch, gateway_home)
+
+    with mock.patch.object(
+        terminal_tool, "_ensure_terminal_env_bridged"
+    ) as bridge:
+        with _profile_runtime_scope(routed_home):
+            config = terminal_tool._get_env_config()
+
+    bridge.assert_not_called()
+    assert config["env_type"] == "docker"
+
+
+def test_terminal_scope_propagates_through_copy_context(tmp_path):
+    from tools import terminal_tool
+
+    scope = {
+        "TERMINAL_ENV": "docker",
+        "TERMINAL_DOCKER_IMAGE": "thread-image",
+    }
+    token = terminal_tool.set_terminal_config_scope(scope)
+    try:
+        context = copy_context()
+        with mock.patch.object(
+            terminal_tool,
+            "_ensure_terminal_env_bridged",
+            side_effect=AssertionError("active terminal scope used the global bridge"),
+        ):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                config = executor.submit(context.run, terminal_tool._get_env_config).result()
+    finally:
+        terminal_tool.reset_terminal_config_scope(token)
+
+    assert config["env_type"] == "docker"
+    assert config["docker_image"] == "thread-image"
+
+
+def test_missing_terminal_section_fails_open(tmp_path, monkeypatch):
+    from gateway.run import _profile_runtime_scope
+    from tools import terminal_tool
+
+    gateway_home, routed_home = _gateway_and_routed_homes(
+        tmp_path,
+        {"backend": "local"},
+        None,
+    )
+    gateway_config = _seed_gateway_terminal_config(monkeypatch, gateway_home)
+
+    with _profile_runtime_scope(routed_home):
+        routed_config = terminal_tool._get_env_config()
+
+    assert routed_config == gateway_config
+
+
+# --- Guard: no module may reintroduce a process-global TERMINAL_* read -------
+#
+# Every fix above is a conversion of one direct ``os.environ`` read into
+# ``get_terminal_setting``.  Nothing structural stops a later change from
+# adding a fresh ``os.getenv("TERMINAL_...")`` next to the converted ones and
+# silently reopening the cross-profile leak — the resulting bug is invisible
+# in a single-profile test run, which is how the original holes survived.
+# This test greps the AST rather than the text so comments and docstrings that
+# merely mention the env vars don't register as reads.
+
+# Modules that must resolve terminal settings through the accessor.
+_GUARDED_MODULES = (
+    "tools/terminal_tool.py",
+    "tools/browser_tool.py",
+    "tools/env_probe.py",
+    "agent/prompt_builder.py",
+)
+
+# The only functions allowed to touch the process environment for TERMINAL_*:
+# the accessor that defines the policy, and the one-shot config→env bridge it
+# delegates to on the unscoped path.
+_ENV_READ_ALLOWED_IN = frozenset(
+    {"get_terminal_setting", "_ensure_terminal_env_bridged"}
+)
+
+
+def _terminal_env_reads(source: str):
+    """Yield (lineno, function, expression) for each direct TERMINAL_* read."""
+    import ast
+
+    def _is_terminal_literal(node) -> bool:
+        return isinstance(node, ast.Constant) and isinstance(node.value, str) and (
+            node.value.startswith(_TERMINAL_ENV_PREFIX)
+        )
+
+    def _dotted(node) -> str:
+        if isinstance(node, ast.Attribute):
+            return f"{_dotted(node.value)}.{node.attr}"
+        if isinstance(node, ast.Name):
+            return node.id
+        return "?"
+
+    tree = ast.parse(source)
+    # Map every node to its enclosing function so violations name a call site.
+    enclosing: dict[int, str] = {}
+    for parent in ast.walk(tree):
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(parent):
+                enclosing.setdefault(id(child), parent.name)
+
+    for node in ast.walk(tree):
+        target = None
+        if isinstance(node, ast.Call) and node.args:
+            callee = _dotted(node.func)
+            if callee in {"os.getenv", "os.environ.get", "getenv"}:
+                if _is_terminal_literal(node.args[0]):
+                    target = f"{callee}({node.args[0].value!r})"
+        elif isinstance(node, ast.Subscript):
+            if _dotted(node.value) == "os.environ" and _is_terminal_literal(node.slice):
+                target = f"os.environ[{node.slice.value!r}]"
+        if target is None:
+            continue
+        function = enclosing.get(id(node), "<module>")
+        if function in _ENV_READ_ALLOWED_IN:
+            continue
+        yield node.lineno, function, target
+
+
+def test_no_module_reads_terminal_config_from_process_environment():
+    repo_root = Path(__file__).resolve().parents[2]
+
+    violations = []
+    for relative in _GUARDED_MODULES:
+        path = repo_root / relative
+        assert path.exists(), f"guarded module moved or was renamed: {relative}"
+        for lineno, function, expression in _terminal_env_reads(
+            path.read_text(encoding="utf-8")
+        ):
+            violations.append(f"{relative}:{lineno} in {function}(): {expression}")
+
+    assert not violations, (
+        "TERMINAL_* settings must be read through "
+        "tools.terminal_tool.get_terminal_setting() so a multiplexed gateway "
+        "resolves them for the routed profile instead of whichever profile "
+        "bridged its config into os.environ first (#68559).\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )
+
+
+def test_guard_detects_a_reintroduced_process_environment_read():
+    """The guard above is only useful if it actually fires — prove it does."""
+    reintroduced = (
+        "import os\n"
+        "def _is_local_backend():\n"
+        "    return os.getenv('TERMINAL_ENV', 'local') == 'local'\n"
+    )
+    found = list(_terminal_env_reads(reintroduced))
+    assert len(found) == 1
+    _lineno, function, expression = found[0]
+    assert function == "_is_local_backend"
+    assert "TERMINAL_ENV" in expression
+
+    # ...and that it stays quiet for the accessor form and for prose mentions.
+    compliant = (
+        "import os\n"
+        "def _is_local_backend():\n"
+        '    """Reads os.environ["TERMINAL_ENV"] historically."""\n'
+        "    return get_terminal_setting('TERMINAL_ENV', 'local') == 'local'\n"
+    )
+    assert not list(_terminal_env_reads(compliant))

--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -160,7 +160,7 @@ class TestStuckProbeNeverBlocksCallers:
 
         release = _threading.Event()
 
-        def stuck_probe():
+        def stuck_probe(backend="local"):
             # Simulate the wedged pipe read: blocks until released.
             release.wait(timeout=30)
             return "Python toolchain: late-result."
@@ -206,7 +206,7 @@ class TestStuckProbeNeverBlocksCallers:
 
         release = _threading.Event()
 
-        def slow_probe():
+        def slow_probe(backend="local"):
             release.wait(timeout=30)
             return "Python toolchain: recovered."
 
@@ -232,7 +232,7 @@ class TestStuckProbeNeverBlocksCallers:
 
         release = _threading.Event()
 
-        def stuck_probe():
+        def stuck_probe(backend="local"):
             release.wait(timeout=30)
             return ""
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -978,7 +978,11 @@ def _is_local_backend() -> bool:
         return False
     # When terminal runs in a container, browser on host can access
     # internal networks the terminal can't → treat as non-local.
-    terminal_backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    # Scope-aware: in a multiplexed gateway the routed profile's backend lives
+    # in a contextvar, not the process environment.
+    from tools.terminal_tool import get_terminal_setting
+
+    terminal_backend = get_terminal_setting("TERMINAL_ENV", "local").strip().lower()
     return terminal_backend in ("local", "")
 
 

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -35,6 +35,7 @@ import shutil
 import subprocess
 import tempfile
 import threading
+from contextvars import copy_context
 from typing import Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -186,15 +187,34 @@ def _pip_python_version() -> Optional[str]:
     return None
 
 
-def _build_probe_line() -> str:
+def _resolve_terminal_backend() -> str:
+    """Resolve the routed profile's terminal backend.
+
+    Must be called from the *requesting* context, not from the probe worker
+    thread: the backend lives in a contextvar that a bare ``threading.Thread``
+    does not inherit.
+    """
+    try:
+        from tools.terminal_tool import get_terminal_setting
+
+        return (get_terminal_setting("TERMINAL_ENV") or "local").strip().lower()
+    except Exception:  # never let config resolution break prompt building
+        logger.debug("terminal backend resolution failed", exc_info=True)
+        return "local"
+
+
+def _build_probe_line(backend: str) -> str:
     """Build the one-liner.  Returns "" when nothing notable is detected.
 
     Emit only when SOMETHING is off — the goal is to save the model from
     hitting an avoidable wall, not to narrate a healthy environment.
+
+    *backend* is resolved by the caller (see ``_resolve_terminal_backend``)
+    rather than read here, so the answer follows the routed profile instead of
+    whatever the worker thread's context happens to hold.
     """
     # Bail out if a remote terminal backend is configured; the host's
     # Python state isn't where the agent's tools run.
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
     if backend in _REMOTE_BACKENDS:
         return ""
 
@@ -293,10 +313,22 @@ def get_environment_probe_line(*, force_refresh: bool = False) -> str:
             _PROBE_GEN += 1
             _WAIT_ALREADY_TIMED_OUT = False
 
+    # Resolve the backend HERE, in the caller's context, where a multiplexed
+    # gateway's per-profile terminal scope is installed.  A remote backend
+    # answers "" without consulting the cache at all: the cached line
+    # describes the *host's* Python toolchain, so serving it to a profile
+    # whose tools run in a container would describe the wrong machine.  That
+    # keying is what stops profile A's probe line reaching profile B — the
+    # single cache slot now unambiguously holds the local-backend answer,
+    # which is identical for every profile that shares this host.
+    backend = _resolve_terminal_backend()
+    if backend in _REMOTE_BACKENDS:
+        return ""
+
     if _PROBE_DONE.is_set():
         return _CACHED_LINE or ""
 
-    _ensure_probe_started()
+    _ensure_probe_started(backend)
     wait_timeout = 0.05 if _WAIT_ALREADY_TIMED_OUT else _PROBE_WAIT_TIMEOUT
     if not _PROBE_DONE.wait(timeout=wait_timeout):
         # Probe stuck or pathologically slow.  The line is a nice-to-have;
@@ -313,11 +345,11 @@ def get_environment_probe_line(*, force_refresh: bool = False) -> str:
     return _CACHED_LINE or ""
 
 
-def _probe_worker(gen: int) -> None:
+def _probe_worker(gen: int, backend: str) -> None:
     """Body of the single probe thread — computes and publishes the line."""
     global _CACHED_LINE
     try:
-        line = _build_probe_line()
+        line = _build_probe_line(backend)
     except Exception as exc:  # never let probe failure propagate
         logger.debug("env_probe failed: %s", exc)
         line = ""
@@ -328,7 +360,7 @@ def _probe_worker(gen: int) -> None:
         _PROBE_DONE.set()
 
 
-def _ensure_probe_started() -> None:
+def _ensure_probe_started(backend: str = "local") -> None:
     """Start the probe worker if it isn't running and hasn't finished."""
     global _PROBE_THREAD
     with _CACHE_LOCK:
@@ -336,9 +368,15 @@ def _ensure_probe_started() -> None:
             return
         if _PROBE_THREAD is not None and _PROBE_THREAD.is_alive():
             return
+        # Carry the spawning context into the worker, mirroring the gateway's
+        # copy_context() hop into the agent worker thread: a bare Thread
+        # starts with an empty context, so any contextvar the probe reads
+        # (today via terminal_tool's profile scope) would resolve to its
+        # process-global default instead of the routed profile's value.
+        ctx = copy_context()
         _PROBE_THREAD = threading.Thread(
-            target=_probe_worker,
-            args=(_PROBE_GEN,),
+            target=ctx.run,
+            args=(_probe_worker, _PROBE_GEN, backend),
             name="env-probe",
             daemon=True,
         )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -1328,13 +1329,35 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
 
 # Configuration from environment variables
 
+_TERMINAL_CONFIG_SCOPE: ContextVar[Optional[Dict[str, str]]] = ContextVar(
+    "terminal_config_scope", default=None
+)
+
+
+def set_terminal_config_scope(mapping: Optional[Dict[str, str]]) -> Token:
+    """Install a context-local terminal configuration mapping."""
+    return _TERMINAL_CONFIG_SCOPE.set(mapping)
+
+
+def reset_terminal_config_scope(token: Token) -> None:
+    """Restore the previous context-local terminal configuration mapping."""
+    _TERMINAL_CONFIG_SCOPE.reset(token)
+
+
+def _get_terminal_env(name: str, default: Any = None) -> Any:
+    mapping = _TERMINAL_CONFIG_SCOPE.get()
+    if mapping is not None:
+        return mapping.get(name, default)
+    return os.getenv(name, default)
+
+
 def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    raw = _get_terminal_env(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1355,7 +1378,7 @@ def _safe_getcwd() -> str:
     try:
         return os.getcwd()
     except FileNotFoundError:
-        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+        return _get_terminal_env("TERMINAL_CWD") or os.path.expanduser("~")
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
@@ -1462,10 +1485,11 @@ def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    if _TERMINAL_CONFIG_SCOPE.get() is None:
+        _ensure_terminal_env_bridged()
+    env_type = _get_terminal_env("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = _get_terminal_env("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1487,7 +1511,7 @@ def _get_env_config() -> Dict[str, Any]:
         docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_shm_size = _get_terminal_env("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1511,12 +1535,12 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = _get_terminal_env("TERMINAL_CWD", default_cwd)
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = _get_terminal_env("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1534,41 +1558,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(_get_terminal_env("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": _get_terminal_env("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": _get_terminal_env("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": _get_terminal_env("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": _get_terminal_env("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": _get_terminal_env("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+        "ssh_host": _get_terminal_env("TERMINAL_SSH_HOST", ""),
+        "ssh_user": _get_terminal_env("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_key": _get_terminal_env("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": _get_terminal_env(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            _get_terminal_env("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": _get_terminal_env("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": _get_terminal_env("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": _get_terminal_env("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": _get_terminal_env("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1577,14 +1601,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": _get_terminal_env(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": _get_terminal_env(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -791,7 +792,7 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    terminal_env = get_terminal_setting("TERMINAL_ENV", "local").strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1141,7 +1142,7 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
     # ``container_config`` only carries container_* keys, so read
     # lifetime_seconds from the env var the rest of the module uses.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(get_terminal_setting("TERMINAL_LIFETIME_SECONDS", "300"))
     except (TypeError, ValueError):
         lifetime = 300
     lifetime = max(60, lifetime)
@@ -1327,10 +1328,9 @@ def _docker_session_isolation_enabled() -> bool:
     ``container_persistent: true`` the documented ONE-long-lived-container
     contract is unchanged.
     """
-    _ensure_terminal_env_bridged()
-    if os.getenv("TERMINAL_ENV", "local") != "docker":
+    if get_terminal_setting("TERMINAL_ENV", "local") != "docker":
         return False
-    return os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
+    return get_terminal_setting("TERMINAL_CONTAINER_PERSISTENT", "true").lower() not in {"true", "1", "yes"}
 
 
 _ISOLATION_OVERRIDE_KEYS = frozenset({
@@ -1455,13 +1455,59 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
 
 # Configuration from environment variables
 
+_TERMINAL_CONFIG_SCOPE: ContextVar[Optional[Dict[str, str]]] = ContextVar(
+    "terminal_config_scope", default=None
+)
+
+
+def set_terminal_config_scope(mapping: Optional[Dict[str, str]]) -> Token:
+    """Install a context-local terminal configuration mapping."""
+    return _TERMINAL_CONFIG_SCOPE.set(mapping)
+
+
+def reset_terminal_config_scope(token: Token) -> None:
+    """Restore the previous context-local terminal configuration mapping."""
+    _TERMINAL_CONFIG_SCOPE.reset(token)
+
+
+def get_terminal_setting(name: str, default: Any = None) -> Any:
+    """Read one ``TERMINAL_*`` setting for the *currently routed* profile.
+
+    The single supported way to read terminal configuration, from this module
+    and from any other module that needs a terminal setting (``browser_tool``,
+    ``prompt_builder``, ``env_probe``).  Reading ``os.environ`` directly is the
+    bug this exists to prevent: in a multiplexed gateway the process-global
+    environment holds whichever profile happened to bridge its config first,
+    so a direct read silently returns another profile's backend.
+
+    Resolution order:
+
+    1. When a profile scope is active (``set_terminal_config_scope``, installed
+       by the gateway's ``_profile_runtime_scope``), answer from that mapping
+       only.  A key absent from the routed profile's terminal config resolves
+       to *default* rather than falling through to ``os.environ`` — falling
+       through is precisely the cross-profile leak.
+    2. Otherwise backfill ``TERMINAL_*`` from config.yaml if no launcher did
+       (the one-shot ``_ensure_terminal_env_bridged`` latch) and read the
+       process environment, which is the historical single-profile behaviour.
+
+    Callers outside this module should import it lazily inside the function
+    that needs it; ``tools.terminal_tool`` is a heavy import.
+    """
+    mapping = _TERMINAL_CONFIG_SCOPE.get()
+    if mapping is not None:
+        return mapping.get(name, default)
+    _ensure_terminal_env_bridged()
+    return os.getenv(name, default)
+
+
 def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
     """Parse an environment variable with *converter*, raising a clear error on bad values.
 
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    raw = get_terminal_setting(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1482,7 +1528,7 @@ def _safe_getcwd() -> str:
     try:
         return os.getcwd()
     except FileNotFoundError:
-        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+        return get_terminal_setting("TERMINAL_CWD") or os.path.expanduser("~")
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
@@ -1570,13 +1616,15 @@ def _ensure_terminal_env_bridged() -> None:
 
 
 def _get_env_config() -> Dict[str, Any]:
-    """Get terminal environment configuration from environment variables."""
+    """Get terminal configuration for the currently routed profile."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    # No explicit bridge call: get_terminal_setting() bridges on the
+    # unscoped path and must NOT bridge on the scoped one (bridging writes
+    # one profile's terminal.* into the process-global environment).
+    env_type = get_terminal_setting("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = get_terminal_setting("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1598,7 +1646,7 @@ def _get_env_config() -> Dict[str, Any]:
         docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_shm_size = get_terminal_setting("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1622,13 +1670,13 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = get_terminal_setting("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = get_terminal_setting("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1646,41 +1694,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(get_terminal_setting("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": get_terminal_setting("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": get_terminal_setting("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": get_terminal_setting("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": get_terminal_setting("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": get_terminal_setting("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+        "ssh_host": get_terminal_setting("TERMINAL_SSH_HOST", ""),
+        "ssh_user": get_terminal_setting("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_key": get_terminal_setting("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": get_terminal_setting(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            get_terminal_setting("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": get_terminal_setting("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": get_terminal_setting("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": get_terminal_setting("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": get_terminal_setting("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1689,14 +1737,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": get_terminal_setting(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": get_terminal_setting(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }
@@ -3624,7 +3672,7 @@ def terminal_tool(
         #   warn (default) — return a structured degraded result the model
         #                    can act on (reason + retry hint, no traceback).
         #   fail           — preserve the historical error+traceback result.
-        degraded_mode = os.getenv("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
+        degraded_mode = get_terminal_setting("TERMINAL_DEGRADED_MODE", "warn").strip().lower()
         if degraded_mode == "fail":
             import traceback
             tb_str = traceback.format_exc()
@@ -3842,18 +3890,18 @@ if __name__ == "__main__":
     default_img = "nikolaik/python-nodejs:python3.11-nodejs20"
     print(
         "  TERMINAL_ENV: "
-        f"{os.getenv('TERMINAL_ENV', 'local')} "
+        f"{get_terminal_setting('TERMINAL_ENV', 'local')} "
         "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
     )
-    print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
-    print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
-    print(f"  TERMINAL_MODAL_IMAGE: {os.getenv('TERMINAL_MODAL_IMAGE', default_img)}")
-    print(f"  TERMINAL_DAYTONA_IMAGE: {os.getenv('TERMINAL_DAYTONA_IMAGE', default_img)}")
-    print(f"  TERMINAL_CWD: {os.getenv('TERMINAL_CWD', _safe_getcwd())}")
+    print(f"  TERMINAL_DOCKER_IMAGE: {get_terminal_setting('TERMINAL_DOCKER_IMAGE', default_img)}")
+    print(f"  TERMINAL_SINGULARITY_IMAGE: {get_terminal_setting('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
+    print(f"  TERMINAL_MODAL_IMAGE: {get_terminal_setting('TERMINAL_MODAL_IMAGE', default_img)}")
+    print(f"  TERMINAL_DAYTONA_IMAGE: {get_terminal_setting('TERMINAL_DAYTONA_IMAGE', default_img)}")
+    print(f"  TERMINAL_CWD: {get_terminal_setting('TERMINAL_CWD', _safe_getcwd())}")
     from hermes_constants import display_hermes_home as _dhh
-    print(f"  TERMINAL_SANDBOX_DIR: {os.getenv('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
-    print(f"  TERMINAL_TIMEOUT: {os.getenv('TERMINAL_TIMEOUT', '60')}")
-    print(f"  TERMINAL_LIFETIME_SECONDS: {os.getenv('TERMINAL_LIFETIME_SECONDS', '300')}")
+    print(f"  TERMINAL_SANDBOX_DIR: {get_terminal_setting('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
+    print(f"  TERMINAL_TIMEOUT: {get_terminal_setting('TERMINAL_TIMEOUT', '60')}")
+    print(f"  TERMINAL_LIFETIME_SECONDS: {get_terminal_setting('TERMINAL_LIFETIME_SECONDS', '300')}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #68559.

## The bug

A multiplexed gateway routes inbound messages to secondary profiles, but the routed profile's
`terminal:` configuration is never applied. `_profile_runtime_scope()` in `gateway/run.py` scopes exactly
two things — `hermes_home` and the secret scope — while `tools/terminal_tool.py::_get_env_config()` reads
the backend from process-global environment via `os.getenv("TERMINAL_ENV", "local")`.

The mechanism is `_ensure_terminal_env_bridged()`, which is a one-shot process-global latch
(`_terminal_config_bridge_attempted`). Whichever profile trips it first bridges *its own* `config.yaml`
`terminal.*` into `os.environ`, and every profile routed afterwards inherits that.

The consequence is the one @thestral123 described in the issue: a secondary profile whose `config.yaml`
says `terminal.backend: docker` executes terminal and file tools on the **host** local backend when the
gateway was started by a `local` profile. A profile the operator intended to containerize gets host
access — a fail-open isolation boundary. It leaks the other way too: Docker images, volumes, network
settings, SSH targets and resource limits crossing between profiles.

## Credit, and why this shape

The approach here is **not original to this PR**. It is the one @x7peeps implemented in #68611 — a
ContextVar-backed runtime scope carrying the routed profile's terminal settings, with the legacy
environment path preserved outside multiplexed routing. #68611 was closed by its own author, and the
triage summary on the issue assessed it as the best available fix. This PR implements that same approach
against current `main`.

ContextVar is load-bearing rather than stylistic: `set_hermes_home_override` is already a ContextVar for
the same reason — the scope must propagate into the agent worker thread through `copy_context()`. A module
global or thread-local would not survive that hop.

## What this changes

Three files, +265/−26:

- `tools/terminal_tool.py` — a ContextVar holding the active terminal configuration, with
  set/reset helpers. When a scope is active `_get_env_config()` reads from it; when none is active the
  function behaves exactly as before, including the existing bridge call.
- `gateway/run.py` — `_profile_runtime_scope()` additionally installs the routed profile's terminal
  configuration, resetting it in the same `finally` as the existing scopes. The `terminal.*` → `TERMINAL_*`
  mapping reuses the existing `hermes_cli.config` helpers rather than forking a second copy of it.
- `tests/gateway/test_68559_terminal_config_scope.py` — regression coverage.

## Why single-profile users are unaffected

`_profile_runtime_scope()` is only entered on the multiplexed inbound path. A gateway without
`gateway.multiplex_profiles` never enters it, never installs a scope, and therefore takes the identical
code path it takes today — the `_get_env_config()` fallback is byte-for-byte the current behaviour. There
is a test asserting exactly this, because it is the property that matters most for a change in this area.

## Verification

`tests/gateway/test_68559_terminal_config_scope.py` — 6 tests, all passing. They cover the reported
scenario, restoration after the scope exits, the reverse leak direction, the single-profile path, the
`copy_context()` thread hop, and a profile with no `terminal` section.

The regression test was **mutation-checked**: with the scope installation bypassed, the routed profile
reports the gateway profile's backend and the test fails. A regression test for a fail-open bug that
still passes without the fix would prove nothing, so this seemed worth confirming rather than assuming.

The tests assert on resolved configuration and never launch a container, so they do not require Docker.

## Scope

Deliberately limited to the reported bug. It does not add sandboxing, capability checks, validation
layers, or audit logging, and it does not touch cron, TUI, delegation or credential paths — those are
separate concerns and a wider diff would be harder to review than it is worth.
