### PR TITLE
fix(dashboard): connection lifecycle — suspend on hide, resume on show

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -996,7 +996,9 @@ _ADVISORY_INSTRUCTION = (
     "[The conversation above is the current state of the task. Give your "
     "most intelligent judgement: what is going on, what should happen next, "
     "what risks or mistakes you see, and how the acting agent should "
-    "proceed.]"
+    "proceed. You have NO tools — any `[called tool: ...]` or `[tool result: ...]` "
+    "lines above are the ACTING AGENT's history, not yours. Do not restate them "
+    "as if you executed them; describe your advice in plain prose.]"
 )
 
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1020,7 +1020,9 @@ _ADVISORY_INSTRUCTION = (
     "[The conversation above is the current state of the task. Give your "
     "most intelligent judgement: what is going on, what should happen next, "
     "what risks or mistakes you see, and how the acting agent should "
-    "proceed.]"
+    "proceed. You have NO tools — any `[called tool: ...]` or `[tool result: ...]` "
+    "lines above are the ACTING AGENT's history, not yours. Do not restate them "
+    "as if you executed them; describe your advice in plain prose.]"
 )
 
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1020,9 +1020,7 @@ _ADVISORY_INSTRUCTION = (
     "[The conversation above is the current state of the task. Give your "
     "most intelligent judgement: what is going on, what should happen next, "
     "what risks or mistakes you see, and how the acting agent should "
-    "proceed. You have NO tools — any `[called tool: ...]` or `[tool result: ...]` "
-    "lines above are the ACTING AGENT's history, not yours. Do not restate them "
-    "as if you executed them; describe your advice in plain prose.]"
+    "proceed.]"
 )
 
 

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -9,6 +9,8 @@ docs/superpowers/specs/2026-06-20-pty-keepalive-reattach-design.md.
 from __future__ import annotations
 
 import asyncio
+import json
+import secrets
 import time
 from typing import Optional
 
@@ -44,7 +46,7 @@ class RingBuffer:
 
     def snapshot_from(self, offset: int) -> bytes | None:
         """Return bytes appended after ``offset``, or ``None`` if ``offset``
-        has been evicted (rolled out of the ring).
+        is outside the retained window.
 
         ``offset`` is a value of ``total_appended`` the client saved before
         disconnecting. If ``offset`` is still within the window we still hold
@@ -52,13 +54,16 @@ class RingBuffer:
         the tail. Otherwise the client's offset is stale and must fall back
         to a full ``snapshot()``.
         """
-        if offset < 0:
+        earliest = self.start_offset
+        if offset < earliest or offset > self._total_appended:
             return None
-        earliest = self._total_appended - len(self._buf)
-        if offset < earliest:
-            return None  # rolled out — caller should full-replay
         skip = offset - earliest  # bytes in buffer that precede the offset
         return bytes(self._buf[skip:])
+
+    @property
+    def start_offset(self) -> int:
+        """Absolute offset of the first byte still retained."""
+        return self._total_appended - len(self._buf)
 
     @property
     def total_appended(self) -> int:
@@ -80,6 +85,8 @@ class PtySession:
         self._read_timeout = read_timeout
         self._ws = None
         self._drain_task: Optional[asyncio.Task] = None
+        self._send_lock = asyncio.Lock()
+        self.epoch = secrets.token_hex(16)
 
     async def start(self) -> None:
         self._drain_task = asyncio.create_task(self._drain())
@@ -89,94 +96,117 @@ class PtySession:
         while True:
             chunk = await loop.run_in_executor(None, self.bridge.read, self._read_timeout)
             if chunk is None:                       # EOF — the agent process exited
-                self.alive = False
-                ws = self._ws
-                if ws is not None:
-                    try:
-                        await ws.close(code=WS_CLOSE_PROCESS_EXITED)
-                    except Exception:
-                        pass
+                async with self._send_lock:
+                    self.alive = False
+                    ws = self._ws
+                    if ws is not None:
+                        try:
+                            await ws.close(code=WS_CLOSE_PROCESS_EXITED)
+                        except Exception:
+                            pass
                 return
             if not chunk:                            # idle tick
                 await asyncio.sleep(0)
                 continue
-            self.buffer.append(chunk)
-            ws = self._ws
-            if ws is not None:
-                try:
-                    await ws.send_bytes(chunk)
-                except Exception:
-                    pass                             # detached mid-send; keep buffering
+            # Appending, choosing the active socket, and sending are one
+            # ordered operation.  attach() takes the same lock while it cuts
+            # and replays a snapshot, so live output can only land entirely
+            # before or entirely after that replay -- never between chunks.
+            async with self._send_lock:
+                self.buffer.append(chunk)
+                ws = self._ws
+                if ws is not None:
+                    try:
+                        await ws.send_bytes(chunk)
+                    except Exception:
+                        pass                         # detached mid-send; keep buffering
 
-    async def attach(self, ws, client_offset: Optional[int] = None, *, force_redraw: bool = False) -> None:
-        """Attach a browser terminal and replay buffered PTY output.
+    async def attach(
+        self,
+        ws,
+        client_offset: Optional[int] = None,
+        client_epoch: Optional[str] = None,
+        *,
+        force_redraw: bool = False,
+    ) -> None:
+        """Attach ``ws`` and replay from a byte cursor when it is safe.
 
-        The TUI uses an alternate screen and differential rendering, so a
-        bounded ANSI tail is not guaranteed to be a self-contained frame.
-        Reattaching a fresh xterm therefore asks the live TUI to emit one
-        complete redraw after the replay.
+        A text control frame always precedes binary PTY bytes.  ``reset`` tells
+        the browser to discard its old terminal state before applying the
+        retained snapshot; this is required when an offset rolled out, points
+        into the future, or belongs to another session incarnation.
         """
-        old = self._ws
-        if old is not None and old is not ws:
+        async with self._send_lock:
+            old = self._ws
+            self._ws = ws
+            self.attached = True
+            self.last_detached_at = None
+            if old is not None and old is not ws:
+                try:
+                    await old.close(code=WS_CLOSE_SUPERSEDED)
+                except Exception:
+                    pass
+
+            reset = True
+            reason = "initial"
+            start_offset = self.buffer.start_offset
+            replay = self.buffer.snapshot()
+
+            if client_offset is not None or client_epoch is not None:
+                if client_epoch != self.epoch:
+                    reason = "epoch_mismatch"
+                elif client_offset is None:
+                    reason = "invalid_cursor"
+                else:
+                    incremental = self.buffer.snapshot_from(client_offset)
+                    if incremental is not None:
+                        reset = False
+                        reason = "resume"
+                        start_offset = client_offset
+                        replay = incremental
+                    elif client_offset > self.buffer.total_appended:
+                        reason = "offset_ahead"
+                    else:
+                        reason = "offset_rolled_out"
+
+            cutover_offset = start_offset + len(replay)
+            control = json.dumps(
+                {
+                    "type": "pty.replay",
+                    "epoch": self.epoch,
+                    "start_offset": start_offset,
+                    "replay_end_offset": cutover_offset,
+                    "reset": reset,
+                    "reason": reason,
+                },
+                separators=(",", ":"),
+            )
             try:
-                await old.close(code=WS_CLOSE_SUPERSEDED)
-            except Exception:
-                pass
-        self._ws = ws
-        self.attached = True
-        self.last_detached_at = None
-        # Incremental replay: if the client sends its last-known byte offset
-        # and that offset is still within our RingBuffer window, send only the
-        # tail. This avoids re-replaying up to 1 MB of history the xterm.js
-        # terminal already has painted (the dashboard keeps ChatPage mounted
-        # persistently, so the terminal buffer survives tab switches — the
-        # bytes are never lost on the client side).
-        if client_offset is not None:
-            incremental = self.buffer.snapshot_from(client_offset)
-            if incremental is not None:
-                # Offset still in window — send only the delta (if any).
-                if incremental:
-                    await self._send_chunked(ws, incremental)
-                # Zero delta: the client's offset already sits at the tail.
-                # Under the connection-lifecycle architecture (suspend on
-                # hide / resume on show), a reconnect always carries a prior
-                # offset and the client does NOT arm the hydration overlay
-                # for incremental replays — so no sentinel frame is needed
-                # here. Just return; live output resumes on the next frame.
-                return
-        # Full replay (first connect, or offset rolled out of the ring).
-        # NOTE: for a reconnecting client whose offset rolled out of the
-        # window, we deliberately do NOT fall back to a full 1MB replay: the
-        # dashboard keeps ChatPage mounted, so xterm.js still holds the full
-        # history the client painted before — a full replay would re-send
-        # megabytes of bytes the client already has and stall rendering
-        # ("tab-return black screen" on long-running sessions that exceed
-        # the ring window while backgrounded). Emit the no-op SGR-reset
-        # frame to clear the hydration gate and let live output resume.
-        snap = self.buffer.snapshot()
-        if client_offset is None and snap:
-            await self._send_chunked(ws, snap)
-            if force_redraw:
+                await ws.send_text(control)
+                if replay:
+                    await self._send_chunked(ws, replay)
+            except BaseException:
+                # attach() runs before the route's receive loop. Restore the
+                # detached/reapable state even if the client vanishes while
+                # the control frame or replay is being sent.
+                self.detach(ws)
+                raise
+            # A fresh xterm cannot reliably reconstruct the TUI from a
+            # bounded tail of alternate-screen, differential ANSI output
+            # (#force-redraw upstream): after a reset replay, ask the live
+            # TUI to emit one complete frame so reconnects never reopen blank.
+            if force_redraw and reset:
                 self.bridge.write(TUI_FORCE_REDRAW)
-        else:
-            # First attach to an empty buffer, or reconnect with a
-            # rolled-out offset: the client's resume-hydration gate is
-            # edge-triggered on the first payload, so emit one no-op frame
-            # or the "loading…" overlay stays up (black screen). SGR reset
-            # is invisible on xterm.
-            try:
-                await ws.send_bytes(b"\x1b[0m")
-            except Exception:
-                pass
 
     async def _send_chunked(self, ws, data: bytes, chunk_size: int = 16384) -> None:
         """Send ``data`` in ``chunk_size`` frames, yielding between frames so a
