### PR TITLE
fix(state): enforce write patience during lock acquisition

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2127,9 +2127,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._conn = _connect_tracked_db(
                     str(self.db_path),
                     check_same_thread=False,
-                    # Short timeout — application-level retry with random
-                    # jitter handles contention instead of sitting in
-                    # SQLite's internal busy handler for up to 30s.
+                    # Short timeout for direct connection operations. Explicit
+                    # write-lock acquisition temporarily disables the SQLite
+                    # busy handler in _execute_write so its application-level
+                    # patience budget remains authoritative.
                     timeout=1.0,
                     # auto-starts transactions on DML, which conflicts with
                     # our explicit BEGIN IMMEDIATE.  None = we manage
@@ -2592,13 +2593,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         while True:
             try:
                 with self._lock:
-                    self._conn.execute("BEGIN IMMEDIATE")
+                    conn = self._conn
+                    if conn is None:
+                        raise RuntimeError("Session database is not initialized")
+                    # BEGIN IMMEDIATE must fail fast so the randomized retry
+                    # loop — not SQLite's deterministic busy handler — owns
+                    # the complete wall-clock patience budget. Restore the
+                    # connection's normal timeout immediately afterward for
+                    # direct maintenance/read operations outside this helper.
+                    busy_timeout_ms = conn.execute(
+                        "PRAGMA busy_timeout"
+                    ).fetchone()[0]
                     try:
-                        result = fn(self._conn)
-                        self._conn.commit()
+                        conn.execute("PRAGMA busy_timeout=0")
+                        conn.execute("BEGIN IMMEDIATE")
+                    finally:
+                        conn.execute(
+                            f"PRAGMA busy_timeout={int(busy_timeout_ms)}"
+                        )
+                    try:
+                        result = fn(conn)
+                        conn.commit()
                     except BaseException:
                         try:
-                            self._conn.rollback()
+                            conn.rollback()
                         except Exception:
                             pass
                         raise

--- a/tests/state/test_write_lock_patience.py
+++ b/tests/state/test_write_lock_patience.py
@@ -109,6 +109,38 @@ class TestTranscriptWritePatience:
         db.append_message(session_id="s2", role="user", content="fast")
         assert time.monotonic() - t0 < 5.0  # loose: no patience-length stall
 
+    def test_busy_timeout_is_restored_after_successful_write(self, db):
+        """The application retry loop must not leak its fail-fast setting."""
+        with db._lock:
+            db._conn.execute("PRAGMA busy_timeout = 73")
+
+        db.set_meta("restore-success", "ok")
+
+        with db._lock:
+            assert db._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 73
+
+    def test_busy_timeout_is_restored_after_exhausted_patience(self, db, monkeypatch):
+        """Lock exhaustion must restore the connection's prior timeout too."""
+        monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 0.05)
+        with db._lock:
+            db._conn.execute("PRAGMA busy_timeout = 73")
+
+        started = threading.Event()
+        holder = threading.Thread(
+            target=_hold_write_lock, args=(db.db_path, 0.3, started)
+        )
+        holder.start()
+        try:
+            assert started.wait(5.0)
+            with pytest.raises(sqlite3.OperationalError):
+                db.set_meta("restore-failure", "never-written")
+        finally:
+            holder.join(timeout=5.0)
+        assert not holder.is_alive()
+
+        with db._lock:
+            assert db._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 73
+
 
 class TestOpenLockPatience:
     def test_open_survives_multi_second_lock_hold(self, tmp_path):


### PR DESCRIPTION
## Summary

Make `_execute_write()`'s application-level `patience_s` budget authoritative for SQLite write-lock acquisition.

`SessionDB` keeps the existing 1-second SQLite timeout for direct connection operations. During `BEGIN IMMEDIATE`, it now snapshots `PRAGMA busy_timeout`, temporarily sets it to `0`, and restores the original value in `finally`. The randomized application retry loop therefore owns the complete wall-clock budget without leaking a fail-fast timeout to later connection users.

## Root cause

The writer connection is opened with a native SQLite busy timeout, while some application write classes use a shorter patience budget (notably 0.5 seconds for S1 activity writes). `BEGIN IMMEDIATE` could block inside SQLite's busy handler before `_execute_write()` regained control to check its deadline. The configured application budget was therefore not end-to-end enforceable.

## Changes

- Snapshot and restore the connection's existing `PRAGMA busy_timeout` around write-lock acquisition.
- Set `busy_timeout=0` only for `BEGIN IMMEDIATE`, so lock contention fails fast into the existing deadline-bounded jitter loop.
- Use a local checked connection reference for the full transaction.
- Add regression tests proving timeout restoration after both a successful write and exhausted lock patience.

## Verification

Fresh evidence on rebased commit `c22367383`:

- `15 passed` — `tests/state/test_write_lock_patience.py` plus `tests/gateway/test_watchdog_review_76354.py`
- `40 passed` — complete `tests/state` plus the gateway watchdog regression
- `ruff check hermes_state.py tests/state/test_write_lock_patience.py` — clean
- `py_compile` for implementation and test — clean
- `git diff --check upstream/main...HEAD` — clean
- Manual probe: a non-default `busy_timeout=73ms` is restored after both success and lock exhaustion

The pre-fix release candidate reproduced the short-budget failures at roughly 3.7–4.1 seconds despite a 0.5-second budget. The patched snapshot keeps the existing retry/error semantics while enforcing the configured wall-clock deadline.

## Independent review

Read-only diff review with Codex `gpt-5.3-codex-spark`: **APPROVE**, no blockers. Claude Fable was attempted first but its OAuth session was expired; no Fable verdict is claimed.
