### PR TITLE
fix(acp): unwedge session when prompt task cancelled or send fails

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1955,6 +1955,17 @@ class HermesACPAgent(acp.Agent):
             # particular — used by the interactive sudo password cache scope).
             ctx = contextvars.copy_context()
             result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
+        except asyncio.CancelledError:
+            # Client pressed stop and then disconnected while the turn was in
+            # flight: the SDK cancels the prompt task. CancelledError is a
+            # BaseException (not an Exception) in Python 3.11+, so the
+            # ``except Exception`` below would not catch it, the
+            # ``state.is_running = False`` reset would be skipped, and every
+            # later prompt would queue forever on a wedged session (#79196).
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
+            raise
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             with state.runtime_lock:
@@ -2048,8 +2059,19 @@ class HermesACPAgent(acp.Agent):
             # or when a plugin hook transformed the response after streaming
             # finished (e.g. transform_llm_output) — otherwise the appended /
             # rewritten text never reaches the client.
-            update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
+            try:
+                update = acp.update_agent_message_text(final_response)
+                await conn.session_update(session_id, update)
+            except Exception:
+                # Client disconnected mid-turn (stop then close): the send
+                # fails, but the session must still return to idle below —
+                # otherwise is_running stays True and every later prompt
+                # queues forever (#79196).
+                logger.debug(
+                    "Failed to deliver ACP final response for %s",
+                    session_id,
+                    exc_info=True,
+                )
 
         # Mark this turn idle before draining queued work so recursive prompt()
         # calls can acquire the session. Queued turns are intentionally run as

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -163,7 +164,79 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     assert state.interrupted_prompt_text == "original request"
 
 
+@pytest.mark.asyncio
+async def test_acp_cancelled_prompt_task_does_not_wedge_session():
+    """A prompt task cancelled mid-turn (client disconnect after cancel) must
+    leave the session idle, not permanently stuck with is_running=True.
 
+    Regression (#79196): cancel() + client disconnect can cancel the prompt()
+    task while the agent runs in the executor. asyncio.CancelledError is a
+    BaseException in Python 3.11+, so the surrounding ``except Exception``
+    does not catch it, the ``state.is_running = False`` reset is skipped, and
+    every later prompt is appended to queued_prompts forever.
+    """
+    import threading
 
+    # Pre-warm the lazy heavy imports _run_agent performs on its first turn
+    # (gateway.session_context, tools.terminal_tool, edit_approval); otherwise
+    # the executor thread spends seconds importing them and run_started is not
+    # set within a short wait.
+    import gateway.session_context  # noqa: F401
+    import acp_adapter.edit_approval  # noqa: F401
+    from tools import terminal_tool  # noqa: F401
 
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    run_started = threading.Event()
+    release_run = threading.Event()
 
+    def run_conversation(**kwargs):
+        run_started.set()
+        release_run.wait(timeout=60)
+        fake.runs.append(kwargs["user_message"])
+        messages = list(kwargs.get("conversation_history") or [])
+        messages.append({"role": "user", "content": kwargs["user_message"]})
+        messages.append({"role": "assistant", "content": "ran"})
+        return {"final_response": "ran", "messages": messages}
+
+    fake.run_conversation = run_conversation
+
+    task = asyncio.create_task(
+        acp_agent.prompt(
+            session_id=state.session_id,
+            prompt=[TextContentBlock(type="text", text="long running prompt")],
+        )
+    )
+    # _run_agent performs heavy lazy imports on its first turn (session
+    # context, terminal approval wiring), so the executor thread may take
+    # several seconds to reach run_conversation. Poll with sleeps instead of a
+    # blocking threading.Event.wait(): this coroutine IS the event loop, and
+    # blocking it would starve the very prompt task we are waiting on.
+    import time
+
+    deadline = time.monotonic() + 30
+    while not run_started.is_set() and time.monotonic() < deadline:
+        await asyncio.sleep(0.1)
+    assert run_started.is_set(), "prompt task never reached run_conversation"
+    assert state.is_running is True
+
+    # Client hits stop then disconnects: the in-flight prompt task is cancelled.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release_run.set()
+
+    # The session must be idle again — not wedged.
+    assert state.is_running is False
+
+    # A subsequent prompt must run, not queue forever. (The executor thread
+    # finishes the cancelled first run in the background, so runs may hold
+    # both prompts in either order — what matters is that the follow-up was
+    # executed at all instead of being appended to queued_prompts.)
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="follow up")],
+    )
+    assert response.stop_reason == "end_turn"
+    assert state.is_running is False
+    assert state.queued_prompts == []
+    assert "follow up" in fake.runs


### PR DESCRIPTION
Fixes #79196

## Summary

Pressing **stop** in an ACP client (e.g. Zed-style editor integrations) and then disconnecting can permanently wedge the session: the in-flight `prompt()` task is cancelled by the SDK, but `asyncio.CancelledError` is a `BaseException` in Python 3.11+ — the surrounding `except Exception` never ran, so `state.is_running` stayed `True` and every later prompt was silently appended to `queued_prompts` forever. Only a full `hermes acp` restart recovered the session.

A second, related exit path had the same effect: if the client's connection closed *after* the turn finished but *before* the final `conn.session_update()` delivered the response, that exception also skipped the `is_running = False` reset.

## Changes

- **`acp_adapter/server.py` — `prompt()`**:
  1. Added an explicit `except asyncio.CancelledError` around the executor call that clears `is_running`/`current_prompt_text` under `runtime_lock` and re-raises, so a cancelled turn (stop → disconnect) returns the session to idle.
  2. Wrapped the final-response `conn.session_update()` in a try/except that logs at debug level, so a closed connection after the turn still reaches the idle reset below.

## Testing

- Added `test_acp_cancelled_prompt_task_does_not_wedge_session` in `tests/acp_adapter/test_acp_commands.py`:
  - starts a prompt that blocks in `run_conversation` (threading.Event),
  - cancels the prompt task mid-turn (simulating stop + disconnect),
  - asserts the session returns to idle (`is_running is False`, no queued prompts),
  - sends a follow-up prompt and asserts it **runs** instead of queueing.
- TDD: the new test failed before the fix with `is_running is True` after cancellation (the wedge); passes after.
- `pytest tests/acp_adapter/` — **15 passed** (regression test stable across repeated runs).

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] Input validated at boundaries
