### PR TITLE
fix(gateway): bound systemd planned-restart helper

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9868,7 +9868,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         automatic restarts and can delay repeated /restart tests.  A transient
         user service survives our cgroup teardown and explicitly starts the
         gateway as soon as this PID exits, while the unit keeps its normal
-        backoff for real crash loops.
+        backoff for real crash loops. If the gateway finishes logical teardown
+        but its process remains wedged, the helper waits only through the
+        configured drain budget plus five seconds, verifies the stale PID is
+        still the service's MainPID, then force-kills it before restarting.
         """
         if sys.platform != "linux" or not os.environ.get("INVOCATION_ID"):
             return
@@ -9912,12 +9915,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             system_pid = _query_pid([])
             user_pid = _query_pid(["--user"])
+            systemctl_arg = shlex.quote(systemctl)
             if str(current_pid) == system_pid:
                 scope_flags = []
-                systemctl_scope = "systemctl"
+                systemctl_scope = systemctl_arg
             elif str(current_pid) == user_pid:
                 scope_flags = ["--user"]
-                systemctl_scope = "systemctl --user"
+                systemctl_scope = f"{systemctl_arg} --user"
             else:
                 # MainPID does not match in either scope — likely invoked
                 # outside of systemd or the unit was renamed.  Bail out
@@ -9925,8 +9929,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
 
             service_arg = shlex.quote(service_name)
+            restart_after_s = max(
+                float(getattr(self, "_restart_drain_timeout", 0.0) or 0.0) + 5.0,
+                5.0,
+            )
             shell_cmd = (
-                f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
+                f"deadline=$(( $(date +%s) + {int(restart_after_s)} )); "
+                f"while kill -0 {current_pid} 2>/dev/null && "
+                f"[ $(date +%s) -lt $deadline ]; do sleep 0.2; done; "
+                f"if kill -0 {current_pid} 2>/dev/null; then "
+                f"main_pid=$({systemctl_scope} show {service_arg} "
+                f"--property=MainPID --value 2>/dev/null); "
+                f"if [ \"$main_pid\" = \"{current_pid}\" ]; then "
+                f"{systemctl_scope} kill --kill-whom=main --signal=SIGKILL "
+                f"{service_arg}; fi; fi; "
                 f"{systemctl_scope} reset-failed {service_arg}; "
                 f"{systemctl_scope} restart {service_arg}"
             )
@@ -9947,10 +9963,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 start_new_session=True,
             )
             logger.info(
-                "Launched systemd planned-restart helper for %s (pid=%s, scope=%s)",
+                "Launched systemd planned-restart helper for %s "
+                "(pid=%s, scope=%s, force-after=%.0fs)",
                 service_name,
                 current_pid,
                 "user" if scope_flags else "system",
+                restart_after_s,
             )
         except Exception as e:
             logger.debug("Failed to launch systemd planned-restart helper: %s", e)

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +10,48 @@ from gateway.platforms.base import MessageEvent
 from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
 from gateway.session import build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def test_systemd_planned_restart_helper_bounds_stale_main_pid(monkeypatch):
+    """A wedged post-drain gateway must not leave the helper waiting forever."""
+    runner, _adapter = make_restart_runner()
+    runner._restart_drain_timeout = 12.9
+    monkeypatch.setenv("INVOCATION_ID", "systemd-test")
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 4321)
+
+    def fake_which(name):
+        return f"/usr/bin/{name}"
+
+    def fake_run(argv, **_kwargs):
+        # The gateway belongs to the user unit, not the system unit.
+        stdout = "4321\n" if "--user" in argv else "0\n"
+        return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+    popen = MagicMock()
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", popen)
+
+    runner._launch_systemd_restart_shortcut()
+
+    argv = popen.call_args.args[0]
+    assert argv[:3] == ["/usr/bin/systemd-run", "--user", "--collect"]
+    shell_cmd = argv[-1]
+    assert "deadline=$(( $(date +%s) + 17 ))" in shell_cmd
+    assert "kill -0 4321" in shell_cmd
+    assert "[ $(date +%s) -lt $deadline ]" in shell_cmd
+    assert (
+        'main_pid=$(/usr/bin/systemctl --user show hermes-gateway '
+        '--property=MainPID --value 2>/dev/null)' in shell_cmd
+    )
+    assert 'if [ "$main_pid" = "4321" ]' in shell_cmd
+    assert (
+        "/usr/bin/systemctl --user kill --kill-whom=main --signal=SIGKILL "
+        "hermes-gateway" in shell_cmd
+    )
+    assert shell_cmd.index("--signal=SIGKILL") < shell_cmd.index("reset-failed")
+    assert shell_cmd.index("reset-failed") < shell_cmd.index("restart hermes-gateway")
 
 
 @pytest.mark.asyncio
@@ -269,5 +312,4 @@ def test_pid_exists_zombie_via_psutil_returns_false(monkeypatch):
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert status._pid_exists(4242) is False
-
 


### PR DESCRIPTION
## Summary

- bound the transient systemd planned-restart helper to `restart_drain_timeout + 5s`
- after that grace period, re-read the unit's `MainPID` and only force-kill when it still matches the original gateway PID
- reset and restart the unit as before, using the resolved `systemctl` path
- add focused coverage for user-unit scope, timeout derivation, PID identity guard, and action ordering

## Why this is valuable

A gateway can finish logical shutdown (drain timeout, adapter disconnect, state cleanup, exit code selected) yet retain a live Python PID because a thread or interpreter teardown path is wedged. In that state systemd still reports the service as active, while Slack/other platforms are offline.

`_launch_systemd_restart_shortcut()` currently waits forever in `while kill -0 <pid>`. Because the PID never disappears, the helper never reaches `systemctl restart`, and systemd has no failed/exited main process to recover. This turns a recoverable stuck shutdown into an indefinite messaging outage.

The change keeps the graceful path intact and uses the existing configured drain budget. Force is a last resort only after that budget, and the fresh `MainPID` equality check prevents killing a recycled PID or a replacement gateway. The result is bounded recovery without weakening normal drain semantics or crash-loop backoff.

This is the remaining systemd-helper variant of the restart fragility discussed in #12438; current `main` already bounds the general detached restart watcher, but not this transient systemd helper.

## Validation

```text
scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py tests/gateway/test_gateway_process_exit.py -q
11 passed
```