### PR TITLE
fix(mcp): rebuild OAuth provider bound to a stopped event loop

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -4,6 +4,7 @@ The manager consolidates the eight scattered MCP-OAuth call sites into a
 single object with disk-mtime watch, dedup'd 401 handling, and a provider
 cache. See `tools/mcp_oauth_manager.py` for design rationale.
 """
+import asyncio
 import json
 import os
 import time
@@ -61,6 +62,77 @@ def test_manager_restore_entry_preserves_newer_concurrent_entry(tmp_path, monkey
 
     assert manager.get_or_build_provider("shared", "https://new.example", {}) is new_provider
     assert new_provider is not old_provider
+
+
+def test_manager_rebuilds_provider_bound_to_stopped_loop(tmp_path, monkeypatch):
+    """A provider cached against a dead MCP loop must not be reused.
+
+    ``shutdown_mcp_servers()`` stops the MCP event loop on every MCP reload
+    but leaves this cache intact. The cached provider holds asyncio/anyio
+    locks bound to that loop; if one was still held by a stranded task, every
+    later ``session.initialize()`` blocks until its ``wait_for`` fires, so the
+    server parks with a bare ``TimeoutError`` and never recovers in-process.
+    """
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    manager = MCPOAuthManager()
+
+    loop = asyncio.new_event_loop()
+    try:
+        stale = loop.run_until_complete(
+            _build_on_loop(manager, "shared", "https://mcp.example")
+        )
+    finally:
+        loop.close()
+
+    fresh = manager.get_or_build_provider("shared", "https://mcp.example", {})
+    assert fresh is not stale
+
+
+def test_manager_keeps_provider_while_binding_loop_alive(tmp_path, monkeypatch):
+    """The guard must not churn providers while the MCP loop is healthy.
+
+    Rebuilding on every call would discard live OAuth state and, in the worst
+    case, force an interactive re-auth on a server that was working fine.
+    """
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    manager = MCPOAuthManager()
+
+    async def _build_twice():
+        first = manager.get_or_build_provider("shared", "https://mcp.example", {})
+        second = manager.get_or_build_provider("shared", "https://mcp.example", {})
+        return first, second
+
+    loop = asyncio.new_event_loop()
+    try:
+        first, second = loop.run_until_complete(_build_twice())
+    finally:
+        loop.close()
+
+    assert first is second
+
+
+def test_manager_keeps_provider_built_without_running_loop(tmp_path, monkeypatch):
+    """Providers built from sync CLI paths record no loop and stay cached."""
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    manager = MCPOAuthManager()
+
+    provider = manager.get_or_build_provider("shared", "https://mcp.example", {})
+    assert manager.get_or_build_provider("shared", "https://mcp.example", {}) is provider
+
+
+async def _build_on_loop(manager, name, url):
+    """Build a provider from inside a running loop so its binding is recorded."""
+    return manager.get_or_build_provider(name, url, {})
+
 
 pytest.importorskip(
     "mcp.client.auth.oauth2",

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -65,6 +65,18 @@ def _same_endpoint(a: str, b: str) -> bool:
     )
 
 
+def _running_loop_or_none() -> Optional[asyncio.AbstractEventLoop]:
+    """Return the running loop, or None when called from sync code.
+
+    Providers are built from both the MCP event loop and synchronous CLI
+    paths; the latter have no loop to record.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Per-server entry
 # ---------------------------------------------------------------------------
@@ -85,6 +97,10 @@ class _ProviderEntry:
             to detect external refreshes.
         lock: Serialises concurrent access to this entry's state. Bound to
             whichever asyncio loop first awaits it (the MCP event loop).
+        loop: The event loop ``lock`` (and the SDK provider's own
+            ``context.lock``) got bound to. Recorded so the entry can be
+            discarded when that loop is gone — see
+            :meth:`MCPOAuthManager._is_entry_loop_usable`.
         pending_401: In-flight 401-handler futures keyed by the failed
             access_token, for deduplicating thundering-herd 401s. Mirrors
             Claude Code's ``pending401Handlers`` map.
@@ -95,6 +111,7 @@ class _ProviderEntry:
     provider: Optional[Any] = None
     last_mtime_ns: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    loop: Optional[asyncio.AbstractEventLoop] = None
     pending_401: dict[str, "asyncio.Future[bool]"] = field(default_factory=dict)
 
 
