### PR TITLE
fix(agent): scope tool_call_id dedup to current turn, not whole session

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3411,6 +3411,20 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # here even though repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
     #   (b) drop later tool result messages reusing an already-seen id
+    #
+    # NOTE (cross-turn id collision, #73412): the seen-sets are reset on
+    # EVERY assistant message. call_ids are deterministic
+    # (_deterministic_call_id hashes fn-name + args + index for prompt-cache
+    # prefix stability), so in a multi-turn Responses-API session the model
+    # legitimately re-issues the SAME tool with the SAME arguments across
+    # turns (e.g. every data-insight task replays skill_view + tool_describe
+    # probes), producing identical call_ids in different assistant messages.
+    # A single session-global seen-set misclassified those legal cross-turn
+    # calls as duplicates, deleted them, and left `tool_calls: []` on the
+    # message — HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on
+    # strict providers. Scoping dedup to the current assistant message (and
+    # its tool results) preserves within-turn dedup while never collapsing
+    # distinct turns.
     seen_assistant_call_ids: set = set()
     seen_result_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
@@ -3418,6 +3432,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     for msg in messages:
         role = msg.get("role")
         if role == "assistant" and msg.get("tool_calls"):
+            # Reset both seen-sets at each assistant turn boundary so the
+            # dedup scope is the CURRENT turn, not the whole session.
+            seen_assistant_call_ids = set()
+            seen_result_call_ids = set()
             kept_tcs = []
             for tc in msg.get("tool_calls") or []:
                 cid = _ra().AIAgent._get_tool_call_id_static(tc)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3671,52 +3671,53 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             len(missing_results),
         )
 
-    # 3. Deduplicate tool_call_ids. Strict providers (DeepSeek) reject a
-    # payload where the same tool_call_id appears more than once with HTTP 400
-    # "Duplicate value for 'tool_call_id'" (#58327). Duplicates can arise from
-    # retries, crash/resume glitches, or a compression window that re-emits a
-    # tool result. This is the final pre-API chokepoint, so dedup defensively
-    # here even though repair_message_sequence also consumes matched ids.
+    # 3. Deduplicate tool_call_ids WITHIN the current assistant turn. The
+    # "Duplicate value for 'tool_call_id'" rejection (#58327) applies when the
+    # SAME call appears twice in one payload as a re-emission of the SAME
+    # logical call — retries, crash/resume glitches, or a compression window
+    # that re-emits a tool result. Identical call_ids across DISTINCT turns
+    # are legal: call_ids are deterministic (_deterministic_call_id hashes
+    # fn-name + args + index for prompt-cache prefix stability), so a
+    # multi-turn Responses-API session (chained via previous_response_id)
+    # legitimately re-issues the SAME tool with the SAME arguments every turn,
+    # producing identical call_ids in different assistant messages — DeepSeek
+    # v4 accepts such payloads (verified against api.deepseek.com). This is
+    # the final pre-API chokepoint, so dedup defensively here even though
+    # repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
     #   (b) drop later tool result messages reusing an already-seen id
     #
-    # NOTE (cross-turn id collision, #73412): the seen-sets are reset on
-    # EVERY assistant message. call_ids are deterministic
-    # (_deterministic_call_id hashes fn-name + args + index for prompt-cache
-    # prefix stability), so in a multi-turn Responses-API session the model
-    # legitimately re-issues the SAME tool with the SAME arguments across
-    # turns (e.g. every data-insight task replays skill_view + tool_describe
-    # probes), producing identical call_ids in different assistant messages.
-    # A single session-global seen-set misclassified those legal cross-turn
-    # calls as duplicates, deleted them, and left `tool_calls: []` on the
-    # message — HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on
-    # strict providers. Scoping dedup to the current assistant message (and
-    # its tool results) preserves within-turn dedup while never collapsing
-    # distinct turns.
+    # The seen-sets are reset on EVERY assistant message, so the dedup scope
+    # is the CURRENT turn (message + its tool results): within-turn duplicates
+    # are still collapsed, while legal identical call_ids across distinct
+    # turns are preserved — never collapsing a turn down to `tool_calls: []`
+    # (HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on strict
+    # providers).
     seen_assistant_call_ids: set = set()
     seen_result_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
         role = msg.get("role")
