### PR TITLE
feat(moa): inject no-tool hint in advisory instruction

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -996,7 +996,9 @@ _ADVISORY_INSTRUCTION = (
     "[The conversation above is the current state of the task. Give your "
     "most intelligent judgement: what is going on, what should happen next, "
     "what risks or mistakes you see, and how the acting agent should "
-    "proceed.]"
+    "proceed. You have NO tools — any `[called tool: ...]` or `[tool result: ...]` "
+    "lines above are the ACTING AGENT's history, not yours. Do not restate them "
+    "as if you executed them; describe your advice in plain prose.]"
 )
 
 

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -992,13 +992,17 @@ def _render_tool_calls(tool_calls: Any) -> str:
     return "\n".join(lines)
 
 
+_NO_TOOL_HINT = (
+    "You have NO tools — any `[called tool: ...]` or `[tool result: ...]` "
+    "lines above are the ACTING AGENT's history, not yours. Do not restate them "
+    "as if you executed them; describe your advice in plain prose."
+)
+
 _ADVISORY_INSTRUCTION = (
     "[The conversation above is the current state of the task. Give your "
     "most intelligent judgement: what is going on, what should happen next, "
     "what risks or mistakes you see, and how the acting agent should "
-    "proceed. You have NO tools — any `[called tool: ...]` or `[tool result: ...]` "
-    "lines above are the ACTING AGENT's history, not yours. Do not restate them "
-    "as if you executed them; describe your advice in plain prose.]"
+    f"proceed. {_NO_TOOL_HINT}]"
 )
 
 
@@ -1116,8 +1120,25 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         rendered.append({"role": "user", "content": _ADVISORY_INSTRUCTION})
     elif rendered and rendered[-1].get("role") == "user":
         # Already ends on a user turn (fresh user prompt, no agent action yet).
-        # Leave it — the reference answers that prompt directly.
-        pass
+        #
+        # In user_turn fanout mode this ends-on-user call is the ONLY view the
+        # references actually receive — later tool iterations append the
+        # advisory (with its no-tool hint) to an assistant-ending view, but
+        # their cache signature is the prefix up to the last real user message,
+        # so they HIT the cache and reuse this first call's outputs without
+        # calling the references again. Appending _NO_TOOL_HINT here (as its
+        # own user turn, NOT merged into the last real user message, so the
+        # turn_prefix signature stays byte-identical) is what carries the
+        # no-tool reminder into the default fanout mode. Only attach it when
+        # the view actually shows tool-log text — a fresh prompt with no tool
+        # history has nothing to disclaim, and unconditionally appending would
+        # grow every advisory view (and its prompt-cache prefix) by the hint.
+        if any(
+            "[called tool:" in m.get("content", "")
+            or "[tool result:" in m.get("content", "")
+            for m in rendered
+        ):
+            rendered.append({"role": "user", "content": _NO_TOOL_HINT})
 
     if not rendered:
         # Degenerate case: nothing rendered. Fall back to the latest user turn.
@@ -1991,7 +2012,9 @@ class MoAChatCompletions:
             last_user_idx = None
             for _i in range(len(ref_messages) - 1, -1, -1):
                 _m = ref_messages[_i]
-                if _m.get("role") == "user" and _m.get("content") != _ADVISORY_INSTRUCTION:
+                if _m.get("role") == "user" and _m.get(
+                    "content"
+                ) not in (_ADVISORY_INSTRUCTION, _NO_TOOL_HINT):
                     last_user_idx = _i
                     break
             if last_user_idx is not None:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -14,6 +14,7 @@ import re
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait as _futures_wait
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
@@ -1006,7 +1007,17 @@ _ADVISORY_INSTRUCTION = (
 )
 
 
