### PR TITLE
fix(model-switch): read picker key_env through the per-profile secret scope

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1916,6 +1916,30 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
     return t
 
 
+def _scoped_key_env(name: str) -> str:
+    """Read a provider key env var through the per-profile secret scope.
+
+    The multiplexed gateway installs a secret scope per turn; a raw
+    ``os.environ`` read hands the current profile whatever key happens to be
+    in the process environment — another profile's, in a multiplexer. That is
+    the class swept in 854007d1c for the fallback/aux key reads; the picker's
+    ``key_env`` reads were not covered.
+
+    Identical to ``os.getenv`` when multiplexing is off. A fail-closed
+    ``UnscopedSecretError`` (multiplexing on, no scope installed) means "no
+    credential visible for this profile here", which is exactly how the picker
+    already treats a missing key.
+    """
+    if not name:
+        return ""
+    try:
+        from agent.secret_scope import get_secret
+
+        return (get_secret(name, "") or "").strip()
+    except Exception:
+        return ""
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -2674,7 +2698,7 @@ def list_authenticated_providers(
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
-                api_key = os.environ.get(key_env, "").strip() if key_env else ""
+                api_key = _scoped_key_env(key_env)
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
@@ -2830,9 +2854,7 @@ def list_authenticated_providers(
                 continue
             inline_api_key = (entry.get("api_key") or "").strip()
             key_env = (entry.get("key_env") or "").strip()
-            api_key = inline_api_key or (
-                os.environ.get(key_env, "").strip() if key_env else ""
-            )
+            api_key = inline_api_key or _scoped_key_env(key_env)
             api_mode = str(
                 entry.get("api_mode")
                 or entry.get("transport")

--- a/tests/hermes_cli/test_model_picker_secret_scope.py
+++ b/tests/hermes_cli/test_model_picker_secret_scope.py
@@ -1,0 +1,44 @@
+"""The /model picker must read provider keys through the per-profile scope.
+
+854007d1c ("route remaining main-agent fallback key reads through
+secret_scope") swept the fallback/auxiliary key reads. ``key_env`` lookups in
+``list_authenticated_providers`` — which the gateway's ``/model`` handler calls
+directly — were not covered, so under ``multiplex_profiles`` one profile's
+picker resolved another profile's key from the process environment.
+"""
+
+import os
+
+from agent import secret_scope
+from hermes_cli.model_switch import _scoped_key_env
+
+
+class TestPickerKeyEnvScope:
+    def test_unscoped_read_matches_the_process_environment(self, monkeypatch):
+        """Single-profile deployments must behave exactly as before."""
+        monkeypatch.setenv("ACME_KEY", "from-environment")
+
+        assert _scoped_key_env("ACME_KEY") == "from-environment"
+
+    def test_installed_scope_wins_over_the_process_environment(self, monkeypatch):
+        """The multiplexed gateway installs a scope per turn; the picker must
+        read that profile's credential, not whatever the process inherited."""
+        monkeypatch.setenv("ACME_KEY", "other-profile-key")
+        token = secret_scope.set_secret_scope({"ACME_KEY": "this-profile-key"})
+        try:
+            assert _scoped_key_env("ACME_KEY") == "this-profile-key"
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert _scoped_key_env("ACME_KEY") == "other-profile-key"
+
+    def test_absent_key_and_empty_name_resolve_empty(self, monkeypatch):
+        monkeypatch.delenv("ACME_KEY", raising=False)
+
+        assert _scoped_key_env("ACME_KEY") == ""
+        assert _scoped_key_env("") == ""
+
+    def test_value_is_stripped(self, monkeypatch):
+        monkeypatch.setenv("ACME_KEY", "  padded  ")
+
+        assert _scoped_key_env("ACME_KEY") == "padded"


### PR DESCRIPTION
## What

854007d1c (2026-07-31, **fix(auth): route remaining main-agent fallback key reads through secret_scope**) closed this class for `agent_init.py` and `chat_completion_helpers.py`, with `fallback_config.py` / `auxiliary_client.py` fixed earlier in the same PR. Its own framing:

> still read key_env via raw os.getenv(), missing the per-profile secret scope installed by the multiplexed gateway

`hermes_cli/model_switch.py::list_authenticated_providers` has the same two `key_env` reads and was not covered — the file does not reference `secret_scope` at all:

```python
api_key = os.environ.get(key_env, "").strip() if key_env else ""
```

That function is not CLI-only: `gateway/slash_commands.py` imports and calls it directly for `/model`. So under `multiplex_profiles`, profile B's `/model` resolves custom-endpoint and fallback-entry credentials from whatever the *process* environment holds — profile A's key — and reports those endpoints as authenticated to B.

Resolution through the scope, run against the real helper:

```
no multiplexing : profileA-key   (unchanged)
scope installed : profileB-key   (was profileA-key)
after reset     : profileA-key
```

SECURITY.md §2.3 makes credential scoping across profiles explicit, and the gateway installs the scope per turn precisely so a profile cannot reach another's secrets.

## The fix

Both reads go through a small `_scoped_key_env()` helper over `agent.secret_scope.get_secret()`.

`get_secret` is documented as "identical to the legacy `os.getenv` behavior every caller had before" when multiplexing is off, so single-profile deployments — including credentials supplied via systemd `Environment=` or a secret-manager wrapper rather than `.env` — are byte-for-byte unchanged.

The one case needing care is `get_secret`'s fail-closed `UnscopedSecretError` (multiplexing on, no scope installed). 854007d1c hit the same thing and added skip-and-continue in the fallback loop; here the helper maps it to `""`, which is exactly how the picker already treats a provider with no key — it lists it as unconfigured instead of crashing the `/model` listing.

Scope: only the two `key_env` credential reads. The other environment reads in that function are provider-presence probes (`AWS_ACCESS_KEY_ID`, `LM_BASE_URL`, per-provider `extra_env_vars`) — presence detection rather than credential resolution, and a separate question.

## Tests

New `tests/hermes_cli/test_model_picker_secret_scope.py`:

- with no scope installed the read matches the process environment — the single-profile path stays as it was
- with a scope installed the profile's own value wins over the process environment, and the process value comes back after the scope resets
- a missing variable and an empty `key_env` both resolve to `""` (what the picker treats as "unconfigured")
- the value is stripped, matching the `.strip()` the previous inline read did

Results:

```
100 passed
```

That is the new file plus every existing `model_switch` suite; on main the same suites are 96 passed, so nothing pre-existing fails on either side and nothing regressed.

The assertions sit on the new seam rather than on a red-then-green call site: the old code was an inline `os.environ.get` inside a ~900-line picker function, so the behaviour change is evidenced by the captured A/B above and pinned going forward by these tests. `scripts/check-windows-footguns.py` passes on both changed files.