### PR TITLE
fix(whatsapp): verify bridge ownership before port cleanup

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -100,8 +100,8 @@ def _listener_pids_on_port(port: int) -> list:
     return pids
 
 
-def _kill_port_process(port: int) -> None:
-    """Kill any process *listening* on the given TCP port (a stale bridge)."""
+def _kill_port_process(port: int, session_path: Path) -> None:
+    """Kill this session's bridge when it is listening on the given port."""
     try:
         if _IS_WINDOWS:
             from hermes_cli._subprocess_compat import windows_hide_flags
@@ -118,8 +118,21 @@ def _kill_port_process(port: int) -> None:
                     local_addr = parts[1]
                     if local_addr.endswith(f":{port}"):
                         try:
+                            pid = int(parts[4])
+                        except ValueError:
+                            continue
+                        if not _bridge_pid_is_ours(pid, session_path, None):
+                            logger.warning(
+                                "[whatsapp] Port %d is held by PID %d, which is not "
+                                "this session's bridge; leaving it running. Set "
+                                "platforms.whatsapp.extra.bridge_port to a free port.",
+                                port,
+                                pid,
+                            )
+                            continue
+                        try:
                             subprocess.run(
-                                ["taskkill", "/PID", parts[4], "/F"],
+                                ["taskkill", "/PID", str(pid), "/F"],
                                 capture_output=True, timeout=5,
                                 creationflags=windows_hide_flags(),
                             )
@@ -130,6 +143,15 @@ def _kill_port_process(port: int) -> None:
             # whose connection happens to involve this port number (a browser
             # tab on a local dev server, etc.) must never be killed.
             for pid in _listener_pids_on_port(port):
+                if not _bridge_pid_is_ours(pid, session_path, None):
+                    logger.warning(
+                        "[whatsapp] Port %d is held by PID %d, which is not "
+                        "this session's bridge; leaving it running. Set "
+                        "platforms.whatsapp.extra.bridge_port to a free port.",
+                        port,
+                        pid,
+                    )
+                    continue
                 try:
                     os.kill(pid, signal.SIGTERM)
                 except (ProcessLookupError, PermissionError, OSError):
@@ -664,7 +686,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             
             # Kill any orphaned bridge from a previous gateway run
             _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
+            _kill_port_process(self._bridge_port, self._session_path)
             await asyncio.sleep(1)
             
             # Start the bridge process in its own process group.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -79,13 +79,20 @@ def _pid_looks_like_node_bridge(pid: int) -> bool:
         return False
 
 
-def _kill_port_process(port: int) -> None:
-    """Kill any node bridge *listening* on the given TCP port (never a client); SIGTERM on POSIX, taskkill /F on Windows."""
+def _kill_port_process(port: int, session_path: Path) -> None:
+    """Kill *this session's* bridge listening on the given TCP port; SIGTERM on POSIX, taskkill /F on Windows.
+
+    "Any node bridge" is too wide: a second Hermes profile (or another app's node server) holding the
+    port is a stranger, and killing it takes down a live WhatsApp session that this gateway does not own.
+    Ownership is the same check the pidfile path uses — the session path must appear in the cmdline.
+    """
     with suppress(Exception):
         for pid in (_windows_listener_pids(port) if _IS_WINDOWS else _listener_pids_on_port(port)):
             # Killing a mistyped or recycled PID is unrecoverable — verify first.
-            if pid <= 0 or not _pid_looks_like_node_bridge(pid):
-                logger.warning("[whatsapp] Not killing PID %s on port %d: process is not a node bridge (or identity unverifiable)", pid, port)
+            if pid <= 0 or not _pid_looks_like_node_bridge(pid) or not _bridge_pid_is_ours(pid, session_path, None):
+                logger.warning(
+                    "[whatsapp] Port %d is held by PID %s, which is not this session's bridge; leaving it "
+                    "running. Set platforms.whatsapp.extra.bridge_port to a free port.", port, pid)
                 continue
             if _IS_WINDOWS:
                 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -466,7 +473,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if await self._reuse_running_bridge(bridge_path):
                 return True
             _kill_stale_bridge_by_pidfile(self._session_path)