-def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+@dataclass(frozen=True)
+class _ReferenceView:
+    """Wire messages plus cache metadata derived from source message shape."""
+
+    messages: list[dict[str, Any]]
+    turn_prefix: list[dict[str, Any]]
+    has_tool_history: bool
+    last_real_user_index: int | None
+
+
+def _build_reference_view(messages: list[dict[str, Any]]) -> _ReferenceView:
     """Build an advisory view of the conversation for reference models.
 
     A reference gives an INFORMED judgement on the current state, so it must
@@ -1036,9 +1047,18 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     The acting aggregator always receives the full, untrimmed transcript; this
     function only shapes the disposable advisory copy.
+
+    ``turn_prefix`` ends at the last user message found in the source
+    transcript, before any synthetic advisory text is added. Keeping that
+    boundary as metadata avoids treating a real user whose text happens to
+    equal one of our prompts as synthetic. Likewise, ``has_tool_history`` is
+    derived only from real ``tool_calls`` / ``role=tool`` structure, never
+    from user-authored text that resembles the flattened tool-log notation.
     """
     rendered: list[dict[str, Any]] = []
     last_user_content: str | None = None
+    last_real_user_index: int | None = None
+    has_tool_history = False
     for msg in messages:
         role = msg.get("role")
         content = msg.get("content")
@@ -1089,17 +1109,20 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 continue
             last_user_content = text
             rendered.append({"role": "user", "content": text})
+            last_real_user_index = len(rendered) - 1
         elif role == "assistant":
             parts: list[str] = []
             if text.strip():
                 parts.append(text.strip())
             calls_text = _render_tool_calls(msg.get("tool_calls"))
             if calls_text:
+                has_tool_history = True
                 parts.append(calls_text)
             # Empty assistant turns (no text, no calls) carry nothing advisory.
             if parts:
                 rendered.append({"role": "assistant", "content": "\n".join(parts)})
         elif role == "tool":
+            has_tool_history = True
             # Fold the tool result into the preceding assistant turn as text so
             # the reference sees what came back, without emitting a tool-role
             # message a reference never produced.
@@ -1113,11 +1136,37 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 rendered.append({"role": "assistant", "content": block})
         # Any other role is ignored.
 
+    if not rendered:
+        # Degenerate case: nothing rendered. Fall back to the latest user turn.
+        if last_user_content is not None:
+            rendered = [{"role": "user", "content": last_user_content}]
+            last_real_user_index = 0
+        else:
+            for msg in reversed(messages):
+                if msg.get("role") == "user":
+                    fallback_text = flatten_message_text(msg.get("content"))
+                    if fallback_text.strip():
+                        rendered = [{"role": "user", "content": fallback_text}]
+                        last_real_user_index = 0
+                        break
+
+    # Cache identity is based on the real, unhinted conversation prefix. The
+    # wire-only no-tool reminder below must never alter this prefix.
+    turn_prefix = (
+        rendered[: last_real_user_index + 1]
+        if last_real_user_index is not None
+        else list(rendered)
+    )
+    wire_messages = rendered
+
     # End on a user turn: append a synthetic advisory request rather than
     # deleting the agent's latest assistant context. This satisfies Anthropic's
     # no-trailing-assistant-prefill rule while preserving full state.
     if rendered and rendered[-1].get("role") == "assistant":
-        rendered.append({"role": "user", "content": _ADVISORY_INSTRUCTION})
+        wire_messages = [
+            *rendered,
+            {"role": "user", "content": _ADVISORY_INSTRUCTION},
+        ]
     elif rendered and rendered[-1].get("role") == "user":
         # Already ends on a user turn (fresh user prompt, no agent action yet).
         #
@@ -1126,30 +1175,30 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # advisory (with its no-tool hint) to an assistant-ending view, but
         # their cache signature is the prefix up to the last real user message,
         # so they HIT the cache and reuse this first call's outputs without
-        # calling the references again. Appending _NO_TOOL_HINT here (as its
-        # own user turn, NOT merged into the last real user message, so the
-        # turn_prefix signature stays byte-identical) is what carries the
-        # no-tool reminder into the default fanout mode. Only attach it when
-        # the view actually shows tool-log text — a fresh prompt with no tool
-        # history has nothing to disclaim, and unconditionally appending would
-        # grow every advisory view (and its prompt-cache prefix) by the hint.
-        if any(
-            "[called tool:" in m.get("content", "")
-            or "[tool result:" in m.get("content", "")
-            for m in rendered
-        ):
-            rendered.append({"role": "user", "content": _NO_TOOL_HINT})
+        # calling the references again. Merge _NO_TOOL_HINT into a COPY of the
+        # trailing real user turn. The separate cache prefix above remains
+        # byte-identical, while strict generic/custom providers never receive
+        # two adjacent user messages. Only attach it when source structure
+        # proved there was real tool history — user prose containing the
+        # flattened marker strings is not evidence of a tool call.
+        if has_tool_history:
+            hinted_user = dict(rendered[-1])
+            hinted_user["content"] = (
+                f"{hinted_user.get('content') or ''}\n\n{_NO_TOOL_HINT}"
+            )
+            wire_messages = [*rendered[:-1], hinted_user]
 
