### PR TITLE
fix(whatsapp): omit participant from DM read-receipt keys (no blue ticks on DMs)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -121,7 +121,8 @@ import {
   assert.deepEqual(event.readReceiptKey, {
     id: 'incoming-1',
     remoteJid: '15551234567@s.whatsapp.net',
-    participant: '15550001111@s.whatsapp.net',
+    // (patch 004) DM keys must NOT carry participant — WhatsApp ignores
+    // group-shaped receipts on DMs. Groups still include it (test below).
     fromMe: false,
   });
   assert.equal(event.hasQuotedMessage, true);

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -486,7 +486,11 @@ export async function extractBridgeEvent({
     readReceiptKey: {
       remoteJid: msg.key.remoteJid || chatId,
       id: msg.key.id,
-      participant: msg.key.participant || senderId,
+      // (patch 004) participant only for group keys: WhatsApp silently
+      // ignores DM read receipts when a participant is present (the key
+      // looks group-shaped). Live-verified 2026-08-04: same DM key with
+      // participant -> no blue ticks; without -> ticks turn blue.
+      ...(isGroup ? { participant: msg.key.participant || senderId } : {}),
       fromMe: Boolean(msg.key.fromMe),
     },
     timestamp: msg.messageTimestamp,


### PR DESCRIPTION
## Problem

WhatsApp DM messages never get blue ticks, even with `send_read_receipts: true` and the bridge's `/read` endpoint returning `{"success": true, "marked": true}`.

`extractBridgeEvent` (bridge_helpers.js) builds the read-receipt key with an unconditional participant:

```js
readReceiptKey: {
  remoteJid: msg.key.remoteJid || chatId,
  id: msg.key.id,
  participant: msg.key.participant || senderId,   // <-- forced on DMs too
  fromMe: Boolean(msg.key.fromMe),
},
```

For direct chats, Baileys' original `msg.key` carries no `participant`. Forcing one in makes the receipt key group-shaped, and WhatsApp silently drops the receipt — `sock.readMessages()` succeeds, nothing happens on the sender's phone.

## Live A/B repro (real WhatsApp account, Baileys 7.0.0-rc13)

Same inbound DM message, receipt sent twice via the bridge's `/read` endpoint:

| Key sent | Result |
|---|---|
| `{remoteJid, id, participant: <senderId>, fromMe: false}` | `readMessages()` OK, **no blue ticks** |
| `{remoteJid, id, fromMe: false}` | `readMessages()` OK, **ticks turn blue immediately** |

(Also reproduces on `@lid` chats.)

## Fix

Include `participant` only for group chats, where Baileys genuinely needs the original key:

```js
...(isGroup ? { participant: msg.key.participant || senderId } : {}),
```

Group receipt behavior is unchanged (existing `inboundReadReceiptKeys` group test still covers it). The DM fixture expectation in `bridge.native.test.mjs` is updated to match; `node --test bridge.native.test.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
