### PR TITLE
docs: surface existing answers users can't find (migration, prompt-size, tool-call parsing)

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -391,3 +391,4 @@ That sequence gets you from "broken vibes" back to a known state fast.
 - **[AI Providers](../integrations/providers.md)** — Full provider list and setup details
 - **[Skills System](../user-guide/features/skills.md)** — Reusable workflows and knowledge
 - **[Tips & Best Practices](../guides/tips.md)** — Power user tips
+- **[Moving to another machine](/reference/faq#exporting-hermes-to-another-machine)** — `hermes backup` migrates your whole setup (or [a single profile](/reference/faq#moving-a-single-profile-to-another-machine)); no need to rebuild from scratch

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -82,6 +82,10 @@ updates:
 
 `updates.pre_update_backup` is a single knob with three modes: `quick` (default — the lightweight state snapshot described above), `full` (the quick snapshot plus a complete `HERMES_HOME` zip; can add minutes on large homes), and `off` (no pre-update backup at all — `--no-backup` does the same for a single run). Legacy boolean values still work: `true` means `full`, `false` means `off`.
 
+:::tip Moving to a new machine instead?
+Update backups protect an in-place update. If you're migrating your whole setup to different hardware, use `hermes backup` + `hermes import` instead — see [Exporting Hermes to another machine](/reference/faq#exporting-hermes-to-another-machine) and [`hermes backup` vs `hermes profile export`](/reference/faq#hermes-backup-vs-hermes-profile-export).
+:::
+
 ### Windows: another `hermes.exe` is running
 
 On Windows, `hermes update` will refuse to run if it detects another `hermes.exe` process holding the venv's entry-point executable open — most commonly the Hermes Desktop app's spawned backend, an open `hermes` REPL in another terminal, or a running gateway:

--- a/website/docs/guides/local-ollama-setup.md
+++ b/website/docs/guides/local-ollama-setup.md
@@ -284,6 +284,8 @@ Smaller models (3B, 7B) sometimes ignore tool-call instructions and produce plai
 - **Hermes has auto-repair** — it detects malformed tool calls and attempts to fix them automatically.
 - **Set up a fallback** — if the local model fails 3 times, Hermes falls back to a cloud provider.
 
+If the model prints raw JSON like `{"name": "web_search", ...}` in its reply instead of actually running the tool, that's usually the *server*, not the model — tool calling isn't enabled or the tool-call format isn't parsed. See the per-server fix table in [Tool calls appear as text instead of executing](/integrations/providers#tool-calls-appear-as-text-instead-of-executing) (llama.cpp needs `--jinja`, vLLM needs `--enable-auto-tool-choice --tool-call-parser hermes`, and so on).
+
 ### Context window errors
 
 The default Ollama context (2048 tokens) is too small for agentic work. See [Step 6](#step-6-optimize-for-speed) to increase it.

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -152,7 +152,7 @@ Instead of running terminal commands one at a time, ask the agent to write a scr
 Use `/model` to switch models mid-session. Use a frontier model (Claude Sonnet/Opus, GPT-4o) for complex reasoning and architecture decisions. Switch to a faster model for simple tasks like formatting, renaming, or boilerplate generation. Keep in mind each switch resets the prompt cache (see above), so on long sessions it's often cheaper to start a fresh session on the other model than to bounce back and forth.
 
 :::tip
-Run `/usage` periodically to see your token consumption. Run `/insights` for a broader view of usage patterns over the last 30 days.
+Run `/usage` periodically to see your token consumption. Run `/insights` for a broader view of usage patterns over the last 30 days. To see what your *fixed* per-message cost is before any conversation — system prompt, skills index, memory, tool schemas — run [`hermes prompt-size`](/reference/cli-commands#hermes-prompt-size) (works offline).
 :::
 
 ## Messaging Tips

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -500,12 +500,18 @@ You can verify the plist has the correct PATH:
 
 **Solution:**
 ```bash
+# See exactly what the fixed prompt costs — breakdown by block
+# (system prompt, skills index, memory, tool schemas). Runs offline.
+hermes prompt-size
+
 # Compress the conversation to reduce tokens
 /compress
 
 # Check session token usage
 /usage
 ```
+
+If the baseline looks high before you've typed anything, that's the fixed prompt budget — the system prompt plus tool schemas sent on every call. Run [`hermes prompt-size`](/reference/cli-commands#hermes-prompt-size) to measure it, then trim: disable toolsets you don't use (`hermes tools`) and uninstall or disable skills you don't need (`hermes skills`).
 
 :::tip
 Use `/compress` regularly during long sessions. It summarizes the conversation history and reduces token usage significantly while preserving context.


### PR DESCRIPTION
## What

- **getting-started/quickstart.md** — Next Steps now links the FAQ's machine-migration sections (`hermes backup` full migration + single-profile export), so new users learn these exist before they need them.
- **getting-started/updating.md** — a tip after the `pre_update_backup` section routes "moving to a new machine" readers to `hermes backup` + `hermes import` instead of update backups.
- **reference/faq.md** — the *High token usage* entry now leads with `hermes prompt-size` and explains the fixed prompt budget with the trimming levers (`hermes tools`, `hermes skills`).
- **guides/tips.md** — the usage-visibility tip mentions `hermes prompt-size` alongside `/usage` and `/insights`.
- **guides/local-ollama-setup.md** — "Model doesn't follow tool calls" now distinguishes the server-side cause (raw JSON in the reply) and cross-links the per-server fix table on the providers page.

No new claims anywhere — every addition links or restates content that already exists in the docs.

## Why

From community feedback triage (Apr–Aug 2026, X/Reddit/GitHub/Discord): the answers above all exist in the docs, but users don't find them.

- machine migration: 18 receipts of users tarring `~/.hermes` by hand or losing setups; none of them found the three FAQ sections that answer it. Nothing in getting-started or the update path points there.
- fixed prompt cost: 11 receipts of "why does every message cost 12–20k tokens" — `hermes prompt-size` answers this exactly but only appears in the CLI reference.
- narration instead of tool calls: 8 receipts, all landing on the Ollama guide's troubleshooting; the per-server fix table they actually needed lives at the bottom of the providers page.

Cheapest category of docs fix: pure discoverability, zero behavioural claims.