### PR TITLE
fix(tools): preserve surrogateescape bytes in local writes

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,7 +6,9 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment, _BoundedOutputCollector
+import pytest
+
+from tools.environments.base import BaseEnvironment, _BoundedOutputCollector, _pipe_stdin
 
 
 class _TestableEnv(BaseEnvironment):
@@ -20,6 +22,20 @@ class _TestableEnv(BaseEnvironment):
 
     def cleanup(self):
         pass
+
+
+class TestPipeStdin:
+    def test_invalid_surrogate_closes_pipe_and_propagates(self):
+        from io import BytesIO
+        from types import SimpleNamespace
+
+        stdin = BytesIO()
+        proc = SimpleNamespace(stdin=stdin)
+
+        with pytest.raises(UnicodeEncodeError):
+            _pipe_stdin(proc, "\ud800")
+
+        assert stdin.closed is True
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_write_verification.py
+++ b/tests/tools/test_write_verification.py
@@ -27,6 +27,26 @@ class TestWriteVerification:
         r = json.loads(write_file_tool(str(f), content, task_id="t-wv"))
         assert r.get("verified") is True
 
+    def test_surrogateescape_content_round_trips_original_bytes(self, workdir):
+        from tools.environments.local import LocalEnvironment
+        from tools.file_operations import ShellFileOperations
+
+        original = b"prefix\xffsuffix\n"
+        content = original.decode("utf-8", "surrogateescape")
+        target = workdir / "surrogate.bin"
+        env = LocalEnvironment(cwd=str(workdir), timeout=5)
+
+        try:
+            result = ShellFileOperations(env).write_file(str(target), content)
+        finally:
+            env.cleanup()
+
+        assert result.error is None
+        assert result.bytes_written == len(original)
+        assert result.verified is True
+        assert target.read_bytes() == original
+        assert list(workdir.glob(".hermes-tmp.*")) == []
+
     def test_crlf_preservation_still_verifies(self, workdir):
         # Existing CRLF file: write_file converts LF content to CRLF before
         # writing; verification hashes the shim-adjusted content, so it must

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -266,7 +266,7 @@ def get_sandbox_dir() -> Path:
 # ---------------------------------------------------------------------------
 
 
-def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
+def _pipe_stdin(proc: subprocess.Popen, data: str | bytes) -> None:
     """Write *data* to proc.stdin on a daemon thread to avoid pipe-buffer deadlocks.
 
     On Windows, text-mode stdin (``text=True`` / ``encoding="utf-8"``)
@@ -283,6 +283,22 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
     produce there.
     """
 
+    # Encode before starting the daemon thread so invalid input fails in the
+    # caller instead of becoming an unhandled thread exception that leaves the
+    # child waiting forever for EOF. ``surrogateescape`` reverses the decoding
+    # used for non-UTF-8 backend output (U+DC80..U+DCFF -> original bytes).
+    target = getattr(proc.stdin, "buffer", proc.stdin)
+    try:
+        raw = data.encode("utf-8", "surrogateescape") if isinstance(data, str) else data
+    except UnicodeEncodeError:
+        # The process already exists by the time stdin is attached. Close the
+        # pipe before propagating so the child observes EOF instead of hanging.
+        try:
+            target.close()
+        except (BrokenPipeError, OSError, ValueError):
+            pass
+        raise
+
     def _write():
         try:
             # proc.stdin is a TextIOWrapper when text=True was set on the
@@ -290,12 +306,14 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
             # that bypasses newline translation.  When Popen was created
             # in byte mode, proc.stdin is already a BufferedWriter with
             # no ``.buffer`` attribute — fall back to .write() directly.
-            raw = data.encode("utf-8") if isinstance(data, str) else data
-            target = getattr(proc.stdin, "buffer", proc.stdin)
             target.write(raw)
-            target.close()
         except (BrokenPipeError, OSError):
             pass
+        finally:
+            try:
+                target.close()
+            except (BrokenPipeError, OSError, ValueError):
+                pass
 
     threading.Thread(target=_write, daemon=True).start()
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1557,6 +1557,17 @@ class ShellFileOperations(FileOperations):
         # rather than an external IDE.
         self._snapshot_lsp_baseline(path)
 
