### PR TITLE
fix(agent): rebind credential pool entry id on env credential refresh (#79156)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5549,6 +5549,21 @@ class AIAgent:
             return False
 
         self._env_creds_seen = resolved
+        # The env credential was just adopted, but ``_credential_pool_entry_id``
+        # may still point at the previously-rotated fallback entry — pool
+        # rotation legitimately moves the session off the env key, and this
+        # refresh intentionally does not stomp that. Rebind the id to the key
+        # now in use so a subsequent 429/401 is attributed to the entry that
+        # actually failed; otherwise ``mark_exhausted_and_rotate`` quarantines
+        # the healthy fallback key with this request's error (issue #79156).
+        try:
+            from agent.agent_runtime_helpers import sync_credential_pool_entry_id
+
+            sync_credential_pool_entry_id(self)
+        except Exception:
+            # Fail-safe: an unresolved id degrades to api_key_hint matching in
+            # mark_exhausted_and_rotate, identical to pre-fix behaviour.
+            pass
         logger.info(
             "Applied updated .env credentials for %s: endpoint %s",
             self.provider,

--- a/tests/run_agent/test_env_credential_turn_refresh.py
+++ b/tests/run_agent/test_env_credential_turn_refresh.py
@@ -146,6 +146,77 @@ class TestLeavesNonEnvStateAlone:
         assert agent._try_refresh_env_client_credentials() is False
 
 
+class TestRebindsCredentialPoolEntryId:
+    """#79156: after adopting an env credential edit, the agent's
+    ``_credential_pool_entry_id`` must be rebound to the key now in use.
+
+    When a pool rotation previously moved the session onto a fallback entry,
+    ``_credential_pool_entry_id`` points at that fallback. If the per-turn env
+    refresh then adopts a different (env) key and a subsequent 429 arrives,
+    ``mark_exhausted_and_rotate`` resolves by ``credential_id`` *first* and
+    quarantines the healthy fallback entry with the env key's error — leaving
+    the pool with "no available entries" despite a healthy key.
+    """
+
+    def test_adoption_rebinds_stale_pool_entry_id(self, env):
+        agent = _make_agent()
+        env["OPENAI_API_KEY"] = "sk-old"
+        assert agent._try_refresh_env_client_credentials() is False
+
+        # Pool rotated the session onto a fallback entry earlier; the env
+        # key is edited mid-session (the #79156 trigger).
+        import agent.agent_runtime_helpers as arh
+
+        pool = MagicMock()
+        pool.entry_id_for_api_key.return_value = "entry-env-key"
+        agent._credential_pool = pool
+        agent._credential_pool_entry_id = "entry-fallback"
+        env["OPENAI_API_KEY"] = "sk-new"
+
+        with pytest.MonkeyPatch.context() as mp:
+            captured = {}
+
+            def _fake_sync(agent_obj):
+                captured["called"] = True
+                agent_obj._credential_pool_entry_id = (
+                    agent_obj._credential_pool.entry_id_for_api_key(
+                        getattr(agent_obj, "api_key", None)
+                    )
+                )
+
+            mp.setattr(arh, "sync_credential_pool_entry_id", _fake_sync)
+
+            assert agent._try_refresh_env_client_credentials() is True
+
+        assert agent.api_key == "sk-new"
+        assert captured.get("called") is True
+        assert agent._credential_pool_entry_id == "entry-env-key"
+
+    def test_noop_turn_keeps_pool_entry_id_untouched(self, env):
+        """An unchanged env (no adoption) must not clobber the rotation's
+        credential binding — the refresh is a no-op and leaves
+        ``_credential_pool_entry_id`` exactly as the rotation set it."""
+        agent = _make_agent()
+        env["OPENAI_API_KEY"] = "sk-old"
+        assert agent._try_refresh_env_client_credentials() is False
+
+        import agent.agent_runtime_helpers as arh
+
+        agent._credential_pool = MagicMock()
+        agent._credential_pool_entry_id = "entry-fallback"
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(
+            arh,
+            "sync_credential_pool_entry_id",
+            lambda a: (_ for _ in ()).throw(AssertionError("must not be called")),
+        )
+        try:
+            assert agent._try_refresh_env_client_credentials() is False
+        finally:
+            monkeypatch.undo()
+        assert agent._credential_pool_entry_id == "entry-fallback"
+
+
 class TestFailedRebuildRetries:
     def test_failed_rebuild_rolls_back_and_retries_next_turn(self, env):
         """A failed client rebuild must not advance the edit baseline: the


### PR DESCRIPTION
## Summary

Fixes #79156. The per-turn env credential refresh (`_try_refresh_env_client_credentials`, added in `2d70f56327`) rewrites `agent.api_key` from `.env` when an edit is adopted, but leaves `agent._credential_pool_entry_id` pointing at the previously-rotated fallback entry. On the next 429/401, `mark_exhausted_and_rotate()` resolves by `credential_id` *first* and quarantines the **healthy** fallback key with the env key's error — including a `last_error_reset_at` parsed from "Resets in N days" — leaving the pool with `no available entries (all exhausted or empty)` despite one usable key. This looks like an auth failure to the user.

This PR rebinds the pool entry id via `sync_credential_pool_entry_id()` immediately after an env credential is adopted, so a subsequent failure is attributed to the entry whose key actually made the request.

## Problem

Mock scenario (no real credentials involved):

- Provider `example-provider`, pooled, 2 credentials:
  - `primary-key` (env-sourced, `EXAMPLE_PROVIDER_API_KEY`, priority 0) — upstream `workspace_A`
  - `backup-key` (manual, priority 1) — upstream `workspace_B` (healthy)
- Sequence in one live session:
  1. `primary-key` hits a real `429 GoUsageLimitError` (monthly usage limit, `workspace_A`) → pool marks it exhausted, rotates to `backup-key`, `_swap_credential()` sets `_credential_pool_entry_id = <backup-entry-id>`.
  2. Next turn: env refresh adopts the (unchanged-on-disk) env key back onto `agent.api_key = <primary-key>`. `_credential_pool_entry_id` still holds `<backup-entry-id>`.
  3. Retried request fails again with 429 (`workspace_A`).
  4. `recover_with_credential_pool` → `mark_exhausted_and_rotate(credential_id=<backup-entry-id>, api_key_hint=<primary-key>)` → `credential_id` wins → **`backup-key` is marked exhausted with `primary-key`'s error**, including `last_error_reset_at` ≈ 6 days out.
  5. Pool logs `marking backup-key exhausted (status=429)` then `no available entries (all exhausted or empty)`. Every subsequent call — including auxiliary compression/approval calls — fails with "rate limit on ... and all fallbacks exhausted".

Observed log evidence (abridged, mock):

```
ERROR chat_completion_helpers: Streaming failed before delivery: 429 GoUsageLimitError ... metadata workspace_A
INFO  credential_pool: credential pool: marking backup-key exhausted (status=429), rotating
INFO  credential_pool: credential pool: no available entries (all exhausted or empty)
WARN  auxiliary_client: Auxiliary compression: rate limit on example-provider and all fallbacks exhausted
```

## Root cause

- `AIAgent._try_refresh_env_client_credentials()` (run_agent.py) updates `self.api_key` / `self.base_url` and rebuilds the client, but never rebinds `self._credential_pool_entry_id`.
- `sync_credential_pool_entry_id()` (agent/agent_runtime_helpers.py) already exists and is used on agent init, fallback activation, and model switch — it is simply missing from the per-turn env refresh path.
- `mark_exhausted_and_rotate()` (agent/credential_pool.py) prefers `credential_id` over `api_key_hint`, so a stale id quarantines the wrong entry.

## Change

`run_agent.py` — in `_try_refresh_env_client_credentials()`, after a successful client rebuild on an adopted env edit:

```python
try:
    from agent.agent_runtime_helpers import sync_credential_pool_entry_id
    sync_credential_pool_entry_id(self)
except Exception:
    pass  # fail-safe: unresolved id degrades to api_key_hint matching (pre-fix behaviour)
```

## Tests

Added `tests/run_agent/test_env_credential_turn_refresh.py`:

- `test_adoption_rebinds_stale_pool_entry_id` — pool rotated to a fallback entry; env key edited mid-session; adoption must rebind `_credential_pool_entry_id` to the env key's entry.
- `test_noop_turn_keeps_pool_entry_id_untouched` — unchanged env (no adoption) must not clobber the rotation's binding (sync helper must not be invoked).

All credential-pool / env-refresh / rotation / fallback suites pass:

```
115 passed in 6.38s
```

(credential_pool, credential_pool_routing, credential_pool_sole_cooldown, credential_pool_quarantine_locking, env_credential_turn_refresh, credential_rotation_route_settings, fallback_credential_isolation)

## Notes / follow-ups

- `hermes auth reset <provider>` is currently ineffective for exhausted entries because `write_credential_pool` → `_merge_disk_cooldown_state` resurrects the newer on-disk cooldown over the cleared in-memory state (see issue #79156 comment). Out of scope here; a separate fix should make the documented recovery path work.
