### PR TITLE
docs: fix stale PATH location in windows-native common pitfalls

### DIFF
--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -288,7 +288,7 @@ Consequence: any codepath that said "check if this PID is alive" via `os.kill(pi
 ## Common pitfalls
 
 **`hermes: command not found` right after install.**
-Open a new PowerShell window. The installer added `%LOCALAPPDATA%\hermes\bin` to User PATH, but existing shells need to be restarted to pick it up. In the meantime you can run `& "$env:LOCALAPPDATA\hermes\bin\hermes.cmd"`.
+Open a new PowerShell window. The installer added `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` to User PATH, but existing shells need to be restarted to pick it up. In the meantime you can run `& "$env:LOCALAPPDATA\hermes\hermes-agent\venv\Scripts\hermes.exe"`.
 
 **`WinError 193: %1 is not a valid Win32 application` when running a tool.**
 You hit a shebang-script invocation that bypassed the `.cmd` shim. Hermes resolves commands through `shutil.which(cmd, path=local_bin)` so PATHEXT picks up `.CMD` — if you're invoking the tool via a hardcoded path instead, switch to the `.cmd` variant (e.g., `npx.cmd`, not `npx`).


### PR DESCRIPTION
## What

One line in `website/docs/user-guide/windows-native.md`, Common pitfalls: the `hermes: command not found` entry said the installer added `%LOCALAPPDATA%\hermes\bin` to User PATH and suggested running `hermes.cmd` from that directory. The installer actually adds `%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts` (`scripts/install.ps1`, `Set-PathVariable`: `$hermesBin = "$InstallDir\venv\Scripts"`), which is also what this guide's own install steps (step 9) and "PATH after install" section state. `%LOCALAPPDATA%\hermes\bin` holds the Hermes-managed `uv.exe` per the guide's directory table, and there is no `hermes.cmd` in it — the workaround command now points at the real `hermes.exe`.

## Why

Users troubleshooting a not-found error follow the pitfalls section; this line sends them to a directory that doesn't contain the binary. For volume context: 54 GitHub issues with "windows install" in the title since 2026-06-11, and PATH-not-found is a recurring shape in that set. Verified against `scripts/install.ps1` on main, 2026-08-05.