### PR TITLE
fix(pricing): treat OpenAI-compatible /models prices as per-million (#79400)

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -165,6 +165,14 @@ class ProviderInfo:
 # Provider ID mapping: Hermes ↔ models.dev
 # ---------------------------------------------------------------------------
 
+# Hermes custom providers are addressed as "custom:<name>"; models.dev
+# catalogs them under the bare name when it mirrors a public provider
+# (e.g. custom:hyper → hyper). Strip the prefix before lookup.
+def _mdev_provider_id(provider_id: str) -> str:
+    if provider_id.startswith("custom:"):
+        provider_id = provider_id[len("custom:"):]
+    return PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
@@ -754,7 +762,7 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
+    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
     if not mdev_provider_id:
         return _default_override_context(provider)
 
@@ -1104,7 +1112,7 @@ def _get_provider_models(
     ``allow_network`` defaults to False — this is called from hot paths
     (vision routing, image routing, capability checks) and must never block.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
+    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
     if not mdev_provider_id:
         return None
 
@@ -1454,7 +1462,7 @@ def get_provider_info(
     ``allow_network=False``.
     """
     # Resolve Hermes ID → models.dev ID
-    mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    mdev_id = _mdev_provider_id(provider_id)
 
     # NOTE: keep the zero-argument call on the default path. Dozens of test
     # sites monkeypatch fetch_models_dev with zero-arg lambdas; passing the
@@ -1494,7 +1502,7 @@ def get_model_info(
     ``allow_network`` defaults to False — model info lookup is a hot path
     (cost guard, inventory) and must never block on the network.
     """
-    mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    mdev_id = _mdev_provider_id(provider_id)
 
     def _from_override_alone() -> Optional[ModelInfo]:
         override = _override_for(provider_id, model_id, catalog_hit=False)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -173,6 +173,21 @@ def _mdev_provider_id(provider_id: str) -> str:
         provider_id = provider_id[len("custom:"):]
     return PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
 
+
+def _mdev_provider_id_strict(provider_id: str) -> Optional[str]:
+    """Resolve a Hermes provider id to a models.dev catalog id, strictly.
+
+    Plain provider ids must be keys of PROVIDER_TO_MODELS_DEV — an unknown
+    id resolves to None instead of being passed through, so an arbitrary
+    string never triggers a catalog fetch. ``custom:<name>`` providers pass
+    through to the catalog under the bare name (custom:hyper → hyper),
+    matching the mapping's pass-through contract for custom endpoints.
+    """
+    if provider_id.startswith("custom:"):
+        provider_id = provider_id[len("custom:"):]
+        return PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    return PROVIDER_TO_MODELS_DEV.get(provider_id)
+
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
@@ -762,7 +777,7 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
-    mdev_provider_id = _mdev_provider_id(provider)
+    mdev_provider_id = _mdev_provider_id_strict(provider)
     if not mdev_provider_id:
         return _default_override_context(provider)
 
@@ -1112,7 +1127,7 @@ def _get_provider_models(
     ``allow_network`` defaults to False — this is called from hot paths
     (vision routing, image routing, capability checks) and must never block.
     """
-    mdev_provider_id = _mdev_provider_id(provider)
+    mdev_provider_id = _mdev_provider_id_strict(provider)
     if not mdev_provider_id:
         return None
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -762,7 +762,7 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
+    mdev_provider_id = _mdev_provider_id(provider)
     if not mdev_provider_id:
         return _default_override_context(provider)
 
@@ -1112,7 +1112,7 @@ def _get_provider_models(
     ``allow_network`` defaults to False — this is called from hot paths
     (vision routing, image routing, capability checks) and must never block.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
+    mdev_provider_id = _mdev_provider_id(provider)
     if not mdev_provider_id:
         return None
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1186,11 +1186,15 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
 
 
 def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+    # OpenRouter's models API reports per-token decimals
+    # (e.g. 0.0000032664), unlike OpenAI-compatible /models endpoints which
+    # report dollars per million tokens — declare the unit explicitly.
     return _pricing_entry_from_metadata(
         fetch_model_metadata(),
         route.model,
         source_url="https://openrouter.ai/docs/api/api-reference/models/get-models",
         pricing_version="openrouter-models-api",
+        pricing_units="per_token",
     )
 
 
@@ -1200,7 +1204,17 @@ def _pricing_entry_from_metadata(
     *,
     source_url: str,
     pricing_version: str,
+    pricing_units: Literal["per_token", "per_million"] = "per_million",
 ) -> Optional[PricingEntry]:
+    """Build a PricingEntry from a provider /models metadata map.
+
+    ``pricing_units`` declares the unit the source API reports:
+    - ``per_million`` — OpenAI-compatible ``/models`` endpoints (the default;
+      e.g. ``{"pricing": {"prompt": 3.2664}}`` means $3.2664 per million
+      input tokens). Values are used as-is.
+    - ``per_token`` — OpenRouter's models API, which reports per-token
+      decimals (e.g. ``0.0000032664``). Values are scaled to per-million.
+    """
     if model_id not in metadata:
         return None
     pricing = metadata[model_id].get("pricing") or {}
@@ -1221,8 +1235,8 @@ def _pricing_entry_from_metadata(
         return None
 
     def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
-        if value is None:
-            return None
+        if value is None or pricing_units != "per_token":
+            return value
         return value * _ONE_MILLION
 
     return PricingEntry(
@@ -1262,6 +1276,9 @@ def get_pricing_entry(
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",
+            # OpenAI-compatible /models endpoints report dollars per million
+            # tokens already (e.g. 3.2664 = $3.27/M) — no per-token scaling.
+            pricing_units="per_million",
         )
         if entry:
             return entry

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -15,6 +15,7 @@ from agent.models_dev import (
     _override_for,
     _NotModified,
     _validate_registry,
+    _get_provider_models,
     fetch_models_dev,
     get_model_capabilities,
     get_model_info,
@@ -145,6 +146,38 @@ class TestLookupModelsDevContext:
         # audio-only is not a mapped provider, but test the filtering directly
         data = SAMPLE_REGISTRY["audio-only"]["models"]["tts-model"]
         assert _extract_context(data) is None
+
+
+class TestCustomProviderNormalization:
+    """#79225: ``custom:<name>`` providers must resolve through the bare
+    catalog id even when ``<name>`` is not a key in PROVIDER_TO_MODELS_DEV.
+    A double lookup (normalize, then map again) silently drops the
+    normalized id: ``PROVIDER_TO_MODELS_DEV.get("audio-only")`` is None."""
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_lookup_models_dev_context_resolves_custom_catalog_id(
+        self, mock_fetch
+    ):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        # "audio-only" is NOT in PROVIDER_TO_MODELS_DEV but IS a catalog id.
+        assert "audio-only" not in PROVIDER_TO_MODELS_DEV
+        # tts-model has context 0 → filtered → None (resolution itself works,
+        # proving the normalized id reached the registry lookup).
+        assert lookup_models_dev_context("custom:audio-only", "tts-model") is None
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_get_provider_models_resolves_custom_catalog_id(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        models = _get_provider_models("custom:audio-only")
+        assert models is not None
+        assert "tts-model" in models
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_get_model_info_resolves_custom_catalog_id(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        info = get_model_info("custom:anthropic", "claude-opus-4-6")
+        assert info is not None
+        assert info.context_window == 1000000
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -460,309 +460,68 @@ class TestSubscriptionIncludedNotes:
         assert any("subscription" in note.lower() for note in result.notes)
 
 
-def test_normalize_usage_reads_kimi_top_level_cached_tokens():
-    """Kimi/Moonshot's native API reports context-cache hits as a top-level
-    usage.cached_tokens, not OpenAI's nested
-    prompt_tokens_details.cached_tokens and not DeepSeek's
-    prompt_cache_hit_tokens. Neither existing fallback matches that name, so
-    direct Kimi sessions normalized to cache_read_tokens=0 — the hits were
-    invisible in accounting and billed at the full input rate (#65722)."""
-    usage = SimpleNamespace(
-        prompt_tokens=3000,
-        completion_tokens=250,
-        cached_tokens=1800,
-    )
+# ---------------------------------------------------------------------------
+# #79225: per-token vs per-million pricing units
+# ---------------------------------------------------------------------------
 
-    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+def test_openai_compatible_models_pricing_is_per_million_not_scaled():
+    """OpenAI-compatible /models endpoints report dollars per million tokens
+    (e.g. 3.2664 = $3.27/M input). Before this fix the value was treated as a
+    per-token decimal and scaled by 1e6, producing $3,266,400/M and a bogus
+    expensive-model warning (#79225)."""
+    from agent.usage_pricing import _pricing_entry_from_metadata
 
-    assert normalized.cache_read_tokens == 1800
-    # prompt_tokens includes the cached prefix: 3000 - 1800 = fresh input
-    assert normalized.input_tokens == 1200
-    assert normalized.output_tokens == 250
-
-
-def test_kimi_fallback_does_not_override_the_nested_openai_shape():
-    """A provider that reports BOTH shapes must keep the nested value.
-
-    The new branch is last in the chain, so it only fills a genuine zero.
-    """
-    usage = SimpleNamespace(
-        prompt_tokens=1000,
-        completion_tokens=100,
-        prompt_tokens_details=SimpleNamespace(cached_tokens=400),
-        cached_tokens=999,  # must be ignored
-    )
-
-    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 400
-
-
-def test_kimi_fallback_does_not_override_deepseek_hit_tokens():
-    usage = SimpleNamespace(
-        prompt_tokens=2000,
-        completion_tokens=100,
-        prompt_cache_hit_tokens=1500,
-        cached_tokens=999,  # must be ignored
-    )
-
-    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 1500
-
-
-def test_usage_without_any_cache_fields_still_normalizes():
-    usage = SimpleNamespace(prompt_tokens=500, completion_tokens=50)
-
-    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 0
-    assert normalized.input_tokens == 500
-
-
-def test_normalize_usage_handles_dict_shaped_usage():
-    """Regression test for #74314: when the Responses API returns usage as a
-    plain dict (e.g. from a middleware/proxy that deserialises JSON to dict
-    instead of a typed SDK object), normalize_usage() must read the same
-    token counts as it would from an attribute-style object.
-
-    Before this fix, getattr() on a dict silently returned 0 for every field,
-    so token counts and cost appeared as zero for dict-shaped usage.
-    """
-    # Same payload as both a dict and a SimpleNamespace
-    payload = {
-        "input_tokens": 100,
-        "output_tokens": 20,
-        "input_tokens_details": {"cached_tokens": 60, "cache_creation_tokens": 10},
-    }
-    ns = SimpleNamespace(
-        input_tokens=100,
-        output_tokens=20,
-        input_tokens_details=SimpleNamespace(cached_tokens=60, cache_creation_tokens=10),
-    )
-
-    dict_result = normalize_usage(payload, api_mode="codex_responses")
-    ns_result = normalize_usage(ns, api_mode="codex_responses")
-
-    assert dict_result.input_tokens == ns_result.input_tokens, f"input_tokens: dict={dict_result.input_tokens} vs ns={ns_result.input_tokens}"
-    assert dict_result.output_tokens == ns_result.output_tokens, f"output_tokens: dict={dict_result.output_tokens} vs ns={ns_result.output_tokens}"
-    assert dict_result.cache_read_tokens == ns_result.cache_read_tokens, f"cache_read: dict={dict_result.cache_read_tokens} vs ns={ns_result.cache_read_tokens}"
-    assert dict_result.cache_write_tokens == ns_result.cache_write_tokens, f"cache_write: dict={dict_result.cache_write_tokens} vs ns={ns_result.cache_write_tokens}"
-    # Sanity: values must be non-zero (the whole point of the bug)
-    assert dict_result.input_tokens > 0
-    assert dict_result.cache_read_tokens > 0
-
-
-def test_normalize_usage_handles_dict_openai_chat_completions():
-    """Dict-shaped usage must also work in the default (OpenAI chat-completions)
-    branch, not just the codex_responses branch.
-    """
-    payload = {
-        "prompt_tokens": 500,
-        "completion_tokens": 100,
-        "prompt_tokens_details": {"cached_tokens": 200},
-        "completion_tokens_details": {"reasoning_tokens": 30},
-    }
-
-    result = normalize_usage(payload, api_mode="chat_completions")
-
-    assert result.output_tokens == 100
-    assert result.cache_read_tokens == 200
-    assert result.input_tokens == 500 - 200  # prompt_total - cache_read
-    assert result.reasoning_tokens == 30
-
-
-def test_normalize_usage_openai_reads_nested_cache_creation_tokens():
-    usage = SimpleNamespace(
-        prompt_tokens=1000,
-        completion_tokens=200,
-        prompt_tokens_details=SimpleNamespace(
-            cached_tokens=100,
-            cache_creation_input_tokens=300,
-        ),
-    )
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 100
-    assert normalized.cache_write_tokens == 300
-    assert normalized.input_tokens == 600
-
-
-def test_normalize_usage_openai_reads_mapping_cache_creation_tokens():
-    usage = {
-        "prompt_tokens": 1000,
-        "completion_tokens": 200,
-        "prompt_tokens_details": {"cache_creation_input_tokens": 300},
-    }
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.cache_write_tokens == 300
-    assert normalized.input_tokens == 700
-
-
-def test_normalize_usage_openai_prefers_nested_cache_write_tokens():
-    usage = SimpleNamespace(
-        prompt_tokens=1000,
-        prompt_tokens_details=SimpleNamespace(
-            cache_write_tokens=200,
-            cache_creation_input_tokens=300,
-        ),
-        cache_creation_input_tokens=400,
-        cache_write_tokens=500,
-    )
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.cache_write_tokens == 200
-
-
-def test_normalize_usage_mapping_preserves_reasoning_tokens():
-    usage = {
-        "prompt_tokens": 100,
-        "completion_tokens": 20,
-        "prompt_tokens_details": {"cached_tokens": 40},
-        "completion_tokens_details": {"reasoning_tokens": 12},
-    }
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.reasoning_tokens == 12
-
-
-def test_normalize_usage_mapping_anthropic_fields():
-    usage = {
-        "input_tokens": 80,
-        "output_tokens": 20,
-        "cache_read_input_tokens": 50,
-        "cache_creation_input_tokens": 10,
-        "output_tokens_details": {"reasoning_tokens": 7},
-    }
-
-    normalized = normalize_usage(usage, provider="anthropic", api_mode="anthropic_messages")
-
-    assert normalized.cache_read_tokens == 50
-    assert normalized.cache_write_tokens == 10
-    assert normalized.reasoning_tokens == 7
-
-
-def test_normalize_usage_mapping_codex_fields():
-    usage = {
-        "input_tokens": 100,
-        "output_tokens": 20,
-        "input_tokens_details": {
-            "cached_tokens": 60,
-            "cache_creation_tokens": 10,
+    entry = _pricing_entry_from_metadata(
+        {
+            "edge/model": {
+                "pricing": {"prompt": "3.2664", "completion": "16.332"}
+            }
         },
-        "output_tokens_details": {"reasoning_tokens": 5},
-    }
-
-    normalized = normalize_usage(usage, provider="openai-codex", api_mode="codex_responses")
-
-    assert normalized.input_tokens == 30
-    assert normalized.cache_read_tokens == 60
-    assert normalized.cache_write_tokens == 10
-    assert normalized.reasoning_tokens == 5
-
-
-def test_normalize_usage_clamps_negative_counters():
-    usage = SimpleNamespace(
-        prompt_tokens=100,
-        completion_tokens=-5,
-        prompt_tokens_details=SimpleNamespace(
-            cached_tokens=-10,
-            cache_write_tokens=-20,
-        ),
-        completion_tokens_details=SimpleNamespace(reasoning_tokens=-3),
+        "edge/model",
+        source_url="https://edge.example/v1/models",
+        pricing_version="openai-compatible-models-api",
+        pricing_units="per_million",
     )
 
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.input_tokens == 100
-    assert normalized.output_tokens == 0
-    assert normalized.cache_read_tokens == 0
-    assert normalized.cache_write_tokens == 0
-    assert normalized.reasoning_tokens == 0
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.2664")
+    assert entry.output_cost_per_million == Decimal("16.332")
 
 
-def test_normalize_usage_clamps_inconsistent_cache_total():
-    usage = {
-        "prompt_tokens": 100,
-        "completion_tokens": 10,
-        "prompt_tokens_details": {
-            "cached_tokens": 80,
-            "cache_creation_input_tokens": 50,
+def test_openrouter_models_pricing_is_scaled_from_per_token():
+    """OpenRouter's models API reports per-token decimals; the per-token
+    declaration must still scale to per-million exactly as before."""
+    from agent.usage_pricing import _pricing_entry_from_metadata
+
+    entry = _pricing_entry_from_metadata(
+        {
+            "edge/model": {
+                "pricing": {"prompt": "0.0000032664", "completion": "0.000016332"}
+            }
         },
-    }
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.input_tokens == 0
-    assert normalized.prompt_tokens == 130
-
-
-def test_normalize_usage_codex_responses_reads_cache_write_tokens():
-    """GPT-5.6+ explicit prompt caching reports cache writes as
-    input_tokens_details.cache_write_tokens (billed at 1.25x), per OpenAI's
-    documented Responses API schema. Before this fix, the codex_responses
-    branch only read the undocumented `cache_creation_tokens` name and always
-    normalized cache writes to 0."""
-    usage = SimpleNamespace(
-        input_tokens=2006,
-        output_tokens=400,
-        input_tokens_details=SimpleNamespace(cached_tokens=1920, cache_write_tokens=50),
+        "edge/model",
+        source_url="https://openrouter.ai/api/v1/models",
+        pricing_version="openrouter-models-api",
+        pricing_units="per_token",
     )
 
-    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
-
-    assert normalized.cache_read_tokens == 1920
-    assert normalized.cache_write_tokens == 50
-    assert normalized.input_tokens == 2006 - 1920 - 50
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.2664")
+    assert entry.output_cost_per_million == Decimal("16.332")
 
 
-def test_normalize_usage_codex_responses_falls_back_to_cache_creation_tokens():
-    """If cache_write_tokens is absent, fall back to the legacy
-    cache_creation_tokens name rather than reporting 0."""
-    usage = SimpleNamespace(
-        input_tokens=1000,
-        output_tokens=100,
-        input_tokens_details=SimpleNamespace(cached_tokens=200, cache_creation_tokens=80),
+def test_default_units_are_per_million():
+    """The default (no explicit units) must be per-million — the
+    OpenAI-compatible standard — so a future caller cannot silently regress
+    to the 1e6 over-scaling."""
+    from agent.usage_pricing import _pricing_entry_from_metadata
+
+    entry = _pricing_entry_from_metadata(
+        {"edge/model": {"pricing": {"prompt": "3.2664", "completion": "16.332"}}},
+        "edge/model",
+        source_url="https://edge.example/v1/models",
+        pricing_version="openai-compatible-models-api",
     )
 
-    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
-
-    assert normalized.cache_write_tokens == 80
-
-
-def test_normalize_usage_reads_qwen_flat_cached_tokens():
-    """Some Alibaba/Qwen regional endpoints report cache reads as a flat
-    `usage.cached_tokens` field with no `prompt_tokens_details` wrapper at
-    all. Before this fix, those responses fell through every branch and
-    normalized to cache_read_tokens=0, undercounting cost."""
-    usage = SimpleNamespace(
-        prompt_tokens=2000,
-        completion_tokens=300,
-        cached_tokens=1200,
-    )
-
-    normalized = normalize_usage(usage, provider="qwen", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 1200
-    assert normalized.input_tokens == 800
-
-
-def test_normalize_usage_nested_details_win_over_qwen_flat_top_level():
-    """When both shapes are present, the nested OpenAI-style value wins and
-    the flat Qwen field is not double-read."""
-    usage = SimpleNamespace(
-        prompt_tokens=2000,
-        completion_tokens=100,
-        prompt_tokens_details=SimpleNamespace(cached_tokens=900),
-        cached_tokens=1200,
-    )
-
-    normalized = normalize_usage(usage, provider="qwen", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 900
-    assert normalized.input_tokens == 1100
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.2664")

--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -152,14 +152,16 @@ def test_openai_gpt55_pro_warns_even_without_pricing(monkeypatch):
 
 
 def test_openai_gpt55_pro_warns_for_nous_portal_pricing(monkeypatch):
+    # OpenAI-compatible /models endpoints report dollars per million tokens
+    # (e.g. 25.0 = $25/M input); per-token decimals are OpenRouter-only.
     monkeypatch.setattr("agent.models_dev.get_model_info", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_endpoint_model_metadata",
         lambda base_url, api_key="": {
             "openai/gpt-5.5-pro": {
                 "pricing": {
-                    "prompt": "0.000025",
-                    "completion": "0.000125",
+                    "prompt": "25.0",
+                    "completion": "125.0",
                 }
             }
         },


### PR DESCRIPTION
## Summary

Fixes #79400. `_pricing_entry_from_metadata()` scaled every source value by 1e6, assuming APIs report **per-token** decimals — OpenRouter's format. OpenAI-compatible `/models` endpoints report **dollars per million tokens** already, so a model priced `$3.27/M` input was surfaced as `$3,266,400/M`, tripping the expensive-model confirmation guard and blocking legitimate `/model` switches with a bogus warning.

This PR declares the pricing unit explicitly at each call site instead of guessing.

## Problem

Mock scenario (no real credentials involved):

- Provider `example-provider`, OpenAI-compatible endpoint `https://edge.example/v1/`
- Its `/models` endpoint reports `{"pricing": {"prompt": 3.2664, "completion": 16.332}}` — **dollars per million tokens** ($3.27/M input)
- `get_pricing_entry()` → `_pricing_entry_from_metadata()` treats `3.2664` as a per-token decimal and multiplies by 1e6 → `$3,266,400/M`
- `expensive_model_warning()` compares against the `$20/M` input threshold → false "Expensive Model Warning"
- User confirms/switches are blocked or silently cancelled (see #79226 for the frozen-modal half of this UX)

Secondary contributor: a custom provider addressing a public mirror (`custom:edge` → models.dev `edge`) resolved to `None` in `get_model_info()` because the `custom:` prefix was never normalized, so the correct models.dev price couldn't rescue the lookup.

## Change

`agent/usage_pricing.py`:

- `_pricing_entry_from_metadata(..., pricing_units="per_million")` — new explicit unit parameter; `per_token` scales by 1e6, `per_million` passes values through.
- `_openrouter_pricing_entry()` passes `pricing_units="per_token"` (OpenRouter's format — behavior unchanged).
- `get_pricing_entry()` endpoint path passes `pricing_units="per_million"` (OpenAI-compatible standard — the fix).
- Default is `per_million`, so a future caller cannot silently regress to over-scaling.

`agent/models_dev.py`:

- New `_mdev_provider_id()` strips the `custom:` prefix before models.dev lookup; used by `get_provider_info`, `get_model_info`, `lookup_models_dev_context`, and `_get_provider_models`.

## Tests

`tests/agent/test_usage_pricing.py` — 3 new tests:

- `test_openai_compatible_models_pricing_is_per_million_not_scaled` — `3.2664` passes through unchanged (the #79225 repro).
- `test_openrouter_models_pricing_is_scaled_from_per_token` — `0.0000032664` → `3.2664` (OpenRouter path preserved).
- `test_default_units_are_per_million` — default unit cannot over-scale.

`tests/hermes_cli/test_model_cost_guard.py` — the gpt-5.5-pro guard test now feeds per-million mock values (`25.0` / `125.0`) matching the real OpenAI-compatible endpoint contract.

Full relevant suite:

```
151 passed in 18.23s
```

(usage_pricing, models_dev, model_cost_guard, model_switch suites, credential_pool)