### PR TITLE
fix(desktop): stop simple-git custom-binary warning spam on Windows

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -38,6 +38,43 @@ test('gitFor accepts an internally resolved git binary path containing spaces', 
   assert.doesNotThrow(() => gitFor(process.cwd(), 'C:\\Program Files\\Git\\cmd\\git.exe'))
 })
 
+test('gitFor does not log simple-git custom-binary warnings for a spaced binary path', () => {
+  const warnings: unknown[][] = []
+  const original = console.warn
+
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args)
+  }
+
+  try {
+    for (let i = 0; i < 5; i += 1) {
+      gitFor(process.cwd(), 'C:\\Program Files\\Git\\cmd\\git.exe')
+    }
+  } finally {
+    console.warn = original
+  }
+
+  assert.deepEqual(warnings, [])
+})
+
+test('gitFor restores console.warn so unrelated warnings still surface', () => {
+  const warnings: unknown[][] = []
+  const original = console.warn
+
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args)
+  }
+
+  try {
+    gitFor(process.cwd(), 'C:\\Program Files\\Git\\cmd\\git.exe')
+    console.warn('unrelated warning')
+  } finally {
+    console.warn = original
+  }
+
+  assert.deepEqual(warnings, [['unrelated warning']])
+})
+
 test('gitFor runs git through a spaced binary path', async () => {
   if (process.platform !== 'win32') {
     return

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -43,6 +43,34 @@ function runGh(args, cwd, ghBin): Promise<{ ok: boolean; stdout: string }> {
   })
 }
 
+// simple-git logs this to `console.warn` on EVERY construction that opts into
+// `unsafe.allowUnsafeCustomBinary`. We opt in deliberately (see `gitFor`), so
+// the warning carries no information — but the coding rail rebuilds a client on
+// every status poll, which turned the desktop log into hundreds of identical
+// lines and buried real errors.
+const SIMPLE_GIT_UNSAFE_BINARY_WARNING = 'Invalid value supplied for custom binary'
+
+// Run `build` with simple-git's known custom-binary warning suppressed. The
+// suppression is synchronous and scoped to the construction call, so unrelated
+// warnings (including any emitted later by the returned client) still surface.
+function withoutUnsafeBinaryWarning<T>(build: () => T): T {
+  const original = console.warn
+
+  console.warn = (...args: unknown[]) => {
+    if (typeof args[0] === 'string' && args[0].startsWith(SIMPLE_GIT_UNSAFE_BINARY_WARNING)) {
+      return
+    }
+
+    original.apply(console, args as [])
+  }
+
+  try {
+    return build()
+  } finally {
+    console.warn = original
+  }
+}
+
 function gitFor(cwd, gitBin) {
   // `gitBin` is resolved inside the Electron main process from known install
   // locations or PATH — never renderer/user input. simple-git's custom-binary
@@ -51,13 +79,18 @@ function gitFor(cwd, gitBin) {
   // For spaced paths, opt into simple-git's trusted-binary escape hatch instead
   // of falling back to PATH (often absent in GUI-launched apps, and PATH lookup
   // could resolve a repo-local git.exe).
-  return simpleGit({
-    baseDir: cwd,
-    binary: gitBin || 'git',
-    maxConcurrentProcesses: 4,
-    trimmed: false,
-    ...(gitBin && /\s/.test(gitBin) ? { unsafe: { allowUnsafeCustomBinary: true } } : {})
-  })
+  const unsafeBinary = Boolean(gitBin && /\s/.test(gitBin))
+
+  const build = () =>
+    simpleGit({
+      baseDir: cwd,
+      binary: gitBin || 'git',
+      maxConcurrentProcesses: 4,
+      trimmed: false,
+      ...(unsafeBinary ? { unsafe: { allowUnsafeCustomBinary: true } } : {})
+    })
+
+  return unsafeBinary ? withoutUnsafeBinaryWarning(build) : build()
 }
 
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve


### PR DESCRIPTION
Fixes #79245

## Symptom

On Windows, `hermes desktop` floods the launching terminal with hundreds of identical lines while the app sits idle:

```
Invalid value supplied for custom binary, restricted characters must be removed or supply the unsafe.allowUnsafeCustomBinary option
```

Real errors in the same stream (`Error occurred in handler for 'hermes:api'`) get buried in the noise.

## Root cause

`apps/desktop/electron/git-review-ops.ts` → `gitFor()` deliberately passes
`unsafe: { allowUnsafeCustomBinary: true }` when the resolved git binary path
contains a space — the default Windows install is `C:\Program Files\Git\cmd\git.exe`.
That opt-in is correct and is what keeps the Review pane working on Windows
(#54888, #64810), so it must be preserved.

But simple-git's `custom-binary.plugin` runs its validation on **every**
construction and simply trades the throw for a warn:

```js
const isBad = input.some(isBadArgument);   // /^([a-z]:)?([a-z0-9/.\\_~-]+)$/i — a space fails
if (isBad) {
  if (allowUnsafe) { console.warn(WRONG_CHARS_ERR); }
  else { throw new GitPluginError(...); }
}
```

`gitFor()` is not memoized: it builds a fresh client per call, and it is called
from `repoStatus()` and the review ops the coding rail polls. One warning per
poll, forever.

The warning carries no information for us — `gitBin` is resolved inside the
Electron main process from known install locations / PATH, never from renderer or
user input, and we opted in knowingly.

## The fix

Suppress *only* that one known warning, *only* around the construction call:

- match on the known prefix, so any other `console.warn` still passes through;
- restore `console.warn` in a `finally`, so the patch cannot leak past the call;
- only wrap at all when we're actually taking the unsafe-binary path — the common
  case is untouched.

The alternative (memoizing `gitFor`) would reduce but not eliminate the spam, and
would introduce client-lifetime/cwd-caching questions this bug doesn't warrant.

## Tests

Added to `apps/desktop/electron/git-review-ops.test.ts`:

- constructing with a spaced binary path 5× emits **zero** warnings;
- `console.warn` is restored afterwards, so an unrelated warning still surfaces.

Both fail on `main` and pass with this change:

```
# main (patch reverted, tests kept)
 × gitFor does not log simple-git custom-binary warnings for a spaced binary path
 × gitFor restores console.warn so unrelated warnings still surface
   Tests  2 failed | 9 passed (11)

# with the fix
 ✓ electron/git-review-ops.test.ts (11 tests) 4449ms
   Tests  11 passed (11)
```

`npx tsc -p tsconfig.electron.json --noEmit` is clean.

Verified on Windows 10 with git at `C:\Program Files\Git\cmd\git.exe`.
