### PR TITLE
fix(cli): make profile.yaml and skin writes atomic to stop silent field loss

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -870,8 +870,17 @@ def write_profile_meta(
         existing["description"] = description.strip()
     if description_auto is not None:
         existing["description_auto"] = bool(description_auto)
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(existing, f, sort_keys=False, default_flow_style=False)
+    # Route through the shared atomic helper (temp file + fsync + replace).
+    # A bare ``open(path, "w")`` truncates before the dump, so a crash or
+    # SIGINT mid-write leaves profile.yaml empty or half-written. The read
+    # half above swallows the resulting parse error and falls back to
+    # ``{}``, so the NEXT call would silently and permanently drop every
+    # field the caller did not pass — breaking this function's documented
+    # merge contract. atomic_yaml_write also emits emoji descriptions as
+    # real UTF-8 rather than ``\UXXXXXXXX`` escapes (GitHub #51356).
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(path, existing, sort_keys=False, default_flow_style=False)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -870,17 +870,12 @@ def write_profile_meta(
         existing["description"] = description.strip()
     if description_auto is not None:
         existing["description_auto"] = bool(description_auto)
-    # Route through the shared atomic helper (temp file + fsync + replace).
-    # A bare ``open(path, "w")`` truncates before the dump, so a crash or
-    # SIGINT mid-write leaves profile.yaml empty or half-written. The read
-    # half above swallows the resulting parse error and falls back to
-    # ``{}``, so the NEXT call would silently and permanently drop every
-    # field the caller did not pass — breaking this function's documented
-    # merge contract. atomic_yaml_write also emits emoji descriptions as
-    # real UTF-8 rather than ``\UXXXXXXXX`` escapes (GitHub #51356).
+    # Atomic write: bare open("w") truncates before the dump, and the read
+    # path above swallows parse errors as {}, so a crashed write would
+    # silently drop unspecified fields on the next call (#51356, #16743).
     from utils import atomic_yaml_write
 
-    atomic_yaml_write(path, existing, sort_keys=False, default_flow_style=False)
+    atomic_yaml_write(path, existing, sort_keys=False)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/skin_cmd.py
+++ b/hermes_cli/skin_cmd.py
@@ -72,17 +72,8 @@ def _skin_set(key: str, value: str, skin: str | None) -> int:
     data["colors"][key] = value
     data.setdefault("name", target)
 
-    # Route through the shared atomic helper (temp file + fsync + replace;
-    # it creates the parent dir and keeps allow_unicode=True for the kaomoji
-    # cursors and box-drawing tool prefixes). ``write_text`` truncates and
-    # writes with no fsync and no atomic swap, so a crash or power loss can
-    # leave <skin>.yaml zero-length — and ``safe_load("")`` returns ``None``,
-    # which the ``or {}`` above turns into an empty palette, so the next
-    # ``hermes skin set`` rewrites from empty and permanently drops every
-    # other color. (A file left with *invalid* YAML raises instead and
-    # aborts the command — loud, and not a loss.) The gateway's skin watcher
-    # repaints live surfaces from this file within ~1s, so a half-written
-    # file is observable, not only a crash-window concern.
+    # Atomic write: write_text truncates with no fsync; safe_load("") → None
+    # → {} would permanently lose the palette on the next set (#51356, #16743).
     from utils import atomic_yaml_write
 
     atomic_yaml_write(path, data, sort_keys=False)

--- a/hermes_cli/skin_cmd.py
+++ b/hermes_cli/skin_cmd.py
@@ -72,8 +72,18 @@ def _skin_set(key: str, value: str, skin: str | None) -> int:
     data["colors"][key] = value
     data.setdefault("name", target)
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    # Route through the shared atomic helper (temp file + fsync + replace;
+    # it creates the parent dir and keeps allow_unicode=True for the kaomoji
+    # cursors and box-drawing tool prefixes). ``write_text`` truncates and
+    # writes with no fsync and no atomic swap, so a crash or power loss can
+    # leave <skin>.yaml zero-length — and the read above falls back to ``{}``
+    # on a parse error, so the next ``hermes skin set`` rewrites from empty
+    # and permanently drops the rest of the palette. The gateway's skin
+    # watcher repaints live surfaces from this file within ~1s, so a
+    # half-written file is observable, not only a crash-window concern.
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(path, data, sort_keys=False)
 
     if target != name:
         _use(target)

--- a/hermes_cli/skin_cmd.py
+++ b/hermes_cli/skin_cmd.py
@@ -76,11 +76,13 @@ def _skin_set(key: str, value: str, skin: str | None) -> int:
     # it creates the parent dir and keeps allow_unicode=True for the kaomoji
     # cursors and box-drawing tool prefixes). ``write_text`` truncates and
     # writes with no fsync and no atomic swap, so a crash or power loss can
-    # leave <skin>.yaml zero-length — and the read above falls back to ``{}``
-    # on a parse error, so the next ``hermes skin set`` rewrites from empty
-    # and permanently drops the rest of the palette. The gateway's skin
-    # watcher repaints live surfaces from this file within ~1s, so a
-    # half-written file is observable, not only a crash-window concern.
+    # leave <skin>.yaml zero-length — and ``safe_load("")`` returns ``None``,
+    # which the ``or {}`` above turns into an empty palette, so the next
+    # ``hermes skin set`` rewrites from empty and permanently drops every
+    # other color. (A file left with *invalid* YAML raises instead and
+    # aborts the command — loud, and not a loss.) The gateway's skin watcher
+    # repaints live surfaces from this file within ~1s, so a half-written
+    # file is observable, not only a crash-window concern.
     from utils import atomic_yaml_write
 
     atomic_yaml_write(path, data, sort_keys=False)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -711,6 +711,110 @@ class TestInternalHelpers:
 
 
 # ===================================================================
+# TestWriteProfileMetaDurability
+# ===================================================================
+
+class TestWriteProfileMetaDurability:
+    """``profile.yaml`` must survive an interrupted ``write_profile_meta``.
+
+    ``write_profile_meta`` is a read-modify-write whose docstring promises
+    "unspecified fields preserve existing values".  Its read half swallows
+    any parse error and falls back to ``{}``, so a truncated profile.yaml is
+    not transient corruption — the *next* call reads ``{}`` and silently and
+    permanently drops every field the caller did not explicitly pass.
+    """
+
+    @staticmethod
+    def _seed(tmp_path):
+        profile_dir = tmp_path / "coder"
+        profile_dir.mkdir()
+        profiles.write_profile_meta(
+            profile_dir, description="Curated by hand", description_auto=False
+        )
+        return profile_dir
+
+    @staticmethod
+    def _interrupted_write(profile_dir):
+        """Run a ``write_profile_meta`` whose serialization fails mid-call.
+
+        The pre-fix code called ``yaml.safe_dump``; ``utils.atomic_yaml_write``
+        calls ``yaml.dump``.  Breaking both keeps this serializer-agnostic, so
+        it measures durability rather than the choice of entry point.  A
+        scoped ``MonkeyPatch.context`` is used instead of the fixture so the
+        patch is reverted immediately, without touching the session-wide env
+        isolation that shares the function-scoped ``monkeypatch`` instance.
+        """
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated interruption mid-write")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(yaml, "safe_dump", _boom)
+            mp.setattr(yaml, "dump", _boom)
+            with pytest.raises(RuntimeError):
+                profiles.write_profile_meta(profile_dir, description_auto=True)
+
+    def test_failed_write_leaves_existing_file_intact(self, tmp_path):
+        profile_dir = self._seed(tmp_path)
+        path = profile_dir / "profile.yaml"
+        before = path.read_text(encoding="utf-8")
+        assert "Curated by hand" in before
+
+        self._interrupted_write(profile_dir)
+
+        # A truncating open() destroys the file before the dump ever runs.
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_failed_write_does_not_silently_drop_unspecified_fields(self, tmp_path):
+        profile_dir = self._seed(tmp_path)
+
+        self._interrupted_write(profile_dir)
+
+        # The user retries; this call does not pass a description, so the
+        # documented merge contract requires the existing one to survive.
+        profiles.write_profile_meta(profile_dir, description_auto=True)
+        meta = profiles.read_profile_meta(profile_dir)
+        assert meta["description"] == "Curated by hand"
+        assert meta["description_auto"] is True
+
+    def test_emoji_description_is_written_as_real_utf8(self, tmp_path):
+        """Astral-plane chars must not become ``\\UXXXXXXXX`` escapes (#51356).
+
+        Supersedes #51808, which fixed this symptom alone by adding
+        ``allow_unicode=True``; ``atomic_yaml_write`` sets it internally.
+        """
+        profile_dir = tmp_path / "wizard"
+        profile_dir.mkdir()
+        profiles.write_profile_meta(profile_dir, description="Code wizard 🧙 ✨")
+
+        raw = (profile_dir / "profile.yaml").read_text(encoding="utf-8")
+        assert "\\U" not in raw
+        assert "🧙" in raw
+        assert profiles.read_profile_meta(profile_dir)["description"] == "Code wizard 🧙 ✨"
+
+    def test_symlinked_profile_yaml_survives_the_write(self, tmp_path):
+        """Guard on the conversion, not a behavior change.
+
+        Dotfile managers (chezmoi/stow) symlink profile.yaml into a tracked
+        repo.  ``open(path, "w")`` wrote through the link; a naive
+        ``os.replace`` would detach it.  ``atomic_replace`` resolves the link
+        first (GitHub #16743), so the link must still be intact afterwards.
+        """
+        profile_dir = tmp_path / "linked"
+        profile_dir.mkdir()
+        real_dir = tmp_path / "dotfiles"
+        real_dir.mkdir()
+        real = real_dir / "profile.yaml"
+        real.write_text("description: from dotfiles\n", encoding="utf-8")
+        (profile_dir / "profile.yaml").symlink_to(real)
+
+        profiles.write_profile_meta(profile_dir, description="updated")
+
+        assert (profile_dir / "profile.yaml").is_symlink()
+        assert "updated" in real.read_text(encoding="utf-8")
+        assert [p.name for p in profile_dir.iterdir() if p.name.endswith(".tmp")] == []
+
+
+# ===================================================================
 # Edge cases and additional coverage
 # ===================================================================
 

--- a/tests/hermes_cli/test_skin_cmd.py
+++ b/tests/hermes_cli/test_skin_cmd.py
@@ -66,10 +66,11 @@ def test_set_persists_the_skin_durably():
     ``write_text`` truncates and writes without ever calling ``fsync``, so a
     power loss or container kill right after the command "succeeds" can leave
     ``<skin>.yaml`` zero-length.  That is not transient: ``_skin_set`` is a
-    read-modify-write whose read half falls back to ``{}``, so the next tweak
-    rewrites the file from that empty state and the rest of the palette is
-    gone for good — and the gateway's skin watcher repaints every live
-    surface from this file within ~1s either way.
+    read-modify-write and ``safe_load("")`` returns ``None``, which its
+    ``or {}`` turns into an empty palette — so the next tweak rewrites the
+    file from that empty state and the rest of the palette is gone for good.
+    The gateway's skin watcher repaints every live surface from this file
+    within ~1s either way.
     """
     path = _skins() / "oasis.yaml"
     path.write_text(

--- a/tests/hermes_cli/test_skin_cmd.py
+++ b/tests/hermes_cli/test_skin_cmd.py
@@ -4,6 +4,9 @@ The whole point is that changing one token never disturbs the rest of the look
 (background especially), which hand-authoring kept getting wrong.
 """
 
+import os
+
+import pytest
 import yaml
 
 from hermes_cli import skin_cmd
@@ -55,3 +58,66 @@ def test_set_forks_a_builtin_without_inventing_a_background():
 def test_set_rejects_non_hex():
     _activate("default")
     assert skin_cmd._skin_set("ui_tool", "teal", None) == 1
+
+
+def test_set_persists_the_skin_durably():
+    """The palette must reach disk before ``skin set`` returns.
+
+    ``write_text`` truncates and writes without ever calling ``fsync``, so a
+    power loss or container kill right after the command "succeeds" can leave
+    ``<skin>.yaml`` zero-length.  That is not transient: ``_skin_set`` is a
+    read-modify-write whose read half falls back to ``{}``, so the next tweak
+    rewrites the file from that empty state and the rest of the palette is
+    gone for good — and the gateway's skin watcher repaints every live
+    surface from this file within ~1s either way.
+    """
+    path = _skins() / "oasis.yaml"
+    path.write_text(
+        'name: oasis\ncolors:\n  background: "#08201f"\n  banner_title: "#f2dfb3"\n',
+        encoding="utf-8",
+    )
+    _activate("oasis")
+
+    synced = []
+    real_fsync = os.fsync
+
+    def _tracking_fsync(fd):
+        synced.append(fd)
+        return real_fsync(fd)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(os, "fsync", _tracking_fsync)
+        assert skin_cmd._skin_set("ui_tool", "#00FFFF", None) == 0
+
+    assert synced, "skin file written without fsync — a crash can leave it empty"
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data["colors"]["ui_tool"] == "#00FFFF"
+    assert data["colors"]["background"] == "#08201f"  # untouched — the whole point
+    assert data["colors"]["banner_title"] == "#f2dfb3"
+    assert [p.name for p in _skins().iterdir() if p.name.endswith(".tmp")] == []
+
+
+def test_set_preserves_a_symlinked_skin_file():
+    """Guard on the conversion, not a behavior change.
+
+    ``write_text`` wrote through a symlink; a naive ``os.replace`` would
+    detach it.  ``atomic_replace`` resolves the link first (GitHub #16743),
+    so a skin file symlinked out to a dotfiles repo must stay a symlink.
+    """
+    real_dir = _skins().parent / "dotfiles"
+    real_dir.mkdir(parents=True, exist_ok=True)
+    real = real_dir / "oasis.yaml"
+    real.write_text(
+        'name: oasis\ncolors:\n  background: "#08201f"\n', encoding="utf-8"
+    )
+    link = _skins() / "oasis.yaml"
+    link.symlink_to(real)
+    _activate("oasis")
+
+    assert skin_cmd._skin_set("ui_tool", "#00FFFF", None) == 0
+
+    assert link.is_symlink()
+    data = yaml.safe_load(real.read_text(encoding="utf-8"))
+    assert data["colors"]["ui_tool"] == "#00FFFF"
+    assert data["colors"]["background"] == "#08201f"


### PR DESCRIPTION
## Summary

`profile.yaml` and skin YAML writes are now atomic — a crash or SIGINT mid-write can no longer leave these files empty/corrupt, which silently destroyed data on the next read-modify-write cycle.

Two CLI helpers used bare truncating writes (`open(path, "w")` / `path.write_text`) that truncate before the YAML dump runs. Both are read-modify-write functions whose read half degrades an unreadable file to `{}`, so a torn write is not transient corruption — the next call reads `{}` and permanently drops every field the caller did not explicitly pass. Routing both through `utils.atomic_yaml_write` (temp file + fsync + atomic replace) eliminates the truncation window.

Supersedes #51808 (which fixed the unicode escaping symptom alone by adding `allow_unicode=True` — `atomic_yaml_write` sets it internally).

## Changes

- `hermes_cli/profiles.py` — `write_profile_meta` now calls `atomic_yaml_write` instead of `open("w")` + `yaml.safe_dump`. Comment trimmed to 3 lines.
- `hermes_cli/skin_cmd.py` — `_skin_set` now calls `atomic_yaml_write` instead of `path.write_text(yaml.safe_dump(...))`. Comment trimmed to 3 lines.
- `tests/hermes_cli/test_profiles.py` — 4 new tests: durability (file intact on failed write), field preservation, emoji UTF-8, symlink survival.
- `tests/hermes_cli/test_skin_cmd.py` — 2 new tests: fsync verification, symlink survival.

## Validation

| | Before (main) | After (this PR) |
|---|---|---|
| Interrupted write leaves file intact | ❌ file truncated | ✅ atomic swap |
| Unspecified fields preserved after retry | ❌ silently dropped | ✅ preserved |
| Emoji written as real UTF-8 | ❌ `\UXXXXXXXX` escapes | ✅ real UTF-8 |
| Symlinked target preserved | ✅ (pre-existing) | ✅ (no regression) |
| No .tmp files left behind | ✅ (pre-existing) | ✅ (no regression) |

- 53/53 tests pass (profiles + skin_cmd suites)
- Ruff clean
- E2E verified with real file I/O (temp HERMES_HOME, real imports)
- /simplify-code 3-reviewer pass: no HIGH findings, 2 MEDIUM fixes applied (comment trim, redundant kwarg removal)

## Credit

Cherry-picked from @briandevans's PR #78301 with authorship preserved via rebase merge. Closes #78301. Supersedes #51808.
