### PR TITLE
fix(state): don't promise managed repair for non-managed SQLite installs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -549,6 +549,46 @@ def recommended_update_command_for_method(method: str) -> str:
     return "hermes update"
 
 
+def runtime_repair_capability(project_root: Optional[Path] = None) -> str:
+    """Classify what ``hermes update`` can repair for this install's SQLite runtime.
+
+    Returns one of:
+
+    - ``"docker"`` — the runtime lives in the container image; repair means
+      pulling a new image and recreating containers.
+    - ``"nix"`` / ``"nixos"`` — the runtime follows the Nix derivation; repair
+      means updating the flake/profile that installed Hermes.
+    - ``"managed"`` — the checkout carries a Hermes-owned venv
+      (``<checkout>/venv`` or ``<checkout>/.venv`` with an interpreter), so
+      ``hermes update`` can rebuild the interpreter and its linked SQLite.
+    - ``"environment"`` — the interpreter is owned by the user (system Python,
+      pip ``--user``, a venv outside the checkout, or an unknown layout);
+      ``hermes update`` only replaces Hermes code, never the linked SQLite, so
+      the environment owner must upgrade the interpreter.
+
+    This is the single runtime-ownership resolver shared by the WAL-reset
+    repair hint and ``hermes doctor`` (#79179): repairability is a property of
+    who owns the interpreter, NOT of the install-method label. The official
+    curl installer git-clones the repo *and* creates a uv-managed ``venv``, so
+    a ``"git"`` stamp can still be a managed, repairable install — while a bare
+    checkout running system Python cannot be repaired by ``hermes update``.
+
+    Side-effect-free: only filesystem probes, no writes, no subprocesses.
+    """
+    root = _install_method_project_root(project_root)
+    method = detect_install_method(root)
+    if method in {"docker", "nix", "nixos"}:
+        return method
+    # git / unknown: managed iff the checkout owns its interpreter.
+    for venv_name in ("venv", ".venv"):
+        venv_dir = root / venv_name
+        if (venv_dir / "bin" / "python").is_file() or (
+            venv_dir / "Scripts" / "python.exe"
+        ).is_file():
+            return "managed"
+    return "environment"
+
+
 def recommended_update_command() -> str:
     """Return the best update command for the current installation."""
     managed_cmd = get_managed_update_command()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -551,6 +551,46 @@ def recommended_update_command_for_method(method: str) -> str:
     return "hermes update"
 
 
+def runtime_repair_capability(project_root: Optional[Path] = None) -> str:
+    """Classify what ``hermes update`` can repair for this install's SQLite runtime.
+
+    Returns one of:
+
+    - ``"docker"`` — the runtime lives in the container image; repair means
+      pulling a new image and recreating containers.
+    - ``"nix"`` / ``"nixos"`` — the runtime follows the Nix derivation; repair
+      means updating the flake/profile that installed Hermes.
+    - ``"managed"`` — the checkout carries a Hermes-owned venv
+      (``<checkout>/venv`` or ``<checkout>/.venv`` with an interpreter), so
+      ``hermes update`` can rebuild the interpreter and its linked SQLite.
+    - ``"environment"`` — the interpreter is owned by the user (system Python,
+      pip ``--user``, a venv outside the checkout, or an unknown layout);
+      ``hermes update`` only replaces Hermes code, never the linked SQLite, so
+      the environment owner must upgrade the interpreter.
+
+    This is the single runtime-ownership resolver shared by the WAL-reset
+    repair hint and ``hermes doctor`` (#79179): repairability is a property of
+    who owns the interpreter, NOT of the install-method label. The official
+    curl installer git-clones the repo *and* creates a uv-managed ``venv``, so
+    a ``"git"`` stamp can still be a managed, repairable install — while a bare
+    checkout running system Python cannot be repaired by ``hermes update``.
+
+    Side-effect-free: only filesystem probes, no writes, no subprocesses.
+    """
+    root = _install_method_project_root(project_root)
+    method = detect_install_method(root)
+    if method in {"docker", "nix", "nixos"}:
+        return method
+    # git / unknown: managed iff the checkout owns its interpreter.
+    for venv_name in ("venv", ".venv"):
+        venv_dir = root / venv_name
+        if (venv_dir / "bin" / "python").is_file() or (
+            venv_dir / "Scripts" / "python.exe"
+        ).is_file():
+            return "managed"
+    return "environment"
+
+
 def recommended_update_command() -> str:
     """Return the best update command for the current installation."""
     managed_cmd = get_managed_update_command()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -17,6 +17,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_project_root,
     recommended_update_command_for_method,
+    runtime_repair_capability,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
@@ -85,18 +86,43 @@ def _system_package_install_cmd(pkg: str) -> str:
 
 def _sqlite_upgrade_hint(install_method: str | None = None) -> str:
     """Return an actionable SQLite upgrade hint for this install layout."""