-            _kill_port_process(self._bridge_port)
+            _kill_port_process(self._bridge_port, self._session_path)
             await asyncio.sleep(1)
             # Bridge output goes to a log file so QR codes, errors, and reconnection messages survive for troubleshooting.
             self._bridge_log = self._session_path.parent / "bridge.log"

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -312,7 +312,7 @@ class TestBridgeRuntimeFailure:
 class TestKillPortProcess:
     """Verify _kill_port_process uses platform-appropriate commands."""
 
-    def test_uses_netstat_and_taskkill_on_windows(self):
+    def test_uses_netstat_and_taskkill_for_our_bridge_on_windows(self, tmp_path):
         from plugins.platforms.whatsapp.adapter import _kill_port_process
 
         netstat_output = (
@@ -331,21 +331,55 @@ class TestKillPortProcess:
             return MagicMock()
 
         with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+                 return_value=True,
+             ) as mock_is_ours, \
              patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run:
-            _kill_port_process(3000)
+            _kill_port_process(3000, tmp_path)
 
         # netstat called
         assert any(
             call.args[0][0] == "netstat" for call in mock_run.call_args_list
         )
+        mock_is_ours.assert_called_once_with(12345, tmp_path, None)
         # taskkill called with correct PID
         assert any(
             call.args[0] == ["taskkill", "/PID", "12345", "/F"]
             for call in mock_run.call_args_list
         )
 
+    def test_spares_unrelated_listener_on_windows(self, tmp_path, caplog):
+        from plugins.platforms.whatsapp.adapter import _kill_port_process
 
-    def test_kills_only_listeners_on_linux(self):
+        netstat_output = (
+            "  Proto  Local Address          Foreign Address        State           PID\n"
+            "  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       12345\n"
+        )
+        mock_netstat = MagicMock(stdout=netstat_output)
+
+        def run_side_effect(cmd, **kwargs):
+            if cmd[0] == "netstat":
+                return mock_netstat
+            return MagicMock()
+
+        with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", True), \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+                 return_value=False,
+             ), \
+             patch(
+                 "plugins.platforms.whatsapp.adapter.subprocess.run",
+                 side_effect=run_side_effect,
+             ) as mock_run:
+            _kill_port_process(3000, tmp_path)
+
+        assert not any(
+            call.args[0][0] == "taskkill" for call in mock_run.call_args_list
+        )
+        assert "not this session's bridge" in caplog.text
+
+    def test_kills_only_owned_listeners_on_linux(self, tmp_path):
         """POSIX path SIGTERMs only LISTENer PIDs (never clients) — the #43846 fix.
 
         Replaces the old fuser-based test: ``fuser``/bare ``lsof -i`` also
@@ -359,12 +393,35 @@ class TestKillPortProcess:
         with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", False), \
              patch("plugins.platforms.whatsapp.adapter._listener_pids_on_port",
                    return_value=[55555]) as mock_listeners, \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+                 return_value=True,
+             ) as mock_is_ours, \
              patch("plugins.platforms.whatsapp.adapter.os.kill",
                    side_effect=lambda pid, sig: kills.append((pid, sig))):
-            wa._kill_port_process(3000)
+            wa._kill_port_process(3000, tmp_path)
 
         mock_listeners.assert_called_once_with(3000)
+        mock_is_ours.assert_called_once_with(55555, tmp_path, None)
         assert kills == [(55555, signal.SIGTERM)]
+
+    def test_spares_unrelated_listener_on_linux(self, tmp_path, caplog):
+        from plugins.platforms.whatsapp import adapter as wa
+
+        with patch("plugins.platforms.whatsapp.adapter._IS_WINDOWS", False), \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._listener_pids_on_port",
+                 return_value=[55555],
+             ), \
+             patch(
+                 "plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+                 return_value=False,
+             ), \
+             patch("plugins.platforms.whatsapp.adapter.os.kill") as mock_kill:
+            wa._kill_port_process(3000, tmp_path)
+
+        mock_kill.assert_not_called()
+        assert "not this session's bridge" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -315,6 +315,8 @@ class TestBridgeRuntimeFailure:
 class TestKillPortProcess:
     """Verify _kill_port_process uses platform-appropriate commands."""
 
+    SESSION = Path("/tmp/hermes-whatsapp-session")
+
     @pytest.mark.windows_only
     def test_uses_netstat_and_taskkill_on_windows(self):
         """``windows_only``: netstat/taskkill are Windows binaries. The old