-    if not rendered:
-        # Degenerate case: nothing rendered. Fall back to the latest user turn.
-        if last_user_content is not None:
-            return [{"role": "user", "content": last_user_content}]
-        for msg in reversed(messages):
-            if msg.get("role") == "user":
-                fallback_text = flatten_message_text(msg.get("content"))
-                if fallback_text.strip():
-                    return [{"role": "user", "content": fallback_text}]
-    return rendered
+    return _ReferenceView(
+        messages=wire_messages,
+        turn_prefix=turn_prefix,
+        has_tool_history=has_tool_history,
+        last_real_user_index=last_real_user_index,
+    )
+
+
+def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the wire-ready advisory messages for reference calls."""
+    return _build_reference_view(messages).messages
 
 
 
@@ -1967,7 +2016,8 @@ class MoAChatCompletions:
         from agent.usage_pricing import CanonicalUsage
 
         reference_outputs: list[tuple[str, str, Any]] = []
-        ref_messages = _reference_messages(messages)
+        reference_view = _build_reference_view(messages)
+        ref_messages = reference_view.messages
 
         # Fan-out cadence. "user_turn" (default — cheapest cadence, #67199):
         # advisors run ONCE per user turn; subsequent tool iterations reuse
@@ -2002,23 +2052,11 @@ class MoAChatCompletions:
         sig_messages = ref_messages
         turn_prefix = ref_messages
         if fanout_mode in ("user_turn",) or every_n >= 2:
-            # Find the last REAL user message. The advisory view appends a
-            # synthetic user marker (_ADVISORY_INSTRUCTION) when it ends on an
-            # assistant turn — i.e. on every tool iteration after the first —
-            # so that marker must not count as a user turn or the prefix
-            # would include the grown mid-turn context and the signature
-            # would change every iteration (defeating the once-per-turn
-            # cadence entirely).
-            last_user_idx = None
-            for _i in range(len(ref_messages) - 1, -1, -1):
-                _m = ref_messages[_i]
-                if _m.get("role") == "user" and _m.get(
-                    "content"
-                ) not in (_ADVISORY_INSTRUCTION, _NO_TOOL_HINT):
-                    last_user_idx = _i
-                    break
-            if last_user_idx is not None:
-                turn_prefix = ref_messages[: last_user_idx + 1]
+            # _build_reference_view records the last REAL user boundary while
+            # reading source roles, before it adds/merges any synthetic hint.
+            # Do not infer that boundary from content: a user is allowed to
+            # send text exactly equal to either internal marker.
+            turn_prefix = reference_view.turn_prefix
             if fanout_mode == "user_turn":
                 sig_messages = turn_prefix
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -787,6 +787,118 @@ def test_reference_messages_flattens_cache_decorated_content():
     assert view == _reference_messages(plain)
 
 
+def test_reference_messages_appends_no_tool_hint_on_user_ending_tool_view():
+    """A user-ending view with tool-log text must carry the no-tool hint.
+
+    In the default ``user_turn`` fanout mode, the ends-on-user call is the
+    ONLY view references actually receive — later tool iterations end on the
+    assistant and append _ADVISORY_INSTRUCTION, but their cache signature is
+    the prefix up to the last real user message, so they hit the cache and
+    never re-call the references. The hint therefore has to ride on the
+    ends-on-user view itself (a follow-up user message after a tool-using
+    exchange), or the default mode never sees it.
+    """
+    from agent.moa_loop import _NO_TOOL_HINT, _reference_messages
+
+    messages = [
+        {"role": "user", "content": "first ask"},
+        {
+            "role": "assistant",
+            "content": "let me look",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool output"},
+        {"role": "user", "content": "follow-up ask"},
+    ]
+
+    view = _reference_messages(messages)
+
+    # The view ends on the real follow-up user turn, and the no-tool hint is
+    # appended as its OWN user turn — not merged into the follow-up's content,
+    # so the turn_prefix signature (up to the last real user message) stays
+    # byte-identical across iterations.
+    assert view[-2] == {"role": "user", "content": "follow-up ask"}
+    assert view[-1] == {"role": "user", "content": _NO_TOOL_HINT}
+    assert "You have NO tools" in view[-1]["content"]
+
+
+def test_reference_messages_skips_no_tool_hint_on_fresh_prompt():
+    """A fresh prompt with no tool history gets no hint (nothing to disclaim)."""
+    from agent.moa_loop import _reference_messages
+
+    messages = [
+        {"role": "system", "content": "hermes system prompt"},
+        {"role": "user", "content": "just a question"},
+    ]
+
+    view = _reference_messages(messages)
+
+    assert view == [{"role": "user", "content": "just a question"}]
+
+
+def test_reference_messages_user_turn_cache_signature_stable_with_hint():
+    """Appending the hint must not change the user_turn cache signature.
+
+    The cache signature is the advisory prefix up to the last REAL user
+    message (the synthetic _ADVISORY_INSTRUCTION / _NO_TOOL_HINT markers are
+    excluded). Iteration 1 (ends-on-user, carries the hint) and iteration 2
+    (ends-on-assistant, carries the advisory) must hash to the SAME prefix —
+    otherwise the default fanout mode would MISS on every tool iteration and
+    re-run the references each time.
+    """
+    from agent.moa_loop import _ADVISORY_INSTRUCTION, _NO_TOOL_HINT, _reference_messages
+
+    iter1 = [
+        {"role": "user", "content": "first ask"},
+        {
+            "role": "assistant",
+            "content": "let me look",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool output"},
+        {"role": "user", "content": "follow-up ask"},
+    ]
+    iter2 = iter1 + [
+        {
+            "role": "assistant",
+            "content": "now I know",
+            "tool_calls": [{"id": "c2", "function": {"name": "g", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c2", "content": "more output"},
+    ]
+
+    def _turn_prefix(messages):
+        view = _reference_messages(messages)
+        last_user_idx = None
+        for _i in range(len(view) - 1, -1, -1):
+            _m = view[_i]
+            if _m.get("role") == "user" and _m.get("content") not in (
+                _ADVISORY_INSTRUCTION,
+                _NO_TOOL_HINT,
+            ):
+                last_user_idx = _i
+                break
+        return view[: last_user_idx + 1] if last_user_idx is not None else view
+
+    import hashlib
+
+    def _sig(msgs):
+        return hashlib.sha256(
+            "\u0000".join(
+                f"{m.get('role')}:{m.get('content')}" for m in msgs
+            ).encode("utf-8", "replace")
+        ).hexdigest()
+
+    v1, v2 = _reference_messages(iter1), _reference_messages(iter2)
+    # Iteration 1 carries the hint, iteration 2 carries the advisory — but
+    # their prefixes up to the last real user message must be identical.
+    assert v1[-1]["content"] == _NO_TOOL_HINT
+    assert v2[-1]["content"] == _ADVISORY_INSTRUCTION
+    assert _sig(_turn_prefix(iter1)) == _sig(_turn_prefix(iter2))
+    # And the prefix actually ends on the real follow-up user message.
+    assert _turn_prefix(iter1)[-1] == {"role": "user", "content": "follow-up ask"}
+
+
 
 
 
@@ -1153,6 +1265,87 @@ moa:
     usage2, cost2 = facade.consume_reference_usage()
     assert usage2.input_tokens == 0
     assert cost2 is None
+
+
+def test_user_turn_fanout_hint_rides_first_call_and_cache_stays_hot(monkeypatch, tmp_path):
+    """Default user_turn fanout: hint on the ends-on-user call, cache still HIT.
+
+    Regression for the triage finding on #79247: the no-tool hint used to live
+    only in _ADVISORY_INSTRUCTION, which is appended to assistant-ending
+    views. In user_turn mode iteration 1 ends on the user's message (so it
+    carried no hint), and later iterations ended on the assistant but HIT the
+    turn cache — meaning the references NEVER saw the hint in the default
+    mode. The fix appends _NO_TOOL_HINT to the ends-on-user view (iteration
+    1), and the cache must remain hot for iteration 2 (same turn_prefix
+    signature → no re-run, no double token charge).
+    """
+    from agent import moa_loop
+    from agent.usage_pricing import CanonicalUsage
+
+    home = tmp_path / ".hermes"
+    _ref_config(home, fanout="user_turn")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    fanout_calls = []
+
+    def fake_fanout(*args, **kwargs):
+        fanout_calls.append(kwargs.get("reference_models"))
+        return [
+            (
+                "openrouter:advisor",
+                "advice",
+                moa_loop._RefAccounting(CanonicalUsage(input_tokens=10)),
+            )
+        ]
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", fake_fanout)
+    monkeypatch.setattr(moa_loop, "call_llm", lambda **k: _response("acted"))
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    facade = moa_loop.MoAChatCompletions("review")
+
+    # Iteration 1: follow-up user message after a tool-using exchange — the
+    # ends-on-user view that carries the hint.
+    iter1 = [
+        {"role": "user", "content": "first ask"},
+        {
+            "role": "assistant",
+            "content": "let me look",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool output"},
+        {"role": "user", "content": "follow-up ask"},
+    ]
+    facade.create(messages=iter1, tools=[])
+
+    # Iteration 2: same turn, now ending on the assistant/tool exchange.
+    iter2 = iter1 + [
+        {
+            "role": "assistant",
+            "content": "now I know",
+            "tool_calls": [{"id": "c2", "function": {"name": "g", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c2", "content": "more output"},
+    ]
+    facade.create(messages=iter2, tools=[])
+
+    # The fan-out ran exactly once — iteration 2 was a cache HIT (no re-run).
+    assert len(fanout_calls) == 1
+
+    # The ONE fan-out's advisory view carried the hint on its user-ending call.
+    from agent.moa_loop import _NO_TOOL_HINT, _reference_messages
+
+    assert facade._ref_cache_key is not None
+    # Reconstruct what the references saw on the miss: _reference_messages
+    # of the iteration-1 messages.
+    view1 = _reference_messages(iter1)
+    assert view1[-1]["content"] == _NO_TOOL_HINT
+    # And the hint was appended to the REAL user turn (follow-up ask intact).
+    assert view1[-2]["content"] == "follow-up ask"
 
 
 class _CountingCtxLen:

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -787,7 +787,7 @@ def test_reference_messages_flattens_cache_decorated_content():
     assert view == _reference_messages(plain)
 
 
-def test_reference_messages_appends_no_tool_hint_on_user_ending_tool_view():
+def test_reference_messages_merges_no_tool_hint_on_user_ending_tool_view():
     """A user-ending view with tool-log text must carry the no-tool hint.
 
     In the default ``user_turn`` fanout mode, the ends-on-user call is the
