### PR TITLE
fix(curator): preserve read marks across tool workers (#79004)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -907,12 +907,16 @@ def _run_review_in_thread(
                     "{tool_name}. Only memory/skill tools are allowed."
                 ),
             )
+            _read_marks_token = None
             try:
-                from tools.skill_manager_tool import _reset_background_review_read_marks
+                from tools.skill_manager_tool import _begin_background_review_read_marks
 
-                _reset_background_review_read_marks()
+                _read_marks_token = _begin_background_review_read_marks()
             except Exception:
-                pass
+                logger.debug(
+                    "Could not initialize background-review read marks",
+                    exc_info=True,
+                )
 
             try:
                 # Routed to a different model -> replay a digest (cache is cold
@@ -932,6 +936,18 @@ def _run_review_in_thread(
                     conversation_history=_review_history,
                 )
             finally:
+                if _read_marks_token is not None:
+                    try:
+                        from tools.skill_manager_tool import (
+                            _end_background_review_read_marks,
+                        )
+
+                        _end_background_review_read_marks(_read_marks_token)
+                    except Exception:
+                        logger.debug(
+                            "Could not release background-review read marks",
+                            exc_info=True,
+                        )
                 clear_thread_tool_whitelist()
 
             # Snapshot review actions before teardown. close() is allowed to

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1952,10 +1952,19 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # terminal. The background-thread runner also hides it; this
         # belt-and-suspenders path matters when a caller invokes
         # run_curator_review(synchronous=True) from the CLI.
-        with open(os.devnull, "w", encoding="utf-8") as _devnull, \
-             contextlib.redirect_stdout(_devnull), \
-             contextlib.redirect_stderr(_devnull):
-            conv_result = review_agent.run_conversation(user_message=prompt)
+        from tools.skill_manager_tool import (
+            _begin_background_review_read_marks,
+            _end_background_review_read_marks,
+        )
+
+        _read_marks_token = _begin_background_review_read_marks()
+        try:
+            with open(os.devnull, "w", encoding="utf-8") as _devnull, \
+                 contextlib.redirect_stdout(_devnull), \
+                 contextlib.redirect_stderr(_devnull):
+                conv_result = review_agent.run_conversation(user_message=prompt)
+        finally:
+            _end_background_review_read_marks(_read_marks_token)
 
         final = ""
         if isinstance(conv_result, dict):

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -195,7 +195,7 @@ class TestEditSkill:
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
         assert result["success"] is True
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
         assert "Updated description" in content
 
 
@@ -205,7 +205,7 @@ class TestEditSkill:
             result = _edit_skill("my-skill", "no frontmatter")
         assert result["success"] is False
         # Original content should be preserved
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
         assert "A test skill" in content
 
 class TestPatchSkill:
@@ -214,7 +214,7 @@ class TestPatchSkill:
             _create_skill("my-skill", VALID_SKILL_CONTENT)
             result = _patch_skill("my-skill", "Do the thing.", "Do the new thing.")
         assert result["success"] is True
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
         assert "Do the new thing." in content
 
 
@@ -237,7 +237,7 @@ word word
 
     def test_patch_supporting_file_symlink_escape_blocked(self, tmp_path):
         outside_file = tmp_path / "outside.txt"
-        outside_file.write_text("old text here")
+        outside_file.write_text("old text here", encoding="utf-8")
 
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
@@ -252,7 +252,7 @@ word word
 
         assert result["success"] is False
         assert "escapes" in result["error"].lower()
-        assert outside_file.read_text() == "old text here"
+        assert outside_file.read_text(encoding="utf-8") == "old text here"
 
 
 class TestDeleteSkill:
@@ -317,7 +317,7 @@ class TestRemoveFile:
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
         outside_file = outside_dir / "keep.txt"
-        outside_file.write_text("content")
+        outside_file.write_text("content", encoding="utf-8")
 
         with _skill_dir(tmp_path):
             _create_skill("my-skill", VALID_SKILL_CONTENT)
@@ -540,7 +540,8 @@ def _write_external_skill(external_dir: Path, name: str = "ext-skill") -> Path:
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {name}\ndescription: An external skill.\n---\n\n"
-        "# External\n\nBody with OLD_MARKER here.\n"
+        "# External\n\nBody with OLD_MARKER here.\n",
+        encoding="utf-8",
     )
     return skill_dir
 
