### PR TITLE
fix(cron): tolerate NUL bytes in referenced-script paths at os.open

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,21 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_nul_byte_in_path_token_does_not_crash_guard(self):
+        """Residual #76762 class: when a NUL byte survives into the *path
+        token itself* (tokenized binary-adjacent command text), ``os.open``
+        raises ValueError — not OSError — inside
+        ``_read_referenced_script``. The guard must treat it as "nothing to
+        scan", never crash.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash ./run\x00me.sh", cwd="/tmp"
+        )
+        assert result is False
+
     def test_read_referenced_script_tolerates_nul_in_path(self):
         """#77703: _read_referenced_script opens by path. A path with an
         embedded NUL byte (a binary's bytes mis-tokenized into a bogus path by


### PR DESCRIPTION
## Summary

Residual #76762 class, reproduced live against current main: the terminal tool's lifecycle guard crashes with `ValueError: embedded null byte` when a command's tokenized path token itself carries a NUL byte:

```
File "cron/lifecycle_guard.py", line 260, in _read_referenced_script
    descriptor = os.open(path, flags)
ValueError: embedded null byte
```

The #76762 fix handled NULs in *file contents* (binary detection) and at `Path.resolve()` (ValueError caught there), but `os.open()` in `_read_referenced_script` only caught `OSError` — and a NUL in the path raises `ValueError`. Hit in the wild running `.venv/bin/ruff` through the guard during eval-harness verification.

## Fix

Catch `ValueError` at the `os.open` site and return `(None, False)` — "nothing to scan", same treatment the resolve-time site already has. A guarded path must never crash the guard.

## Verification

- Two regressions added (guard-level walk + direct `_read_referenced_script` unit), **sabotage-verified**: 2 failed without the fix, 84/84 pass with it (`scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py`)
- Sibling-site audit: `os.fstat`/`os.read` operate on the already-open descriptor (unreachable if open raises); `resolve(strict=False)` site already tolerates ValueError. No other unguarded path-consuming sites in the walk.

## Infographic

![lifecycle-guard-nul](https://v3b.fal.media/files/b/0aa5168c/4XicKHoOoSI6t3Kpqn_sY_3ObjFSzT.png)
