### PR TITLE
fix(whatsapp): load group allowlist from profile env

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -449,7 +449,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             allow_raw = None
         self._allow_from = self._coerce_allow_list(allow_raw)
         self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        # Mirror DM allowlist precedence: explicit config (including an empty
+        # list) is authoritative, with the documented profile-scoped env var
+        # as a fallback for legacy/setup-created configurations.
+        if "group_allow_from" in config.extra:
+            group_allow_raw = config.extra.get("group_allow_from")
+        elif "groupAllowFrom" in config.extra:
+            group_allow_raw = config.extra.get("groupAllowFrom")
+        else:
+            group_allow_raw = _wenv("WHATSAPP_GROUP_ALLOWED_USERS")
+        self._group_allow_from = self._coerce_allow_list(group_allow_raw)
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (
             read_receipts if isinstance(read_receipts, bool)

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -183,6 +183,61 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
 
 
+def test_adapter_group_allowlist_falls_back_to_environment(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv(
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+        "120363000000000001@g.us,120363000000000002@g.us",
+    )
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(enabled=True, extra={"group_policy": "allowlist"})
+    )
+
+    assert adapter._group_allow_from == {
+        "120363000000000001@g.us",
+        "120363000000000002@g.us",
+    }
+
+
+def test_adapter_group_allowlist_keeps_explicit_config_over_environment(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv(
+        "WHATSAPP_GROUP_ALLOWED_USERS", "120363000000000002@g.us"
+    )
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "group_policy": "allowlist",
+                "group_allow_from": ["120363000000000001@g.us"],
+            },
+        )
+    )
+
+    assert adapter._group_allow_from == {"120363000000000001@g.us"}
+
+
+def test_adapter_explicit_empty_group_allowlist_blocks_environment(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv(
+        "WHATSAPP_GROUP_ALLOWED_USERS", "120363000000000002@g.us"
+    )
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"group_policy": "allowlist", "group_allow_from": []},
+        )
+    )
+
+    assert adapter._group_allow_from == set()
+
+
 # --- Broadcast / status / newsletter pseudo-chats are always dropped ---
 
 


### PR DESCRIPTION
## Summary

- fall back to profile-scoped `WHATSAPP_GROUP_ALLOWED_USERS` when no group allowlist key is present in `PlatformConfig.extra`
- preserve explicit snake_case/camelCase config precedence, including an intentionally empty list
- add coverage for environment fallback, explicit config precedence, and explicit-empty fail-closed behavior

## Root cause

The Baileys bridge and Python adapter enforce separate inbound gates. Legacy/setup-created configurations may provide group JIDs through `WHATSAPP_GROUP_ALLOWED_USERS`; unlike the DM path, adapter construction only read `group_allow_from` / `groupAllowFrom` from `config.extra`. After a gateway restart, `group_policy: allowlist` could therefore start with an empty Python-side group allowlist even though the documented profile environment contained valid groups.

This mirrors the existing DM resolution contract and uses `_wenv` so multiplexed profiles remain isolated.

## Verification

- `tests/gateway/test_whatsapp_group_gating.py`: 13 passed
- relevant `tests/gateway/test_pairing_allowlist_bypass.py` DM precedence cases: 4 passed
- `git diff --check`
