### PR TITLE
TELEGRAM_REACTIONS=off incorrectly enabled reactions

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -305,7 +305,7 @@ from plugins.platforms.telegram.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
-from utils import atomic_replace, env_float, env_int
+from utils import atomic_replace, env_float, env_int, env_var_enabled
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
@@ -9802,7 +9802,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
-        return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+        return env_var_enabled("TELEGRAM_REACTIONS", default="false")
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -53,6 +53,22 @@ def test_reactions_enabled_when_set_true(monkeypatch):
     assert adapter._reactions_enabled() is True
 
 
+@pytest.mark.parametrize("val", ["false", "0", "no", "off", "FALSE", "Off"])
+def test_reactions_disabled_by_falsy_aliases(monkeypatch, val):
+    """All shared falsy aliases (including ``off``) must disable reactions."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", val)
+    adapter = _make_adapter()
+    assert adapter._reactions_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["true", "1", "yes", "on", "TRUE", "On"])
+def test_reactions_enabled_by_truthy_aliases(monkeypatch, val):
+    """All shared truthy aliases must enable reactions."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", val)
+    adapter = _make_adapter()
+    assert adapter._reactions_enabled() is True
+
+
 # ── _set_reaction ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- `TELEGRAM_REACTIONS` (default `false`) used an inverted falsy set that omitted `off`, so `=off` ironically **enabled** reactions instead of keeping them disabled.
- Route through `env_var_enabled(..., default="false")` so all shared falsy aliases (`off`/`false`/`0`/`no`) are honoured consistently.
- Add parametrized regression tests for both truthy and falsy alias sets.
