### PR TITLE
fix(anthropic): repair trailing-assistant tail for models that reject prefill

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -2805,6 +2806,62 @@ def convert_messages_to_anthropic(
     return system, result
 
 
+def model_rejects_assistant_prefill(model: str | None) -> bool:
+    """True when the Claude model rejects a trailing assistant message.
+
+    Claude Sonnet/Opus 4.6+ (and the Fable family) return a non-retryable
+    HTTP 400 — "This model does not support assistant message prefill. The
+    conversation must end with a user message." — when ``messages[-1]`` has
+    ``role=assistant``. Older Claude models treat that shape as intentional
+    prefill, so only the rejecting families are matched here.
+    """
+    m = str(model or "").lower()
+    if "claude" not in m:
+        return False
+    if "fable" in m:
+        return True
+    match = re.search(r"(?:sonnet|opus|haiku)[.-](\d{1,2})(?!\d)(?:[.-](\d{1,2})(?!\d))?", m)
+    if not match:
+        return False
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    return (major, minor) >= (4, 6)
+
+
+def ensure_user_tail_for_no_prefill(anthropic_messages: List[Dict]) -> None:
+    """Append a synthetic user turn when the wire tail is a plain assistant turn.
+
+    Mutates *anthropic_messages* in place. Hermes never intentionally prefills
+    the tail on the agent loop — a trailing assistant message is leftover
+    streamed preamble/status text (e.g. persisted before an interrupt or
+    gateway restart). For models that reject prefill, the request would
+    otherwise hard-400 before the model can recover. Assistant turns ending in
+    ``tool_use`` are left alone: those need real tool results, not a fake user
+    continuation.
+    """
+    if not anthropic_messages:
+        return
+    last = anthropic_messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "assistant":
+        return
+    content = last.get("content")
+    if isinstance(content, list) and any(
+        isinstance(b, dict) and b.get("type") == "tool_use" for b in content
+    ):
+        return
+    anthropic_messages.append(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Continue from the previous assistant message.",
+                }
+            ],
+        }
+    )
+
+
 def build_anthropic_kwargs(
     model: str,
     messages: List[Dict],
@@ -2860,6 +2917,10 @@ def build_anthropic_kwargs(
     system, anthropic_messages = convert_messages_to_anthropic(
         messages, base_url=base_url, model=model
     )
+    # Claude 4.6+ / Fable reject trailing assistant prefill with a
+    # non-retryable 400. Repair the tail before the request is built.
+    if model_rejects_assistant_prefill(model):
+        ensure_user_tail_for_no_prefill(anthropic_messages)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
     # Nous Portal routes on its own catalog ids (``anthropic/claude-opus-4.8``);

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -197,6 +197,57 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _rejects_trailing_assistant_prefill(
+    *,
+    model: Any,
+    base_url: Any = None,
+    provider_name: Any = None,
+    provider_profile: Any = None,
+) -> bool:
+    """Return True for Chat Completions endpoints that reject assistant prefill.
+
+    Newer native Anthropic/Claude endpoints reject requests whose final message
+    is ``role=assistant`` with: "This model does not support assistant message
+    prefill. The conversation must end with a user message." Hermes can create
+    such tails when streamed status/preamble text is persisted before the next
+    tool-backed request. OpenAI-style providers tolerate that as prefill; Claude
+    4.6+ does not, so only patch the Anthropic/Claude wire shape.
+    """
+    profile_name = str(getattr(provider_profile, "name", "") or "").strip().lower()
+    provider = str(provider_name or "").strip().lower()
+    url = str(base_url or "").strip().lower()
+    model_name = str(model or "").strip().lower()
+
+    if profile_name in {"anthropic", "claude", "claude-oauth", "claude-code"}:
+        return True
+    if provider in {"anthropic", "claude", "claude-oauth", "claude-code"}:
+        return True
+    if "api.anthropic.com" in url and "claude" in model_name:
+        return True
+    return False
+
+
+def _ensure_user_tail_for_no_prefill(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Append a tiny synthetic user turn when an endpoint forbids prefill.
+
+    The original list is left untouched. Assistant turns with tool calls are not
+    repaired here; those need the normal tool-result sanitizer, not a fake user
+    continuation.
+    """
+    if not messages or not isinstance(messages[-1], dict):
+        return messages
+    last = messages[-1]
+    if last.get("role") != "assistant" or last.get("tool_calls"):
+        return messages
+    return [
+        *messages,
+        {
+            "role": "user",
+            "content": "Continue from the previous assistant message.",
+        },
+    ]
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -407,6 +458,12 @@ class ChatCompletionsTransport(ProviderTransport):
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")
         if _profile:
+            if _rejects_trailing_assistant_prefill(
+                model=model,
+                base_url=params.get("base_url"),
+                provider_profile=_profile,
+            ):
+                sanitized = _ensure_user_tail_for_no_prefill(sanitized)
             return self._build_kwargs_from_profile(
                 _profile, model, sanitized, tools, params
             )
@@ -425,6 +482,13 @@ class ChatCompletionsTransport(ProviderTransport):
         ):
             sanitized = list(sanitized)
             sanitized[0] = {**sanitized[0], "role": "developer"}
+
+        if _rejects_trailing_assistant_prefill(
+            model=model,
+            base_url=params.get("base_url"),
+            provider_name=params.get("provider_name"),
+        ):
+            sanitized = _ensure_user_tail_for_no_prefill(sanitized)
 
         api_kwargs: dict[str, Any] = {
             "model": model,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -197,6 +197,60 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     return "gemini" in m or "gemma" in m
 
 
+def _rejects_trailing_assistant_prefill(
+    *,
+    model: Any,
+    base_url: Any = None,
+    provider_name: Any = None,
+    provider_profile: Any = None,
+) -> bool:
+    """Return True for Chat Completions endpoints that reject assistant prefill.
+
+    Newer native Anthropic/Claude endpoints reject requests whose final message
+    is ``role=assistant`` with: "This model does not support assistant message
+    prefill. The conversation must end with a user message." Hermes can create
+    such tails when streamed status/preamble text is persisted before the next
+    tool-backed request. OpenAI-style providers tolerate that as prefill; Claude
+    4.6+ does not, so only patch the Anthropic/Claude wire shape.
+    """
+    profile_name = str(getattr(provider_profile, "name", "") or "").strip().lower()
+    provider = str(provider_name or "").strip().lower()
+    url = str(base_url or "").strip().lower()
+
+    # Endpoint identity alone is insufficient: older Claude versions support
+    # intentional assistant prefill, and profiles can route non-Claude models.
+    from agent.anthropic_adapter import model_rejects_assistant_prefill
+
+    if not model_rejects_assistant_prefill(model):
+        return False
+    if profile_name in {"anthropic", "claude", "claude-oauth", "claude-code"}:
+        return True
+    if provider in {"anthropic", "claude", "claude-oauth", "claude-code"}:
+        return True
+    return "api.anthropic.com" in url
+
+
+def _ensure_user_tail_for_no_prefill(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Append a tiny synthetic user turn when an endpoint forbids prefill.
+
+    The original list is left untouched. Assistant turns with tool calls are not
+    repaired here; those need the normal tool-result sanitizer, not a fake user
+    continuation.
+    """
+    if not messages or not isinstance(messages[-1], dict):
+        return messages
+    last = messages[-1]
+    if last.get("role") != "assistant" or last.get("tool_calls"):
+        return messages
+    return [
+        *messages,
+        {
+            "role": "user",
+            "content": "Continue from the previous assistant message.",
+        },
+    ]
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -407,6 +461,12 @@ class ChatCompletionsTransport(ProviderTransport):
         # ── Provider profile: single-path when present ──────────────────
         _profile = params.get("provider_profile")
         if _profile:
+            if _rejects_trailing_assistant_prefill(
+                model=model,
+                base_url=params.get("base_url"),
+                provider_profile=_profile,
+            ):
+                sanitized = _ensure_user_tail_for_no_prefill(sanitized)
             return self._build_kwargs_from_profile(
                 _profile, model, sanitized, tools, params
             )
@@ -425,6 +485,13 @@ class ChatCompletionsTransport(ProviderTransport):
         ):
             sanitized = list(sanitized)
             sanitized[0] = {**sanitized[0], "role": "developer"}
+
+        if _rejects_trailing_assistant_prefill(
+            model=model,
+            base_url=params.get("base_url"),
+            provider_name=params.get("provider_name"),
+        ):
+            sanitized = _ensure_user_tail_for_no_prefill(sanitized)
 
         api_kwargs: dict[str, Any] = {
             "model": model,

--- a/tests/agent/test_anthropic_prefill_repair.py
+++ b/tests/agent/test_anthropic_prefill_repair.py
@@ -1,0 +1,137 @@
+"""Tests for trailing-assistant prefill repair on Claude 4.6+/Fable.
+
+Claude Sonnet/Opus 4.6+ and the Fable family reject requests whose final
+message is role=assistant with a non-retryable HTTP 400:
+"This model does not support assistant message prefill. The conversation
+must end with a user message."
+
+Hermes can produce that tail when streamed preamble/status text is persisted
+as an assistant turn before the next request (interrupt, gateway restart,
+cron resume). The adapter must append a synthetic user continuation for the
+rejecting model families and leave genuine prefill behaviour alone elsewhere.
+"""
+
+import pytest
+
+from agent.anthropic_adapter import (
+    build_anthropic_kwargs,
+    ensure_user_tail_for_no_prefill,
+    model_rejects_assistant_prefill,
+)
+
+
+class TestModelRejectsAssistantPrefill:
+
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4-6",
+        "claude-sonnet-4.6",
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-haiku-4-6",
+        "claude-fable-5",
+        "anthropic/claude-sonnet-4-6",
+    ])
+    def test_rejecting_models(self, model):
+        assert model_rejects_assistant_prefill(model) is True
+
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4-5",
+        "claude-opus-4-1",
+        "claude-haiku-4-5-20251001",
+        "claude-3-5-sonnet-20241022",  # legacy naming, no (sonnet)-N suffix ≥4.6
+        "gpt-4o",
+        "gemini-3-pro",
+        "",
+        None,
+    ])
+    def test_prefill_capable_models(self, model):
+        assert model_rejects_assistant_prefill(model) is False
+
+
+class TestEnsureUserTail:
+
+    def test_appends_user_turn_after_text_assistant_tail(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "go"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Checking logs."}]},
+        ]
+        ensure_user_tail_for_no_prefill(msgs)
+        assert msgs[-1]["role"] == "user"
+        assert msgs[-2]["role"] == "assistant"
+        assert "Continue" in msgs[-1]["content"][0]["text"]
+
+    def test_noop_when_tail_is_user(self):
+        msgs = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        ensure_user_tail_for_no_prefill(msgs)
+        assert len(msgs) == 1
+
+    def test_noop_when_tail_assistant_has_tool_use(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "run"}]},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "Running."},
+                {"type": "tool_use", "id": "toolu_1", "name": "terminal", "input": {}},
+            ]},
+        ]
+        ensure_user_tail_for_no_prefill(msgs)
+        assert len(msgs) == 2  # tool_use tails need real tool results, not fakes
+
+    def test_noop_on_empty(self):
+        msgs = []
+        ensure_user_tail_for_no_prefill(msgs)
+        assert msgs == []
+
+
+class TestBuildKwargsIntegration:
+
+    def _msgs(self):
+        return [
+            {"role": "system", "content": "be useful"},
+            {"role": "user", "content": "diagnose the cron"},
+            {"role": "assistant", "content": "Smoking gun hunt, checking configs."},
+        ]
+
+    def test_sonnet_46_gets_user_tail(self):
+        kw = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=self._msgs(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles[-2:] == ["assistant", "user"]
+
+    def test_fable_gets_user_tail(self):
+        kw = build_anthropic_kwargs(
+            model="claude-fable-5",
+            messages=self._msgs(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        assert kw["messages"][-1]["role"] == "user"
+
+    def test_older_claude_keeps_prefill(self):
+        kw = build_anthropic_kwargs(
+            model="claude-sonnet-4-5",
+            messages=self._msgs(),
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        assert kw["messages"][-1]["role"] == "assistant"
+
+    def test_user_tail_already_present_unchanged(self):
+        msgs = self._msgs() + [{"role": "user", "content": "and?"}]
+        kw = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        # No double user tail beyond what _merge_consecutive_roles produces
+        assert kw["messages"][-1]["role"] == "user"
+        assert kw["messages"][-2]["role"] == "assistant"

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -162,6 +162,77 @@ class TestChatCompletionsBuildKwargs:
 
 
 
+    def test_anthropic_chat_completions_appends_user_tail_after_assistant(self, transport):
+        """Claude Chat Completions rejects trailing assistant prefill.
+
+        Hermes can persist streamed preamble/status text as the current tail;
+        append a tiny synthetic user turn for Anthropic/Claude endpoints instead
+        of sending a request that hard-400s before the model can recover.
+        """
+        msgs = [
+            {"role": "user", "content": "diagnose this"},
+            {"role": "assistant", "content": "Smoking gun: ..."},
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_name="anthropic",
+        )
+        assert kw["messages"][-2]["role"] == "assistant"
+        assert kw["messages"][-1]["role"] == "user"
+        assert kw["messages"][-1]["content"] == "Continue from the previous assistant message."
+        assert not any(k.startswith("_") for k in kw["messages"][-1])
+        assert msgs[-1]["role"] == "assistant"  # original untouched
+
+    def test_anthropic_profile_path_appends_user_tail_after_assistant(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("anthropic")
+        msgs = [
+            {"role": "user", "content": "run cron"},
+            {"role": "assistant", "content": "Checking logs."},
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_profile=profile,
+        )
+        assert [m["role"] for m in kw["messages"][-2:]] == ["assistant", "user"]
+
+    def test_openai_style_provider_keeps_trailing_assistant_prefill(self, transport):
+        msgs = [
+            {"role": "user", "content": "diagnose this"},
+            {"role": "assistant", "content": "Partial prefill"},
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            base_url="https://api.openai.com/v1",
+            provider_name="openai",
+        )
+        assert kw["messages"] is msgs
+        assert kw["messages"][-1]["role"] == "assistant"
+
+    def test_anthropic_tail_repair_does_not_fake_tool_results(self, transport):
+        msgs = [
+            {"role": "user", "content": "run tool"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_name="anthropic",
+        )
+        assert kw["messages"][-1]["role"] == "assistant"
+        assert kw["messages"][-1]["tool_calls"]
+
     def test_tools_included(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -162,6 +162,94 @@ class TestChatCompletionsBuildKwargs:
 
 
 
+    def test_anthropic_chat_completions_appends_user_tail_after_assistant(self, transport):
+        """Claude Chat Completions rejects trailing assistant prefill.
+
+        Hermes can persist streamed preamble/status text as the current tail;
+        append a tiny synthetic user turn for Anthropic/Claude endpoints instead
+        of sending a request that hard-400s before the model can recover.
+        """
+        msgs = [
+            {"role": "user", "content": "diagnose this"},
+            {"role": "assistant", "content": "Smoking gun: ..."},
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_name="anthropic",
+        )
+        assert kw["messages"][-2]["role"] == "assistant"
+        assert kw["messages"][-1]["role"] == "user"
+        assert kw["messages"][-1]["content"] == "Continue from the previous assistant message."
+        assert not any(k.startswith("_") for k in kw["messages"][-1])
+        assert msgs[-1]["role"] == "assistant"  # original untouched
+
+    def test_anthropic_profile_path_appends_user_tail_after_assistant(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("anthropic")
+        msgs = [
+            {"role": "user", "content": "run cron"},
+            {"role": "assistant", "content": "Checking logs."},
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_profile=profile,
+        )
+        assert [m["role"] for m in kw["messages"][-2:]] == ["assistant", "user"]
+
+    @pytest.mark.parametrize("model", ["claude-3-5-sonnet", "gpt-4o"])
+    def test_anthropic_profile_keeps_prefill_for_non_rejecting_models(self, transport, model):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("anthropic")
+        msgs = [
+            {"role": "user", "content": "continue"},
+            {"role": "assistant", "content": "Partial prefill"},
+        ]
+        kw = transport.build_kwargs(
+            model=model,
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_profile=profile,
+        )
+        assert kw["messages"][-1]["role"] == "assistant"
+
+    def test_openai_style_provider_keeps_trailing_assistant_prefill(self, transport):
+        msgs = [
+            {"role": "user", "content": "diagnose this"},
+            {"role": "assistant", "content": "Partial prefill"},
+        ]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            base_url="https://api.openai.com/v1",
+            provider_name="openai",
+        )
+        assert kw["messages"] is msgs
+        assert kw["messages"][-1]["role"] == "assistant"
+
+    def test_anthropic_tail_repair_does_not_fake_tool_results(self, transport):
+        msgs = [
+            {"role": "user", "content": "run tool"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="claude-sonnet-4-6",
+            messages=msgs,
+            base_url="https://api.anthropic.com/chat/completions",
+            provider_name="anthropic",
+        )
+        assert kw["messages"][-1]["role"] == "assistant"
+        assert kw["messages"][-1]["tool_calls"]
+
     def test_tools_included(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]


### PR DESCRIPTION
## Symptom

A conversation whose stored transcript ends with a **plain assistant message** (no `tool_use`) hard-fails on every subsequent turn against Claude 4.6+ / Fable models:

```
HTTP 400 — This model does not support assistant message prefill.
The conversation must end with a user message.
```

The 400 is non-retryable, so the session is effectively bricked — the model never gets a request through to recover, and the user has to manually surgery session state.

## How a trailing assistant tail happens in practice

Hermes never *intentionally* prefills on the agent loop. But streamed preamble/status text gets persisted as an assistant message as it arrives; if the turn is interrupted at the wrong moment (gateway restart, crash, `/stop`, process kill), the transcript legitimately ends on a plain assistant turn. We hit this repeatedly in production on gateway restarts — the next inbound message on the affected conversation 400s forever.

## Fix

Repair the tail at the adapter boundary, on the outgoing wire payload only:

- `model_rejects_assistant_prefill(model)` — gate matching only the families documented to reject prefill (Sonnet/Opus/Haiku ≥ 4.6, Fable). Older Claude models keep intentional-prefill semantics untouched.
- `ensure_user_tail_for_no_prefill(messages)` — appends a synthetic `"Continue from the previous assistant message."` user turn when the wire tail is a plain assistant message. Assistant tails ending in `tool_use` are deliberately left alone (those need real tool results).
- Applied in both transports: `agent/anthropic_adapter.py` and `agent/transports/chat_completions.py` (OpenAI-compatible transport routed at an Anthropic-backed model).

Invariants: stored transcript is not mutated; role alternation is preserved (assistant → synthetic user); prompt-cache prefixes are unaffected since the change is strictly at the tail, after the cached span.

## Tests

`tests/agent/test_anthropic_prefill_repair.py` + additions to `tests/agent/transports/test_chat_completions.py`:
- model-gate matrix (families, versions, non-Claude passthrough)
- tail repaired for plain assistant tails in both transports
- `tool_use` tails left untouched
- user/absent tails pass through unchanged

72 passed locally on top of current `main`.

## Provenance

Running as a local carry in production since v0.17.0; has survived multiple gateway-restart incidents that previously bricked sessions.
