### PR TITLE
fix(update): verify autostash before destructive reset

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1130,12 +1130,36 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 
     if push.returncode != 0:
         if stash_created:
-            # git stash push exits non-zero when it saved everything but could
-            # not delete some swept untracked files from the working tree
-            # (e.g. a root-owned directory: "warning: failed to remove ...:
-            # Permission denied").  The stash entry is complete — the changes
-            # are safe — so this is not a failure.  Leave the undeletable
-            # files in place and continue the update.
+            # A new refs/stash entry is not, by itself, proof that a failed
+            # stash push captured every tracked change.  Older Git versions can
+            # create a partial entry before failing to remove an untracked file.
+            # Compare the stash tree to the still-present tracked working tree
+            # before allowing the destructive cleanup below.
+            tracked_tree_check = subprocess.run(
+                git_cmd + ["diff", "--quiet", stash_ref, "--"],
+                cwd=cwd,
+                capture_output=True,
+            )
+            if tracked_tree_check.returncode != 0:
+                print("✗ Could not safely complete the update autostash — update aborted.")
+                if push.stderr.strip():
+                    print(f"  {push.stderr.strip().splitlines()[0]}")
+                print(
+                    "  The saved stash does not match the tracked working tree; "
+                    "no hard reset was attempted."
+                )
+                print(
+                    "  Commit, stash, or clean up your local changes manually, "
+                    "then re-run `hermes update`."
+                )
+                raise subprocess.CalledProcessError(
+                    push.returncode, push.args, output=push.stdout, stderr=push.stderr
+                )
+
+            # The tracked tree is proven present in the stash.  The non-zero
+            # exit is therefore limited to cleanup of swept untracked files
+            # (e.g. a root-owned directory: Permission denied).  Leave those
+            # files in place and continue after cleaning only tracked changes.
             if push.stderr.strip():
                 print(push.stderr.strip())
             print(
@@ -1146,10 +1170,6 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
                 "    They were still saved to the stash and were left in "
                 "place — the update will continue."
             )