-        large replay (up to 1 MB) doesn't block the event loop."""
+        large replay (up to 1 MB) doesn't block the event loop.
+
+        The caller holds ``_send_lock`` across the complete replay, including
+        the yields, so the drain task cannot interleave live frames.
+        """
         for i in range(0, len(data), chunk_size):
-            try:
-                await ws.send_bytes(data[i:i + chunk_size])
-            except Exception:
-                return
+            await ws.send_bytes(data[i:i + chunk_size])
             if i + chunk_size < len(data):
                 await asyncio.sleep(0)
 

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -18,15 +18,22 @@ TUI_FORCE_REDRAW = b"\x0c"
 
 
 class RingBuffer:
-    """Keeps only the most recent ``capacity`` bytes appended to it."""
+    """Keeps only the most recent ``capacity`` bytes appended to it.
+
+    Tracks ``total_appended`` — the total number of bytes ever appended — so a
+    reconnecting client can request an incremental replay starting from its
+    last-known byte offset instead of re-receiving the entire buffer.
+    """
 
     def __init__(self, capacity: int) -> None:
         self._cap = capacity
         self._buf = bytearray()
         self._truncated = False
+        self._total_appended = 0
 
     def append(self, data: bytes) -> None:
         self._buf.extend(data)
+        self._total_appended += len(data)
         overflow = len(self._buf) - self._cap
         if overflow > 0:
             del self._buf[:overflow]
@@ -34,6 +41,28 @@ class RingBuffer:
 
     def snapshot(self) -> bytes:
         return bytes(self._buf)
+
+    def snapshot_from(self, offset: int) -> bytes | None:
+        """Return bytes appended after ``offset``, or ``None`` if ``offset``
+        has been evicted (rolled out of the ring).
+
+        ``offset`` is a value of ``total_appended`` the client saved before
+        disconnecting. If ``offset`` is still within the window we still hold
+        (i.e. ``total_appended - len(buffer) <= offset``), we can send just
+        the tail. Otherwise the client's offset is stale and must fall back
+        to a full ``snapshot()``.
+        """
+        if offset < 0:
+            return None
+        earliest = self._total_appended - len(self._buf)
+        if offset < earliest:
+            return None  # rolled out — caller should full-replay
+        skip = offset - earliest  # bytes in buffer that precede the offset
+        return bytes(self._buf[skip:])
+
+    @property
+    def total_appended(self) -> int:
+        return self._total_appended
 
     @property
     def truncated(self) -> bool:
@@ -79,7 +108,7 @@ class PtySession:
                 except Exception:
                     pass                             # detached mid-send; keep buffering
 
-    async def attach(self, ws, *, force_redraw: bool = False) -> None:
+    async def attach(self, ws, client_offset: Optional[int] = None, *, force_redraw: bool = False) -> None:
         """Attach a browser terminal and replay buffered PTY output.
 
         The TUI uses an alternate screen and differential rendering, so a
@@ -96,11 +125,60 @@ class PtySession:
         self._ws = ws
         self.attached = True
         self.last_detached_at = None
+        # Incremental replay: if the client sends its last-known byte offset
+        # and that offset is still within our RingBuffer window, send only the
+        # tail. This avoids re-replaying up to 1 MB of history the xterm.js
+        # terminal already has painted (the dashboard keeps ChatPage mounted
+        # persistently, so the terminal buffer survives tab switches — the
+        # bytes are never lost on the client side).
+        if client_offset is not None:
+            incremental = self.buffer.snapshot_from(client_offset)
+            if incremental is not None:
+                # Offset still in window — send only the delta (if any).
+                if incremental:
+                    await self._send_chunked(ws, incremental)
+                # Zero delta: the client's offset already sits at the tail.
+                # Under the connection-lifecycle architecture (suspend on
+                # hide / resume on show), a reconnect always carries a prior
+                # offset and the client does NOT arm the hydration overlay
+                # for incremental replays — so no sentinel frame is needed
+                # here. Just return; live output resumes on the next frame.
+                return
+        # Full replay (first connect, or offset rolled out of the ring).
+        # NOTE: for a reconnecting client whose offset rolled out of the
+        # window, we deliberately do NOT fall back to a full 1MB replay: the
+        # dashboard keeps ChatPage mounted, so xterm.js still holds the full
+        # history the client painted before — a full replay would re-send
+        # megabytes of bytes the client already has and stall rendering
+        # ("tab-return black screen" on long-running sessions that exceed
+        # the ring window while backgrounded). Emit the no-op SGR-reset
+        # frame to clear the hydration gate and let live output resume.
         snap = self.buffer.snapshot()
-        if snap:
-            await ws.send_bytes(snap)
-        if force_redraw:
-            self.bridge.write(TUI_FORCE_REDRAW)
+        if client_offset is None and snap:
+            await self._send_chunked(ws, snap)
+            if force_redraw:
+                self.bridge.write(TUI_FORCE_REDRAW)
+        else:
+            # First attach to an empty buffer, or reconnect with a
+            # rolled-out offset: the client's resume-hydration gate is
+            # edge-triggered on the first payload, so emit one no-op frame
+            # or the "loading…" overlay stays up (black screen). SGR reset
+            # is invisible on xterm.
+            try:
+                await ws.send_bytes(b"\x1b[0m")
+            except Exception:
+                pass
+
+    async def _send_chunked(self, ws, data: bytes, chunk_size: int = 16384) -> None:
+        """Send ``data`` in ``chunk_size`` frames, yielding between frames so a
+        large replay (up to 1 MB) doesn't block the event loop."""
+        for i in range(0, len(data), chunk_size):
+            try:
+                await ws.send_bytes(data[i:i + chunk_size])
+            except Exception:
+                return
+            if i + chunk_size < len(data):
+                await asyncio.sleep(0)
 
     def detach(self, ws) -> None:
         # Only the currently-attached socket may mark the session detached.

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -17,15 +17,22 @@ WS_CLOSE_SUPERSEDED = 4409
 
 
 class RingBuffer:
-    """Keeps only the most recent ``capacity`` bytes appended to it."""
+    """Keeps only the most recent ``capacity`` bytes appended to it.
+
+    Tracks ``total_appended`` — the total number of bytes ever appended — so a
+    reconnecting client can request an incremental replay starting from its
+    last-known byte offset instead of re-receiving the entire buffer.
+    """
 
     def __init__(self, capacity: int) -> None:
         self._cap = capacity
         self._buf = bytearray()
         self._truncated = False
+        self._total_appended = 0
 
     def append(self, data: bytes) -> None:
         self._buf.extend(data)
+        self._total_appended += len(data)
         overflow = len(self._buf) - self._cap
         if overflow > 0:
             del self._buf[:overflow]
@@ -33,6 +40,28 @@ class RingBuffer:
 
     def snapshot(self) -> bytes:
         return bytes(self._buf)
+
+    def snapshot_from(self, offset: int) -> bytes | None:
+        """Return bytes appended after ``offset``, or ``None`` if ``offset``
+        has been evicted (rolled out of the ring).
+
+        ``offset`` is a value of ``total_appended`` the client saved before
+        disconnecting. If ``offset`` is still within the window we still hold
+        (i.e. ``total_appended - len(buffer) <= offset``), we can send just
+        the tail. Otherwise the client's offset is stale and must fall back
+        to a full ``snapshot()``.
+        """
+        if offset < 0:
+            return None
+        earliest = self._total_appended - len(self._buf)
+        if offset < earliest:
+            return None  # rolled out — caller should full-replay
+        skip = offset - earliest  # bytes in buffer that precede the offset
+        return bytes(self._buf[skip:])
+
+    @property
+    def total_appended(self) -> int:
+        return self._total_appended
 
     @property
     def truncated(self) -> bool:
@@ -78,7 +107,7 @@ class PtySession:
                 except Exception:
                     pass                             # detached mid-send; keep buffering
 
-    async def attach(self, ws) -> None:
+    async def attach(self, ws, client_offset: Optional[int] = None) -> None:
         old = self._ws
         if old is not None and old is not ws:
             try:
@@ -88,9 +117,58 @@ class PtySession:
         self._ws = ws
         self.attached = True
         self.last_detached_at = None
+        # Incremental replay: if the client sends its last-known byte offset
+        # and that offset is still within our RingBuffer window, send only the
+        # tail. This avoids re-replaying up to 1 MB of history the xterm.js
+        # terminal already has painted (the dashboard keeps ChatPage mounted
+        # persistently, so the terminal buffer survives tab switches — the
+        # bytes are never lost on the client side).
+        if client_offset is not None:
+            incremental = self.buffer.snapshot_from(client_offset)
+            if incremental is not None:
+                # Offset still in window — send only the delta (if any).
+                if incremental:
+                    await self._send_chunked(ws, incremental)
+                # Zero delta: the client's offset already sits at the tail.
+                # Under the connection-lifecycle architecture (suspend on
+                # hide / resume on show), a reconnect always carries a prior
+                # offset and the client does NOT arm the hydration overlay
+                # for incremental replays — so no sentinel frame is needed
+                # here. Just return; live output resumes on the next frame.
+                return
+        # Full replay (first connect, or offset rolled out of the ring).
+        # NOTE: for a reconnecting client whose offset rolled out of the
+        # window, we deliberately do NOT fall back to a full 1MB replay: the
+        # dashboard keeps ChatPage mounted, so xterm.js still holds the full
+        # history the client painted before — a full replay would re-send
+        # megabytes of bytes the client already has and stall rendering
+        # ("tab-return black screen" on long-running sessions that exceed
+        # the ring window while backgrounded). Emit the no-op SGR-reset
+        # frame to clear the hydration gate and let live output resume.
         snap = self.buffer.snapshot()
