### PR TITLE
fix(sessions): read stale profile schemas without migration

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2026,6 +2026,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._fts_cjk_available = False
         self._fts_unavailable_warned = False
         self._conn = None
+        # Read-only cross-profile attachments deliberately skip schema
+        # reconciliation. Cache their live sessions columns so list queries
+        # can tolerate a profile DB that has not yet been opened writable by
+        # the newly-installed version.
+        self._read_only_session_columns: Optional[frozenset[str]] = None
         # Async token accounting (see queue_token_counts). The condition
         # guards queue + writer state; it is distinct from self._lock so
         # enqueue/flush bookkeeping never contends with SQLite writes.
@@ -2065,6 +2070,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 try:
                     apply_database_pragmas(self._conn, db_label="state.db")
                     cursor = self._conn.cursor()
+                    self._read_only_session_columns = frozenset(
+                        row["name"]
+                        for row in cursor.execute(
+                            'PRAGMA table_info("sessions")'
+                        ).fetchall()
+                    )
                     self._fts_enabled = (
                         self._fts_table_probe(cursor, "messages_fts") is True
                     )
@@ -3282,7 +3293,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             SELECT sessions.*,
                    COALESCE(sp.prompt, sessions.system_prompt)
                        AS _system_prompt_resolved,
-                   {_sql_session_last_active("sessions")} AS last_active
+                   {self._session_last_active_sql("sessions")} AS last_active
             FROM sessions
             LEFT JOIN system_prompts sp
               ON sp.hash = sessions.system_prompt_hash
@@ -5683,7 +5694,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         WHEN child.ended_at IS NULL THEN 1
                         ELSE 2
                       END,
-                      {_sql_session_last_active("child")} DESC,
+                      {self._session_last_active_sql("child")} DESC,
                       child.started_at DESC,
                       child.id DESC
                     LIMIT 1
@@ -5935,7 +5946,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 chain_max AS (
                     SELECT
                         root_id,
-                        MAX({_sql_session_last_active_by_id("cur_id")}) AS effective_last_active
+                        MAX({self._session_last_active_by_id_sql("cur_id")}) AS effective_last_active
                     FROM chain
                     GROUP BY root_id
                 )
@@ -5947,7 +5958,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
-                    {_sql_session_last_active("s")} AS last_active,
+                    {self._session_last_active_sql("s")} AS last_active,
                     COALESCE(cm.effective_last_active, s.started_at) AS _effective_last_active
                 FROM sessions s
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
@@ -5970,7 +5981,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
-                    {_sql_session_last_active("s")} AS last_active
+                    {self._session_last_active_sql("s")} AS last_active
                 FROM sessions s
                 {prompt_join}
                 {where_sql}
@@ -7648,7 +7659,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         select_with_last_active = (
             "SELECT s.*, "
             "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved, "
-            f"{_sql_session_last_active('s')} AS last_active "
+            f"{self._session_last_active_sql('s')} AS last_active "
             "FROM sessions s "
             "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
         )
@@ -9204,7 +9215,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
-                        {_sql_session_last_active("s")} AS last_active
+                        {self._session_last_active_sql("s")} AS last_active
                     FROM sessions s
                     LEFT JOIN system_prompts sp
                       ON sp.hash = s.system_prompt_hash
@@ -9234,7 +9245,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
-                        {_sql_session_last_active("s")} AS last_active
+                        {self._session_last_active_sql("s")} AS last_active
                     FROM sessions s
                     LEFT JOIN system_prompts sp
                       ON sp.hash = s.system_prompt_hash

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -102,7 +102,9 @@ def _ephemeral_child_sql(alias: str = "s") -> str:
     )
 
 