@@ -813,13 +813,16 @@ def test_reference_messages_appends_no_tool_hint_on_user_ending_tool_view():
 
     view = _reference_messages(messages)
 
-    # The view ends on the real follow-up user turn, and the no-tool hint is
-    # appended as its OWN user turn — not merged into the follow-up's content,
-    # so the turn_prefix signature (up to the last real user message) stays
-    # byte-identical across iterations.
-    assert view[-2] == {"role": "user", "content": "follow-up ask"}
-    assert view[-1] == {"role": "user", "content": _NO_TOOL_HINT}
+    # The hint rides in a COPY of the real follow-up turn. Strict providers
+    # therefore see a valid alternating wire view, while the source transcript
+    # remains untouched for cache identity and the acting aggregator.
+    assert view[-1] == {
+        "role": "user",
+        "content": f"follow-up ask\n\n{_NO_TOOL_HINT}",
+    }
     assert "You have NO tools" in view[-1]["content"]
+    assert all(left["role"] != right["role"] for left, right in zip(view, view[1:]))
+    assert messages[-1] == {"role": "user", "content": "follow-up ask"}
 
 
 def test_reference_messages_skips_no_tool_hint_on_fresh_prompt():
@@ -836,17 +839,34 @@ def test_reference_messages_skips_no_tool_hint_on_fresh_prompt():
     assert view == [{"role": "user", "content": "just a question"}]
 
 