-        if snap:
-            await ws.send_bytes(snap)
+        if client_offset is None and snap:
+            await self._send_chunked(ws, snap)
+        else:
+            # First attach to an empty buffer, or reconnect with a
+            # rolled-out offset: the client's resume-hydration gate is
+            # edge-triggered on the first payload, so emit one no-op frame
+            # or the "loading…" overlay stays up (black screen). SGR reset
+            # is invisible on xterm.
+            try:
+                await ws.send_bytes(b"\x1b[0m")
+            except Exception:
+                pass
+
+    async def _send_chunked(self, ws, data: bytes, chunk_size: int = 16384) -> None:
+        """Send ``data`` in ``chunk_size`` frames, yielding between frames so a
+        large replay (up to 1 MB) doesn't block the event loop."""
+        for i in range(0, len(data), chunk_size):
+            try:
+                await ws.send_bytes(data[i:i + chunk_size])
+            except Exception:
+                return
+            if i + chunk_size < len(data):
+                await asyncio.sleep(0)
 
     def detach(self, ws) -> None:
         # Only the currently-attached socket may mark the session detached.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15596,6 +15596,8 @@ _PTY_READ_CHUNK_TIMEOUT = 0.2
 # the event loop.  A positive sleep lets other coroutines run and keeps
 # dashboard idle CPU low (#42627).
 _PTY_IDLE_BACKOFF = 0.05
+_PTY_EPOCH_RE = re.compile(r"[0-9a-f]{32}")
+_PTY_MAX_CLIENT_OFFSET = (1 << 53) - 1
 
 # Keep-alive PTY sessions: a terminal connecting with ``?attach=<token>`` is
 # bound to a process that survives disconnect/refresh and is reattachable.
@@ -15607,6 +15609,39 @@ PTY_REGISTRY = PtySessionRegistry(
     buffer_cap=1 * 1024 * 1024,
     read_timeout=_PTY_READ_CHUNK_TIMEOUT,
 )
+
+
+def _parse_pty_replay_cursor(ws: "WebSocket") -> tuple[Optional[str], Optional[int]]:
+    """Parse the optional all-or-nothing PTY replay cursor.
+
+    Offsets cross the JavaScript/Python boundary, so they are restricted to
+    non-negative safe integers and canonical decimal spelling. Epochs are the
+    128-bit lowercase-hex values minted by ``PtySession``. Rejecting malformed
+    cursors before spawning or attaching avoids silently treating typos as a
+    first connection and duplicating terminal history.
+    """
+    epochs = ws.query_params.getlist("epoch")
+    offsets = ws.query_params.getlist("offset")
+    if len(epochs) > 1 or len(offsets) > 1:
+        raise ValueError("duplicate epoch or offset")
+
+    raw_epoch = epochs[0] if epochs else None
+    raw_offset = offsets[0] if offsets else None
+    if raw_epoch is None and raw_offset is None:
+        return None, None
+    if raw_epoch is None or raw_offset is None:
+        raise ValueError("epoch and offset must be provided together")
+    if not (ws.query_params.get("attach") or "").strip():
+        raise ValueError("epoch and offset require an attach token")
+    if _PTY_EPOCH_RE.fullmatch(raw_epoch) is None:
+        raise ValueError("epoch must be 32 lowercase hexadecimal characters")
+    if re.fullmatch(r"0|[1-9][0-9]*", raw_offset) is None:
+        raise ValueError("offset must be a canonical non-negative integer")
+
+    offset = int(raw_offset)
+    if offset > _PTY_MAX_CLIENT_OFFSET:
+        raise ValueError("offset exceeds the JavaScript safe-integer range")
+    return raw_epoch, offset
 
 
 async def _legacy_pump(ws: "WebSocket", bridge) -> None:
@@ -16854,6 +16889,16 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=4408, reason=_ws_close_reason(client_reason))
         return
 
+    try:
+        client_epoch, client_offset = _parse_pty_replay_cursor(ws)
+    except ValueError as exc:
+        _log.warning("pty refused: invalid replay cursor peer=%s error=%s", peer, exc)
+        await ws.close(
+            code=4400,
+            reason=_ws_close_reason(f"invalid replay cursor: {exc}"),
+        )
+        return
+
     await ws.accept()
     _log.info("pty accepted peer=%s mode=%s cred=%s", peer, mode, cred)
 
@@ -16956,15 +17001,21 @@ async def pty_ws(ws: WebSocket) -> None:
     # A fresh xterm cannot reliably reconstruct the TUI from an arbitrary
     # bounded tail of alternate-screen, differential ANSI output. Reused PTYs
     # emit a complete frame after replay so reconnects never reopen blank.
-    await session.attach(ws, force_redraw=not _created)
 
-    # --- writer loop: WebSocket → PTY master ----------------------------
-    # No reader task here: the session's drain task (spawned once per PTY,
-    # inside the registry) forwards PTY output to whichever socket is
-    # attached and rings-buffers it while detached.  On child EOF the drain
-    # closes the attached socket with 4410, which unparks ``ws.receive()``
-    # below — same half-open-socket protection the legacy pump has (#54028).
     try:
+        await session.attach(
+            ws,
+            client_offset=client_offset,
+            client_epoch=client_epoch,
+            force_redraw=not _created,
+        )
+
+        # --- writer loop: WebSocket → PTY master ------------------------
+        # No reader task here: the session's drain task (spawned once per PTY,
+        # inside the registry) forwards PTY output to whichever socket is
+        # attached and rings-buffers it while detached. On child EOF the drain
+        # closes the attached socket with 4410, which unparks ``ws.receive()``
+        # below -- same half-open-socket protection the legacy pump has.
         while True:
             try:
                 msg = await ws.receive()

--- a/tests/hermes_cli/test_web_server_pty_reconnect.py
+++ b/tests/hermes_cli/test_web_server_pty_reconnect.py
@@ -1,16 +1,10 @@
 """Focused tests for dashboard PTY reconnect breadcrumbs."""
 
 import json
-import sys
-from pathlib import Path
+import time
 from urllib.parse import urlencode
 
 import pytest
-
-
-pytestmark = pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="PTY bridge is POSIX-only"
-)
 
 
 class _OneFrameBridge:
@@ -43,9 +37,21 @@ def pty_client(monkeypatch, _isolate_hermes_home):
     from starlette.testclient import TestClient
 
     import hermes_cli.web_server as ws
+    from hermes_cli.pty_session import PtySessionRegistry
 
     monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
-    monkeypatch.setattr(ws.PtyBridge, "spawn", _OneFrameBridge.spawn)
+    monkeypatch.setattr(ws, "_PTY_BRIDGE_AVAILABLE", True)
+    monkeypatch.setattr(ws, "PtyBridge", _OneFrameBridge)
+    monkeypatch.setattr(
+        ws,
+        "PTY_REGISTRY",
+        PtySessionRegistry(
+            ttl=1800,
+            max_sessions=16,
+            buffer_cap=1024,
+            read_timeout=0.01,
+        ),
+    )
     ws.app.state.pty_active_session_files = {}
 
     client = TestClient(ws.app)
@@ -120,9 +126,92 @@ def test_child_eof_closes_socket_and_bridge(pty_client, monkeypatch):
     # bridge.close() runs in the handler's `finally` via asyncio.to_thread,
     # which can lag the client-side context exit by a tick or two. Poll briefly
     # instead of asserting immediately so the teardown isn't a race.
-    import time
-
     deadline = time.monotonic() + 5.0
     while not bridges[0].closed and time.monotonic() < deadline:
         time.sleep(0.01)
     assert bridges[0].closed is True
+
+
+def test_replay_cursor_is_strictly_validated_before_attach(pty_client, monkeypatch):
+    from starlette.websockets import WebSocketDisconnect
+
+    ws, client, token = pty_client
+    monkeypatch.setattr(
+        ws, "_resolve_chat_argv", lambda **kw: (["fake-hermes-tui"], None, None)
+    )
+
+    url = _url(
+        token,
+        channel="bad-cursor",
+        attach="bad-cursor",
+        epoch="0" * 32,
+        offset="+1",
+    )
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(url):
+            pass
+    assert exc_info.value.code == 4400
+
+
+def test_websocket_reconnect_passes_byte_cursor_to_session(pty_client, monkeypatch):
+    """The real /api/pty route resumes raw bytes through its query cursor."""
+    ws, client, token = pty_client
+    bridges = []
+
+    class _RetainedBridge:
+        def __init__(self):
+            self._first = True
+            self.closed = False
+
+        @classmethod
+        def spawn(cls, *args, **kwargs):
+            bridge = cls()
+            bridges.append(bridge)
+            return bridge
+
+        def read(self, timeout):
+            if self._first:
+                self._first = False
+                return b"\xc3"
+            return b""
+
+        def resize(self, *, cols, rows):
+            pass
+
+        def write(self, raw):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(ws.PtyBridge, "spawn", _RetainedBridge.spawn)
+    monkeypatch.setattr(
+        ws, "_resolve_chat_argv", lambda **kw: (["fake-hermes-tui"], None, None)
+    )
+
+    base = {"channel": "cursor-chan", "attach": "cursor-session"}
+    with client.websocket_connect(_url(token, **base)) as conn:
+        first = conn.receive_json()
+        assert first["reset"] is True
+        assert conn.receive_bytes() == b"\xc3"
+
+    # TestClient tears down the per-WebSocket event loop between contexts, so
+    # inject detached output at the authoritative retained-buffer boundary.
+    # The second connection still exercises the real route's query parsing and
+    # attach() cursor propagation end to end.
+    session = ws.PTY_REGISTRY._sessions["cursor-session"]
+    session.buffer.append(b"\xa9\xff")
+
+    with client.websocket_connect(
+        _url(
+            token,
+            **base,
+            epoch=first["epoch"],
+            offset="1",
+        )
+    ) as conn:
+        resumed = conn.receive_json()
+        assert resumed["reset"] is False
+        assert resumed["reason"] == "resume"
+        assert resumed["start_offset"] == 1
+        assert conn.receive_bytes() == b"\xa9\xff"

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -178,4 +178,59 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
         await task
     except asyncio.CancelledError:
         pass
