### PR TITLE
fix(tools): tolerate around_message_id=0 placeholder in session_search scroll mode

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -905,7 +905,17 @@ def session_search(
             current_session_id = None
 
     # Scroll shape takes precedence — explicit anchor beats any query.
-    if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+    # Guard: a non-positive anchor (0 or negative) can never match a real
+    # message id in the DB. Some models emit around_message_id=0 as a
+    # placeholder when they have no real anchor (gpt-5.6-luna does this
+    # consistently); treating it as a valid scroll anchor makes every call
+    # fail and the agent retry forever. Treat non-positive anchors as "no
+    # anchor" and fall through to read/discovery.
+    try:
+        _anchor_ok = around_message_id is not None and int(around_message_id) > 0
+    except (TypeError, ValueError):
+        _anchor_ok = False
+    if (isinstance(session_id, str) and session_id.strip()) and _anchor_ok:
         return _scroll(
             db=db,
             session_id=session_id,


### PR DESCRIPTION
## Bug Description

When a model calls `session_search` in scroll mode with a placeholder anchor, the agent loops forever: every call fails with `around_message_id 0 not in session_id ...` and the model retries across different sessions until the tool-loop guardrail hard-stops the turn — wasting API budget and ending with no answer at all.

Reproduced with `gpt-5.6-luna` via a third-party relay: the model consistently emits `around_message_id: 0` as a placeholder when it has no real anchor (observed with "我昨天做了些啥" / "what did I do yesterday"-style recall questions). DeepSeek and other models that omit the anchor work fine, which is why this went unnoticed.

## Root Cause

`session_search`'s mode dispatch treats *any* non-None `around_message_id` as an explicit scroll anchor:

```python
if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
    return _scroll(...)
```

`around_message_id` values are DB message IDs, which are always positive. `0` (and any negative value) can never match a real message, so the scroll always errors. The model receives the error, tries the "same" call against another session (a new attempt in its eyes, not a repeat), and the failure signature differs per session — so even `repeated_exact_failure` guardrails don't trigger until `same_tool_failure` eventually halts the turn.

## Fix

Treat non-positive anchors as "no anchor" and fall through to read/discovery:

```python
try:
    _anchor_ok = around_message_id is not None and int(around_message_id) > 0
except (TypeError, ValueError):
    _anchor_ok = False
if (isinstance(session_id, str) and session_id.strip()) and _anchor_ok:
    return _scroll(...)
```

With `around_message_id=0` + a session_id, the call now falls through to the read shape (dumps the session), which is exactly what the model wanted — it asked to see that session's content. With no session_id, it falls through to discovery as before. Genuine scroll calls (real positive anchor) are unaffected.

## How to Verify

1. Call `session_search(query="...", session_id="<any real session>", around_message_id=0)` — previously returned `around_message_id 0 not in session_id ...`, now returns the session content in read mode.
2. Call `session_search(session_id="<real session>", around_message_id=<real message id>)` — still returns the anchored window in scroll mode.
3. Call `session_search(query="...")` — still returns discovery results.

## Test Plan

- [x] Existing tests pass: `tests/tools/test_session_search.py` — 39 passed
- [x] Manual verification of the three shapes above (read / scroll / discovery)
- [ ] Added regression test (can add if maintainers want one — the dispatch guard is covered by existing scroll tests)

## Risk Assessment

Low — the change only widens the fall-through condition for anchors that could never resolve anyway. Positive anchors behave identically to before.