-def _sql_session_last_active(alias: str = "s") -> str:
+def _sql_session_last_active(
+    alias: str = "s", *, include_activity: bool = True
+) -> str:
     """SQL expression for session recency used by list/status surfaces.
 
     Freshest of ``last_activity_at`` (mid-turn agent activity heartbeat) and
@@ -116,6 +118,8 @@ def _sql_session_last_active(alias: str = "s") -> str:
         f"(SELECT MAX(_act_m.timestamp) FROM messages _act_m "
         f"WHERE _act_m.session_id = {alias}.id)"
     )
+    if not include_activity:
+        return f"COALESCE({msg_max}, {alias}.started_at)"
     return (
         f"COALESCE("
         f"(SELECT MAX(_act_v.v) FROM ("
@@ -127,7 +131,9 @@ def _sql_session_last_active(alias: str = "s") -> str:
     )
 
 
-def _sql_session_last_active_by_id(session_id_expr: str) -> str:
+def _sql_session_last_active_by_id(
+    session_id_expr: str, *, include_activity: bool = True
+) -> str:
     """Same freshest-of expression keyed by a session-id SQL expression."""
     msg_max = (
         f"(SELECT MAX(_act_m.timestamp) FROM messages _act_m "
@@ -141,6 +147,8 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
         f"(SELECT started_at FROM sessions _act_s "
         f"WHERE _act_s.id = {session_id_expr})"
     )
+    if not include_activity:
+        return f"COALESCE({msg_max}, {started})"
     return (
         f"COALESCE("
         f"(SELECT MAX(_act_v.v) FROM ("

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -19,6 +19,7 @@ from hermes_state_common import (
     _PREVIEW_RAW_SELECT,
     _shape_preview,
     _sql_session_last_active,
+    _sql_session_last_active_by_id,
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -29,18 +30,40 @@ logger = logging.getLogger("hermes_state")
 class SessionPortabilityMixin:
     """See module docstring — mixin for SessionDB (Port cluster)."""
 
-    @classmethod
-    def _compact_session_cols(cls) -> str:
+    def _has_session_column(self, name: str) -> bool:
+        live_columns = self._read_only_session_columns
+        return live_columns is None or name in live_columns
+
+    def _session_last_active_sql(self, alias: str = "s") -> str:
+        return _sql_session_last_active(
+            alias,
+            include_activity=self._has_session_column("last_activity_at"),
+        )
+
+    def _session_last_active_by_id_sql(self, session_id_expr: str) -> str:
+        return _sql_session_last_active_by_id(
+            session_id_expr,
+            include_activity=self._has_session_column("last_activity_at"),
+        )
+
+    def _compact_session_cols(self) -> str:
         """SELECT list for compact_rows: every ``sessions`` column declared in
         SCHEMA_SQL except prompt storage internals, aliased with the ``s``
         prefix used by list_sessions_rich/_get_session_rich_row queries."""
+        cls = type(self)
         if cls._session_compact_cols_sql is None:
-            declared = cls._parse_schema_columns(SCHEMA_SQL)["sessions"]
+            declared = self._parse_schema_columns(SCHEMA_SQL)["sessions"]
             cls._session_compact_cols_sql = ", ".join(
                 f"s.{name}" for name in declared
-                if name not in cls._SESSION_COMPACT_EXCLUDED
+                if name not in self._SESSION_COMPACT_EXCLUDED
             )
-        return cls._session_compact_cols_sql
+        current_projection = cls._session_compact_cols_sql
+        if self._read_only_session_columns is None:
+            return current_projection
+        return ", ".join(
+            column for column in current_projection.split(", ")
+            if column.removeprefix("s.") in self._read_only_session_columns
+        )
 
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
@@ -110,7 +133,7 @@ class SessionPortabilityMixin:
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
-                {_sql_session_last_active("s")} AS last_active
+                {self._session_last_active_sql("s")} AS last_active
             FROM sessions s
             LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
             WHERE s.source = 'cron' AND s.id >= ? AND s.id < ?
@@ -194,7 +217,7 @@ class SessionPortabilityMixin:
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
-                {_sql_session_last_active("s")} AS last_active
+                {self._session_last_active_sql("s")} AS last_active
             FROM sessions s
             {prompt_join}
             WHERE s.id IN ({placeholders})

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -135,6 +135,78 @@ class TestConnectionLifecycle:
             "fts-read-only"
         ]
 
+    def test_read_only_list_tolerates_unmigrated_session_columns(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        writable = SessionDB(db_path=db_path)
+        writable.create_session(
+            "legacy-profile-session",
+            source="telegram",
+            session_key="agent:main:telegram:dm:legacy-chat",
+            chat_id="legacy-chat",
+            chat_type="dm",
+            user_id="legacy-user",
+        )
+        writable.append_message(
+            "legacy-profile-session",
+            role="user",
+            content="history survives an upgrade",
+        )
+        writable.close()
+
+        conn = sqlite3.connect(db_path)
+        conn.execute("ALTER TABLE sessions DROP COLUMN last_activity_at")
+        conn.execute("ALTER TABLE sessions DROP COLUMN profile_name")
+        columns_before = {
+            row[1] for row in conn.execute("PRAGMA table_info(sessions)")
+        }
+        conn.close()
+
+        read_only = SessionDB(db_path=db_path, read_only=True)
+        try:
+            sessions = read_only.list_sessions_rich(
+                limit=20,
+                min_message_count=1,
+                order_by_last_active=True,
+                compact_rows=True,
+                include_pinned=True,
+            )
+            gateway_sessions = read_only.list_gateway_sessions()
+            searched_sessions = read_only.search_sessions()
+            telegram_sessions = (
+                read_only.list_unlinked_telegram_sessions_for_user(
+                    chat_id="legacy-chat",
+                    user_id="legacy-user",
+                )
+            )
+        finally:
+            read_only.close()
+
+        assert [session["id"] for session in sessions] == [
+            "legacy-profile-session"
+        ]
+        assert sessions[0]["preview"] == "history survives an upgrade"
+        assert [session["id"] for session in gateway_sessions] == [
+            "legacy-profile-session"
+        ]
+        assert [session["id"] for session in searched_sessions] == [
+            "legacy-profile-session"
+        ]
+        assert [session["id"] for session in telegram_sessions] == [
+            "legacy-profile-session"
+        ]
+
+        verify = sqlite3.connect(db_path)
+        try:
+            columns_after = {
+                row[1] for row in verify.execute("PRAGMA table_info(sessions)")
+            }
+        finally:
+            verify.close()
+
+        assert columns_after == columns_before
+        assert "last_activity_at" not in columns_after
+        assert "profile_name" not in columns_after
+
     def test_failed_read_only_open_does_not_leak_tracked_connection(
         self, tmp_path
     ):


### PR DESCRIPTION
## What does this PR do?

Fixes cross-profile session listing for dormant profiles whose databases predate newer `sessions` columns.

The Desktop sidebar reads other profiles through read-only `SessionDB` connections. Those connections intentionally cannot migrate a stale schema, but the listing queries unconditionally selected and ordered by newer columns such as `last_activity_at` and `profile_name`. The resulting per-profile query error was swallowed by the aggregation layer, leaving that profile's history absent until another code path opened the database writable and migrated it.

This change keeps read-only access non-mutating. It discovers the columns that actually exist, falls back to `started_at` when activity metadata is unavailable, and limits compact projections to live columns. Writable connections retain their existing migration behavior.

## Related Issue

Fixes #79029

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: cache the live `sessions` schema for read-only connections and route listing queries through schema-aware recency handling.
- `hermes_state_common.py`: allow recency SQL helpers to fall back when `last_activity_at` is unavailable.
- `hermes_state_portability.py`: build schema-aware list and compact-projection queries.
- `tests/test_hermes_state.py`: add a regression test covering rich, sidebar, gateway, search, and Telegram-style listing paths against a stale schema, while asserting the database is not migrated.

## How to Test

1. Create a sessions database, then remove `last_activity_at` and `profile_name` to simulate a dormant profile created by an older Hermes version.
2. Open it through `SessionDB(read_only=True)` and exercise the supported session-listing paths.
3. Verify the stored session is returned and the schema remains unchanged.
4. Run `scripts/run_tests.sh tests/test_hermes_state.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container, Python 3.11

The focused state suite passes: **179 passed**. The full locked-dependency suite has six reproducible environment-sensitive failures outside the changed session-state code (macOS launcher harness, Termux/container detection, Camofox port assumptions, GNU `sort` probing, and Vercel doctor environment detection), so the full-suite checkbox is intentionally left unchecked.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/test_hermes_state.py -q
179 passed
```