### PR TITLE
feat(tui): expose exact session identity to widgets

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -50,6 +50,11 @@ def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
 
 
+def get_session_cwd() -> str:
+    """Return the cwd bound to the current execution context, if any."""
+    return _session_cwd_override()
+
+
 def _session_cwd_override() -> str:
     value = _SESSION_CWD.get()
     if value is _UNSET:

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -46,6 +46,13 @@ The plugin manager injects this field into every hook payload:
 telemetry_schema_version = "hermes.observer.v1"
 ```
 
+When a hook runs inside a live UI session, the plugin manager also supplies
+the current `ui_session_id`, `session_profile`, and `session_cwd`. These
+fields are empty outside a scoped UI turn. `ui_session_id` identifies the
+frontend tab/window and is intentionally distinct from the durable
+conversation `session_id`. Plugins that publish UI-scoped state must require
+both identities instead of guessing the active session.
+
 Hook callbacks are fail-open. Hermes catches callback exceptions, logs a
 warning, and keeps the agent loop running.
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1929,6 +1929,20 @@ class PluginManager:
         persisted to session DB.
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        try:
+            from gateway.session_context import get_session_env
+
+            kwargs.setdefault("ui_session_id", get_session_env("HERMES_UI_SESSION_ID"))
+            kwargs.setdefault("session_profile", get_session_env("HERMES_SESSION_PROFILE"))
+        except Exception:
+            kwargs.setdefault("ui_session_id", "")
+            kwargs.setdefault("session_profile", "")
+        try:
+            from agent.runtime_cwd import get_session_cwd
+
+            kwargs.setdefault("session_cwd", str(get_session_cwd() or ""))
+        except Exception:
+            kwargs.setdefault("session_cwd", "")
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
         for cb in callbacks:

--- a/skills/autonomous-ai-agents/hermes-agent/references/tui-widgets.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/tui-widgets.md
@@ -91,6 +91,8 @@ Contract essentials:
   paints over the transcript):
   - Docks (chrome rows): `dock-top` (under the top status bar),
     `dock-bottom` (default — above the bottom one).
+  - Transcript edge: `transcript-bottom` reserves rows below the scrolling
+    transcript and directly above the prompt/composer.
   - Rails (side columns beside the transcript; text reflows around them):
     `top-left`, `top-right`, `bottom-left`, `bottom-right` — corner names
     pick the rail side and its top/bottom anchor. Set `width` on the app

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -90,7 +90,7 @@ class TestFinalizeSessionUsesAgentSessionId:
 
         # Monkeypatch _get_db to return our test DB
         with patch.object(server, "_get_db", return_value=db):
-            with patch.object(server, "_notify_session_boundary", lambda *a: None):
+            with patch.object(server, "_notify_session_boundary", lambda *args, **kwargs: None):
                 server._finalize_session(session, end_reason="tui_close")
 
         # The continuation session should be ended

--- a/tests/test_plugin_session_scope.py
+++ b/tests/test_plugin_session_scope.py
@@ -1,0 +1,66 @@
+from hermes_cli.plugins import PluginManager
+
+
+def test_hook_envelope_includes_current_ui_scope(monkeypatch):
+    from agent import runtime_cwd
+    from gateway import session_context
+
+    values = {
+        "HERMES_UI_SESSION_ID": "ui-7",
+        "HERMES_SESSION_PROFILE": "work",
+    }
+    monkeypatch.setattr(session_context, "get_session_env", lambda name, default="": values.get(name, default))
+    monkeypatch.setattr(runtime_cwd, "get_session_cwd", lambda: "/workspace")
+
+    manager = PluginManager()
+    seen = []
+    manager._hooks["post_tool_call"] = [lambda **kwargs: seen.append(kwargs)]
+    manager.invoke_hook("post_tool_call", session_id="durable-1", tool_name="todo")
+
+    assert seen[0]["ui_session_id"] == "ui-7"
+    assert seen[0]["session_profile"] == "work"
+    assert seen[0]["session_cwd"] == "/workspace"
+
+
+def test_explicit_hook_scope_is_not_overwritten(monkeypatch):
+    from agent import runtime_cwd
+    from gateway import session_context
+
+    monkeypatch.setattr(session_context, "get_session_env", lambda name, default="": "ambient")
+    monkeypatch.setattr(runtime_cwd, "get_session_cwd", lambda: "/ambient")
+
+    manager = PluginManager()
+    seen = []
+    manager._hooks["post_tool_call"] = [lambda **kwargs: seen.append(kwargs)]
+    manager.invoke_hook(
+        "post_tool_call",
+        session_id="durable-1",
+        ui_session_id="ui-explicit",
+        session_profile="profile-explicit",
+        session_cwd="/explicit",
+    )
+
+    assert seen[0]["ui_session_id"] == "ui-explicit"
+    assert seen[0]["session_profile"] == "profile-explicit"
+    assert seen[0]["session_cwd"] == "/explicit"
+
+
+def test_post_tool_call_producer_forwards_turn_id(monkeypatch):
+    from hermes_cli import lifecycle
+    import model_tools
+
+    seen = []
+    monkeypatch.setattr(lifecycle, "has_hook", lambda hook: hook == "post_tool_call")
+    monkeypatch.setattr(lifecycle, "invoke_hook", lambda hook, **kwargs: seen.append((hook, kwargs)))
+
+    model_tools._emit_post_tool_call_hook(
+        function_name="todo",
+        function_args={"todos": []},
+        result={"todos": []},
+        session_id="durable-1",
+        turn_id="turn-7",
+        status="ok",
+    )
+
+    assert seen[0][0] == "post_tool_call"
+    assert seen[0][1]["turn_id"] == "turn-7"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -90,6 +90,64 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
         reset_hermes_home_override(token)
 
 
+def test_session_create_initial_info_includes_known_durable_id(monkeypatch):
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    response = server._methods["session.create"]("create-id", {"cols": 80})
+    sid = response["result"]["session_id"]
+    try:
+        durable_id = response["result"]["stored_session_id"]
+        assert durable_id
+        assert response["result"]["info"]["stored_session_id"] == durable_id
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_lazy_resume_and_fallback_info_include_exact_known_identity(monkeypatch, tmp_path):
+    lazy = server._lazy_resume_info(
+        "/work/project",
+        stored_session_id="resume-durable",
+    )
+    assert lazy["stored_session_id"] == "resume-durable"
+
+    project = tmp_path / "project"
+    project.mkdir()
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    session = {
+        "session_key": "fallback-durable",
+        "agent": None,
+        "cwd": str(project),
+        "profile_home": str(profile_home),
+    }
+    monkeypatch.setattr(server, "_completion_cwd", lambda: "/wrong/workspace")
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda name: profile_home if name == "work" else None,
+    )
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "wrong-profile")
+    fallback = server._fallback_session_info(session)
+    assert fallback["stored_session_id"] == "fallback-durable"
+    assert fallback["cwd"] == str(project)
+    assert fallback["profile_name"] == "work"
+
+    agent = object()
+    session["agent"] = agent
+    seen = []
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda actual_agent, actual_session=None: seen.append(
+            (actual_agent, actual_session)
+        )
+        or {"stored_session_id": "live-durable"},
+    )
+    assert server._fallback_session_info(session)["stored_session_id"] == "live-durable"
+    assert seen == [(agent, session)]
+
+
 def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     """Desktop/TUI sessions must pin the agent cwd per session.
 
@@ -117,6 +175,158 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     finally:
         server._clear_session_context(tokens)
         server._sessions.pop(sid, None)
+
+
+def test_session_context_binds_profile_and_ui_identity(monkeypatch, tmp_path):
+    from gateway.session_context import get_session_env
+    from hermes_cli.plugins import PluginManager
+
+    sid = "ui-sid"
+    session_key = "durable-key"
+    project = tmp_path / "project"
+    project.mkdir()
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    session = {
+        "session_key": session_key,
+        "cwd": str(project),
+        "profile_home": str(profile_home),
+    }
+    monkeypatch.setattr(server, "_response_profile_name", lambda profile=None: profile or "default")
+    decoy_home = tmp_path / "profiles" / "other"
+    decoy_home.mkdir(parents=True)
+    server._sessions["decoy-ui"] = {
+        "session_key": session_key,
+        "cwd": str(project),
+        "profile_home": str(decoy_home),
+    }
+    server._sessions[sid] = session
+
+    tokens = server._set_session_context(session_key, ui_session_id=sid)
+    try:
+        assert get_session_env("HERMES_UI_SESSION_ID") == sid
+        assert get_session_env("HERMES_SESSION_PROFILE") == "work"
+        manager = PluginManager()
+        seen = []
+        manager._hooks["post_tool_call"] = [lambda **kwargs: seen.append(kwargs)]
+        manager.invoke_hook("post_tool_call", session_id=session_key, tool_name="todo")
+        assert seen[0]["ui_session_id"] == sid
+        assert seen[0]["session_profile"] == "work"
+        assert seen[0]["session_cwd"] == str(project)
+    finally:
+        server._clear_session_context(tokens)
+        server._sessions.pop("decoy-ui", None)
+        server._sessions.pop(sid, None)
+
+
+def test_session_context_binds_detached_record_before_registry_insert(monkeypatch, tmp_path):
+    from gateway.session_context import get_session_env
+    from agent.runtime_cwd import get_session_cwd
+
+    project = tmp_path / "project"
+    project.mkdir()
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    session = {
+        "session_key": "durable-detached",
+        "cwd": str(project),
+        "profile_home": str(profile_home),
+        "source": "tui",
+    }
+    monkeypatch.setattr(
+        server,
+        "_response_profile_name",
+        lambda profile=None: profile or "default",
+    )
+
+    tokens = server._set_session_context(
+        "durable-detached",
+        ui_session_id="ui-detached",
+        session=session,
+    )
+    try:
+        assert "ui-detached" not in server._sessions
+        assert get_session_env("HERMES_UI_SESSION_ID") == "ui-detached"
+        assert get_session_env("HERMES_SESSION_PROFILE") == "work"
+        assert get_session_cwd() == str(project)
+        assert get_session_env("HERMES_SESSION_ID") == "durable-detached"
+    finally:
+        server._clear_session_context(tokens)
+
+
+def test_session_boundary_forwards_exact_tui_scope(monkeypatch, tmp_path):
+    from hermes_cli import lifecycle
+
+    sid = "ui-sid"
+    project = tmp_path / "project"
+    project.mkdir()
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    session = {
+        "session_key": "durable-key",
+        "cwd": str(project),
+        "profile_home": str(profile_home),
+    }
+    monkeypatch.setattr(server, "_response_profile_name", lambda profile=None: profile or "default")
+    reset_calls = []
+    finalize_calls = []
+    monkeypatch.setattr(lifecycle, "invoke_hook", lambda hook, **kwargs: reset_calls.append((hook, kwargs)))
+    monkeypatch.setattr(lifecycle, "finalize_session", lambda **kwargs: finalize_calls.append(kwargs))
+
+    server._notify_session_boundary(
+        "on_session_reset",
+        "durable-key",
+        "tui",
+        ui_session_id=sid,
+        session=session,
+    )
+    server._notify_session_boundary(
+        "on_session_finalize",
+        "durable-key",
+        "tui",
+        ui_session_id=sid,
+        session=session,
+    )
+
+    expected = {
+        "session_id": "durable-key",
+        "platform": "tui",
+        "ui_session_id": sid,
+        "session_profile": "work",
+        "session_cwd": str(project),
+    }
+    assert reset_calls == [("on_session_reset", expected)]
+    assert finalize_calls == [expected]
+
+
+def test_popped_session_uses_stamped_ui_identity_for_finalize(monkeypatch, tmp_path):
+    from hermes_cli import lifecycle
+
+    sid = "ui-popped"
+    project = tmp_path / "project"
+    project.mkdir()
+    session = {
+        "session_key": "durable-popped",
+        "cwd": str(project),
+    }
+    server._sessions[sid] = session
+    popped = server._pop_session_by_id(sid)
+    assert popped is session
+    assert sid not in server._sessions
+    assert server._ui_session_id_for_session(popped) == sid
+
+    calls = []
+    monkeypatch.setattr(lifecycle, "finalize_session", lambda **kwargs: calls.append(kwargs))
+    server._notify_session_boundary(
+        "on_session_finalize",
+        "durable-popped",
+        "tui",
+        ui_session_id=server._ui_session_id_for_session(popped),
+        session=popped,
+    )
+
+    assert calls[0]["ui_session_id"] == sid
+    assert calls[0]["session_cwd"] == str(project)
 
 
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
@@ -2449,7 +2659,7 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
 
     monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(
         server,
@@ -2719,6 +2929,7 @@ def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch,
     texts = [m.get("text") for m in resp["result"]["messages"]]
     assert "child substantive answer" in texts
     assert texts == ["child prompt", "child substantive answer", "child terse reply"]
+    assert resp["result"]["info"]["stored_session_id"] == "child1"
 
 
 def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
@@ -2766,7 +2977,7 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(
@@ -2827,7 +3038,7 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": agent.model, "provider": agent.provider})
@@ -2914,17 +3125,27 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
         captured["agent_db"] = session_db
         return types.SimpleNamespace(model="test/model")
 
+    def capture_session_context(target, **kwargs):
+        captured["context_target"] = target
+        captured["context_kwargs"] = kwargs
+        return []
+
+    def capture_boundary(hook_name, *_args, **kwargs):
+        if hook_name == "on_session_reset":
+            captured["reset_session"] = dict(kwargs["session"])
+
     monkeypatch.setenv("TERMINAL_CWD", str(launch_cwd))
     monkeypatch.setattr(server, "_profile_home", lambda _profile: profile_home)
     monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: profile_db)
     monkeypatch.setattr(server, "_get_db", lambda: launch_db)
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", capture_session_context)
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
     monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", capture_boundary)
     monkeypatch.setattr(
         server,
         "_session_info",
@@ -2952,6 +3173,15 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
         assert captured["agent_db"] is profile_db
         assert server._sessions[sid]["cwd"] == str(profile_cwd)
         assert resp["result"]["info"]["cwd"] == str(profile_cwd)
+        assert captured["context_target"] == target
+        assert captured["context_kwargs"]["ui_session_id"] == sid
+        assert captured["context_kwargs"]["session"] == {
+            "session_key": target,
+            "cwd": str(profile_cwd),
+            "profile_home": str(profile_home),
+            "source": "tui",
+        }
+        assert captured["reset_session"]["profile_home"] == str(profile_home)
         assert "launch_update" not in captured
     finally:
         server._sessions.clear()
@@ -2992,6 +3222,92 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
     assert captured["profile_update"] == (target, str(new_cwd))
     assert captured["profile_closed"] is True
     assert "launch_update" not in captured
+
+
+def test_lazy_session_info_preserves_identity_across_cwd_and_workspace_moves(
+    monkeypatch, tmp_path
+):
+    target = "lazy-durable"
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    emitted = []
+    session = {
+        "agent": None,
+        "cwd": str(first),
+        "profile_home": str(profile_home),
+        "running": False,
+        "session_key": target,
+    }
+    server._sessions["ui-lazy"] = session
+
+    def set_cwd(actual_session, raw):
+        actual_session["cwd"] = str(raw)
+        return str(raw)
+
+    class FakeDB:
+        def get_session(self, session_id):
+            assert session_id == target
+            return {"id": target}
+
+        def update_session_cwd(self, *_args, **_kwargs):
+            return None
+
+    class DBContext:
+        def __enter__(self):
+            return FakeDB()
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(server, "_set_session_cwd", set_cwd)
+    monkeypatch.setattr(server, "_profile_db", lambda _params: DBContext())
+    monkeypatch.setattr(server, "_session_db", lambda _session: DBContext())
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_session_git_meta", lambda *_args: None)
+    monkeypatch.setattr(
+        server,
+        "_profile_home",
+        lambda name: profile_home if name == "worker" else None,
+    )
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "wrong-profile")
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "branch")
+    monkeypatch.setattr(server, "_git_common_repo_root_for_cwd", lambda _cwd: "")
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda _cwd: None)
+    monkeypatch.setattr(
+        server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload))
+    )
+
+    try:
+        cwd_response = server.handle_request(
+            {
+                "id": "cwd",
+                "method": "session.cwd.set",
+                "params": {"session_id": "ui-lazy", "cwd": str(second)},
+            }
+        )
+        assert cwd_response["result"]["stored_session_id"] == target
+        assert cwd_response["result"]["profile_name"] == "worker"
+
+        workspace_response = server.handle_request(
+            {
+                "id": "workspace",
+                "method": "session.workspace.move",
+                "params": {"session_key": target, "cwd": str(first)},
+            }
+        )
+        assert "error" not in workspace_response
+        assert emitted[-1][2]["stored_session_id"] == target
+        assert emitted[-1][2]["profile_name"] == "worker"
+
+        server._apply_project_workspace(target, str(second))
+        assert emitted[-1][2]["stored_session_id"] == target
+        assert emitted[-1][2]["profile_name"] == "worker"
+    finally:
+        server._sessions.pop("ui-lazy", None)
 
 
 def test_stored_session_runtime_overrides_skips_bare_billing_provider():
@@ -3593,7 +3909,7 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: calls["hooks"].append((event, session_id)),
+        lambda event, session_id, *_args, **_kwargs: calls["hooks"].append((event, session_id)),
     )
 
     try:
@@ -3857,6 +4173,47 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
     assert closed["count"] == 1
 
 
+def test_finalize_session_end_hook_receives_exact_public_scope(monkeypatch, tmp_path):
+    import hermes_cli.lifecycle as lifecycle
+
+    captured = {}
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    agent = types.SimpleNamespace(
+        session_id="continuation-session",
+        model="test/model",
+        platform="tui",
+    )
+    session = _session(
+        agent=agent,
+        session_key="parent-session",
+        cwd="/work/project",
+        profile_home=str(profile_home),
+        _sid="ui-finalize",
+    )
+
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda name, **kwargs: captured.update(name=name, **kwargs),
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "_response_profile_name",
+        lambda profile=None: profile or "default",
+    )
+
+    server._finalize_session(session)
+
+    assert captured["name"] == "on_session_end"
+    assert captured["session_id"] == "continuation-session"
+    assert captured["ui_session_id"] == "ui-finalize"
+    assert captured["session_profile"] == "work"
+    assert captured["session_cwd"] == "/work/project"
+
+
 def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     """A session that rebinds a live transport is NOT considered orphaned."""
 
@@ -3994,7 +4351,7 @@ def test_init_session_fires_reset_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: hooks.append((event, session_id)),
+        lambda event, session_id, *_args, **_kwargs: hooks.append((event, session_id)),
     )
 
     import tools.approval as _approval
@@ -8748,6 +9105,22 @@ def test_session_info_includes_session_title(monkeypatch):
     assert info["title"] == "Dashboard title"
 
 
+def test_session_info_prefers_live_agent_durable_id_after_compression():
+    agent = types.SimpleNamespace(
+        session_id="continuation-session",
+        tools=[],
+        model="test/model",
+        provider="openai-codex",
+    )
+
+    info = server._session_info(
+        agent,
+        {"session_key": "parent-session", "history": []},
+    )
+
+    assert info["stored_session_id"] == "continuation-session"
+
+
 def test_session_info_reports_pending_model_switch(monkeypatch):
     """A model queued mid-turn shows as the session's model in session.info, so
     the end-of-turn settle doesn't blip the UI back to the still-live old model
@@ -11483,8 +11856,13 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         seen["agent_session_db"] = k.get("session_db")
         return FakeAgent()
 
+    def capture_session_context(target, **kwargs):
+        seen["context_target"] = target
+        seen["context_kwargs"] = kwargs
+        return {}
+
     monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
-    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_set_session_context", capture_session_context)
     monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
     monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
@@ -11510,6 +11888,14 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         assert seen.get("launch_create") is None
         child_sid = resp["result"]["session_id"]
         assert server._sessions[child_sid]["profile_home"] == str(profile_home)
+        assert seen["context_target"] == seen["created"]
+        assert seen["context_kwargs"]["ui_session_id"] == child_sid
+        assert seen["context_kwargs"]["session"] == {
+            "session_key": seen["created"],
+            "cwd": str(tmp_path),
+            "profile_home": str(profile_home),
+            "source": "tui",
+        }
         # The branched AGENT must be bound to the parent profile's state.db —
         # not just the row. Otherwise its own flushes (and a later compression
         # rotation) land on the launch db, splitting the lineage again.
@@ -12286,7 +12672,11 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, session=None: {"model": agent.model},
+    )
 
     def _emit(event, sid, payload=None):
         if event == "message.complete":
@@ -12349,7 +12739,11 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     that copy without leaking the transport object.
     """
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "queue")
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, session=None: {"model": agent.model},
+    )
     agent = types.SimpleNamespace(model="model-live")
     session = _session(
         agent=agent,
@@ -12382,7 +12776,11 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
 
 
 def test_session_activate_switches_live_session_without_closing_siblings(monkeypatch):
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, session=None: {"model": agent.model},
+    )
     server._sessions["sid-a"] = _session(
         agent=types.SimpleNamespace(model="model-a"),
         history=[{"role": "user", "content": "old"}],
@@ -12419,7 +12817,11 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
 
 
 def test_session_activate_can_omit_duplicate_desktop_transcript(monkeypatch):
-    monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, session=None: {"model": agent.model},
+    )
     server._sessions["sid-large"] = _session(
         agent=types.SimpleNamespace(model="model-large"),
         history=[
@@ -14794,7 +15196,7 @@ def test_start_agent_build_passes_session_model_override(
         captured.update(kwargs)
         return types.SimpleNamespace(model="claude-sonnet-4.6")
 
-    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda target, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(server, "_SlashWorker", FakeWorker)
@@ -14854,7 +15256,7 @@ def test_reset_session_agent_clears_session_overrides(monkeypatch):
         captured.update(kwargs)
         return new_agent
 
-    monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
+    monkeypatch.setattr(server, "_set_session_context", lambda _key, **_kwargs: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
     monkeypatch.setattr(server, "_make_agent", make_agent)
     monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))

--- a/tests/tui_gateway/test_compute_host.py
+++ b/tests/tui_gateway/test_compute_host.py
@@ -126,3 +126,72 @@ def test_compute_host_interrupt_uses_explicit_stop_compatibility(kind):
 
     assert calls == ["hard" if kind == "hard-only" else "legacy"]
     assert emitted[-1]["applied"] is True
+
+
+def test_compute_host_binds_exact_frame_identity_before_agent_build(monkeypatch, tmp_path):
+    seen = {}
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+
+    class FakeDB:
+        def close(self):
+            seen["db_closed"] = True
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: FakeDB())
+
+    class FakeServer:
+        _sessions = {}
+
+        @staticmethod
+        def _set_session_context(key, **kwargs):
+            seen["context"] = (key, kwargs)
+            return ["token"]
+
+        @staticmethod
+        def _clear_session_context(tokens):
+            seen["cleared"] = tokens
+
+        @staticmethod
+        def _make_agent(sid, key, **kwargs):
+            seen["agent"] = (sid, key, kwargs)
+            return object()
+
+        @classmethod
+        def _init_session(cls, sid, key, agent, history, **kwargs):
+            seen["init_kwargs"] = kwargs
+            cls._sessions[sid] = {
+                "agent": agent,
+                "session_key": key,
+                "history": history,
+                "cwd": kwargs.get("cwd"),
+            }
+
+    frame = {
+        "sid": "ui-compute",
+        "session_key": "durable-compute",
+        "cwd": "/work/compute",
+        "profile_home": str(profile_home),
+        "source": "tui",
+        "history": [],
+    }
+    host = ComputeHost(heartbeat_secs=0)
+    try:
+        host._ensure_server_session(FakeServer, frame)
+    finally:
+        host.close()
+
+    assert seen["context"] == (
+        "durable-compute",
+        {
+            "ui_session_id": "ui-compute",
+            "session": {
+                "session_key": "durable-compute",
+                "cwd": "/work/compute",
+                "profile_home": str(profile_home),
+                "source": "tui",
+            },
+        },
+    )
+    assert seen["init_kwargs"]["profile_home"] == str(profile_home)
+    assert seen["agent"][0:2] == ("ui-compute", "durable-compute")
+    assert seen["cleared"] == ["token"]

--- a/tests/tui_gateway/test_finalize_session_persist.py
+++ b/tests/tui_gateway/test_finalize_session_persist.py
@@ -13,7 +13,7 @@ Scenarios:
 
 import threading
 import time
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -269,5 +269,8 @@ class TestOnSessionEndHook:
             interrupted=True,
             model="claude-sonnet-4",
             platform="tui",
+            ui_session_id=ANY,
+            session_profile=ANY,
+            session_cwd=ANY,
         )
 

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -551,16 +551,30 @@ class ComputeHost:
                 home_token = set_hermes_home_override(profile_home)
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
                 session_db = SessionDB(db_path=Path(profile_home) / "state.db")
-            agent = server._make_agent(
-                sid,
+            provisional_session = {
+                "session_key": key,
+                "cwd": str(frame.get("cwd") or ""),
+                "profile_home": profile_home or None,
+                "source": frame.get("source"),
+            }
+            context_tokens = server._set_session_context(
                 key,
-                session_id=key,
-                model_override=frame.get("model_override"),
-                reasoning_config_override=frame.get("reasoning_config_override"),
-                service_tier_override=frame.get("service_tier_override"),
-                platform_override=frame.get("source"),
-                session_db=session_db,
+                ui_session_id=sid,
+                session=provisional_session,
             )
+            try:
+                agent = server._make_agent(
+                    sid,
+                    key,
+                    session_id=key,
+                    model_override=frame.get("model_override"),
+                    reasoning_config_override=frame.get("reasoning_config_override"),
+                    service_tier_override=frame.get("service_tier_override"),
+                    platform_override=frame.get("source"),
+                    session_db=session_db,
+                )
+            finally:
+                server._clear_session_context(context_tokens)
         finally:
             if home_token is not None:
                 try:
@@ -585,6 +599,7 @@ class ComputeHost:
                     cwd=str(frame.get("cwd") or "") or None,
                     session_db=session_db,
                     source=frame.get("source"),
+                    profile_home=profile_home or None,
                 )
             finally:
                 reset_transport(token)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -151,6 +151,7 @@ def _(rid, params: dict) -> dict:
                 "cwd": _sessions[sid]["cwd"],
                 "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
                 "project": _project_info_for_cwd(_sessions[sid]["cwd"]),
+                "stored_session_id": key,
                 "lazy": True,
                 "desktop_contract": DESKTOP_BACKEND_CONTRACT,
                 "profile_name": _response_profile_name(profile),
@@ -464,7 +465,11 @@ def _(rid, params: dict) -> dict:
                 "message_count": len(display_history) if omit_messages else len(messages),
                 "messages": messages,
                 "messages_omitted": omit_messages,
-                "info": _lazy_resume_info(cwd, profile=profile),
+                "info": _lazy_resume_info(
+                    cwd,
+                    profile=profile,
+                    stored_session_id=target,
+                ),
                 "inflight": None,
                 "running": child_running,
                 "session_key": target,
@@ -554,6 +559,7 @@ def _(rid, params: dict) -> dict:
                 model=model_override.get("model") or "",
                 provider=overrides.get("provider_override") or "",
                 profile=profile,
+                stored_session_id=target,
             ),
             "inflight": None,
             "running": False,
@@ -605,7 +611,17 @@ def _(rid, params: dict) -> dict:
         )
         history = sanitize_replay_history(raw_history)
         messages = [] if omit_messages else _history_to_messages(display_history)
-        tokens = _set_session_context(target)
+        provisional_session = {
+            "session_key": target,
+            "cwd": profile_resume_cwd,
+            "profile_home": str(profile_home) if profile_home is not None else None,
+            "source": source,
+        }
+        tokens = _set_session_context(
+            target,
+            ui_session_id=sid,
+            session=provisional_session,
+        )
         try:
             # Pass the profile's db so the agent persists turns to the right
             # state.db; home override is active here so config/skills/model
@@ -678,6 +694,7 @@ def _(rid, params: dict) -> dict:
                     cwd=profile_resume_cwd,
                     session_db=db,
                     source=source,
+                    profile_home=str(profile_home) if profile_home is not None else None,
                 )
             finally:
                 if init_home_token is not None:
@@ -737,12 +754,15 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
-    info = _session_info(agent, session) if agent is not None else {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
-        "lazy": True,
-    }
+    info = (
+        _session_info(agent, session)
+        if agent is not None
+        else _lazy_resume_info(
+            cwd,
+            profile=_profile_name_for_session(session),
+            stored_session_id=_session_lookup_key(session),
+        )
+    )
     _emit("session.info", params.get("session_id", ""), info)
     return _ok(rid, info)
 
@@ -810,12 +830,15 @@ def _(rid, params: dict) -> dict:
         except ValueError as e:
             return _err(rid, 4017, str(e))
         agent = live.get("agent")
-        info = _session_info(agent, live) if agent is not None else {
-            "cwd": resolved,
-            "branch": branch,
-            "project": _project_info_for_cwd(resolved),
-            "lazy": True,
-        }
+        info = (
+            _session_info(agent, live)
+            if agent is not None
+            else _lazy_resume_info(
+                resolved,
+                profile=_profile_name_for_session(live),
+                stored_session_id=_session_lookup_key(live),
+            )
+        )
         _emit("session.info", live_sid, info)
 
     return _ok(rid, {"cwd": resolved, "branch": branch, "git_repo_root": root})
@@ -2773,7 +2796,17 @@ def _(rid, params: dict) -> dict:
             else None
         )
         try:
-            tokens = _set_session_context(new_key)
+            provisional_session = {
+                "session_key": new_key,
+                "cwd": _session_cwd(session),
+                "profile_home": parent_home,
+                "source": source,
+            }
+            tokens = _set_session_context(
+                new_key,
+                ui_session_id=new_sid,
+                session=provisional_session,
+            )
             try:
                 agent = _make_agent(
                     new_sid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -482,22 +482,36 @@ def _load_interim_assistant_messages() -> bool:
 
 
 def _notify_session_boundary(
-    event_type: str, session_id: str | None, platform: str | None = None
+    event_type: str,
+    session_id: str | None,
+    platform: str | None = None,
+    *,
+    ui_session_id: str = "",
+    session: dict | None = None,
 ) -> None:
     """Fire session lifecycle hooks with CLI parity."""
     try:
         from hermes_cli.lifecycle import finalize_session, invoke_hook
 
+        session_profile = _profile_name_for_session(session)
+        session_cwd = _session_cwd(session) if session is not None else ""
+        scope = {
+            "ui_session_id": str(ui_session_id or ""),
+            "session_profile": session_profile,
+            "session_cwd": session_cwd,
+        }
         if event_type == "on_session_finalize":
             finalize_session(
                 session_id=session_id,
                 platform=_resolve_agent_platform(platform),
+                **scope,
             )
         else:
             invoke_hook(
                 event_type,
                 session_id=session_id,
                 platform=_resolve_agent_platform(platform),
+                **scope,
             )
     except Exception:
         pass
@@ -714,6 +728,9 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
                 interrupted=True,
                 model=getattr(agent, "model", "unknown"),
                 platform=getattr(agent, "platform", None) or "tui",
+                ui_session_id=_ui_session_id_for_session(session),
+                session_profile=_profile_name_for_session(session),
+                session_cwd=_session_cwd(session),
             )
         except Exception:
             pass
@@ -726,7 +743,13 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
     session_key = session.get("session_key")
     session_id = getattr(agent, "session_id", None) or session_key
-    _notify_session_boundary("on_session_finalize", session_id, _session_source(session))
+    _notify_session_boundary(
+        "on_session_finalize",
+        session_id,
+        _session_source(session),
+        ui_session_id=_ui_session_id_for_session(session),
+        session=session,
+    )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
     # Use session_id (from agent.session_id) not session_key — after compression,
@@ -2110,7 +2133,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
         secret_token = None
         profile_home = current.get("profile_home")
         try:
-            tokens = _set_session_context(key)
+            tokens = _set_session_context(
+                key, ui_session_id=sid, session=current
+            )
             # Build against the session's profile (global-remote): bind its
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
@@ -2224,7 +2249,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-            _notify_session_boundary("on_session_reset", key, _session_source(current))
+            _notify_session_boundary(
+                "on_session_reset",
+                key,
+                _session_source(current),
+                ui_session_id=sid,
+                session=current,
+            )
 
             info = _session_info(agent, current)
             cfg_warn = _probe_config_health(_load_cfg())
@@ -3037,11 +3068,30 @@ def _cwd_for_session_key(session_key: str) -> str:
     return ""
 
 
+def _profile_name_for_session(session: dict | None) -> str:
+    if not isinstance(session, dict):
+        return ""
+    profile_home = str(session.get("profile_home") or "").strip()
+    return _response_profile_name(Path(profile_home).name if profile_home else None)
+
+
+def _ui_session_id_for_session(session: dict | None) -> str:
+    if not isinstance(session, dict):
+        return ""
+    stamped = str(session.get("_sid") or "").strip()
+    if stamped:
+        return stamped
+    with _sessions_lock:
+        matches = [sid for sid, candidate in _sessions.items() if candidate is session]
+    return str(matches[0]) if len(matches) == 1 else ""
+
+
 def _set_session_context(
     session_key: str,
     cwd: str | None = None,
     *,
     ui_session_id: str = "",
+    session: dict | None = None,
 ) -> list:
     try:
         from gateway.session_context import set_session_vars
@@ -3050,7 +3100,6 @@ def _set_session_context(
         # reverse-map returns "" and would clear the cwd override. Callers that
         # know the parent workspace pass it explicitly so spawned agents inherit
         # it instead of falling back to the gateway launch dir.
-        resolved = cwd if cwd is not None else _cwd_for_session_key(session_key)
         source = _resolve_session_platform()
         # Derive the live conversation id so terminal/execute_code subprocesses
         # can read HERMES_SESSION_ID. Without this, set_session_vars leaves the
@@ -3062,19 +3111,44 @@ def _set_session_context(
         # fall back to the session_key (matching the id derivation used at
         # session-finalize), so an identified session is never left blank.
         session_id = session_key
+        profile = ""
         with _sessions_lock:
-            for sess in list(_sessions.values()):
-                if sess.get("session_key") == session_key:
-                    source = _session_source(sess)
-                    session_id = (
-                        getattr(sess.get("agent"), "session_id", None) or session_key
-                    )
-                    break
+            selected = None
+            matches = [
+                sess for sess in _sessions.values()
+                if sess.get("session_key") == session_key
+            ]
+            if isinstance(session, dict) and session.get("session_key") == session_key:
+                selected = session
+            elif ui_session_id:
+                candidate = _sessions.get(ui_session_id)
+                if isinstance(candidate, dict) and candidate.get("session_key") == session_key:
+                    selected = candidate
+            elif len(matches) == 1:
+                selected = matches[0]
+            if selected is not None:
+                source = _session_source(selected)
+                profile = _profile_name_for_session(selected)
+            id_source = selected or (matches[0] if len(matches) == 1 else None)
+            if id_source is not None:
+                session_id = (
+                    getattr(id_source.get("agent"), "session_id", None) or session_key
+                )
+        resolved = (
+            cwd
+            if cwd is not None
+            else _session_cwd(selected)
+            if selected is not None
+            else ""
+            if ui_session_id
+            else _cwd_for_session_key(session_key)
+        )
         return set_session_vars(
             session_key=session_key,
             session_id=session_id,
             source=source,
             cwd=resolved,
+            profile=profile,
             ui_session_id=ui_session_id,
             cron_session="",
         )
@@ -5014,6 +5088,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     session_key = str(
         (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
     )
+    durable_session_id = str(getattr(agent, "session_id", "") or session_key)
     cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
@@ -5071,7 +5146,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
         "title": _session_live_title(session or {}, session_key) if session_key else "",
-        "stored_session_id": session_key or "",
+        "stored_session_id": durable_session_id,
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
         "version": "",
         "release_date": "",
@@ -5742,12 +5817,11 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         info = (
             _session_info(agent, session)
             if agent is not None
-            else {
-                "cwd": resolved,
-                "branch": _git_branch_for_cwd(resolved),
-                "project": _project_info_for_cwd(resolved),
-                "lazy": True,
-            }
+            else _lazy_resume_info(
+                resolved,
+                profile=_profile_name_for_session(session),
+                stored_session_id=_session_lookup_key(session),
+            )
         )
         _emit("session.info", sid, info)
     except Exception:
@@ -6101,7 +6175,9 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
 
 def _reset_session_agent(sid: str, session: dict) -> dict:
-    tokens = _set_session_context(session["session_key"])
+    tokens = _set_session_context(
+        session["session_key"], ui_session_id=sid, session=session
+    )
     try:
         # /new is a full conversation boundary: session-scoped runtime
         # overrides (/model, /reasoning, /fast) do NOT carry forward — the
@@ -6581,7 +6657,13 @@ def _init_session(
     with _sessions_lock:
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
+    _notify_session_boundary(
+        "on_session_reset",
+        key,
+        _session_source(_sessions.get(sid, {})),
+        ui_session_id=sid,
+        session=_sessions.get(sid, {}),
+    )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 
@@ -7639,6 +7721,7 @@ def _lazy_resume_info(
     model: str = "",
     provider: str = "",
     profile: str | None = None,
+    stored_session_id: str = "",
 ) -> dict:
     """session.info for a not-yet-built session (the shape session.create
     returns). tools/skills land later when the deferred build emits session.info."""
@@ -7646,6 +7729,7 @@ def _lazy_resume_info(
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
+        "stored_session_id": stored_session_id,
         "model": model or _resolve_model(),
         "tools": {},
         "skills": {},
@@ -7836,11 +7920,16 @@ def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
 def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
-        return _session_info(agent)
-    cwd = _default_session_cwd()
+        return _session_info(agent, session)
+    cwd = _display_session_cwd(session)
+    profile_home = str(session.get("profile_home") or "").strip()
     return {
         "cwd": cwd,
         "project": _project_info_for_cwd(cwd),
+        "profile_name": _response_profile_name(Path(profile_home).name)
+        if profile_home
+        else _current_profile_name(),
+        "stored_session_id": _session_lookup_key(session),
         "lazy": True,
         "model": _resolve_model(),
         "skills": {},
@@ -9409,6 +9498,7 @@ def _run_prompt_submit(
             session_tokens = _set_session_context(
                 session["session_key"],
                 ui_session_id=sid,
+                session=session,
             )
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -66,6 +66,10 @@ npm test         # single run
 npm run test:watch
 ```
 
