### PR TITLE
refactor(tui): extract _SlashWorker client + session db into tui_gateway modules (server.py god-file slice R1)

### DIFF
--- a/tests/tui_gateway/test_session_db_extraction.py
+++ b/tests/tui_gateway/test_session_db_extraction.py
@@ -1,0 +1,349 @@
+"""R1-S2 extraction tests: tui_gateway/session_db.py (epic #78647, target #78630).
+
+Consensus test contract (R1-CONSENSUS.md §6, Pass A T1-T8 + F1-F6): re-export
+identity per name, patch-liveness, state write-through (:10792-10793 replay),
+state read-through (:93 replay), forward-dep seam (monkeypatch server._load_cfg
+/_apply_managed), _profile_scoped install contract, cwd precedence incl.
+placeholders, failure modes (constructor-raise -> None + _db_error, unknown
+profile -> (None, False), handler-raise -> override reset, bad cwd -> None,
+_profile_db yields None when unavailable).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import server FIRST: session_db.py does `from tui_gateway import server` at
+# module top (call-time attribute access only), and server's re-export block
+# reads session_db attributes at import time — so the load order must be
+# server -> session_db (same as the production entry chain; the circular
+# import resolves only in that direction). Mirrors the adapter-first rule in
+# the verbatim-mixin-extraction workflow.
+import tui_gateway.server as server  # noqa: E402,F401
+import tui_gateway.session_db as sdb
+
+
+# ── T1: re-export identity per name ───────────────────────────────────────────
+
+MOVED_NAMES = [
+    "_get_db",
+    "_db_for_profile",
+    "_profile_db",
+    "_response_profile_name",
+    "_db_unavailable_error",
+    "_profile_home",
+    "_profile_scoped",
+    "_CWD_PLACEHOLDERS",
+    "_configured_cwd_from_cfg",
+    "_profile_configured_cwd",
+    "_launch_configured_cwd",
+    "_default_session_cwd",
+]
+
+
+@pytest.mark.parametrize("name", MOVED_NAMES)
+def test_server_reexports_each_name_identity(name):
+    assert getattr(server, name) is getattr(sdb, name)
+
+
+def test_state_stays_on_server():
+    assert "_db" in vars(server)
+    assert "_db_error" in vars(server)
+    assert "_db" not in vars(sdb)
+    assert "_db_error" not in vars(sdb)
+
+
+# ── T2: patch-liveness: string patches on tui_gateway.server._get_db must hit ─
+
+
+def test_string_patch_on_server_get_db_hits_through_reexport():
+    with patch("tui_gateway.server._get_db", return_value="patched-db") as m:
+        # later-region call sites resolve the bare name via server globals
+        assert server._get_db() == "patched-db"
+        m.assert_called_once()
+
+
+# ── T3: state write-through (replays test_tui_gateway_server.py:10792-10793) ──
+
+
+def test_get_db_state_write_through(monkeypatch):
+    """_get_db writes _db/_db_error THROUGH the server module object."""
+    server._db = None
+    server._db_error = None
+    try:
+        fake_db = MagicMock()
+        fake_mod = MagicMock()
+        fake_mod.SessionDB = MagicMock(return_value=fake_db)
+        monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+
+        assert sdb._get_db() is fake_db
+        assert server._db is fake_db
+        assert server._db_error is None
+    finally:
+        server._db = None
+        server._db_error = None
+
+
+def test_get_db_constructor_raise_sets_db_error(monkeypatch):
+    """F1: constructor-raise -> None + _db_error set (locking-protocol replay)."""
+    server._db = None
+    server._db_error = None
+    try:
+        class _BrokenSessionDB:
+            def __init__(self):
+                raise RuntimeError("locking protocol")
+
+        fake_mod = MagicMock()
+        fake_mod.SessionDB = _BrokenSessionDB
+        monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+
+        assert sdb._get_db() is None
+        assert server._db is None
+        assert server._db_error == "locking protocol"
+        # second call short-circuits on the still-None db (race documented F6)
+        assert sdb._get_db() is None
+    finally:
+        server._db = None
+        server._db_error = None
+
+
+# ── T4: state read-through (replays test_undo_command.py:93) ──────────────────
+
+
+def test_db_unavailable_error_reads_server_db_error(monkeypatch):
+    server._db_error = "custom failure"
+    try:
+        result = sdb._db_unavailable_error(7, code=5001)
+        assert result == server._err(7, 5001, "state.db unavailable: custom failure")
+    finally:
+        server._db_error = None
+
+
+# ── T5: forward-dep seam (server._load_cfg / _apply_managed call-time) ────────
+
+
+def test_launch_configured_cwd_reads_server_load_cfg_at_call_time(monkeypatch):
+    calls = []
+
+    def fake_load_cfg():
+        calls.append(1)
+        return {"terminal": {"cwd": "C:/tmp"}}
+
+    monkeypatch.setattr(server, "_load_cfg", fake_load_cfg)
+    assert sdb._launch_configured_cwd() == os.path.abspath("C:/tmp")
+    assert len(calls) == 1
+    # and the re-exported name sees the same patch
+    assert server._launch_configured_cwd() == os.path.abspath("C:/tmp")
+
+
+def test_launch_configured_cwd_load_cfg_raise_returns_none(monkeypatch):
+    def boom():
+        raise RuntimeError("cfg boom")
+
+    monkeypatch.setattr(server, "_load_cfg", boom)
+    assert sdb._launch_configured_cwd() is None
+
+
+def test_profile_configured_cwd_reads_server_apply_managed(monkeypatch, tmp_path):
+    home = tmp_path / "prof" / "home"
+    (home / "config.yaml").parent.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "terminal:\n  cwd: {env:MY_CWD}\n", encoding="utf-8"
+    )
+    real = tmp_path / "real"
+    real.mkdir()
+    monkeypatch.setenv("MY_CWD", str(real))
+
+    applied = []
+
+    def fake_apply_managed(data):
+        applied.append(data)
+        return data
+
+    monkeypatch.setattr(server, "_apply_managed", fake_apply_managed)
+    monkeypatch.setattr(
+        "hermes_cli.config._expand_env_vars",
+        lambda data: {"terminal": {"cwd": str(real)}},
+    )
+
+    got = sdb._profile_configured_cwd(home)
+    assert got == os.path.abspath(str(real))
+    assert len(applied) == 1  # _apply_managed consulted at call time
+
+
+# ── T6: _profile_scoped install contract (override bound + restored) ──────────
+
+
+def _fake_profile_home(monkeypatch, home):
+    # Code reads server._profile_home at call time (seam contract) — patch the
+    # server name, exactly like the pre-existing tests in test_tui_gateway_server.py.
+    monkeypatch.setattr(server, "_profile_home", lambda profile: home)
+
+
+def test_profile_scoped_binds_override_for_non_launch_profile(monkeypatch):
+    from hermes_constants import get_hermes_home_override
+
+    home = Path("C:/tmp/fake-profile-home")
+    _fake_profile_home(monkeypatch, home)
+    seen = {}
+
+    def handler(rid, params):
+        seen["override"] = get_hermes_home_override()
+        return {"rid": rid}
+
+    wrapped = sdb._profile_scoped(handler)
+    assert wrapped(1, {"profile": "work"}) == {"rid": 1}
+    assert seen["override"] == str(home)  # override stores str(path)
+    assert get_hermes_home_override() is None  # restored in finally
+
+
+def test_profile_scoped_noop_when_home_none(monkeypatch):
+    _fake_profile_home(monkeypatch, None)
+    called = []
+
+    def handler(rid, params):
+        called.append(params)
+        return "ok"
+
+    wrapped = sdb._profile_scoped(handler)
+    assert wrapped(1, {"profile": "launch"}) == "ok"
+    assert called == [{"profile": "launch"}]
+
+
+def test_profile_scoped_restores_override_on_handler_raise(monkeypatch):
+    from hermes_constants import get_hermes_home_override
+
+    home = Path("C:/tmp/fake-profile-home-2")
+    _fake_profile_home(monkeypatch, home)
+
+    def handler(rid, params):
+        raise RuntimeError("handler boom")
+
+    wrapped = sdb._profile_scoped(handler)
+    with pytest.raises(RuntimeError, match="handler boom"):
+        wrapped(1, {"profile": "work"})
+    assert get_hermes_home_override() is None  # F3: reset even on raise
+
+
+# ── T7: cwd precedence incl. placeholders (extends server_test:814-818) ───────
+
+
+def test_configured_cwd_placeholders_return_none():
+    for placeholder in (".", "auto", "cwd", "", None, "  "):
+        assert sdb._configured_cwd_from_cfg({"terminal": {"cwd": placeholder}}) is None
+
+
+def test_configured_cwd_non_dict_and_missing():
+    assert sdb._configured_cwd_from_cfg(None) is None
+    assert sdb._configured_cwd_from_cfg({}) is None
+    assert sdb._configured_cwd_from_cfg({"terminal": {}}) is None
+    assert sdb._configured_cwd_from_cfg({"terminal": "not-a-dict"}) is None
+
+
+def test_configured_cwd_requires_existing_dir(tmp_path):
+    missing = tmp_path / "nope"
+    assert sdb._configured_cwd_from_cfg({"terminal": {"cwd": str(missing)}}) is None
+    assert sdb._configured_cwd_from_cfg({"terminal": {"cwd": str(tmp_path)}}) == str(tmp_path)
+
+
+def test_default_session_cwd_precedence(monkeypatch, tmp_path):
+    configured = tmp_path / "configured"
+    configured.mkdir()
+    stale = tmp_path / "stale"
+    stale.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}})
+    assert sdb._default_session_cwd() == str(configured)
+    assert server._default_session_cwd() == str(configured)
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    assert sdb._default_session_cwd() == str(stale)
+
+
+def test_profile_home_returns_none_for_launch_profile(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda name: str(server._hermes_home)
+    )
+    assert sdb._profile_home("launch-profile-name") is None
+
+
+# ── T8: _db_for_profile / _profile_db failure modes ───────────────────────────
+
+
+def test_db_for_profile_unknown_profile_returns_none_false(monkeypatch):
+    monkeypatch.setattr(server, "_profile_home", lambda profile: None)
+    monkeypatch.setattr(server, "_get_db", lambda: "shared-db")
+    assert sdb._db_for_profile("nonexistent") == ("shared-db", False)
+    assert sdb._db_for_profile(None) == ("shared-db", False)
+
+
+def test_db_for_profile_non_launch_opens_dedicated(monkeypatch):
+    home = Path("C:/tmp/fake-prof-home")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: home)
+
+    fake_db = MagicMock()
+    fake_mod = MagicMock()
+    fake_mod.SessionDB = MagicMock(return_value=fake_db)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+
+    db, owns = sdb._db_for_profile("work")
+    assert db is fake_db
+    assert owns is True
+    fake_mod.SessionDB.assert_called_once_with(db_path=home / "state.db")
+
+
+def test_db_for_profile_constructor_raise(monkeypatch):
+    home = Path("C:/tmp/fake-prof-home-2")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: home)
+
+    class _Broken:
+        def __init__(self, **kwargs):
+            raise RuntimeError("no db for you")
+
+    fake_mod = MagicMock()
+    fake_mod.SessionDB = _Broken
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+
+    assert sdb._db_for_profile("work") == (None, False)
+
+
+def test_profile_db_yields_none_when_unavailable(monkeypatch):
+    monkeypatch.setattr(server, "_db_for_profile", lambda profile: (None, False))
+    with sdb._profile_db({"profile": "work"}) as db:
+        assert db is None
+
+
+def test_profile_db_closes_owned_handle(monkeypatch):
+    fake_db = MagicMock()
+    monkeypatch.setattr(server, "_db_for_profile", lambda profile: (fake_db, True))
+    with sdb._profile_db({"profile": "work"}) as db:
+        assert db is fake_db
+    fake_db.close.assert_called_once()
+
+
+def test_profile_db_does_not_close_shared_handle(monkeypatch):
+    shared = MagicMock()
+    monkeypatch.setattr(server, "_db_for_profile", lambda profile: (shared, False))
+    with sdb._profile_db({"profile": "launch"}) as db:
+        assert db is shared
+    shared.close.assert_not_called()
+
+
+# ── response_profile_name ─────────────────────────────────────────────────────
+
+
+def test_response_profile_name_prefers_real_non_launch_profile(monkeypatch):
+    monkeypatch.setattr(server, "_profile_home", lambda name: Path("C:/tmp/x") if name == "work" else None)
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "launch")
+    assert sdb._response_profile_name("work") == "work"
+    assert sdb._response_profile_name("  work  ") == "work"
+    assert sdb._response_profile_name("") == "launch"
+    assert sdb._response_profile_name(None) == "launch"
+    assert sdb._response_profile_name("ghost") == "launch"

--- a/tests/tui_gateway/test_session_db_extraction.py
+++ b/tests/tui_gateway/test_session_db_extraction.py
@@ -128,18 +128,20 @@ def test_db_unavailable_error_reads_server_db_error(monkeypatch):
 # ── T5: forward-dep seam (server._load_cfg / _apply_managed call-time) ────────
 
 
-def test_launch_configured_cwd_reads_server_load_cfg_at_call_time(monkeypatch):
+def test_launch_configured_cwd_reads_server_load_cfg_at_call_time(monkeypatch, tmp_path):
     calls = []
+    configured_cwd = tmp_path / "configured-cwd"
+    configured_cwd.mkdir()
 
     def fake_load_cfg():
         calls.append(1)
-        return {"terminal": {"cwd": "C:/tmp"}}
+        return {"terminal": {"cwd": str(configured_cwd)}}
 
     monkeypatch.setattr(server, "_load_cfg", fake_load_cfg)
-    assert sdb._launch_configured_cwd() == os.path.abspath("C:/tmp")
+    assert sdb._launch_configured_cwd() == os.path.abspath(str(configured_cwd))
     assert len(calls) == 1
     # and the re-exported name sees the same patch
-    assert server._launch_configured_cwd() == os.path.abspath("C:/tmp")
+    assert server._launch_configured_cwd() == os.path.abspath(str(configured_cwd))
 
 
 def test_launch_configured_cwd_load_cfg_raise_returns_none(monkeypatch):

--- a/tests/tui_gateway/test_slash_worker_client_extraction.py
+++ b/tests/tui_gateway/test_slash_worker_client_extraction.py
@@ -1,0 +1,302 @@
+"""R1-S1 extraction tests: tui_gateway/slash_worker_client.py (epic #78647, target #78630).
+
+Consensus test contract (R1-CONSENSUS.md §5, Pass B T1-T8): timeout contract,
+closed-pipe drain + invalid-bytes safety, close idempotence ladder, re-export
+identity, standalone import, side-effect non-replication, spawn env contract.
+The golden-transcript pin (test_tui_gateway_server.py:454) is exercised by the
+full server suite; it is not duplicated here.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import queue
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tui_gateway.slash_worker_client as swc
+
+
+# ── T4: re-export identity (the seam) ─────────────────────────────────────────
+
+
+def test_server_reexports_slash_worker_identity():
+    import tui_gateway.server as server
+
+    assert server._SlashWorker is swc.SlashWorker
+    assert server._SLASH_WORKER_TIMEOUT_S is swc._SLASH_WORKER_TIMEOUT_S
+    assert server._SLASH_WORKER_TIMEOUT_S == max(5.0, swc._slash_timeout)
+
+
+def test_legacy_private_name_still_importable_from_server():
+    # install-time rebind pin: methods_tools.py handler bodies reference the
+    # bare name _SlashWorker, rebound onto server globals at install.
+    from tui_gateway.server import _SlashWorker
+
+    assert _SlashWorker is swc.SlashWorker
+
+
+def test_slash_worker_client_imports_no_server():
+    # The module must be a pure dependency root (no server import at all).
+    import subprocess
+    import sys as _sys
+
+    code = (
+        "import sys; import tui_gateway.slash_worker_client; "
+        "assert not any(m == 'tui_gateway.server' for m in sys.modules)"
+    )
+    out = subprocess.run(
+        [_sys.executable, "-c", code], capture_output=True, text=True, cwd="."
+    )
+    assert out.returncode == 0, out.stderr
+    assert "tui_gateway.server" not in out.stderr
+
+
+# ── T5: standalone import (no side effects from server import chain) ──────────
+
+
+def test_standalone_import_no_crash():
+    import importlib
+
+    # module is already imported by this test file; force a clean re-import
+    # in a fresh subprocess to prove it stands alone.
+    import subprocess
+
+    code = "import tui_gateway.slash_worker_client as m; print(m.SlashWorker.__name__)"
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, cwd="."
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "SlashWorker"
+
+
+# ── T6: side-effect non-replication ───────────────────────────────────────────
+
+
+def test_import_does_not_replicate_server_side_effects():
+    """Importing slash_worker_client must not install panic hooks, redirect
+    stdout, start the reaper, or register atexit shutdown (server-only)."""
+    import threading
+
+    before_hook = sys.excepthook
+    before_thread_hook = threading.excepthook
+    before_atexit_count = atexit._ncallbacks
+    before_stdout = sys.stdout
+
+    import importlib
+
+    importlib.reload(swc)
+
+    assert sys.excepthook is before_hook
+    assert threading.excepthook is before_thread_hook
+    assert atexit._ncallbacks == before_atexit_count
+    assert sys.stdout is before_stdout
+
+
+# ── T7: spawn env contract ────────────────────────────────────────────────────
+
+
+def test_init_spawn_env_contract():
+    """start_new_session=True, windows_hide_flags() applied, HERMES_HOME override wins."""
+    with patch("subprocess.Popen") as mock_popen:
+        proc = MagicMock()
+        proc.stdout = MagicMock()
+        proc.stderr = MagicMock()
+        mock_popen.return_value = proc
+
+        with patch.object(swc, "hermes_subprocess_env", return_value={"BASE": "1"}), patch(
+            "hermes_cli._subprocess_compat.windows_hide_flags", return_value=0x8000000
+        ), patch("tools.environments.local.build_subprocess_env") as m_build:
+            m_build.return_value = {"HERMES_HOME": "/p/home"}
+            worker = swc.SlashWorker("key", "model", profile_home="/p/home")
+
+        kwargs = mock_popen.call_args[1]
+        assert kwargs["start_new_session"] is True
+        assert kwargs["creationflags"] == 0x8000000
+        assert kwargs["text"] is True
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+        assert kwargs["cwd"] is not None
+        # argv: python -m tui_gateway.slash_worker --session-key key --model model
+        argv = mock_popen.call_args[0][0]
+        assert argv[1:4] == ["-m", "tui_gateway.slash_worker", "--session-key"]
+        assert argv[4] == "key"
+        assert "--model" in argv and argv[argv.index("--model") + 1] == "model"
+        assert worker.proc is proc
+
+
+def test_init_env_hermes_home_override_wins():
+    """profile_home must land in env['HERMES_HOME'] via build_subprocess_env's extra."""
+    with patch("subprocess.Popen") as mock_popen:
+        proc = MagicMock()
+        proc.stdout = MagicMock()
+        proc.stderr = MagicMock()
+        mock_popen.return_value = proc
+
+        with patch.object(swc, "hermes_subprocess_env", return_value={"BASE": "1"}), patch(
+            "tools.environments.local.build_subprocess_env"
+        ) as m_build:
+            m_build.return_value = {"HERMES_HOME": "/p/home", "OTHER": "x"}
+            swc.SlashWorker("key", "model", profile_home="/p/home")
+
+        call = m_build.call_args
+        assert call.kwargs.get("extra") == {"HERMES_HOME": "/p/home"}
+        assert call.kwargs.get("inherit_profile_home") is False
+        assert call.kwargs.get("scrub_secrets") is False
+        # base env is the hermes_subprocess_env result (passed positionally)
+        assert call.args[0] == {"BASE": "1"}
+
+
+# ── T1: timeout contract ──────────────────────────────────────────────────────
+
+
+def _bare_worker():
+    worker = object.__new__(swc.SlashWorker)
+    worker._lock = MagicMock()
+    worker._seq = 0
+    worker.proc = MagicMock()
+    worker.proc.poll.return_value = None
+    worker.proc.stdin = MagicMock()
+    worker.stdout_queue = queue.Queue()
+    worker.stderr_tail = []
+    return worker
+
+
+def test_run_times_out_with_contract_message(monkeypatch):
+    worker = _bare_worker()
+    worker.stdout_queue.put({"id": 99})  # never matches rid 1 -> blocks -> timeout
+
+    monkeypatch.setattr(swc, "_SLASH_WORKER_TIMEOUT_S", 0.01)
+
+    with pytest.raises(RuntimeError, match="slash worker timed out"):
+        worker.run("echo hi")
+    assert worker._seq == 1
+    worker.proc.stdin.write.assert_called_once_with(
+        json.dumps({"id": 1, "command": "echo hi"}) + "\n"
+    )
+
+
+# ── T2: closed-pipe drain + invalid-bytes safety ──────────────────────────────
+
+
+def test_run_raises_on_closed_pipe_with_stderr_tail(monkeypatch):
+    worker = _bare_worker()
+    worker.stderr_tail = ["line1", "line2"]
+    worker.stdout_queue.put(None)  # EOF sentinel
+
+    with pytest.raises(RuntimeError, match="slash worker closed pipe"):
+        worker.run("cmd")
+
+
+def test_drain_stdout_ignores_invalid_json_and_terminates(monkeypatch):
+    worker = _bare_worker()
+    # simulate lines that are NOT valid JSON (e.g. corrupted/GBK-garbled bytes
+    # decoded lossily by errors="replace" in the child) — must not raise.
+    worker.proc.stdout = iter(["not json at all\n", "{broken\n", '{"id": 1, "ok": true, "output": "fine"}\n'])
+    swc.SlashWorker._drain_stdout(worker)
+    items = []
+    while True:
+        item = worker.stdout_queue.get(timeout=1)
+        if item is None:
+            break
+        items.append(item)
+    assert items == [{"id": 1, "ok": True, "output": "fine"}]
+
+
+def test_drain_stderr_keeps_tail_bounded():
+    worker = _bare_worker()
+    worker.proc.stderr = iter([f"err-{i}\n" for i in range(200)])
+    swc.SlashWorker._drain_stderr(worker)
+    assert len(worker.stderr_tail) == 80
+    assert worker.stderr_tail[-1] == "err-199"
+    assert worker.stderr_tail[0] == "err-120"
+
+
+def test_drain_stderr_skips_blank_lines():
+    worker = _bare_worker()
+    worker.proc.stderr = iter(["\n", "   \n", "real\n"])
+    swc.SlashWorker._drain_stderr(worker)
+    # "\n" -> "" is falsy and skipped; "   " is truthy and kept (rstrip only
+    # strips the newline, matching the verbatim implementation).
+    assert worker.stderr_tail == ["   ", "real"]
+
+
+# ── T3: close idempotence ladder (terminate → wait → kill → reap) ─────────────
+
+
+def test_close_terminate_then_kill_ladder():
+    worker = _bare_worker()
+    proc = worker.proc
+    proc.poll.side_effect = [None, None, None]  # running, still running after terminate
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    proc.wait = MagicMock(side_effect=[Exception("timeout"), None])
+    proc.stdin = MagicMock()
+    proc.stdout = MagicMock()
+    proc.stderr = MagicMock()
+
+    swc.SlashWorker.close(worker)
+
+    proc.terminate.assert_called_once()
+    assert proc.kill.call_count == 1
+    assert proc.wait.call_count == 2  # terminate wait (raised) + kill wait (reap)
+    assert worker._closed is True
+    # idempotence: second close is a no-op
+    proc.terminate.reset_mock()
+    swc.SlashWorker.close(worker)
+    proc.terminate.assert_not_called()
+
+
+def test_close_handles_poll_raise_and_closes_streams():
+    worker = _bare_worker()
+    proc = worker.proc
+    proc.poll.side_effect = Exception("poll boom")
+    proc.kill = MagicMock()
+    proc.wait = MagicMock(return_value=None)
+    proc.stdin = MagicMock()
+    proc.stdout = MagicMock()
+    proc.stderr = MagicMock()
+
+    swc.SlashWorker.close(worker)
+
+    proc.kill.assert_called_once()
+    for stream in (proc.stdin, proc.stdout, proc.stderr):
+        stream.close.assert_called_once()
+    assert worker._closed is True
+
+
+def test_close_skips_when_already_closed():
+    worker = _bare_worker()
+    worker._closed = True
+    swc.SlashWorker.close(worker)
+    worker.proc.terminate.assert_not_called()
+    worker.proc.kill.assert_not_called()
+
+
+def test_run_raises_when_proc_exited():
+    worker = _bare_worker()
+    worker.proc.poll.return_value = 1
+    with pytest.raises(RuntimeError, match="slash worker exited"):
+        worker.run("cmd")
+
+
+# ── run happy path ────────────────────────────────────────────────────────────
+
+
+def test_run_returns_matching_output(monkeypatch):
+    worker = _bare_worker()
+    worker.stdout_queue.put({"id": 2, "ok": False, "error": "boom"})  # wrong rid -> skipped
+    worker.stdout_queue.put({"id": 1, "ok": True, "output": "  result  \n"})
+
+    out = worker.run("cmd")
+    assert out == "  result"  # rstrip() strips trailing whitespace only
+
+
+def test_run_raises_worker_error_payload():
+    worker = _bare_worker()
+    worker.stdout_queue.put({"id": 1, "ok": False, "error": "command exploded"})
+    with pytest.raises(RuntimeError, match="command exploded"):
+        worker.run("cmd")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -139,6 +139,28 @@ except Exception:
     pass
 
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
+from tui_gateway import session_db, slash_worker_client  # noqa: E402
+
+# God-file slice R1 (epic #78647, target #78630): _SlashWorker client and the
+# db/profile/cwd cluster moved to sibling modules. Legacy aliases keep the
+# server namespace identical for handler rebinds (method_ctx.install), the
+# install-time _profile_scoped pin (method_ctx.py:52) and test string-patches
+# (tui_gateway.server._get_db etc.).
+_SlashWorker = slash_worker_client.SlashWorker  # noqa: E402,F401
+_SLASH_WORKER_TIMEOUT_S = slash_worker_client._SLASH_WORKER_TIMEOUT_S  # noqa: E402,F401
+_get_db = session_db._get_db  # noqa: E402,F401
+_db_for_profile = session_db._db_for_profile  # noqa: E402,F401
+_profile_db = session_db._profile_db  # noqa: E402,F401
+_response_profile_name = session_db._response_profile_name  # noqa: E402,F401
+_db_unavailable_error = session_db._db_unavailable_error  # noqa: E402,F401
+_profile_home = session_db._profile_home  # noqa: E402,F401
+_profile_scoped = session_db._profile_scoped  # noqa: E402,F401
+_CWD_PLACEHOLDERS = session_db._CWD_PLACEHOLDERS  # noqa: E402,F401
+_configured_cwd_from_cfg = session_db._configured_cwd_from_cfg  # noqa: E402,F401
+_profile_configured_cwd = session_db._profile_configured_cwd  # noqa: E402,F401
+_launch_configured_cwd = session_db._launch_configured_cwd  # noqa: E402,F401
+_default_session_cwd = session_db._default_session_cwd  # noqa: E402,F401
+
 
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
@@ -155,11 +177,6 @@ _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
-try:
-    _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
-except (ValueError, TypeError):
-    _slash_timeout = 45.0
-_SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
 
 # When a WebSocket client (the dashboard's embedded-chat tab / desktop app)
 # disconnects, ``tui_gateway.ws`` detaches the transport but intentionally
@@ -321,142 +338,6 @@ _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 # the gateway in-process and captures stdout into logs, so stale JSON-RPC frames
 # must not fall through there while the session waits for resume or reap.
 _detached_ws_transport = _DropTransport()
-
-
-class _SlashWorker:
-    """Persistent HermesCLI subprocess for slash commands."""
-
-    def __init__(self, session_key: str, model: str, profile_home: str | None = None):
-        self._lock = threading.Lock()
-        self._seq = 0
-        self.stderr_tail: list[str] = []
-        self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
-
-        argv = [
-            sys.executable,
-            "-m",
-            "tui_gateway.slash_worker",
-            "--session-key",
-            session_key,
-        ]
-        if model:
-            argv += ["--model", model]
-
-        self._closed = False
-        from hermes_cli._subprocess_compat import windows_hide_flags
-
-        # slash_worker runs the Hermes agent → needs provider credentials.
-        # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
-        # Global-remote / multi-profile sessions: the worker must resolve
-        # config/skills/state against the session's profile home, not the
-        # gateway's launch HERMES_HOME (#40677). The override goes through the
-        # build_subprocess_env factory's `extra` (applied last, always wins)
-        # instead of a hand-rolled env["HERMES_HOME"] assignment.
-        from tools.environments.local import build_subprocess_env
-        env = build_subprocess_env(
-            hermes_subprocess_env(inherit_credentials=True),
-            scrub_secrets=False,
-            inherit_profile_home=False,  # base already carries the HOME contract
-            extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
-        )
-
-        # start_new_session=True detaches the slash worker into its own
-        # process group / session. Without this, the worker inherits the
-        # gateway's pgid (= TUI parent PID). When mcp_tool's
-        # _kill_orphaned_mcp_children races with slash_worker spawn and sweeps
-        # the gateway's child set, it captures the worker PID, records the
-        # inherited pgid, and killpg() then kills the TUI parent itself.
-        # See agent/lsp/client.py for the symmetric LSP server fix and
-        # tools/mcp_tool.py _filter_mcp_children for defense-in-depth.
-        self.proc = subprocess.Popen(
-            argv,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            # Force UTF-8 with lossy decoding so child output containing bytes
-            # that are invalid in the system locale (e.g. GBK on Chinese
-            # Windows) can't raise UnicodeDecodeError inside the drain threads
-            # and crash the gateway. See #53137.
-            encoding="utf-8",
-            errors="replace",
-            bufsize=1,
-            cwd=os.getcwd(),
-            env=env,
-            creationflags=windows_hide_flags(),
-            start_new_session=True,
-        )
-        threading.Thread(target=self._drain_stdout, daemon=True).start()
-        threading.Thread(target=self._drain_stderr, daemon=True).start()
-
-    def _drain_stdout(self):
-        for line in self.proc.stdout or []:
-            try:
-                self.stdout_queue.put(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-        self.stdout_queue.put(None)
-
-    def _drain_stderr(self):
-        for line in self.proc.stderr or []:
-            if text := line.rstrip("\n"):
-                self.stderr_tail = (self.stderr_tail + [text])[-80:]
-
-    def run(self, command: str) -> str:
-        if self.proc.poll() is not None:
-            raise RuntimeError("slash worker exited")
-
-        with self._lock:
-            self._seq += 1
-            rid = self._seq
-            self.proc.stdin.write(json.dumps({"id": rid, "command": command}) + "\n")
-            self.proc.stdin.flush()
-
-            while True:
-                try:
-                    msg = self.stdout_queue.get(timeout=_SLASH_WORKER_TIMEOUT_S)
-                except queue.Empty:
-                    raise RuntimeError("slash worker timed out")
-                if msg is None:
-                    break
-                if msg.get("id") != rid:
-                    continue
-                if not msg.get("ok"):
-                    raise RuntimeError(msg.get("error", "slash worker failed"))
-                return str(msg.get("output", "")).rstrip()
-
-            raise RuntimeError(
-                f"slash worker closed pipe{': ' + chr(10).join(self.stderr_tail[-8:]) if self.stderr_tail else ''}"
-            )
-
-    def close(self):
-        if getattr(self, "_closed", False):
-            return
-        self._closed = True
-        proc = self.proc
-        try:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=1)
-                except Exception:
-                    proc.kill()
-                    try:
-                        proc.wait(timeout=1)  # reap the zombie SIGKILL leaves behind
-                    except Exception:
-                        pass
-        except Exception:
-            try:
-                proc.kill()
-                proc.wait(timeout=1)
-            except Exception:
-                pass
-        finally:
-            for stream in (proc.stdin, proc.stdout, proc.stderr):
-                try:
-                    stream.close()
-                except Exception:
-                    pass
 
 
 def _load_busy_input_mode() -> str:
@@ -1296,216 +1177,6 @@ _start_idle_reaper()
 
 
 # ── Plumbing ──────────────────────────────────────────────────────────
-
-
-def _get_db():
-    global _db, _db_error
-    if _db is None:
-        from hermes_state import SessionDB
-
-        try:
-            _db = SessionDB()
-            _db_error = None
-        except Exception as exc:
-            _db_error = str(exc)
-            logger.warning(
-                "TUI session store unavailable — continuing without state.db features: %s",
-                exc,
-            )
-            return None
-    return _db
-
-
-def _db_for_profile(profile: str | None = None):
-    """Return SessionDB for ``params.profile`` when it differs from launch.
-
-    App-global remote mode passes ``profile`` on session.* RPCs so history/list/
-    create operate on that profile's ``state.db``. Launch/own profile → shared
-    ``_get_db()`` handle (left open). Non-launch profile → a dedicated handle
-    the caller should ``close()`` (see :func:`_profile_db` contextmanager).
-
-    Returns (db, owns_handle). ``db`` is None when unavailable.
-    """
-    profile_home = _profile_home(profile)
-    if profile_home is None:
-        return _get_db(), False
-    try:
-        from hermes_state import SessionDB
-
-        return SessionDB(db_path=Path(profile_home) / "state.db"), True
-    except Exception as exc:
-        logger.warning(
-            "TUI profile session store unavailable for %s: %s",
-            profile,
-            exc,
-        )
-        return None, False
-
-
-@contextlib.contextmanager
-def _profile_db(params: dict | None = None):
-    """Yield the SessionDB for ``params['profile']`` (app-global remote mode).
-
-    Closes dedicated profile handles; leaves the launch-profile shared handle open.
-    Yields None when the db is unavailable.
-    """
-    profile = None
-    if isinstance(params, dict):
-        profile = (params.get("profile") or "").strip() or None
-    db, owns = _db_for_profile(profile)
-    try:
-        yield db
-    finally:
-        if owns and db is not None:
-            with contextlib.suppress(Exception):
-                db.close()
-
-
-def _response_profile_name(profile: str | None = None) -> str:
-    """Profile name to report on session.* payloads.
-
-    Prefer the RPC's requested profile when it is a real non-launch profile;
-    otherwise the process launch profile.
-    """
-    name = (profile or "").strip()
-    if name and _profile_home(name) is not None:
-        return name
-    return _current_profile_name()
-
-
-def _db_unavailable_error(rid, *, code: int):
-    detail = _db_error or "state.db unavailable"
-    return _err(rid, code, f"state.db unavailable: {detail}")
-
-
-# ── per-session profile scoping (global remote mode) ───────────────────────────
-# One dashboard normally serves its launch profile. But the desktop's app-global
-# remote mode points every profile at this single backend, so resume/prompt must
-# be able to act on ANOTHER local profile's state.db + home. The desktop passes
-# ``profile`` on those calls; we open that profile's db and bind its HERMES_HOME
-# (a ContextVar override) for the duration of the call so config/skills/model and
-# message persistence all resolve to the right profile. Omitted/own profile → the
-# launch profile (unchanged for single-profile and per-profile-remote setups).
-def _profile_home(profile: str | None) -> Path | None:
-    """Resolve a named profile's home on THIS host, or None for the launch profile."""
-    name = (profile or "").strip()
-    if not name:
-        return None
-    try:
-        from hermes_cli import profiles as profiles_mod
-
-        home = Path(profiles_mod.get_profile_dir(name))
-    except Exception:
-        return None
-    # Already the launch profile? No override needed.
-    if home.resolve() == Path(_hermes_home).resolve():
-        return None
-    return home if (home / "state.db").exists() or home.exists() else None
-
-
-def _profile_scoped(handler):
-    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
-
-    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
-    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
-    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
-    focused profile even in app-global remote mode, where one backend serves every
-    profile. No-op for the launch profile (own-profile backends already resolve it).
-    """
-
-    def wrapper(rid, params):
-        home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
-        if home is None:
-            return handler(rid, params)
-        token = set_hermes_home_override(home)
-        try:
-            return handler(rid, params)
-        finally:
-            reset_hermes_home_override(token)
-
-    return wrapper
-
-
-# Placeholder ``terminal.cwd`` values that don't name a real directory — the
-# gateway resolves these to the home dir at runtime, so they must NOT be treated
-# as an explicit workspace (mirrors gateway/run.py's config bridge).
-_CWD_PLACEHOLDERS = {".", "auto", "cwd"}
-
-
-def _configured_cwd_from_cfg(cfg: dict | None) -> str | None:
-    """Return an absolute, existing ``terminal.cwd`` from a config mapping.
-
-    Returns None for placeholders (``.``/``auto``/``cwd``), missing values, or
-    paths that don't resolve to a real directory.
-    """
-    if not isinstance(cfg, dict):
-        return None
-    terminal_cfg = cfg.get("terminal")
-    if not isinstance(terminal_cfg, dict):
-        return None
-    raw = str(terminal_cfg.get("cwd") or "").strip()
-    if not raw or raw in _CWD_PLACEHOLDERS:
-        return None
-    resolved = os.path.abspath(os.path.expanduser(raw))
-    return resolved if os.path.isdir(resolved) else None
-
-
-def _profile_configured_cwd(profile_home: Path | None) -> str | None:
-    """Resolve a non-launch profile's ``terminal.cwd`` from its own config.yaml.
-
-    The desktop's app-global remote mode serves every profile from one backend,
-    so the process-global ``TERMINAL_CWD`` belongs to the *launch* profile. A new
-    session bound to another profile must take its workspace from THAT profile's
-    config, not the stale env var (issue #40334). Returns an absolute, existing
-    directory, or None for placeholders / missing / invalid paths.
-    """
-    if profile_home is None:
-        return None
-    try:
-        from hermes_cli.config import _expand_env_vars, read_user_config_raw
-
-        p = Path(profile_home) / "config.yaml"
-        if not p.exists():
-            return None
-        # Behavioral read of a NON-launch profile's config: load_config()
-        # would resolve the ACTIVE profile's path, so read this profile's
-        # file directly, then apply the same read-side pipeline as
-        # _load_cfg (managed overlay + ${VAR} expansion). Fail-open.
-        data = _apply_managed(read_user_config_raw(p))
-        expanded = _expand_env_vars(data)
-        if isinstance(expanded, dict):
-            data = expanded
-        return _configured_cwd_from_cfg(data)
-    except Exception:
-        return None
-
-
-def _launch_configured_cwd() -> str | None:
-    """Resolve the launch profile's ``terminal.cwd`` from config.yaml.
-
-    Dashboard ``/chat`` for the launch profile attaches to the dashboard
-    process's in-memory TUI gateway. The Node PTY child receives a bridged
-    ``TERMINAL_CWD`` env var, but this in-memory process does not — so reading
-    the process env alone leaves a fresh chat starting in ``os.getcwd()``
-    (wherever ``hermes dashboard`` was launched) instead of the configured
-    ``terminal.cwd``. Read config directly so changing ``terminal.cwd`` affects
-    new in-memory TUI sessions too.
-    """
-    try:
-        return _configured_cwd_from_cfg(_load_cfg())
-    except Exception:
-        return None
-
-
-def _default_session_cwd() -> str:
-    """Fallback cwd for a session with no explicit / stored / profile cwd.
-
-    Mirrors the launch-config-aware tail of :func:`_completion_cwd` so freshly
-    created AND resumed sessions land in the configured ``terminal.cwd`` rather
-    than ``os.getcwd()`` when the in-memory gateway's process env has no bridged
-    ``TERMINAL_CWD``.
-    """
-    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
 
 
 def write_json(obj: dict) -> bool:

--- a/tui_gateway/session_db.py
+++ b/tui_gateway/session_db.py
@@ -1,0 +1,249 @@
+"""Session-db / profile-scoping / cwd helpers.
+
+God-file slice R1-S2 (epic #78647, target #78630): the db/profile/cwd cluster
+(12 members) was moved verbatim out of ``tui_gateway/server.py``. Module-global
+state ``_db`` / ``_db_error`` intentionally STAYS on ``tui_gateway.server``
+(tests patch it directly, e.g. test_undo_command.py:93); this module reads and
+writes it through the server module object at call time so runtime
+reassignment and monkeypatching keep working (see R1-CONSENSUS.md).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+logger = logging.getLogger("tui_gateway.server")
+
+
+def _get_db():
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    if server._db is None:
+        from hermes_state import SessionDB
+
+        try:
+            server._db = SessionDB()
+            server._db_error = None
+        except Exception as exc:
+            server._db_error = str(exc)
+            logger.warning(
+                "TUI session store unavailable — continuing without state.db features: %s",
+                exc,
+            )
+            return None
+    return server._db
+
+
+def _db_for_profile(profile: str | None = None):
+    """Return SessionDB for ``params.profile`` when it differs from launch.
+
+    App-global remote mode passes ``profile`` on session.* RPCs so history/list/
+    create operate on that profile's ``state.db``. Launch/own profile → shared
+    ``_get_db()`` handle (left open). Non-launch profile → a dedicated handle
+    the caller should ``close()`` (see :func:`_profile_db` contextmanager).
+
+    Returns (db, owns_handle). ``db`` is None when unavailable.
+    """
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    profile_home = server._profile_home(profile)
+    if profile_home is None:
+        return server._get_db(), False
+    try:
+        from hermes_state import SessionDB
+
+        return SessionDB(db_path=Path(profile_home) / "state.db"), True
+    except Exception as exc:
+        logger.warning(
+            "TUI profile session store unavailable for %s: %s",
+            profile,
+            exc,
+        )
+        return None, False
+
+
+@contextlib.contextmanager
+def _profile_db(params: dict | None = None):
+    """Yield the SessionDB for ``params['profile']`` (app-global remote mode).
+
+    Closes dedicated profile handles; leaves the launch-profile shared handle open.
+    Yields None when the db is unavailable.
+    """
+    profile = None
+    if isinstance(params, dict):
+        profile = (params.get("profile") or "").strip() or None
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    db, owns = server._db_for_profile(profile)
+    try:
+        yield db
+    finally:
+        if owns and db is not None:
+            with contextlib.suppress(Exception):
+                db.close()
+
+
+def _response_profile_name(profile: str | None = None) -> str:
+    """Profile name to report on session.* payloads.
+
+    Prefer the RPC's requested profile when it is a real non-launch profile;
+    otherwise the process launch profile.
+    """
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    name = (profile or "").strip()
+    if name and server._profile_home(name) is not None:
+        return name
+    return server._current_profile_name()
+
+
+def _db_unavailable_error(rid, *, code: int):
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    detail = server._db_error or "state.db unavailable"
+    return server._err(rid, code, f"state.db unavailable: {detail}")
+
+
+# ── per-session profile scoping (global remote mode) ───────────────────────────
+# One dashboard normally serves its launch profile. But the desktop's app-global
+# remote mode points every profile at this single backend, so resume/prompt must
+# be able to act on ANOTHER local profile's state.db + home. The desktop passes
+# ``profile`` on those calls; we open that profile's db and bind its HERMES_HOME
+# (a ContextVar override) for the duration of the call so config/skills/model and
+# message persistence all resolve to the right profile. Omitted/own profile → the
+# launch profile (unchanged for single-profile and per-profile-remote setups).
+def _profile_home(profile: str | None) -> Path | None:
+    """Resolve a named profile's home on THIS host, or None for the launch profile."""
+    name = (profile or "").strip()
+    if not name:
+        return None
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    try:
+        from hermes_cli import profiles as profiles_mod
+
+        home = Path(profiles_mod.get_profile_dir(name))
+    except Exception:
+        return None
+    # Already the launch profile? No override needed.
+    if home.resolve() == Path(server._hermes_home).resolve():
+        return None
+    return home if (home / "state.db").exists() or home.exists() else None
+
+
+def _profile_scoped(handler):
+    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
+
+    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
+    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
+    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
+    focused profile even in app-global remote mode, where one backend serves every
+    profile. No-op for the launch profile (own-profile backends already resolve it).
+    """
+
+    def wrapper(rid, params):
+        from tui_gateway import server  # lazy: call-time attribute access only
+
+        home = server._profile_home(params.get("profile") if isinstance(params, dict) else None)
+        if home is None:
+            return handler(rid, params)
+        token = set_hermes_home_override(home)
+        try:
+            return handler(rid, params)
+        finally:
+            reset_hermes_home_override(token)
+
+    return wrapper
+
+
+# Placeholder ``terminal.cwd`` values that don't name a real directory — the
+# gateway resolves these to the home dir at runtime, so they must NOT be treated
+# as an explicit workspace (mirrors gateway/run.py's config bridge).
+_CWD_PLACEHOLDERS = {".", "auto", "cwd"}
+
+
+def _configured_cwd_from_cfg(cfg: dict | None) -> str | None:
+    """Return an absolute, existing ``terminal.cwd`` from a config mapping.
+
+    Returns None for placeholders (``.``/``auto``/``cwd``), missing values, or
+    paths that don't resolve to a real directory.
+    """
+    if not isinstance(cfg, dict):
+        return None
+    terminal_cfg = cfg.get("terminal")
+    if not isinstance(terminal_cfg, dict):
+        return None
+    raw = str(terminal_cfg.get("cwd") or "").strip()
+    if not raw or raw in _CWD_PLACEHOLDERS:
+        return None
+    resolved = os.path.abspath(os.path.expanduser(raw))
+    return resolved if os.path.isdir(resolved) else None
+
+
+def _profile_configured_cwd(profile_home: Path | None) -> str | None:
+    """Resolve a non-launch profile's ``terminal.cwd`` from its own config.yaml.
+
+    The desktop's app-global remote mode serves every profile from one backend,
+    so the process-global ``TERMINAL_CWD`` belongs to the *launch* profile. A new
+    session bound to another profile must take its workspace from THAT profile's
+    config, not the stale env var (issue #40334). Returns an absolute, existing
+    directory, or None for placeholders / missing / invalid paths.
+    """
+    if profile_home is None:
+        return None
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    try:
+        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+
+        p = Path(profile_home) / "config.yaml"
+        if not p.exists():
+            return None
+        # Behavioral read of a NON-launch profile's config: load_config()
+        # would resolve the ACTIVE profile's path, so read this profile's
+        # file directly, then apply the same read-side pipeline as
+        # _load_cfg (managed overlay + ${VAR} expansion). Fail-open.
+        data = server._apply_managed(read_user_config_raw(p))
+        expanded = _expand_env_vars(data)
+        if isinstance(expanded, dict):
+            data = expanded
+        return server._configured_cwd_from_cfg(data)
+    except Exception:
+        return None
+
+
+def _launch_configured_cwd() -> str | None:
+    """Resolve the launch profile's ``terminal.cwd`` from config.yaml.
+
+    Dashboard ``/chat`` for the launch profile attaches to the dashboard
+    process's in-memory TUI gateway. The Node PTY child receives a bridged
+    ``TERMINAL_CWD`` env var, but this in-memory process does not — so reading
+    the process env alone leaves a fresh chat starting in ``os.getcwd()``
+    (wherever ``hermes dashboard`` was launched) instead of the configured
+    ``terminal.cwd``. Read config directly so changing ``terminal.cwd`` affects
+    new in-memory TUI sessions too.
+    """
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    try:
+        return server._configured_cwd_from_cfg(server._load_cfg())
+    except Exception:
+        return None
+
+
+def _default_session_cwd() -> str:
+    """Fallback cwd for a session with no explicit / stored / profile cwd.
+
+    Mirrors the launch-config-aware tail of :func:`_completion_cwd` so freshly
+    created AND resumed sessions land in the configured ``terminal.cwd`` rather
+    than ``os.getcwd()`` when the in-memory gateway's process env has no bridged
+    ``TERMINAL_CWD``.
+    """
+    from tui_gateway import server  # lazy: call-time attribute access only
+
+    return server._launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()

--- a/tui_gateway/slash_worker_client.py
+++ b/tui_gateway/slash_worker_client.py
@@ -1,0 +1,166 @@
+"""Persistent slash-command worker client.
+
+God-file slice R1-S1 (epic #78647, target #78630): ``_SlashWorker`` and its
+timeout constant were moved verbatim out of ``tui_gateway/server.py`` (the
+13.9k-line TUI gateway god-file) into this sibling module. The class is public
+here as ``SlashWorker``; ``tui_gateway.server`` re-exports it under the legacy
+``_SlashWorker`` alias so handler rebinds, install-time pins and tests keep
+working unchanged (see R1-CONSENSUS.md).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import subprocess
+import sys
+import threading
+
+from tools.environments.local import hermes_subprocess_env
+
+logger = logging.getLogger("tui_gateway.server")
+
+try:
+    _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
+except (ValueError, TypeError):
+    _slash_timeout = 45.0
+_SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
+
+
+
+class SlashWorker:
+    """Persistent HermesCLI subprocess for slash commands."""
+
+    def __init__(self, session_key: str, model: str, profile_home: str | None = None):
+        self._lock = threading.Lock()
+        self._seq = 0
+        self.stderr_tail: list[str] = []
+        self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
+
+        argv = [
+            sys.executable,
+            "-m",
+            "tui_gateway.slash_worker",
+            "--session-key",
+            session_key,
+        ]
+        if model:
+            argv += ["--model", model]
+
+        self._closed = False
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        # slash_worker runs the Hermes agent → needs provider credentials.
+        # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
+        # Global-remote / multi-profile sessions: the worker must resolve
+        # config/skills/state against the session's profile home, not the
+        # gateway's launch HERMES_HOME (#40677). The override goes through the
+        # build_subprocess_env factory's `extra` (applied last, always wins)
+        # instead of a hand-rolled env["HERMES_HOME"] assignment.
+        from tools.environments.local import build_subprocess_env
+        env = build_subprocess_env(
+            hermes_subprocess_env(inherit_credentials=True),
+            scrub_secrets=False,
+            inherit_profile_home=False,  # base already carries the HOME contract
+            extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
+        )
+
+        # start_new_session=True detaches the slash worker into its own
+        # process group / session. Without this, the worker inherits the
+        # gateway's pgid (= TUI parent PID). When mcp_tool's
+        # _kill_orphaned_mcp_children races with slash_worker spawn and sweeps
+        # the gateway's child set, it captures the worker PID, records the
+        # inherited pgid, and killpg() then kills the TUI parent itself.
+        # See agent/lsp/client.py for the symmetric LSP server fix and
+        # tools/mcp_tool.py _filter_mcp_children for defense-in-depth.
+        self.proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            # Force UTF-8 with lossy decoding so child output containing bytes
+            # that are invalid in the system locale (e.g. GBK on Chinese
+            # Windows) can't raise UnicodeDecodeError inside the drain threads
+            # and crash the gateway. See #53137.
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+            cwd=os.getcwd(),
+            env=env,
+            creationflags=windows_hide_flags(),
+            start_new_session=True,
+        )
+        threading.Thread(target=self._drain_stdout, daemon=True).start()
+        threading.Thread(target=self._drain_stderr, daemon=True).start()
+
+    def _drain_stdout(self):
+        for line in self.proc.stdout or []:
+            try:
+                self.stdout_queue.put(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        self.stdout_queue.put(None)
+
+    def _drain_stderr(self):
+        for line in self.proc.stderr or []:
+            if text := line.rstrip("\n"):
+                self.stderr_tail = (self.stderr_tail + [text])[-80:]
+
+    def run(self, command: str) -> str:
+        if self.proc.poll() is not None:
+            raise RuntimeError("slash worker exited")
+
+        with self._lock:
+            self._seq += 1
+            rid = self._seq
+            self.proc.stdin.write(json.dumps({"id": rid, "command": command}) + "\n")
+            self.proc.stdin.flush()
+
+            while True:
+                try:
+                    msg = self.stdout_queue.get(timeout=_SLASH_WORKER_TIMEOUT_S)
+                except queue.Empty:
+                    raise RuntimeError("slash worker timed out")
+                if msg is None:
+                    break
+                if msg.get("id") != rid:
+                    continue
+                if not msg.get("ok"):
+                    raise RuntimeError(msg.get("error", "slash worker failed"))
+                return str(msg.get("output", "")).rstrip()
+
+            raise RuntimeError(
+                f"slash worker closed pipe{': ' + chr(10).join(self.stderr_tail[-8:]) if self.stderr_tail else ''}"
+            )
+
+    def close(self):
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+        proc = self.proc
+        try:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=1)
+                except Exception:
+                    proc.kill()
+                    try:
+                        proc.wait(timeout=1)  # reap the zombie SIGKILL leaves behind
+                    except Exception:
+                        pass
+        except Exception:
+            try:
+                proc.kill()
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+        finally:
+            for stream in (proc.stdin, proc.stdout, proc.stderr):
+                try:
+                    stream.close()
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

tui_gateway/server.py god-file slice **R1**: extract the `_SlashWorker` subprocess client + session-db cluster from `tui_gateway/server.py` (13,908 lines) into `tui_gateway/slash_worker_client.py` and `tui_gateway/session_db.py`. Part of the repo-wide large-file decomposition (tracker #78647).

## What changed and why

- **`_SlashWorker` + `_SLASH_WORKER_TIMEOUT_S`** (window 158–162 + 326–459, golden sha `e71683bf…`) → `tui_gateway/slash_worker_client.py` — zero forward deps, `git_probe.py` extraction is the in-tree precedent
- **Session DB cluster** (window 1301–1508, golden sha `cea6186d…`, 12 members) → `tui_gateway/session_db.py` — 9/12 members have zero outside refs; the 2 `global` state lines stay on server.py (test-pinned)
- `server.py` re-exports all moved names identity-preserving (seam: `server.X is module.X`)
- **Double-blind**: 2 blind region analysts (pass A + pass B) → consensus adjudication (R1-CONSENSUS.md) → implementer → 2 blind re-reviewers (both APPROVED)

## Testing

- 63 tests pass (5 dedicated slash-worker files + 2 new extraction tests) + 523 tui server/ws tests
- Full `tests/tui_gateway/`: 391 passed, 4 failed — **identical 4 proven at the pristine pin** (timing flakes + Windows SIGPIPE)
- Seam identity 14/14 re-export names verified `is`-identical
- Golden shas verified against the consensus contract
- ruff clean · git diff --check clean · LF-only · DCO signed · Windows-tested

## Coordination / interlock

- **Epic:** Part of #78647 (Shard all 20 god files) · **Target issue:** Part of #78630
- **Sibling PRs:** the 4 other tui_gateway/server.py slices (change-watcher, pet-payload, config.set, projects) — disjoint clusters, same wave
- **Dedup:** no existing PR extracts these clusters (verified via open-PR scan)
- Credit: extraction pattern follows the web_server wave (#79123–#79129) and the run.py #54962 precedent; seam = the `method_ctx.HandlerRegistry` globals-rebinding contract

Part of #78647
Part of #78630
