### PR TITLE
fix(agent): fire on_session_start only when the session is genuinely new

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -520,6 +520,7 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "cache will miss for this turn.",
                 agent.session_id, exc,
             )
+            stored_state = "read_error"
 
     if stored_prompt and _stored_prompt_matches_runtime(agent, stored_prompt):
         # Continuing session — reuse the exact system prompt from the
@@ -570,16 +571,27 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).
-    try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start",
-            session_id=agent.session_id,
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+    #
+    # By this point ``stored_state`` is one of: "missing" (no stored row
+    # was found — a genuine first turn, or a brand-new session that was
+    # handed parent history), "read_error" (the session DB lookup raised,
+    # so whether this session is new is UNKNOWN), "stale_runtime",
+    # "null", or "empty" ("present" returns early above).  Everything
+    # except "missing" is either a continuing session whose stored
+    # prompt merely needs a rebuild or an indeterminate lookup — firing
+    # the hook there would duplicate session-scoped plugin work
+    # mid-conversation, so only "missing" fires it.
+    if stored_state == "missing":
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_start hook failed: %s", exc)
 
     # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
     # desktop build seeds at session OPEN (see seed_credits_at_session_start in

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -191,6 +191,131 @@ class TestSilentFailureWarnings:
 
 
 # ---------------------------------------------------------------------------
+# on_session_start hook firing (follow-up A to #72253)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStartHookGuard:
+    """``on_session_start`` is documented as firing "once when a brand-new
+    session is created (not on continuation)". The stale-runtime and
+    null/empty fallthroughs below are CONTINUING sessions whose stored
+    prompt just needs a rebuild — the hook must not re-fire there (it
+    would duplicate session-scoped plugin work, e.g. re-warming a memory
+    cache mid-conversation). Only a true first-turn build should fire it.
+    """
+
+    def test_stale_runtime_fallthrough_does_not_fire_hook(self, monkeypatch):
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "Model: anthropic/claude-opus-4.8-fast\n"
+            "Provider: openrouter"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(
+            session_db=db,
+            prebuilt_prompt=(
+                "You are Hermes Agent.\n\nModel: openai/gpt-5.5\nProvider: openrouter"
+            ),
+        )
+        agent.model = "openai/gpt-5.5"
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once()
+        hook.assert_not_called()
+
+    def test_null_row_fallthrough_does_not_fire_hook(self, monkeypatch):
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": None}
+        agent = _make_agent(session_db=db)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once()
+        hook.assert_not_called()
+
+    def test_empty_row_fallthrough_does_not_fire_hook(self, monkeypatch):
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": ""}
+        agent = _make_agent(session_db=db)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once()
+        hook.assert_not_called()
+
+    def test_db_read_error_fallthrough_does_not_fire_hook(self, monkeypatch):
+        """``get_session`` raising leaves the session's newness UNKNOWN —
+        the continuing-session case is indistinguishable there, so the
+        hook must stay quiet (same double-fire class as the three
+        fallthrough states above).
+        """
+        db = MagicMock()
+        db.get_session.side_effect = RuntimeError("db locked")
+        agent = _make_agent(session_db=db)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once()
+        hook.assert_not_called()
+
+    def test_no_row_with_history_still_fires_hook(self, monkeypatch):
+        """History plus an attached DB but NO session row is a brand-new
+        session that was handed parent history (the DB-attached sibling of
+        the preview-restart shape) — its start hook is legitimate. This
+        pins that intent so the choice is explicit, not accidental.
+        """
+        db = MagicMock()
+        db.get_session.return_value = None
+        agent = _make_agent(session_db=db)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        agent._build_system_prompt.assert_called_once()
+        hook.assert_called_once()
+
+    def test_fresh_build_still_fires_hook(self, monkeypatch):
+        """True first turn (no history, no DB row) legitimately fires the hook."""
+        agent = _make_agent(session_db=None)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(agent, None, [])
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        hook.assert_called_once()
+        assert hook.call_args.args[0] == "on_session_start"
+
+    def test_preview_restart_with_parent_history_still_fires_hook(self, monkeypatch):
+        """The preview-restart shape: a brand-new session that deliberately
+        receives nonempty PARENT history but has no session DB. Its start
+        hook is legitimate — a guard keyed on history truthiness (instead of
+        the stale-runtime/null/empty states) would wrongly suppress it.
+        """
+        agent = _make_agent(session_db=None)
+        hook = MagicMock()
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "from parent session"}]
+        )
+
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        hook.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Byte-stability invariant
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -746,7 +746,7 @@ def my_callback(session_id: str, model: str, platform: str, **kwargs):
 | `model` | `str` | The model identifier |
 | `platform` | `str` | Where the session is running |
 