+## User widget session identity
+
+Plain ESM files under `$HERMES_HOME/tui-widgets/*.mjs` receive the public SDK in `register(sdk)`....[truncated]
+
 ## App model
 
 `src/app.tsx` is the center of the UI. Heavy logic is split into `src/app/`:

--- a/ui-tui/src/__tests__/taskBoardTranscriptPlacement.test.tsx
+++ b/ui-tui/src/__tests__/taskBoardTranscriptPlacement.test.tsx
@@ -1,0 +1,146 @@
+import { PassThrough } from 'stream'
+
+import { renderSync, Text } from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, expect, it } from 'vitest'
+
+import { GatewayProvider } from '../app/gatewayContext.js'
+import type { AppLayoutProps } from '../app/interfaces.js'
+import { patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { AppLayout } from '../components/appLayout.js'
+import type { GatewayClient } from '../gatewayClient.js'
+import { DEFAULT_VOICE_RECORD_KEY } from '../lib/platform.js'
+import { stripAnsi } from '../lib/text.js'
+import { openWidget } from '../sdk/host.js'
+import { defineWidgetApp } from '../sdk/registry.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const gatewayStub = {
+  gw: {
+    request: () => new Promise<never>(() => {}),
+    send: () => {}
+  } as unknown as GatewayClient,
+  rpc: (() => new Promise<never>(() => {})) as never
+}
+
+const layoutProps: AppLayoutProps = {
+  actions: {
+    activateLiveSession: () => {},
+    answerApproval: () => {},
+    answerClarify: () => {},
+    answerSecret: () => {},
+    answerSudo: () => {},
+    clearSelection: () => {},
+    closeLiveSession: () => Promise.resolve(null),
+    newLiveSession: () => {},
+    newPromptSession: () => {},
+    onModelSelect: () => {},
+    resumeById: () => {},
+    setStickyPrompt: () => {}
+  },
+  composer: {
+    cols: 120,
+    compIdx: 0,
+    completions: [],
+    empty: false,
+    handleTextPaste: () => null,
+    input: 'COMPOSER_ANCHOR',
+    inputBuf: [],
+    pagerPageSize: 10,
+    queueEditIdx: null,
+    queuedDisplay: [],
+    submit: () => {},
+    updateInput: () => {},
+    voiceRecordKey: DEFAULT_VOICE_RECORD_KEY
+  },
+  mouseTracking: 'off',
+  progress: { showProgressArea: false },
+  status: {
+    cwdLabel: '~/repo',
+    goodVibesTick: 0,
+    lastTurnEndedAt: null,
+    sessionStartedAt: 1_800_000_000_000,
+    showStickyPrompt: false,
+    statusColor: DEFAULT_THEME.color.ok,
+    stickyPrompt: '',
+    turnStartedAt: null,
+    voiceLabel: ''
+  },
+  transcript: {
+    historyItems: [],
+    scrollRef: { current: null },
+    virtualHistory: {
+      bottomSpacer: 0,
+      end: 0,
+      measureRef: () => () => {},
+      offsets: [],
+      start: 0,
+      topSpacer: 0
+    },
+    virtualRows: []
+  }
+}
+
+beforeEach(() => {
+  resetOverlayState()
+  resetUiState()
+})
+
+afterEach(() => {
+  resetOverlayState()
+  resetUiState()
+})
+
+it('reserves transcript-bottom widgets above the composer', async () => {
+  const app = defineWidgetApp({
+    help: 'transcript placement regression',
+    id: 'transcript-placement-test',
+    mode: 'ambient',
+    zone: 'transcript-bottom',
+    init: () => ({}),
+    reduce: state => state,
+    render: () => <Text>TRANSCRIPT_BOARD_ANCHOR</Text>
+  })
+
+  openWidget(app, {})
+  patchUiState({ sessionTitle: 'test', sid: 'sid-1', status: 'ready' })
+  patchOverlayState({})
+
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 120, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: true, ref: () => {}, setRawMode: () => {}, unref: () => {} })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(
+    <GatewayProvider value={gatewayStub}>
+      <AppLayout {...layoutProps} />
+    </GatewayProvider>,
+    {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    }
+  )
+
+  try {
+    await new Promise(resolve => setTimeout(resolve, 20))
+    const screen = stripAnsi(output)
+    const boardIndex = screen.indexOf('TRANSCRIPT_BOARD_ANCHOR')
+    const composerIndex = screen.indexOf('COMPOSER_ANCHOR')
+
+    expect(boardIndex).toBeGreaterThanOrEqual(0)
+    expect(composerIndex).toBeGreaterThan(boardIndex)
+  } finally {
+    instance.unmount()
+    instance.cleanup()
+  }
+})

