### PR TITLE
fix(desktop): seed context_max so the context-usage statusbar item is visible

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-context-usage-seed.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-usage-seed.test.ts
@@ -96,9 +96,11 @@ describe('useContextUsageSeed', () => {
 
   it('skips publishing a stale result after the session changes mid-fetch', async () => {
     const resolvers: Array<(data: ContextBreakdown) => void> = []
+
     const requestGateway = vi
       .fn()
       .mockImplementation(() => new Promise<ContextBreakdown>(r => resolvers.push(r)))
+
     const published = vi.fn()
 
     const { rerender } = renderHook(

--- a/apps/desktop/src/app/shell/hooks/use-context-usage-seed.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-usage-seed.test.ts
@@ -1,0 +1,126 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ContextBreakdown } from '@/types/hermes'
+
+import { useContextUsageSeed } from './use-context-usage-seed'
+
+const breakdown: ContextBreakdown = {
+  categories: [{ color: 'teal', id: 'conversation', label: 'Conversation', tokens: 241_400 }],
+  context_max: 272_000,
+  context_percent: 89,
+  context_used: 241_400,
+  estimated_total: 286_600,
+  model: 'test-model'
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('useContextUsageSeed', () => {
+  it('fetches the breakdown once and seeds context_max for the active session', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+    const published = vi.fn()
+
+    const { result } = renderHook(() =>
+      useContextUsageSeed({
+        activeSessionId: 'runtime-1',
+        contextMax: undefined,
+        publishContextUsage: published,
+        requestGateway
+      })
+    )
+
+    await waitFor(() => {
+      expect(published).toHaveBeenCalledWith({
+        context_max: 272_000,
+        context_percent: 89,
+        context_used: 241_400
+      })
+      expect(requestGateway).toHaveBeenCalledWith('session.context_breakdown', { session_id: 'runtime-1' })
+    })
+
+    await act(async () => {})
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(result.current).toBeUndefined()
+  })
+
+  it('does not fetch when context_max is already known', () => {
+    const requestGateway = vi.fn()
+
+    renderHook(() =>
+      useContextUsageSeed({
+        activeSessionId: 'runtime-1',
+        contextMax: 272_000,
+        publishContextUsage: vi.fn(),
+        requestGateway
+      })
+    )
+
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when there is no active session', () => {
+    const requestGateway = vi.fn()
+
+    renderHook(() =>
+      useContextUsageSeed({
+        activeSessionId: null,
+        contextMax: undefined,
+        publishContextUsage: vi.fn(),
+        requestGateway
+      })
+    )
+
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('does not seed when the fetch fails', async () => {
+    const requestGateway = vi.fn().mockRejectedValue(new Error('backend unreachable'))
+    const published = vi.fn()
+
+    renderHook(() =>
+      useContextUsageSeed({
+        activeSessionId: 'runtime-1',
+        contextMax: undefined,
+        publishContextUsage: published,
+        requestGateway
+      })
+    )
+
+    await act(async () => {})
+    expect(published).not.toHaveBeenCalled()
+  })
+
+  it('skips publishing a stale result after the session changes mid-fetch', async () => {
+    const resolvers: Array<(data: ContextBreakdown) => void> = []
+    const requestGateway = vi
+      .fn()
+      .mockImplementation(() => new Promise<ContextBreakdown>(r => resolvers.push(r)))
+    const published = vi.fn()
+
+    const { rerender } = renderHook(
+      (props: { activeSessionId: string | null }) =>
+        useContextUsageSeed({
+          activeSessionId: props.activeSessionId,
+          contextMax: undefined,
+          publishContextUsage: published,
+          requestGateway
+        }),
+      { initialProps: { activeSessionId: 'runtime-1' } }
+    )
+
+    // Switch sessions while the first fetch is still in flight; the first
+    // effect's cleanup marks it cancelled.
+    rerender({ activeSessionId: 'runtime-2' })
+
+    await act(async () => {
+      // Resolve only the FIRST (now-cancelled) fetch. It must not publish.
+      resolvers[0]?.(breakdown)
+    })
+
+    expect(published).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-context-usage-seed.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-usage-seed.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react'
+
+import type { ContextBreakdown, UsageStats } from '@/types/hermes'
+
+/**
+ * Eagerly seeds `context_max` for the active session so the context-usage
+ * statusbar item is visible from the start of a session.
+ *
+ * Without this the item stays hidden until the user opens the context panel —
+ * which can't happen while the item is hidden (the Catch-22 in #78936). The
+ * panel still refetches on open, so this is a one-time seed: once `contextMax`
+ * is known we stop, and a failed fetch fails open (the item stays hidden
+ * rather than showing bad data).
+ */
+export function useContextUsageSeed({
+  activeSessionId,
+  contextMax,
+  publishContextUsage,
+  requestGateway
+}: {
+  activeSessionId: string | null
+  contextMax: number | undefined
+  publishContextUsage: (snapshot: Pick<UsageStats, 'context_max' | 'context_percent' | 'context_used'>) => void
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+}): void {
+  useEffect(() => {
+    if (!activeSessionId || contextMax) {
+      return
+    }
+
+    let cancelled = false
+
+    void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: activeSessionId })
+      .then(data => {
+        if (!cancelled) {
+          publishContextUsage({
+            context_max: data.context_max,
+            context_percent: data.context_percent,
+            context_used: data.context_used
+          })
+        }
+      })
+      .catch(() => {
+        // Fail open — leave the item hidden rather than showing bad data.
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeSessionId, contextMax, publishContextUsage, requestGateway])
+}

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -49,6 +49,7 @@ import type { StatusResponse, UsageStats } from '@/types/hermes'
 
 import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
+import { useContextUsageSeed } from './use-context-usage-seed'
 
 const EMPTY_USAGE = { calls: 0, input: 0, output: 0, total: 0 } as const
 
@@ -154,7 +155,7 @@ export function useStatusbarItems({
 
   // EMPTY_USAGE (module constant) keeps the fallback referentially stable —
   // a fresh `{...}` each render would bust the usage-label memos below.
-  const currentUsage = primaryFocused ? primaryUsage : (focusedUsage ?? EMPTY_USAGE)
+  const currentUsage: UsageStats = primaryFocused ? primaryUsage : (focusedUsage ?? EMPTY_USAGE)
 
   const turnStartedAt = primaryFocused ? primaryTurnStartedAt : focusedTurnStartedAt
 
@@ -232,6 +233,18 @@ export function useStatusbarItems({
     },
     []
   )
+
+  // Eagerly populate context_max for the active session so the context-usage
+  // statusbar item is visible from the start. Without this, the item stays
+  // hidden until the user opens the context panel — which can't happen while
+  // the item is hidden (the Catch-22 in #78936). The panel still refetches on
+  // open, so this is a one-time seed: once context_max is known we stop.
+  useContextUsageSeed({
+    activeSessionId,
+    contextMax: currentUsage.context_max,
+    publishContextUsage,
+    requestGateway
+  })
 
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -49,6 +49,7 @@ import type { StatusResponse, UsageStats } from '@/types/hermes'
 
 import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
+
 import { useContextUsageSeed } from './use-context-usage-seed'
 
 const EMPTY_USAGE = { calls: 0, input: 0, output: 0, total: 0 } as const


### PR DESCRIPTION
Fixes #78936

## Problem

The context-usage statusbar item is permanently hidden after a session restart. The root cause is a Catch-22:

- `usageContextLabel()` returns empty (so the item's `hidden` is true) whenever `context_max` is unset.
- `context_max` was only populated by `ContextUsagePanel`'s `onUsageSnapshot`, which fires only when the panel mounts — i.e. only when the user clicks the item to open the panel.
- The item is hidden, so it can never be clicked, so `context_max` is never populated.

Normal `message.complete` events only carry `input_tokens`/`output_tokens`, never `context_max`.

## Fix

Eagerly fetch `session.context_breakdown` for the active session and seed `context_max`/`context_percent`/`context_used` into `$currentUsage` once, so the item is visible from the start.

- New `useContextUsageSeed` hook (pure, DI-testable): fetches the breakdown for the active session when `context_max` is unknown, publishes the snapshot via the existing `publishContextUsage` path, and stops once `context_max` is known. Fails open — a failed fetch leaves the item hidden rather than showing bad data. Cancels in-flight fetches on session switch.
- Wired into `useStatusbarItems` after `publishContextUsage` is defined.
- The `ContextUsagePanel` still refetches on open, so the panel and the seeded statusbar stay consistent.

## Verification

- New `use-context-usage-seed.test.ts` (5 tests): seeds once for the active session, skips when `context_max` is known, skips with no active session, fails open on fetch error, and discards stale results after a mid-fetch session switch.
- `npx tsc --noEmit` clean.
- Existing `context-usage-panel.test.tsx` and `statusbar-visibility.test.tsx` still pass.