### PR TITLE
fix(model_metadata): normalize provider pricing units

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import time
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse
@@ -26,6 +27,11 @@ from utils import atomic_json_write, base_url_host_matches, base_url_hostname
 from hermes_constants import OPENROUTER_MODELS_URL
 
 logger = logging.getLogger(__name__)
+
+_PRICING_UNIT_DIVISORS: dict[str, Decimal] = {
+    "per_1m_tokens": Decimal("1000000"),
+    "per_1k_tokens": Decimal("1000"),
+}
 
 # ``requests`` (with urllib3) costs ~27 ms of the `import cli` waterfall and
 # is only used inside the fetch functions below. It's resolved lazily:
@@ -1131,11 +1137,20 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         normalized = {str(key).lower(): value for key, value in mapping.items()}
         if not any(any(alias in normalized for alias in aliases) for aliases in alias_map.values()):
             continue
+        unit_divisor = _PRICING_UNIT_DIVISORS.get(
+            str(normalized.get("unit", "")).lower()
+        )
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
                 if alias in normalized and normalized[alias] not in {None, ""}:
-                    pricing[target] = normalized[alias]
+                    value = normalized[alias]
+                    if unit_divisor is not None and target != "request":
+                        try:
+                            value = str(Decimal(str(value)) / unit_divisor)
+                        except (InvalidOperation, TypeError, ValueError):
+                            pass
+                    pricing[target] = value
                     break
         if pricing:
             return pricing

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -20,6 +20,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     DEFAULT_FALLBACK_CONTEXT,
+    _extract_pricing,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -1003,6 +1004,53 @@ class TestFetchModelMetadata:
         assert "anthropic/claude-3.5-sonnet:beta" in result
         assert "anthropic/claude-3.5-sonnet" in result
         assert result["anthropic/claude-3.5-sonnet"]["context_length"] == 200000
+
+
+class TestExtractPricing:
+    def test_generic_pricing_respects_per_million_unit(self):
+        pricing = _extract_pricing(
+            {
+                "pricing": {
+                    "currency": "CNY",
+                    "unit": "per_1m_tokens",
+                    "prompt": 1,
+                    "completion": 2,
+                    "cache_read": "0.5",
+                }
+            }
+        )
+
+        assert pricing["prompt"] == "0.000001"
+        assert pricing["completion"] == "0.000002"
+        assert pricing["cache_read"] == "5E-7"
+
+    def test_generic_pricing_respects_per_thousand_unit(self):
+        pricing = _extract_pricing(
+            {
+                "pricing": {
+                    "unit": "per_1k_tokens",
+                    "input": "1.5",
+                    "output": 2,
+                }
+            }
+        )
+
+        assert pricing["prompt"] == "0.0015"
+        assert pricing["completion"] == "0.002"
+
+    def test_generic_pricing_leaves_request_cost_unscaled(self):
+        pricing = _extract_pricing(
+            {
+                "pricing": {
+                    "unit": "per_1m_tokens",
+                    "prompt": 1,
+                    "request": "0.25",
+                }
+            }
+        )
+
+        assert pricing["prompt"] == "0.000001"
+        assert pricing["request"] == "0.25"
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -312,3 +312,28 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_provider_models_api_respects_per_million_pricing_units(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "custom/model": {
+                "pricing": {
+                    "prompt": "0.000001",
+                    "completion": "0.000002",
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "custom/model",
+        provider="custom",
+        base_url="https://tokenrhythm.studio/v1",
+    )
+
+    assert entry is not None
+    assert entry.source == "provider_models_api"
+    assert entry.input_cost_per_million == 1
+    assert entry.output_cost_per_million == 2


### PR DESCRIPTION
## Summary
- normalize generic provider `/models` pricing entries that declare `unit: per_1m_tokens` or `unit: per_1k_tokens`
- keep request-cost fields unscaled while converting only token-priced buckets back to Hermes' per-token metadata carrier
- add regression coverage for both `_extract_pricing()` and the provider-models pricing pipeline

## Problem
On current `main`, the generic pricing fallback in `agent/model_metadata.py::_extract_pricing()` copies `prompt` / `completion` / `cache_*` values verbatim and ignores the sibling `unit` field. `agent/usage_pricing.py::_pricing_entry_from_metadata()` then assumes those values are per-token and multiplies them by 1,000,000, so providers that already report per-million units produce a 1,000,000x inflated expensive-model warning.

## Fix
Read the enclosing pricing unit in `_extract_pricing()`'s generic path and convert token-priced fields back to Hermes' per-token metadata convention:
- `per_1m_tokens` -> divide by 1,000,000
- `per_1k_tokens` -> divide by 1,000
- leave `request` unscaled

This keeps the downstream pricing pipeline unchanged while fixing the unit mismatch at the metadata boundary.

## Testing
- `.venv/bin/pytest tests/agent/test_model_metadata.py tests/agent/test_usage_pricing.py -q`

Fixes #79174