-            # A partially-failed stash push also aborts its working-tree
-            # cleanup for TRACKED modifications — they are saved in the stash
-            # but still dirty the tree, which would break the checkout/pull
-            # that follows. Safe to reset: everything is in the stash entry.
             subprocess.run(
                 git_cmd + ["reset", "--hard", "HEAD"],
                 cwd=cwd,
@@ -1230,6 +1250,37 @@ def _stash_apply_failed_only_on_existing_untracked(stderr: str) -> bool:
             return False
     return saw_untracked_error
 
+
+def _stash_tracked_patch_is_present(
+    git_cmd: list[str], cwd: Path, stash_ref: str
+) -> bool:
+    """Return whether the stash's tracked patch is present in the working tree.
+
+    Some older Git versions report only the untracked-file collision from
+    ``stash apply`` but abort before applying the tracked patch.  Prove the
+    patch is present by checking whether Git could cleanly reverse it.  Any
+    inability to produce or validate the patch fails closed.
+    """
+    patch = subprocess.run(
+        git_cmd + ["diff", "--binary", f"{stash_ref}^1", stash_ref, "--"],
+        cwd=cwd,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    if patch.returncode != 0:
+        return False
+    if not patch.stdout:
+        return True
+    reverse_check = subprocess.run(
+        git_cmd + ["apply", "--reverse", "--check", "-"],
+        cwd=cwd,
+        input=patch.stdout,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    return reverse_check.returncode == 0
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -1272,9 +1323,16 @@ def _restore_stashed_changes(
     )
     has_conflicts = bool(unmerged.stdout.strip())
 
-    if restore.returncode != 0 and not has_conflicts and (
-        _stash_apply_failed_only_on_existing_untracked(restore.stderr)
-    ):
+    untracked_only_failure = (
+        restore.returncode != 0
+        and not has_conflicts
+        and _stash_apply_failed_only_on_existing_untracked(restore.stderr)
+    )
+    tracked_patch_present = untracked_only_failure and _stash_tracked_patch_is_present(
+        git_cmd, cwd, stash_ref
+    )
+
+    if untracked_only_failure and tracked_patch_present:
         # Permission-denied autostash tail end: the tracked changes applied
         # cleanly; the only "failure" is untracked files that never left the
         # working tree (git could not delete them at stash time, so it now
@@ -1285,7 +1343,10 @@ def _restore_stashed_changes(
             "tree and were kept as-is."
         )
     elif restore.returncode != 0 or has_conflicts:
-        print("✗ Update pulled new code, but restoring local changes hit conflicts.")
+        print(
+            "✗ Update pulled new code, but restoring local changes hit conflicts "
+            "or could not be verified."
+        )
         if restore.stdout.strip():
             print(restore.stdout.strip())
         if restore.stderr.strip():

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -282,7 +282,7 @@ def test_bootstrap_marker_not_autostashed_by_update(tmp_path):
 
 # ---------------------------------------------------------------------------
 # Permission-denied autostash class: undeletable untracked files (root-owned
-# packaging/ etc.) must not abort the update when the stash entry was created.
+# packaging/ etc.) must never cause tracked changes to be lost.
 # ---------------------------------------------------------------------------
 
 
@@ -290,10 +290,10 @@ def test_bootstrap_marker_not_autostashed_by_update(tmp_path):
 
 
 
-def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
+def test_update_autostash_never_loses_changes_with_undeletable_untracked_dir(tmp_path):
     """Behavioral E2E of the whole permission-denied class with real git:
-    root-owned-style undeletable untracked dir → stash succeeds, update-style
-    reset works, restore round-trips, nothing lost. (#70127 follow-up)"""
+    a verified complete stash may continue; an unverifiable partial stash must
+    abort without touching the tracked working tree. (#70127 follow-up)"""
     import os
     import shutil
     import subprocess
@@ -323,7 +323,14 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
     (pkg / "hermes-agent.rb").write_text("formula\n")
     os.chmod(pkg, 0o555)  # undeletable contents, like a root-owned dir
     try:
-        stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+        try:
+            stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+        except CalledProcessError:
+            # Older Git versions can create a partial stash entry before the
+            # permission error.  Failing closed must preserve the local edit.
+            assert (tmp_path / "tracked.txt").read_text() == "v2 local change\n"
+            assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
+            return
         assert stash_ref
 
         # The tracked change is stashed; simulate the updater's checkout window.
@@ -332,8 +339,50 @@ def test_update_autostash_survives_undeletable_untracked_dir(tmp_path):
         restored = hermes_main._restore_stashed_changes(
             ["git"], tmp_path, stash_ref, prompt_user=False
         )
-        assert restored is True
-        assert (tmp_path / "tracked.txt").read_text() == "v2 local change\n"
+        if restored:
+            assert (tmp_path / "tracked.txt").read_text() == "v2 local change\n"
+        else:
+            # Fail-closed restore keeps the complete stash for manual recovery.
+            stashed = git("show", f"{stash_ref}:tracked.txt").stdout
+            assert stashed == "v2 local change\n"
+            assert git("rev-parse", "--verify", "refs/stash").stdout.strip()
         assert (pkg / "hermes-agent.rb").read_text() == "formula\n"
     finally:
         os.chmod(pkg, 0o755)
+
+
+def test_partial_stash_never_resets_when_tracked_tree_was_not_captured(
+    monkeypatch, tmp_path, capsys
+):
+    """A new stash ref is not proof that a failed stash captured tracked data."""
+    calls = []
+    stash_probes = iter(("old-stash", "partial-stash"))
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M tracked.txt\n", stderr="", returncode=0)
+        if cmd[-2:] == ["ls-files", "--unmerged"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd[-3:] == ["rev-parse", "--verify", "refs/stash"]:
+            return SimpleNamespace(
+                stdout=f"{next(stash_probes)}\n", stderr="", returncode=0
+            )
+        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
+            return SimpleNamespace(
+                args=cmd,
+                stdout="Saved working directory and index state\n",
+                stderr="warning: failed to remove packaging/: Permission denied\n",
+                returncode=1,
+            )
+        if cmd[1:3] == ["diff", "--quiet"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=1)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    with pytest.raises(CalledProcessError):
+        hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+
+    assert not any(cmd[1:3] == ["reset", "--hard"] for cmd in calls)
+    assert "saved stash does not match the tracked working tree" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- verify that a non-zero `git stash push --include-untracked` captured the current tracked worktree before `reset --hard`
- verify that tracked stash changes were actually applied before accepting an untracked-collision restore as successful
- preserve the stash and fail closed whenever either proof is unavailable

## Root cause

Apple Git 2.30 can create a new `refs/stash` while an undeletable untracked directory causes the stash/apply operation to be incomplete. The updater previously treated the new stash ref and an untracked-collision diagnostic as proof of success, reset the worktree, dropped the stash, and silently lost a tracked local edit.

## Verification

- `140 passed` across `tests/hermes_cli/test_update*.py` with Homebrew Git 2.55
- autostash regression file: `6 passed` with Homebrew Git 2.55
- autostash regression file: `6 passed` with Apple Git 2.30.1
- focused undeletable-directory + partial-stash tests: `2 passed` under both Git versions
- Ruff, `py_compile`, and `git diff --check` clean
- independent read-only review: APPROVE