### PR TITLE
fix(skills): validate external directory config

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -5,6 +5,7 @@ heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
 
+import json
 import logging
 import os
 import re
@@ -465,6 +466,98 @@ def _normalize_string_set(values) -> Set[str]:
 
 # ── External skills directories ──────────────────────────────────────────
 
+
+class ExternalSkillsConfigError(ValueError):
+    """Raised when ``skills.external_dirs`` is not a supported path list."""
+
+
+def normalize_external_skills_dirs(raw_dirs: Any) -> List[str]:
+    """Normalize ``skills.external_dirs`` into a validated list of strings.
+
+    A YAML sequence is canonical.  For compatibility with values written by
+    older ``hermes config set`` versions, a scalar that looks like a JSON array
+    is decoded as that array.  A plain scalar remains a supported shorthand for
+    one directory.  Malformed JSON-looking values and non-string list entries
+    are rejected instead of being treated as literal path names.
+    """
+    if raw_dirs is None:
+        return []
+
+    if isinstance(raw_dirs, str):
+        stripped = raw_dirs.strip()
+        if not stripped:
+            return []
+        if stripped.startswith(("[", "{")):
+            try:
+                raw_dirs = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ExternalSkillsConfigError(
+                    "JSON-looking scalar is not valid JSON "
+                    f"({exc.msg} at character {exc.pos})"
+                ) from exc
+            if not isinstance(raw_dirs, list):
+                raise ExternalSkillsConfigError(
+                    "JSON-looking scalar must decode to an array of path strings"
+                )
+        else:
+            raw_dirs = [stripped]
+
+    if not isinstance(raw_dirs, list):
+        raise ExternalSkillsConfigError(
+            "expected a YAML list of path strings or a JSON array string, "
+            f"got {type(raw_dirs).__name__}"
+        )
+
+    normalized: List[str] = []
+    for index, entry in enumerate(raw_dirs):
+        if not isinstance(entry, str):
+            raise ExternalSkillsConfigError(
+                f"entry {index + 1} must be a path string, "
+                f"got {type(entry).__name__}"
+            )
+        entry = entry.strip()
+        if entry:
+            normalized.append(entry)
+    return normalized
+
+
+def resolve_external_skills_dirs(
+    raw_dirs: Any,
+    *,
+    existing_only: bool = True,
+) -> List[Path]:
+    """Resolve configured external skill paths with runtime path semantics.
+
+    ``~`` and environment variables are expanded, relative paths are anchored
+    to ``HERMES_HOME``, the local skills directory is excluded, and duplicate
+    resolved paths are removed.  Set ``existing_only=False`` for diagnostics
+    that need to report missing directories separately from malformed config.
+    """
+    from hermes_constants import get_hermes_home
+
+    hermes_home = get_hermes_home()
+    local_skills = get_skills_dir().resolve()
+    seen: Set[Path] = set()
+    result: List[Path] = []
+
+    for entry in normalize_external_skills_dirs(raw_dirs):
+        expanded = os.path.expanduser(os.path.expandvars(entry))
+        path = Path(expanded)
+        if not path.is_absolute():
+            path = (hermes_home / path).resolve()
+        else:
+            path = path.resolve()
+        if path == local_skills or path in seen:
+            continue
+        seen.add(path)
+        if existing_only and not path.is_dir():
+            logger.debug("External skills dir does not exist, skipping: %s", path)
+            continue
+        result.append(path)
+
+    return result
+
+
 # (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
 # mtime_ns so a config.yaml edit mid-run is picked up automatically;
 # otherwise every call would re-read + re-YAML-parse the 15KB config,
@@ -472,25 +565,30 @@ def _normalize_string_set(values) -> Set[str]:
 # each trigger a category lookup during banner construction (10+ seconds
 # of pure waste).
 _EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+_EXTERNAL_DIRS_ERROR_CACHE: Set[Tuple[str, int]] = set()
 
 
 def _external_dirs_cache_clear() -> None:
     """Test hook — drop the in-process cache."""
     _EXTERNAL_DIRS_CACHE.clear()
