### PR TITLE
fix(cron): extend inactivity limit for reasoning-model stale timeouts (#78862)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3541,6 +3541,39 @@ def run_job(
         else:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+
+        # ── Stale-timeout headroom (#78862) ──────────────────────────
+        # The non-stream stale detector (agent/reasoning_timeouts.py) uses
+        # a 600s floor for known reasoning models.  When the cron
+        # inactivity limit equals that floor, the scheduler's 5s poll
+        # interval means it kills the job at ~605s — *before* the stale
+        # detector fires at 600s and triggers retry / provider fallback.
+        # Auto-extend the inactivity limit so the stale detector plus at
+        # least one retry+fallback cycle fits inside the window.
+        if _cron_inactivity_limit is not None:
+            try:
+                _stale_base, _uses_implicit = (
+                    agent._resolved_api_call_stale_timeout_base()
+                )
+                # Only extend when the stale timeout is close to (or
+                # exceeds) the cron limit — i.e. the two timeouts would
+                # race.  30s margin accounts for the poll interval plus
+                # jitter in the stale detector's 0.3s poll.
+                if _stale_base > 0 and _stale_base >= _cron_inactivity_limit - 30:
+                    _STALE_HEADROOM = 180.0  # seconds for retry + fallback
+                    _extended = _stale_base + _STALE_HEADROOM
+                    if _extended > _cron_inactivity_limit:
+                        logger.info(
+                            "Job '%s': extending inactivity limit from "
+                            "%.0fs to %.0fs to accommodate reasoning-model "
+                            "stale timeout floor (%.0fs) + retry headroom",
+                            job_name, _cron_inactivity_limit, _extended,
+                            _stale_base,
+                        )
+                        _cron_inactivity_limit = _extended
+            except Exception:
+                pass  # best-effort — don't break cron on stale-query failure
+
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a


### PR DESCRIPTION
## Problem

Cron jobs using reasoning models (e.g. `deepseek-v4-flash`) die with `TimeoutError` when the provider hangs on a non-streaming call — before the stale-stream detector fires, so no retry and no fallback provider ever engages.

**Root cause**: A race between two independent 600s limits:
1. **Reasoning-model stale-timeout floor** (`agent/reasoning_timeouts.py`): 600s for deepseek-r1, o1/o3, etc.
2. **Cron inactivity limit** (`cron/scheduler.py`): 600s default (`HERMES_CRON_TIMEOUT`)

The scheduler's 5s poll interval means it checks at ~605s — after the stale detector's 600s floor — and kills the job before the stale detector can trigger retry/fallback.

## Fix

After computing the cron inactivity limit, query the agent's stale timeout floor via `_resolved_api_call_stale_timeout_base()`. When the stale timeout is within 30s of the cron limit (i.e. they would race), auto-extend the inactivity limit by 180s to give the stale detector + retry + fallback chain room to complete.

**Before**: `cron_timeout=600s`, `stale_floor=600s` → cron kills at ~605s, stale never fires  
**After**: `cron_timeout=780s` (auto-extended), `stale_floor=600s` → stale fires at 600s, retry + fallback has 180s headroom

## Behavior

- **Non-reasoning models** (stale default 90s): no change — 90 < 570, no extension triggered
- **Reasoning models** (stale floor 600s): limit extends to 780s automatically
- **Explicit HERMES_CRON_TIMEOUT**: respected — extension only applies when stale floor >= limit - 30s
- **HERMES_CRON_TIMEOUT=0** (unlimited): no change — `_cron_inactivity_limit` is None
- Logs an `INFO` message when extending so operators can see the adjustment

## Testing

- All 6 existing `tests/cron/test_cron_inactivity_timeout.py` tests pass
- `py_compile` clean

Fixes #78862
