### PR TITLE
feat: add Claude Code tmux bridge

### DIFF
--- a/agent/claude_code_tmux_bridge.py
+++ b/agent/claude_code_tmux_bridge.py
@@ -1,0 +1,357 @@
+"""Claude Code tmux bridge.
+
+Submits prompts to a running Claude Code session in a named tmux pane,
+waits for a unique completion marker, and returns the sanitised response.
+
+Usage::
+
+    from agent.claude_code_tmux_bridge import submit_prompt, BridgeStatus
+
+    result = submit_prompt("claude-momentum", "Refactor utils.py to use dataclasses")
+    if result.status == BridgeStatus.SUCCESS:
+        print(result.response)
+
+One pre-configured worker is registered at module level:
+  session ``claude-momentum``, workspace ``/home/michael/code``.
+
+Additional workers can be registered via ``register_worker()``.
+
+Notes
+-----
+* Newlines in prompts are collapsed to spaces before sending; tmux
+  ``send-keys`` treats each newline as an Enter keystroke.  Single-paragraph
+  prompts work best.
+* Auth failure is detected only at timeout (not during polling) to avoid
+  false positives from unrelated pane history.
+* No tmux session is created automatically; the session must already exist.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import logging
+import re
+import subprocess
+import threading
+import time
+import uuid
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ── ANSI / credential / auth patterns ────────────────────────────────────────
+
+_ANSI_RE = re.compile(
+    r"\x1b\[[0-9;]*[mGKHFABCDEJ]"
+    r"|\x1b\][\S\s]*?\x07"
+    r"|\x1b[()][AB012]"
+    r"|\x1b[=>]"
+    r"|\r",
+)
+
+# Redact token-shaped values that might appear in captured pane output.
+_CREDENTIAL_RE = re.compile(
+    r"(?:Bearer\s+|(?:api[-_]?key|token|password|oauth|secret)[\s=:]+)"
+    r"[A-Za-z0-9_\-\.]{16,}",
+    re.IGNORECASE,
+)
+
+_AUTH_FAILURE_RE = re.compile(
+    r"(?:"
+    r"authentication\s+(?:required|failed|expired|error)"
+    r"|oauth\s+(?:\w+\s+)*(?:error|expired|invalid|required|revoked)"
+    r"|sign[\s-]?in\s+(?:required|to|with)"
+    r"|login\s+(?:required|to|with)"
+    r"|please\s+(?:authenticate|log\s*in|sign\s*in)"
+    r"|unauthorized"
+    r"|session\s+expired"
+    r"|credentials?\s+(?:expired|invalid|required)"
+    r")",
+    re.IGNORECASE,
+)
+
+
+# ── Public types ──────────────────────────────────────────────────────────────
+
+class BridgeStatus(enum.Enum):
+    SUCCESS = "success"
+    TIMEOUT = "timeout"
+    BUSY = "busy"
+    AUTH_FAILURE = "auth_failure"
+    SESSION_MISSING = "session_missing"
+    SESSION_DEAD = "session_dead"
+    FAILURE = "failure"
+
+
+@dataclasses.dataclass
+class BridgeResult:
+    status: BridgeStatus
+    response: str = ""
+    error: str = ""
+
+
+@dataclasses.dataclass
+class WorkerConfig:
+    session: str
+    workspace: str
+    timeout: float = 300.0
+    poll_interval: float = 2.0
+
+
+# ── Worker registry ───────────────────────────────────────────────────────────
+
+_WORKERS: dict[str, WorkerConfig] = {}
+
+
+def register_worker(config: WorkerConfig) -> None:
+    """Register a named tmux worker configuration."""
+    _WORKERS[config.session] = config
+
+
+def get_worker(session: str) -> Optional[WorkerConfig]:
+    """Return the WorkerConfig for *session*, or None."""
+    return _WORKERS.get(session)
+
+
+# Pre-configured worker for Momentum Studio
+register_worker(WorkerConfig(session="claude-momentum", workspace="/home/michael/code"))
+
+
+# ── Per-session locks ─────────────────────────────────────────────────────────
+
+_session_locks: dict[str, threading.Lock] = {}
+_registry_lock = threading.Lock()
+
+
+def _get_session_lock(session: str) -> threading.Lock:
+    with _registry_lock:
+        if session not in _session_locks:
+            _session_locks[session] = threading.Lock()
+        return _session_locks[session]
+
+
+# ── Low-level tmux helpers ────────────────────────────────────────────────────
+
+def _run_tmux(*args: str, timeout: float = 10.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["tmux", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _session_exists(session: str) -> bool:
+    result = _run_tmux("has-session", "-t", session)
+    return result.returncode == 0
+
+
+def _pane_alive(session: str) -> bool:
+    result = _run_tmux("list-panes", "-t", session, "-F", "#{pane_id}")
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _send_keys(session: str, text: str) -> bool:
+    """Send *text* literally to *session* then press Enter."""
+    r = _run_tmux("send-keys", "-t", session, "-l", text)
+    if r.returncode != 0:
+        return False
+    return _run_tmux("send-keys", "-t", session, "Enter").returncode == 0
+
+
+def _capture_pane(session: str, history_lines: int = 5000) -> str:
+    result = _run_tmux(
+        "capture-pane", "-p",
+        "-t", session,
+        "-S", f"-{history_lines}",
+        timeout=15.0,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+# ── Output sanitisation ───────────────────────────────────────────────────────
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _redact_credentials(text: str) -> str:
+    return _CREDENTIAL_RE.sub("[REDACTED]", text)
+
+
+def _is_auth_failure(text: str) -> bool:
+    return bool(_AUTH_FAILURE_RE.search(_strip_ansi(text)))
+
+
+def _extract_response(pre_line_count: int, post_raw: str, done_marker: str) -> Optional[str]:
+    """Extract response lines from pane content captured after sending.
+
+    Returns lines from *pre_line_count* up to (not including) the done
+    marker line, sanitised; or None if the marker is absent.
+    """
+    clean_lines = _strip_ansi(post_raw).splitlines()
+
+    done_idx = None
+    for i, line in enumerate(clean_lines):
+        if done_marker in line:
+            done_idx = i
+            break
+
+    if done_idx is None:
+        return None
+
+    response_lines = clean_lines[pre_line_count:done_idx]
+    return _redact_credentials("\n".join(response_lines).strip())
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def submit_prompt(
+    session: str,
+    prompt: str,
+    *,
+    timeout: Optional[float] = None,
+    poll_interval: Optional[float] = None,
+) -> BridgeResult:
+    """Submit *prompt* to the Claude Code session *session*.
+
+    Parameters
+    ----------
+    session:
+        Name of the tmux session running Claude Code.
+    prompt:
+        Prompt text.  Newlines are collapsed to spaces before sending.
+    timeout:
+        Seconds to wait for a response.  Falls back to the worker's
+        configured timeout (default 300 s).
+    poll_interval:
+        Seconds between pane captures.  Falls back to the worker's
+        configured poll interval (default 2 s).
+
+    Returns
+    -------
+    BridgeResult with status one of:
+
+    SUCCESS         Response captured successfully.
+    TIMEOUT         Completion marker not seen before deadline.
+    BUSY            Another call already holds the per-session lock.
+    AUTH_FAILURE    Pane shows authentication or OAuth error at timeout.
+    SESSION_MISSING Named tmux session does not exist.
+    SESSION_DEAD    Session exists but has no responsive pane.
+    FAILURE         Subprocess error or unexpected condition.
+    """
+    worker = _WORKERS.get(session) or WorkerConfig(session=session, workspace="")
+    eff_timeout = timeout if timeout is not None else worker.timeout
+    eff_poll = poll_interval if poll_interval is not None else worker.poll_interval
+
+    # Verify session exists
+    try:
+        if not _session_exists(session):
+            return BridgeResult(
+                status=BridgeStatus.SESSION_MISSING,
+                error=f"tmux session {session!r} not found",
+            )
+    except subprocess.TimeoutExpired:
+        return BridgeResult(status=BridgeStatus.FAILURE, error="has-session timed out")
+    except FileNotFoundError:
+        return BridgeResult(status=BridgeStatus.FAILURE, error="tmux not found on PATH")
+    except OSError as exc:
+        return BridgeResult(status=BridgeStatus.FAILURE, error=str(exc))
+
+    # Verify pane is alive
+    try:
+        if not _pane_alive(session):
+            return BridgeResult(
+                status=BridgeStatus.SESSION_DEAD,
+                error=f"tmux session {session!r} has no live pane",
+            )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return BridgeResult(status=BridgeStatus.FAILURE, error=str(exc))
+
+    # Acquire per-session lock (non-blocking — BUSY if already held)
+    lock = _get_session_lock(session)
+    if not lock.acquire(blocking=False):
+        return BridgeResult(
+            status=BridgeStatus.BUSY,
+            error=f"Session {session!r} is already handling a prompt",
+        )
+    try:
+        return _run_prompt(
+            session=session,
+            prompt=prompt,
+            timeout=eff_timeout,
+            poll_interval=eff_poll,
+        )
+    finally:
+        lock.release()
+
+
+def _run_prompt(
+    *,
+    session: str,
+    prompt: str,
+    timeout: float,
+    poll_interval: float,
+) -> BridgeResult:
+    run_id = uuid.uuid4().hex
+    done_marker = f"HERMES_BRIDGE_DONE_{run_id}"
+
+    # Collapse newlines — tmux send-keys treats each \n as Enter
+    flat_prompt = " ".join(prompt.splitlines())
+    instrumented = (
+        f"{flat_prompt} "
+        f"(When your response is complete, output exactly on its own line: {done_marker})"
+    )
+
+    # Snapshot pane before sending so we can slice out only new content
+    try:
+        pre_raw = _capture_pane(session)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return BridgeResult(status=BridgeStatus.FAILURE, error=str(exc))
+    pre_line_count = len(_strip_ansi(pre_raw).splitlines())
+
+    logger.debug(
+        "bridge: sending to %r run_id=%s pre_lines=%d",
+        session, run_id, pre_line_count,
+    )
+
+    try:
+        if not _send_keys(session, instrumented):
+            return BridgeResult(status=BridgeStatus.FAILURE, error="tmux send-keys failed")
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return BridgeResult(status=BridgeStatus.FAILURE, error=str(exc))
+
+    # Poll for completion marker
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(poll_interval)
+        try:
+            post_raw = _capture_pane(session)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return BridgeResult(status=BridgeStatus.FAILURE, error=str(exc))
+
+        response = _extract_response(pre_line_count, post_raw, done_marker)
+        if response is not None:
+            logger.debug("bridge: done run_id=%s chars=%d", run_id, len(response))
+            return BridgeResult(status=BridgeStatus.SUCCESS, response=response)
+
+    # Timeout — check whether pane shows an auth error
+    try:
+        final_raw = _capture_pane(session)
+    except (subprocess.TimeoutExpired, OSError):
+        final_raw = ""
+
+    new_content = "\n".join(_strip_ansi(final_raw).splitlines()[pre_line_count:])
+    if _is_auth_failure(new_content):
+        return BridgeResult(
+            status=BridgeStatus.AUTH_FAILURE,
+            error="Authentication or OAuth failure detected in pane output",
+        )
+
+    return BridgeResult(
+        status=BridgeStatus.TIMEOUT,
+        error=f"Completion marker not seen within {timeout:.0f}s",
+    )

--- a/tests/test_claude_code_tmux_bridge.py
+++ b/tests/test_claude_code_tmux_bridge.py
@@ -1,0 +1,379 @@
+"""Tests for agent.claude_code_tmux_bridge.
+
+All tmux subprocess calls are mocked; no real tmux session is required.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+import agent.claude_code_tmux_bridge as bridge
+from agent.claude_code_tmux_bridge import (
+    BridgeResult,
+    BridgeStatus,
+    WorkerConfig,
+    _extract_response,
+    _is_auth_failure,
+    _redact_credentials,
+    _strip_ansi,
+)
+
+FAKE_RUN_ID = "cafebabe" * 4  # 32 hex chars
+
+
+@pytest.fixture(autouse=True)
+def _clear_session_locks():
+    bridge._session_locks.clear()
+    yield
+    bridge._session_locks.clear()
+
+
+# ── Pure helper unit tests ────────────────────────────────────────────────────
+
+class TestStripAnsi:
+    def test_removes_sgr_codes(self):
+        assert _strip_ansi("\x1b[32mgreen\x1b[0m") == "green"
+
+    def test_removes_osc_sequences(self):
+        assert _strip_ansi("\x1b]0;title\x07text") == "text"
+
+    def test_removes_carriage_return(self):
+        assert _strip_ansi("a\rb") == "ab"
+
+    def test_passthrough_plain_text(self):
+        assert _strip_ansi("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert _strip_ansi("") == ""
+
+
+class TestRedactCredentials:
+    def test_redacts_bearer_token(self):
+        text = "Authorization: Bearer sk-abcdef1234567890abcdef1234567890"
+        out = _redact_credentials(text)
+        assert "[REDACTED]" in out
+        assert "sk-abcdef" not in out
+
+    def test_redacts_api_key_value(self):
+        text = "api_key=supersecretlongvalue12345"
+        out = _redact_credentials(text)
+        assert "[REDACTED]" in out
+
+    def test_leaves_short_values_alone(self):
+        # Values shorter than 16 chars are not credential-shaped
+        assert _redact_credentials("token: abc") == "token: abc"
+
+    def test_leaves_unrelated_text_alone(self):
+        text = "The answer is 42."
+        assert _redact_credentials(text) == text
+
+
+class TestIsAuthFailure:
+    @pytest.mark.parametrize("text", [
+        "Authentication required",
+        "OAuth token expired",
+        "Please sign in to continue",
+        "Unauthorized",
+        "Session expired",
+        "Login required",
+        "credentials expired",
+        "Please authenticate",
+    ])
+    def test_detects_known_patterns(self, text):
+        assert _is_auth_failure(text)
+
+    def test_ignores_plain_text(self):
+        assert not _is_auth_failure("The function returns a boolean value.")
+
+    def test_strips_ansi_before_matching(self):
+        assert _is_auth_failure("\x1b[31mAuthentication required\x1b[0m")
+
+    def test_case_insensitive(self):
+        assert _is_auth_failure("AUTHENTICATION REQUIRED")
+
+
+class TestExtractResponse:
+    def test_extracts_lines_after_pre_count_up_to_marker(self):
+        done = f"HERMES_BRIDGE_DONE_{FAKE_RUN_ID}"
+        pane = "\n".join([
+            "old line 1",
+            "old line 2",
+            "The answer is 42.",
+            done,
+            "stuff after",
+        ])
+        result = _extract_response(pre_line_count=2, post_raw=pane, done_marker=done)
+        assert result is not None
+        assert "The answer is 42." in result
+        assert "old line" not in result
+        assert done not in result
+
+    def test_returns_none_when_marker_absent(self):
+        assert _extract_response(0, "line 1\nline 2", "NO_MARKER") is None
+
+    def test_strips_ansi_from_extracted_text(self):
+        done = f"HERMES_BRIDGE_DONE_{FAKE_RUN_ID}"
+        pane = f"preamble\n\x1b[32mgreen text\x1b[0m\n{done}"
+        result = _extract_response(1, pane, done)
+        assert result is not None
+        assert "\x1b" not in result
+        assert "green text" in result
+
+    def test_returns_empty_string_when_nothing_between(self):
+        done = f"HERMES_BRIDGE_DONE_{FAKE_RUN_ID}"
+        pane = f"pre\n{done}"
+        result = _extract_response(1, pane, done)
+        assert result == ""
+
+    def test_redacts_credential_in_response(self):
+        done = f"HERMES_BRIDGE_DONE_{FAKE_RUN_ID}"
+        pane = f"pre\nBearer sk-supersecretlongtokenvalue1234567\n{done}"
+        result = _extract_response(1, pane, done)
+        assert result is not None
+        assert "[REDACTED]" in result
+        assert "sk-supersecret" not in result
+
+
+# ── Integration tests with mocked tmux helpers ────────────────────────────────
+
+def _setup_session(monkeypatch, *, exists: bool = True, alive: bool = True) -> None:
+    monkeypatch.setattr(bridge, "_session_exists", lambda s: exists)
+    monkeypatch.setattr(bridge, "_pane_alive", lambda s: alive)
+
+
+def _setup_io(
+    monkeypatch,
+    *,
+    pre_pane: str = "",
+    post_pane: str = "",
+    send_ok: bool = True,
+) -> None:
+    """Mock _capture_pane to return pre_pane on first call, post_pane thereafter."""
+    call_count = [0]
+
+    def _mock_capture(s, **kw):
+        call_count[0] += 1
+        return pre_pane if call_count[0] == 1 else post_pane
+
+    monkeypatch.setattr(bridge, "_capture_pane", _mock_capture)
+    monkeypatch.setattr(bridge, "_send_keys", lambda s, t: send_ok)
+
+
+class TestSessionVerification:
+    def test_missing_session_returns_session_missing(self, monkeypatch):
+        _setup_session(monkeypatch, exists=False)
+        result = bridge.submit_prompt("claude-momentum", "hello")
+        assert result.status == BridgeStatus.SESSION_MISSING
+        assert "claude-momentum" in result.error
+
+    def test_dead_session_returns_session_dead(self, monkeypatch):
+        _setup_session(monkeypatch, exists=True, alive=False)
+        result = bridge.submit_prompt("claude-momentum", "hello")
+        assert result.status == BridgeStatus.SESSION_DEAD
+
+    def test_tmux_not_found_returns_failure(self, monkeypatch):
+        def _raise(s):
+            raise FileNotFoundError("tmux")
+        monkeypatch.setattr(bridge, "_session_exists", _raise)
+        result = bridge.submit_prompt("claude-momentum", "hello")
+        assert result.status == BridgeStatus.FAILURE
+        assert "not found" in result.error.lower()
+
+    def test_os_error_returns_failure(self, monkeypatch):
+        def _raise(s):
+            raise OSError("permission denied")
+        monkeypatch.setattr(bridge, "_session_exists", _raise)
+        result = bridge.submit_prompt("claude-momentum", "hello")
+        assert result.status == BridgeStatus.FAILURE
+
+    def test_unknown_session_uses_default_config(self, monkeypatch):
+        """Ad-hoc sessions not in _WORKERS are accepted with defaults."""
+        _setup_session(monkeypatch, exists=False)
+        result = bridge.submit_prompt("some-other-session", "hello")
+        assert result.status == BridgeStatus.SESSION_MISSING
+
+
+class TestLocking:
+    def test_busy_when_lock_already_held(self, monkeypatch):
+        _setup_session(monkeypatch)
+        lock = bridge._get_session_lock("claude-momentum")
+        lock.acquire()
+        try:
+            result = bridge.submit_prompt("claude-momentum", "hello")
+            assert result.status == BridgeStatus.BUSY
+            assert "claude-momentum" in result.error
+        finally:
+            lock.release()
+
+    def test_lock_released_after_successful_call(self, monkeypatch):
+        run_id = FAKE_RUN_ID
+        done = f"HERMES_BRIDGE_DONE_{run_id}"
+        pre = "history\n"
+        post = f"history\nresponse line\n{done}\n"
+
+        monkeypatch.setattr(bridge.uuid, "uuid4", lambda: MagicMock(hex=run_id))
+        _setup_session(monkeypatch)
+        _setup_io(monkeypatch, pre_pane=pre, post_pane=post)
+        monkeypatch.setattr(bridge.time, "sleep", lambda x: None)
+
+        result = bridge.submit_prompt("claude-momentum", "hi", timeout=30.0)
+        assert result.status == BridgeStatus.SUCCESS
+
+        # Lock must be free after the call
+        lock = bridge._get_session_lock("claude-momentum")
+        assert lock.acquire(blocking=False)
+        lock.release()
+
+    def test_lock_released_after_send_failure(self, monkeypatch):
+        _setup_session(monkeypatch)
+        monkeypatch.setattr(bridge, "_capture_pane", lambda s, **kw: "")
+        monkeypatch.setattr(bridge, "_send_keys", lambda s, t: False)
+
+        result = bridge.submit_prompt("claude-momentum", "hello", timeout=5.0)
+        assert result.status == BridgeStatus.FAILURE
+
+        lock = bridge._get_session_lock("claude-momentum")
+        assert lock.acquire(blocking=False)
+        lock.release()
+
+    def test_separate_sessions_use_separate_locks(self, monkeypatch):
+        lock_a = bridge._get_session_lock("session-a")
+        lock_b = bridge._get_session_lock("session-b")
+        assert lock_a is not lock_b
+
+        lock_a.acquire()
+        try:
+            # session-b lock is independent
+            assert lock_b.acquire(blocking=False)
+            lock_b.release()
+        finally:
+            lock_a.release()
+
+
+class TestSuccessPath:
+    def test_returns_success_with_response(self, monkeypatch):
+        run_id = FAKE_RUN_ID
+        done = f"HERMES_BRIDGE_DONE_{run_id}"
+        pre = "prior history\n"
+        post = f"prior history\nThe answer is 42.\n{done}\n"
+
+        monkeypatch.setattr(bridge.uuid, "uuid4", lambda: MagicMock(hex=run_id))
+        _setup_session(monkeypatch)
+        _setup_io(monkeypatch, pre_pane=pre, post_pane=post)
+        monkeypatch.setattr(bridge.time, "sleep", lambda x: None)
+
+        result = bridge.submit_prompt("claude-momentum", "What is 6×7?", timeout=30.0)
+        assert result.status == BridgeStatus.SUCCESS
+        assert "The answer is 42." in result.response
+
+    def test_excludes_prior_pane_history(self, monkeypatch):
+        run_id = FAKE_RUN_ID
+        done = f"HERMES_BRIDGE_DONE_{run_id}"
+        pre = "old output line 1\nold output line 2\n"
+        post = f"old output line 1\nold output line 2\nnew response\n{done}\n"
+
+        monkeypatch.setattr(bridge.uuid, "uuid4", lambda: MagicMock(hex=run_id))
+        _setup_session(monkeypatch)
+        _setup_io(monkeypatch, pre_pane=pre, post_pane=post)
+        monkeypatch.setattr(bridge.time, "sleep", lambda x: None)
+
+        result = bridge.submit_prompt("claude-momentum", "hello", timeout=30.0)
+        assert result.status == BridgeStatus.SUCCESS
+        assert "old output" not in result.response
+        assert "new response" in result.response
+
+    def test_ansi_codes_stripped_from_response(self, monkeypatch):
+        run_id = FAKE_RUN_ID
+        done = f"HERMES_BRIDGE_DONE_{run_id}"
+        post = f"\x1b[32mColoured output\x1b[0m\n{done}\n"
+
+        monkeypatch.setattr(bridge.uuid, "uuid4", lambda: MagicMock(hex=run_id))
+        _setup_session(monkeypatch)
+        _setup_io(monkeypatch, pre_pane="", post_pane=post)
+        monkeypatch.setattr(bridge.time, "sleep", lambda x: None)
+
+        result = bridge.submit_prompt("claude-momentum", "color?", timeout=30.0)
+        assert result.status == BridgeStatus.SUCCESS
+        assert "\x1b" not in result.response
+        assert "Coloured output" in result.response
+
+
+class TestTimeoutAndAuthFailure:
+    def _fast_monotonic(self):
+        ticks = [0.0]
+        def _advance():
+            ticks[0] += 10.0
+            return ticks[0]
+        return _advance
+
+    def test_returns_timeout_when_marker_never_appears(self, monkeypatch):
+        _setup_session(monkeypatch)
+        monkeypatch.setattr(bridge, "_capture_pane", lambda s, **kw: "no marker here")
+        monkeypatch.setattr(bridge, "_send_keys", lambda s, t: True)
+        monkeypatch.setattr(bridge.time, "monotonic", self._fast_monotonic())
+
+        result = bridge.submit_prompt("claude-momentum", "hello", timeout=5.0)
+        assert result.status == BridgeStatus.TIMEOUT
+        assert "5s" in result.error
+
+    def test_returns_auth_failure_when_detected_at_timeout(self, monkeypatch):
+        _setup_session(monkeypatch)
+        monkeypatch.setattr(bridge, "_send_keys", lambda s, t: True)
+        monkeypatch.setattr(bridge.time, "monotonic", self._fast_monotonic())
+
+        call_count = [0]
+        def _mock_capture(s, **kw):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ""  # pre-send snapshot
+            return "Claude: Authentication required. Please sign in."
+
+        monkeypatch.setattr(bridge, "_capture_pane", _mock_capture)
+
+        result = bridge.submit_prompt("claude-momentum", "hello", timeout=5.0)
+        assert result.status == BridgeStatus.AUTH_FAILURE
+
+    def test_no_false_auth_failure_on_success(self, monkeypatch):
+        """Old pane history with auth text must not prevent SUCCESS."""
+        run_id = FAKE_RUN_ID
+        done = f"HERMES_BRIDGE_DONE_{run_id}"
+        # Pre-existing history contains an old auth message
+        pre = "Authentication required (old history)\n"
+        post = f"Authentication required (old history)\nNew response\n{done}\n"
+
+        monkeypatch.setattr(bridge.uuid, "uuid4", lambda: MagicMock(hex=run_id))
+        _setup_session(monkeypatch)
+        _setup_io(monkeypatch, pre_pane=pre, post_pane=post)
+        monkeypatch.setattr(bridge.time, "sleep", lambda x: None)
+
+        result = bridge.submit_prompt("claude-momentum", "hi", timeout=30.0)
+        assert result.status == BridgeStatus.SUCCESS
+
+
+class TestSendFailure:
+    def test_failure_when_send_keys_returns_false(self, monkeypatch):
+        _setup_session(monkeypatch)
+        monkeypatch.setattr(bridge, "_capture_pane", lambda s, **kw: "")
+        monkeypatch.setattr(bridge, "_send_keys", lambda s, t: False)
+
+        result = bridge.submit_prompt("claude-momentum", "hello", timeout=5.0)
+        assert result.status == BridgeStatus.FAILURE
+        assert "send-keys" in result.error
+
+
+class TestWorkerRegistry:
+    def test_default_worker_registered(self):
+        w = bridge.get_worker("claude-momentum")
+        assert w is not None
+        assert w.workspace == "/home/michael/code"
+
+    def test_register_worker_roundtrip(self):
+        cfg = WorkerConfig(session="test-session", workspace="/tmp/test", timeout=60.0)
+        bridge.register_worker(cfg)
+        assert bridge.get_worker("test-session") is cfg
+
+    def test_get_worker_returns_none_for_unknown(self):
+        assert bridge.get_worker("nonexistent-xyz") is None


### PR DESCRIPTION
## Summary

- Adds `agent/claude_code_tmux_bridge.py`: a minimal, reliable helper for submitting prompts to a running Claude Code session in a named tmux pane and capturing the sanitised response.
- Adds `tests/test_claude_code_tmux_bridge.py`: 44 focused tests with mocked tmux subprocess calls (no real tmux required).

### What the bridge provides

- **Session verification**: checks tmux session exists and has a live pane before attempting to send.
- **Per-session locking**: a `threading.Lock` per session name prevents overlapping concurrent prompts, returning `BUSY` immediately to the second caller.
- **Unique completion markers**: a UUID-based `HERMES_BRIDGE_DONE_<run_id>` is embedded in the instrumented prompt; the bridge polls `tmux capture-pane` until the marker appears.
- **Output sanitisation**: ANSI escape codes are stripped and credential-shaped tokens are redacted from all captured pane content.
- **Auth/OAuth failure detection**: checked at timeout against only the new pane content (lines added after the prompt was sent), avoiding false positives from unrelated session history.
- **Clean status enum**: `SUCCESS`, `TIMEOUT`, `BUSY`, `AUTH_FAILURE`, `SESSION_MISSING`, `SESSION_DEAD`, `FAILURE`.
- **Pre-configured worker**: `session=claude-momentum`, `workspace=/home/michael/code`.

### Out of scope (not included)

- Automatic tmux session creation
- Automatic coding-task classification or repository detection
- Provider fallback changes
- Direct integration into Discord coding request handling

## Test plan

- [ ] `uv run --extra dev pytest tests/test_claude_code_tmux_bridge.py -v` — all 44 tests pass
- [ ] `uv run --extra dev ruff check agent/claude_code_tmux_bridge.py tests/test_claude_code_tmux_bridge.py` — no lint errors
- [ ] No changes to existing files; no unrelated modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)