+    _EXTERNAL_DIRS_ERROR_CACHE.clear()
     _raw_config_cache_clear()
 
 
 def get_external_skills_dirs() -> List[Path]:
-    """Read ``skills.external_dirs`` from config.yaml and return validated paths.
+    """Read ``skills.external_dirs`` from config.yaml and return existing paths.
 
-    Each entry is expanded (``~`` and ``${VAR}``) and resolved to an absolute
-    path.  Only directories that actually exist are returned.  Duplicates and
-    paths that resolve to the local ``~/.hermes/skills/`` are silently skipped.
+    Valid YAML lists and legacy JSON-array scalar strings are supported.  Each
+    entry is expanded (``~`` and ``${VAR}``) and resolved to an absolute path.
+    Only directories that actually exist are returned.  Duplicates and paths
+    that resolve to the local ``~/.hermes/skills/`` are silently skipped.
+    Invalid values emit one actionable error per config revision rather than
+    silently becoming a nonexistent literal directory.
 
-    Cached in-process, keyed on ``config.yaml`` mtime — the function is
-    called once per skill during banner / tool-registry scans, and YAML
-    parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    Cached in-process, keyed on ``config.yaml`` mtime — the function is called
+    once per skill during banner / tool-registry scans, and YAML parsing a
+    non-trivial config dominates ``hermes`` cold-start time when the cache is
+    absent.
     """
     config_path = get_config_path()
     if not config_path.exists():
@@ -519,44 +617,21 @@ def get_external_skills_dirs() -> List[Path]:
         return []
 
     raw_dirs = skills_cfg.get("external_dirs")
-    if not raw_dirs:
-        result: List[Path] = []
-        if cache_key is not None:
-            _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
-        return result
-    if isinstance(raw_dirs, str):
-        raw_dirs = [raw_dirs]
-    if not isinstance(raw_dirs, list):
-        return []
-
-    from hermes_constants import get_hermes_home
-
-    hermes_home = get_hermes_home()
-    local_skills = get_skills_dir().resolve()
-    seen: Set[Path] = set()
-    result = []
-
-    for entry in raw_dirs:
-        entry = str(entry).strip()
-        if not entry:
-            continue
-        # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
-        p = Path(expanded)
-        # Resolve relative paths against HERMES_HOME, not cwd
-        if not p.is_absolute():
-            p = (hermes_home / p).resolve()
-        else:
-            p = p.resolve()
-        if p == local_skills:
-            continue
-        if p in seen:
-            continue
-        if p.is_dir():
-            seen.add(p)
-            result.append(p)
-        else:
-            logger.debug("External skills dir does not exist, skipping: %s", p)
+    try:
+        result = resolve_external_skills_dirs(raw_dirs)
+    except ExternalSkillsConfigError as exc:
+        should_report = cache_key is None or cache_key not in _EXTERNAL_DIRS_ERROR_CACHE
+        if should_report:
+            print(
+                f"Invalid skills.external_dirs in {config_path}: {exc}. "
+                "Use a YAML list of paths or run "
+                "`hermes config set skills.external_dirs "
+                "'[\"/path/one\",\"/path/two\"]'`.",
+                file=sys.stderr,
+            )
+            if cache_key is not None:
+                _EXTERNAL_DIRS_ERROR_CACHE.add(cache_key)
+        result = []
 
     if cache_key is not None:
         _EXTERNAL_DIRS_CACHE[cache_key] = list(result)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4900,8 +4900,30 @@ def set_config_value(key: str, value: str, force: bool = False):
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
+    #
+    # ``skills.external_dirs`` is list-typed, but older versions persisted a
+    # JSON-looking CLI value as one YAML scalar.  Parse that narrow setting
+    # explicitly so ``config set`` writes the canonical YAML sequence and
+    # rejects malformed JSON-looking input before it can become a fake path.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    if key == "skills.external_dirs":
+        from agent.skill_utils import (
+            ExternalSkillsConfigError,
+            normalize_external_skills_dirs,
+        )
+
+        try:
+            coerced_value = normalize_external_skills_dirs(value)
+        except ExternalSkillsConfigError as exc:
+            print(
+                f"✗ Cannot set skills.external_dirs: {exc}.\n"
+                "  Use a JSON array of path strings, for example:\n"
+                "    hermes config set skills.external_dirs "
+                "'[\"/path/one\",\"/path/two\"]'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    elif not isinstance(_default_value_for_key(key), str):
         if value.lower() in {'true', 'yes', 'on'}:
             coerced_value = True
         elif value.lower() in {'false', 'no', 'off'}:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -226,6 +226,49 @@ def _fail_and_issue(text: str, detail: str, fix: str, issues: list[str]) -> None
     issues.append(fix)
 
 
+def _check_external_skills_dirs_config(config: dict, issues: list[str]) -> None:
+    """Diagnose malformed and missing ``skills.external_dirs`` entries."""
+    skills_config = config.get("skills")
+    if not isinstance(skills_config, dict) or "external_dirs" not in skills_config:
+        return
+
+    from agent.skill_utils import (
+        ExternalSkillsConfigError,
+        normalize_external_skills_dirs,
+        resolve_external_skills_dirs,
+    )
+
+    raw_dirs = skills_config.get("external_dirs")
+    try:
+        entries = normalize_external_skills_dirs(raw_dirs)
+        resolved = resolve_external_skills_dirs(entries, existing_only=False)
+    except ExternalSkillsConfigError as exc:
+        fix = (
+            "Replace skills.external_dirs with a YAML list of path strings, "
+            "or run `hermes config set skills.external_dirs "
+            "'[\"/path/one\",\"/path/two\"]'`."
+        )
+        _fail_and_issue(
+            "skills.external_dirs is malformed",
+            f"({exc})",
+            fix,
+            issues,
+        )
+        check_info(f"Fix: {fix}")
+        return
+
+    existing = [path for path in resolved if path.is_dir()]
+    missing = [path for path in resolved if not path.is_dir()]
+    if existing:
+        noun = "directory" if len(existing) == 1 else "directories"
+        check_ok(f"{len(existing)} external skills {noun} available")
+    for path in missing:
+        check_warn("External skills directory does not exist", str(path))
+        issues.append(
+            f"Create or remove the missing skills.external_dirs path: {path}"
+        )
+
+
 # Deprecated / legacy config keys still read for back-compat. Doctor surfaces
 # them as non-failing warnings with the modern replacement — it does not
 # auto-migrate or delete (migrations live in config.py version steps).
@@ -962,6 +1005,7 @@ def run_doctor(args):
             # Raw-file diagnostic: inspects what the user actually wrote.
             from hermes_cli.config import read_user_config_raw
             cfg = read_user_config_raw(config_path)
+            _check_external_skills_dirs_config(cfg, issues)
             model_section = cfg.get("model") or {}
             provider_raw = (model_section.get("provider") or "").strip()
             provider = provider_raw.lower()

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -47,9 +47,124 @@ class TestGetExternalSkillsDirs:
         assert len(result) == 1
         assert result[0] == external_skills_dir.resolve()
 
+    def test_json_array_scalar_loads_multiple_dirs(self, hermes_home, tmp_path):
+        first = tmp_path / "external-one"
+        second = tmp_path / "external-two"
+        first.mkdir()
+        second.mkdir()
+        encoded = json.dumps([str(first), str(second)])
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs: '{encoded}'\n"
+        )
 
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import (
+                _external_dirs_cache_clear,
+                get_external_skills_dirs,
+            )
 
+            _external_dirs_cache_clear()
+            result = get_external_skills_dirs()
 
+        assert result == [first.resolve(), second.resolve()]
+
+    def test_malformed_json_scalar_reports_once(self, hermes_home, capsys):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  external_dirs: '[\"/tmp/one\",]'\n"
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import (
+                _external_dirs_cache_clear,
+                get_external_skills_dirs,
+            )
+
+            _external_dirs_cache_clear()
+            assert get_external_skills_dirs() == []
+            assert get_external_skills_dirs() == []
+
+        err = capsys.readouterr().err
+        assert err.count("Invalid skills.external_dirs") == 1
+        assert "not valid JSON" in err
+        assert "hermes config set skills.external_dirs" in err
+
+    def test_non_list_type_reports_configuration_error(self, hermes_home, capsys):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  external_dirs:\n    unexpected: mapping\n"
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import (
+                _external_dirs_cache_clear,
+                get_external_skills_dirs,
+            )
+
+            _external_dirs_cache_clear()
+            assert get_external_skills_dirs() == []
+
+        err = capsys.readouterr().err
+        assert "Invalid skills.external_dirs" in err
+        assert "got dict" in err
+
+    def test_expansion_relative_paths_and_duplicates_are_preserved(
+        self, hermes_home, tmp_path
+    ):
+        relative_dir = hermes_home / "relative-skills"
+        env_dir = tmp_path / "environment-skills"
+        fake_home = tmp_path / "user-home"
+        tilde_dir = fake_home / "shared-skills"
+        for path in (relative_dir, env_dir, tilde_dir):
+            path.mkdir(parents=True)
+
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n"
+            "  external_dirs:\n"
+            "    - relative-skills\n"
+            "    - ${EXTERNAL_SKILLS_TEST_DIR}\n"
+            "    - ~/shared-skills\n"
+            "    - relative-skills\n"
+            f"    - {hermes_home / 'skills'}\n"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_HOME": str(hermes_home),
+                "EXTERNAL_SKILLS_TEST_DIR": str(env_dir),
+                "HOME": str(fake_home),
+            },
+        ):
+            from agent.skill_utils import (
+                _external_dirs_cache_clear,
+                get_external_skills_dirs,
+            )
+
+            _external_dirs_cache_clear()
+            result = get_external_skills_dirs()
+
+        assert result == [
+            relative_dir.resolve(),
+            env_dir.resolve(),
+            tilde_dir.resolve(),
+        ]
+
+    def test_valid_nonexistent_path_is_not_reported_as_malformed(
+        self, hermes_home, capsys
+    ):
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  external_dirs:\n    - missing-skills\n"
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import (
+                _external_dirs_cache_clear,
+                get_external_skills_dirs,
+            )
+
+            _external_dirs_cache_clear()
+            assert get_external_skills_dirs() == []
+
+        assert "Invalid skills.external_dirs" not in capsys.readouterr().err
 
 
 class TestGetAllSkillsDirs:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1410,3 +1410,55 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestDoctorExternalSkillsDirs:
+    def _run_config_section(self, monkeypatch, tmp_path, config_yaml):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        (hermes_home / ".env").write_text(
+            "OPENAI_API_KEY=sk-test\n", encoding="utf-8"
+        )
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+        monkeypatch.setattr(doctor_mod, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), pytest.raises(SystemExit):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def test_flags_malformed_json_scalar_with_actionable_remediation(
+        self, monkeypatch, tmp_path
+    ):
+        out = self._run_config_section(
+            monkeypatch,
+            tmp_path,
+            "skills:\n  external_dirs: '[\"/path/one\",]'\n",
+        )
+
+        assert "skills.external_dirs is malformed" in out
+        assert "not valid JSON" in out
+        assert "hermes config set skills.external_dirs" in out
+
+    def test_distinguishes_valid_nonexistent_path_from_malformed_config(
+        self, monkeypatch, tmp_path
+    ):
+        missing = tmp_path / "missing-external-skills"
+        out = self._run_config_section(
+            monkeypatch,
+            tmp_path,
+            f"skills:\n  external_dirs:\n    - {missing}\n",
+        )
+
+        assert "External skills directory does not exist" in out
+        assert str(missing.resolve()) in out
+        assert "skills.external_dirs is malformed" not in out

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -97,6 +97,58 @@ class TestConfigYamlRouting:
         assert "gpt-4o" in config
         assert "model" not in _read_env(_isolated_hermes_home)
 
+    def test_external_dirs_json_array_is_persisted_as_yaml_list(
+        self, _isolated_hermes_home
+    ):
+        first = _isolated_hermes_home / "external-one"
+        second = _isolated_hermes_home / "external-two"
+        first.mkdir()
+        second.mkdir()
+        args = argparse.Namespace(
+            config_command="set",
+            key="skills.external_dirs",
+            value=json.dumps([str(first), str(second)]),
+            force=False,
+        )
+
+        config_command(args)
+
+        import yaml
+
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["skills"]["external_dirs"] == [str(first), str(second)]
+        assert isinstance(reloaded["skills"]["external_dirs"], list)
+
+    def test_external_dirs_plain_scalar_is_canonicalized_to_yaml_list(
+        self, _isolated_hermes_home
+    ):
+        set_config_value("skills.external_dirs", "/shared/team-skills")
+
+        import yaml
+
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["skills"]["external_dirs"] == ["/shared/team-skills"]
+
+    def test_external_dirs_malformed_json_is_rejected_before_write(
+        self, _isolated_hermes_home, capsys
+    ):
+        args = argparse.Namespace(
+            config_command="set",
+            key="skills.external_dirs",
+            value='["/path/one",]',
+            force=False,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            config_command(args)
+
+        assert exc_info.value.code == 1
+        assert not (_isolated_hermes_home / "config.yaml").exists()
+        err = capsys.readouterr().err
+        assert "Cannot set skills.external_dirs" in err
+        assert "not valid JSON" in err
+        assert "JSON array of path strings" in err
+
 
     def test_terminal_image_goes_to_config(self, _isolated_hermes_home):
         """TERMINAL_DOCKER_IMAGE doesn't match _API_KEY or _TOKEN, so config.yaml."""


