### PR TITLE
fix(stt): respect explicit Apple whisper config

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -397,12 +397,24 @@ class TestTranscribeLocalExtended:
              patch("faster_whisper.WhisperModel", mock_whisper_cls), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None), \
-             patch("tools.transcription_tools._load_stt_config", return_value=fake_config):
+             patch("tools.transcription_tools._load_stt_config", return_value=fake_config), \
+             patch("tools.transcription_tools._should_force_faster_whisper_cpu", return_value=True):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio), "base")
 
         assert result["success"] is True
         mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="float32")
+
+    def test_apple_silicon_auto_config_still_forces_cpu_int8(self):
+        """Apple Silicon safety still overrides unsafe device autodetection."""
+        mock_whisper_cls = MagicMock()
+
+        with patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch("tools.transcription_tools._should_force_faster_whisper_cpu", return_value=True):
+            from tools.transcription_tools import _load_local_whisper_model
+            _load_local_whisper_model("base", device="auto", compute_type="auto")
+
+        mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="int8")
 
 
     def test_cuda_out_of_memory_does_not_trigger_cpu_fallback(self, tmp_path):

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1465,19 +1465,19 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
     We try the requested config first (fast CUDA path when it works), and on
     any CUDA library load failure fall back to CPU + int8.
     """
-    force_cpu = _should_force_faster_whisper_cpu()
-    if force_cpu:
+    apple_silicon = _should_force_faster_whisper_cpu()
+    if apple_silicon:
         # Importing ctranslate2/faster-whisper itself can abort on some
         # Apple Silicon/Rosetta installs because multiple Intel OpenMP runtimes
-        # are already loaded.  Set this before importing faster_whisper so the
-        # gateway survives, then keep inference on CPU to avoid device probing.
+        # are already loaded. Set this before importing faster_whisper even
+        # when the user explicitly selected a safe CPU configuration.
         os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
     from faster_whisper import WhisperModel
-    if force_cpu:
+    if apple_silicon and device == "auto":
         logger.info(
-            "Apple Silicon/Rosetta detected — loading faster-whisper on CPU "
-            "(int8) to avoid native device autodetection crashes"
+            "Apple Silicon/Rosetta detected with device=auto — loading "
+            "faster-whisper on CPU (int8) to avoid native device autodetection crashes"
         )
         return WhisperModel(model_name, device="cpu", compute_type="int8")
 


### PR DESCRIPTION
## Summary
- keep the Apple Silicon/Rosetta import safety environment guard
- force CPU/int8 only when `device=auto`
- preserve explicitly configured faster-whisper `device` and `compute_type` values
- add deterministic Apple-Silicon regressions for explicit and auto modes

## Why
The Apple safety fallback currently overrides explicit `device=cpu, compute_type=float32`, regressing the provider config contract. Automatic mode still needs the conservative CPU/int8 fallback.

## Verification
- focused regressions: 2 passed
- repeated focused tests: 5/5 iterations passed
- transcription suite excluding unrelated open 100ms idle-timeout flake: 50 passed, 1 deselected
- Ruff, py_compile, and `git diff --check`: passed
- independent read-only review: APPROVE