### PR TITLE
fix(desktop): re-read live argv before gateway exemption in venv-blocker scan

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -140,16 +140,34 @@ def main() -> None:
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
-    processes = [
-        {
-            "pid": pid,
-            "name": name,
-            "cmdline": _redact_sensitive_cmdline(cmdline),
-        }
-        for pid, name, cmdline in matches
-        if not _is_pausable_gateway(cmdline)
-    ]
-    exempted = sum(1 for _pid, _name, cmdline in matches if _is_pausable_gateway(cmdline))
+    processes: list[dict] = []
+    exempted = 0
+    for pid, name, cmdline in matches:
+        # The blocker scan captures only a 120-char cmdline prefix
+        # (``_detect_venv_python_processes``). A uv-managed CPython worker
+        # path (``.hermes-runtime\\python\\generation-*\\...\\python.exe``)
+        # is long enough to push the trailing ``gateway run`` tokens past
+        # the truncation point, so ``_is_pausable_gateway`` misses the
+        # process and the Desktop preflight dead-ends with ``venv-blocked``
+        # even though the CLI updater would pause the gateway itself.
+        # Re-read the live argv where psutil allows — the same fallback
+        # ``update_cmd._leftover_pausable_gateway_pids`` uses for its guard
+        # — so the exemption and the guard cannot drift apart.
+        argv = cmdline
+        try:
+            argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
+        except Exception:
+            pass
+        if _is_pausable_gateway(argv):
+            exempted += 1
+            continue
+        processes.append(
+            {
+                "pid": pid,
+                "name": name,
+                "cmdline": _redact_sensitive_cmdline(argv),
+            }
+        )
     data = {
         "ok": True,
         "blocked": bool(processes),

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -33,6 +33,23 @@ def _psutil_fake() -> dict:
     return {"psutil": types.SimpleNamespace(Process=lambda *a: MagicMock())}
 
 
+def _psutil_fake_with_argv(argv_by_pid: dict) -> dict:
+    """psutil fake whose Process(pid).cmdline() returns a live argv list.
+
+    Simulates the real psutil re-read the scanner performs on the captured
+    (possibly truncated) cmdline before the gateway exemption runs.
+    """
+
+    class _Proc:
+        def __init__(self, pid: int) -> None:
+            self._pid = pid
+
+        def cmdline(self):
+            return argv_by_pid.get(self._pid)
+
+    return {"psutil": types.SimpleNamespace(Process=_Proc)}
+
+
 
 
 
@@ -211,4 +228,76 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert code == 0
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
+    assert data["pausable_gateways"] == 0
+
+
+def test_main_rereads_truncated_argv_before_gateway_exemption(monkeypatch, capsys):
+    """A uv-side gateway worker whose captured cmdline was truncated at 120
+    chars (the managed-CPython path alone exceeds the budget) must still be
+    exempted: the scanner re-reads the live argv via psutil before running
+    the gateway matcher. Regression for the Desktop ``venv-blocked`` dead-end
+    where the reported holder is a gateway the updater would pause itself.
+    """
+    worker_pid = 3401
+    truncated_worker = (
+        worker_pid,
+        "python.exe",
+        # The 120-char prefix captured by _detect_venv_python_processes;
+        # "gateway run" lies beyond the truncation point.
+        r"E:\hermes\hermes-agent\.hermes-runtime\python\generation-1785786039-27004-e71ff1af\cpython-3.11-windows-x86_64-none\pyth",
+    )
+    full_argv = [
+        r"E:\hermes\hermes-agent\.hermes-runtime\python\generation-1785786039-27004-e71ff1af\cpython-3.11-windows-x86_64-none\python.exe",
+        "-m",
+        "hermes_cli.main",
+        "gateway",
+        "run",
+    ]
+
+    for name, mod in _psutil_fake_with_argv({worker_pid: full_argv}).items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    import hermes_cli.main as cli_main
+
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: [truncated_worker])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert excinfo.value.code == 0
+    assert data["ok"] is True
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 1
+
+
+def test_main_truncated_gateway_worker_without_live_argv_falls_back(
+    monkeypatch, capsys
+):
+    """When psutil cannot re-read the live argv (dead PID, access denied),
+    the scanner falls back to the captured cmdline — a truncated gateway
+    worker then still counts as a blocker, preserving pre-fix behavior.
+    """
+    truncated_worker = (
+        3402,
+        "python.exe",
+        r"E:\hermes\hermes-agent\.hermes-runtime\python\generation-1785786039-27004-e71ff1af\cpython-3.11-windows-x86_64-none\pyth",
+    )
+
+    # Default fake: Process(pid).cmdline() returns a MagicMock, so the join
+    # fails and the captured (truncated) cmdline is used.
+    for name, mod in _psutil_fake().items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    import hermes_cli.main as cli_main
+
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: [truncated_worker])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert excinfo.value.code == 0
+    assert data["ok"] is True
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [3402]
     assert data["pausable_gateways"] == 0