### PR DESCRIPTION
## Summary

Fixes malformed `skills.external_dirs` configuration handling.

The supported command:

```bash
hermes config set skills.external_dirs '["/path/one","/path/two"]'
```

could persist the bracketed value as a single YAML scalar string. The external skill loader then treated the entire string as one literal directory path, silently skipped the real external directories, and left `hermes doctor` reporting no problem. This made external skills disappear without an actionable configuration error.

This PR:

- canonicalizes `hermes config set skills.external_dirs` values into YAML path lists;
- parses legacy JSON-array scalar values at runtime while rejecting malformed JSON-looking input loudly;
- adds `hermes doctor` diagnostics that distinguish malformed configuration from valid-but-missing directories;
- preserves existing `~`, environment-variable, `HERMES_HOME`-relative, deduplication, and local-skill-root semantics.

Closes #79270.

## Verification

- `scripts/run_tests.sh tests/agent/test_external_skills.py tests/agent/test_external_skills_dirs_cache.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_doctor.py -k 'not vercel_backend_diagnostics' -q` — 148 passed
- `scripts/run_tests.sh tests/agent/test_skill_utils.py tests/agent/test_skill_commands.py tests/hermes_cli/test_skills_config.py tests/hermes_cli/test_commands.py tests/tools/test_skills_tool.py tests/tools/test_skills_sync.py -q` — 169 passed
- `git diff --check`

## Baseline note

`tests/hermes_cli/test_doctor.py::test_doctor_reports_vercel_backend_diagnostics` fails unchanged on upstream `main` at `1be70d63548845eb8918c08ed698cda0674cf9a7`; it was excluded from the ticket-specific doctor run after reproducing the same failure in a clean worktree.
