### PR TITLE
fix(agent): preserve sub-cent usage cost labels

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1357,7 +1357,7 @@ def estimate_usage_cost(
         amount += Decimal(usage.request_count) * entry.request_cost
 
     status: CostStatus = "estimated"
-    label = f"~${amount:.2f}"
+    label = _format_estimated_cost_label(amount)
     if entry.source == "none" and amount == _ZERO:
         status = "included"
         label = "included"
@@ -1374,6 +1374,20 @@ def estimate_usage_cost(
         pricing_version=entry.pricing_version,
         notes=tuple(notes),
     )
+
+
+def _format_estimated_cost_label(amount: Decimal) -> str:
+    """Format USD estimates without rounding non-zero sub-cent costs to zero."""
+    text = f"{amount:.2f}"
+    if amount.is_finite() and amount != _ZERO and abs(amount) < Decimal("0.01"):
+        # Match the adaptive precision used for model prices: find the first
+        # decimal place that renders a non-zero value, keep one extra digit,
+        # then trim insignificant trailing zeros.
+        precision = 3
+        while precision < 12 and round(abs(amount), precision) == _ZERO:
+            precision += 1
+        text = f"{amount:.{min(precision + 1, 12)}f}".rstrip("0").rstrip(".")
+    return f"~${text}"
 
 
 def has_known_pricing(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -120,6 +121,48 @@ def test_deepseek_deprecated_aliases_price_as_v4_flash():
         assert (
             entry.cache_read_cost_per_million == flash.cache_read_cost_per_million
         ), alias
+
+
+def test_estimated_cost_labels_preserve_nonzero_sub_cent_values():
+    """Non-zero per-turn costs must not collapse to ``~$0.00`` (#79220)."""
+    reported = estimate_usage_cost(
+        "deepseek-v4-pro",
+        CanonicalUsage(
+            input_tokens=8000,
+            output_tokens=1200,
+            cache_read_tokens=32000,
+            reasoning_tokens=5000,
+        ),
+        provider="deepseek",
+        base_url="https://api.deepseek.com/v1",
+    )
+    assert reported.amount_usd == Decimal("0.004640")
+    assert reported.label == "~$0.0046"
+
+    tiny = estimate_usage_cost(
+        "deepseek-v4-pro",
+        CanonicalUsage(cache_read_tokens=1),
+        provider="deepseek",
+    )
+    assert tiny.amount_usd is not None and tiny.amount_usd > 0
+    assert Decimal(tiny.label.removeprefix("~$")) > 0
+
+
+def test_estimated_cost_labels_keep_existing_zero_and_cent_precision():
+    zero = estimate_usage_cost(
+        "deepseek-v4-pro",
+        CanonicalUsage(),
+        provider="deepseek",
+    )
+    standard = estimate_usage_cost(
+        "deepseek-v4-pro",
+        CanonicalUsage(output_tokens=20000),
+        provider="deepseek",
+    )
+
+    assert zero.label == "~$0.00"
+    assert standard.amount_usd == Decimal("0.01740")
+    assert standard.label == "~$0.02"
 
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents non-zero sub-cent usage estimates from being displayed as
`~$0.00`.

Estimated costs below `$0.01` now extend decimal precision until the first
non-zero place, keep one additional digit, and trim trailing zeros. This
matches the existing adaptive formatting used for sub-cent model prices.
Zero values and estimates of at least one cent retain the existing two-decimal
format.

## Related Issue

Fixes #79220

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔐 Security fix
- [ ] 📑 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎆 New skill (bundled or hub)

## Changes Made

- `agent/usage_pricing.py`: format non-zero sub-cent estimates with adaptive
  Decimal precision while preserving existing zero and standard-cost labels.
- `tests/agent/test_usage_pricing.py`: cover the reported DeepSeek example,
  an extremely small non-zero estimate, a zero estimate, and a normal
  cent-level estimate.

## How to Test

1. Reproduce the original example from #79220 and confirm an
   `amount_usd` of `0.004640` now has label `~$0.0046` instead of `~$0.00`.
2. Run the affected test file:

   ```bash
   scripts/run_tests.sh tests/agent/test_usage_pricing.py -q
   ```

   Result: `13 passed, 0 failed`.
3. Run the blocking lint and production-file type check:

   ```bash
   uv tool run ruff check .
   uv tool run ty check agent/usage_pricing.py
   ```

   Result: both checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: native Windows, Python 3.12.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public API or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before:

```text
0.004640 estimated ~$0.00
```

After:

```text
0.004640 estimated ~$0.0046
```