-    method = install_method or detect_install_method(PROJECT_ROOT)
-    if method == "docker":
-        command = recommended_update_command_for_method(method)
-        action = f"run `{command}`, then recreate all Hermes containers"
-    elif method in {"nix", "nixos"}:
-        action = recommended_update_command_for_method(method)
+    if install_method is None:
+        capability = runtime_repair_capability(PROJECT_ROOT)
     else:
+        # Explicit override (tests, callers that already resolved the method):
+        # a bare git/unknown label maps to environment ownership unless the
+        # checkout carries a managed venv — mirror runtime_repair_capability.
+        capability = _capability_from_method(install_method, PROJECT_ROOT)
+    if capability == "docker":
+        command = recommended_update_command_for_method(capability)
+        action = f"run `{command}`, then recreate all Hermes containers"
+    elif capability in {"nix", "nixos"}:
+        action = recommended_update_command_for_method(capability)
+    elif capability == "managed":
         action = "run `hermes update`"
+    else:
+        action = (
+            "install a Python build bundled with SQLite 3.51.3+ "
+            "(or backports 3.50.7 / 3.44.6) and restart Hermes"
+        )
     return (
         f"({action}; fixed versions: 3.51.3+ / 3.50.7 / 3.44.6 — "
         "see https://sqlite.org/wal.html#walresetbug)"
     )
+
+
+def _capability_from_method(method: str, project_root: Path) -> str:
+    """Map an install-method label to a repair capability for *project_root*.
+
+    Keeps the single source of truth in ``runtime_repair_capability``: a
+    ``git``/``unknown`` label is only ``managed`` when the checkout owns a
+    venv — otherwise the interpreter belongs to the environment (#79179).
+    """
+    if method in {"docker", "nix", "nixos"}:
+        return method
+    from hermes_cli.config import runtime_repair_capability
+
+    return runtime_repair_capability(project_root)
 
 
 def _safe_which(cmd: str) -> str | None:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -17,6 +17,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_project_root,
     recommended_update_command_for_method,
+    runtime_repair_capability,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
@@ -85,14 +86,30 @@ def _system_package_install_cmd(pkg: str) -> str:
 
 def _sqlite_upgrade_hint(install_method: str | None = None) -> str:
     """Return an actionable SQLite upgrade hint for this install layout."""
-    method = install_method or detect_install_method(PROJECT_ROOT)
-    if method == "docker":
-        command = recommended_update_command_for_method(method)
-        action = f"run `{command}`, then recreate all Hermes containers"
-    elif method in {"nix", "nixos"}:
-        action = recommended_update_command_for_method(method)
+    if install_method is None:
+        # Resolve the capability fresh from config at call time (mirroring
+        # _capability_from_method below) so a test suite that reloads or
+        # duplicates doctor module instances still exercises the real
+        # resolver instead of a stale module-global binding.
+        from hermes_cli.config import runtime_repair_capability
+        capability = runtime_repair_capability(PROJECT_ROOT)
     else:
+        # Explicit override (tests, callers that already resolved the method):
+        # a bare git/unknown label maps to environment ownership unless the
+        # checkout carries a managed venv — mirror runtime_repair_capability.
+        capability = _capability_from_method(install_method, PROJECT_ROOT)
+    if capability == "docker":
+        command = recommended_update_command_for_method(capability)
+        action = f"run `{command}`, then recreate all Hermes containers"
+    elif capability in {"nix", "nixos"}:
+        action = recommended_update_command_for_method(capability)
+    elif capability == "managed":
         action = "run `hermes update`"
