### PR TITLE
fix(gateway): honor QQBOT_HOME_CHANNEL when QQ credentials are yaml-only QQBOT home channel handling to support legacy env…

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2429,29 +2429,31 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         qq_group_allowed = getenv("QQ_GROUP_ALLOWED_USERS", "").strip()
         if qq_group_allowed:
             extra["group_allow_from"] = qq_group_allowed
-        qq_home = getenv("QQBOT_HOME_CHANNEL", "").strip()
-        qq_home_name_env = "QQBOT_HOME_CHANNEL_NAME"
-        if not qq_home:
-            # Back-compat: accept the pre-rename name and log a one-time warning.
-            legacy_home = getenv("QQ_HOME_CHANNEL", "").strip()
-            if legacy_home:
-                qq_home = legacy_home
-                qq_home_name_env = "QQ_HOME_CHANNEL_NAME"
-                logging.getLogger(__name__).warning(
-                    "QQ_HOME_CHANNEL is deprecated; rename to QQBOT_HOME_CHANNEL "
-                    "in your .env for consistency with the platform key."
-                )
-        if qq_home:
-            config.platforms[Platform.QQBOT].home_channel = HomeChannel(
-                platform=Platform.QQBOT,
-                chat_id=qq_home,
-                name=getenv("QQBOT_HOME_CHANNEL_NAME") or getenv(qq_home_name_env, "Home"),
-                thread_id=(
-                    getenv("QQBOT_HOME_CHANNEL_THREAD_ID")
-                    or getenv("QQ_HOME_CHANNEL_THREAD_ID")
-                    or None
-                ),
+    # Home channel is applied independently of the credential env vars — the
+    # platform may have been configured entirely from config.yaml.
+    qq_home = getenv("QQBOT_HOME_CHANNEL", "").strip()
+    qq_home_name_env = "QQBOT_HOME_CHANNEL_NAME"
+    if not qq_home:
+        # Back-compat: accept the pre-rename name and log a one-time warning.
+        legacy_home = getenv("QQ_HOME_CHANNEL", "").strip()
+        if legacy_home:
+            qq_home = legacy_home
+            qq_home_name_env = "QQ_HOME_CHANNEL_NAME"
+            logging.getLogger(__name__).warning(
+                "QQ_HOME_CHANNEL is deprecated; rename to QQBOT_HOME_CHANNEL "
+                "in your .env for consistency with the platform key."
             )
+    if qq_home and Platform.QQBOT in config.platforms:
+        config.platforms[Platform.QQBOT].home_channel = HomeChannel(
+            platform=Platform.QQBOT,
+            chat_id=qq_home,
+            name=getenv("QQBOT_HOME_CHANNEL_NAME") or getenv(qq_home_name_env, "Home"),
+            thread_id=(
+                getenv("QQBOT_HOME_CHANNEL_THREAD_ID")
+                or getenv("QQ_HOME_CHANNEL_THREAD_ID")
+                or None
+            ),
+        )
 
     # Yuanbao — YUANBAO_APP_ID preferred
     yuanbao_app_id = getenv("YUANBAO_APP_ID") or getenv("YUANBAO_APP_KEY")

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1037,6 +1037,24 @@ class TestHomeChannelEnvOverrides:
                 {"SMS_HOME_CHANNEL": "+15559876543", "SMS_HOME_CHANNEL_NAME": "My Phone"},
                 ("+15559876543", "My Phone"),
             ),
+            (
+                Platform.QQBOT,
+                PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "102000000", "client_secret": "secret_from_yaml"},
+                ),
+                {"QQBOT_HOME_CHANNEL": "OPENID_ABC", "QQBOT_HOME_CHANNEL_NAME": "QQ Home"},
+                ("OPENID_ABC", "QQ Home"),
+            ),
+            (
+                Platform.QQBOT,
+                PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "102000000", "client_secret": "secret_from_yaml"},
+                ),
+                {"QQ_HOME_CHANNEL": "OPENID_LEGACY", "QQ_HOME_CHANNEL_NAME": "Legacy"},
+                ("OPENID_LEGACY", "Legacy"),
+            ),
         ]
 
         for platform, platform_config, env, expected in cases:
@@ -1047,6 +1065,14 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+    def test_home_channel_env_does_not_create_unconfigured_platform(self):
+        """A stray home-channel env var must not conjure a platform entry."""
+        config = GatewayConfig(platforms={})
+        with patch.dict(os.environ, {"QQBOT_HOME_CHANNEL": "OPENID_ABC"}, clear=True):
+            _apply_env_overrides(config)
+
+        assert Platform.QQBOT not in config.platforms
 
 
 class TestMultiplexProfilesEnvOverride:


### PR DESCRIPTION
## Problem

`QQBOT_HOME_CHANNEL` was only applied inside the `QQ_APP_ID` / `QQ_CLIENT_SECRET` env guard. If credentials lived in `config.yaml` (`platforms.qqbot.extra`) and the home channel lived in `.env`, the guard was skipped and home channel stayed unset — breaking cron delivery and home-channel notifications.

Fixes #73977

## Fix

Apply the QQ home-channel env vars independently of the credential guard, matching Email / Discord / BlueBubbles. Still require `Platform.QQBOT` to already exist so a stray env var cannot create a platform entry. Legacy `QQ_HOME_CHANNEL*` back-compat is unchanged.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_config.py -q`
- [ ] Credentials only in yaml + `QQBOT_HOME_CHANNEL` in `.env` → `get_home_channel(QQBOT)` returns the openid
- [ ] `hermes gateway restart` delivers the home-channel online notification