### PR TITLE
feat(codex): make app-server timeouts configurable

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -27,6 +27,19 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def resolve_codex_app_server_timeouts() -> tuple[float, float]:
+    """Return configured app-server deadlines; non-positive values disable them."""
+    from hermes_cli.config import load_config_readonly
+
+    agent_config = load_config_readonly()["agent"]
+    turn_timeout = float(agent_config["codex_app_server_turn_timeout"])
+    quiet_timeout = float(agent_config["codex_app_server_post_tool_quiet_timeout"])
+    return (
+        float("inf") if turn_timeout <= 0 else turn_timeout,
+        float("inf") if quiet_timeout <= 0 else quiet_timeout,
+    )
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -695,7 +708,12 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn_timeout, quiet_timeout = resolve_codex_app_server_timeouts()
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            turn_timeout=turn_timeout,
+            post_tool_quiet_timeout=quiet_timeout,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3608,7 +3608,10 @@ def _compress_context_via_codex_app_server(
     _activity_heartbeat: Optional[_CompressionActivityHeartbeat] = None
     try:
         _activity_heartbeat = _CompressionActivityHeartbeat(agent).start()
-        result = codex_session.compact_thread()
+        from agent.codex_runtime import resolve_codex_app_server_timeouts
+
+        turn_timeout, _ = resolve_codex_app_server_timeouts()
+        result = codex_session.compact_thread(turn_timeout=turn_timeout)
     except BaseException:
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression failed")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -831,6 +831,13 @@ agent:
   # Set to 0 to disable the warning.
   # gateway_timeout_warning: 900
 
+  # Codex app-server wall-clock turn deadline (seconds, 0 = unlimited).
+  # codex_app_server_turn_timeout: 600
+
+  # Stop a Codex app-server turn when it stays silent this long after a
+  # completed tool call (seconds, 0 = unlimited).
+  # codex_app_server_post_tool_quiet_timeout: 90
+
   # Session stall watchdog (seconds). When a busy session has a pending
   # inbound follow-up and the agent activity clock is idle this long, the
   # gateway logs a WARNING and notifies the user to try /new. Does not kill

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -30,6 +30,11 @@ DEFAULT_CONFIG = {
     "max_live_sessions": 16,
     "agent": {
         "max_turns": 500,
+        # Codex app-server wall-clock turn deadline (seconds). 0 disables it.
+        "codex_app_server_turn_timeout": 600,
+        # Silence deadline after a completed Codex tool call (seconds).
+        # 0 disables it.
+        "codex_app_server_post_tool_quiet_timeout": 90,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -26,7 +26,7 @@ duplicate the user turn (#860 / #42039). This test locks in:
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from agent.codex_runtime import run_codex_app_server_turn
 from hermes_state import SessionDB
@@ -74,6 +74,33 @@ def test_codex_success_flushes_and_reports_persisted():
     assert result["completed"] is True
     # With the agent as sole persister, the gateway must SKIP its DB write.
     assert result["agent_persisted"] is True
+
+
+@patch(
+    "hermes_cli.config.load_config_readonly",
+    return_value={
+        "agent": {
+            "codex_app_server_turn_timeout": 0,
+            "codex_app_server_post_tool_quiet_timeout": 12,
+        }
+    },
+)
+def test_codex_runtime_passes_configured_timeouts(_load_config):
+    agent = _make_agent(session_db=None)
+
+    run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    agent._codex_session.run_turn.assert_called_once_with(
+        user_input="hello",
+        turn_timeout=float("inf"),
+        post_tool_quiet_timeout=12.0,
+    )
 
 
 def test_codex_user_interrupt_is_reported_and_cleared():

--- a/tests/run_agent/test_codex_app_server_compaction.py
+++ b/tests/run_agent/test_codex_app_server_compaction.py
@@ -1,5 +1,7 @@
+import math
 import time
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -13,9 +15,11 @@ class FakeCodexSession:
         self.result = result
         self.calls = 0
         self.closed = False
+        self.turn_timeout = None
 
-    def compact_thread(self):
+    def compact_thread(self, *, turn_timeout=600.0):
         self.calls += 1
+        self.turn_timeout = turn_timeout
         return self.result
 
     def close(self):
@@ -27,8 +31,9 @@ class SlowCodexSession(FakeCodexSession):
         super().__init__(result)
         self.touch_calls = touch_calls
 
-    def compact_thread(self):
+    def compact_thread(self, *, turn_timeout=600.0):
         self.calls += 1
+        self.turn_timeout = turn_timeout
         _wait_for_touch(self.touch_calls, "context compression in progress")
         return self.result
 
@@ -111,6 +116,30 @@ def test_codex_app_server_native_auto_mode_leaves_thread_compaction_to_codex():
     assert agent._codex_session.calls == 0
     assert agent.context_compressor.compression_count == 0
     assert agent.events == []
+
+
+@patch(
+    "hermes_cli.config.load_config_readonly",
+    return_value={
+        "agent": {
+            "codex_app_server_turn_timeout": 0,
+            "codex_app_server_post_tool_quiet_timeout": 90,
+        }
+    },
+)
+def test_codex_app_server_compaction_uses_configured_turn_timeout(_load_config):
+    agent = DummyAgent(TurnResult(thread_id="thread-1", turn_id="compact-turn-1"))
+
+    compress_context(
+        agent,
+        [{"role": "user", "content": "hi"}],
+        "system",
+        approx_tokens=100000,
+        task_id="test",
+        force=True,
+    )
+
+    assert math.isinf(agent._codex_session.turn_timeout)
 
 
 def test_codex_app_server_compaction_heartbeat_refreshes_activity_while_waiting():


### PR DESCRIPTION
## Summary

- Add `agent.codex_app_server_turn_timeout` with the existing 600-second default.
- Add `agent.codex_app_server_post_tool_quiet_timeout` with the existing 90-second default.
- Treat non-positive values as unlimited.
- Apply the configured turn timeout to native Codex app-server compaction as well as normal turns.

## Why

The Codex app-server transport currently uses hard-coded host-side deadlines for turns and post-tool silence. These deadlines can terminate otherwise healthy long-running workflows even when the outer gateway inactivity timeout is disabled.

Operators need an explicit way to disable these policy deadlines while retaining user interrupts and subprocess-death detection.

## Behavior

The defaults remain unchanged:

```yaml
agent:
  codex_app_server_turn_timeout: 600
  codex_app_server_post_tool_quiet_timeout: 90
```

Set either value to `0` to disable that deadline:

```yaml
agent:
  codex_app_server_turn_timeout: 0
  codex_app_server_post_tool_quiet_timeout: 0
```

Explicit interruption and Codex subprocess-death detection remain active.

## Validation

- `scripts/run_tests.sh tests/agent/test_codex_app_server_persist.py tests/run_agent/test_codex_app_server_compaction.py tests/agent/transports/test_codex_app_server_session.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_config.py -q`
- Ruff checks for all changed Python files
- YAML parsing for `cli-config.yaml.example`
