### PR TITLE
fix(tui): don't treat right-button motion as a fresh click when idle

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -120,4 +120,18 @@ describe('handleMouseEvent right-click selection behavior', () => {
     expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
     expect(app.props.onMouseDownAt).toHaveBeenCalledWith(2, 0, 2)
   })
+
+  // #79204: some terminals (observed: Ghostty) report repeated right-button
+  // MOTION frames (bit 0x20 set) while the pointer merely moves, with no
+  // real click. Without a selection these used to fall through to
+  // onMouseDownAt — which the composer's right-click handler treats as a
+  // paste request — so every such motion frame re-fired a clipboard paste.
+  it('does not treat right-button motion as a press when there is no selection', () => {
+    const app = makeApp()
+
+    handleMouseEvent(app, { action: 'press', button: 0x20 | 2, col: 3, kind: 'mouse', row: 1 })
+
+    expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -818,14 +818,20 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     }
 
     if (baseButton !== 0) {
+      // A motion/drag frame for a non-left button (bit 0x20 set) is not a
+      // fresh press — some terminals (observed: Ghostty) report repeated
+      // button-2 motion frames while the pointer merely moves/hovers with
+      // no real click. Without this guard those frames fell through to
+      // onMouseDownAt below whenever there was no active selection,
+      // re-firing right-click-paste on every such frame (#79204).
+      if ((m.button & 0x20) !== 0) {
+        return
+      }
+
       // Non-left press breaks the multi-click chain.
       app.clickCount = 0
 
       if (baseButton === 2 && hasSelection(sel)) {
-        if ((m.button & 0x20) !== 0) {
-          return
-        }
-
         if (!app.props.getSelectedText()) {
           return
         }


### PR DESCRIPTION
Fixes #79204

Some terminals (observed: Ghostty) report repeated right-button **motion** frames (SGR bit `0x20` set) while the pointer merely moves over a panel, with no real click. In `handleMouseEvent` (`ui-tui/packages/hermes-ink/src/ink/components/App.tsx`), the `0x20` drag-frame guard only applied inside the `baseButton === 2 && hasSelection(sel)` branch. With no active text selection, a motion frame fell straight through to `onMouseDownAt`, which the composer's right-click handler (`textInput.tsx`) treats as a deliberate press — and since there's nothing selected to copy, it pastes the clipboard. Every subsequent motion frame re-fired the paste, which is what the issue reports as hex/clipboard text appearing in the input box while hovering.

**Fix:** move the motion-bit check above the branch so it applies to all non-left buttons unconditionally, not just the has-selection copy path.

**Tests:** added a regression test in `app-mouse.test.ts` covering right-button motion with no active selection. Ran the full `ui-tui` vitest suite before/after — same pre-existing unrelated failures (subscriptionOverlay timing assertions, one flaky ink-backpressure test) on both, no new failures introduced.