--- a/ui-tui/src/__tests__/widgetSdk.test.ts
+++ b/ui-tui/src/__tests__/widgetSdk.test.ts
@@ -1,9 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
 import { dialogTestApp, gridTestApp } from '../sdk/apps/index.js'
 import { closeWidget, dispatchWidgetInput, launchWidget, openWidget } from '../sdk/host.js'
 import { getWidgetApp, listWidgetApps } from '../sdk/registry.js'
+import { widgetSdk } from '../sdk/userWidgets.js'
 import type { WidgetInput } from '../sdk/types.js'
 
 const key = (overrides: Partial<WidgetInput['key']> = {}, ch = ''): WidgetInput =>
@@ -12,9 +14,203 @@ const key = (overrides: Partial<WidgetInput['key']> = {}, ch = ''): WidgetInput 
     key: { ctrl: false, escape: false, leftArrow: false, return: false, rightArrow: false, ...overrides }
   }) as WidgetInput
 
-beforeEach(() => resetOverlayState())
+beforeEach(() => {
+  resetOverlayState()
+  resetUiState()
+})
 
 describe('widget SDK host', () => {
+  it('exposes reactive UI and durable session identity to user widgets', async () => {
+    const { defineWidgetApp } = await import('../sdk/registry.js')
+    const { AmbientDock } = await import('../sdk/host.js')
+    const { renderToScreen } = await import('../../packages/hermes-ink/src/ink/render-to-screen.js')
+    const { cellAtIndex } = await import('../../packages/hermes-ink/src/ink/screen.js')
+    const { createElement } = await import('react')
+    const textOf = () => {
+      const { screen, height } = renderToScreen(createElement(AmbientDock, { placement: 'dock-bottom' }), 100)
+
+      return Array.from({ length: height * 100 }, (_, index) => cellAtIndex(screen, index).char).join('')
+    }
+
+    defineWidgetApp({
+      help: 'identity test',
+      id: 'identity-test',
+      mode: 'ambient',
+      init: () => ({}),
+      reduce: state => state,
+      render: () => {
+        const identity = widgetSdk.useSessionIdentity()
+
+        return widgetSdk.h(
+          widgetSdk.Text,
+          null,
+          `${identity.uiSessionId}|${identity.durableSessionId}|${identity.profileId}|${identity.workspace}`
+        )
+      }
+    })
+
+    patchUiState({
+      sid: 'ui-a',
+      info: {
+        cwd: '/work/a',
+        model: 'm',
+        profile_name: 'default',
+        skills: {},
+        stored_session_id: 'durable-a',
+        tools: {}
+      }
+    })
+    launchWidget('identity-test', '')
+    expect(textOf().replace(/\s+/g, '')).toContain('ui-a|durable-a|default|/work/a')
+
+    patchUiState({
+      sid: 'ui-b',
+      info: { cwd: '/work/b', model: 'm', profile_name: 'work', skills: {}, stored_session_id: 'durable-b', tools: {} }
+    })
+    expect(textOf().replace(/\s+/g, '')).toContain('ui-b|durable-b|work|/work/b')
+  })
+
+  it('isolates widget hooks across dynamic add and remove', async () => {
+    const { PassThrough } = await import('stream')
+    const { renderSync } = await import('@hermes/ink')
+    const { createElement } = await import('react')
+    const { AmbientDock } = await import('../sdk/host.js')
+    const { defineWidgetApp } = await import('../sdk/registry.js')
+
+    defineWidgetApp({
+      help: 'hook order test',
+      id: 'hook-order-test',
+      mode: 'ambient',
+      init: () => ({}),
+      reduce: state => state,
+      render: () => {
+        const identity = widgetSdk.useSessionIdentity()
+
+        return widgetSdk.h(widgetSdk.Text, null, identity.uiSessionId || 'no-session')
+      }
+    })
+
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    Object.assign(stdout, { columns: 100, isTTY: false, rows: 40 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const element = createElement(AmbientDock, { placement: 'dock-bottom' })
+    const instance = renderSync(element, {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      expect(() => {
+        launchWidget('hook-order-test', '')
+        instance.rerender(element)
+      }).not.toThrow()
+      expect(() => {
+        launchWidget('hook-order-test', '')
+        instance.rerender(element)
+      }).not.toThrow()
+      expect(consoleError.mock.calls.flat().join(' ')).not.toMatch(/change in the order of Hooks|Rendered more hooks/)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+      consoleError.mockRestore()
+    }
+  })
+
+  it('remounts modal renderers across app switches and same-id hot reloads', async () => {
+    const { PassThrough } = await import('stream')
+    const { renderSync } = await import('@hermes/ink')
+    const { createElement, useRef } = await import('react')
+    const { ActiveWidgetSlot } = await import('../sdk/host.js')
+    const { defineWidgetApp } = await import('../sdk/registry.js')
+
+    const seenRefs: string[] = []
+    defineWidgetApp({
+      help: 'modal hook a',
+      id: 'modal-hook-a',
+      mode: 'modal',
+      init: () => ({}),
+      reduce: state => state,
+      render: () => {
+        const ref = useRef('a')
+        seenRefs.push(`a:${ref.current}`)
+
+        return widgetSdk.h(widgetSdk.Text, null, 'modal-a')
+      }
+    })
+    defineWidgetApp({
+      help: 'modal hook b',
+      id: 'modal-hook-b',
+      mode: 'modal',
+      init: () => ({}),
+      reduce: state => state,
+      render: () => {
+        const ref = useRef('b')
+        seenRefs.push(`b:${ref.current}`)
+
+        return widgetSdk.h(widgetSdk.Text, null, 'modal-b')
+      }
+    })
+
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    Object.assign(stdout, { columns: 100, isTTY: false, rows: 40 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const element = createElement(ActiveWidgetSlot)
+    const instance = renderSync(element, {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      expect(() => {
+        launchWidget('modal-hook-a', '')
+        instance.rerender(element)
+      }).not.toThrow()
+      expect(() => {
+        launchWidget('modal-hook-b', '')
+        instance.rerender(element)
+      }).not.toThrow()
+      expect(seenRefs.at(-1)).toBe('b:b')
+
+      defineWidgetApp({
+        help: 'modal hook b reloaded',
+        id: 'modal-hook-b',
+        mode: 'modal',
+        init: () => ({}),
+        reduce: state => state,
+        render: () => {
+          const ref = useRef('reloaded')
+          seenRefs.push(`reload:${ref.current}`)
+
+          return widgetSdk.h(widgetSdk.Text, null, 'modal-b-reloaded')
+        }
+      })
+      expect(() => instance.rerender(element)).not.toThrow()
+      expect(seenRefs.at(-1)).toBe('reload:reloaded')
+      expect(consoleError.mock.calls.flat().join(' ')).not.toMatch(
+        /change in the order of Hooks|Rendered (fewer|more) hooks/
+      )
+    } finally {
+      closeWidget()
+      instance.unmount()
+      instance.cleanup()
+      consoleError.mockRestore()
+    }
+  })
+
   it('registers the reference apps', () => {
     expect(listWidgetApps().map(app => app.id)).toEqual(
       expect.arrayContaining(['dialog-test', 'grid-test', 'ticker', 'weather'])

--- a/ui-tui/src/__tests__/widgetSdk.test.ts
+++ b/ui-tui/src/__tests__/widgetSdk.test.ts
@@ -5,8 +5,8 @@ import { patchUiState, resetUiState } from '../app/uiStore.js'
 import { dialogTestApp, gridTestApp } from '../sdk/apps/index.js'
 import { closeWidget, dispatchWidgetInput, launchWidget, openWidget } from '../sdk/host.js'
 import { getWidgetApp, listWidgetApps } from '../sdk/registry.js'
-import { widgetSdk } from '../sdk/userWidgets.js'
 import type { WidgetInput } from '../sdk/types.js'
+import { widgetSdk } from '../sdk/userWidgets.js'
 
 const key = (overrides: Partial<WidgetInput['key']> = {}, ch = ''): WidgetInput =>
   ({
@@ -26,6 +26,7 @@ describe('widget SDK host', () => {
     const { renderToScreen } = await import('../../packages/hermes-ink/src/ink/render-to-screen.js')
     const { cellAtIndex } = await import('../../packages/hermes-ink/src/ink/screen.js')
     const { createElement } = await import('react')
+
     const textOf = () => {
       const { screen, height } = renderToScreen(createElement(AmbientDock, { placement: 'dock-bottom' }), 100)
 
@@ -99,6 +100,7 @@ describe('widget SDK host', () => {
 
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const element = createElement(AmbientDock, { placement: 'dock-bottom' })
+
     const instance = renderSync(element, {
       patchConsole: false,
       stderr: stderr as unknown as NodeJS.WriteStream,
@@ -131,18 +133,28 @@ describe('widget SDK host', () => {
     const { defineWidgetApp } = await import('../sdk/registry.js')
 
     const seenRefs: string[] = []
+
+    const ModalHookA = () => {
+      const ref = useRef('a')
+      seenRefs.push(`a:${ref.current}`)
+
+      return widgetSdk.h(widgetSdk.Text, null, 'modal-a')
+    }
+
+    const ModalHookB = () => {
+      const ref = useRef('b')
+      seenRefs.push(`b:${ref.current}`)
+
+      return widgetSdk.h(widgetSdk.Text, null, 'modal-b')
+    }
+
     defineWidgetApp({
       help: 'modal hook a',
       id: 'modal-hook-a',
       mode: 'modal',
       init: () => ({}),
       reduce: state => state,
-      render: () => {
-        const ref = useRef('a')
-        seenRefs.push(`a:${ref.current}`)
-
-        return widgetSdk.h(widgetSdk.Text, null, 'modal-a')
-      }
+      render: ModalHookA
     })
     defineWidgetApp({
       help: 'modal hook b',
@@ -150,12 +162,7 @@ describe('widget SDK host', () => {
       mode: 'modal',
       init: () => ({}),
       reduce: state => state,
-      render: () => {
-        const ref = useRef('b')
-        seenRefs.push(`b:${ref.current}`)
-
-        return widgetSdk.h(widgetSdk.Text, null, 'modal-b')
-      }
+      render: ModalHookB
     })
 
     const stdout = new PassThrough()
@@ -167,6 +174,7 @@ describe('widget SDK host', () => {
 
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const element = createElement(ActiveWidgetSlot)
+
     const instance = renderSync(element, {
       patchConsole: false,
       stderr: stderr as unknown as NodeJS.WriteStream,
@@ -185,18 +193,20 @@ describe('widget SDK host', () => {
       }).not.toThrow()
       expect(seenRefs.at(-1)).toBe('b:b')
 
+      const ModalHookBReloaded = () => {
+        const ref = useRef('reloaded')
+        seenRefs.push(`reload:${ref.current}`)
+
+        return widgetSdk.h(widgetSdk.Text, null, 'modal-b-reloaded')
+      }
+
       defineWidgetApp({
         help: 'modal hook b reloaded',
         id: 'modal-hook-b',
         mode: 'modal',
         init: () => ({}),
         reduce: state => state,
-        render: () => {
-          const ref = useRef('reloaded')
-          seenRefs.push(`reload:${ref.current}`)
-
-          return widgetSdk.h(widgetSdk.Text, null, 'modal-b-reloaded')
-        }
+        render: ModalHookBReloaded
       })
       expect(() => instance.rerender(element)).not.toThrow()
       expect(seenRefs.at(-1)).toBe('reload:reloaded')

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -553,6 +553,8 @@ export const AppLayout = memo(function AppLayout({
 
         {!overlay.agents && !overlay.journey && (
           <>
+            <AmbientDock placement="transcript-bottom" />
+
             <PerfPane id="prompt">
               <PromptZone
                 cols={composer.cols}

--- a/ui-tui/src/sdk/host.tsx
+++ b/ui-tui/src/sdk/host.tsx
@@ -240,10 +240,10 @@ export function ActiveWidgetSlot(): ReactNode {
   return overlay.widget ? <WidgetAppMount active={overlay.widget} ctx={ctx} /> : null
 }
 
-/** An in-FLOW dock row: reserves real rows in the chrome (never covers
- *  content), right-aligned cards. `dock-top` renders under the top status
- *  bar, `dock-bottom` above the bottom one. */
-export function AmbientDock({ placement }: { placement: 'dock-bottom' | 'dock-top' }): ReactNode {
+/** An in-FLOW dock row: reserves real rows instead of covering content.
+ *  Chrome placements surround the composer; `transcript-bottom` renders at
+ *  the transcript's lower edge, directly above the prompt/composer. */
+export function AmbientDock({ placement }: { placement: 'dock-bottom' | 'dock-top' | 'transcript-bottom' }): ReactNode {
   const overlay = useStore($overlayState)
   const ctx = useRenderCtx()
   const docked = overlay.ambient.filter(active => zoneOf(active) === placement)

--- a/ui-tui/src/sdk/host.tsx
+++ b/ui-tui/src/sdk/host.tsx
@@ -3,11 +3,30 @@ import { useStore } from '@nanostores/react'
 import { Component, type ReactNode } from 'react'
 
 import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
-import { $uiTheme } from '../app/uiStore.js'
+import { $uiState, $uiTheme } from '../app/uiStore.js'
 import { recordParentLifecycle } from '../lib/parentLog.js'
 
-import { getWidgetApp } from './registry.js'
+import { $widgetRegistryRevision, getWidgetApp, getWidgetAppRevision } from './registry.js'
 import type { ActiveWidget, AmbientZone, WidgetApp, WidgetInput } from './types.js'
+
+export interface WidgetSessionIdentity {
+  durableSessionId: string
+  profileId: string
+  uiSessionId: string
+  workspace: string
+}
+
+/** Reactive identity for the TUI session currently rendering a user widget. */
+export function useSessionIdentity(): WidgetSessionIdentity {
+  const ui = useStore($uiState)
+
+  return {
+    durableSessionId: String(ui.info?.stored_session_id || ''),
+    profileId: String(ui.info?.profile_name || ''),
+    uiSessionId: String(ui.sid || ''),
+    workspace: String(ui.info?.cwd || '')
+  }
+}
 
 /**
  * The widget-app host. Core integrates through exactly four touchpoints:
@@ -178,7 +197,7 @@ const useRenderCtx = (): RenderCtx => {
   return { cols: stdout?.columns ?? 80, rows: stdout?.rows ?? 24, t: t as never }
 }
 
-const renderApp = (active: ActiveWidget, ctx: RenderCtx) => {
+const WidgetAppRenderer = ({ active, ctx }: { active: ActiveWidget; ctx: RenderCtx }) => {
   const app = getWidgetApp(active.appId)
 
   if (!app) {
@@ -196,10 +215,18 @@ const renderApp = (active: ActiveWidget, ctx: RenderCtx) => {
   )
 }
 
+const WidgetAppMount = ({ active, ctx }: { active: ActiveWidget; ctx: RenderCtx }) => {
+  useStore($widgetRegistryRevision)
+
+  return <WidgetAppRenderer active={active} ctx={ctx} key={`${active.appId}:${getWidgetAppRevision(active.appId)}`} />
+}
+
 const CardStack = ({ apps, ctx }: { apps: ActiveWidget[]; ctx: RenderCtx }) => (
   <Box flexDirection="column" rowGap={1}>
     {apps.map(active => (
-      <Box key={active.appId}>{renderApp(active, ctx)}</Box>
+      <Box key={active.appId}>
+        <WidgetAppMount active={active} ctx={ctx} />
+      </Box>
     ))}
   </Box>
 )
@@ -210,7 +237,7 @@ export function ActiveWidgetSlot(): ReactNode {
   const overlay = useStore($overlayState)
   const ctx = useRenderCtx()
 
-  return overlay.widget ? renderApp(overlay.widget, ctx) : null
+  return overlay.widget ? <WidgetAppMount active={overlay.widget} ctx={ctx} /> : null
 }
 
 /** An in-FLOW dock row: reserves real rows in the chrome (never covers
@@ -230,7 +257,9 @@ export function AmbientDock({ placement }: { placement: 'dock-bottom' | 'dock-to
   return (
     <Box columnGap={1} flexDirection="row" justifyContent="flex-end" paddingRight={2} width="100%">
       {docked.map(active => (
-        <Box key={active.appId}>{renderApp(active, ctx)}</Box>
+        <Box key={active.appId}>
+          <WidgetAppMount active={active} ctx={ctx} />
+        </Box>
       ))}
     </Box>
   )

--- a/ui-tui/src/sdk/registry.ts
+++ b/ui-tui/src/sdk/registry.ts
@@ -1,19 +1,41 @@
+import { atom } from 'nanostores'
+
 import type { WidgetApp } from './types.js'
 
 const apps = new Map<string, WidgetApp<never>>()
+const revisions = new Map<string, number>()
+export const $widgetRegistryRevision = atom(0)
+
+const bumpRevision = (id: string): void => {
+  revisions.set(id, (revisions.get(id) ?? 0) + 1)
+  $widgetRegistryRevision.set($widgetRegistryRevision.get() + 1)
+}
 
 /** Identity helper that pins the state type, then registers. Last writer
  *  wins so a user/plugin app can shadow a built-in of the same id. */
 export function defineWidgetApp<S>(app: WidgetApp<S>): WidgetApp<S> {
   apps.set(app.id, app as WidgetApp<never>)
+  bumpRevision(app.id)
 
   return app
 }
 
 export const getWidgetApp = (id: string): undefined | WidgetApp<never> => apps.get(id)
 
+/** Monotonic implementation revision. Same-id hot reloads must remount their
+ * React render fiber because the new app may use a different Hook layout. */
+export const getWidgetAppRevision = (id: string): number => revisions.get(id) ?? 0
+
 /** Unregister (user-widget file deleted). Built-ins never call this. */
-export const removeWidgetApp = (id: string): boolean => apps.delete(id)
+export const removeWidgetApp = (id: string): boolean => {
+  const removed = apps.delete(id)
+
+  if (removed) {
+    bumpRevision(id)
+  }
+
+  return removed
+}
 
 /** All registered apps, id-sorted — the registry IS the catalog: slash
  *  commands and `/` completions derive from it, nothing is hardcoded. */

--- a/ui-tui/src/sdk/types.ts
+++ b/ui-tui/src/sdk/types.ts
@@ -67,10 +67,13 @@ export interface WidgetApp<S = unknown> {
  * same corner stack vertically. Content under a float stays live — floats
  * suit sparse corners; prefer docks for anything tall.
  *
- * Users phrase placement loosely ("top right", "pin it above the status
- * bar") — map words to the nearest zone; corners mean floats.
+ * `transcript-bottom` reserves rows at the bottom of the transcript, directly
+ * above the prompt/composer. Users phrase placement loosely ("top right",
+ * "pin it above the status bar") — map words to the nearest zone; corners
+ * mean floats.
  */
-export type AmbientZone = 'bottom-left' | 'bottom-right' | 'dock-bottom' | 'dock-top' | 'top-left' | 'top-right'
+export type AmbientZone =
+  'bottom-left' | 'bottom-right' | 'dock-bottom' | 'dock-top' | 'top-left' | 'top-right' | 'transcript-bottom'
 
 /** The host's serializable record of the active app. */
 export interface ActiveWidget {

--- a/ui-tui/src/sdk/userWidgets.ts
+++ b/ui-tui/src/sdk/userWidgets.ts
@@ -14,7 +14,7 @@ import { GridAreas, WidgetGrid } from '../components/widgetGrid.js'
 import { gauge, hbars, sparkline, sparkRows } from '../lib/charts.js'
 import { recordParentLifecycle } from '../lib/parentLog.js'
 
-import { openWidget, updateWidget } from './host.js'
+import { openWidget, updateWidget, useSessionIdentity } from './host.js'
 import { defineWidgetApp, listWidgetApps, removeWidgetApp } from './registry.js'
 import { isCtrl } from './types.js'
 
@@ -53,6 +53,7 @@ export const widgetSdk = {
   sparkRows,
   sparkline,
   updateWidget,
+  useSessionIdentity,
   useShimmerPhase
 } as const
 

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -169,6 +169,7 @@ export interface SessionInfo {
   mcp_servers?: McpServerStatus[]
   model: string
   profile_name?: string
+  stored_session_id?: string
   project?: null | ProjectInfo
   reasoning_effort?: string
   release_date?: string


### PR DESCRIPTION
## Summary

Expose exact, reactive TUI session identity to public widgets and plugin hooks without private imports or session-database reads.

## Changes

- add reactive `widgetSdk.useSessionIdentity()`
- enrich hook envelopes with UI session, profile, and current-turn cwd
- select TUI context by exact `ui_session_id`; ambiguous key-only lookup fails closed
- pass exact UI ids and session records from build, resume, branch, compute-host, reset, and turn callers
- bind detached resume/branch records before registry insertion without falling back to another live session
- expose `agent.runtime_cwd.get_session_cwd()`
- preserve stamped `session['_sid']` after registry pop so finalize closes the exact publisher
- pass exact public scope to both `on_session_end` and finalize hooks
- prefer the live agent durable id in `session.info` after compression rotation
- keep live and pre-build fallback `session.info` bound to the exact session record's profile and cwd
- forward exact reset/finalize scope
- pin the existing `post_tool_call.turn_id` producer contract
- isolate each dynamic widget render in a keyed React component so user hooks cannot alter the parent hook order
- remount same-ID widget hot reloads through a reactive registry revision
- add collision, pop→finalize, binder→PluginManager, lifecycle, and widget rotation tests

## Safety

- no process-environment identity assumption
- no session DB or transcript reads
- missing or ambiguous identity remains fail-closed
- concurrent UI views cannot borrow another session's profile
- lifecycle envelopes preserve explicit caller scope

## Validation

Rebased and rerun on current upstream `main` at `a6e1e270b1103cc026275419a21ba9b5f581f96b`:

- Python tests-only regression: **11 failed** as expected before production changes
- widget Hook-order tests-only regression: **2 failed / 11 passed** as expected before renderer isolation
- `pytest -q tests/test_tui_gateway_server.py`: 526 passed
- plugin/session-hook regression files: **19 passed**
- compute-host/session-id regression files: **7 passed**
- `widgetSdk.test.ts`: **13 passed**
- TypeScript typecheck: **PASS**
- full UI suite: task candidate and clean `origin/main` both reproduce the same **21 pre-existing failures** in three unrelated files
- `git diff --check`: **PASS**

An unrelated upstream collection-order failure between `test_tui_gateway_server.py` and `test_transform_tool_result_hook.py` reproduces unchanged on clean `main`; each affected suite passes in its normal isolated process above.

Made with [Orca](https://github.com/stablyai/orca) 🐋
