### PR TITLE
fix(memory): route holographic save_config through atomic_yaml_write

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -127,19 +127,28 @@ class HolographicMemoryProvider(MemoryProvider):
         return True  # SQLite is always available, numpy is optional
 
     def save_config(self, values, hermes_home):
-        """Write config to config.yaml under plugins.hermes-memory-store."""
-        from pathlib import Path
-        config_path = Path(hermes_home) / "config.yaml"
+        """Write config to config.yaml under plugins.hermes-memory-store.
+
+        Routes through hermes_cli.config's load_config()/save_config(), the
+        same atomic (utils.atomic_yaml_write-backed) round-trip every other
+        memory provider's save_config uses (hindsight/mem0/honcho via
+        atomic_json_write for their own files; supermemory likewise;
+        openviking via this same load_config()/save_config() pair) — a bare
+        open(path, "w") + yaml.dump was a truncating, non-atomic write
+        directly against the shared main config.yaml: an interruption
+        mid-write left the file corrupt/zero-length, silently dropping every
+        section (provider credentials included), not just this plugin's.
+        """
         try:
-            import yaml
-            # Write-back round-trip: raw read is correct (merged defaults
-            # must not be persisted back into the user's file).
-            from hermes_cli.config import read_user_config_raw
-            existing = read_user_config_raw(config_path)
-            existing.setdefault("plugins", {})
-            existing["plugins"]["hermes-memory-store"] = values
-            with open(config_path, "w", encoding="utf-8") as f:
-                yaml.dump(existing, f, default_flow_style=False)
+            from hermes_cli.config import load_config, save_config
+
+            config = load_config()
+            plugins_config = config.get("plugins")
+            if not isinstance(plugins_config, dict):
+                plugins_config = {}
+                config["plugins"] = plugins_config
+            plugins_config["hermes-memory-store"] = values
+            save_config(config)
         except Exception:
             pass
 

