### PR TITLE
fix(credential_pool): resolve key_env for custom providers in _seed_custom_pool (#79130)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3020,10 +3020,20 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
         def _is_suppressed(_p, _s):  # type: ignore[misc]
             return False
 
-    # Seed from the custom_providers config entry's api_key field
+    # Seed from the custom_providers config entry's api_key / key_env field
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
         api_key = str(cp_config.get("api_key") or "").strip()
+        if not api_key:
+            # Resolve key_env (the documented convention) when inline
+            # api_key is not set (#79130).
+            _key_env_name = str(
+                cp_config.get("key_env")
+                or cp_config.get("api_key_env")
+                or ""
+            ).strip()
+            if _key_env_name:
+                api_key = os.getenv(_key_env_name, "").strip()
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
         if api_key:


### PR DESCRIPTION
## Problem

`_seed_custom_pool()` in `agent/credential_pool.py` only reads the inline `api_key` field from custom provider config, ignoring the `key_env` field (the documented convention for custom providers).

This means custom providers configured with `key_env` have an **empty credential pool**, which breaks credential rotation, failover, and health tracking — even though runtime API calls still work (runtime_provider.py resolves `key_env` correctly).

## Root Cause

Line ~3026 in `agent/credential_pool.py`:
```python
api_key = str(cp_config.get("api_key") or "").strip()
# key_env is NEVER resolved here
```

Every other code path resolves `key_env`:
- `auxiliary_client.py:6048` — resolves `key_env` / `api_key_env`
- `auxiliary_client.py:7329` — resolves `key_env` / `api_key_env`
- `fallback_config.py:28` — resolves `key_env`

## Fix

After reading `api_key`, also check `key_env` / `api_key_env` and resolve from the environment when inline `api_key` is not set. Matches the existing pattern in `auxiliary_client.py`.

```python
api_key = str(cp_config.get("api_key") or "").strip()
if not api_key:
    _key_env_name = str(
        cp_config.get("key_env")
        or cp_config.get("api_key_env")
        or ""
    ).strip()
    if _key_env_name:
        api_key = os.getenv(_key_env_name, "").strip()
```

## Testing

- `py_compile` clean
- Pattern matches existing `key_env` resolution in auxiliary_client.py

Fixes #79130