@@ -565,7 +566,7 @@ class TestExternalSkillMutations:
             result = _patch_skill("ext-skill", "OLD_MARKER", "NEW_MARKER")
 
         assert result["success"] is True, result
-        assert "NEW_MARKER" in (skill_dir / "SKILL.md").read_text()
+        assert "NEW_MARKER" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
         # No duplicate in local
         assert not (local / "ext-skill").exists()
 
@@ -743,7 +744,7 @@ class TestPinnedGuard:
                 result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
         assert result["success"] is True, result
         # Content updated
-        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text(encoding="utf-8")
         assert "A test skill" not in content
 
     def test_delete_refuses_pinned(self, tmp_path):
@@ -797,7 +798,7 @@ class TestDeleteSkillRmtreeGuard:
         otherwise follow it and delete the link target's contents."""
         victim = tmp_path.parent / "precious_victim"
         victim.mkdir()
-        (victim / "important.txt").write_text("DO NOT DELETE")
+        (victim / "important.txt").write_text("DO NOT DELETE", encoding="utf-8")
         skills = tmp_path / "skills"
         skills.mkdir()
         evil = skills / "evil-skill"
@@ -822,7 +823,7 @@ class TestDeleteSkillRmtreeGuard:
         skills.mkdir()
         outside = tmp_path / "outside_skill"
         outside.mkdir()
