### PR TITLE
fix(cli): run /model expensive-confirm off the main thread (#79401)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10079,6 +10079,33 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception as exc:
                 logger.debug("preflight-compression switch warning failed: %s", exc)
 
+        # Run the confirm + apply sequence off the main thread. The
+        # expensive-model confirmation modal blocks the calling thread on a
+        # response queue (see _prompt_text_input_modal); running it on the
+        # prompt_toolkit main thread freezes TUI rendering, so the modal never
+        # appears and the switch silently cancels after the 120s timeout.
+        # Mirror the picker path (_handle_model_picker_selection), which
+        # already dispatches confirm+apply on a worker thread.
+        if getattr(self, "_app", None):
+            threading.Thread(
+                target=self._confirm_and_apply_cli_model_switch,
+                args=(result, persist_global, one_turn, custom_provs),
+                daemon=True,
+            ).start()
+            return
+        self._confirm_and_apply_cli_model_switch(
+            result, persist_global, one_turn, custom_provs
+        )
+        return
+
+    def _confirm_and_apply_cli_model_switch(
+        self, result, persist_global: bool, one_turn: bool, custom_provs=None
+    ) -> None:
+        """Confirm an expensive model switch and apply it to CLI state.
+
+        Runs on a worker thread when the TUI is active (see
+        _handle_model_switch) so the confirmation modal can render.
+        """
         if not self._confirm_expensive_model_switch(result):
             _cprint("  Model switch cancelled.")
             return

--- a/tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py
+++ b/tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py
@@ -56,6 +56,15 @@ class _StubCLI:
     def _confirm_expensive_model_switch(self, result) -> bool:
         return True
 
+    def _confirm_and_apply_cli_model_switch(
+        self, result, persist_global, one_turn, custom_provs=None
+    ):
+        import cli as cli_mod
+
+        return cli_mod.HermesCLI._confirm_and_apply_cli_model_switch(
+            self, result, persist_global, one_turn, custom_provs
+        )
+
     def _open_model_picker(self, *a, **k):
         raise AssertionError("picker should not open when a model name is given")
 

--- a/tests/hermes_cli/test_cli_model_once.py
+++ b/tests/hermes_cli/test_cli_model_once.py
@@ -33,6 +33,15 @@ class _StubCLI:
     def _confirm_expensive_model_switch(self, result):
         return True
 
+    def _confirm_and_apply_cli_model_switch(
+        self, result, persist_global, one_turn, custom_provs=None
+    ):
+        import cli as cli_mod
+
+        return cli_mod.HermesCLI._confirm_and_apply_cli_model_switch(
+            self, result, persist_global, one_turn, custom_provs
+        )
+
 
 def test_cli_model_once_records_restore_and_does_not_persist(monkeypatch):
     import cli as cli_mod

--- a/tests/hermes_cli/test_model_switch_confirm_thread.py
+++ b/tests/hermes_cli/test_model_switch_confirm_thread.py
@@ -1,0 +1,161 @@
+"""The /model <name> --provider <p> path must run the expensive-model
+confirm + apply sequence off the main thread.
+
+The confirm modal blocks its calling thread on a response queue (see
+``_prompt_text_input_modal``). When invoked inline from the prompt_toolkit
+main thread the TUI event loop freezes, the modal never renders, and the
+switch silently cancels after the 120s timeout — the user sees a frozen
+terminal and "Model switch cancelled." without ever seeing the warning.
+
+The picker path (_handle_model_picker_selection) already dispatches
+confirm+apply on a worker thread; this regression test pins the command
+path to the same contract: with ``_app`` present the modal runs off the
+main thread, and without ``_app`` (tests / non-interactive) it stays
+synchronous.
+"""
+
+import threading
+from types import SimpleNamespace
+
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.calls = []
+        self.model = "old/model"
+        self.provider = "openrouter"
+
+    def switch_model(self, **kwargs):
+        self.calls.append(kwargs)
+        self.model = kwargs["new_model"]
+        self.provider = kwargs["new_provider"]
+
+
+class _StubCLI:
+    model = "old/model"
+    provider = "openrouter"
+    requested_provider = "openrouter"
+    api_key = "sk-old"
+    _explicit_api_key = "sk-old"
+    _explicit_base_url = ""
+    base_url = "https://openrouter.ai/api/v1"
+    api_mode = "chat_completions"
+    conversation_history = []
+    agent = None
+    _pending_model_switch_note = None
+    _pending_one_turn_model_restore = None
+    _app = None
+
+    def _confirm_expensive_model_switch(self, result):
+        return True
+
+    def _confirm_and_apply_cli_model_switch(
+        self, result, persist_global, one_turn, custom_provs=None
+    ):
+        import cli as cli_mod
+
+        return cli_mod.HermesCLI._confirm_and_apply_cli_model_switch(
+            self, result, persist_global, one_turn, custom_provs
+        )
+
+
+def _make_result():
+    return ModelSwitchResult(
+        success=True,
+        new_model="claude-sonnet-4.6",
+        target_provider="anthropic",
+        api_key="sk-ant",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+        provider_label="Anthropic",
+    )
+
+
+def _patch_deps(monkeypatch, printed):
+    import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda s, *a, **k: printed.append(str(s)))
+    monkeypatch.setattr(
+        "hermes_cli.inventory.load_picker_context",
+        lambda: SimpleNamespace(
+            user_providers=None,
+            custom_providers=None,
+            with_overrides=lambda **_: SimpleNamespace(
+                user_providers=None, custom_providers=None
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_: _make_result()
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_display_context_length", lambda *a, **k: None
+    )
+    return cli_mod
+
+
+def test_confirm_runs_off_main_thread_when_tui_present(monkeypatch):
+    """With ``_app`` set, the confirm modal must not block the caller's
+    thread: the switch is dispatched on a worker thread and the command
+    handler returns immediately."""
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.agent = _FakeAgent()
+    stub._app = SimpleNamespace(loop=None)
+    printed = []
+    cli_mod = _patch_deps(monkeypatch, printed)
+
+    called_on = {}
+    ready = threading.Event()
+
+    def _confirm(self, result):
+        called_on["thread_id"] = threading.get_ident()
+        called_on["is_main"] = threading.current_thread() is threading.main_thread()
+        ready.set()
+        return True
+
+    # The stub's own confirm would shadow the patched one — bind the
+    # recorder onto the instance so the worker thread hits it.
+    monkeypatch.setattr(stub, "_confirm_expensive_model_switch", _confirm.__get__(stub))
+
+    cli_mod.HermesCLI._handle_model_switch(
+        stub, "/model claude-sonnet-4.6 --provider anthropic"
+    )
+
+    # The worker thread performs the confirm and completes the apply.
+    assert ready.wait(timeout=10)
+    assert called_on["is_main"] is False
+
+    # Apply still lands on CLI + agent state.
+    assert stub.model == "claude-sonnet-4.6"
+    assert stub.provider == "anthropic"
+    assert stub.agent.calls[-1]["new_model"] == "claude-sonnet-4.6"
+
+
+def test_confirm_stays_synchronous_without_app(monkeypatch):
+    """Without a TUI app (unit tests / non-interactive) the old inline
+    behaviour is preserved: confirm + apply run on the calling thread."""
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.agent = _FakeAgent()
+    printed = []
+    cli_mod = _patch_deps(monkeypatch, printed)
+
+    called_on = {}
+
+    def _confirm(self, result):
+        called_on["is_main"] = threading.current_thread() is threading.main_thread()
+        return True
+
+    monkeypatch.setattr(stub, "_confirm_expensive_model_switch", _confirm.__get__(stub))
+
+    cli_mod.HermesCLI._handle_model_switch(
+        stub, "/model claude-sonnet-4.6 --provider anthropic"
+    )
+
+    assert called_on.get("is_main") is True
+    assert stub.model == "claude-sonnet-4.6"
+    assert stub.provider == "anthropic"


### PR DESCRIPTION
## Summary

Fixes #79401. The `/model <name> --provider <p>` command path called `_confirm_expensive_model_switch()` **inline on the main thread**. That confirmation modal blocks its calling thread on a response queue (`_prompt_text_input_modal`); on the prompt_toolkit main thread the TUI event loop freezes, the modal never renders, and the switch silently cancels after the 120s timeout — the user sees a frozen terminal and `Model switch cancelled.` without ever seeing the warning.

The picker path (`_handle_model_picker_selection`) already dispatched confirm+apply on a worker thread; the command path did not. This PR brings the command path under the same contract.

## Problem

Mock scenario:

- TUI session on `example-provider`; user runs `/model edge-model --provider custom:edge`
- `switch_model()` resolves successfully, then `_confirm_expensive_model_switch()` opens the confirmation modal
- The modal is set up on `self._app.loop` via `call_soon_threadsafe`, then the caller blocks on `response_queue.get(timeout=1)` — all on the main thread
- The event loop can no longer render (the main thread is the one blocked), so the modal never appears on screen
- After 120s the deadline elapses → `None` → treated as "Cancel" → `Model switch cancelled.` — model unchanged

User-visible symptoms: "terminal froze for two minutes", "the warning never appeared", "the model didn't change".

## Change

`cli.py` — extract the inline confirm+apply block into `_confirm_and_apply_cli_model_switch(result, persist_global, one_turn, custom_provs)` and dispatch it:

- TUI app present (`self._app`): run on a daemon worker thread (mirrors `_handle_model_picker_selection`), handler returns immediately
- No app (unit tests / non-interactive): synchronous path unchanged

`--once` restore snapshot and `--global` persistence semantics are preserved by the extracted method.

## Tests

New `tests/hermes_cli/test_model_switch_confirm_thread.py`:

- `test_confirm_runs_off_main_thread_when_tui_present` — with `_app` set, the confirm executes on a non-main thread and the switch still lands on CLI + agent state.
- `test_confirm_stays_synchronous_without_app` — no app: confirm runs on the calling thread (existing inline behaviour).

Existing `_StubCLI` helpers in `test_cli_model_once.py` and `test_25106_global_switch_persists_base_url_api_mode.py` forward to the extracted method.

Full relevant suite:

```
151 passed in 18.23s
```

(usage_pricing, models_dev, model_cost_guard, model_switch suites, credential_pool)