-**Fires:** In `run_agent.py`, inside `run_conversation()`, during the first turn of a new session — specifically after the system prompt is built but before the tool loop starts. The check is `if not conversation_history` (no prior messages = new session).
+**Fires:** In `agent/conversation_loop.py`, inside `_restore_or_build_system_prompt()`, after the system prompt is built but before the tool loop starts. The check is the stored-session lookup state: the hook fires only when the session classifies as *missing* — the conversation history is empty (the session DB is not consulted), the agent has no session DB attached, or `get_session` finds no row for this session. It does not fire on continuation rebuilds: stale runtime identity, a row whose stored prompt is NULL or empty, or a session-DB read error.
 
 **Return value:** Ignored.
 


### PR DESCRIPTION
`_restore_or_build_system_prompt` fires the `on_session_start` plugin hook on
every path that reaches the rebuild section. The hook's own comment says it
fires "once when a brand-new session is created (not on continuation)", but
most of the states that reach that point are continuations:

- `stale_runtime`: a stored prompt exists, its model/provider lines just no
  longer match the live agent
- `null`: the session row exists with `system_prompt` NULL
- `empty`: the session row exists with `system_prompt` ""
- a `get_session` read error: the lookup raised, so whether the session is
  new is unknown

On stale_runtime, null, and empty the hook re-fires mid-conversation, and
session-scoped plugin work (the docstring's example is warming a memory
cache) runs twice for one session. The read-error path is murkier: the
lookup failed, so whether the session is new is unknown, and the hook may be
re-firing during a continuation there too.

The fix gates the invocation on `stored_state == "missing"`, the only state
consistent with a first turn. Three shapes reach it: the history is empty
(the DB is never consulted), the history is nonempty but no session DB is
attached (the preview-restart case, where the lookup never runs), or
`get_session` found no row. The read-error path gets its own
`read_error` state so it stays distinguishable from "no row". An unknown
session must not re-init plugins mid-conversation, so it does not fire.
`present` returns early before this point.

This also updates `website/docs/user-guide/features/hooks.md`, which still
described the old check (`if not conversation_history`) and pointed at
`run_agent.py`. It now states the stored-state condition and the actual
location.

### Tests

Seven new tests in `tests/agent/test_system_prompt_restore.py`
(`TestSessionStartHookGuard`):

- the three continuation states (stale_runtime / null / empty) assert the
  hook does not fire. All three were red before the fix.
- the read-error path asserts the hook does not fire
- a true first turn (no history, no DB row) asserts the hook still fires once
- history plus an attached DB but no session row asserts the hook fires,
  since a brand-new session handed parent history is still a start
- the preview-restart shape (nonempty parent history, no session DB) asserts
  the hook still fires, which pins the guard to `stored_state` rather than
  history truthiness

A full `tests/agent` sweep at the same base commit shows the same failure
set before and after the change, with no new failures. The target suite
passes.

### Relation to #74129

#74129 (Tranquil-Flow) works in the same area but on a different defect and
a different function: it changes `_stored_prompt_matches_runtime`, a helper
this function calls, to catch stored prompts that lost their MEMORY/USER
blocks (stored-content validity). This PR only touches
`_restore_or_build_system_prompt` and decides which rebuild paths may fire
the start hook (session lifecycle). The two compose, and the diffs do not
overlap.

Split out of the #72253 work.
