### PR TITLE
fix(session-search): cap discovery payloads

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -13,6 +13,7 @@ import time
 import pytest
 
 from hermes_state import SessionDB
+from tools.registry import registry
 from tools.session_search_tool import (
     SESSION_SEARCH_SCHEMA,
     _format_timestamp,
@@ -80,6 +81,9 @@ class TestSchema:
         assert "role_filter" in params
         # Mode is inferred from which args are set — no explicit mode param
         assert "mode" not in params
+
+    def test_registry_caps_large_discovery_payloads(self):
+        assert registry.get_max_result_size("session_search") == 12_000
 
 
 class TestFormatTimestamp:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -1158,4 +1158,8 @@ registry.register(
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",
+    # Discovery can include bookends plus a hit window from several huge
+    # sessions. Keep it inline-sized; callers can scroll/read the precise
+    # session slice instead of flooding the next model request.
+    max_result_size_chars=12_000,
 )


### PR DESCRIPTION
## Problem
A discovery over a very long session returned 43K characters inline. Combined with parallel memory/skill results, the next model call returned empty content repeatedly.

## Fix
Register `session_search` with a 12K result cap. Oversized discovery output is persisted/previewed, while targeted scroll/read remains available.

## Verification
`scripts/run_tests.sh tests/tools/test_session_search.py tests/tools/test_tool_result_storage.py` — 66 passed.