### PR TITLE
desktop: open a session from a hermes:// deep link

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11731,6 +11731,7 @@ function handleDeepLink(url) {
   }
 
   // hermes://blueprint/<key>?slot=val  -> host="blueprint", path="/<key>"
+  // hermes://session/<id>              -> host="session",   path="/<id>"
   const kind = parsed.hostname || ''
   const name = decodeURIComponent((parsed.pathname || '').replace(/^\//, ''))
   const params = {}

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations-deep-link.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations-deep-link.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDesktopIntegrations } from './use-desktop-integrations'
+
+// The hook wires up a dozen desktop integrations; this file is only about the
+// `hermes://` deep-link one. Everything it reaches for on mount is stubbed so
+// the effect under test runs in isolation rather than dragging in the update
+// poller, the session store and the notification bridge.
+vi.mock('@/store/updates', () => ({
+  openUpdatesWindow: vi.fn(),
+  startUpdatePoller: vi.fn(),
+  stopUpdatePoller: vi.fn()
+}))
+vi.mock('@/store/session-sync', () => ({ onSessionsChanged: vi.fn(() => () => undefined) }))
+vi.mock('@/store/native-notifications', () => ({ respondToApprovalAction: vi.fn() }))
+vi.mock('@/store/projects', () => ({ openFolderAsProject: vi.fn() }))
+vi.mock('@/store/windows', () => ({ isSecondaryWindow: () => false }))
+vi.mock('@/app/chat/close-tab', () => ({ closeActiveTab: vi.fn() }))
+vi.mock('@/app/open-session', () => ({ openSession: vi.fn() }))
+
+const { openSession } = await import('@/app/open-session')
+vi.mock('@/lib/session-ids', () => ({ storedSessionIdForNotification: vi.fn() }))
+vi.mock('../../chat/composer/focus', () => ({
+  requestComposerFocus: vi.fn(),
+  requestComposerInsert: vi.fn()
+}))
+
+type DeepLinkPayload = { kind: string; name: string; params?: Record<string, string> }
+
+/** Captures the deep-link subscriber the hook registers, so a test can fire it. */
+function mountWithDeepLink(navigate: (to: string, options?: { replace?: boolean }) => void) {
+  let deliver: ((payload: DeepLinkPayload) => void) | undefined
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      onDeepLink: (cb: (payload: DeepLinkPayload) => void) => {
+        deliver = cb
+
+        return () => undefined
+      },
+      signalDeepLinkReady: vi.fn()
+    },
+    writable: true
+  })
+
+  renderHook(() =>
+    useDesktopIntegrations({
+      activeProfile: 'default',
+      chatOpen: false,
+      hasPreview: false,
+      locationPathname: '/',
+      navigate,
+      profileReady: true,
+      refreshSessions: vi.fn(),
+      resumeExhaustedSessionId: null,
+      routedSessionId: null,
+      runtimeIdByStoredSessionId: { current: new Map<string, string>() },
+      sessions: []
+    })
+  )
+
+  if (deliver === undefined) {
+    throw new Error('the hook never subscribed to deep links')
+  }
+
+  return deliver
+}
+
+describe('hermes:// session deep links', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // `openSession`, not a bare `navigate` — the distinction is the whole bug this
+  // covers. Navigating alone changes the address without selecting the session,
+  // which renders an empty pane until something else forces the selection.
+  it('opens the named session through openSession', () => {
+    const navigate = vi.fn()
+    mountWithDeepLink(navigate)({ kind: 'session', name: '20260804_184317_5b179b' })
+
+    expect(openSession).toHaveBeenCalledWith('20260804_184317_5b179b', navigate)
+  })
+
+  it('does not route without selecting — a bare navigate would leave an empty pane', () => {
+    const navigate = vi.fn()
+    mountWithDeepLink(navigate)({ kind: 'session', name: '20260804_184317_5b179b' })
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('ignores a session link with no id', () => {
+    const navigate = vi.fn()
+    mountWithDeepLink(navigate)({ kind: 'session', name: '' })
+
+    expect(openSession).not.toHaveBeenCalled()
+  })
+
+  it('leaves other kinds alone — a blueprint link must not open a session', () => {
+    const navigate = vi.fn()
+    mountWithDeepLink(navigate)({ kind: 'blueprint', name: 'morning-brief' })
+
+    expect(openSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -187,10 +187,35 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links.
+  //
+  //   hermes://blueprint/<key>?slot=val  -> a reviewable /blueprint command
+  //   hermes://session/<id>              -> open that session
+  //
+  // The session form exists so another tool can hand a conversation back to
+  // Hermes. Without it, an external app that knows a session id can raise the
+  // window but not land anywhere useful — the id is right there and unusable.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
+      if (!payload || !payload.name) {
+        return
+      }
+
+      if (payload.kind === 'session') {
+        // `openSession`, not a bare `navigate`: it fronts an already-open tile
+        // or loads the session into main, and only routes when routing is what
+        // is actually needed. Navigating alone changes the address without
+        // selecting the session, which renders an empty pane until something
+        // else forces the selection.
+        //
+        // It ignores an empty id, and percent-encodes the one it routes with,
+        // so a malformed or hostile id cannot escape into the query or hash.
+        openSession(payload.name, navigate)
+
+        return
+      }
+
+      if (payload.kind !== 'blueprint') {
         return
       }
 
@@ -210,7 +235,10 @@ export function useDesktopIntegrations({
     void window.hermesDesktop?.signalDeepLinkReady?.()
 
     return () => unsubscribe?.()
-  }, [])
+    // Re-subscribing on a new `navigate` is safe: the main process nulls
+    // `_pendingDeepLink` before re-dispatching, so a queued link flushes
+    // exactly once however many times the renderer signals ready.
+  }, [navigate])
 
   // ⌘W via the macOS menu accelerator → close the focused tab; if nothing is
   // closeable, fall back to closing the window (so ⌘W still works as the


### PR DESCRIPTION
## What

`hermes://session/<id>` opens that session in the desktop app.

## Why

The protocol handler already parses any `hermes://<kind>/<name>` and forwards `{kind, name, params}` to the renderer — but `blueprint` is the only kind anything listens for. So an external tool holding a session id can raise the window and land nowhere useful.

That is a concrete gap rather than a hypothetical one. A kanban run creates a genuine session (`source='kanban'`, with a title, full message history and its tool calls), so a companion app that dispatches work to Hermes knows the session id it caused. Today it can show you what the agent concluded, but it cannot hand you back the conversation to correct it — the id is right there and unusable.

## The change

One new branch in the deep-link effect, plus the scheme comment in `main.ts`:

```ts
if (payload.kind === 'session') {
  openSession(payload.name, navigate)
  return
}
```

## `openSession`, not `navigate` — and this was found the hard way

The first version called `navigate(sessionRoute(payload.name))`. It typechecked, linted, passed its tests, and the main process logged `[deeplink] delivered session/<id>`.

**It opened a blank pane.** Clicking to another tab and back showed the conversation.

`navigate` changes the address without selecting the session. `openSession` — already imported in this file — fronts an already-open tile or loads the session into main, and routes only when routing is what is actually needed. The routing is the *last* step of opening a session, and calling it alone does the last step without the first.

The tests now assert the hook does **not** navigate directly, because that distinction is the entire bug.

## Cross-profile links work, for free

Verified on a real build: sending a `dev`-profile session id while the app was showing `dec-admin` **switched profile and opened the conversation**.

That is `openSession` inheriting `resolveStoredSession` → `ensureGatewayProfile`, which already resolves a session id to its owning profile (the #67603 cross-profile open asymmetry). A bare `navigate` would not have got this either — another reason to delegate rather than route directly.

So a deep link needs only the session id. It does not have to carry a profile.

## The dependency array

The effect depends on `navigate`, matching the ⌘W effect immediately below it. That is safe despite this effect also calling `signalDeepLinkReady`: the main process nulls `_pendingDeepLink` **before** re-dispatching, so a queued link flushes exactly once however many times the renderer signals ready.

A ref was tried first, to keep the subscription one-time — and correctly rejected by this repo's own lint rule against mirroring reactive values into refs. The rule was right; the concern it guards against does not arise here.

## Verification

- `tsc -p . --noEmit` — clean
- `eslint` on both touched files — clean
- `vitest run --project ui src/app/contrib/hooks/` — **36/36**, including four new tests: the new kind, that it does not route directly, an empty id, and that a `blueprint` link still does not open a session
- **Built and run for real**: `[deeplink] delivered session/<id>`, conversation renders immediately

## Not included

An endpoint to *send* a turn into an existing session, which would let an external app host the conversation rather than hand it over. That is a larger change touching the agent loop and worth its own PR. This one is small enough to review in a sitting and independently useful.