-    assert calls["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_attach_incremental_replay_from_offset():
+    """Reconnect with a prior byte offset sends only the delta, not the full buffer.
+
+    The connection-lifecycle architecture (suspend on hide / resume on show)
+    relies on this: when a tab returns, the client reconnects with the offset
+    it had before suspend, and the server sends only bytes appended after that
+    offset — not the entire 1MB buffer.
+    """
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"hello ", b"world", None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)  # drain consumes "hello world"
+
+    # First attach: full replay
+    ws1 = FakeWS()
+    await s.attach(ws1, client_offset=None)
+    replay1 = b"".join(p for kind, p in ws1.sent if kind == "bytes")
+    assert replay1 == b"hello world"
+
+    # Reconnect with offset = len("hello world") — should send nothing (zero delta)
+    ws2 = FakeWS()
+    await s.attach(ws2, client_offset=len(b"hello world"))
+    replay2 = b"".join(p for kind, p in ws2.sent if kind == "bytes")
+    assert replay2 == b""  # no sentinel, no full replay — just return
+
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_rolled_out_offset_sends_sentinel_not_full_replay():
+    """Offset rolled out of the ring window must NOT fall back to full replay.
+
+    ChatPage stays mounted across tab switches, so the client already holds the
+    full history. A rolled-out offset means the server can't send the exact
+    delta — but the client doesn't need it. Emit the sentinel (first-attach
+    empty-buffer case) or nothing (rolled-out reconnect) and let live output
+    resume.
+    """
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"a" * 2000, None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)  # drain consumes 2000 bytes (cap=1024, so oldest evicted)
+
+    # Reconnect with offset=100 (rolled out — earliest available is 2000-1024=976)
+    ws = FakeWS()
+    await s.attach(ws, client_offset=100)
+    replay = b"".join(p for kind, p in ws.sent if kind == "bytes")
+    # Should NOT be the full 1024-byte buffer — should be sentinel or nothing
+    assert len(replay) < 1024
+
+    await s.close()

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -1,4 +1,7 @@
 import asyncio
+import json
+import queue
+import threading
 import time
 
 import pytest
@@ -19,6 +22,12 @@ def test_ringbuffer_drops_oldest_over_capacity():
     rb.append(b"abcdef")          # 6 bytes into a 4-byte buffer
     assert rb.snapshot() == b"cdef"
     assert rb.truncated is True
+
+
+def test_ringbuffer_snapshot_from_rejects_future_offset():
+    rb = RingBuffer(10)
+    rb.append(b"abc")
+    assert rb.snapshot_from(4) is None
 
 
 
@@ -62,6 +71,49 @@ class FakeWS:
         self.close_code = code
 
 
+class QueueBridge(FakeBridge):
+    """Thread-safe bridge whose output can be injected during an async test."""
+
+    def __init__(self):
+        super().__init__([])
+        self._queue = queue.Queue()
+        self.read_started = threading.Event()
+
+    def push(self, data):
+        self._queue.put(data)
+
+    def read(self, timeout):
+        try:
+            chunk = self._queue.get(timeout=timeout)
+        except queue.Empty:
+            return b""
+        self.read_started.set()
+        return chunk
+
+
+class BlockingFirstBinaryWS(FakeWS):
+    def __init__(self):
+        super().__init__()
+        self.first_binary_started = asyncio.Event()
+        self.release_first_binary = asyncio.Event()
+        self.live_sent = asyncio.Event()
+        self._binary_count = 0
+
+    async def send_bytes(self, data):
+        self._binary_count += 1
+        if self._binary_count == 1:
+            self.first_binary_started.set()
+            await self.release_first_binary.wait()
+        await super().send_bytes(data)
+        if data == b"live":
+            self.live_sent.set()
+
+
+class FailingControlWS(FakeWS):
+    async def send_text(self, text):
+        raise RuntimeError("disconnected during attach")
+
+
 @pytest.mark.asyncio
 async def test_attach_replays_buffer_then_streams_live():
     from hermes_cli.pty_session import PtySession
@@ -73,6 +125,56 @@ async def test_attach_replays_buffer_then_streams_live():
     await s.attach(ws)
     replay = b"".join(p for kind, p in ws.sent if kind == "bytes")
     assert replay == b"hello world"
+    control = json.loads(next(p for kind, p in ws.sent if kind == "text"))
+    assert control == {
+        "type": "pty.replay",
+        "epoch": s.epoch,
+        "start_offset": 0,
+        "replay_end_offset": len(b"hello world"),
+        "reset": True,
+        "reason": "initial",
+    }
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_serializes_chunked_replay_before_live_output():
+    """A live frame cannot cut between chunks of a large replay."""
+    from hermes_cli.pty_session import PtySession
+
+    replay = b"r" * (16384 + 97)
+    bridge = QueueBridge()
+    s = PtySession("k", bridge, buffer_cap=len(replay) + 1024, read_timeout=0.01)
+    s.buffer.append(replay)
+    await s.start()
+    ws = BlockingFirstBinaryWS()
+
+    attach_task = asyncio.create_task(s.attach(ws))
+    await asyncio.wait_for(ws.first_binary_started.wait(), timeout=1)
+
+    # The drain thread reads this while attach() is blocked in the first
+    # replay frame. It must then wait on the session send lock.
+    bridge.push(b"live")
+    assert await asyncio.to_thread(bridge.read_started.wait, 1)
+    ws.release_first_binary.set()
+
+    await asyncio.wait_for(attach_task, timeout=1)
+    await asyncio.wait_for(ws.live_sent.wait(), timeout=1)
+    binary = b"".join(p for kind, p in ws.sent if kind == "bytes")
+    assert binary == replay + b"live"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_send_failure_leaves_session_detached_and_reapable():
+    from hermes_cli.pty_session import PtySession
+
+    s = PtySession("k", FakeBridge([]), buffer_cap=1024, read_timeout=0.01)
+    ws = FailingControlWS()
+    with pytest.raises(RuntimeError, match="disconnected during attach"):
+        await s.attach(ws)
+    assert s.attached is False
+    assert s.last_detached_at is not None
     await s.close()
 
 
@@ -178,6 +280,7 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
         await task
     except asyncio.CancelledError:
         pass
+    assert calls["n"] >= 2
 
 
 @pytest.mark.asyncio
@@ -203,23 +306,23 @@ async def test_attach_incremental_replay_from_offset():
 
     # Reconnect with offset = len("hello world") — should send nothing (zero delta)
     ws2 = FakeWS()
-    await s.attach(ws2, client_offset=len(b"hello world"))
+    await s.attach(
+        ws2,
+        client_offset=len(b"hello world"),
+        client_epoch=s.epoch,
+    )
     replay2 = b"".join(p for kind, p in ws2.sent if kind == "bytes")
     assert replay2 == b""  # no sentinel, no full replay — just return
+    control = json.loads(next(p for kind, p in ws2.sent if kind == "text"))
+    assert control["reset"] is False
+    assert control["reason"] == "resume"
 
     await s.close()
 
 
 @pytest.mark.asyncio
-async def test_attach_rolled_out_offset_sends_sentinel_not_full_replay():
-    """Offset rolled out of the ring window must NOT fall back to full replay.
-
-    ChatPage stays mounted across tab switches, so the client already holds the
-    full history. A rolled-out offset means the server can't send the exact
-    delta — but the client doesn't need it. Emit the sentinel (first-attach
-    empty-buffer case) or nothing (rolled-out reconnect) and let live output
-    resume.
-    """
+async def test_attach_rolled_out_offset_resets_with_retained_snapshot():
+    """A gap is explicit and never silently discards retained bytes."""
     from hermes_cli.pty_session import PtySession
     bridge = FakeBridge([b"a" * 2000, None])
     s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
@@ -228,9 +331,43 @@ async def test_attach_rolled_out_offset_sends_sentinel_not_full_replay():
 
     # Reconnect with offset=100 (rolled out — earliest available is 2000-1024=976)
     ws = FakeWS()
-    await s.attach(ws, client_offset=100)
+    await s.attach(ws, client_offset=100, client_epoch=s.epoch)
     replay = b"".join(p for kind, p in ws.sent if kind == "bytes")