+def test_reference_messages_does_not_infer_tool_history_from_user_text():
+    """Flattened marker prose is not evidence that a tool actually ran."""
+    from agent.moa_loop import _reference_messages
+
+    user_text = (
+        "Please explain the literal examples [called tool: fake] and "
+        "[tool result: fake]."
+    )
+
+    assert _reference_messages([{"role": "user", "content": user_text}]) == [
+        {"role": "user", "content": user_text}
+    ]
+
+
 def test_reference_messages_user_turn_cache_signature_stable_with_hint():
     """Appending the hint must not change the user_turn cache signature.
 
     The cache signature is the advisory prefix up to the last REAL user
-    message (the synthetic _ADVISORY_INSTRUCTION / _NO_TOOL_HINT markers are
-    excluded). Iteration 1 (ends-on-user, carries the hint) and iteration 2
-    (ends-on-assistant, carries the advisory) must hash to the SAME prefix —
-    otherwise the default fanout mode would MISS on every tool iteration and
-    re-run the references each time.
+    boundary recorded before synthetic text is added. Iteration 1
+    (ends-on-user, carries the hint) and iteration 2 (ends-on-assistant,
+    carries the advisory) must use the SAME prefix — otherwise the default
+    fanout mode would MISS on every tool iteration and re-run the references.
     """