@@ -485,6 +502,24 @@ class MCPOAuthManager:
                 )
                 entry = None
 
+            # A cached provider carries two asyncio primitives bound to the
+            # loop that first awaited them: this entry's ``lock`` and the SDK's
+            # own ``context.lock`` (mcp/client/auth/oauth2.py). MCP runs on a
+            # dedicated loop from ``mcp_tool._ensure_mcp_loop()``, which
+            # ``shutdown_mcp_servers()`` stops and replaces on every MCP reload
+            # without touching this cache. Reusing a provider whose lock is
+            # still *held* by a task stranded on the dead loop blocks forever:
+            # ``session.initialize()`` never issues a request and the caller
+            # only sees a bare ``TimeoutError`` from its own ``wait_for``.
+            # Rebuild instead — tokens live on disk, so this costs one reload.
+            if entry is not None and not self._is_entry_loop_usable(entry):
+                logger.info(
+                    "MCP OAuth '%s': cached provider was bound to a stopped "
+                    "event loop, rebuilding to avoid a stranded lock",
+                    server_name,
+                )
+                entry = None
+
             if entry is None:
                 entry = _ProviderEntry(
                     server_url=server_url,
@@ -496,8 +531,27 @@ class MCPOAuthManager:
                 entry.provider = self._build_provider(server_name, entry)
                 if entry.provider is not None:
                     entry.provider._hermes_home = key[0]
+                    entry.loop = _running_loop_or_none()
 
             return entry.provider
+
+    @staticmethod
+    def _is_entry_loop_usable(entry: _ProviderEntry) -> bool:
+        """True when ``entry``'s locks can still be awaited safely.
+
+        Only a *stopped or closed* loop is fatal: its waiters can never be
+        woken, so a lock left held there strands every future acquirer. A
+        different-but-live loop is fine — an uncontended asyncio/anyio lock
+        rebinds on next acquire.
+
+        Fail-open: when the binding loop was never recorded (built from a
+        sync CLI path with no running loop), keep the cache. Dropping a
+        healthy provider would force an avoidable re-auth.
+        """
+        loop = entry.loop
+        if loop is None:
+            return True
+        return not loop.is_closed() and loop.is_running()
 
     @staticmethod
     def _key(


### PR DESCRIPTION
## What does this PR do?

An OAuth MCP server can park with a bare `TimeoutError` and stay unusable for the **entire life of the process**, while its endpoint is reachable and its tokens are valid. Only a full restart recovers it.

`MCPOAuthManager.get_or_build_provider()` caches one `OAuthClientProvider` per server and discards it *only* when `server_url` changes. That provider owns two asyncio primitives bound to the event loop that first awaited them:

* `_ProviderEntry.lock` — whose own docstring already documents the hazard: *"Bound to whichever asyncio loop first awaits it (the MCP event loop)."*
* the MCP SDK's `OAuthContext.lock` (`mcp/client/auth/oauth2.py`), held across the **whole** auth flow — including its `yield`s.

MCP runs on a dedicated loop from `mcp_tool._ensure_mcp_loop()`, and nothing invalidates the OAuth cache when that loop is replaced. The next connect reuses the same provider, so `session.initialize()` blocks on a lock no live loop can ever release.

One concrete way the loop gets replaced under a live cache: `shutdown_mcp_servers()` stops and closes the loop and clears `_servers`, but never touches the OAuth cache. Its inner shutdown is bounded by `future.result(timeout=15)`, and on expiry the exception is swallowed at `debug` level while `_stop_mcp_loop()` runs regardless — so an auth flow still in flight is stranded holding the lock on a loop that will never run again.

I want to be precise about scope here: what I have **verified** is the invariant — a cached provider whose lock is held on a stopped loop deadlocks silently and permanently, and no code path evicts it. Which event strands the lock in any given outage is **not** something I can claim from logs alone; the empty `TimeoutError` is the only trace, by construction. #77765 reports the same terminal state reached via a **keepalive** failure rather than a reload, which fits: both routes converge on the same unguarded cache. The guard is placed at the cache, so it covers either path.

**Why this is hard to diagnose:** the request never reaches the wire, so the *only* symptom is the empty `TimeoutError` from the `asyncio.wait_for` guarding the handshake:

```
WARNING tools.mcp_tool: MCP server '<name>' failed initial connection after 3
attempts, parking until a reconnect is requested (state: connecting → parked):
TimeoutError:
```

That reads exactly like a network fault, so it sends you looking at egress, proxies, or credentials. Two traps worth flagging for anyone who hits this:

* **`hermes mcp reauth` / `login` will not help**, and non-interactively they *delete the tokens* — the error message reads like "nothing was there," but it reports the state *after* the purge. The tokens were valid the whole time.
* **The parked self-probe cannot recover it.** It rebuilds the transport every `_PARKED_RETRY_INTERVAL`, but reuses the same poisoned provider.

Observed in the wild as multi-hour outages across separate gateway PIDs, against an endpoint measured reachable (`405` on GET, correct for a POST-only MCP endpoint) and tokens days from expiry. See #77765 for an independent report of the same failure on a different OS, provider, and SDK version.

**Fix:** record the binding loop on `_ProviderEntry`, and treat a stopped-or-closed one exactly like the existing URL-change case — drop the entry and rebuild.

**Why this approach.** It reuses the eviction path already in `get_or_build_provider()` rather than adding a parallel recovery mechanism, and it is deliberately narrow:

* Only a **stopped or closed** loop invalidates. A different-but-live loop is fine — an uncontended `asyncio`/`anyio` lock rebinds on next acquire.
* An **unrecorded** loop (provider built from a sync CLI path) **fails open**. Churning providers would discard live OAuth state for no reason.
* A rebuild **cannot** trigger re-auth: tokens live on disk, and `_build_provider` only raises `OAuthNonInteractiveError` when `not storage.has_cached_tokens()`. This matters given the `reauth` trap above — the fix must not become another way to lose credentials.

Affects OAuth HTTP servers only. stdio servers have no provider and were never impacted (a stdio server in the same process stayed healthy throughout both outages).

Side note, not changed here: `MCPOAuthManager.evict()` — precisely the "drop the in-process provider, preserve persisted OAuth state" primitive this needs — exists but has **zero production callers**. Worth a look as dead code that would have prevented this.

## Related Issue

Fixes #77765

That report (`type/bug`, `tool/mcp`, `P2`, `needs-repro`) describes this failure independently: empty `TimeoutError`, ~9-minute park cadence, `curl` with the stored token returning `200` in 0.26s, a fresh process connecting fine, `/reload-mcp` not helping, only a restart recovering, stdio servers unaffected — on macOS with a different OAuth provider and mcp SDK 1.28.1. Different OS, provider, and SDK version, same failure.

Their "fresh process connects, this process never will" is the signature of a poisoned **process-global** provider, which is what the guard below addresses.

Two notes for the maintainer:

- It is labelled **`needs-repro`**. `test_manager_rebuilds_provider_bound_to_stopped_loop` is a deterministic, network-free repro of the terminal state.
- Their trigger is the keepalive path, not a reload. If you'd rather keep that distinction open pending confirmation on their setup, downgrade this to `Refs #77765` — I don't want to auto-close their report on a mechanism match I inferred rather than reproduced on their box.

Their suggested investigation independently pointed at "the OAuth auth flow / httpx client construction / streamable_http session establishment *as executed in the gateway's background loop thread*" — that is where this lands.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth_manager.py`
  - Add `_running_loop_or_none()` — returns the running loop, or `None` from sync code.
  - Add `_ProviderEntry.loop` to record the loop the entry's locks were bound to.
  - Add `MCPOAuthManager._is_entry_loop_usable()` — `False` only when the recorded loop is closed or no longer running; fails open when unrecorded.
  - `get_or_build_provider()`: discard and rebuild a cached entry whose binding loop is gone, alongside the existing URL-change check; record the loop when a provider is built.
- `tests/tools/test_mcp_oauth_manager.py`
  - `test_manager_rebuilds_provider_bound_to_stopped_loop` — the regression.
  - `test_manager_keeps_provider_while_binding_loop_alive` — guards against churning providers on a healthy loop.
  - `test_manager_keeps_provider_built_without_running_loop` — pins the fail-open path for sync CLI callers.

No config keys, tool schemas, or public APIs changed.

## How to Test

**Verify the regression test actually pins the bug** (it fails without the fix):

```bash
git stash push -- tools/mcp_oauth_manager.py   # remove the fix, keep the tests
scripts/run_tests.sh tests/tools/test_mcp_oauth_manager.py \
  -k test_manager_rebuilds_provider_bound_to_stopped_loop
#   ✗ assert fresh is not stale
#     -> same HermesMCPOAuthProvider object returned after its loop was closed
git stash pop
```

**Confirm the fix:**

```bash
scripts/run_tests.sh tests/tools/test_mcp_oauth_manager.py
# 12 tests passed, 0 failed

scripts/run_tests.sh $(ls tests/tools/test_mcp*.py)
# 48 files, 426 tests passed, 0 failed
```

**Reproducing end-to-end** needs a live `auth: oauth` HTTP MCP server plus an event that strands the lock while the loop is torn down — a narrow race (e.g. the 15s `future.result` window) that isn't practical to script, which is why the regression above targets the invariant instead. To confirm the diagnosis on a gateway that has already latched:

```bash
# Endpoint healthy? 405 on GET is correct for a POST-only MCP endpoint.
curl -s -o /dev/null -w '%{http_code} %{time_total}s\n' https://<mcp-host>/<path>

# Tokens present and unexpired? (never run `reauth`/`login` to test this)
ls -la ~/.hermes/mcp-tokens/

# Both healthy + repeating `TimeoutError:` parks at a fixed cadence
# (4 x connect_timeout + backoff + _PARKED_RETRY_INTERVAL, ~547s by default)
# with zero intervening SDK log output => the request never reached the wire.
grep -E 'parking until|Received session ID' ~/.hermes/logs/agent.log | tail -20
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(mcp):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched issues and PRs (all states) for `oauth provider event loop`, `parking until a reconnect`, `mcp oauth TimeoutError`, `stranded lock oauth`. Found #77765 (the bug report this fixes; no PR attached). No competing fix PR. #78403 is adjacent but touches only `tests/tools/test_mcp_failure_classification.py` — no overlap.
- [x] My PR contains **only** changes related to this fix (2 files, no unrelated commits)
- [x] I've run the tests and all pass — `scripts/run_tests.sh` (CI-parity: hermetic `env -i`, per-file subprocess isolation), 426 passed / 0 failed across all 48 `test_mcp*.py` files
- [x] I've added tests for my changes (required for bug fixes) — 3, including one verified to fail without the fix
- [x] I've tested on my platform: Ubuntu 24.04.1 LTS on WSL2 (kernel 6.18.33.2-microsoft-standard-WSL2), Python 3.11.15, mcp 1.26.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings for the new field/helpers; the `_ProviderEntry.lock` docstring's existing loop-binding warning now points at the guard that enforces it. No user-facing docs affected.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**
- [x] I've considered cross-platform impact — pure `asyncio` state tracking; no file I/O, process management, or terminal handling. Behaviour is identical on macOS/Linux/WSL2/Windows. Verified on WSL2 only; nothing here is platform-conditional.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**, no schema changes

## Screenshots / Logs

Symptom before the fix — the endpoint answers `405` on GET in 0.3s and the tokens are valid, yet every attempt parks:

```
WARNING tools.mcp_tool: MCP server '<server>' failed initial connection after 3 attempts, parking until a reconnect is requested (state: connecting → parked): TimeoutError:
WARNING tools.mcp_tool: MCP server '<server>' failed initial connection after 3 attempts, parking until a reconnect is requested (state: connecting → parked): TimeoutError:
WARNING tools.mcp_tool: MCP server '<server>' failed initial connection after 3 attempts, parking until a reconnect is requested (state: connecting → parked): TimeoutError:
```

Two details are the useful discriminators:

- The cadence is **fixed** (~547s with default settings = 4 × 60s `connect_timeout` + backoff + 300s `_PARKED_RETRY_INTERVAL`). A flapping endpoint does not keep a metronome.
- There is **zero** intervening SDK output between parks — no `Received session ID`, no transport retry. The request never reached the wire.

For contrast, an out-of-process handshake to the same endpoint with the same on-disk token completed `initialize` → `tools/list` in **1.65s**, returning every tool schema. The transport and credentials were never the problem. #77765 independently measured the same contrast (`200` in 0.26s via `curl`, fresh process connects).

After the fix, the connect path logs the recovery instead of stranding:

```
INFO tools.mcp_oauth_manager: MCP OAuth '<server>': cached provider was bound to a stopped event loop, rebuilding to avoid a stranded lock
```