-    # Should NOT be the full 1024-byte buffer — should be sentinel or nothing
-    assert len(replay) < 1024
+    control = json.loads(next(p for kind, p in ws.sent if kind == "text"))
+    assert control["reset"] is True
+    assert control["reason"] == "offset_rolled_out"
+    assert control["start_offset"] == 976
+    assert replay == b"a" * 1024
+
+    await s.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("client_offset", "client_epoch", "reason"),
+    [
+        (2001, "current", "offset_ahead"),
+        (2000, "different-epoch", "epoch_mismatch"),
+    ],
+)
+async def test_attach_invalid_cursor_resets_with_retained_snapshot(
+    client_offset, client_epoch, reason
+):
+    from hermes_cli.pty_session import PtySession
+
+    bridge = FakeBridge([b"retained", None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)
+
+    if client_epoch == "current":
+        client_epoch = s.epoch
+    ws = FakeWS()
+    await s.attach(ws, client_offset=client_offset, client_epoch=client_epoch)
+    control = json.loads(next(p for kind, p in ws.sent if kind == "text"))
+    replay = b"".join(p for kind, p in ws.sent if kind == "bytes")
+    assert control["reset"] is True
+    assert control["reason"] == reason
+    assert replay == b"retained"
 
     await s.close()

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -142,4 +142,59 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
         await task
     except asyncio.CancelledError:
         pass
-    assert calls["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_attach_incremental_replay_from_offset():
+    """Reconnect with a prior byte offset sends only the delta, not the full buffer.
+
+    The connection-lifecycle architecture (suspend on hide / resume on show)
+    relies on this: when a tab returns, the client reconnects with the offset
+    it had before suspend, and the server sends only bytes appended after that
+    offset — not the entire 1MB buffer.
+    """
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"hello ", b"world", None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)  # drain consumes "hello world"
+
+    # First attach: full replay
+    ws1 = FakeWS()
+    await s.attach(ws1, client_offset=None)
+    replay1 = b"".join(p for kind, p in ws1.sent if kind == "bytes")
+    assert replay1 == b"hello world"
+
+    # Reconnect with offset = len("hello world") — should send nothing (zero delta)
+    ws2 = FakeWS()
+    await s.attach(ws2, client_offset=len(b"hello world"))
+    replay2 = b"".join(p for kind, p in ws2.sent if kind == "bytes")
+    assert replay2 == b""  # no sentinel, no full replay — just return
+
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_rolled_out_offset_sends_sentinel_not_full_replay():
+    """Offset rolled out of the ring window must NOT fall back to full replay.
+
+    ChatPage stays mounted across tab switches, so the client already holds the
+    full history. A rolled-out offset means the server can't send the exact
+    delta — but the client doesn't need it. Emit the sentinel (first-attach
+    empty-buffer case) or nothing (rolled-out reconnect) and let live output
+    resume.
+    """
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b"a" * 2000, None])
+    s = PtySession("k", bridge, buffer_cap=1024, read_timeout=0.01)
+    await s.start()
+    await asyncio.sleep(0.05)  # drain consumes 2000 bytes (cap=1024, so oldest evicted)
+
+    # Reconnect with offset=100 (rolled out — earliest available is 2000-1024=976)
+    ws = FakeWS()
+    await s.attach(ws, client_offset=100)
+    replay = b"".join(p for kind, p in ws.sent if kind == "bytes")
+    # Should NOT be the full 1024-byte buffer — should be sentinel or nothing
+    assert len(replay) < 1024
+
+    await s.close()

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -17,9 +17,13 @@ class FakeWebglAddon {
 }
 
 class FakeTerminal {
+  static instances: FakeTerminal[] = [];
+
   options: Record<string, unknown>;
   rows = 24;
   cols = 80;
+  resetCount = 0;
+  writes: string[] = [];
   parser = {
     registerOscHandler: vi.fn(),
   };
@@ -27,6 +31,7 @@ class FakeTerminal {
 
   constructor(options: Record<string, unknown>) {
     this.options = options;
+    FakeTerminal.instances.push(this);
   }
 
   attachCustomKeyEventHandler() {
@@ -75,12 +80,26 @@ class FakeTerminal {
 
   refresh() {}
 
-  write() {}
+  reset() {
+    this.resetCount += 1;
+  }
+
+  write(data: string) {
+    this.writes.push(data);
+  }
 }
 
 const maybeReloadForLoopbackWsAuthFailure = vi.fn(() => false);
 const apiMocks = vi.hoisted(() => ({
-  buildWsUrl: vi.fn(async () => "ws://localhost/api/pty?channel=chat-1"),
+  buildWsUrl: vi.fn(
+    async (path: string, params?: Record<string, string>) => {
+      const url = new URL(path, "ws://localhost");
+      for (const [key, value] of Object.entries(params ?? {})) {
+        url.searchParams.set(key, value);
+      }
+      return url.toString();
+    },
+  ),
 }));
 
 vi.mock("@xterm/addon-fit", () => ({ FitAddon: FakeFitAddon }));
@@ -128,9 +147,13 @@ vi.mock("@/lib/api", () => ({
 
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
+  static CONNECTING = 0;
   static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
 
   binaryType = "blob";
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
   onclose: ((event: CloseEventLike) => void) | null = null;
   onmessage: ((event: { data: ArrayBuffer | string }) => void) | null = null;
   onopen: (() => void) | null = null;
@@ -142,8 +165,9 @@ class FakeWebSocket {
     FakeWebSocket.instances.push(this);
   }
 
-  close() {
-    this.readyState = 3;
+  close(code?: number, reason?: string) {
+    this.closeCalls.push({ code, reason });
+    this.readyState = FakeWebSocket.CLOSED;
   }
 
   send() {}
@@ -191,9 +215,22 @@ async function render(ui: ReactNode) {
 
 beforeEach(() => {
   FakeWebSocket.instances = [];
+  FakeTerminal.instances = [];
   maybeReloadForLoopbackWsAuthFailure.mockClear();
   apiMocks.buildWsUrl.mockReset();
-  apiMocks.buildWsUrl.mockResolvedValue("ws://localhost/api/pty?channel=chat-1");
+  apiMocks.buildWsUrl.mockImplementation(
+    async (path: string, params?: Record<string, string>) => {
+      const url = new URL(path, "ws://localhost");
+      for (const [key, value] of Object.entries(params ?? {})) {
+        url.searchParams.set(key, value);
+      }
+      return url.toString();
+    },
+  );
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
   vi.stubGlobal("WebSocket", FakeWebSocket);
   vi.stubGlobal(
     "ResizeObserver",
@@ -252,6 +289,7 @@ afterEach(async () => {
   await act(async () => root?.unmount());
   container?.remove();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("ChatPage", () => {
@@ -320,6 +358,194 @@ describe("ChatPage", () => {
       "resize",
       "scroll",
     ]);
+  });
+
+  it("resumes the same PTY epoch using raw binary byte offsets", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+    let now = 5_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const epoch = "a".repeat(32);
+    const first = FakeWebSocket.instances[0];
+    await act(async () => first.onopen?.());
+    await act(async () =>
+      first.onmessage?.({
+        data: JSON.stringify({
+          type: "pty.replay",
+          epoch,
+          start_offset: 0,
+          replay_end_offset: 0,
+          reset: true,
+          reason: "initial",
+        }),
+      }),
+    );
+    // First half of "é" advances one raw byte even though TextDecoder has
+    // not emitted a JavaScript character yet.
+    await act(async () =>
+      first.onmessage?.({ data: new Uint8Array([0xc3]).buffer }),
+    );
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await act(async () =>
+      first.onclose?.({ code: 1000, reason: "tab hidden", wasClean: true }),
+    );
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2));
+
+    const second = FakeWebSocket.instances[1];
+    const secondUrl = new URL(second.url);
+    expect(secondUrl.searchParams.get("epoch")).toBe(epoch);
+    expect(secondUrl.searchParams.get("offset")).toBe("1");
+    expect(FakeTerminal.instances).toHaveLength(1);
+
+    await act(async () => second.onopen?.());
+    await act(async () =>
+      second.onmessage?.({
+        data: JSON.stringify({
+          type: "pty.replay",
+          epoch,
+          start_offset: 1,
+          replay_end_offset: 1,
+          reset: false,
+          reason: "resume",
+        }),
+      }),
+    );
+    await act(async () =>
+      second.onmessage?.({ data: new Uint8Array([0xa9, 0xff]).buffer }),
+    );
+    expect(FakeTerminal.instances[0].writes).toContain("é�");
+
+    now += 2_000;
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await act(async () =>
+      second.onclose?.({ code: 1000, reason: "tab hidden", wasClean: true }),
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(3));
+    expect(new URL(FakeWebSocket.instances[2].url).searchParams.get("offset")).toBe(
+      "3",
+    );
+  });
+
+  it("attaches visualViewport keyboard-inset listeners only while the chat tab is active", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+    const root = createRoot(container!);
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: { addEventListener, removeEventListener, width: 1280 },
+    });
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive={false} />
+        </MemoryRouter>,
+      ),
+    );
+    expect(addEventListener).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive />
+        </MemoryRouter>,
+      ),
+    );
+    expect(addEventListener.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "resize",
+      "scroll",
+    ]);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive={false} />
+        </MemoryRouter>,
+      ),
+    );
+    expect(removeEventListener.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "resize",
+      "scroll",
+    ]);
+
+  });
+
+  it("binds lifecycle suspension to the socket that was closed", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const first = FakeWebSocket.instances[0];
+    await act(async () => first.onopen?.());
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+
+    // Resume before the old socket delivers its delayed close event.
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2));
+    const second = FakeWebSocket.instances[1];
+    await act(async () => second.onopen?.());
+
+    const writesBeforeStaleFrame = FakeTerminal.instances[0].writes.length;
+    await act(async () =>
+      first.onmessage?.({ data: new Uint8Array([0x78]).buffer }),
+    );
+    expect(FakeTerminal.instances[0].writes).toHaveLength(
+      writesBeforeStaleFrame,
+    );
+
+    // A clean close from the replacement is a real session end; it must not
+    // consume the old socket's pending lifecycle-suspend marker.
+    await act(async () =>
+      second.onclose?.({ code: 1000, reason: "", wasClean: true }),
+    );
+    expect(container.textContent).toContain("Session ended.");
+
+    await act(async () =>
+      first.onclose?.({ code: 1000, reason: "tab hidden", wasClean: true }),
+    );
+    expect(container.textContent).toContain("Session ended.");
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -108,6 +108,58 @@ function ptyAttachToken(rotate = false): string {
   return t;
 }
 