-        (outside / "SKILL.md").write_text("x")
+        (outside / "SKILL.md").write_text("x", encoding="utf-8")
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills]), \
              patch("tools.skill_manager_tool._find_skill",
@@ -947,3 +948,95 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+def test_background_review_read_mark_returns_from_worker_thread(tmp_path):
+    """A skill_view worker's mark must authorize the review's next tool call."""
+    import threading
+
+    from tools.skill_manager_tool import (
+        _begin_background_review_read_marks,
+        _background_review_has_read,
+        _end_background_review_read_marks,
+        mark_background_review_skill_read,
+    )
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+    from tools.thread_context import propagate_context_to_thread
+
+    target = tmp_path / "reviewed" / "SKILL.md"
+    origin_token = set_current_write_origin(BACKGROUND_REVIEW)
+    marks_token = _begin_background_review_read_marks()
+    try:
+        worker = threading.Thread(
+            target=propagate_context_to_thread(
+                lambda: mark_background_review_skill_read(target)
+            )
+        )
+        worker.start()
+        worker.join(timeout=5)
+
+        assert not worker.is_alive()
+        assert _background_review_has_read(target) is True
+    finally:
+        _end_background_review_read_marks(marks_token)
+        reset_current_write_origin(origin_token)
+
+
+def test_background_review_read_marks_are_scope_isolated(tmp_path):
+    from tools.skill_manager_tool import (
+        _background_review_has_read,
+        _begin_background_review_read_marks,
+        _end_background_review_read_marks,
+        mark_background_review_skill_read,
+    )
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+
+    target = tmp_path / "reviewed" / "SKILL.md"
+    origin_token = set_current_write_origin(BACKGROUND_REVIEW)
+    outer_token = _begin_background_review_read_marks()
+    try:
+        mark_background_review_skill_read(target)
+        assert _background_review_has_read(target) is True
+
+        inner_token = _begin_background_review_read_marks()
+        try:
+            assert _background_review_has_read(target) is False
+        finally:
+            _end_background_review_read_marks(inner_token)
+
+        assert _background_review_has_read(target) is True
+    finally:
+        _end_background_review_read_marks(outer_token)
+        reset_current_write_origin(origin_token)
+
+
+def test_background_review_end_releases_the_scope_bound_to_its_token():
+    from tools.skill_manager_tool import (
+        _background_review_read_lock,
+        _background_review_read_paths,
+        _background_review_read_scope,
+        _begin_background_review_read_marks,
+        _end_background_review_read_marks,
+    )
+
+    outer_state = _begin_background_review_read_marks()
+    outer_scope = _background_review_read_scope.get()
+    inner_state = _begin_background_review_read_marks()
+    inner_scope = _background_review_read_scope.get()
+    try:
+        _end_background_review_read_marks(outer_state)
+
+        with _background_review_read_lock:
+            assert outer_scope not in _background_review_read_paths
+            assert inner_scope in _background_review_read_paths
+    finally:
+        _end_background_review_read_marks(inner_state)
+        _background_review_read_scope.set(None)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -37,6 +37,7 @@ import logging
 import re
 import shutil
 import contextvars as _ctxvars
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -52,9 +53,43 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
+_background_review_read_scope: "_ctxvars.ContextVar[object | None]" = _ctxvars.ContextVar(
+    "background_review_read_scope", default=None
 )
+_background_review_read_lock = threading.Lock()
+_background_review_read_paths: Dict[object, set[str]] = {}
+
+
+def _begin_background_review_read_marks() -> tuple[
+    "_ctxvars.Token[object | None]",
+    object,
+]:
+    """Create an isolated read-mark scope inherited by tool workers."""
+    scope = object()
+    token = _background_review_read_scope.set(scope)
+    with _background_review_read_lock:
+        _background_review_read_paths[scope] = set()
+    return token, scope
+
+
+def _end_background_review_read_marks(
+    state: tuple["_ctxvars.Token[object | None]", object],
+) -> None:
+    """Drop the scope created by ``_begin`` and restore its prior context."""
+    token, scope = state
+    with _background_review_read_lock:
+        _background_review_read_paths.pop(scope, None)
+    _background_review_read_scope.reset(token)
+
+
+def _ensure_background_review_read_scope() -> object:
+    scope = _background_review_read_scope.get()
+    if scope is None:
+        scope = object()
+        _background_review_read_scope.set(scope)
+    with _background_review_read_lock:
+        _background_review_read_paths.setdefault(scope, set())
+    return scope
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -77,9 +112,9 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    scope = _ensure_background_review_read_scope()
+    with _background_review_read_lock:
+        _background_review_read_paths[scope].add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -87,12 +122,18 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    scope = _background_review_read_scope.get()
+    if scope is None:
+        return False
+    with _background_review_read_lock:
+        return resolved in _background_review_read_paths.get(scope, set())
 
 
 def _reset_background_review_read_marks() -> None:
     """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    scope = _ensure_background_review_read_scope()
+    with _background_review_read_lock:
+        _background_review_read_paths[scope].clear()
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.


### PR DESCRIPTION
## What does this PR do?

Preserves Curator read-before-write marks across worker-thread tool calls.
Background review workers now record reads in a lock-protected registry keyed
by an inherited review scope, instead of mutating a ContextVar value that
cannot flow back to the review thread.

Each review gets an isolated scope and releases it on completion, so concurrent
reviews cannot authorize one another's writes.

## Related Issue

Fixes #79004

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replace the `ContextVar[frozenset]` mark store with:
  - a ContextVar carrying an opaque review-scope identity;
  - a lock-protected per-scope path registry.
- Add begin/end lifecycle hooks to normal background review and the full
  Curator review pass.
- Release registry entries after each review to avoid stale authorization.
- Add regressions for worker-to-review visibility and nested scope isolation.

## How to Test

1. Before the fix:
   `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -k read_mark_returns_from_worker_thread -q`
   fails because the parent review cannot see the worker's mark.
2. After the fix:
   `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q`
   reports 47 passed.
3. Lifecycle regressions:
   `scripts/run_tests.sh tests/run_agent/test_background_review.py tests/agent/test_curator.py tests/run_agent/test_background_review_toolset_restriction.py -q`
   reports 29 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I checked issue-linked, open, and closed PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [x] Focused and lifecycle tests pass (76 total).
- [x] I've added regressions for the bug and isolation boundary.
- [x] Tested on macOS 26.5.1 / Python 3.11 project environment.

### Documentation & Housekeeping

- [x] Documentation update: N/A; internal lifecycle only.
- [x] Config example update: N/A.
- [x] Architecture workflow update: N/A.
- [x] Cross-platform impact considered; uses stdlib ContextVar/threading locks.
- [x] Tool schema update: N/A.