-    from agent.moa_loop import _ADVISORY_INSTRUCTION, _NO_TOOL_HINT, _reference_messages
+    from agent.moa_loop import (
+        _ADVISORY_INSTRUCTION,
+        _NO_TOOL_HINT,
+        _build_reference_view,
+    )
 
     iter1 = [
         {"role": "user", "content": "first ask"},
@@ -867,36 +887,56 @@ def test_reference_messages_user_turn_cache_signature_stable_with_hint():
         {"role": "tool", "tool_call_id": "c2", "content": "more output"},
     ]
 
-    def _turn_prefix(messages):
-        view = _reference_messages(messages)
-        last_user_idx = None
-        for _i in range(len(view) - 1, -1, -1):
-            _m = view[_i]
-            if _m.get("role") == "user" and _m.get("content") not in (
-                _ADVISORY_INSTRUCTION,
-                _NO_TOOL_HINT,
-            ):
-                last_user_idx = _i
-                break
-        return view[: last_user_idx + 1] if last_user_idx is not None else view
-
-    import hashlib
-
-    def _sig(msgs):
-        return hashlib.sha256(
-            "\u0000".join(
-                f"{m.get('role')}:{m.get('content')}" for m in msgs
-            ).encode("utf-8", "replace")
-        ).hexdigest()
-
-    v1, v2 = _reference_messages(iter1), _reference_messages(iter2)
+    v1 = _build_reference_view(iter1)
+    v2 = _build_reference_view(iter2)
     # Iteration 1 carries the hint, iteration 2 carries the advisory — but
     # their prefixes up to the last real user message must be identical.
-    assert v1[-1]["content"] == _NO_TOOL_HINT
-    assert v2[-1]["content"] == _ADVISORY_INSTRUCTION
-    assert _sig(_turn_prefix(iter1)) == _sig(_turn_prefix(iter2))
-    # And the prefix actually ends on the real follow-up user message.
-    assert _turn_prefix(iter1)[-1] == {"role": "user", "content": "follow-up ask"}
+    assert v1.messages[-1]["content"].endswith(_NO_TOOL_HINT)
+    assert v2.messages[-1]["content"] == _ADVISORY_INSTRUCTION
+    assert v1.turn_prefix == v2.turn_prefix
+    # The stable prefix is the real, unmodified conversation boundary.
+    assert v1.turn_prefix[-1] == {"role": "user", "content": "follow-up ask"}
+
+
+def test_generic_strict_reference_receives_alternating_hint_wire_view(monkeypatch):
+    """A generic/custom reference must not receive adjacent user turns."""
+    from agent import moa_loop
+
+    source = [
+        {"role": "user", "content": "first ask"},
+        {
+            "role": "assistant",
+            "content": "let me look",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool output"},
+        {"role": "user", "content": "follow-up ask"},
+    ]
+    captured = {}
+
+    def fake_strict_call(**kwargs):
+        captured.update(kwargs)
+        roles = [message["role"] for message in kwargs["messages"]]
+        if any(left == right for left, right in zip(roles, roles[1:])):
+            raise ValueError("strict provider rejects adjacent roles")
+        return _response("advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_strict_call)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": "custom", "model": slot["model"]},
+    )
+
+    label, text, _acct = moa_loop._run_reference(
+        {"provider": "custom", "model": "strict-model"},
+        moa_loop._reference_messages(source),
+    )
+
+    assert label == "custom:strict-model"
+    assert text == "advice"
+    assert captured["provider"] == "custom"
+    assert captured["messages"][-1]["content"].endswith(moa_loop._NO_TOOL_HINT)
 
 
 