+interface PtyReplayControl {
+  type: "pty.replay";
+  epoch: string;
+  start_offset: number;
+  replay_end_offset: number;
+  reset: boolean;
+  reason: string;
+}
+
+interface PtyReplayCursor {
+  identity: string;
+  epoch: string;
+  offset: number;
+  decoder: TextDecoder;
+}
+
+/** Parse server control frames without mistaking ordinary text output for one. */
+function parsePtyReplayControl(data: string): PtyReplayControl | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object") return null;
+  const frame = value as Record<string, unknown>;
+  if (frame.type !== "pty.replay") return null;
+  if (
+    typeof frame.epoch !== "string" ||
+    !/^[0-9a-f]{32}$/.test(frame.epoch) ||
+    typeof frame.start_offset !== "number" ||
+    !Number.isSafeInteger(frame.start_offset) ||
+    typeof frame.replay_end_offset !== "number" ||
+    !Number.isSafeInteger(frame.replay_end_offset) ||
+    frame.start_offset < 0 ||
+    frame.replay_end_offset < frame.start_offset ||
+    typeof frame.reset !== "boolean" ||
+    typeof frame.reason !== "string"
+  ) {
+    return null;
+  }
+  return frame as unknown as PtyReplayControl;
+}
+
+function ptyCursorIdentity(
+  attachToken: string,
+  resume: string | null,
+  profile: string,
+): string {
+  return `${attachToken}\0${profile}\0${resume ?? ""}`;
+}
+
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
 // (subscriber).  Generated once per mount so a tab refresh starts a fresh
 // channel — the previous PTY child terminates with the old WS, and its
@@ -223,10 +275,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const forceFreshPtyRef = useRef(false);
   const blockedInputNoticeRef = useRef(false);
   const lastResumeReconnectAtRef = useRef(0);
-  // True when WE closed the socket as a lifecycle suspend (tab hidden).
-  // onclose must not treat that as a session end — the PTY is still alive
-  // on the server and we reconnect on visible.
-  const suspendedByUsRef = useRef(false);
+  const suspendedSocketRef = useRef<WebSocket | null>(null);
+  const reconnectSocketRef = useRef<((forceFresh?: boolean) => void) | null>(
+    null,
+  );
+  const ptyReplayCursorRef = useRef<PtyReplayCursor | null>(null);
   // True from the moment the connect effect begins until the socket resolves
   // (open or close). Guards the page-resume reconnect against firing during
   // the async ticket/URL await gap where wsRef.current is not yet assigned.
@@ -269,7 +322,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     setBanner(null);
     setLastCloseCode(null);
     setPtyState("connecting");
