### PR TITLE
fix(tools): explain permission-denied writes instead of leaking the temp path

### DIFF
--- a/tests/test_write_permission_denied_message.py
+++ b/tests/test_write_permission_denied_message.py
@@ -1,0 +1,119 @@
+"""Permission-denied writes must explain themselves.
+
+The atomic-write path streams into a ``.hermes-tmp.XXXXXX`` file beside the
+target, so a bare permission failure used to surface as::
+
+    Failed to write file: /usr/local/sbin/.hermes-tmp.38704: Permission denied
+
+That names a temp path the caller never asked for, points at the wrong thing
+(the *directory* is unwritable, not that temp file), and reads like an internal
+Hermes bug -- so the agent retries the same doomed write instead of reaching for
+sudo. These tests pin the actionable message instead.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.file_operations import ShellFileOperations  # noqa: E402
+
+
+class _LocalEnv:
+    """Minimal terminal backend: execute() -> {output, returncode}."""
+
+    def __init__(self, cwd):
+        self.cwd = str(cwd)
+
+    def execute(self, command, cwd=None, stdin_data=None, **kwargs):
+        proc = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            cwd=cwd or self.cwd,
+            input=stdin_data if stdin_data is not None else None,
+        )
+        return {
+            "output": (proc.stdout or "") + (proc.stderr or ""),
+            "returncode": proc.returncode,
+        }
+
+
+@pytest.fixture
+def ops(tmp_path):
+    return ShellFileOperations(_LocalEnv(tmp_path))
+
+
+@pytest.fixture
+def readonly_dir(tmp_path):
+    """A directory the current user cannot write into.
+
+    Uses mode 0o500 rather than a real system path so the test is
+    hermetic and does not depend on the host layout.
+    """
+    d = tmp_path / "locked"
+    d.mkdir()
+    (d / "existing.txt").write_text("original\n")
+    d.chmod(0o500)
+    yield d
+    d.chmod(0o700)  # let pytest clean up
+
+
+@pytest.mark.skipif(
+    __import__("os").geteuid() == 0,
+    reason="root bypasses directory permissions",
+)
+class TestPermissionDeniedMessage:
+    def test_existing_file_in_unwritable_dir(self, ops, readonly_dir):
+        target = readonly_dir / "existing.txt"
+        err = ops.write_file(str(target), "new content\n").error
+
+        assert err, "write into an unwritable directory must fail"
+        assert "hermes-tmp" not in err, "internal temp path must not leak"
+        assert str(target) in err, "the real target must be named"
+        assert "permission denied" in err.lower()
+        assert "sudo install" in err, "must suggest the elevated-write remedy"
+        # original untouched -- the atomic write never swapped anything in
+        assert target.read_text() == "original\n"
+
+    def test_new_file_in_unwritable_dir(self, ops, readonly_dir):
+        target = readonly_dir / "brand-new.txt"
+        err = ops.write_file(str(target), "hello\n").error
+
+        assert err
+        assert "hermes-tmp" not in err
+        assert str(target) in err
+        assert "sudo install" in err
+
+    def test_patch_inherits_the_explanation(self, ops, readonly_dir):
+        """patch_replace routes through write_file, so it must not leak either."""
+        target = readonly_dir / "existing.txt"
+        err = ops.patch_replace(str(target), "original", "patched").error
+
+        assert err
+        assert "hermes-tmp" not in err, "patch must not leak the temp path either"
+
+    def test_non_permission_errors_pass_through(self, ops, tmp_path):
+        """Only permission failures get rewritten; other errors stay verbatim."""
+        # A path whose parent is a regular file -> ENOTDIR, not EACCES.
+        blocker = tmp_path / "iam_a_file"
+        blocker.write_text("x")
+        err = ops.write_file(str(blocker / "child.txt"), "data").error
+
+        assert err
+        assert "sudo install" not in err, "non-permission errors must not be rewritten"
+
+
+@pytest.mark.skipif(
+    __import__("os").geteuid() == 0,
+    reason="root bypasses directory permissions",
+)
+def test_writable_paths_still_work(ops, tmp_path):
+    """Non-regression: the happy path is untouched."""
+    target = tmp_path / "fine.txt"
+    result = ops.write_file(str(target), "hello\n")
+
+    assert result.error is None
+    assert target.read_text() == "hello\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1084,6 +1084,48 @@ class ShellFileOperations(FileOperations):
         )
         return self._exec(script, stdin_data=content)
 
+    def _explain_write_failure(self, path: str, raw_stderr: str) -> str:
+        """Turn a raw shell write failure into an actionable message.
+
+        The atomic-write path streams into a ``.hermes-tmp.XXXXXX`` file
+        beside the target, so a plain permission error surfaces as e.g.
+        ``/usr/local/sbin/.hermes-tmp.38704: Permission denied`` — a temp
+        path the caller never named. That reads like an internal Hermes
+        bug, hides the fact that the *directory* is the thing we can't
+        write, and gives no hint at the fix. Rewrite it to name the real
+        target and the actual remedy; anything we don't recognise is
+        passed through untouched.
+        """
+        raw = (raw_stderr or "").strip()
+        if "Permission denied" not in raw:
+            return raw or "unknown error"
+
+        parent = os.path.dirname(path) or "."
+        # Whether the blocked write is on the file itself or on its
+        # directory changes the remedy, so probe before advising.
+        probe = self._exec(
+            f"if [ -e {self._escape_shell_arg(path)} ]; then echo exists; fi; "
+            f"if [ -w {self._escape_shell_arg(parent)} ]; then echo dir-writable; fi"
+        )
+        flags = (probe.stdout or "").split()
+        target_exists = "exists" in flags
+        dir_writable = "dir-writable" in flags
+
+        if target_exists and not dir_writable:
+            reason = f"the directory {parent} is not writable by the current user"
+        elif target_exists:
+            reason = f"{path} is not writable by the current user"
+        else:
+            reason = f"cannot create files in {parent} (directory not writable)"
+
+        return (
+            f"permission denied — {reason}. "
+            f"This path needs elevated privileges: write the content to a temp "
+            f"location first, then install it with the terminal tool "
+            f"(e.g. `sudo install -m <mode> -o <owner> /tmp/<file> {path}`). "
+            f"Editing it directly with the file tools will keep failing."
+        )
+
     def _detect_file_line_ending(self, path: str, pre_content: Optional[str] = None) -> Optional[str]:
         """Detect the dominant line ending of a file on disk.
 
