### PR TITLE
fix(agent): reset length_continue_retries after successful tool-call round (#79100)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6400,6 +6400,7 @@ def run_conversation(
                 # execution so a single truncation doesn't poison the
                 # entire conversation.
                 truncated_tool_call_retries = 0
+                length_continue_retries = 0
 
                 # Signal that a paragraph break is needed before the next
                 # streamed text.  We don't emit it immediately because


### PR DESCRIPTION
## Problem

`length_continue_retries` accumulates across unrelated truncation episodes within the same turn. After a successful tool-call round resets the truncation state, the continuation counter is NOT reset, causing the4-retry budget to be consumed by prior episodes.

**Observed sequence:**
| Response | Result | Counter |
|---|---|---:|
| `length` | continuation | 1 |
| `length` | continuation | 2 |
| `tool_calls` | executed normally | still 2 |
| later `length` | continuation | 3 |
| `tool_calls` | executed normally | still 3 |
| much later `length` | **abort** (4/4) | 4 |

Only 3 continuations were sent, but the 4th event aborts because the counter was never reset.

## Fix

Add `length_continue_retries = 0` alongside the existing `truncated_tool_call_retries = 0` reset after successful tool execution (line ~6402 in `conversation_loop.py`).

The existing comment already describes the intent: *"Reset per-turn retry counters after successful tool execution so a single truncation doesn't poison the entire conversation."* — `length_continue_retries` was simply missing from this reset.

## Testing

- `py_compile` clean
-1 file,1 insertion — minimal change

Fixes #79100
