### PR TITLE
fix(auxiliary): thread failure_reason=billing into pool exhaustion

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -111,7 +111,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
-from agent.credential_pool import load_pool
+from agent.credential_pool import FAILURE_REASON_BILLING, load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -4246,11 +4246,20 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
         return False
 
     if _is_payment_error(exc) or _is_rate_limit_error(exc):
-        fallback_status = 402 if _is_payment_error(exc) else 429
+        is_billing = _is_payment_error(exc)
+        fallback_status = 402 if is_billing else 429
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
             api_key_hint=hint,
+            # Without this, a billing 403 (OpenRouter "key limit exceeded",
+            # xAI spending limit) is indistinguishable from a transient
+            # edge-throttle 403 to _exhausted_ttl(), so a sole credential
+            # gets the short transient cooldown and the auxiliary path
+            # retries the depleted key every ~60s indefinitely (#78941-class
+            # bug, mirrors the primary path's FailoverReason.billing wiring
+            # in agent_runtime_helpers.recover_with_credential_pool).
+            failure_reason=FAILURE_REASON_BILLING if is_billing else None,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -160,7 +160,7 @@ def aux_probe_mode():
     finally:
         _aux_probe_state.active = prev
 
-from agent.credential_pool import load_pool
+from agent.credential_pool import FAILURE_REASON_BILLING, load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -4477,11 +4477,20 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
         return False
 
     if _is_payment_error(exc) or _is_rate_limit_error(exc):
-        fallback_status = 402 if _is_payment_error(exc) else 429
+        is_billing = _is_payment_error(exc)
+        fallback_status = 402 if is_billing else 429
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
             api_key_hint=hint,
+            # Without this, a billing 403 (OpenRouter "key limit exceeded",
+            # xAI spending limit) is indistinguishable from a transient
+            # edge-throttle 403 to _exhausted_ttl(), so a sole credential
+            # gets the short transient cooldown and the auxiliary path
+            # retries the depleted key every ~60s indefinitely (#78941-class
+            # bug, mirrors the primary path's FailoverReason.billing wiring
+            # in agent_runtime_helpers.recover_with_credential_pool).
+            failure_reason=FAILURE_REASON_BILLING if is_billing else None,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -37,6 +37,7 @@ from agent.auxiliary_client import (
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
+    _recover_provider_pool,
 )
 
 
@@ -2651,6 +2652,95 @@ class TestAuxiliaryPoolRotationRetry:
         assert pool.rotate_calls[0]["status_code"] == 429
         mock_fallback.assert_not_called()
 
+
+class TestRecoverProviderPoolFailureReason:
+    """_recover_provider_pool must thread failure_reason="billing" through to
+    mark_exhausted_and_rotate() for billing errors, mirroring the primary
+    runtime path (agent_runtime_helpers.recover_with_credential_pool). A sole
+    credential's cooldown is only benched for the full TTL when the pool can
+    tell a billing 403 apart from a transient edge-throttle 403 — without
+    failure_reason, _exhausted_ttl() can't make that distinction and applies
+    the short transient cooldown to a depleted billing key.
+    """
+
+    @staticmethod
+    def _make_pool():
+        class _Pool:
+            def __init__(self):
+                self.rotate_calls = []
+
+            def has_credentials(self):
+                return True
+
+            def try_refresh_current(self):
+                return None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                self.rotate_calls.append(kwargs)
+                return SimpleNamespace(id="cred-b")
+
+        return _Pool()
+
+    def test_billing_403_threads_failure_reason_billing(self):
+        exc = Exception("insufficient funds: balance_depleted for this account")
+        exc.status_code = 403
+        pool = self._make_pool()
+
+        with (
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients"),
+        ):
+            recovered = _recover_provider_pool("openrouter", exc)
+
+        assert recovered is True
+        assert len(pool.rotate_calls) == 1
+        assert pool.rotate_calls[0]["status_code"] == 403
+        assert pool.rotate_calls[0]["failure_reason"] == "billing"
+
+    def test_billing_402_threads_failure_reason_billing(self):
+        exc = Exception("payment required")
+        exc.status_code = 402
+        pool = self._make_pool()
+
+        with (
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients"),
+        ):
+            recovered = _recover_provider_pool("openrouter", exc)
+
+        assert recovered is True
+        assert pool.rotate_calls[0]["failure_reason"] == "billing"
+
+    def test_transient_rate_limit_does_not_set_billing_reason(self):
+        exc = Exception("rate limit exceeded, please retry")
+        exc.status_code = 429
+        pool = self._make_pool()
+
+        with (
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients"),
+        ):
+            recovered = _recover_provider_pool("openrouter", exc)
+
+        assert recovered is True
+        assert pool.rotate_calls[0]["status_code"] == 429
+        assert pool.rotate_calls[0]["failure_reason"] is None
+
+    def test_transient_403_does_not_set_billing_reason(self):
+        """A 403 with no billing keywords (edge-throttle, generic forbidden)
+        must stay classified as transient, not billing."""
+        exc = Exception("forbidden")
+        exc.status_code = 403
+        pool = self._make_pool()
+
+        with (
+            patch("agent.auxiliary_client.load_pool", return_value=pool),
+            patch("agent.auxiliary_client._evict_cached_clients"),
+        ):
+            recovered = _recover_provider_pool("openrouter", exc)
+
+        assert recovered is False
+        assert len(pool.rotate_calls) == 0
 
 
 class TestAnthropicAuxiliaryReasoningTranslation:


### PR DESCRIPTION
## Summary

`_recover_provider_pool()` (the auxiliary client's independent credential-pool recovery path, used for compression/MoA/title-generation calls) classifies billing errors via `_is_payment_error()` — which correctly detects a 402, or a 403/429 carrying billing keywords ("insufficient funds", "balance_depleted", "key limit exceeded", etc.) — but never passed that classification to `mark_exhausted_and_rotate()`.

`_exhausted_ttl()` can only distinguish a genuine billing exhaustion from a transient edge-throttle via the `failure_reason` kwarg:

```python
is_billing = error_code == 402 or failure_reason == FAILURE_REASON_BILLING
if sole_credential and not is_billing:
    return min(base, EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS)
```

Without `failure_reason`, a sole credential hit by a billing 403 (OpenRouter "key limit exceeded", xAI spending limit) is misclassified as transient, gets the short cooldown, and the auxiliary path retries the depleted key every ~60s indefinitely — the exact bug the same-day fix in `_exhausted_ttl()`/`mark_exhausted_and_rotate()` addressed, just missed on this second, independent recovery path.

The primary runtime path (`agent_runtime_helpers.recover_with_credential_pool`) already threads `FailoverReason.billing` through to `mark_exhausted_and_rotate(failure_reason=...)` for exactly this reason. This PR mirrors that for the auxiliary client.

## Fix

`_recover_provider_pool()`'s payment/rate-limit branch now passes `failure_reason=FAILURE_REASON_BILLING` when `_is_payment_error(exc)` is true, `None` otherwise (same as before — no behavior change for non-billing errors).

## Test plan

- New `TestRecoverProviderPoolFailureReason` (4 cases): billing 403 and billing 402 correctly set `failure_reason="billing"`; a transient 429 rate-limit and a generic non-billing 403 do not (and the latter doesn't even reach the pool, confirming no over-matching).
- Mutation-verified: reverted the production fix, confirmed 3/4 new tests fail (`KeyError: 'failure_reason'`); the 4th is an unrelated negative-control case, correctly still passing.
- `pytest tests/agent/test_auxiliary_client.py` — 175 passed.
- `pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_sole_cooldown.py tests/agent/test_credential_pool_key_rotation.py` — 67 passed.
- `ruff check` — clean.

## Notes for reviewers

Two currently-open PRs touch the same `_recover_provider_pool()` function for unrelated concerns (a `model=` parameter for model-scoped exhaustion, and an upstream-vs-account 429 distinction) — this diff will need a routine rebase against whichever lands first, but doesn't overlap in behavior with either.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Tests added and passing