### PR TITLE
fix(tui_gateway): honor per-session profile override in _save_cfg

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3010,7 +3010,12 @@ def _save_cfg(cfg: dict):
 
     from hermes_cli.config import atomic_config_write
 
-    path = _hermes_home / "config.yaml"
+    # Honour the per-session profile override so config writes land in the
+    # active profile, matching _load_cfg's resolution rather than always
+    # targeting the launch profile.
+    override = get_hermes_home_override()
+    home = override if isinstance(override, str) and override else _hermes_home
+    path = Path(home) / "config.yaml"
     atomic_config_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)


### PR DESCRIPTION
### Problem

In `tui_gateway/server.py`, config **reads** honour the per-session profile
override but config **writes** do not. A session running under a non-default
profile reads its own `config.yaml` and writes to the default profile's —
silently. No exception, no warning, no log line.

`_load_cfg()` — the read path — resolves the override:

```python
override = get_hermes_home_override()
home = override if isinstance(override, str) and override else _hermes_home
p = Path(home) / "config.yaml"
```

`_save_cfg()` — the write path — does not:

```python
path = _hermes_home / "config.yaml"
```

So a setting changed from the machine dashboard while a non-default profile is
active is written to the wrong file, and the next read — which *does* resolve the
override — doesn't see it. The change appears not to have taken.

### Fix

Apply the same three lines the read path already uses.

### Why this is low-risk

- `get_hermes_home_override` is already imported in this file and already used in
  three other places: `_load_cfg`, `_skin_sig`, and `_watcher_home`. No new
  dependency.
- `Path` is already imported.
- The `isinstance(override, str) and override` guard is copied verbatim from the
  existing call sites, so behaviour with no override set is byte-for-byte what it
  is today: `_hermes_home`.
- The change is confined to resolving one path. `atomic_config_write` and the
  cache update below it are untouched.

### Suggested test

```python
def test_save_cfg_targets_override_profile(tmp_path, monkeypatch):
    launch, active = tmp_path / "launch", tmp_path / "active"
    launch.mkdir(); active.mkdir()
    monkeypatch.setattr(server, "_hermes_home", launch)
    monkeypatch.setattr(server, "get_hermes_home_override", lambda: str(active))

    server._save_cfg({"model": {"default": "x"}})

    assert (active / "config.yaml").exists()
    assert not (launch / "config.yaml").exists()
```

A companion case with the override unset should assert the write lands in
`launch`, pinning the no-regression path.