### PR TITLE
fix(telegram): store/restore short description across status-indicator cycles (#78784)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -835,6 +835,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._status_offline_text: str = str(
             self.config.extra.get("status_offline", "Offline")
         )
+        # Operator's original short description, captured the first time we go
+        # online so it can be restored on disconnect instead of permanently
+        # clobbering the profile (#78784).
+        self._status_saved_description: Optional[str] = None
+        self._status_desc_captured: bool = False
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
         # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
@@ -4220,6 +4225,10 @@ class TelegramAdapter(BasePlatformAdapter):
         profile. It is the closest Bot API surface to a presence indicator —
         bots have no real online/offline dot (that's a user-account feature).
 
+        When going online the operator's existing description is captured (once)
+        so it can be **restored** on disconnect instead of being permanently
+        overwritten by "Offline" text (#78784).
+
         No-op unless ``extra.status_indicator`` is enabled. Best-effort: any
         failure is logged at debug and swallowed so it never blocks connect or
         disconnect. The default (no language_code) description applies to every
@@ -4230,7 +4239,34 @@ class TelegramAdapter(BasePlatformAdapter):
         bot = self._bot
         if bot is None:
             return
-        text = self._status_online_text if online else self._status_offline_text
+
+        if online:
+            # Capture the operator's real description the first time we go
+            # online, before we overwrite it with status text (#78784).
+            if not self._status_desc_captured:
+                try:
+                    current = await bot.get_my_short_description()
+                    self._status_saved_description = (
+                        getattr(current, "short_description", "") or ""
+                    )
+                    self._status_desc_captured = True
+                except Exception as e:
+                    logger.debug(
+                        "[%s] Failed to capture original short description: %s",
+                        self.name, _redact_telegram_error_text(e),
+                    )
+                    # Leave _status_desc_captured False so the offline path
+                    # falls back to the configured offline text rather than
+                    # restoring an empty description.
+            text = self._status_online_text
+        elif self._status_desc_captured:
+            # Restore the operator's original instead of leaving "Offline".
+            text = self._status_saved_description or ""
+        else:
+            # Capture never happened (e.g. connect failed before this point):
+            # fall back to the configured offline text.
+            text = self._status_offline_text
+
         # Telegram caps short_description at 120 chars.
         text = text[:120]
         try:

--- a/tests/gateway/test_telegram_status_indicator.py
+++ b/tests/gateway/test_telegram_status_indicator.py
@@ -3,8 +3,9 @@
 Telegram bots have no real online/offline presence dot (that's a user-account
 feature). The closest Bot API surface is the bot's *short description* — the
 line shown under the bot's name in its profile. When `extra.status_indicator`
-is enabled, the adapter sets it to "Online" on connect and "Offline" on clean
-disconnect so users can tell whether the gateway is up.
+is enabled, the adapter sets it to "Online" on connect and restores the
+operator's original description on clean disconnect so the profile text
+survives reconnect cycles (#78784).
 """
 
 import sys
@@ -40,6 +41,9 @@ def _make_adapter(extra):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***", extra=extra))
     adapter._bot = MagicMock()
     adapter._bot.set_my_short_description = AsyncMock()
+    adapter._bot.get_my_short_description = AsyncMock(
+        return_value=MagicMock(short_description="Original profile text")
+    )
     return adapter
 
 
@@ -62,5 +66,83 @@ async def test_online_sets_default_text():
     adapter._bot.set_my_short_description.assert_awaited_once_with(
         short_description="Online"
     )
+
+
+class TestStatusDescriptionStoreRestore:
+    """The short description must survive connect/disconnect cycles (#78784).
+
+    Before the fix, every connect overwrote the operator's profile text with
+    "Online" and every disconnect overwrote it with "Offline" — no capture,
+    no restore, so the original was permanently lost.
+    """
+
+    @pytest.mark.asyncio
+    async def test_online_captures_original_before_overwriting(self):
+        adapter = _make_adapter(extra={"status_indicator": True})
+        adapter._bot.get_my_short_description = AsyncMock(
+            return_value=MagicMock(short_description="Set via BotFather")
+        )
+        await adapter._set_status_indicator(online=True)
+        # Must fetch the existing description before clobbering it.
+        adapter._bot.get_my_short_description.assert_awaited_once()
+        # And still set "Online".
+        adapter._bot.set_my_short_description.assert_awaited_once_with(
+            short_description="Online"
+        )
+
+    @pytest.mark.asyncio
+    async def test_offline_restores_original_not_offline_text(self):
+        adapter = _make_adapter(extra={"status_indicator": True})
+        adapter._bot.get_my_short_description = AsyncMock(
+            return_value=MagicMock(short_description="My real description")
+        )
+        await adapter._set_status_indicator(online=True)   # capture + Online
+        await adapter._set_status_indicator(online=False)  # restore original
+        # Last call must restore the original, NOT "Offline".
+        adapter._bot.set_my_short_description.assert_awaited_with(
+            short_description="My real description"
+        )
+
+    @pytest.mark.asyncio
+    async def test_description_survives_reconnect_cycle(self):
+        adapter = _make_adapter(extra={"status_indicator": True})
+        adapter._bot.get_my_short_description = AsyncMock(
+            return_value=MagicMock(short_description="Persistent text")
+        )
+        await adapter._set_status_indicator(online=True)   # capture
+        await adapter._set_status_indicator(online=False)  # restore
+        await adapter._set_status_indicator(online=True)   # reconnect
+        # After a full cycle the saved original must be unchanged.
+        assert adapter._status_saved_description == "Persistent text"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_does_not_recapture_status_text(self):
+        """Second online must not re-capture "Online" as the original."""
+        adapter = _make_adapter(extra={"status_indicator": True})
+        adapter._bot.get_my_short_description = AsyncMock(
+            return_value=MagicMock(short_description="Real desc")
+        )
+        await adapter._set_status_indicator(online=True)
+        first_call_count = adapter._bot.get_my_short_description.await_count
+        await adapter._set_status_indicator(online=True)  # second online
+        # get_my_short_description must NOT be called again.
+        assert adapter._bot.get_my_short_description.await_count == first_call_count
+
+    @pytest.mark.asyncio
+    async def test_capture_failure_falls_back_gracefully(self):
+        """If get_my_short_description raises, Online is still set and Offline
+        is used on disconnect (no crash, no garbage restore)."""
+        adapter = _make_adapter(extra={"status_indicator": True})
+        adapter._bot.get_my_short_description = AsyncMock(
+            side_effect=RuntimeError("network error")
+        )
+        await adapter._set_status_indicator(online=True)
+        adapter._bot.set_my_short_description.assert_awaited_once_with(
+            short_description="Online"
+        )
+        await adapter._set_status_indicator(online=False)
+        adapter._bot.set_my_short_description.assert_awaited_with(
+            short_description="Offline"
+        )
 
 


### PR DESCRIPTION
## Problem

When `extra.status_indicator` is enabled, the Telegram adapter calls `set_my_short_description` on every connect/disconnect cycle, permanently clobbering the operator's real profile text (shown on the bot profile page and in share links) with "Online"/"Offline". There is no restore path, so any BotFather-set description is lost on the next reconnect. (#78784)

## Fix

Implements the store/restore approach (option b from the issue) while keeping the opt-in status indicator feature intact:

- **Connect (online):** the first time we go online, capture the existing short description via `get_my_short_description()` and store it. Subsequent online transitions reuse the stored original (so "Online" is never re-captured as the "original").
- **Disconnect (offline):** restore the operator's original description instead of leaving "Offline" text permanently.
- **Capture failure:** if the capture call fails, fall back to the configured offline text on disconnect (graceful degradation — no crash, no garbage restore).

This is the conservative choice: it fixes the data-loss bug without removing the status-indicator feature users opted into.

## Verification

- 3/3 layers from the issue addressed (connect clobber, disconnect clobber, capture-failure edge case).
- 3 production-path regression tests proven RED on `upstream/main` before the fix (capture never called; "Offline" set instead of original; `_status_saved_description` attribute missing) → GREEN after.
- `tests/gateway/test_telegram_status_indicator.py`: 8/8 pass (incl. reconnect-cycle + capture-failure).
- Broader telegram suite (connect + polling-progress): 17 pass, no regressions.
- `ruff check`: clean.

## Competitor analysis

No focused open PR for this issue. The andrexibiza epic refactor PRs (#79066–#79070) cross-reference #78784 but do not address the status-description clobber.

Auto-published by Moonsong via Path B automated pipeline.