@@ -1267,6 +1307,54 @@ moa:
     assert cost2 is None
 
 
+def test_real_user_marker_text_starts_a_new_user_turn_fanout(monkeypatch, tmp_path):
+    """Internal prompt text is still real when it came from a user role."""
+    from agent import moa_loop
+    from agent.usage_pricing import CanonicalUsage
+
+    home = tmp_path / ".hermes"
+    _ref_config(home, fanout="user_turn")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    fanout_calls = []
+
+    def fake_fanout(*args, **kwargs):
+        fanout_calls.append([dict(message) for message in args[1]])
+        return [
+            (
+                "openrouter:advisor",
+                "advice",
+                moa_loop._RefAccounting(CanonicalUsage(input_tokens=10)),
+            )
+        ]
+
+    monkeypatch.setattr(moa_loop, "_run_references_parallel", fake_fanout)
+    monkeypatch.setattr(moa_loop, "call_llm", lambda **k: _response("acted"))
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+
+    for marker in (moa_loop._NO_TOOL_HINT, moa_loop._ADVISORY_INSTRUCTION):
+        fanout_calls.clear()
+        facade = moa_loop.MoAChatCompletions("review")
+        facade.create(messages=[{"role": "user", "content": "first ask"}], tools=[])
+        facade.create(
+            messages=[
+                {"role": "user", "content": "first ask"},
+                {"role": "assistant", "content": "first answer"},
+                {"role": "user", "content": marker},
+            ],
+            tools=[],
+        )
+
+        # Content equality cannot erase the second real-user boundary: each
+        # marker-valued follow-up is a new state and must trigger fresh advice.
+        assert len(fanout_calls) == 2
+        assert fanout_calls[-1][-1] == {"role": "user", "content": marker}
+
+
 def test_user_turn_fanout_hint_rides_first_call_and_cache_stays_hot(monkeypatch, tmp_path):
     """Default user_turn fanout: hint on the ends-on-user call, cache still HIT.
 
@@ -1275,9 +1363,9 @@ def test_user_turn_fanout_hint_rides_first_call_and_cache_stays_hot(monkeypatch,
     views. In user_turn mode iteration 1 ends on the user's message (so it
     carried no hint), and later iterations ended on the assistant but HIT the
     turn cache — meaning the references NEVER saw the hint in the default
-    mode. The fix appends _NO_TOOL_HINT to the ends-on-user view (iteration
-    1), and the cache must remain hot for iteration 2 (same turn_prefix
-    signature → no re-run, no double token charge).
+    mode. The fix merges _NO_TOOL_HINT into the ends-on-user wire view
+    (iteration 1), and the cache must remain hot for iteration 2 (same
+    unhinted turn_prefix signature → no re-run, no double token charge).
     """
     from agent import moa_loop
     from agent.usage_pricing import CanonicalUsage
