### PR TITLE
fix(ui-tui/ink): don't skip a zero-height box that hosts absolute children

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/absolute-in-zero-height-box.test.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/absolute-in-zero-height-box.test.tsx
@@ -1,0 +1,77 @@
+import { EventEmitter } from 'events'
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Box from './components/Box.js'
+import Text from './components/Text.js'
+import Ink from './ink.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 40
+  rows = 8
+  isTTY = true
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+const paint = (node: React.ReactElement) => {
+  const stdout = new FakeTty()
+  const stdin = new FakeTty()
+  const stderr = new FakeTty()
+
+  const ink = new Ink({
+    exitOnCtrlC: false,
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  ink.render(node)
+  ink.onRender()
+  const frame = stdout.chunks.join('')
+  ink.unmount()
+
+  return frame
+}
+
+// The composer's floating panels (session switcher, model picker, …) are
+// absolute `bottom: 100%` children of a relative Box whose only OTHER children
+// — the input rows — unmount while an overlay is open. That leaves the host box
+// at height 0 with a sibling on the same row, which is exactly the shape the
+// same-row ghost guard skips. The guard must not take the escaping absolute
+// child with it: it paints outside the host's bounds and can never ghost.
+describe('absolute children of a zero-height box', () => {
+  it('paints an absolute bottom:100% panel when its host box collapses to h=0', () => {
+    const frame = paint(
+      <Box flexDirection="column">
+        <Text>transcript</Text>
+
+        <Box flexDirection="column" position="relative">
+          <Box bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
+            <Text>PANEL-CONTENT</Text>
+          </Box>
+        </Box>
+
+        <Text>footer</Text>
+      </Box>
+    )
+
+    expect(frame).toContain('PANEL-CONTENT')
+  })
+
+  // NOT covered here: that the guard still SUPPRESSES the same-row ghost it
+  // exists for (a squeezed box and its sibling both writing one row, leaving
+  // the longer content's tail behind). That path has no test upstream either,
+  // and the obvious candidates are vacuous — they pass with the guard deleted
+  // outright, which would silently reintroduce the ghost. Asserting it needs a
+  // tree where Yoga actually squeezes a node to h=0 onto a sibling's row (the
+  // HelpV2 shortcuts column is the known real case); worth adding separately.
+})

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -624,7 +624,14 @@ function renderNodeToOutput(
     // can give a box h=0 while still leaving a row for it (next sibling at
     // y+1, not y). HelpV2's third shortcuts column hits this — skipping
     // unconditionally drops "ctrl + z to suspend" from /help output.
-    if (height === 0 && siblingSharesY(node, yogaNode)) {
+    //
+    // So is the absolute-descendant check: a squeezed box still HOSTS
+    // overlays that escape its bounds (`bottom: 100%` floats above it), and
+    // those can't ghost the shared row because they never write it. The
+    // composer's relative Box hits this every time a floating panel opens —
+    // the input rows unmount, the host collapses to h=0, and skipping it
+    // would take the panel down with it (blank /resume, /model, /skills).
+    if (height === 0 && siblingSharesY(node, yogaNode) && !hasAbsoluteDescendant(node)) {
       nodeCache.set(node, { x, y, width, height, top: yogaTop })
       node.dirty = false
 
@@ -1679,6 +1686,27 @@ function siblingSharesY(node: DOMElement, yogaNode: LayoutNode): boolean {
     }
 
     return sib.getComputedTop() === myTop
+  }
+
+  return false
+}
+
+// Does this subtree contain a position:absolute node? Such a node paints
+// outside its host's layout bounds, so the host's own rect being empty says
+// nothing about whether the subtree has something to draw. Only consulted
+// from the h=0 ghost guard — already a rare shape — so the walk never runs
+// on the hot path.
+function hasAbsoluteDescendant(node: DOMElement): boolean {
+  for (const child of node.childNodes) {
+    if (child.nodeName === '#text') {
+      continue
+    }
+
+    const elem = child as DOMElement
+
+    if (elem.style.position === 'absolute' || hasAbsoluteDescendant(elem)) {
+      return true
+    }
   }
 
   return false


### PR DESCRIPTION
## What

Floating panels in the TUI (`/resume`, `/sessions`, `/models`, `/skills`, `/plugins`, pager) open into an invisible overlay when an ambient dock widget is loaded. The panel takes input — Esc is the only way out — but never paints. This is the overlay half of #69592.

## Root cause

`renderNodeToOutput` skips boxes Yoga squeezes to `height === 0` whose sibling lands on the same row, to stop the shorter content leaving the longer one's tail on screen. The guard `return`s **before rendering children**.

The panels are `position: absolute; bottom: 100%` children of a relative Box that also holds the composer input rows. Opening a panel sets `$isBlocked`, unmounting those rows, so the host collapses to h=0 with a sibling on its row — and the guard drops the subtree, overlay included. An absolute child paints outside its host's layout bounds, never writes the shared row, and so can't ghost it.

This corrects the analysis in #69592, which attributes the bug to the ambient dock consuming the overlay's vertical space. The overlay renders at full width with full content on every frame — instrumenting `WidgetCell` shows `width=145 node=yes` throughout while the screen is blank. What is zero-height is the *host* box, and an absolutely-positioned panel never competes for rows with the dock at all. Instrumenting the guard shows it firing on exactly this shape:

```
[h0-skip] ink-box y=72 kids=1 absKids=1 SKIPPED
```

## Fix

Skip only when the subtree has no absolute descendant. The walk runs solely inside the already-rare h=0 branch, so it stays off the hot path.

## Verification

- `absolute-in-zero-height-box.test.tsx` — red on unmodified `main`, green with the change. Reproduces in a bare 40×8 fake TTY with a three-node tree, so it needs no app config, theme, or terminal specifics.
- Full `ui-tui` suite: 1529 passed. The 3 `src/lib/memory.test.ts` (heapdump) failures reproduce identically on unmodified `main` and are unrelated.
- `tsc --noEmit` and `eslint` clean on both files.
- End-to-end in a real 145×67 TUI: `/resume` lists sessions, `/model` lists providers, Esc restores the composer cleanly.
- Trigger confirmed empirically rather than assumed — a from-scratch minimal widget (below), loaded alone, reproduces the blank overlay on an unfixed build and renders correctly with the fix.

## Repro (tmux, deterministic)

A loaded ambient widget is required — with none, the bug does not occur.

```bash
mkdir -p ~/.hermes/tui-widgets
cat > ~/.hermes/tui-widgets/repro-dock.mjs <<'EOF'
export default function register(sdk) {
  const { Text, defineWidgetApp, h, openWidget } = sdk
  const app = defineWidgetApp({
    id: 'repro-dock',
    help: 'minimal ambient dock widget',
    mode: 'ambient',
    zone: 'dock-bottom',
    init() { return {} },
    reduce(state) { return state },
    render() { return h(Text, null, 'repro-dock') }
  })
  openWidget(app, app.init(''))
}
EOF

# --tui is explicit; `display.interface: tui` in config.yaml is equivalent.
tmux new-session -d -s repro -x 145 -y 67 'hermes --tui'
sleep 16
tmux send-keys -t repro "/resume"; sleep 1; tmux send-keys -t repro Enter; sleep 5
tmux capture-pane -p -t repro | tail -20
```

Before this change the prompt row disappears and nothing replaces it, while `repro-dock` stays visible on the dock line; Esc restores the prompt. After it, the session switcher renders. Verified on 145x67 with this widget as the only one loaded, so the trigger is the dock itself rather than any particular widget.

## Relationship to #72208

#72208 was already open for this when I filed; I missed it, and this is not intended to compete. It moves blocking overlays into normal flow so they cannot lose their anchor (+319/-11, `ui-tui` app code, and it also covers `/reload`). This PR instead fixes the ink guard that drops the subtree (+114/-1, one condition in the vendored fork) and does not touch `/reload`.

Maintainers should take whichever direction they prefer — happy to close this one. Note that @teknium1's `keep_open` on #72208 asks for an integrated regression rendering an `AmbientDock` with `/sessions` open; the tmux sequence above is a deterministic dock-level repro and is not specific to this patch, so it can be used there too.

## Scope and caveats

- The guard's ghost-SUPPRESSION path has no test upstream, and none is added here — the obvious candidates pass with the guard deleted outright. Noted in the test file as a follow-up.
- Only reproduced against the **TUI**, which is what we run locally. The guard lives in the shared ink fork, so other ink surfaces could hit the same shape, but I have not tested those and make no claim about them.
- Does **not** address the `/reload` half of #69592, which is a separate defect in the RPC handler — hence no `Fixes` keyword, so that issue stays open on its own merits.
- Troubleshooting, root-cause analysis, and the code change were done by **Claude Opus 5** (Claude Code). @daromaj confirmed the fix resolves the symptom on a local TUI install, but has not reviewed the diff — please review on that basis.