-        if role == "assistant" and msg.get("tool_calls"):
-            # Reset both seen-sets at each assistant turn boundary so the
-            # dedup scope is the CURRENT turn, not the whole session.
+        if role == "assistant":
+            # Reset both seen-sets at EVERY assistant message so the dedup
+            # scope is the CURRENT turn, not the whole session.
             seen_assistant_call_ids = set()
             seen_result_call_ids = set()
-            kept_tcs = []
-            for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                if cid and cid in seen_assistant_call_ids:
-                    removed_dupes += 1
-                    continue
-                if cid:
-                    seen_assistant_call_ids.add(cid)
-                kept_tcs.append(tc)
-            if kept_tcs:
-                msg = {**msg, "tool_calls": kept_tcs}
-            elif len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+            if msg.get("tool_calls"):
+                kept_tcs = []
+                for tc in msg.get("tool_calls") or []:
+                    cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                    if cid and cid in seen_assistant_call_ids:
+                        removed_dupes += 1
+                        continue
+                    if cid:
+                        seen_assistant_call_ids.add(cid)
+                    kept_tcs.append(tc)
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                elif len(kept_tcs) != len(msg.get("tool_calls") or []):
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3679,6 +3679,20 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # here even though repair_message_sequence also consumes matched ids.
     #   (a) collapse duplicate tool_calls WITHIN an assistant message
     #   (b) drop later tool result messages reusing an already-seen id
+    #
+    # NOTE (cross-turn id collision, #73412): the seen-sets are reset on
+    # EVERY assistant message. call_ids are deterministic
+    # (_deterministic_call_id hashes fn-name + args + index for prompt-cache
+    # prefix stability), so in a multi-turn Responses-API session the model
+    # legitimately re-issues the SAME tool with the SAME arguments across
+    # turns (e.g. every data-insight task replays skill_view + tool_describe
+    # probes), producing identical call_ids in different assistant messages.
+    # A single session-global seen-set misclassified those legal cross-turn
+    # calls as duplicates, deleted them, and left `tool_calls: []` on the
+    # message — HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on
+    # strict providers. Scoping dedup to the current assistant message (and
+    # its tool results) preserves within-turn dedup while never collapsing
+    # distinct turns.
     seen_assistant_call_ids: set = set()
     seen_result_call_ids: set = set()
     deduped: List[Dict[str, Any]] = []
@@ -3686,6 +3700,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     for msg in messages:
         role = msg.get("role")
         if role == "assistant" and msg.get("tool_calls"):
+            # Reset both seen-sets at each assistant turn boundary so the
+            # dedup scope is the CURRENT turn, not the whole session.
+            seen_assistant_call_ids = set()
+            seen_result_call_ids = set()
             kept_tcs = []
             for tc in msg.get("tool_calls") or []:
                 cid = _ra().AIAgent._get_tool_call_id_static(tc)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -356,6 +356,76 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_sanitize_preserves_identical_call_ids_across_turns():
