### PR TITLE
docs(sessions): document session_search read shape (#78991)

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -2,7 +2,7 @@
 """
 Session Search Tool - Long-Term Conversation Recall
 
-Single-shape tool with three calling modes (inferred from args, no explicit
+Single-shape tool with four calling modes (inferred from args, no explicit
 mode parameter):
 
   1. DISCOVERY — pass ``query``. Runs FTS5, dedupes hits by session lineage,
@@ -15,10 +15,14 @@ mode parameter):
      scroll forward / backward, re-anchor on the last / first message id of
      the returned window.
 
-  3. BROWSE — no args. Returns recent sessions chronologically (titles,
+  3. READ — pass ``session_id`` only. Returns the full session when small;
+     large sessions are bounded to the first 20 and last 10 messages. This
+     also resolves ``@session:<profile>/<id>`` links from discovery results.
+
+  4. BROWSE — no args. Returns recent sessions chronologically (titles,
      previews, timestamps).
 
-All three modes operate on the SQLite session DB via the FTS5 index and
+All four modes operate on the SQLite session DB via the FTS5 index and
 the get_anchored_view / get_messages_around primitives in hermes_state.
 No LLM calls anywhere — every shape returns actual messages from the DB.
 

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -569,9 +569,9 @@ For deeper analytics — token usage, cost estimates, tool breakdown, and activi
 
 ## Session Search Tool
 
-The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls, no summarization, no truncation. Every shape returns actual messages from the DB.
+The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls or summarization: every shape returns actual messages from the DB. Small session reads return in full; large reads are bounded to the first 20 and last 10 messages.
 
-### Three calling shapes
+### Four calling shapes
 
 The tool infers what you want from which arguments you set. There's no `mode` parameter.
 
@@ -607,7 +607,17 @@ Returns a window of ±`window` messages centered on the anchor. No FTS5, no book
 
 Typical wall time: 1–2ms per scroll call.
 
-**3. Browse — no args:**
+**3. Read — pass `session_id` only:**
+
+```python
+session_search(session_id="20260510_174648_805cc2")
+```
+
+Reads one session without an FTS5 query or anchor. Small sessions return in
+full; large sessions are bounded to the first 20 and last 10 messages. This
+shape also resolves `@session:<profile>/<id>` links returned by discovery.
+
+**4. Browse — no args:**
 
 ```python
 session_search()

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -147,7 +147,7 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 
 | 工具 | 描述 | 所需环境 |
 |------|------|----------|
-| `session_search` | 搜索存储在本地会话数据库中的历史会话，或在某个会话内滚动浏览。基于 FTS5 检索；返回数据库中的实际消息（无 LLM 调用）。三种形态：发现（传入 `query`）、滚动（传入 `session_id` + `around_message_id`）、浏览（无参数）。 | — |
+| `session_search` | 搜索存储在本地会话数据库中的历史会话，或在某个会话内滚动浏览。基于 FTS5 检索；返回数据库中的实际消息（无 LLM 调用）。四种形态：发现（传入 `query`）、滚动（传入 `session_id` + `around_message_id`）、读取（仅传入 `session_id`）、浏览（无参数）。 | — |
 
 ## `skills` 工具集
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
@@ -434,9 +434,9 @@ Database size: 12.4 MB
 
 ## Session 搜索工具
 
-Agent 内置了 `session_search` 工具，使用 SQLite 的 FTS5 引擎对所有历史对话进行全文搜索，并允许 agent 滚动浏览找到的任何 session。无需 LLM 调用、无需摘要、无截断。每种调用形式都从数据库返回实际消息。
+Agent 内置了 `session_search` 工具，使用 SQLite 的 FTS5 引擎对所有历史对话进行全文搜索，并允许 agent 滚动浏览找到的任何 session。无需 LLM 调用或摘要：每种调用形式都从数据库返回实际消息。较小的 session 会完整读取；较大的 session 则限制为前 20 条和后 10 条消息。
 
-### 三种调用形式
+### 四种调用形式
 
 工具根据你设置的参数推断意图，没有 `mode` 参数。
 
@@ -472,7 +472,17 @@ session_search(session_id="20260510_174648_805cc2", around_message_id=590803, wi
 
 每次滚动调用的典型耗时：1–2ms。
 
-**3. 浏览——无参数：**
+**3. 读取——仅传入 `session_id`：**
+
+```python
+session_search(session_id="20260510_174648_805cc2")
+```
+
+无需 FTS5 查询或锚点即可读取一个 session。较小的 session 会完整返回；较大的
+session 则限制为前 20 条和后 10 条消息。此调用形式也用于解析发现结果返回的
+`@session:<profile>/<id>` 链接。
+
+**4. 浏览——无参数：**
 
 ```python
 session_search()


### PR DESCRIPTION
## What does this PR do?

Documents the existing `session_id`-only READ shape of `session_search`.
The module header, English and Simplified Chinese session guides, and Chinese
tool reference now agree with the public schema and runtime behavior.

## Related Issue

Fixes #78991

## Type of Change

- [x] Documentation update

## Changes Made

- Change the documented count from three to four inferred shapes.
- Add READ examples using `session_search(session_id="...")`.
- Document full output for small sessions and the first-20/last-10 bound for
  large sessions.
- Document READ as the resolver for `@session:<profile>/<id>` links.
- Align the Simplified Chinese tool reference with the English reference.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_session_search.py -k 'full_session or session_id' -q`
   reports 2 passed.
2. `cd website && npm run build` successfully builds both `en` and `zh-Hans`.
   The build continues to report pre-existing zh-Hans broken-link warnings.
3. Search the changed files for the stale "three shapes" wording; no matches
   remain.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I checked issue-linked, open, and closed PRs for duplicates.
- [x] My PR contains only changes related to this documentation correction.
- [x] Runtime contract tests pass.
- [x] Both documentation locales build successfully.
- [x] Tested on macOS 26.5.1.

### Documentation & Housekeeping

- [x] Relevant English and Simplified Chinese documentation is updated.
- [x] Config example update: N/A.
- [x] Architecture workflow update: N/A.
- [x] Cross-platform impact: N/A.
- [x] Tool description already documented READ correctly; no schema change.
