### PR TITLE
fix(state): stop delegate/tool children corrupting compression lineage

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7831,7 +7831,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # Export and cleanup
     # =========================================================================
 
-    def _is_branch_child_row(self, session: Dict[str, Any]) -> bool:
+    def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
+        if session.get("source") == "tool":
+            return True
         raw = session.get("model_config")
         if not raw:
             return False
@@ -7839,11 +7841,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cfg = json.loads(raw) if isinstance(raw, str) else raw
         except (TypeError, json.JSONDecodeError):
             return False
-        return isinstance(cfg, dict) and cfg.get("_branched_from") is not None
+        return isinstance(cfg, dict) and (
+            cfg.get("_branched_from") is not None
+            or cfg.get("_delegate_from") is not None
+        )
 
     def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
         parent_id = child.get("parent_session_id")
-        if not parent_id or self._is_branch_child_row(child):
+        if not parent_id or self._is_explicit_fork_child_row(child):
             return False
         parent = self.get_session(parent_id)
         return bool(parent and parent.get("end_reason") == "compression")
@@ -7851,7 +7856,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def get_compression_lineage(self, session_id: str) -> List[str]:
         """Return compression ancestors through tip in chronological order."""
         session = self.get_session(session_id)
-        if not session or self._is_branch_child_row(session):
+        if not session or self._is_explicit_fork_child_row(session):
             return [session_id] if session else []
 
         root = session
@@ -7879,7 +7884,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             next_child = None
             for row in rows:
                 candidate = dict(row)
-                if not self._is_branch_child_row(candidate):
+                if self._is_compression_child_row(candidate):
                     next_child = candidate
                     break
             if not next_child or next_child["id"] in seen:

--- a/tests/hermes_state/test_session_md_export.py
+++ b/tests/hermes_state/test_session_md_export.py
@@ -40,10 +40,56 @@ def test_get_compression_lineage_returns_only_compression_chain(tmp_path):
         db.end_session("child", "compression")
         db.create_session("tip", source="cli", parent_session_id="child")
         db.create_session("branch", source="cli", parent_session_id="root", model_config={"_branched_from": "root"})
+        db.create_session("delegate", source="delegate", parent_session_id="child", model_config={"_delegate_from": "child"})
+        db.create_session("tool", source="tool", parent_session_id="child")
 
         assert db.get_compression_lineage("tip") == ["root", "child", "tip"]
         assert db.get_compression_lineage("branch") == ["branch"]
+        assert db.get_compression_lineage("delegate") == ["delegate"]
+        assert db.get_compression_lineage("tool") == ["tool"]
     finally:
         db.close()
 
+
+def test_fork_children_created_before_continuation_do_not_hijack_lineage(tmp_path):
+    # Regression: the forward walk used to accept any non-branch child as the
+    # compression continuation. A delegate/tool child spawned BEFORE the real
+    # continuation row (the common runtime ordering — the subagent exists
+    # before compression rotates the session) was picked as the successor,
+    # so lineage and session .md export followed the subagent's transcript.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="cli")
+        db.append_message("root", role="user", content="root msg")
+        db.create_session(
+            "delegate",
+            source="delegate",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+        db.append_message("delegate", role="user", content="delegate private msg")
+        db.end_session("root", "compression")
+        db.create_session("continuation", source="cli", parent_session_id="root")
+        db.append_message("continuation", role="user", content="continuation msg")
+
+        db.create_session("root2", source="cli")
+        db.create_session("toolchild", source="tool", parent_session_id="root2")
+        db.end_session("root2", "compression")
+        db.create_session("cont2", source="cli", parent_session_id="root2")
+
+        assert db.get_compression_lineage("root") == ["root", "continuation"]
+        assert db.get_compression_lineage("continuation") == ["root", "continuation"]
+        assert db.get_compression_lineage("root2") == ["root2", "cont2"]
+
+        exported = db.export_session_lineage("root")
+        assert exported is not None
+        assert exported["lineage_session_ids"] == ["root", "continuation"]
+        contents = [
+            m.get("content")
+            for seg in exported["segments"]
+            for m in (seg.get("messages") or [])
+        ]
+        assert contents == ["root msg", "continuation msg"]
+    finally:
+        db.close()
 


### PR DESCRIPTION
## Summary
Delegate and tool child sessions no longer corrupt a conversation's compression lineage — session `.md` export now follows the real continuation instead of a subagent's transcript.

Root cause: `get_compression_lineage`'s forward walk accepted *any non-branch child* of a compressed session as the compression continuation. A delegate subagent (`_delegate_from`) or tool-tagged (`source="tool"`) child created before the real continuation row — the common runtime ordering, since the subagent exists before compression rotates the session — was picked as the lineage successor.

## Context (real-world impact)
Reproduced on current `main`: a CLI session that spawns a delegate child and then compresses exports the **delegate's private transcript** as its continuation:

```
main:  lineage(root) = ['root', 'delegate']          # subagent hijacks the chain
       lineage(continuation) = ['continuation']      # real continuation orphaned
       export_session_lineage('root') messages: ['root user msg', 'DELEGATE PRIVATE msg']

fixed: lineage(root) = ['root', 'continuation']
       export messages: ['root user msg', 'continuation msg']
```

Anyone using `/export` (or anything built on `export_session_lineage` / `get_compression_lineage`) on a session that delegated work before compressing gets the wrong transcript today.

## Changes
- `hermes_state.py`: rename `_is_branch_child_row` → `_is_explicit_fork_child_row`; treat `_delegate_from` and `source="tool"` rows as explicit forks alongside `_branched_from`; the forward walk now requires `_is_compression_child_row` instead of merely excluding branches.
- `tests/hermes_state/test_session_md_export.py`: extend the lineage test with delegate/tool isolation asserts; new regression test for the fork-child-before-continuation ordering including export content (mutation-checked — fails on `main`, passes with the fix).

## Validation
| | Result |
|---|---|
| tests/hermes_state/ | 49 passed |
| tests/run_agent/ | 1438 passed, 1 pre-existing failure (reproduces on clean upstream/main) |
| Mutation check | new test fails on main's `hermes_state.py`, passes with fix |
| ruff | clean |

Sliced from #79024 by @RyderFreeman4Logos — cherry-picked with authorship preserved. The prompt-cache-scope portion of that PR is a design question tracked in #79017 (alongside #78956) and is intentionally not included here.
