### PR TITLE
docs: explain the slow silent first turn (prefill) on local hardware

### DIFF
--- a/website/docs/guides/local-llm-on-mac.md
+++ b/website/docs/guides/local-llm-on-mac.md
@@ -238,3 +238,7 @@ HERMES_STREAM_READ_TIMEOUT=1800
 | API call (non-streaming) | 1800s | No change needed | `HERMES_API_TIMEOUT` |
 
 The stream read timeout is the one most likely to cause issues — it's the socket-level deadline for receiving the next chunk of data. During prefill on large contexts, local models may produce no output for minutes while processing the prompt. The auto-detection handles this transparently.
+
+:::tip A silent first turn is usually prefill, not a hang
+Hermes sends its system prompt and tool schemas on every call, so on slower hardware the first turn can involve minutes of silence while the model processes that prompt before generating anything. That's prefill at work, not a stalled session. See [Slow first response (prefill)](./local-ollama-setup.md#slow-first-response-prefill) in the Ollama guide for mitigations like keeping the model loaded and trimming the fixed prompt with `hermes prompt-size`.
+:::

--- a/website/docs/guides/local-ollama-setup.md
+++ b/website/docs/guides/local-ollama-setup.md
@@ -276,6 +276,17 @@ ollama serve
 - **Check `ollama ps`:** If no GPU layers are offloaded, responses are CPU-bound. This is normal for CPU-only servers.
 - **Reduce context:** Large conversations slow down inference. Use `/compress` regularly, or set a lower compression threshold in config.
 
+### Slow first response (prefill)
+
+Hermes sends a fixed payload on every API call — the system prompt plus the tool schemas for all enabled tools — before any of your conversation content. On CPU-only or low-VRAM setups, processing that prompt (the *prefill* phase) dominates the first turn: the model can sit silent for minutes while it works through the prompt, then generate at its normal pace. This is expected behaviour, not a hang. The [Mac local-LLM guide](./local-llm-on-mac.md#timeouts) documents the same effect — during prefill on large contexts, local models may produce no output for minutes while processing the prompt — and Hermes automatically raises its stream read timeout from 120s to 1800s for local endpoints (`HERMES_STREAM_READ_TIMEOUT`).
+
+What helps:
+
+- **Keep the model loaded** — Ollama unloads idle models after 5 minutes, adding a full reload before the next prefill. Set `OLLAMA_KEEP_ALIVE=24h` (see [Step 6](#keep-the-model-loaded)).
+- **Widen the API timeout** — set `HERMES_API_TIMEOUT=1800` in `~/.hermes/.env` (see [What You Need](#what-you-need)).
+- **Measure and trim the fixed prompt** — run `hermes prompt-size` for a byte breakdown of the system prompt and tool schemas, then disable unused toolsets with `hermes tools` and uninstall skills you don't need with `hermes skills`.
+- **Use GPU offloading** — even a partial offload gives a significant speedup (see [Step 6](#use-gpu-offloading-if-available)).
+
 ### Model doesn't follow tool calls
 
 Smaller models (3B, 7B) sometimes ignore tool-call instructions and produce plain text instead of structured function calls. Solutions:


### PR DESCRIPTION
## What

- **guides/local-ollama-setup.md** — new Troubleshooting subsection "Slow first response (prefill)": Hermes sends the system prompt + tool schemas on every call; on low-throughput hardware processing that prompt dominates the first turn, so a multi-minute silent first response is expected, not a hang. Mitigations listed are all already in the guide (keep-alive, `HERMES_API_TIMEOUT`, `hermes prompt-size` trimming, GPU offload) plus a cross-link to the Mac guide's timeout table.
- **guides/local-llm-on-mac.md** — a three-sentence `:::tip` after the timeout table ("a silent first turn is usually prefill, not a hang") cross-linking the new subsection.

Zero new numbers: every figure cited (120s→1800s stream-timeout relax, keep-alive, timeout values) already lives in these two pages.

## Why

From community feedback triage (Apr–Aug 2026): the loudest local-model theme at 34 receipts — sizing and first-turn-latency confusion from Raspberry Pi setups to multi-GPU rigs, including working setups torn down because a slow prefill read as a hang (one user shipped a competing lightweight CLI citing exactly this). The docs document the timeout mechanics but never say the sentence users need first: *this is expected on your hardware*.