### PR TITLE
fix(update): bound the seven unbounded git network calls in hermes update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1407,6 +1407,33 @@ OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 
+# Ceiling for every git operation in the update flow that talks to a remote
+# (fetch / pull / push).  These calls were unbounded, so a remote that accepts
+# the TCP connection and then stops responding — captive-portal Wi-Fi, a
+# half-up VPN, a filtering corporate proxy, a throttled forge — left the CLI
+# printing "→ Fetching updates..." forever, with Ctrl-C the only way out.
+#
+# The bound is deliberately generous.  The background probe in
+# ``hermes_cli/banner.py`` uses ``timeout=10`` because it is non-blocking and
+# its result is discardable; these are foreground, user-initiated operations
+# where a first fetch over a slow link can legitimately run for minutes.  The
+# defect is the *unbounded* wait, so a large finite ceiling closes it without
+# regressing any setup that works today.
+_GIT_NETWORK_TIMEOUT_SECONDS = 300
+
+def _print_git_network_timeout(remote: str) -> None:
+    """Report a stalled git network operation in the house error style.
+
+    Callers decide what to do next: the ``hermes update`` / ``--check``
+    entry points exit non-zero, while the optional fork-sync path degrades
+    and continues.
+    """
+    print(
+        f"✗ Timed out after {_GIT_NETWORK_TIMEOUT_SECONDS}s fetching from "
+        f"{remote} — the remote accepted the connection but stopped responding."
+    )
+    print("  Check your network (VPN, proxy, captive portal) and try again.")
+
 def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     """Get the URL of the origin remote, or None if not set."""
     try:
@@ -1505,6 +1532,10 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
             cwd=cwd,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            # A stalled push here must not wedge the whole update: the
+            # ``except`` below already degrades to False, and the caller
+            # prints "couldn't push to fork".
+            timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
         )
         return result.returncode == 0
     except Exception:
@@ -1567,9 +1598,18 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             cwd=cwd,
             capture_output=True,
             check=True,
+            timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
         )
     except subprocess.CalledProcessError:
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
+        return
+    except subprocess.TimeoutExpired:
+        # Degrade, don't abort: the upstream sync is a convenience on top of
+        # the user's actual update, so a stalled upstream must not block it.
+        print(
+            f"  ✗ Fetching upstream timed out after {_GIT_NETWORK_TIMEOUT_SECONDS}s. "
+            "Skipping upstream sync."
+        )
         return
 
     # Compare origin/main with upstream/main
@@ -1606,10 +1646,18 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
             git_cmd + ["pull", "--ff-only", "upstream", "main"],
             cwd=cwd,
             check=True,
+            timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
         )
     except subprocess.CalledProcessError:
         print(
             "  ✗ Failed to pull from upstream. You may need to resolve conflicts manually."
+        )
+        return
+    except subprocess.TimeoutExpired:
+        # Same degrade-and-continue contract as the fetch above.
+        print(
+            f"  ✗ Pulling from upstream timed out after {_GIT_NETWORK_TIMEOUT_SECONDS}s. "
+            "Skipping upstream sync."
         )
         return
 
@@ -2253,35 +2301,56 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         fetch_result = None
         if has_upstream_remote:
             print("→ Fetching from upstream...")