### PR DESCRIPTION
## Summary

The Desktop update preflight (`venv\Scripts\python.exe -m hermes_cli._scan_venv_blockers`) still aborts with `venv-blocked` on gateway-enabled Windows installs even after the pausable-gateway exemption from #75881. The exemption classifies holders from a **cmdline truncated to 120 characters** by `_detect_venv_python_processes()`, while a gateway worker launched from the uv-managed runtime (`.hermes-runtime\python\generation-<id>\cpython-3.11-windows-x86_64-none\python.exe`) has a ~186-char cmdline — the trailing `gateway run` tokens fall past the cut, the matcher returns `False`, and the preflight dead-ends before the CLI updater's `_pause_windows_gateways_for_update()` ever runs. Every Desktop update aborts; the only workaround is stopping the gateway by hand.

## Root cause

`_scan_venv_blockers.py` classifies every holder with `_is_pausable_gateway(cmdline)`, where `cmdline` is the 120-char prefix captured at scan time. The CLI-side guard (`update_cmd._leftover_pausable_gateway_pids`) already compensates for this truncation by re-reading the live argv via psutil — the Desktop preflight never got that compensation, so the two views of the same process table drifted apart and the exemption silently stopped matching.

Verified live on Windows 10, Hermes v0.20.0 (HEAD `34c3f06f9`, contains #75881), three always-on profile gateways (`default` / `github-agent` / `teacher` launched via scheduled startup scripts):

PID 7728 ...\cpython-3.11-windows-x86_64-none\pyth <- captured prefix, cut at 120 chars looks_like_gateway_command_line(full argv) = True looks_like_gateway_command_line(truncated) = False <- exemption defeated

Scan output before the fix: `{"blocked": true, "pausable_gateways": 1}` — the scan's own diagnostic contradicted its verdict, exactly the #78089 pattern.

## Fix

In `hermes_cli/_scan_venv_blockers.py`, re-read the live argv via psutil **before** the gateway exemption runs, falling back to the captured cmdline when the process is gone or unreadable (same pattern as `_leftover_pausable_gateway_pids`, same `try/except` tolerance). Blocked-process reports now also show the full redacted cmdline instead of a truncated prefix, so users can actually see which process holds the install.

Design note: this keeps the capture layer (`_detect_venv_python_processes`) untouched and makes the preflight self-healing regardless of where truncation happens upstream — an alternative to #78094 / #78188, which move the truncation out of the capture layer entirely. Non-gateway holders (`serve` backends, operator REPLs, stray scripts) keep blocking exactly as before: `_is_pausable_gateway` still rejects them and the re-read only widens what is visible, never what blocks.

## Verification

- New regression tests in `tests/hermes_cli/test_scan_venv_blockers.py`:
  - `test_main_rereads_truncated_argv_before_gateway_exemption` — a 120-char-truncated uv-side gateway worker is exempted when the live argv is readable
  - `test_main_truncated_gateway_worker_without_live_argv_falls_back` — pre-fix behavior is preserved when psutil cannot re-read (dead PID / access denied)
- `scripts/run_tests.sh tests/hermes_cli/test_scan_venv_blockers.py` (canonical CI-equivalent runner, clean env): **25/25 passed, 0 failed**.
- End-to-end on the affected machine, same process snapshot: before the fix the scan reported the gateway worker as a blocker (`pausable_gateways: 1`); after the fix the worker is exempted (`pausable_gateways: 2`, only the Desktop `serve` backend remains — which `releaseBackendLockForUpdate` stops before the updater spawns anyway).

## Related

- Fixes the same symptom as #78089 (alternative implementation to #78094 and #78188, which relocate the truncation instead of re-reading the argv)
- Builds on #75881 (pausable-gateway preflight exemption)
- Original gateway/update coordination chain: #50090