### PR TITLE
fix: resolve callable API keys in auxiliary custom endpoint (#79121)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5949,6 +5949,11 @@ def resolve_provider_client(
         custom_key = ""
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # Resolve callable API keys (short-lived credential suppliers)
+            # before string operations — the runtime path preserves callables
+            # but auxiliary resolution must invoke them first. (#79121)
+            if callable(explicit_api_key):
+                explicit_api_key = str(explicit_api_key() or "").strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or _scoped_key_env("OPENAI_API_KEY")
@@ -5969,7 +5974,10 @@ def resolve_provider_client(
             # OpenRouter or a wrong API-key provider — the main agent already
             # solved this, we just need to reuse its answer. (#45472)
             _main_base = str(main_runtime.get("base_url") or "").strip().rstrip("/")
-            _main_key = str(main_runtime.get("api_key") or "").strip()
+            _main_raw = main_runtime.get("api_key")
+            if callable(_main_raw):
+                _main_raw = _main_raw()
+            _main_key = str(_main_raw or "").strip()
             if _main_base and _main_key:
                 custom_base = _main_base
                 custom_key = _main_key


### PR DESCRIPTION
## Summary

`vision_analyze` crashes with `AttributeError: 'function' object has no attribute 'strip'` when the main runtime uses a callable `api_key` (short-lived credential supplier) with a custom OpenAI-compatible endpoint.

## Root Cause

The auxiliary client's custom-endpoint branch in `resolve_provider_client()` calls `.strip()` directly on `explicit_api_key` without resolving callables first. The runtime path (line 3069) already preserves callables with `api_key if callable(api_key)`, but the auxiliary resolution path crashes when it encounters a callable.

Two code paths affected:
1. **explicit_base_url path** (line 5953): `(explicit_api_key or "").strip()` — callable is truthy, so `callable or ""` returns the callable, then `.strip()` raises `AttributeError`
2. **main_runtime fallback path** (line 5977): `str(main_runtime.get("api_key") or "").strip()` — `str(callable)` returns `"<function ...>"`, which is a string but wrong as an API key

## Fix

Resolve callable API keys before string operations in both paths:
- Call the callable and normalize the result to a stripped string
- Consistent with the runtime path's existing callable handling pattern

## Test Plan

- [x] Syntax check passes
- [ ] Callable `explicit_api_key` with custom endpoint resolves correctly
- [ ] String `explicit_api_key` continues to work unchanged
- [ ] `main_runtime` with callable `api_key` resolves correctly

Fixes #79121