+        # Prepare the exact bytes before starting the atomic-write subprocess.
+        # ``surrogateescape`` reverses backend decoding for U+DC80..U+DCFF;
+        # other lone surrogates are unsupported and must fail before a child
+        # can be left waiting for stdin.
+        try:
+            content_bytes = content.encode("utf-8", "surrogateescape")
+        except UnicodeEncodeError as exc:
+            return WriteResult(
+                error=f"Failed to write file: content cannot be encoded as UTF-8: {exc}"
+            )
+
         # Write atomically.  ``mkdir -p`` is folded into _atomic_write
         # (one fewer subprocess vs. a separate mkdir call).
         # ``dirs_created`` has always meant "parent dirs ensured" —
@@ -1589,13 +1600,12 @@ class ShellFileOperations(FileOperations):
 
         # Get bytes written — compute from the content we just wrote
         # (len of the UTF-8 encoding matches wc -c) instead of spawning a
-        # ``wc -c`` subprocess. ``surrogatepass`` matches the sha256
-        # verification below: content that flowed through a surrogateescape
-        # decode (backend output via patch_replace) may carry lone
-        # surrogates a strict encode would reject.  Encode ONCE and share
+        # ``wc -c`` subprocess. ``surrogateescape`` matches the stdin
+        # transport: content decoded from non-UTF-8 backend output may carry
+        # U+DC80..U+DCFF, which must map back to the original bytes rather than
+        # the three-byte encoding produced by ``surrogatepass``. Encode ONCE and share
         # the bytes with the sha256 block — a second full encode of a
         # multi-MB file is measurable.
-        content_bytes = content.encode('utf-8', 'surrogatepass')
         bytes_written = len(content_bytes)
 
         # Post-write content verification (cheap, one shell call): compare


### PR DESCRIPTION
## What does this PR do?

Preserves the original bytes when `write_file` receives text produced by
Python's `surrogateescape` decoder.

The local stdin writer previously encoded on a daemon thread with strict
UTF-8. A value such as `U+DCFF` raised `UnicodeEncodeError` in that thread,
left stdin open, and made the atomic-write child wait for EOF until timeout.
The later byte-count and SHA-256 logic also used `surrogatepass`, which maps
`U+DCFF` to `ED B3 BF` instead of restoring the original `FF` byte.

This change:

- encodes stdin synchronously with `surrogateescape`, so encoding failures
  propagate to the caller;
- always closes the child stdin pipe in a `finally` block;
- prepares the exact content bytes before starting the atomic write;
- reuses those bytes for byte count and SHA-256 verification.

## Related Issue

Fixes #79178

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/environments/base.py`: round-trip surrogateescaped bytes through
  subprocess stdin and guarantee EOF.
- `tools/file_operations.py`: use one surrogateescape byte representation
  for transport, length, and hash verification.
- `tests/tools/test_write_verification.py`: exercise the real
  `LocalEnvironment` path and verify original bytes, count, hash, and temp
  cleanup.
- `tests/tools/test_base_environment.py`: verify unsupported lone surrogates
  propagate while closing stdin.

## How to Test

```powershell
python -m pytest tests\tools\test_write_verification.py tests\tools\test_base_environment.py::TestPipeStdin -q
python -m py_compile tools\environments\base.py tools\file_operations.py tests\tools\test_base_environment.py tests\tools\test_write_verification.py
python scripts\check-windows-footguns.py tools\environments\base.py tools\file_operations.py tests\tools\test_base_environment.py tests\tools\test_write_verification.py
```

Result: 7 focused tests passed; Python compilation, diff checks, and
Windows-footgun checks passed.

A broader related run produced 63 passes and 11 pre-existing Windows-only
failures caused by tests that hard-code `/bin/bash`, assert POSIX
modes/symlinks, or use POSIX shell path semantics. None touched the changed
paths or failed the new regression.

## Checklist

- [x] I've read the contributing guide.
- [x] The commit follows Conventional Commits.
- [x] I searched for existing PRs by issue number and relevant keywords.
- [x] The PR contains only changes related to this fix.
- [x] I added regression tests for the bug.
- [x] Tested on native Windows with Python 3.12.2.
- [x] Documentation/config/tool schemas: N/A.
- [x] Cross-platform impact considered: `surrogateescape` is Python's
  reversible backend byte mapping on all supported platforms.