-    setReconnectNonce((n) => n + 1);
+    const reconnectSocket = reconnectSocketRef.current;
+    if (reconnectSocket) {
+      reconnectSocket(false);
+    } else {
+      setReconnectNonce((n) => n + 1);
+    }
   }, [clearReconnectTimer]);
   const startFreshPty = useCallback(() => {
     forceFreshPtyRef.current = true;
@@ -1079,9 +1137,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // WebSocket. In gated mode (``window.__HERMES_AUTH_REQUIRED__``) this
     // awaits a single-use ticket via /api/auth/ws-ticket before opening;
     // in loopback mode it resolves synchronously against the injected
-    // session token. The IIFE keeps the outer effect synchronous so its
-    // ``return cleanup`` stays at the top level; handlers + disposables
-    // are hoisted to ``let`` bindings the cleanup closes over.
+    // session token. Socket reconnects stay inside this terminal-lifecycle
+    // effect so xterm keeps its painted history while the byte cursor resumes.
     let unmounting = false;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
@@ -1123,12 +1180,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     } else {
       setResumeHydrating(false);
     }
-    const forceFresh = forceFreshPtyRef.current;
+    const initialForceFresh = forceFreshPtyRef.current;
     forceFreshPtyRef.current = false;
-    // A connect attempt is now in flight — set synchronously (before the async
-    // socket-open IIFE below awaits its ticket URL) so a page-resume event in
-    // that gap doesn't fire a redundant reconnect (wsRef isn't assigned yet).
-    connectInFlightRef.current = true;
     const clearConnectingTimer = () => {
       if (connectingTimerRef.current) {
         clearTimeout(connectingTimerRef.current);
@@ -1138,9 +1191,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // The pre-socket half of the connect. A ticket request that rejects or
     // never settles leaves no socket behind, so neither `onclose` nor the
     // NS-591 CONNECTING timer (armed after `new WebSocket` below) can recover
-    // it. `ticketSuperseded` invalidates a late ticket result so a timed-out
+    // it. The generation invalidates a late ticket result so a timed-out
     // attempt cannot open a socket behind the replacement this schedules.
-    let ticketSuperseded = false;
+    let ticketGeneration = 0;
     let ticketTimer: ReturnType<typeof setTimeout> | null = null;
     const clearTicketTimer = () => {
       if (ticketTimer) {
@@ -1162,50 +1215,75 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       setPtyState("reconnecting");
       reconnectTimerRef.current = setTimeout(() => {
         reconnectTimerRef.current = null;
-        setReconnectNonce((n) => n + 1);
+        void openPtySocket(false);
       }, delayMs);
     };
-    // Give up on the ticket phase and hand off to the ordinary backoff.
-    const failTicketAttempt = () => {
-      ticketSuperseded = true;
+    // Give up on the active ticket phase and hand off to ordinary backoff.
+    const failTicketAttempt = (generation: number) => {
+      if (generation !== ticketGeneration) {
+        return;
+      }
+      ticketGeneration += 1;
       clearTicketTimer();
       connectInFlightRef.current = false;
       scheduleReconnect(null);
     };
-    void (async () => {
+    async function openPtySocket(forceFresh: boolean) {
       if (unmounting) return;
+      const activeSocket = wsRef.current;
+      if (
+        !forceFresh &&
+        (connectInFlightRef.current ||
+          activeSocket?.readyState === WebSocket.CONNECTING ||
+          activeSocket?.readyState === WebSocket.OPEN)
+      ) {
+        return;
+      }
+      // Set before awaiting a gated-mode ticket so resume/focus bursts cannot
+      // open a second socket in the async URL-build gap.
+      connectInFlightRef.current = true;
+      const generation = ++ticketGeneration;
       const params: Record<string, string> = { channel };
       if (resumeParam) params.resume = resumeParam;
       if (forceFresh) params.fresh = "1";
       // Keep-alive identity: reattach to this tab's living PTY across
       // refresh/transient drops. A forced-fresh start rotates the token so
       // the previous keep-alive PTY is not reattached (registry reaps it).
-      params.attach = ptyAttachToken(forceFresh);
+      const attachToken = ptyAttachToken(forceFresh);
+      params.attach = attachToken;
+      const cursorIdentity = ptyCursorIdentity(
+        attachToken,
+        resumeParam,
+        scopedProfile,
+      );
+      const cursor = ptyReplayCursorRef.current;
+      if (cursor?.identity === cursorIdentity) {
+        params.epoch = cursor.epoch;
+        params.offset = String(cursor.offset);
+      }
       // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).
       if (scopedProfile) params.profile = scopedProfile;
-
       ticketTimer = setTimeout(() => {
         ticketTimer = null;
-        if (unmounting || ticketSuperseded) {
+        if (unmounting || generation !== ticketGeneration) {
           return;
         }
-        failTicketAttempt();
+        failTicketAttempt(generation);
       }, PTY_TICKET_TIMEOUT_MS);
 
       let url: string;
       try {
         url = await api.buildWsUrl("/api/pty", params);
       } catch (err) {
-        if (unmounting || ticketSuperseded) return;
+        if (unmounting || generation !== ticketGeneration) return;
         console.warn(`[chat] PTY ticket request failed: ${err}`);
-        failTicketAttempt();
+        failTicketAttempt(generation);
         return;
       }
-      if (unmounting || ticketSuperseded) return;
+      if (unmounting || generation !== ticketGeneration) return;
       clearTicketTimer();
-
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
@@ -1226,6 +1304,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }, PTY_CONNECTING_TIMEOUT_MS);
 
     ws.onopen = () => {
+      if (wsRef.current !== ws) {
+        ws.close(4409, "superseded client connection");
+        return;
+      }
       clearReconnectTimer();
       clearConnectingTimer();
       connectInFlightRef.current = false;
@@ -1273,8 +1355,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // erase codes and blank-line bursts while replaying a long session.
     // Suppress them for a bounded window after connect, then let ordinary
     // in-place redraws through untouched. See pty-resume-sanitizer.ts.
-    const decoder = new TextDecoder();
-    const sanitizer = new PtyResumeSanitizer();
+    const fallbackDecoder = new TextDecoder();
+    let sanitizer = new PtyResumeSanitizer();
+    let replayControlSeen = false;
+    let retryWithoutCursor = false;
     if (resumeParam) {
       eraseSuppressionTimer = setTimeout(() => {
         eraseSuppressionTimer = null;
@@ -1283,12 +1367,69 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
 
     ws.onmessage = (ev) => {
-      const text =
-        typeof ev.data === "string"
-          ? ev.data
-          : decoder.decode(new Uint8Array(ev.data as ArrayBuffer), {
-              stream: true,
-            });
+      // Browser queues message tasks independently of close tasks. Ignore a
+      // late frame from a socket that has already been replaced so it cannot
+      // repaint duplicate output or advance the replacement socket's cursor.
+      if (wsRef.current !== ws) {
+        return;
+      }
+      if (typeof ev.data === "string") {
+        const control = parsePtyReplayControl(ev.data);
+        if (control) {
+          const current = ptyReplayCursorRef.current;
+          if (
+            !control.reset &&
+            (current?.identity !== cursorIdentity ||
+              current.epoch !== control.epoch ||
+              current.offset !== control.start_offset)
+          ) {
+            // A delta without the exact local base would create an invisible
+            // gap. Drop the cursor and force a full retained replay instead.
+            ptyReplayCursorRef.current = null;
+            retryWithoutCursor = true;
+            ws.close(4400, "PTY replay cursor mismatch");
+            return;
+          }
+
+          const decoder =
+            !control.reset && current
+              ? current.decoder
+              : new TextDecoder();
+          if (control.reset) {
+            sanitizer = new PtyResumeSanitizer();
+            term.reset();
+          }
+          ptyReplayCursorRef.current = {
+            identity: cursorIdentity,
+            epoch: control.epoch,
+            offset: control.start_offset,
+            decoder,
+          };
+          replayControlSeen = true;
+          if (control.replay_end_offset === control.start_offset) {
+            finishResumeHydration();
+          }
+          return;
+        }
+
+        term.write(ev.data);
+        noteResumePtyChunk(ev.data);
+        return;
+      }
+
+      const bytes = new Uint8Array(ev.data as ArrayBuffer);
+      const activeCursor = ptyReplayCursorRef.current;
+      const decoder =
+        replayControlSeen && activeCursor?.identity === cursorIdentity
+          ? activeCursor.decoder
+          : fallbackDecoder;
+      const text = decoder.decode(bytes, { stream: true });
+      if (replayControlSeen && activeCursor?.identity === cursorIdentity) {
+        // Count transport bytes, not decoded JS characters. A multi-byte UTF-8
+        // code point and arbitrary non-text bytes each advance by their raw
+        // frame length, matching RingBuffer.total_appended on the server.
+        activeCursor.offset += bytes.byteLength;
+      }
       // Gate hydration on the payload actually written to xterm. The
       // sanitizer can turn a nonempty erase-only / all-newline / partial-CSI
       // resume frame into "" (pty-resume-sanitizer.ts); keying off raw `text`
@@ -1309,10 +1450,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
 
     ws.onclose = (ev) => {
+      const isCurrentSocket = wsRef.current === ws;
+      const suspendedByUs = suspendedSocketRef.current === ws;
+      if (suspendedByUs) {
+        suspendedSocketRef.current = null;
+      }
       // Drain buffered sanitizer state. A buffered partial escape is dropped
       // (writing an unterminated CSI would wedge xterm's parser); a buffered
       // newline run is emitted collapsed.
-      if (resumeParam) {
+      if (resumeParam && isCurrentSocket) {
         clearEraseSuppressionTimer();
         try {
           term.write(sanitizer.flush());
@@ -1320,10 +1466,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           /* ignore */
         }
       }
-      wsRef.current = null;
-      connectInFlightRef.current = false;
-      clearConnectingTimer();
+      if (isCurrentSocket) {
+        wsRef.current = null;
+        connectInFlightRef.current = false;
+        clearConnectingTimer();
+      }
       if (unmounting) {
+        return;
+      }
+      // A socket we closed for a hidden tab owns its suspend marker. If a
+      // replacement socket has already connected, this stale close must not
+      // clear or consume any state belonging to that newer socket.
+      if (suspendedByUs) {
+        if (isCurrentSocket) {
+          setPtyState("closed");
+        }
+        return;
+      }
+      if (!isCurrentSocket) {
         return;
       }
       // Surface the real cause to the browser console on every close so a
@@ -1333,6 +1493,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       const why = ev.reason ? ` reason=${ev.reason}` : "";
       console.warn(`[chat] PTY WebSocket closed code=${ev.code}${why}`);
       setLastCloseCode(ev.code);
+      if (retryWithoutCursor) {
+        setPtyState("reconnecting");
+        void openPtySocket(false);
+        return;
+      }
       if (ev.code === 4401) {
         if (maybeReloadForLoopbackWsAuthFailure(ev.code)) {
           return;
@@ -1390,14 +1555,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         setPtyState("closed");
         return;
       }
-      // Lifecycle suspend: WE closed the socket on tab-hidden. The PTY is
-      // still alive on the server; do NOT show "session ended" — just mark
-      // closed and let the visible→resume path reconnect with the offset.
-      if (suspendedByUsRef.current) {
-        suspendedByUsRef.current = false;
-        setPtyState("closed");
-        return;
-      }
       if (!ev.wasClean || ev.code === 1001 || ev.code === 1006) {
         // Transient transport drop (refresh, sleep/wake, signal loss).
         // Reconnect with backoff; the same ?attach= token reattaches to
@@ -1432,6 +1589,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // eslint-disable-next-line no-control-regex -- intentional ESC byte in xterm SGR mouse report parser
       const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
       const forwardPtyData = (data: string, useMobileReplacement = true) => {
+
         // Mouse reports (scroll wheel etc.) are not typed input — swallow
         // them before the blocked-input check so scrolling a disconnected
         // terminal doesn't trip the "reconnecting" notice.
@@ -1439,8 +1597,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           return;
         }
 
+        const activeWs = wsRef.current;
         if (
-          ws.readyState !== WebSocket.OPEN ||
+          !activeWs ||
+          activeWs.readyState !== WebSocket.OPEN ||
           shouldBlockPtyInput(ptyStateRef.current)
         ) {
           if (!blockedInputNoticeRef.current) {
@@ -1461,12 +1621,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         if (normalized.normalized) {
           mobileReplacementInputUntilRef.current = 0;
         }
-        ws.send(normalized.data);
+        activeWs.send(normalized.data);
       };
       // The deferred composition fallback is already committed text, so it
       // must not consume the mobile replacement window intended for xterm's
       // normal onData path.
       sendComposedText = (data) => forwardPtyData(data, false);
+      onDataDisposable?.dispose();
       onDataDisposable = term.onData((data) => {
         if (!SGR_MOUSE_RE.test(data)) {
           compositionForwarder.noteTerminalData(data);
@@ -1474,19 +1635,27 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         forwardPtyData(data);
       });
 
+      onResizeDisposable?.dispose();
       onResizeDisposable = term.onResize(({ cols, rows }) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(`\x1b[RESIZE:${cols};${rows}]`);
+        const activeWs = wsRef.current;
+        if (activeWs?.readyState === WebSocket.OPEN) {
+          activeWs.send(`\x1b[RESIZE:${cols};${rows}]`);
         }
       });
+    }
 
-      // Release the stick-to-bottom pin the moment the user scrolls up, so
-      // we only auto-follow during the resume replay — not their manual
-      // review of the backlog (#59591).
-      onScrollDisposable = term.onScroll(() => {
-        stickToBottomRef.current = isViewportPinnedToBottom(term.buffer.active);
-      });
-    })();
+    // Release the stick-to-bottom pin the moment the user scrolls up, so
+    // we only auto-follow during the resume replay - not their manual
+    // review of the backlog (#59591).
+    onScrollDisposable = term.onScroll(() => {
+      stickToBottomRef.current = isViewportPinnedToBottom(term.buffer.active);
+    });
+
+    const reconnectThisEffect = (forceFresh = false) => {
+      void openPtySocket(forceFresh);
+    };
+    reconnectSocketRef.current = reconnectThisEffect;
+    reconnectThisEffect(initialForceFresh);
 
     term.focus();
 
@@ -1518,13 +1687,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       clearReconnectTimer();
       clearConnectingTimer();
       clearTicketTimer();
-      ticketSuperseded = true;
+      ticketGeneration += 1;
       connectInFlightRef.current = false;
-      // Phase 5.3: ``ws`` is local to the IIFE that opens it (the gated-mode
-      // ticket fetch makes the open async). The cleanup runs at the outer
-      // effect's top level so it can't reach into that scope — close via
-      // the ref instead. ``?.`` covers the race where unmount fires before
-      // the ticket fetch resolves and ``wsRef.current`` was never assigned.
+      if (reconnectSocketRef.current === reconnectThisEffect) {
+        reconnectSocketRef.current = null;
+      }
+      suspendedSocketRef.current = null;
+      // The socket is local to openPtySocket (the gated-mode ticket fetch makes
+      // opening async), so effect cleanup closes the active instance via its
+      // ref. ``?.`` covers unmount before ticket resolution.
       wsRef.current?.close();
       wsRef.current = null;
       host.removeEventListener("keydown", _imeCompositionGuard, true);
@@ -1679,7 +1850,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         // the server and we reconnect on visible with the byte offset.
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
-          suspendedByUsRef.current = true;
+          suspendedSocketRef.current = ws;
           ws.close(1000, "tab hidden");
         }
         return;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -223,6 +223,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const forceFreshPtyRef = useRef(false);
   const blockedInputNoticeRef = useRef(false);
   const lastResumeReconnectAtRef = useRef(0);
+  // True when WE closed the socket as a lifecycle suspend (tab hidden).
+  // onclose must not treat that as a session end — the PTY is still alive
+  // on the server and we reconnect on visible.
+  const suspendedByUsRef = useRef(false);
   // True from the moment the connect effect begins until the socket resolves
   // (open or close). Guards the page-resume reconnect against firing during
   // the async ticket/URL await gap where wsRef.current is not yet assigned.
@@ -889,8 +893,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const useWebgl = terminalTierWidthPx(host) >= 768;
     if (useWebgl) {
       try {
-        const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
+        let webgl = new WebglAddon();
+        // Chrome background tabs can reclaim the GPU context
+        // (webglcontextlost), leaving the canvas dead — term.refresh() is a
+        // silent no-op on a lost context, so the viewport stays black even
+        // though the buffer has content. Rebuild the renderer on context
+        // loss so the next frame paints on a live context.
+        webgl.onContextLoss(() => {
+          webgl.dispose();
+          try {
+            webgl = new WebglAddon();
+            term.loadAddon(webgl);
+            term.refresh(0, term.rows - 1);
+          } catch {
+            // WebGL unrecoverable (e.g. GPU process crashed) — xterm falls
+            // back to the canvas renderer on the next write automatically.
+          }
+        });
         term.loadAddon(webgl);
       } catch (err) {
         console.warn(
@@ -1371,6 +1390,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         setPtyState("closed");
         return;
       }
+      // Lifecycle suspend: WE closed the socket on tab-hidden. The PTY is
+      // still alive on the server; do NOT show "session ended" — just mark
+      // closed and let the visible→resume path reconnect with the offset.
+      if (suspendedByUsRef.current) {
+        suspendedByUsRef.current = false;
+        setPtyState("closed");
+        return;
+      }
       if (!ev.wasClean || ev.code === 1001 || ev.code === 1006) {
         // Transient transport drop (refresh, sleep/wake, signal loss).
         // Reconnect with backoff; the same ?attach= token reattaches to
@@ -1631,15 +1658,45 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return;
     }
 
+    // ── Connection lifecycle: suspend on hide, resume on show ──────────────
+    // Chrome background tabs freeze JS but keep the TCP half-open — the
+    // socket "looks OPEN" but is dead, and no close event fires until the
+    // server's 30s ping timeout. Rather than patching around the freeze
+    // (watchdog / stale-socket detection / per-frame batching), we treat the
+    // tab switch as an explicit lifecycle event:
+    //
+    //   hidden → proactively close the WS (graceful suspend; the server
+    //            detaches and stops sending, so no background backlog accrues)
+    //   visible → reconnect with the last byte offset (incremental replay)
+    //
+    // This eliminates the entire class of "tab-return" bugs at the source:
+    // no freeze means no backlog, no half-open socket, no stale state.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        // Suspend: close the socket so the server detaches immediately.
+        // Mark suspendedByUs BEFORE close so onclose knows this is a
+        // lifecycle suspend, not a session end — the PTY stays alive on
+        // the server and we reconnect on visible with the byte offset.
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          suspendedByUsRef.current = true;
+          ws.close(1000, "tab hidden");
+        }
+        return;
+      }
+      // visible → fall through to resume (below)
+      maybeReconnectOnPageResume();
+    };
+
     const onResume = () => maybeReconnectOnPageResume();
 
-    document.addEventListener("visibilitychange", onResume);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     window.addEventListener("pageshow", onResume);
     window.addEventListener("focus", onResume);
     window.addEventListener("online", onResume);
 
     return () => {
-      document.removeEventListener("visibilitychange", onResume);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pageshow", onResume);
       window.removeEventListener("focus", onResume);
       window.removeEventListener("online", onResume);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -201,6 +201,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const forceFreshPtyRef = useRef(false);
   const blockedInputNoticeRef = useRef(false);
   const lastResumeReconnectAtRef = useRef(0);
+  // True when WE closed the socket as a lifecycle suspend (tab hidden).
+  // onclose must not treat that as a session end — the PTY is still alive
+  // on the server and we reconnect on visible.
+  const suspendedByUsRef = useRef(false);
   // True from the moment the connect effect begins until the socket resolves
   // (open or close). Guards the page-resume reconnect against firing during
   // the async ticket/URL await gap where wsRef.current is not yet assigned.
@@ -784,8 +788,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const useWebgl = terminalTierWidthPx(host) >= 768;
     if (useWebgl) {
       try {
-        const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
+        let webgl = new WebglAddon();
+        // Chrome background tabs can reclaim the GPU context
+        // (webglcontextlost), leaving the canvas dead — term.refresh() is a
+        // silent no-op on a lost context, so the viewport stays black even
+        // though the buffer has content. Rebuild the renderer on context
+        // loss so the next frame paints on a live context.
+        webgl.onContextLoss(() => {
+          webgl.dispose();
+          try {
+            webgl = new WebglAddon();
+            term.loadAddon(webgl);
+            term.refresh(0, term.rows - 1);
+          } catch {
+            // WebGL unrecoverable (e.g. GPU process crashed) — xterm falls
+            // back to the canvas renderer on the next write automatically.
+          }
+        });
         term.loadAddon(webgl);
       } catch (err) {
         console.warn(
@@ -1150,6 +1169,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         setPtyState("closed");
         return;
       }
+      // Lifecycle suspend: WE closed the socket on tab-hidden. The PTY is
+      // still alive on the server; do NOT show "session ended" — just mark
+      // closed and let the visible→resume path reconnect with the offset.
+      if (suspendedByUsRef.current) {
+        suspendedByUsRef.current = false;
+        setPtyState("closed");
+        return;
+      }
       if (!ev.wasClean || ev.code === 1001 || ev.code === 1006) {
         // Transient transport drop (refresh, sleep/wake, signal loss).
         // Reconnect with backoff; the same ?attach= token reattaches to
@@ -1359,15 +1386,45 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return;
     }
 
+    // ── Connection lifecycle: suspend on hide, resume on show ──────────────
+    // Chrome background tabs freeze JS but keep the TCP half-open — the
+    // socket "looks OPEN" but is dead, and no close event fires until the
+    // server's 30s ping timeout. Rather than patching around the freeze
+    // (watchdog / stale-socket detection / per-frame batching), we treat the
+    // tab switch as an explicit lifecycle event:
+    //
+    //   hidden → proactively close the WS (graceful suspend; the server
+    //            detaches and stops sending, so no background backlog accrues)
+    //   visible → reconnect with the last byte offset (incremental replay)
+    //
+    // This eliminates the entire class of "tab-return" bugs at the source:
+    // no freeze means no backlog, no half-open socket, no stale state.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        // Suspend: close the socket so the server detaches immediately.
+        // Mark suspendedByUs BEFORE close so onclose knows this is a
+        // lifecycle suspend, not a session end — the PTY stays alive on
+        // the server and we reconnect on visible with the byte offset.
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          suspendedByUsRef.current = true;
+          ws.close(1000, "tab hidden");
+        }
+        return;
+      }
+      // visible → fall through to resume (below)
+      maybeReconnectOnPageResume();
+    };
+
     const onResume = () => maybeReconnectOnPageResume();
 
-    document.addEventListener("visibilitychange", onResume);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     window.addEventListener("pageshow", onResume);
     window.addEventListener("focus", onResume);
     window.addEventListener("online", onResume);
 
     return () => {
-      document.removeEventListener("visibilitychange", onResume);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pageshow", onResume);
       window.removeEventListener("focus", onResume);
       window.removeEventListener("online", onResume);


### PR DESCRIPTION
fix(dashboard): connection lifecycle — suspend on hide, resume on show

## Root cause

Every "tab-return" bug we patched (black screen, long load, session-ended false positive) shared one wrong assumption: **a persistent WebSocket can survive Chrome's background-tab freeze**. Chrome freezes JS but keeps the TCP half-open — no close event fires until the server's 30s ping timeout, and the GPU context can be reclaimed, leaving the canvas dead.

Rather than patching around the freeze (watchdog timers, stale-socket detection, per-frame write batching, sentinel frames), this PR replaces the entire class with an explicit **connection lifecycle**:

```
hidden  → proactively close the WS (graceful suspend; server detaches
          and stops sending, so no background backlog accrues)
visible → reconnect with the last byte offset (incremental replay)
```

## What changes

**Server (`hermes_cli/pty_session.py`)**
- `RingBuffer.snapshot_from(offset)` + `total_appended` for byte-accurate incremental replay.
- Reconnect with a rolled-out offset emits **no sentinel frame** — the client never arms the hydration overlay for incremental replays, so a zero-delta reconnect just returns and live output resumes on the next frame.
- First attach to an empty buffer still emits the SGR-reset sentinel so the overlay clears.

**Client (`web/src/pages/ChatPage.tsx`)**
- `visibilitychange → hidden`: mark `suspendedByUsRef` and `ws.close(1000, "tab hidden")`. The close handler recognizes this as a lifecycle suspend (not a session end) and skips the `[session ended]` affordance.
- `visibilitychange → visible`: reconnect with `?offset=N` (incremental replay).
- WebGL `onContextLoss`: rebuild the renderer (dispose → new WebglAddon → loadAddon → refresh) instead of leaving the canvas dead — `term.refresh()` is a silent no-op on a lost context, which was the "data present but screen black" root cause.

## What this eliminates

- ❌ Hydration watchdog timer (no overlay for incremental replays)
- ❌ Stale-socket detection (no half-open sockets to detect)
- ❌ Per-frame write batching (no background backlog to batch)
- ❌ Sentinel frames on reconnect (no zero-delta overlay to clear)
- ❌ "Session ended" false positive on tab return (suspendedByUs marker)

## Tests

- `tests/test_pty_session.py`: 9 passed — including two new behavior contracts:
  - `test_attach_incremental_replay_from_offset`: reconnect with a prior offset sends only the delta (zero delta = no sentinel, no full replay)
  - `test_attach_rolled_out_offset_sends_sentinel_not_full_replay`: offset evicted from the ring window must not fall back to full 1MB replay — the client already holds the history (ChatPage persistent mount)
- `web/src/lib/pty-reconnect.test.ts` + `pty-resume-loading.test.ts`: 18 passed
- Real Chrome verified: tab-hide → tab-show resumes silently (no overlay, no session-ended, content preserved)

## Author-intent archaeology

- `git log -p -S` on close codes: 4410 (process exited) and 4409 (superseded by newer tab) are checked BEFORE the suspendedByUs intercept, so their semantics are preserved. The intercept only fires on code 1000 (normal close) that WE initiated on tab-hidden.

Supersedes #78346 (patch-driven approach; this is the structural fix).
