### PR TITLE
feat(gateway): announce startups after signal-initiated shutdowns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12980,7 +12980,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            # Signal-initiated shutdowns (container orchestrators, service
+            # managers, bare SIGTERM) also deserve a home-channel notice on
+            # the next boot: the shutdown itself is announced, but without
+            # the marker the comeback is silent. The marker only speaks if
+            # a next boot happens, so writing it on a final shutdown is
+            # harmless.
+            planned_restart = self._restart_requested and self._restart_command_source is None
+            external_stop = not self._restart_requested and getattr(
+                self, "_signal_initiated_shutdown", False
+            )
+            if planned_restart or external_stop:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),
@@ -12988,6 +12998,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "requested_at": time.time(),
                             "via_service": bool(self._restart_via_service),
                             "detached": bool(self._restart_detached),
+                            "reason": "restart" if planned_restart else "shutdown",
                         },
                         indent=None,
                     )

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -413,3 +413,39 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     adapter.send.assert_not_awaited()
 
 
+# ── signal-initiated shutdowns write the planned-restart marker ───────────
+
+
+@pytest.mark.asyncio
+async def test_signal_shutdown_writes_startup_notification_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.0
+    runner._signal_initiated_shutdown = True
+
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+        patch("agent.auxiliary_client.shutdown_cached_clients"),
+    ):
+        await runner.stop()
+
+    marker = tmp_path / ".restart_pending.json"
+    assert marker.exists()
+    assert json.loads(marker.read_text())["reason"] == "shutdown"
+
+
+@pytest.mark.asyncio
+async def test_plain_stop_does_not_write_startup_notification_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, _adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.0
+
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+        patch("agent.auxiliary_client.shutdown_cached_clients"),
+    ):
+        await runner.stop()
+
+    assert not (tmp_path / ".restart_pending.json").exists()


### PR DESCRIPTION
## What does this PR do?

Container orchestrators and service managers stop the gateway with a bare SIGTERM. The shutdown itself notifies home channels ("⚠️ Gateway shutting down"), but the comeback stays silent: the `.restart_pending.json` marker that drives `_send_home_channel_startup_notifications` is only written when the shutdown came from a `/restart` command. This writes the marker for signal-initiated shutdowns too, so the next boot posts the existing "♻️ Gateway online" notice. The marker only speaks if a next boot happens, so a final shutdown stays silent; a `reason` field (`restart` vs `shutdown`) records the origin.

## Related Issue

None found (searched open and closed issues/PRs for startup/shutdown notification coverage).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py`: extend the marker-write condition in the shutdown path to cover `_signal_initiated_shutdown`; add a `reason` field to the marker payload.
- `tests/gateway/test_restart_notification.py`: two tests — signal-initiated `stop()` writes the marker with `reason: shutdown`; a plain `stop()` does not write it.

## How to Test

1. `pytest tests/gateway/test_restart_notification.py tests/gateway/test_gateway_shutdown.py -q` — 56 passed.
2. Manually: run `hermes gateway` with a Slack home channel configured, `kill -TERM` the process, start it again — the home channel receives "♻️ Gateway online — Hermes is back and ready."

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the two affected gateway suites, 56 passed; full-suite collection needs optional extras not in `dev`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A