+    """Cross-turn dedup scope: legal identical call_ids in DIFFERENT assistant
+    turns must NOT be collapsed (guards against over-dedup re-introducing
+    ``tool_calls: []``).
+
+    call_ids are deterministic (_deterministic_call_id hashes fn-name + args +
+    index for prompt-cache prefix stability), so a multi-turn session where the
+    model legitimately re-issues the same tool with the same arguments
+    produces IDENTICAL call_ids in different assistant messages. The dedup
+    pass used a session-global seen-set, misclassified those legal cross-turn
+    calls as duplicates, deleted them, and wrote ``tool_calls: []`` back —
+    HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on strict
+    providers (DeepSeek v4). Dedup must be scoped to the CURRENT assistant
+    turn (message + its tool results), not the whole session.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    # Turn 1: assistant issues call_00/call_01, both results follow.
+    # Turn 2: the model repeats the SAME tools with SAME args → same ids.
+    messages = [
+        {"role": "user", "content": "task 1"},
+        {"role": "assistant", "content": "t1", "tool_calls": [
+            {"id": "call_00_abc", "type": "function",
+             "function": {"name": "skill_view", "arguments": '{"name": "data-insight"}'}},
+            {"id": "call_01_abc", "type": "function",
+             "function": {"name": "tool_describe", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_00_abc", "content": "r1a"},
+        {"role": "tool", "tool_call_id": "call_01_abc", "content": "r1b"},
+        {"role": "user", "content": "task 2"},
+        {"role": "assistant", "content": "t2", "tool_calls": [
+            {"id": "call_00_abc", "type": "function",
+             "function": {"name": "skill_view", "arguments": '{"name": "data-insight"}'}},
+            {"id": "call_01_abc", "type": "function",
+             "function": {"name": "tool_describe", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_00_abc", "content": "r2a"},
+        {"role": "tool", "tool_call_id": "call_01_abc", "content": "r2b"},
+    ]
+    out = sanitize_api_messages(list(messages))
+
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert len(assistants) == 2
+    # BOTH turns must keep their (identical) tool_calls — never emptied.
+    for am in assistants:
+        assert [tc["id"] for tc in am["tool_calls"]] == ["call_00_abc", "call_01_abc"]
+    # All four tool results survive; duplicate ids across turns are legal.
+    tool_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+    assert tool_ids == ["call_00_abc", "call_01_abc", "call_00_abc", "call_01_abc"]
+
+
+def test_sanitize_still_dedups_identical_call_ids_within_one_turn():
+    """Within-turn dedup must still collapse true duplicates (regression guard:
+    the per-turn seen-set reset must not disable within-message dedup)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "assistant", "content": "t", "tool_calls": [
+            {"id": "call_Z", "type": "function",
+             "function": {"name": "a", "arguments": "{}"}},
+            {"id": "call_Z", "type": "function",
+             "function": {"name": "b", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_Z", "content": "r"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
 
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -453,6 +453,40 @@ def test_sanitize_still_dedups_identical_call_ids_within_one_turn():
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
 
 
+def test_sanitize_resets_dedup_across_content_only_assistant_message():
+    """The seen-sets are reset at EVERY assistant message, including
+    content-only ones. A content-only assistant message between two tool
+    turns must not leak the earlier turn's ids into the next turn — the
+    later turn's identical call_ids are legal cross-turn repeats, not
+    duplicates of the earlier turn."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "task 1"},
+        {"role": "assistant", "content": "t1", "tool_calls": [
+            {"id": "call_A", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "r1"},
+        # content-only assistant message (no tool_calls) between the turns
+        {"role": "assistant", "content": "interim summary"},
+        {"role": "user", "content": "task 2"},
+        {"role": "assistant", "content": "t2", "tool_calls": [
+            {"id": "call_A", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "r2"},
+    ]
+    out = sanitize_api_messages(list(messages))
+
+    tool_assistants = [m for m in out
+                       if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert len(tool_assistants) == 2
+    for am in tool_assistants:
+        assert [tc["id"] for tc in am["tool_calls"]] == ["call_A"]
+    # Both tool results survive — cross-turn repeat, not a within-turn dupe.
+    tool_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+    assert tool_ids == ["call_A", "call_A"]
+
+
 
 
 
@@ -465,48 +499,3 @@ def test_sanitize_still_dedups_identical_call_ids_within_one_turn():
 # "all messages must have non-empty content except for the optional final
 # assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
 # such turns on the per-call copy so the session recovers itself in memory.
-
-
-def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
-    """When dedup removes ALL tool_calls from an assistant message,
-    the key is dropped instead of writing tool_calls: [].
-
-    DeepSeek v4 and newer OpenAI reject empty tool_calls with HTTP 400.
-    The dedup pass introduced by #58327 can produce this state when
-    all tool_call_ids are duplicates of earlier messages in a long
-    history. The fix (#64335) drops the key entirely rather than
-    writing an empty array.
-    """
-    from agent.agent_runtime_helpers import sanitize_api_messages
-
-    # Simulate a long conversation where the same tool_call_id appears
-    # in multiple assistant messages (e.g., crash/resume glitch or
-    # compression window re-emission). The first occurrence is kept,
-    # later duplicates are removed.
-    messages = [
-        {"role": "user", "content": "step 1"},
-        {"role": "assistant", "content": "running",
-         "tool_calls": [{"id": "call_A", "type": "function",
-                         "function": {"name": "foo", "arguments": "{}"}}]},
-        {"role": "tool", "tool_call_id": "call_A", "content": "result 1"},
-        # Simulate a later assistant message that reuses call_A
-        # (this would be invalid, but the dedup pass handles it)
-        {"role": "assistant", "content": "retrying",
-         "tool_calls": [{"id": "call_A", "type": "function",
-                         "function": {"name": "foo", "arguments": "{}"}}]},
-    ]
-
-    out = sanitize_api_messages(list(messages))
-
-    # First assistant should keep tool_calls (first occurrence)
-    assistant1 = [m for m in out if m.get("role") == "assistant"][0]
-    assert "tool_calls" in assistant1
-    assert len(assistant1["tool_calls"]) == 1
-    assert assistant1["tool_calls"][0]["id"] == "call_A"
-
-    # Second assistant should have tool_calls key DROPPED
-    # (all tool_calls were deduped as duplicates of call_A)
-    assistant2 = [m for m in out if m.get("role") == "assistant"][1]
-    assert "tool_calls" not in assistant2
-    # Content should be preserved
-    assert assistant2["content"] == "retrying"

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -383,6 +383,76 @@ def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
     assert "second" in assistants[0]["content"]
 
 
+def test_sanitize_preserves_identical_call_ids_across_turns():
+    """Cross-turn dedup scope: legal identical call_ids in DIFFERENT assistant
+    turns must NOT be collapsed (guards against over-dedup re-introducing
+    ``tool_calls: []``).
+
+    call_ids are deterministic (_deterministic_call_id hashes fn-name + args +
+    index for prompt-cache prefix stability), so a multi-turn session where the
+    model legitimately re-issues the same tool with the same arguments
+    produces IDENTICAL call_ids in different assistant messages. The dedup
+    pass used a session-global seen-set, misclassified those legal cross-turn
+    calls as duplicates, deleted them, and wrote ``tool_calls: []`` back —
+    HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on strict
+    providers (DeepSeek v4). Dedup must be scoped to the CURRENT assistant
+    turn (message + its tool results), not the whole session.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    # Turn 1: assistant issues call_00/call_01, both results follow.
+    # Turn 2: the model repeats the SAME tools with SAME args → same ids.
+    messages = [
+        {"role": "user", "content": "task 1"},
+        {"role": "assistant", "content": "t1", "tool_calls": [
+            {"id": "call_00_abc", "type": "function",
+             "function": {"name": "skill_view", "arguments": '{"name": "data-insight"}'}},
+            {"id": "call_01_abc", "type": "function",
+             "function": {"name": "tool_describe", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_00_abc", "content": "r1a"},
+        {"role": "tool", "tool_call_id": "call_01_abc", "content": "r1b"},
+        {"role": "user", "content": "task 2"},
+        {"role": "assistant", "content": "t2", "tool_calls": [
+            {"id": "call_00_abc", "type": "function",
+             "function": {"name": "skill_view", "arguments": '{"name": "data-insight"}'}},
+            {"id": "call_01_abc", "type": "function",
+             "function": {"name": "tool_describe", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_00_abc", "content": "r2a"},
+        {"role": "tool", "tool_call_id": "call_01_abc", "content": "r2b"},
+    ]
+    out = sanitize_api_messages(list(messages))
+
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    assert len(assistants) == 2
+    # BOTH turns must keep their (identical) tool_calls — never emptied.
+    for am in assistants:
+        assert [tc["id"] for tc in am["tool_calls"]] == ["call_00_abc", "call_01_abc"]
+    # All four tool results survive; duplicate ids across turns are legal.
+    tool_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+    assert tool_ids == ["call_00_abc", "call_01_abc", "call_00_abc", "call_01_abc"]
+
+
+def test_sanitize_still_dedups_identical_call_ids_within_one_turn():
+    """Within-turn dedup must still collapse true duplicates (regression guard:
+    the per-turn seen-set reset must not disable within-message dedup)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "assistant", "content": "t", "tool_calls": [
+            {"id": "call_Z", "type": "function",
+             "function": {"name": "a", "arguments": "{}"}},
+            {"id": "call_Z", "type": "function",
+             "function": {"name": "b", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_Z", "content": "r"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistant = [m for m in out if m.get("role") == "assistant"][0]
+    assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_Z"]
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

sanitize_api_messages() in agent/agent_runtime_helpers.py scopes its tool_call_id dedup pass to the current assistant turn instead of the whole message list.

Root cause. The dedup pass used a session-global seen_assistant_call_ids set across all messages. call_ids are deterministic (_deterministic_call_id hashes fn-name + args + index for prompt-cache prefix stability), so in a multi-turn session (e.g. Responses API chained via previous_response_id) the model legitimately re-issues the same tool with the same arguments across turns — producing identical call_ids in different assistant messages.

The global seen-set misclassified those legal cross-turn calls as duplicates, deleted them, and wrote `tool_calls: []` back onto the message (the dedup pass runs after the empty-array sanitizer, so the empty array escaped). Strict OpenAI-compatible providers (DeepSeek v4) reject it with HTTP 400 `Invalid 'messages[N].tool_calls': empty array` — a non-retryable client error that permanently wedges the session.

Why this approach. Dropping the `tool_calls` key when `kept_tcs` is empty (the symptom-level fix now merged on main, ref #64335) stops the 400 but still silently deletes legal cross-turn tool calls — in the real failing session below that was 30 legal calls and 37 tool results erased from a 63-message history. Scoping dedup to the current turn fixes the root cause: within-turn duplicates are still collapsed (original intent of #58327), while identical call_ids across distinct turns are preserved — so the empty array is never created in the first place.

Cross-turn duplicate ids are legal. Verified live against api.deepseek.com: a chat.completions payload carrying the same tool_call_id in two assistant messages and two tool results (the exact post-fix shape) returns HTTP 200 on deepseek-chat. The #58327 "Duplicate value for 'tool_call_id'" rejection applies to re-emissions of the SAME logical call within a turn (retries, crash/resume glitches, compression re-emission), which per-turn dedup still handles. This fix has also been running in production on DeepSeek v4 since Aug 5 without a single duplicate-id 400.

## Related Issue

Fixes #64335

Related (same empty-array 400 class, still reproducible after symptom-level fixes): #74101, #70126, #77921.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- agent/agent_runtime_helpers.py — reset both seen_assistant_call_ids / seen_result_call_ids sets at EVERY assistant message in the dedup pass of sanitize_api_messages(), scoping dedup to the current turn; comment updated to scope the #58327 duplicate-id rejection to within-turn re-emissions (cross-turn repeats verified accepted by DeepSeek v4).
- tests/run_agent/test_message_sequence_repair.py —
  - test_sanitize_preserves_identical_call_ids_across_turns — the failure shape; fails on main's global dedup
  - test_sanitize_still_dedups_identical_call_ids_within_one_turn — guards within-turn dedup
  - test_sanitize_resets_dedup_across_content_only_assistant_message — content-only assistant messages between tool turns also reset the seen-sets
  - test_repair_drops_stale_empty_tool_calls_on_merged_assistant retained from main (PR rebased onto current main)
  - test_sanitize_dedup_drops_tool_calls_key_when_all_removed removed: it asserted the payload-global premise this fix corrects (a later turn reusing an id is "invalid" and must be deduped away); that scenario is covered by the cross-turn test with the correct outcome. The key-drop branch stays in the code as defense-in-depth.

## How to Test

1. Reproduce: in a multi-turn Responses-API session (chained via previous_response_id) where each turn replays the same tool probes (e.g. an agent that calls skill_view + tool_describe with identical args every turn), run enough turns to accumulate history — main's global dedup erases the later turns' tool calls and results; pre-key-drop builds 400 with `Invalid 'messages[N].tool_calls': empty array` on strict providers (DeepSeek v4).
2. Regression suites: `pytest tests/run_agent/test_message_sequence_repair.py -q` → 18 passed; related sanitize/repair suites → 100 passed.
3. Verified against a real failing session (63-message history): before the fix removed_dupes = 30, `tool_calls: []` written to 7 assistant messages, 37 tool-result messages deleted; after the fix removed_dupes = 0, zero empty arrays, all tool results retained. Since then running in production on DeepSeek v4.

## Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass (ran the sanitize/repair-related suites instead: 100 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 (Ubuntu), Python 3.11

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A (docstring updated in the dedup pass explaining the per-turn scope)
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix — real failing session (63-message history through sanitize_api_messages):
Pre-call sanitizer: removed 30 duplicate tool_call_id reference(s)
→ 7 assistant messages carry tool_calls: [] → DeepSeek HTTP 400
  "Invalid 'messages[26].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead."

After fix — same session:
removed_dupes = 0, zero empty tool_calls arrays, 37 tool-result messages retained
pytest tests/run_agent/test_message_sequence_repair.py -q → 18 passed