### PR TITLE
fix(approval): fire pre/post approval hooks in elicitation CLI/TUI path

### DIFF
--- a/tests/tools/test_elicitation_approval_hooks.py
+++ b/tests/tools/test_elicitation_approval_hooks.py
@@ -1,0 +1,115 @@
+"""Regression test: request_elicitation_consent()'s CLI/TUI branch must fire
+pre_approval_request / post_approval_response, same as its own gateway branch
+(via _await_gateway_decision) and every other prompt_dangerous_approval call
+site (check_all_command_guards, check_execute_code_guard) — see
+tests/tools/test_approval_plugin_hooks.py.
+
+Before this fix, an MCP elicitation answered on a CLI/TUI session called
+prompt_dangerous_approval() directly with zero hook instrumentation, making
+it invisible to the tool-approval observability pipeline while the
+structurally identical dangerous-command approval flow fires hooks.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import tools.approval as approval_module
+from tools.approval import request_elicitation_consent
+
+
+@pytest.fixture
+def cli_session(monkeypatch):
+    """Force the CLI/TUI branch: no gateway session context."""
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(approval_module, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(
+        approval_module, "get_current_session_key", lambda default="default": "cli:test-session"
+    )
+
+
+class TestElicitationCliHooksFire:
+    def test_accept_fires_pre_and_post_with_choice(self, cli_session, monkeypatch):
+        captured = []
+        monkeypatch.setattr(
+            approval_module,
+            "_fire_approval_hook",
+            lambda hook_name, **kw: captured.append((hook_name, kw)),
+        )
+        monkeypatch.setattr(
+            approval_module, "prompt_dangerous_approval", lambda *a, **kw: "once"
+        )
+
+        result = request_elicitation_consent("Allow X?", "MCP server wants to do X")
+
+        assert result == "accept"
+        hook_names = [c[0] for c in captured]
+        assert hook_names == ["pre_approval_request", "post_approval_response"]
+
+        pre_kwargs = captured[0][1]
+        assert pre_kwargs["command"] == "Allow X?"
+        assert pre_kwargs["description"] == "MCP server wants to do X"
+        assert pre_kwargs["pattern_key"] == "mcp_elicitation"
+        assert pre_kwargs["pattern_keys"] == ["mcp_elicitation"]
+        assert pre_kwargs["session_key"] == "cli:test-session"
+        assert pre_kwargs["surface"] == "mcp-elicitation"
+
+        post_kwargs = captured[1][1]
+        assert post_kwargs["choice"] == "once"
+        assert post_kwargs["session_key"] == "cli:test-session"
+
+    def test_decline_still_fires_post_hook(self, cli_session, monkeypatch):
+        captured = []
+        monkeypatch.setattr(
+            approval_module,
+            "_fire_approval_hook",
+            lambda hook_name, **kw: captured.append((hook_name, kw)),
+        )
+        monkeypatch.setattr(
+            approval_module, "prompt_dangerous_approval", lambda *a, **kw: "declined"
+        )
+
+        result = request_elicitation_consent("Allow X?", "desc")
+
+        assert result == "decline"
+        assert [c[0] for c in captured] == ["pre_approval_request", "post_approval_response"]
+        assert captured[1][1]["choice"] == "declined"
+
+    def test_prompt_exception_still_fires_post_hook_and_fails_closed(
+        self, cli_session, monkeypatch
+    ):
+        """Fail-closed contract must hold even with hooks added: an
+        exception in the CLI prompt still declines, and still reports a
+        completed (not silently dropped) post_approval_response."""
+        captured = []
+        monkeypatch.setattr(
+            approval_module,
+            "_fire_approval_hook",
+            lambda hook_name, **kw: captured.append((hook_name, kw)),
+        )
+
+        def _raise(*a, **kw):
+            raise RuntimeError("prompt backend unavailable")
+
+        monkeypatch.setattr(approval_module, "prompt_dangerous_approval", _raise)
+
+        result = request_elicitation_consent("Allow X?", "desc")
+
+        assert result == "decline"
+        assert [c[0] for c in captured] == ["pre_approval_request", "post_approval_response"]
+        assert captured[1][1]["choice"] == "error"
+
+    def test_surface_kwarg_propagates_to_hooks(self, cli_session, monkeypatch):
+        captured = []
+        monkeypatch.setattr(
+            approval_module,
+            "_fire_approval_hook",
+            lambda hook_name, **kw: captured.append((hook_name, kw)),
+        )
+        monkeypatch.setattr(
+            approval_module, "prompt_dangerous_approval", lambda *a, **kw: "once"
+        )
+
+        request_elicitation_consent("Allow X?", "desc", surface="custom-mcp-server")
+
+        assert captured[0][1]["surface"] == "custom-mcp-server"
+        assert captured[1][1]["surface"] == "custom-mcp-server"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4354,6 +4354,22 @@ def request_elicitation_consent(
 
     # CLI / TUI path. allow_permanent=False because elicitation is a
     # per-call confirmation — there is no pattern to remember.
+    #
+    # Fires the same pre/post approval hooks as the gateway branch above
+    # (via _await_gateway_decision) and every other prompt_dangerous_approval
+    # call site (check_all_command_guards, check_execute_code_guard) — this
+    # branch was the one CLI/TUI approval surface not wired into
+    # TOOL_APPROVAL_METRIC, making every MCP elicitation answered outside a
+    # gateway session invisible to approval observability.
+    cli_hook_payload = {
+        "command": message,
+        "description": description,
+        "pattern_key": "mcp_elicitation",
+        "pattern_keys": ["mcp_elicitation"],
+        "session_key": session_key,
+        "surface": surface,
+    }
+    _fire_approval_hook("pre_approval_request", **cli_hook_payload)
     try:
         choice = prompt_dangerous_approval(
             message,
@@ -4365,7 +4381,13 @@ def request_elicitation_consent(
         logger.error(
             "Elicitation CLI prompt failed: %s", exc, exc_info=True,
         )
+        _fire_approval_hook(
+            "post_approval_response", **cli_hook_payload, choice="error",
+        )
         return "decline"
+    _fire_approval_hook(
+        "post_approval_response", **cli_hook_payload, choice=choice,
+    )
 
     if choice in ("once", "session", "always"):
         return "accept"


### PR DESCRIPTION
## Summary

`request_elicitation_consent()` routes an MCP elicitation request to whichever approval surface owns the active session. Its gateway branch fires `pre_approval_request`/`post_approval_response` via `_await_gateway_decision()`, matching every other `prompt_dangerous_approval` call site in this file (`check_all_command_guards`, `check_execute_code_guard` — see `tests/tools/test_approval_plugin_hooks.py`'s own framing: these hooks "must fire on BOTH the CLI-interactive path and the async gateway path").

The CLI/TUI branch, however, calls `prompt_dangerous_approval()` directly with zero hook instrumentation:

```python
# before
choice = prompt_dangerous_approval(
    message, description, timeout_seconds=timeout_seconds, allow_permanent=False,
)
```

So any MCP elicitation answered on a CLI/TUI session (as opposed to a gateway platform like Telegram/Slack) was completely invisible to the tool-approval observability pipeline, while the structurally near-identical dangerous-command approval flow fires hooks on every surface.

## Fix

Wraps the CLI/TUI prompt with the same `pre_approval_request`/`post_approval_response` pair the other call sites use, with matching payload shape (`command`, `description`, `pattern_key="mcp_elicitation"`, `pattern_keys`, `session_key`, `surface`).

The exception path also fires `post_approval_response` (with `choice="error"`) before returning `"decline"` — mirroring how `_await_gateway_decision` fires `post_approval_response` with `choice="notify_failed"` on its own failure path, so the fail-closed contract this function documents ("exceptions all map to decline") still reports a completed observation instead of silently dropping it.

## Test plan

New `tests/tools/test_elicitation_approval_hooks.py::TestElicitationCliHooksFire` (4 cases):
- Accept and decline outcomes both fire `pre_approval_request` then `post_approval_response` with the expected payload.
- A `prompt_dangerous_approval` exception still fires `post_approval_response` (`choice="error"`) while preserving the decline-on-error fail-closed contract.
- The `surface` kwarg (defaults to `"mcp-elicitation"`) propagates through to both hook calls.

Mutation-verified: reverted the production fix, confirmed all 4 new tests fail (no hooks captured / `IndexError`).

- `pytest tests/tools/test_elicitation_approval_hooks.py tests/tools/test_mcp_elicitation.py tests/tools/test_approval_plugin_hooks.py tests/tools/test_approval.py` — 132 passed, 1 unrelated pre-existing failure (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, a macOS `/tmp` symlink-resolution quirk — confirmed identical failure on a clean checkout with this fix stashed out).
- `ruff check` — clean.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Tests added and passing