@@ -1585,7 +1627,9 @@ class ShellFileOperations(FileOperations):
         write_result = self._atomic_write(path, content)
 
         if write_result.exit_code != 0:
-            return WriteResult(error=f"Failed to write file: {write_result.stdout}")
+            return WriteResult(
+                error=f"Failed to write file: {self._explain_write_failure(path, write_result.stdout)}"
+            )
 
         # Get bytes written — compute from the content we just wrote
         # (len of the UTF-8 encoding matches wc -c) instead of spawning a


### PR DESCRIPTION
## What does this PR do?

`write_file` streams content into a `.hermes-tmp.XXXXXX` file beside the target (atomic temp-file + rename), so a plain `EACCES` surfaced the temp path the caller never named:

```text
Failed to write file: /usr/local/sbin/.hermes-tmp.38704: Permission denied
```

Three problems with that message:

- **It reads like an internal Hermes bug.** `.hermes-tmp.NNNNN` is an implementation detail of `_atomic_write`; seeing it in a user-facing error suggests a malfunction rather than a permission boundary.
- **It names the wrong object.** The unwritable thing is the *directory*, not that temp file — and nothing distinguishes "file is read-only" from "directory is read-only".
- **It offers no remedy.** `sudo` via the `terminal` tool is right there, but nothing points at it, so the agent retries the same doomed write (or narrates a success it didn't achieve) and the file-mutation verifier contradicts it afterwards. That contradiction is exactly how this surfaced in practice.

This PR rewrites `EACCES` failures to name the real target, say whether the file or its parent directory is the blocker, and point at the elevated-write path:

```text
Failed to write file: permission denied — the directory /usr/local/sbin is not
writable by the current user. This path needs elevated privileges: write the
content to a temp location first, then install it with the terminal tool
(e.g. `sudo install -m <mode> -o <owner> /tmp/<file> /usr/local/sbin/ha-tailnet-ip-sync`).
Editing it directly with the file tools will keep failing.
```

**Scope is deliberately narrow.** Only messaging changes — no new permissions, no privilege escalation, no attempt to auto-`sudo`. The write still fails; it just explains itself. Non-`EACCES` failures pass through byte-for-byte unchanged.

### Relationship to #69962 / #70137

Same end-user symptom (a failed mutation the agent doesn't recover from, caught only by the finalizer), different door. #69962 covers the **policy** refusal from `HERMES_WRITE_SAFE_ROOT`; this covers a plain **OS `EACCES`**, which never reaches that code path. The two are complementary and don't overlap in code — this touches only the raw-stderr passthrough in `write_file`.

## Related Issue

Fixes #79187

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`
  - Added `_explain_write_failure(path, raw_stderr)`: on `Permission denied`, probes whether the target exists and whether its parent directory is writable, then returns a message naming the target, the specific blocker, and the `sudo install` remedy. Anything not matching `Permission denied` is returned verbatim.
  - `write_file` routes its non-zero-exit branch through that helper instead of interpolating raw stderr.
  - `patch_replace` routes through `write_file`, so it inherits the fix — no second call site to keep in sync.
- `tests/test_write_permission_denied_message.py` — new coverage (5 tests).

## How to Test

As a non-root user on current `main`:

1. Ask the agent to edit a root-owned file, e.g. `patch` on `/usr/local/sbin/<some-script>`.
2. **Before:** `Failed to write file: /usr/local/sbin/.hermes-tmp.38704: Permission denied`
3. **After:** the message names `/usr/local/sbin/<some-script>`, identifies the directory as unwritable, and suggests `sudo install`.

Automated:

```bash
pytest tests/test_write_permission_denied_message.py -q     # 5 passed
```

The tests are hermetic — they build an unwritable directory with `chmod 0o500` under `tmp_path` rather than touching real system paths, and skip under root (`geteuid() == 0`), since root bypasses directory permissions.

**Proof the tests actually bind:** reverting just the one-line change in `write_file` (keeping the helper) fails 3 of the 5 — `test_existing_file_in_unwritable_dir`, `test_new_file_in_unwritable_dir`, and `test_patch_inherits_the_explanation` — each on the `"hermes-tmp" not in err` assertion. Restoring it returns all 5 to green.

**Regression scope:** 298 tests pass across every test file referencing `file_operations` / `ShellFileOperations`:

```bash
pytest $(grep -rl 'file_operations\|ShellFileOperations' tests/) -q   # 298 passed
ruff check tools/file_operations.py tests/test_write_permission_denied_message.py  # clean
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nearest neighbours are #69962 / #70137 (safe-root policy denial), which don't touch this code path; see the note above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 (local backend)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — helper is documented with a docstring explaining the failure mode; no user-facing docs describe this message
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the probe uses only POSIX `[ -e ]` / `[ -w ]` via the same `_exec` path `_atomic_write` already relies on, and matches on the `Permission denied` substring emitted by sh/bash/dash/zsh alike; on a backend that phrases it differently the message simply passes through unchanged (pre-fix behaviour, no regression)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (error text only; no schema or signature change)
