### PR TITLE
fix(git): handle zombie-child case in probe tree-kill

### DIFF
--- a/contributors/emails/593171080@qq.com
+++ b/contributors/emails/593171080@qq.com
@@ -1,0 +1,2 @@
+JimZhang-lab
+# PR: git probe tree-kill after wrapper exit

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -349,7 +349,7 @@ def noninteractive_git_env(
 # -----------------------------------------------------------------------------
 
 
-def _kill_git_process_tree(proc: "subprocess.Popen") -> None:
+def _kill_git_process_tree(proc: "subprocess.Popen", *, leads_own_group: bool = False) -> None:
     """Best-effort terminate *proc* and its descendants on both platforms.
 
     ``proc.kill()`` alone only terminates the direct child. On Windows a
@@ -361,10 +361,24 @@ def _kill_git_process_tree(proc: "subprocess.Popen") -> None:
     (credential helpers, ``git-remote-https``, hook children) running and
     holding the pipe write ends. The probe is spawned in its own process group
     (``process_group=0`` in :func:`bounded_git_probe`), so when — and only
-    when — the child leads its own group (``pgid == pid``), the entire group is
-    signalled with ``os.killpg``. The ownership check means a fallback spawn
-    that shares our group can never cause us to kill unrelated processes.
+    when — the child leads its own group, the entire group is signalled with
+    ``os.killpg``. The ownership check means a fallback spawn that shares our
+    group can never cause us to kill unrelated processes.
     Ported from openai/codex#36793 ("Terminate timed-out Git process trees").
+
+    ``leads_own_group`` states that ownership up front, for callers that spawned
+    with ``process_group=0`` and therefore know ``pgid == pid`` by construction.
+    It must not be inferred from ``os.getpgid(proc.pid)`` at kill time: once the
+    direct child has exited (even unreaped), ``getpgid`` raises
+    ``ProcessLookupError`` on macOS, which would skip the group signal and leak
+    exactly the descendants this exists to collect — a background helper that
+    outlives the launcher still holds the pipe write ends, so the pipes never
+    reach EOF and the probe still burns its full timeout. Signalling the pid is
+    safe even then: the caller reaches cleanup without having reaped *proc*, and
+    an unreaped child stays a zombie, so its pid cannot be recycled onto an
+    unrelated group leader. The group also remains addressable through the
+    leader's pid while any member lives. Callers that did not create a new group
+    leave this False and keep the runtime ownership check.
 
     All failures are swallowed — this is cleanup on an already-failing path, and
     the caller's contract is to fail open. ``kill()`` can raise (access denied,
@@ -374,12 +388,21 @@ def _kill_git_process_tree(proc: "subprocess.Popen") -> None:
     own timeout cleanup has no reader threads to join.
     """
     if not IS_WINDOWS:
-        # Group-kill first: verify the child actually leads its own process
-        # group before signalling it, so we never blast a shared group.
+        # Group-kill first, but only for a group the child actually leads, so we
+        # never blast a shared group. A caller that spawned with
+        # ``process_group=0`` asserts that via ``leads_own_group``; otherwise
+        # fall back to asking the OS (which only answers while the child lives).
+        # ``returncode is None`` means we have not reaped the child, so its pid is
+        # still reserved (a dead child stays a zombie) and cannot have been
+        # recycled onto some unrelated group leader — that check is what makes
+        # trusting the caller's claim safe rather than merely convenient.
         try:
             import signal as _signal
 
-            pgid = os.getpgid(proc.pid)
+            if leads_own_group and proc.returncode is None:
+                pgid = proc.pid
+            else:
+                pgid = os.getpgid(proc.pid)
             if pgid == proc.pid:
                 os.killpg(pgid, _signal.SIGKILL)  # windows-footgun: ok — inside `if not IS_WINDOWS` gate
         except Exception:
@@ -455,7 +478,9 @@ def bounded_git_probe(argv: Sequence[str], *, timeout: float) -> str:
         # Timeout OR any other communicate() failure (torn-down pipe, decode
         # error): terminate the child + descendants and drain bounded. Leaving
         # it running would leak the same suspended-descendant class this guards.
-        _kill_git_process_tree(proc)
+        # On POSIX we spawned the group, so state that rather than re-deriving it
+        # — the child may already have exited while a helper holds the pipes.
+        _kill_git_process_tree(proc, leads_own_group=not IS_WINDOWS)
         try:
             proc.communicate(timeout=1)
         except Exception:

--- a/tests/hermes_cli/test_git_probe_tree_kill.py
+++ b/tests/hermes_cli/test_git_probe_tree_kill.py
@@ -27,17 +27,25 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _write_forking_script(tmp_path, marker_name="child.pid"):
-    """A fake ``git`` that forks a long-lived descendant, then stalls."""
+def _write_forking_script(tmp_path, marker_name="child.pid", *, wrapper_exits=False):
+    """A fake ``git`` that forks a long-lived descendant, then stalls.
+
+    With ``wrapper_exits`` the launcher returns immediately instead of stalling,
+    leaving the descendant holding the captured pipe write ends — a shell-wrapped
+    ``git``, an alias, or a hook that backgrounds work and returns. The probe
+    still times out (the pipes never reach EOF) but the direct child is already
+    gone by cleanup time, so cleanup cannot rely on querying it.
+    """
     marker = tmp_path / marker_name
     script = tmp_path / "fakegit.sh"
+    tail = "exit 0" if wrapper_exits else "sleep 300"
     script.write_text(
         textwrap.dedent(
             f"""\
             #!/bin/bash
             sleep 300 &
             echo $! > {marker}
-            sleep 300
+            {tail}
             """
         )
     )
@@ -79,6 +87,35 @@ def test_timeout_kills_descendants(tmp_path):
     if alive:  # cleanup so a failure doesn't leak a 300s sleeper
         os.kill(child_pid, 9)
     assert not alive, f"descendant {child_pid} survived probe timeout"
+
+
+def test_timeout_kills_descendants_after_wrapper_exits(tmp_path):
+    """The descendant must die even when the launcher exited before cleanup.
+
+    Upstream openai/codex#36793 covers cleanup both while the wrapper runs and
+    after it exits; this is the second half. Deriving the process group from
+    ``os.getpgid(proc.pid)`` at kill time fails here — the direct child is an
+    unreaped zombie, so ``getpgid`` raises ``ProcessLookupError`` on macOS, the
+    group signal is skipped, and the helper survives holding the pipes.
+    """
+    script, marker = _write_forking_script(tmp_path, wrapper_exits=True)
+
+    out = bounded_git_probe([str(script)], timeout=1.0)
+    assert out == ""
+
+    child_pid = _wait_marker(marker)
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and _pid_alive(child_pid):
+        time.sleep(0.05)
+    alive = _pid_alive(child_pid)
+    if alive:
+        # Cleanup so a failure doesn't leak a 300s sleeper. Spawn ``kill``
+        # instead of calling os.kill: on the failing path the survivor has been
+        # reparented to init, so conftest's live-system guard rejects it as
+        # outside the test subtree and its RuntimeError would mask the assertion
+        # below — the actual diagnosis.
+        subprocess.run(["kill", "-9", str(child_pid)], check=False)
+    assert not alive, f"descendant {child_pid} survived after wrapper exited"
 
 
 def test_posix_spawn_uses_own_process_group(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes a process leak in `bounded_git_probe` when a git wrapper (alias, hook, shell script) forks a long-lived background helper and exits immediately. The direct child becomes a zombie by timeout, and `os.getpgid(zombie_pid)` raises `ProcessLookupError` on macOS, which the broad `except Exception` swallows — so `os.killpg` never runs and the background helper leaks, holding the pipe write ends. Every subsequent drain burns its full 1s timeout.

The process group is fully reachable via the leader's pid as long as any member lives. The fix: add `leads_own_group` kwarg to `_kill_git_process_tree` so callers that spawned with `process_group=0` can state that fact up front and bypass the `getpgid` round-trip. Safety is enforced by requiring `proc.returncode is None` (unreaped child → pid not recycled → no risk of killing an unrelated group). `bounded_git_probe` passes `True` on POSIX.

Also adds `test_timeout_kills_descendants_after_wrapper_exits` — the half of the upstream `openai/codex#36793` regression suite that the initial port dropped.

**Reproduced on macOS 25.5.0 / Python 3.12.9:** leaked process survives, probe waits 2+ seconds. After fix: process killed, 1s drain.

## Related Issue

Fixes a bug discovered during audit of recent commits (no existing issue filed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_subprocess_compat.py:352` — add `leads_own_group` kwarg to `_kill_git_process_tree`; use `proc.pid` directly when caller asserts ownership and child is unreaped, bypassing the `getpgid` round-trip that raises on zombies
- `hermes_cli/_subprocess_compat.py:471` — `bounded_git_probe` passes `leads_own_group=not IS_WINDOWS` to cleanup call
- `tests/hermes_cli/test_git_probe_tree_kill.py:30` — extend `_write_forking_script` with `wrapper_exits` mode (launcher returns immediately, descendant survives)
- `tests/hermes_cli/test_git_probe_tree_kill.py:65` — add `test_timeout_kills_descendants_after_wrapper_exits` regression test (passes with fix, fails without)
- `contributors/emails/593171080@qq.com` — contributor mapping (CI requirement)

## How to Test

1. Checkout this branch
2. Run tree-kill tests: `python3 -m pytest tests/hermes_cli/test_git_probe_tree_kill.py -v`
   - All 6 tests pass, including the new `after_wrapper_exits` case
3. Run tui_gateway (heaviest user of `bounded_git_probe`): `python3 -m pytest tests/tui_gateway/ -q`
   - 342/342 pass
4. To reproduce the bug on macOS: revert the source fix (keep the new test), re-run step 2 → the new test fails with assertion `descendant <pid> survived after wrapper exited`

## Checklist

- [x] Tests pass locally (`ruff check .` clean, 6/6 tree-kill tests, 342/342 tui_gateway tests)
- [x] Added regression test for the exact failure mode (wrapper-exits case)
- [x] Followed Conventional Commits format
- [x] Contributor email mapped (CI requirement)
- [x] No unrelated changes (clean diff, only the fix)