--- a/tests/plugins/memory/test_holographic_save_config.py
+++ b/tests/plugins/memory/test_holographic_save_config.py
@@ -1,0 +1,96 @@
+"""Regression test: HolographicMemoryProvider.save_config() must write the
+shared main config.yaml atomically, like every sibling memory provider does.
+
+Before this fix, save_config() bypassed hermes_cli.config's atomic
+(utils.atomic_yaml_write-backed) round-trip and instead did a bare
+``open(config_path, "w")`` truncating write directly against config.yaml —
+the single file holding every provider's credentials and settings, not just
+this plugin's. An interruption mid-write (crash, kill -9, power loss) left
+the file truncated/corrupt; the read half then silently fell back to an
+empty config on the next load, wiping every unrelated section.
+
+hindsight/mem0/honcho route through utils.atomic_json_write for their own
+separate files; supermemory and openviking route through
+hermes_cli.config.save_config() (atomic_yaml_write-backed) for the shared
+config.yaml. holographic was the only one of the six memory providers still
+using the unsafe bare-write pattern.
+"""
+
+import yaml
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    token = set_hermes_home_override(str(home))
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_save_config_preserves_unrelated_sections(hermes_home):
+    """A read-modify-write must not drop sibling config sections — the exact
+    failure mode a bare truncating write risks on interruption."""
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": "claude-fable-5",
+                "providers": {"anthropic": {"api_key": "sk-existing-secret"}},
+                "plugins": {"some-other-plugin": {"enabled": True}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    provider = HolographicMemoryProvider()
+    provider.save_config({"db_path": "/tmp/x.db", "hrr_dim": 128}, str(hermes_home))
+
+    on_disk = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert on_disk["providers"]["anthropic"]["api_key"] == "sk-existing-secret"
+    assert on_disk["plugins"]["some-other-plugin"] == {"enabled": True}
+    assert on_disk["plugins"]["hermes-memory-store"] == {
+        "db_path": "/tmp/x.db",
+        "hrr_dim": 128,
+    }
+
+
+def test_save_config_routes_through_atomic_yaml_write(hermes_home, monkeypatch):
+    """The write must go through utils.atomic_yaml_write (temp file + fsync +
+    atomic rename), not a bare truncating open()."""
+    calls = []
+    import utils
+
+    real_atomic_yaml_write = utils.atomic_yaml_write
+
+    def spy(path, data, *args, **kwargs):
+        calls.append((path, data))
+        return real_atomic_yaml_write(path, data, *args, **kwargs)
+
+    monkeypatch.setattr(utils, "atomic_yaml_write", spy)
+
+    provider = HolographicMemoryProvider()
+    provider.save_config({"db_path": "/tmp/x.db"}, str(hermes_home))
+
+    assert len(calls) == 1, "save_config must write via atomic_yaml_write exactly once"
+    written_path, written_data = calls[0]
+    assert written_data["plugins"]["hermes-memory-store"] == {"db_path": "/tmp/x.db"}
+
+
+def test_save_config_creates_file_when_missing(hermes_home):
+    """No pre-existing config.yaml — save_config must still succeed and
+    create one (matches the prior bare-write behavior's happy path)."""
+    provider = HolographicMemoryProvider()
+    provider.save_config({"db_path": "/tmp/new.db"}, str(hermes_home))
+
+    config_path = hermes_home / "config.yaml"
+    assert config_path.exists()
+    on_disk = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert on_disk["plugins"]["hermes-memory-store"] == {"db_path": "/tmp/new.db"}


### PR DESCRIPTION
## Summary

`HolographicMemoryProvider.save_config()` writes the **shared main `config.yaml`** — the single file holding every provider's credentials, model config, and all settings — via a bare `open(config_path, "w")` + `yaml.dump()`. That's a truncating, non-atomic write: an interruption exactly mid-write (crash, `kill -9`, power loss) leaves the file truncated/corrupt. The read half it uses on the next load (`read_user_config_raw`/`load_config`) falls back to an empty dict on a parse failure, so the *next* save through this same code path — or the next normal config load anywhere in the app — silently loses every section, not just this plugin's.

```python
# before
with open(config_path, "w", encoding="utf-8") as f:
    yaml.dump(existing, f, default_flow_style=False)
```

All five sibling memory providers already avoid this:
- `hindsight` / `mem0` / `honcho` → `utils.atomic_json_write` for their own private JSON files
- `supermemory` → `utils.atomic_json_write` for its own private JSON file
- `openviking` → `hermes_cli.config.load_config()` + `save_config()` (the same `atomic_yaml_write`-backed round-trip this PR adopts) for the shared `config.yaml`

`holographic` was the only one of the six still using the unsafe bare-write pattern, and the only one writing directly to the shared `config.yaml` instead of a plugin-private file — so the blast radius of an interrupted write is the whole app's config, not one plugin's.

## Fix

Mirrors `openviking`'s existing approach exactly: `load_config()` + mutate the `plugins.hermes-memory-store` section + `save_config()`. The `hermes_home` parameter goes unused (matching `openviking`'s precedent) — the two production call sites (`hermes_cli/web_server.py`, `hermes_cli/memory_setup.py`) always pass `str(get_hermes_home())`, which is exactly what `load_config()`/`save_config()` resolve to internally, so this isn't a behavior change for either existing caller.

## Test plan

New `tests/plugins/memory/test_holographic_save_config.py` (3 cases):
- `test_save_config_preserves_unrelated_sections` — a read-modify-write must not drop sibling config sections (providers, other plugins).
- `test_save_config_routes_through_atomic_yaml_write` — spies on `utils.atomic_yaml_write` and asserts it's the actual write mechanism used.
- `test_save_config_creates_file_when_missing` — no pre-existing config.yaml still works.

Mutation-verified: reverted the production fix, confirmed `test_save_config_routes_through_atomic_yaml_write` fails (`0 == 1`, the atomic path is never called); the other two still pass since the old bare-write also succeeds in the non-interrupted happy path — expected, since the bug is specifically about interruption, and only the routing test targets the mechanism itself.

- `pytest tests/plugins/memory/ tests/plugins/test_holographic_vector_storage.py` (excluding `test_hindsight_provider.py`, which fails on a pre-existing, unrelated missing-package issue in this environment — `ModuleNotFoundError: No module named 'hindsight_client_api'`, confirmed independent of this change) — 218 passed, 2 skipped.
- `pytest tests/hermes_cli/test_config.py` — 74 passed.
- `ruff check` — clean.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #48399 — a different, cosmetic `sort_keys` fix to the same file that doesn't touch atomicity; #14276 and #77646 — both touch `hermes_cli/config.py`'s `save_config()` internals for unrelated bugs, neither touches this plugin file)
- [x] My PR contains only changes related to this fix
- [x] Tests added and passing