### PR TITLE
fix(acp): reset session to idle when an in-flight prompt is cancelled (#79196)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1955,6 +1955,19 @@ class HermesACPAgent(acp.Agent):
             # particular — used by the interactive sudo password cache scope).
             ctx = contextvars.copy_context()
             result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
+        except asyncio.CancelledError:
+            # A client stop that tears down the stdio connection makes the ACP
+            # task supervisor cancel this in-flight request while the turn is
+            # still running. CancelledError is a BaseException, so the plain
+            # `except Exception` below never fires — without this handler the
+            # session would stay `is_running=True` forever and every later
+            # prompt would queue behind a turn that will never drain. Reset to
+            # idle and re-raise; the executor thread keeps finishing in the
+            # background and its result is dropped.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
+            raise
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             with state.runtime_lock:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,75 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_cancelled_prompt_resets_is_running(self, agent, mock_manager):
+        """A cancelled in-flight prompt must not wedge the session forever.
+
+        Regression for #79196: when an ACP client stops a turn and the stdio
+        connection tears down, the ACP task supervisor cancels the in-flight
+        prompt request. ``asyncio.CancelledError`` is a BaseException, so the
+        old ``except Exception`` around the executor await never fired —
+        ``state.is_running`` stayed ``True`` and every later prompt queued
+        behind a turn that would never drain.
+        """
+        import threading
+
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+
+        blocker = threading.Event()
+
+        def _blocking_run(*_args, **_kwargs):
+            blocker.wait(10)
+            return {"final_response": "done", "messages": []}
+
+        state.agent.run_conversation = _blocking_run
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        task = asyncio.create_task(
+            agent.prompt(
+                prompt=[TextContentBlock(type="text", text="hello")],
+                session_id=resp.session_id,
+            )
+        )
+        # Let the turn start and the executor thread block inside the agent run.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 5.0
+        while not state.is_running:
+            if loop.time() > deadline:
+                raise AssertionError("prompt never entered the running state")
+            await asyncio.sleep(0.01)
+
+        # Client stop: a cancel request followed by stdio teardown, which makes
+        # the ACP task supervisor cancel the in-flight prompt handler task.
+        await agent.cancel(session_id=resp.session_id)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The session must be back to idle so later prompts actually run.
+        assert state.is_running is False
+        assert state.current_prompt_text == ""
+
+        # Un-block the abandoned executor thread so it finishes quietly.
+        blocker.set()
+
+        # And a follow-up prompt must run normally instead of queueing forever.
+        state.agent.run_conversation = (
+            lambda *_a, **_k: {"final_response": "ok", "messages": []}
+        )
+        resp2 = await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="again")],
+            session_id=resp.session_id,
+        )
+        assert resp2.stop_reason == "end_turn"
+        assert state.is_running is False
+
 
 
 


### PR DESCRIPTION
## Problem

Pressing **stop** in an ACP client (or having the client disconnect mid-turn) can permanently wedge the session. After the first stop:
1. The client reports an `internal error`.
2. Every subsequent prompt is silently appended to `state.queued_prompts` and **never runs** ("Queued for the next turn (N queued)" forever).
3. The only recovery is restarting the whole `hermes acp` process.

## Root cause

`HermesACPAgent.prompt()` awaits the turn via `loop.run_in_executor(_executor, ...)` inside a `try/except Exception` block. When the client stops a turn and the stdio connection tears down, the ACP task supervisor (`acp.task.supervisor.TaskSupervisor.shutdown`) **cancels the in-flight prompt handler task**. `asyncio.CancelledError` is a `BaseException`, so the plain `except Exception` never fires — `state.is_running` stays `True` and `state.current_prompt_text` stays set. Every later prompt sees `is_running == True` and appends to `queued_prompts`, which is only drained after a turn completes — a turn that will never complete. Permanent wedge.

## Fix

Catch `asyncio.CancelledError` around the executor await, reset `state.is_running = False` and `state.current_prompt_text = ""` under `state.runtime_lock`, then re-raise. The executor thread keeps finishing in the background and its result is dropped, so the session returns to idle and follow-up prompts (including deictic "stop-and-correct" follow-ups, which still get the interrupted-prompt salvage) run normally.

## Test

Added `test_cancelled_prompt_resets_is_running` to `tests/acp/test_server.py`:
- Starts a prompt whose agent run blocks on a `threading.Event`.
- Sends `cancel()` then cancels the handler task (simulating stdio teardown).
- Asserts `is_running` resets to `False` and a follow-up prompt runs to `end_turn` instead of queueing forever.

Verified red-green: the test fails on `main` (`assert state.is_running is False` → stuck `True`) and passes with the fix.

Full ACP suite: **127 passed** in ~11s.

Closes #79196