-            fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["upstream", branch],
-                cwd=_m().PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-            )
+            try:
+                fetch_result = subprocess.run(
+                    git_cmd + ["fetch"] + depth_args + ["upstream", branch],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                    timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired:
+                # Treat a stall exactly like the existing "upstream fetch
+                # failed" case: fall through to the origin fallback below
+                # instead of aborting, because origin may still be reachable.
+                print(
+                    "  ⚠ Upstream fetch timed out after "
+                    f"{_GIT_NETWORK_TIMEOUT_SECONDS}s — falling back to origin."
+                )
+                fetch_result = None
         if fetch_result is not None and fetch_result.returncode == 0:
             upstream_exists = True
             compare_branch = f"upstream/{branch}"
         else:
             # No upstream remote, or the upstream fetch failed — use origin.
             print("→ Fetching from origin...")
-            fetch_result = subprocess.run(
-                git_cmd + ["fetch"] + depth_args + ["origin", branch],
-                cwd=_m().PROJECT_ROOT,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-            )
+            try:
+                fetch_result = subprocess.run(
+                    git_cmd + ["fetch"] + depth_args + ["origin", branch],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                    timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired:
+                _print_git_network_timeout("origin")
+                sys.exit(1)
             upstream_exists = False
             compare_branch = f"origin/{branch}"
     else:
         # Non-default branch: compare against origin/<branch> directly.
         print("→ Fetching from origin...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch"] + depth_args + ["origin", branch],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-        )
+        try:
+            fetch_result = subprocess.run(
+                git_cmd + ["fetch"] + depth_args + ["origin", branch],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            _print_git_network_timeout("origin")
+            sys.exit(1)
         upstream_exists = False
         compare_branch = f"origin/{branch}"
 
@@ -3735,12 +3804,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
         branch = _m()._resolve_update_branch(args)
 
         print("→ Fetching updates...")
-        fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
-            cwd=_m().PROJECT_ROOT,
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
-        )
+        try:
+            fetch_result = subprocess.run(
+                git_cmd + ["fetch", "origin", branch],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=_GIT_NETWORK_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            _print_git_network_timeout("origin")
+            sys.exit(1)
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
             if "Could not resolve host" in stderr or "unable to access" in stderr:

--- a/tests/hermes_cli/test_update_network_timeout.py
+++ b/tests/hermes_cli/test_update_network_timeout.py
@@ -68,6 +68,17 @@ def _assert_all_bounded(mock_run, *, expected_at_least: int) -> None:
         assert timeout > 0, f"non-positive timeout on: {_joined(call)}"
 
 
+def _drain(capsys) -> tuple:
+    """Return ``(stdout, stdout + stderr)`` from ``capsys``.
+
+    The diagnostics under test are printed to stdout, but a leaked traceback
+    or an unhandled exception surfaces on *stderr* — so "no traceback" has to
+    be asserted against both streams, or the assertion is false confidence.
+    """
+    captured = capsys.readouterr()
+    return captured.out, captured.out + captured.err
+
+
 def _check_side_effect(
     *,
     upstream_fetch_ok: bool = True,
@@ -148,8 +159,9 @@ class TestUpdateCheckTimeoutHandling:
 
         cmd_update(SimpleNamespace(check=True, branch=None))
 
-        out = capsys.readouterr().out
-        assert "Traceback" not in out
+        out, both = _drain(capsys)
+        assert "Traceback" not in both
+        assert "TimeoutExpired" not in both
         assert "timed out" in out
         assert "falling back to origin" in out
         assert any(
@@ -167,9 +179,9 @@ class TestUpdateCheckTimeoutHandling:
             cmd_update(SimpleNamespace(check=True, branch="bb/gui"))
         assert exc_info.value.code == 1
 
-        out = capsys.readouterr().out
-        assert "Traceback" not in out
-        assert "TimeoutExpired" not in out
+        out, both = _drain(capsys)
+        assert "Traceback" not in both
+        assert "TimeoutExpired" not in both
         assert "Timed out" in out
         assert str(_GIT_NETWORK_TIMEOUT_SECONDS) in out
 
@@ -213,9 +225,9 @@ class TestUpdateApplyFetch:
             cmd_update(SimpleNamespace(branch="main"))
         assert exc_info.value.code == 1
 
-        out = capsys.readouterr().out
-        assert "Traceback" not in out
-        assert "TimeoutExpired" not in out
+        out, both = _drain(capsys)
+        assert "Traceback" not in both
+        assert "TimeoutExpired" not in both
         assert "Timed out" in out
 
 
@@ -279,8 +291,9 @@ class TestUpstreamSyncDegradesOnTimeout:
         # Must return normally — no SystemExit, no TimeoutExpired escaping.
         _sync_with_upstream_if_needed(["git"], tmp_path)
 
-        out = capsys.readouterr().out
-        assert "Traceback" not in out
+        out, both = _drain(capsys)
+        assert "Traceback" not in both
+        assert "TimeoutExpired" not in both
         assert "timed out" in out
         assert "Skipping upstream sync" in out
         # The pull must not have been attempted after the fetch stalled.
@@ -292,8 +305,9 @@ class TestUpstreamSyncDegradesOnTimeout:
 
         _sync_with_upstream_if_needed(["git"], tmp_path)
 
-        out = capsys.readouterr().out
-        assert "Traceback" not in out
+        out, both = _drain(capsys)
+        assert "Traceback" not in both
+        assert "TimeoutExpired" not in both
         assert "timed out" in out
         assert "Skipping upstream sync" in out
         # Bailed before the fork push.

--- a/tests/hermes_cli/test_update_network_timeout.py
+++ b/tests/hermes_cli/test_update_network_timeout.py
@@ -1,0 +1,313 @@
+"""Every git network call in ``hermes update`` must be bounded.
+
+``hermes update`` and ``hermes update --check`` shell out to git for seven
+remote operations (fetch / pull / push).  None of them passed ``timeout=``,
+so a remote that completes the TCP handshake and then stops responding —
+captive-portal Wi-Fi, a half-up VPN, a filtering corporate proxy, a throttled
+forge — left the CLI printing ``→ Fetching updates...`` forever, with Ctrl-C
+the only exit.
+
+Two invariants are pinned here:
+
+1. every remote-talking invocation carries a positive ``timeout`` kwarg;
+2. a ``subprocess.TimeoutExpired`` is handled, never propagated as a
+   traceback — the user-facing entry points exit non-zero with a diagnostic,
+   while the optional fork/upstream sync degrades and lets the update
+   continue.
+
+The asymmetry in (2) is deliberate: the upstream sync is a convenience layered
+on top of the user's actual update, so a stalled *upstream* must not block it,
+whereas a stalled *origin* means there is nothing to update against.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.main import cmd_update
+from hermes_cli.update_cmd import (
+    _GIT_NETWORK_TIMEOUT_SECONDS,
+    _sync_fork_with_upstream,
+    _sync_with_upstream_if_needed,
+)
+
+# Verbs that actually talk to a remote.  ``git stash push`` and
+# ``git merge --ff-only`` are purely local and are intentionally excluded.
+_NETWORK_VERBS = ("fetch", "pull", "push")
+
+
+def _joined(call) -> str:
+    return " ".join(str(part) for part in call.args[0])
+
+
+def _network_calls(mock_run) -> list:
+    """Return the ``subprocess.run`` calls that reach a remote."""
+    found = []
+    for call in mock_run.call_args_list:
+        if not call.args:
+            continue
+        joined = _joined(call)
+        if "stash" in joined:  # `git stash push` never leaves the machine
+            continue
+        words = joined.split()
+        if any(verb in words for verb in _NETWORK_VERBS):
+            found.append(call)
+    return found
+
+
+def _assert_all_bounded(mock_run, *, expected_at_least: int) -> None:
+    calls = _network_calls(mock_run)
+    assert len(calls) >= expected_at_least, [_joined(c) for c in calls]
+    for call in calls:
+        timeout = call.kwargs.get("timeout")
+        assert timeout is not None, f"unbounded git network call: {_joined(call)}"
+        assert timeout > 0, f"non-positive timeout on: {_joined(call)}"
+
+
+def _check_side_effect(
+    *,
+    upstream_fetch_ok: bool = True,
+    timeout_on: str | None = None,
+    commit_count: str = "0",
+):
+    """Drive ``_cmd_update_check``'s git pipeline.
+
+    ``timeout_on`` is a substring; the matching invocation raises
+    ``subprocess.TimeoutExpired`` instead of returning.
+    """
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+
+        if timeout_on and timeout_on in joined:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+
+        if "fetch" in joined and "upstream" in joined:
+            rc = 0 if upstream_fetch_ok else 128
+            err = "" if upstream_fetch_ok else "fatal: 'upstream' does not appear to be a git repository\n"
+            return subprocess.CompletedProcess(cmd, rc, stdout="", stderr=err)
+
+        if "rev-list" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{commit_count}\n", stderr="")
+
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+class TestUpdateCheckFetchesAreBounded:
+    """``hermes update --check`` — the three ``_cmd_update_check`` fetches."""
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_upstream_fetch_is_bounded(self, mock_run, _method):
+        mock_run.side_effect = _check_side_effect()
+
+        cmd_update(SimpleNamespace(check=True, branch=None))
+
+        _assert_all_bounded(mock_run, expected_at_least=1)
+        assert any("upstream" in _joined(c) for c in _network_calls(mock_run))
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_origin_fallback_fetch_is_bounded(self, mock_run, _method):
+        """Upstream missing → origin fallback must be bounded too."""
+        mock_run.side_effect = _check_side_effect(upstream_fetch_ok=False)
+
+        cmd_update(SimpleNamespace(check=True, branch=None))
+
+        calls = _network_calls(mock_run)
+        _assert_all_bounded(mock_run, expected_at_least=2)
+        assert any(
+            "fetch" in _joined(c) and "origin" in _joined(c) for c in calls
+        ), [_joined(c) for c in calls]
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_non_default_branch_fetch_is_bounded(self, mock_run, _method):
+        """``--check --branch <name>`` skips upstream and fetches origin directly."""
+        mock_run.side_effect = _check_side_effect()
+
+        cmd_update(SimpleNamespace(check=True, branch="bb/gui"))
+
+        calls = _network_calls(mock_run)
+        _assert_all_bounded(mock_run, expected_at_least=1)
+        assert not any("upstream" in _joined(c) for c in calls), [_joined(c) for c in calls]
+
+
+class TestUpdateCheckTimeoutHandling:
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_upstream_timeout_falls_back_to_origin(self, mock_run, _method, capsys):
+        """A stalled upstream is treated like a failed upstream: try origin."""
+        mock_run.side_effect = _check_side_effect(timeout_on="fetch upstream")
+
+        cmd_update(SimpleNamespace(check=True, branch=None))
+
+        out = capsys.readouterr().out
+        assert "Traceback" not in out
+        assert "timed out" in out
+        assert "falling back to origin" in out
+        assert any(
+            "fetch" in _joined(c) and "origin" in _joined(c)
+            for c in _network_calls(mock_run)
+        )
+
+    @patch("hermes_cli.config.detect_install_method", return_value="git")
+    @patch("subprocess.run")
+    def test_origin_timeout_exits_cleanly(self, mock_run, _method, capsys):
+        """A stalled origin has no fallback: diagnose and exit 1, no traceback."""
+        mock_run.side_effect = _check_side_effect(timeout_on="fetch origin")
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(SimpleNamespace(check=True, branch="bb/gui"))
+        assert exc_info.value.code == 1
+
+        out = capsys.readouterr().out
+        assert "Traceback" not in out
+        assert "TimeoutExpired" not in out
+        assert "Timed out" in out
+        assert str(_GIT_NETWORK_TIMEOUT_SECONDS) in out
+
+
+def _apply_side_effect(*, timeout_on: str | None = None, commit_count: str = "0"):
+    """Drive ``_cmd_update_impl`` far enough to exercise the apply-path fetch."""
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+
+        if timeout_on and timeout_on in joined:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+
+        if "rev-list" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{commit_count}\n", stderr="")
+
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+class TestUpdateApplyFetch:
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_apply_fetch_is_bounded(self, mock_run, _which):
+        mock_run.side_effect = _apply_side_effect()
+
+        cmd_update(SimpleNamespace(branch="main"))
+
+        _assert_all_bounded(mock_run, expected_at_least=1)
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_apply_fetch_timeout_exits_cleanly(self, mock_run, _which, capsys):
+        mock_run.side_effect = _apply_side_effect(timeout_on="fetch origin")
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(SimpleNamespace(branch="main"))
+        assert exc_info.value.code == 1
+
+        out = capsys.readouterr().out
+        assert "Traceback" not in out
+        assert "TimeoutExpired" not in out
+        assert "Timed out" in out
+
+
+def _upstream_sync_side_effect(
+    *,
+    timeout_on: str | None = None,
+    origin_ahead: str = "0",
+    upstream_ahead: str = "3",
+):
+    """Drive ``_sync_with_upstream_if_needed`` down to the fetch/pull/push."""
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+
+        if timeout_on and timeout_on in joined:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 1))
+
+        # `_count_commits_between(base, head)` → `rev-list --count base..head`
+        if "rev-list" in joined and "upstream/main..origin/main" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{origin_ahead}\n", stderr="")
+        if "rev-list" in joined and "origin/main..upstream/main" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout=f"{upstream_ahead}\n", stderr="")
+
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+class TestUpstreamSyncIsBounded:
+    """The fork-sync path: ``fetch upstream``, ``pull upstream``, ``push origin``."""
+
+    @patch("subprocess.run")
+    def test_fetch_pull_and_push_are_all_bounded(self, mock_run, tmp_path):
+        mock_run.side_effect = _upstream_sync_side_effect()
+
+        _sync_with_upstream_if_needed(["git"], tmp_path)
+
+        calls = _network_calls(mock_run)
+        joined = [_joined(c) for c in calls]
+        assert any("fetch upstream main" in j for j in joined), joined
+        assert any("pull --ff-only upstream main" in j for j in joined), joined
+        assert any("push origin main" in j for j in joined), joined
+        _assert_all_bounded(mock_run, expected_at_least=3)
+
+    @patch("subprocess.run")
+    def test_fork_push_is_bounded(self, mock_run, tmp_path):
+        mock_run.side_effect = _upstream_sync_side_effect()
+
+        assert _sync_fork_with_upstream(["git"], tmp_path) is True
+
+        _assert_all_bounded(mock_run, expected_at_least=1)
+
+
+class TestUpstreamSyncDegradesOnTimeout:
+    """A stalled upstream must be skipped, not fatal — the update goes on."""
+
+    @patch("subprocess.run")
+    def test_upstream_fetch_timeout_skips_sync(self, mock_run, tmp_path, capsys):
+        mock_run.side_effect = _upstream_sync_side_effect(timeout_on="fetch upstream")
+
+        # Must return normally — no SystemExit, no TimeoutExpired escaping.
+        _sync_with_upstream_if_needed(["git"], tmp_path)
+
+        out = capsys.readouterr().out
+        assert "Traceback" not in out
+        assert "timed out" in out
+        assert "Skipping upstream sync" in out
+        # The pull must not have been attempted after the fetch stalled.
+        assert not any("pull" in _joined(c) for c in _network_calls(mock_run))
+
+    @patch("subprocess.run")
+    def test_upstream_pull_timeout_skips_sync(self, mock_run, tmp_path, capsys):
+        mock_run.side_effect = _upstream_sync_side_effect(timeout_on="pull --ff-only")
+
+        _sync_with_upstream_if_needed(["git"], tmp_path)
+
+        out = capsys.readouterr().out
+        assert "Traceback" not in out
+        assert "timed out" in out
+        assert "Skipping upstream sync" in out
+        # Bailed before the fork push.
+        assert not any("push" in _joined(c) for c in _network_calls(mock_run))
+
+    @patch("subprocess.run")
+    def test_fork_push_timeout_degrades_to_false(self, mock_run, tmp_path):
+        """Contract test, not a regression test.
+
+        ``_sync_fork_with_upstream`` already had a catch-all ``except``, so
+        this passes with or without the fix — it pins the degrade contract
+        that makes bounding the push safe.  Its companion,
+        ``test_fork_push_is_bounded``, is the one that is red without the fix.
+        """
+        mock_run.side_effect = _upstream_sync_side_effect(timeout_on="push origin")
+
+        assert _sync_fork_with_upstream(["git"], tmp_path) is False


### PR DESCRIPTION
## What does this PR do?

Supersedes **#49181** (rblume32120), which started this fix in June and has been CONFLICTING/DIRTY ever since — no force-push, no commit since 2026-06-19, and it patches `hermes_cli/main.py`, a file the entire update implementation has since been mechanically extracted out of (into `hermes_cli/update_cmd.py`). **#50391** (Morad37) is a strictly narrower duplicate of the same idea — the apply-path fetch only, no test — and is also CONFLICTING with no commit since 2026-06-21. Both have to be rewritten against current `main` regardless of who does it; this is that rewrite, plus the coverage the maintainer asked for on #49181.

**The user symptom.** Run `hermes update` or `hermes update --check` on a network that blackholes packets — captive-portal Wi-Fi, a half-up VPN, a filtering corporate proxy, a throttled forge — and the remote completes the TCP handshake and then goes silent. The CLI prints `→ Fetching updates...` (or `→ Fetching from upstream...`) and **blocks forever**: no timeout, no error, no way out but Ctrl-C. `hermes update` is a universal command and the fork-sync path fires automatically inside it, so any user on a bad link is exposed.

**Root cause.** Every git subprocess in the update flow that talks to a remote is called without `timeout=`, so `subprocess.run` waits indefinitely on a stalled socket.

### The maintainer's acceptance checklist on #49181

> ### Suggested changes
> - Cover those `_cmd_update_check` fetches with bounded timeouts, user-facing timeout handling, and regression tests alongside the apply-path cases.

- [x] `_cmd_update_check` upstream fetch — bounded
- [x] `_cmd_update_check` origin fallback fetch — bounded
- [x] `_cmd_update_check` non-default-branch origin fetch — bounded
- [x] apply-path fetch (`_cmd_update_impl`) — bounded
- [x] upstream fork-sync fetch + ff-only pull (`_sync_with_upstream_if_needed`) — bounded
- [x] user-facing timeout handling at every site (no traceback, no bare hang)
- [x] regression tests covering both the check path and the apply path

### Sibling sweep — a seventh site the original review did not list

Grepping every `subprocess.run` in the `hermes update` flow whose argv carries a remote-talking verb turns up **seven** unbounded calls, not six. The extra one is `_sync_fork_with_upstream`'s `git push origin main --force-with-lease`, which runs at the end of the same fork-sync path — a stalled *push* hangs the update just as hard as a stalled *fetch*. It is included here.

The sweep's boundary is deliberate, and these are explicitly **not** touched:

- `hermes_cli/mcp_catalog.py` and `hermes_cli/profile_distribution.py` also run unbounded `git clone`. Different commands, different user flows, different concern — bundling them would make this PR two ideas instead of one.
- `update_cmd.py`'s `git stash push` and `git merge --ff-only origin/<branch>` match on the words `push`/`pull` but never leave the machine. Correctly excluded; the tests encode that exclusion so a future refactor cannot quietly widen it.

### Why 300s and not `banner.py`'s 10s

`hermes_cli/banner.py` bounds its update probe at `timeout=10`. That probe is a **background, non-blocking** check whose result is discardable, so a tight bound costs nothing. These seven are **foreground, user-initiated** operations, and a first fetch over a slow or metered link can legitimately run for minutes — a 10s bound would break setups that work today. The defect here is the *unbounded* wait, so a generous finite ceiling is a complete fix with no regression risk.

No new config surface: `update_cmd.py` has no env-override convention for tunables, so this adds a single module constant and does not invent one.

### The error handling is deliberately asymmetric

| path | on `TimeoutExpired` | why |
|---|---|---|
| `_cmd_update_impl` apply fetch | diagnostic + `sys.exit(1)` | a stalled origin means there is nothing to update against |
| `_cmd_update_check` origin fetches | diagnostic + `sys.exit(1)` | same — no fallback left |
| `_cmd_update_check` upstream fetch | warn, fall through to the origin fallback | mirrors the existing "upstream fetch failed → use origin" branch; origin may still be reachable |
| `_sync_with_upstream_if_needed` fetch/pull | message + `return` (degrade) | mirrors its existing `CalledProcessError` branches — the upstream sync is a convenience on top of the user's actual update and must not block it |
| `_sync_fork_with_upstream` push | existing catch-all → `return False` | caller already prints "couldn't push to fork" |

Preserving that asymmetry is the point: unifying it would either abort updates over a slow upstream or silently swallow a dead origin.

## Related Issue

No filed issue — the demand is stated directly in the maintainer review on #49181, quoted above.

Supersedes #49181. Narrower duplicate: #50391.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`
  - New module constant `_GIT_NETWORK_TIMEOUT_SECONDS = 300`, with the rationale for 300-vs-10 in the comment.
  - New helper `_print_git_network_timeout(remote)` — one diagnostic, in the same style as the existing `✗ Network error — cannot reach the remote repository.` branch, used by the three fatal sites.
  - `_sync_fork_with_upstream` — bound the `git push origin main --force-with-lease`.
  - `_sync_with_upstream_if_needed` — bound `git fetch upstream main` and `git pull --ff-only upstream main`; added a `TimeoutExpired` branch to each that degrades and returns.
  - `_cmd_update_check` — bound all three `git fetch` calls; upstream stall falls back to origin, origin stall exits 1.
  - `_cmd_update_impl` — bound `git fetch origin <branch>`; stall exits 1.
- `tests/hermes_cli/test_update_network_timeout.py` (new, 12 tests)
  - Pins that every remote-talking invocation carries a **positive** `timeout` kwarg, on all three entry paths.
  - Pins that a `TimeoutExpired` never propagates: fatal paths exit 1 with a diagnostic and no traceback; the upstream-sync path prints and returns without aborting; the upstream stall in `--check` still reaches the origin fallback.
  - The helper that classifies "network call" excludes `git stash` and local `merge`, so the tests fail if a future change bounds only some sites.

## How to Test

1. **Reproduce the hang.** Point the repo's `origin` at an address that accepts connections and never answers, e.g. `git remote set-url origin https://10.255.255.1/x.git` (an unroutable host behind a stateful firewall), then run `hermes update --check`. Before this change the CLI prints `→ Fetching from origin...` and hangs indefinitely. After it, the fetch is bounded and you get:
   ```
   ✗ Timed out after 300s fetching from origin — the remote accepted the connection but stopped responding.
     Check your network (VPN, proxy, captive portal) and try again.
   ```
   and exit status 1.
2. **Headless regression suite** (no network, no git server — `subprocess.run` is mocked):
   ```
   pytest tests/hermes_cli/test_update_network_timeout.py -v
   ```
   12 passed.
3. **Before/after evidence.** Restoring `hermes_cli/update_cmd.py` from `main` and re-running the new file turns **11 of the 12 red**. The twelfth, `test_fork_push_timeout_degrades_to_false`, is labelled in its docstring as a contract test rather than a regression test — `_sync_fork_with_upstream` already had a catch-all `except`, so it is green either way; its companion `test_fork_push_is_bounded` is the one that fails without the fix.
4. **No collateral damage.** `pytest tests/hermes_cli/ -q -p no:randomly` produces a byte-identical failure set on this branch and on clean `main` (`82c6aca`) — 142 pre-existing failures on both, **zero** new and zero fixed. Adjacent update suites (`test_cmd_update.py`, `test_update_check.py`, `test_update_yes_flag.py`, `test_update_hangup_protection.py`, `test_update_fleet_restart_timeout.py`, `test_update_autostash.py`) are all green: 55 passed.
5. `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_update_network_timeout.py` — clean. Source parses under `ast.parse(..., feature_version=(3, 9))`.

## Related / Positioning

**#73751** (Frowtek) touches the same functions but fixes a different hang: it adds `stdin=DEVNULL` + a non-interactive git env so a *credential prompt* can't block. That is orthogonal and complementary to bounding the *network* wait — neither change subsumes the other. It is also CONFLICTING against `hermes_cli/main.py`. This PR does not touch stdin or the git env, so the two remain independently applicable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- scoped to tests/hermes_cli/: failure set is byte-identical to clean main (142 pre-existing on both), zero new -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- N/A: internal timeout, no user-facing docs surface -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A: module constant, deliberately no new config key -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- subprocess timeout= is portable; no platform-specific branches added. Verified on macOS only. -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
