### PR TITLE
docs(developer-guide): correct Node.js prerequisite to match package.json engines

### DIFF
--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -36,7 +36,7 @@ We value contributions in this order:
 | **Git**              | With the `git-lfs` extension installed                                                        |
 | **Python 3.11–3.13** | uv will install it if missing                                                                 |
 | **uv**               | Fast Python package manager ([install](https://docs.astral.sh/uv/))                           |
-| **Node.js 26+**      | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
+| **Node.js 22.22+**   | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines; `Node.js 26+` shown in earlier revisions was stale) |
 
 ### Install with the standard installer
 


### PR DESCRIPTION
## What & why

The `Prerequisites` table in `website/docs/developer-guide/contributing.md` lists `Node.js 26+` and claims it `matches root package.json engines`. The actual root `package.json` declares `"node": ">=22.22.0"` (npm: `"<11.10.0 || >=11.17.0"`). The current string tells contributors to install a Node version that is not required (and is not yet widely available), which is worse than no requirement because it makes contributors chase a phantom toolchain. This corrects the requirement to the actual engines floor and notes that the previous `26+` wording was stale.

## How to test

Read the rendered docs page for `developer-guide/contributing.md` and verify the prerequisite table now reads `Node.js 22.22+` with the explanatory note about the previous stale value.

## Platforms tested

None (docs-only).

## References

Observational cleanup — no specific issue filed. Cross-checked against root `package.json` engines field via `grep -A2 '"engines"' package.json`.