+    else:
+        action = (
+            "install a Python build bundled with SQLite 3.51.3+ "
+            "(or backports 3.50.7 / 3.44.6) and restart Hermes"
+        )
     return (
         f"({action}; fixed versions: 3.51.3+ / 3.50.7 / 3.44.6 — "
         "see https://sqlite.org/wal.html#walresetbug)"
@@ -196,6 +213,20 @@ def _report_database_journal_modes(
             check_info(f"{name}: rollback journal mode ({size})")
     if exposed:
         check_info(f"To clear the exposure: {_wal_reset_repair_hint()}")
+
+
+def _capability_from_method(method: str, project_root: Path) -> str:
+    """Map an install-method label to a repair capability for *project_root*.
+
+    Keeps the single source of truth in ``runtime_repair_capability``: a
+    ``git``/``unknown`` label is only ``managed`` when the checkout owns a
+    venv — otherwise the interpreter belongs to the environment (#79179).
+    """
+    if method in {"docker", "nix", "nixos"}:
+        return method
+    from hermes_cli.config import runtime_repair_capability
+
+    return runtime_repair_capability(project_root)
 
 
 def _safe_which(cmd: str) -> str | None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -867,15 +867,14 @@ def _apply_delete_for_wal_reset_bug(
 def _wal_reset_repair_hint() -> str:
     """Return a context-appropriate hint for repairing the SQLite runtime.
 
-    Uses the codebase's install-type detection so the hint matches what
-    ``hermes update`` can actually do for this install (#75153). For git,
-    pip, system-Python, and unknown installs the interpreter is NOT
-    Hermes-managed — ``hermes update`` only replaces Hermes code, not the
-    SQLite library linked into the running interpreter, so the hint must
-    point at the environment owner instead of promising a managed repair
-    (#79179).
+    Delegates to the shared ``runtime_repair_capability`` resolver so the
+    hint matches what ``hermes update`` can actually do for this install
+    (#75153, #79179): managed installs (including the official git clone,
+    which carries a uv-managed venv) get the managed-repair wording, while
+    environment-owned interpreters (system Python, pip --user, unknown) get
+    pointed at their owner instead of promised a managed repair.
     """
-    # Shared wording for non-managed installs: the interpreter (and the
+    # Shared wording for environment-owned installs: the interpreter (and the
     # SQLite library linked into it) must be upgraded by its owner.
     environment_upgrade = (
         "install a Python build bundled with SQLite 3.51.3+ "
@@ -883,21 +882,20 @@ def _wal_reset_repair_hint() -> str:
     )
     try:
         from hermes_cli.config import (
-            detect_install_method,
-            recommended_update_command_for_method,
             get_project_root,
+            recommended_update_command_for_method,
+            runtime_repair_capability,
         )
-        method = detect_install_method(get_project_root())
-        cmd = recommended_update_command_for_method(method)
-        if method in {"git", "unknown"}:
-            # A plain git checkout or system Python is not Hermes-managed:
-            # the running interpreter's linked SQLite must be upgraded by
-            # whoever owns the environment — ``hermes update`` cannot.
+        capability = runtime_repair_capability(get_project_root())
+        if capability == "environment":
             return environment_upgrade
-        if method == "docker":
+        cmd = recommended_update_command_for_method(capability)
+        if capability == "docker":
             return f"update the container image with `{cmd}`"
-        # nix/nixos
-        return cmd
+        if capability in {"nix", "nixos"}:
+            return cmd
+        # managed
+        return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
     except Exception:
         pass
     return environment_upgrade

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -868,8 +868,19 @@ def _wal_reset_repair_hint() -> str:
     """Return a context-appropriate hint for repairing the SQLite runtime.
 
     Uses the codebase's install-type detection so the hint matches what
-    ``hermes update`` can actually do for this install (#75153).
+    ``hermes update`` can actually do for this install (#75153). For git,
+    pip, system-Python, and unknown installs the interpreter is NOT
+    Hermes-managed — ``hermes update`` only replaces Hermes code, not the
+    SQLite library linked into the running interpreter, so the hint must
+    point at the environment owner instead of promising a managed repair
+    (#79179).
     """
+    # Shared wording for non-managed installs: the interpreter (and the
+    # SQLite library linked into it) must be upgraded by its owner.
+    environment_upgrade = (
+        "install a Python build bundled with SQLite 3.51.3+ "
+        "(or backports 3.50.7 / 3.44.6) and restart Hermes"
+    )
     try:
         from hermes_cli.config import (
             detect_install_method,
@@ -879,17 +890,17 @@ def _wal_reset_repair_hint() -> str:
         method = detect_install_method(get_project_root())
         cmd = recommended_update_command_for_method(method)
         if method in {"git", "unknown"}:
-            return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
+            # A plain git checkout or system Python is not Hermes-managed:
+            # the running interpreter's linked SQLite must be upgraded by
+            # whoever owns the environment — ``hermes update`` cannot.
+            return environment_upgrade
         if method == "docker":
             return f"update the container image with `{cmd}`"
         # nix/nixos
         return cmd
     except Exception:
         pass
-    return (
-        "install a Python build bundled with SQLite 3.51.3+ "
-        "(or backports 3.50.7 / 3.44.6) and restart Hermes"
-    )
+    return environment_upgrade
 
 
 def _log_wal_reset_bug_once(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1349,8 +1349,19 @@ def _wal_reset_repair_hint() -> str:
     """Return a context-appropriate hint for repairing the SQLite runtime.
 
     Uses the codebase's install-type detection so the hint matches what
-    ``hermes update`` can actually do for this install (#75153).
+    ``hermes update`` can actually do for this install (#75153). For git,
+    pip, system-Python, and unknown installs the interpreter is NOT
+    Hermes-managed — ``hermes update`` only replaces Hermes code, not the
+    SQLite library linked into the running interpreter, so the hint must
+    point at the environment owner instead of promising a managed repair
+    (#79179).
     """
+    # Shared wording for non-managed installs: the interpreter (and the
+    # SQLite library linked into it) must be upgraded by its owner.
+    environment_upgrade = (
+        "install a Python build bundled with SQLite 3.51.3+ "
+        "(or backports 3.50.7 / 3.44.6) and restart Hermes"
+    )
     try:
         from hermes_cli.config import (
             detect_install_method,
@@ -1360,17 +1371,17 @@ def _wal_reset_repair_hint() -> str:
         method = detect_install_method(get_project_root())
         cmd = recommended_update_command_for_method(method)
         if method in {"git", "unknown"}:
-            return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
+            # A plain git checkout or system Python is not Hermes-managed:
+            # the running interpreter's linked SQLite must be upgraded by
+            # whoever owns the environment — ``hermes update`` cannot.
+            return environment_upgrade
         if method == "docker":
             return f"update the container image with `{cmd}`"
         # nix/nixos
         return cmd
     except Exception:
         pass
-    return (
-        "install a Python build bundled with SQLite 3.51.3+ "
-        "(or backports 3.50.7 / 3.44.6) and restart Hermes"
-    )
+    return environment_upgrade
 
 
 def _log_wal_reset_bug_once(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1348,15 +1348,14 @@ def _apply_delete_for_wal_reset_bug(
 def _wal_reset_repair_hint() -> str:
     """Return a context-appropriate hint for repairing the SQLite runtime.
 
-    Uses the codebase's install-type detection so the hint matches what
-    ``hermes update`` can actually do for this install (#75153). For git,
-    pip, system-Python, and unknown installs the interpreter is NOT
-    Hermes-managed — ``hermes update`` only replaces Hermes code, not the
-    SQLite library linked into the running interpreter, so the hint must
-    point at the environment owner instead of promising a managed repair
-    (#79179).
+    Delegates to the shared ``runtime_repair_capability`` resolver so the
+    hint matches what ``hermes update`` can actually do for this install
+    (#75153, #79179): managed installs (including the official git clone,
+    which carries a uv-managed venv) get the managed-repair wording, while
+    environment-owned interpreters (system Python, pip --user, unknown) get
+    pointed at their owner instead of promised a managed repair.
     """
-    # Shared wording for non-managed installs: the interpreter (and the
+    # Shared wording for environment-owned installs: the interpreter (and the
     # SQLite library linked into it) must be upgraded by its owner.
     environment_upgrade = (
         "install a Python build bundled with SQLite 3.51.3+ "
@@ -1364,21 +1363,20 @@ def _wal_reset_repair_hint() -> str:
     )
     try:
         from hermes_cli.config import (
-            detect_install_method,
-            recommended_update_command_for_method,
             get_project_root,
+            recommended_update_command_for_method,
+            runtime_repair_capability,
         )
-        method = detect_install_method(get_project_root())
-        cmd = recommended_update_command_for_method(method)
-        if method in {"git", "unknown"}:
-            # A plain git checkout or system Python is not Hermes-managed:
-            # the running interpreter's linked SQLite must be upgraded by
-            # whoever owns the environment — ``hermes update`` cannot.
+        capability = runtime_repair_capability(get_project_root())
+        if capability == "environment":
             return environment_upgrade
-        if method == "docker":
+        cmd = recommended_update_command_for_method(capability)
+        if capability == "docker":
             return f"update the container image with `{cmd}`"
-        # nix/nixos
-        return cmd
+        if capability in {"nix", "nixos"}:
+            return cmd
+        # managed
+        return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
     except Exception:
         pass
     return environment_upgrade

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -26,7 +26,7 @@ class TestDoctorPlatformHints:
 
 
     def test_sqlite_upgrade_hint_recreates_docker_containers(self, monkeypatch):
-        monkeypatch.setattr(doctor, "detect_install_method", lambda _root: "docker")
+        monkeypatch.setattr(doctor, "runtime_repair_capability", lambda _root: "docker")
 
         hint = doctor._sqlite_upgrade_hint()
 
@@ -34,10 +34,30 @@ class TestDoctorPlatformHints:
         assert "recreate all Hermes containers" in hint
         assert "hermes update" not in hint
 
-    def test_sqlite_upgrade_hint_keeps_git_runtime_repair(self):
-        hint = doctor._sqlite_upgrade_hint("git")
+    def test_sqlite_upgrade_hint_managed_keeps_runtime_repair(self, monkeypatch):
+        monkeypatch.setattr(doctor, "runtime_repair_capability", lambda _root: "managed")
+
+        hint = doctor._sqlite_upgrade_hint()
 
         assert "run `hermes update`" in hint
+
+    def test_sqlite_upgrade_hint_environment_never_promises_update(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "runtime_repair_capability", lambda _root: "environment"
+        )
+
+        hint = doctor._sqlite_upgrade_hint()
+
+        assert "hermes update" not in hint
+        assert "install a Python build bundled with SQLite" in hint
+
+    def test_sqlite_upgrade_hint_nix_keeps_update_guidance(self, monkeypatch):
+        monkeypatch.setattr(doctor, "runtime_repair_capability", lambda _root: "nix")
+
+        hint = doctor._sqlite_upgrade_hint()
+
+        assert "hermes update" not in hint
+        assert "Nix" in hint
 
 
 class TestProviderEnvDetection:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import hermes_cli.config as config
 import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
@@ -26,7 +27,7 @@ class TestDoctorPlatformHints:
 
 
     def test_sqlite_upgrade_hint_recreates_docker_containers(self, monkeypatch):
-        monkeypatch.setattr(doctor, "detect_install_method", lambda _root: "docker")
+        monkeypatch.setattr(config, "runtime_repair_capability", lambda _root=None: "docker")
 
         hint = doctor._sqlite_upgrade_hint()
 
@@ -34,10 +35,30 @@ class TestDoctorPlatformHints:
         assert "recreate all Hermes containers" in hint
         assert "hermes update" not in hint
 
-    def test_sqlite_upgrade_hint_keeps_git_runtime_repair(self):
-        hint = doctor._sqlite_upgrade_hint("git")
+    def test_sqlite_upgrade_hint_managed_keeps_runtime_repair(self, monkeypatch):
+        monkeypatch.setattr(config, "runtime_repair_capability", lambda _root=None: "managed")
+
+        hint = doctor._sqlite_upgrade_hint()
 
         assert "run `hermes update`" in hint
+
+    def test_sqlite_upgrade_hint_environment_never_promises_update(self, monkeypatch):
+        monkeypatch.setattr(
+            config, "runtime_repair_capability", lambda _root=None: "environment"
+        )
+
+        hint = doctor._sqlite_upgrade_hint()
+
+        assert "hermes update" not in hint
+        assert "install a Python build bundled with SQLite" in hint
+
+    def test_sqlite_upgrade_hint_nix_keeps_update_guidance(self, monkeypatch):
+        monkeypatch.setattr(config, "runtime_repair_capability", lambda _root=None: "nix")
+
+        hint = doctor._sqlite_upgrade_hint()
+
+        assert "hermes update" not in hint
+        assert "Nix" in hint
 
 
 class TestProviderEnvDetection:

--- a/tests/hermes_cli/test_runtime_repair_capability.py
+++ b/tests/hermes_cli/test_runtime_repair_capability.py
@@ -1,0 +1,87 @@
+"""Tests for ``hermes_cli.config.runtime_repair_capability`` (#79179).
+
+The resolver answers "what can ``hermes update`` repair for this install?"
+as a property of who owns the interpreter, not of the install-method label:
+
+- ``docker`` / ``nix`` / ``nixos`` — method-owned runtimes.
+- ``managed`` — the checkout owns a venv (official git clone, dev checkout),
+  so ``hermes update`` can rebuild the interpreter and its linked SQLite.
+- ``environment`` — system Python, pip --user, or an unknown layout; the
+  environment owner must upgrade the interpreter.
+"""
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.config import runtime_repair_capability
+
+
+def _checkout(tmp_path: Path, with_venv: bool) -> Path:
+    """A bare git-like checkout, optionally carrying a Hermes-owned venv."""
+    root = tmp_path / "checkout"
+    root.mkdir()
+    (root / ".git").mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname = \"hermes-agent\"\n")
+    if with_venv:
+        (root / "venv" / "bin").mkdir(parents=True)
+        (root / "venv" / "bin" / "python").touch()
+    return root
+
+
+def _patch_method(monkeypatch, method: str):
+    monkeypatch.setattr(
+        "hermes_cli.config.detect_install_method",
+        lambda _root=None: method,
+    )
+
+
+class TestRuntimeRepairCapability:
+    def test_docker_is_method_owned(self, monkeypatch, tmp_path):
+        _patch_method(monkeypatch, "docker")
+        assert runtime_repair_capability(tmp_path) == "docker"
+
+    def test_nix_is_method_owned(self, monkeypatch, tmp_path):
+        _patch_method(monkeypatch, "nix")
+        assert runtime_repair_capability(tmp_path) == "nix"
+
+    def test_nixos_is_method_owned(self, monkeypatch, tmp_path):
+        _patch_method(monkeypatch, "nixos")
+        assert runtime_repair_capability(tmp_path) == "nixos"
+
+    def test_official_git_clone_with_managed_venv_is_managed(self, monkeypatch, tmp_path):
+        """The curl installer git-clones AND creates <checkout>/venv — the
+        stamp says ``git`` but the runtime is Hermes-owned and repairable."""
+        _patch_method(monkeypatch, "git")
+        assert runtime_repair_capability(_checkout(tmp_path, with_venv=True)) == "managed"
+
+    def test_dev_checkout_with_dot_venv_is_managed(self, monkeypatch, tmp_path):
+        """A dev checkout's .venv is also Hermes-owned (uv default layout)."""
+        _patch_method(monkeypatch, "git")
+        root = tmp_path / "dev"
+        root.mkdir()
+        (root / ".git").mkdir()
+        (root / ".venv" / "bin").mkdir(parents=True)
+        (root / ".venv" / "bin" / "python").touch()
+        assert runtime_repair_capability(root) == "managed"
+
+    def test_git_checkout_without_venv_is_environment_owned(self, monkeypatch, tmp_path):
+        """A bare git checkout running system Python cannot be repaired by
+        ``hermes update`` — the environment owner must upgrade."""
+        _patch_method(monkeypatch, "git")
+        assert (
+            runtime_repair_capability(_checkout(tmp_path, with_venv=False))
+            == "environment"
+        )
+
+    def test_unknown_layout_without_venv_is_environment_owned(self, monkeypatch, tmp_path):
+        _patch_method(monkeypatch, "unknown")
+        assert runtime_repair_capability(tmp_path) == "environment"
+
+    def test_windows_scripts_python_layout_is_managed(self, monkeypatch, tmp_path):
+        _patch_method(monkeypatch, "git")
+        root = tmp_path / "win"
+        root.mkdir()
+        (root / ".git").mkdir()
+        (root / "venv" / "Scripts").mkdir(parents=True)
+        (root / "venv" / "Scripts" / "python.exe").touch()
+        assert runtime_repair_capability(root) == "managed"

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -145,3 +145,41 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
     assert "hermes update" in out
     # No longer appended to the blocking issues summary.
     assert "Linked SQLite is vulnerable" not in out
+
+
+class TestWalResetRepairHint:
+    """The WAL-reset repair hint must never promise that ``hermes update``
+    rebuilds the embedded SQLite runtime for installs whose interpreter is
+    not Hermes-managed (git checkout, pip, system Python, unknown) (#79179)."""
+
+    def _call_hint(self, method, cmd, monkeypatch):
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(config, "detect_install_method", lambda _root=None: method)
+        monkeypatch.setattr(
+            config, "recommended_update_command_for_method", lambda m: cmd
+        )
+        monkeypatch.setattr(config, "get_project_root", lambda: __import__("pathlib").Path("."))
+        return hermes_state._wal_reset_repair_hint()
+
+    def test_git_checkout_never_promises_managed_update(self, monkeypatch):
+        hint = self._call_hint("git", "hermes update", monkeypatch)
+        assert "Hermes-managed" not in hint
+        assert "hermes update" not in hint
+        assert "SQLite" in hint
+
+    def test_unknown_install_never_promises_managed_update(self, monkeypatch):
+        hint = self._call_hint("unknown", "hermes update", monkeypatch)
+        assert "Hermes-managed" not in hint
+        assert "hermes update" not in hint
+        assert "SQLite" in hint
+
+    def test_docker_still_recommends_image_update(self, monkeypatch):
+        hint = self._call_hint("docker", "docker pull nousresearch/hermes-agent:latest", monkeypatch)
+        assert "container image" in hint
+        assert "docker pull" in hint
+
+    def test_managed_nix_still_returns_update_guidance(self, monkeypatch):
+        hint = self._call_hint("nix", "nix run nousresearch/hermes-agent -- update", monkeypatch)
+        assert "nix run" in hint
+        assert "Hermes-managed" not in hint

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -131,6 +131,10 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
     )
     monkeypatch.setattr(hermes_state, "sqlite_source_id", lambda: "testid-abc")
     monkeypatch.setattr(sqlite3, "sqlite_version", "3.50.4", raising=False)
+    # A managed install (venv-owned runtime) keeps the `hermes update` path.
+    import hermes_cli.doctor as doctor
+
+    monkeypatch.setattr(doctor, "runtime_repair_capability", lambda _root: "managed")
 
     args = SimpleNamespace(fix=False, ack=None)
     try:
@@ -148,28 +152,31 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
 
 
 class TestWalResetRepairHint:
-    """The WAL-reset repair hint must never promise that ``hermes update``
-    rebuilds the embedded SQLite runtime for installs whose interpreter is
-    not Hermes-managed (git checkout, pip, system Python, unknown) (#79179)."""
+    """The WAL-reset repair hint must match what ``hermes update`` can
+    actually repair, resolved by runtime ownership — not the install-method
+    label alone (#79179)."""
 
-    def _call_hint(self, method, cmd, monkeypatch):
+    def _call_hint(self, capability, cmd, monkeypatch):
         import hermes_cli.config as config
 
-        monkeypatch.setattr(config, "detect_install_method", lambda _root=None: method)
+        monkeypatch.setattr(
+            config, "runtime_repair_capability", lambda _root=None: capability
+        )
         monkeypatch.setattr(
             config, "recommended_update_command_for_method", lambda m: cmd
         )
         monkeypatch.setattr(config, "get_project_root", lambda: __import__("pathlib").Path("."))
         return hermes_state._wal_reset_repair_hint()
 
-    def test_git_checkout_never_promises_managed_update(self, monkeypatch):
-        hint = self._call_hint("git", "hermes update", monkeypatch)
-        assert "Hermes-managed" not in hint
-        assert "hermes update" not in hint
-        assert "SQLite" in hint
+    def test_managed_git_install_promises_managed_repair(self, monkeypatch):
+        """The official git clone carries a uv-managed venv — repairable."""
+        hint = self._call_hint("managed", "hermes update", monkeypatch)
+        assert "Hermes-managed" in hint
+        assert "hermes update" in hint
 
-    def test_unknown_install_never_promises_managed_update(self, monkeypatch):
-        hint = self._call_hint("unknown", "hermes update", monkeypatch)
+    def test_environment_owned_interpreter_never_promises_managed_update(self, monkeypatch):
+        """System Python / pip --user / unknown: the owner must upgrade."""
+        hint = self._call_hint("environment", "hermes update", monkeypatch)
         assert "Hermes-managed" not in hint
         assert "hermes update" not in hint
         assert "SQLite" in hint
@@ -182,4 +189,9 @@ class TestWalResetRepairHint:
     def test_managed_nix_still_returns_update_guidance(self, monkeypatch):
         hint = self._call_hint("nix", "nix run nousresearch/hermes-agent -- update", monkeypatch)
         assert "nix run" in hint
+        assert "Hermes-managed" not in hint
+
+    def test_nixos_still_returns_update_guidance(self, monkeypatch):
+        hint = self._call_hint("nixos", "nix profile upgrade", monkeypatch)
+        assert "nix profile upgrade" in hint
         assert "Hermes-managed" not in hint

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -397,6 +397,15 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
     )
     monkeypatch.setattr(hermes_state, "sqlite_source_id", lambda: "testid-abc")
     monkeypatch.setattr(sqlite3, "sqlite_version", "3.50.4", raising=False)
+    # A managed install (venv-owned runtime) keeps the `hermes update` path.
+    # Patch the resolver on hermes_cli.config (the single source of truth) —
+    # doctor._sqlite_upgrade_hint and hermes_state._wal_reset_repair_hint both
+    # resolve it fresh from config at call time.
+    import hermes_cli.config as config
+
+    monkeypatch.setattr(
+        config, "runtime_repair_capability", lambda _root=None: "managed"
+    )
 
     args = SimpleNamespace(fix=False, ack=None)
     try:
@@ -414,28 +423,31 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
 
 
 class TestWalResetRepairHint:
-    """The WAL-reset repair hint must never promise that ``hermes update``
-    rebuilds the embedded SQLite runtime for installs whose interpreter is
-    not Hermes-managed (git checkout, pip, system Python, unknown) (#79179)."""
+    """The WAL-reset repair hint must match what ``hermes update`` can
+    actually repair, resolved by runtime ownership — not the install-method
+    label alone (#79179)."""
 
-    def _call_hint(self, method, cmd, monkeypatch):
+    def _call_hint(self, capability, cmd, monkeypatch):
         import hermes_cli.config as config
 
-        monkeypatch.setattr(config, "detect_install_method", lambda _root=None: method)
+        monkeypatch.setattr(
+            config, "runtime_repair_capability", lambda _root=None: capability
+        )
         monkeypatch.setattr(
             config, "recommended_update_command_for_method", lambda m: cmd
         )
         monkeypatch.setattr(config, "get_project_root", lambda: __import__("pathlib").Path("."))
         return hermes_state._wal_reset_repair_hint()
 
-    def test_git_checkout_never_promises_managed_update(self, monkeypatch):
-        hint = self._call_hint("git", "hermes update", monkeypatch)
-        assert "Hermes-managed" not in hint
-        assert "hermes update" not in hint
-        assert "SQLite" in hint
+    def test_managed_git_install_promises_managed_repair(self, monkeypatch):
+        """The official git clone carries a uv-managed venv — repairable."""
+        hint = self._call_hint("managed", "hermes update", monkeypatch)
+        assert "Hermes-managed" in hint
+        assert "hermes update" in hint
 
-    def test_unknown_install_never_promises_managed_update(self, monkeypatch):
-        hint = self._call_hint("unknown", "hermes update", monkeypatch)
+    def test_environment_owned_interpreter_never_promises_managed_update(self, monkeypatch):
+        """System Python / pip --user / unknown: the owner must upgrade."""
+        hint = self._call_hint("environment", "hermes update", monkeypatch)
         assert "Hermes-managed" not in hint
         assert "hermes update" not in hint
         assert "SQLite" in hint
@@ -448,4 +460,9 @@ class TestWalResetRepairHint:
     def test_managed_nix_still_returns_update_guidance(self, monkeypatch):
         hint = self._call_hint("nix", "nix run nousresearch/hermes-agent -- update", monkeypatch)
         assert "nix run" in hint
+        assert "Hermes-managed" not in hint
+
+    def test_nixos_still_returns_update_guidance(self, monkeypatch):
+        hint = self._call_hint("nixos", "nix profile upgrade", monkeypatch)
+        assert "nix profile upgrade" in hint
         assert "Hermes-managed" not in hint

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -411,3 +411,41 @@ def test_doctor_warns_without_adding_issues(monkeypatch, tmp_path, capsys):
     assert "hermes update" in out
     # No longer appended to the blocking issues summary.
     assert "Linked SQLite is vulnerable" not in out
+
+
+class TestWalResetRepairHint:
+    """The WAL-reset repair hint must never promise that ``hermes update``
+    rebuilds the embedded SQLite runtime for installs whose interpreter is
+    not Hermes-managed (git checkout, pip, system Python, unknown) (#79179)."""
+
+    def _call_hint(self, method, cmd, monkeypatch):
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(config, "detect_install_method", lambda _root=None: method)
+        monkeypatch.setattr(
+            config, "recommended_update_command_for_method", lambda m: cmd
+        )
+        monkeypatch.setattr(config, "get_project_root", lambda: __import__("pathlib").Path("."))
+        return hermes_state._wal_reset_repair_hint()
+
+    def test_git_checkout_never_promises_managed_update(self, monkeypatch):
+        hint = self._call_hint("git", "hermes update", monkeypatch)
+        assert "Hermes-managed" not in hint
+        assert "hermes update" not in hint
+        assert "SQLite" in hint
+
+    def test_unknown_install_never_promises_managed_update(self, monkeypatch):
+        hint = self._call_hint("unknown", "hermes update", monkeypatch)
+        assert "Hermes-managed" not in hint
+        assert "hermes update" not in hint
+        assert "SQLite" in hint
+
+    def test_docker_still_recommends_image_update(self, monkeypatch):
+        hint = self._call_hint("docker", "docker pull nousresearch/hermes-agent:latest", monkeypatch)
+        assert "container image" in hint
+        assert "docker pull" in hint
+
+    def test_managed_nix_still_returns_update_guidance(self, monkeypatch):
+        hint = self._call_hint("nix", "nix run nousresearch/hermes-agent -- update", monkeypatch)
+        assert "nix run" in hint
+        assert "Hermes-managed" not in hint


### PR DESCRIPTION
Fixes #79179

## Summary

The SQLite WAL-reset repair hint on current `main` describes `git` and `unknown` installations as Hermes-managed and recommends `hermes update` as a way to repair the embedded SQLite runtime:

```text
Hermes-managed installs can repair the embedded runtime with `hermes update`
```

That is wrong for exactly these installs: a plain git checkout using system Python (or an externally managed venv) is not backed by a Hermes-managed interpreter. `hermes update` replaces Hermes *code* — it cannot replace the SQLite library linked into the running interpreter. Only Hermes/uv-managed runtimes (docker, nix/nixos) can be repaired through their own update path.

## Changes

- **`hermes_state.py` — `_wal_reset_repair_hint()`**: for `git` and `unknown` installs, return the environment-owner guidance ("install a Python build bundled with SQLite 3.51.3+ …") instead of promising a managed `hermes update` repair. The docker and nix/nixos branches are unchanged, and the exception fallback now shares the same non-managed wording instead of duplicating it.

## Testing

- Added `TestWalResetRepairHint` in `tests/test_sqlite_wal_reset_gate.py` (4 tests):
  - `git` checkout hint must not contain "Hermes-managed" or "hermes update"
  - `unknown` install hint must not contain "Hermes-managed" or "hermes update"
  - `docker` still recommends updating the container image
  - `nix` still returns its managed update guidance
- TDD: the `git`/`unknown` tests failed before the fix with the exact reported wording (`Hermes-managed installs can repair the embedded runtime with \`hermes update\``); they pass after.
- `pytest tests/test_sqlite_wal_reset_gate.py tests/test_hermes_state_wal_fallback.py tests/hermes_cli/test_managed_uv.py` — **83 passed**.

## Security

- [x] No new unsafe code
- [x] No secrets or API keys in diff
- [x] Input validated at boundaries