@@ -339,8 +341,10 @@ class TestKillPortProcess:
 
         with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run, \
              patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
+                   return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
                    return_value=True):
-            _kill_port_process(3000)
+            _kill_port_process(3000, self.SESSION)
 
         # netstat called
         assert any(
@@ -371,7 +375,7 @@ class TestKillPortProcess:
         with patch("plugins.platforms.whatsapp.adapter.subprocess.run", side_effect=run_side_effect) as mock_run, \
              patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
                    return_value=False):
-            _kill_port_process(3000)
+            _kill_port_process(3000, self.SESSION)
 
         assert not any(
             call.args[0][0] == "taskkill" for call in mock_run.call_args_list
@@ -397,9 +401,11 @@ class TestKillPortProcess:
                    return_value=[55555]) as mock_listeners, \
              patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
                    return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+                   return_value=True), \
              patch("plugins.platforms.whatsapp.adapter.os.kill",
                    side_effect=lambda pid, sig: kills.append((pid, sig))):
-            wa._kill_port_process(3000)
+            wa._kill_port_process(3000, self.SESSION)
 
         mock_listeners.assert_called_once_with(3000)
         assert kills == [(55555, signal.SIGTERM)]
@@ -416,8 +422,32 @@ class TestKillPortProcess:
                    return_value=False), \
              patch("plugins.platforms.whatsapp.adapter.os.kill",
                    side_effect=lambda pid, sig: kills.append((pid, sig))):
-            wa._kill_port_process(3000)
+            wa._kill_port_process(3000, self.SESSION)
 
+        assert kills == []
+
+    @pytest.mark.linux_only
+    def test_another_sessions_bridge_is_never_killed(self):
+        """A node bridge on the port that belongs to a different session must survive.
+
+        ``_pid_looks_like_node_bridge`` alone accepts any node process, so a second Hermes
+        profile holding the port was force-killed and its live WhatsApp session dropped.
+        Ownership is what decides the kill, not "looks like a bridge".
+        """
+        from plugins.platforms.whatsapp import adapter as wa
+
+        kills = []
+        with patch("plugins.platforms.whatsapp.adapter._listener_pids_on_port",
+                   return_value=[55555]), \
+             patch("plugins.platforms.whatsapp.adapter._pid_looks_like_node_bridge",
+                   return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter._bridge_pid_is_ours",
+                   return_value=False) as mock_ours, \
+             patch("plugins.platforms.whatsapp.adapter.os.kill",
+                   side_effect=lambda pid, sig: kills.append((pid, sig))):
+            wa._kill_port_process(3000, self.SESSION)
+
+        mock_ours.assert_called_once_with(55555, self.SESSION, None)
         assert kills == []
 
 


### PR DESCRIPTION
## Summary

WhatsApp bridge startup can terminate an unrelated application that already owns `bridge_port`. The foreign listener is killed, but the bridge still cannot start because the port remains unavailable.

This PR makes port cleanup fail safe: a listener is terminated only when it is verified as the Node bridge for the active WhatsApp session. Unrecognized listeners are left running, with a warning that points to `platforms.whatsapp.extra.bridge_port`.

Fixes #78365

## Root cause

The pidfile cleanup path already uses `_bridge_pid_is_ours()` to guard against recycled or unrelated PIDs. The fallback `_kill_port_process()` path did not perform that identity check and treated ownership of the configured port as proof that the listener belonged to Hermes.

After a failed bridge health check, `connect()` calls that fallback on both POSIX and Windows, allowing an unrelated listener to receive `SIGTERM` or `taskkill`.

## Fix

- Pass the active WhatsApp session path into `_kill_port_process()`.
- Reuse `_bridge_pid_is_ours()` before every POSIX `SIGTERM` and Windows `taskkill`.
- Preserve foreign listeners and log the configuration key for selecting a free port.
- Add Windows and POSIX regression coverage for both owned and unrelated listeners.

## Validation

- WhatsApp connect, pidfile, and stale-bridge suites: 22 passed
- Full repository runner: 25,567 passed; the same 17 unrelated macOS/environment failures reproduce on the unmodified `origin/main` base
- `ruff check .`: passed
- `python scripts/check-windows-footguns.py --all`: passed
- `git diff --check`: passed