@@ -1289,7 +1377,9 @@ def test_user_turn_fanout_hint_rides_first_call_and_cache_stays_hot(monkeypatch,
     fanout_calls = []
 
     def fake_fanout(*args, **kwargs):
-        fanout_calls.append(kwargs.get("reference_models"))
+        # Capture the actual wire view passed by the facade, not a reconstructed
+        # helper result, so this test covers the integration boundary.
+        fanout_calls.append([dict(message) for message in args[1]])
         return [
             (
                 "openrouter:advisor",
@@ -1336,16 +1426,22 @@ def test_user_turn_fanout_hint_rides_first_call_and_cache_stays_hot(monkeypatch,
     # The fan-out ran exactly once — iteration 2 was a cache HIT (no re-run).
     assert len(fanout_calls) == 1
 
-    # The ONE fan-out's advisory view carried the hint on its user-ending call.
-    from agent.moa_loop import _NO_TOOL_HINT, _reference_messages
+    # The ONE fan-out's advisory wire view carried the hint on its user-ending
+    # call without adding a second adjacent user message.
+    from agent.moa_loop import _NO_TOOL_HINT
 
     assert facade._ref_cache_key is not None
-    # Reconstruct what the references saw on the miss: _reference_messages
-    # of the iteration-1 messages.
-    view1 = _reference_messages(iter1)
-    assert view1[-1]["content"] == _NO_TOOL_HINT
-    # And the hint was appended to the REAL user turn (follow-up ask intact).
-    assert view1[-2]["content"] == "follow-up ask"
+    wire_view = fanout_calls[0]
+    assert wire_view[-1] == {
+        "role": "user",
+        "content": f"follow-up ask\n\n{_NO_TOOL_HINT}",
+    }
+    assert all(
+        left["role"] != right["role"]
+        for left, right in zip(wire_view, wire_view[1:])
+    )
+    # Hint injection is wire-only; the real transcript/cache prefix is intact.
+    assert iter1[-1] == {"role": "user", "content": "follow-up ask"}
 
 
 class _CountingCtxLen:


### PR DESCRIPTION
feat(moa): inject no-tool hint in advisory instruction

## Problem

MOA reference models sometimes restate tool logs from the conversation transcript as if they executed them (`TOOL: [terminal] ran ... exit 0`). This happens because `_reference_messages` renders the acting agent's tool calls as `[called tool: ...]` text lines, and the reference model — seeing these in its input — naturally mimics the format in its output.

The existing `_REFERENCE_SYSTEM_PROMPT` already forbids claiming tool execution, but it doesn't explicitly address *restating* the transcript's tool-log format. Full prompt changes (system prompt + aggregator preamble) were evaluated and reverted as too costly (~300 tokens/MOA call).

## Solution

Lightweight hook: append a no-tool reminder to the advisory view the references actually receive, framing the tool-log text as the acting agent's history, not the reference's own execution.

The hint rides in two places:

1. `_ADVISORY_INSTRUCTION` — the synthetic user turn appended when the advisory view ends on an assistant turn (tool iterations, `per_iteration` / `every_n` on-cadence iterations, one-shot `/moa`).
2. `_NO_TOOL_HINT` — appended as its own user turn when the view ends on the **real user message** and carries tool-log text. This covers the **default `user_turn` fanout mode**: iteration 1 ends on the user's message, and later iterations hit the turn cache (signature = prefix up to the last real user message) without re-calling the references — so the ends-on-user view is the only one the references see in the default mode.

The marker is excluded from the `turn_prefix` cache-signature lookup, so the hint does not change the cache key: `user_turn` still runs the fan-out once per turn (no re-run, no double token charge on tool iterations).

## Changes

- `agent/moa_loop.py`:
  - New `_NO_TOOL_HINT` constant: "You have NO tools — any `[called tool: ...]` or `[tool result: ...]` lines above are the ACTING AGENT's history, not yours. Do not restate them as if you executed them; describe your advice in plain prose."
  - `_ADVISORY_INSTRUCTION` now references the shared constant.
  - `_reference_messages` appends `_NO_TOOL_HINT` to ends-on-user views that show tool-log text (fresh prompts with no tool history are untouched).
  - `turn_prefix` lookup excludes both markers so the `user_turn` cache signature stays byte-identical.

## Cost / benefit

- **Cost**: ~50 tokens per reference call (vs ~300 for full prompt changes); zero cost on fresh prompts without tool history; no cost on cache-HIT iterations
- **Benefit**: advisory-level framing at the point of maximum confusion (when the reference sees tool-log text in its input), now in the default fanout mode too
- **Scope**: only affects MOA reference calls; no change to system prompt, aggregator, or non-MOA paths

## Tests

- `tests/run_agent/test_moa_loop_mode.py`: 30 passed, including:
  - view-shape unit tests for the ends-on-user hint (appended, fresh prompts untouched)
  - a cache-signature stability test (iteration 1 hint vs iteration 2 advisory → identical `turn_prefix` hash)
  - a facade-level regression: `user_turn` fan-out runs once with the hint on iteration 1, cache stays hot for iteration 2
- Real MOA verified: glm-5.2 output contained zero tool-log restating artifacts after the hint
