### PR TITLE
fix(cli): close stdout pipe after npm build to prevent update hang

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5379,6 +5379,16 @@ def _run_with_idle_timeout(
 
     # Drain reader so we don't leak the stdout file descriptor.
     reader_thread.join(timeout=2)
+    # Close the stdout pipe so that orphaned child processes (e.g. vite
+    # spawned by npm) that inherited the write end cannot keep the parent
+    # process alive via an open pipe fd.  If the reader thread is still
+    # stuck (join timed out), closing the fd unblocks it and lets the
+    # thread exit cleanly.  See issue #79040.
+    if proc.stdout is not None:
+        try:
+            proc.stdout.close()
+        except Exception:
+            pass
 
     combined = "".join(merged_chunks)
     if idle_killed:


### PR DESCRIPTION
hermes update completes all steps but the process never exits, breaking cron auto-update scripts. The process remains alive indefinitely and is only killed by an external timeout.

Root cause: when npm/vite build runs during update, orphaned child processes can inherit the write end of the stdout pipe. Even after the main process exits, the inherited pipe fd keeps the Python process alive because the reader thread is stuck on readline() waiting for EOF that never comes.

Fix: close proc.stdout explicitly after the reader thread join in _run_with_idle_timeout. If the reader thread is still stuck (join timed out because child processes hold the pipe open), closing the fd from the parent side releases it and allows clean process exit.

Fixes #79040