### PR TITLE
 Guard session_id against unhashable JSON-RPC types

### DIFF
--- a/tests/tui_gateway/test_session_id_unhashable_guard.py
+++ b/tests/tui_gateway/test_session_id_unhashable_guard.py
@@ -1,0 +1,38 @@
+"""Regression tests: malformed JSON-RPC `session_id` must not crash handlers.
+
+Some TUI JSON-RPC methods directly do `_sessions.get(params["session_id"])`.
+If a client sends an unhashable type (e.g. list/dict), Python raises
+`TypeError` before any handler error handling — crashing the request.
+
+This test covers a representative path (`process.list`) and a second
+helper path (`_completion_cwd`).
+"""
+
+import pytest
+
+import tui_gateway.server as server
+
+
+@pytest.fixture(autouse=True)
+def _disable_deferred_agent_build(monkeypatch):
+    # Avoid background timers arming during these unit tests.
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+
+
+def test_process_list_rejects_unhashable_session_id(monkeypatch):
+    resp = server.handle_request(
+        {
+            "id": "r1",
+            "method": "process.list",
+            "params": {"session_id": ["not", "hashable"]},
+        }
+    )
+    assert "error" in resp
+    assert resp["error"]["code"] == 4001
+
+
+def test_completion_cwd_never_crashes_on_unhashable_session_id():
+    cwd = server._completion_cwd({"session_id": {"x": 1}})
+    assert isinstance(cwd, str)
+    assert cwd
+

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -329,7 +329,7 @@ def _(rid, params: dict) -> dict:
     try:
         from hermes_cli.inventory import build_model_options_payload
 
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         agent = session.get("agent") if session else None
         # Layer agent-session state on top of disk config — once an agent
         # is spawned, IT owns the live provider/model/base_url. Empty
@@ -400,7 +400,7 @@ def _(rid, params: dict) -> dict:
         # surface stays in lock-step with model.options + dashboard
         # /api/model/options. picker_hints=True ensures the returned row
         # carries `authenticated` for the TUI frontend.
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         agent = session.get("agent") if session else None
         ctx = _model_picker_context(agent)
         payload = build_models_payload(

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -215,7 +215,7 @@ def _(rid, params: dict) -> dict:
         )
     if key == "reasoning":
         cfg = _load_cfg()
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         reasoning_config = None
         if session is not None:
             if isinstance(session.get("create_reasoning_override"), dict):
@@ -249,7 +249,7 @@ def _(rid, params: dict) -> dict:
         # Prefer the session's live/pinned value — `config.set fast` is
         # session-scoped, so the global key may not reflect this chat. A
         # pre-build session keeps its pin in create_service_tier_override.
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         tier = None
         if session is not None:
             agent = session.get("agent")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1103,7 +1103,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4030, "llm.oneshot requires a template or instructions/input")
 
     # Optional: inherit the live session's model (no error if absent).
-    session = _sessions.get(params.get("session_id") or "")
+    session = _safe_session_get(params.get("session_id"))
     main_runtime = _main_runtime_from_agent(session.get("agent")) if session else None
 
     try:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -83,7 +83,7 @@ def _(rid, params: dict) -> dict:
 
 @method("reload.mcp")
 def _(rid, params: dict) -> dict:
-    session = _sessions.get(params.get("session_id", ""))
+    session = _safe_session_get(params.get("session_id"))
     try:
         # Gate: /reload-mcp invalidates the prompt cache for this session.
         # Respect the ``approvals.mcp_reload_confirm`` config toggle — if
@@ -435,7 +435,7 @@ def _(rid, params: dict) -> dict:
     resolved = _resolve_name(name)
     if resolved != name:
         name = resolved
-    session = _sessions.get(params.get("session_id", ""))
+    session = _safe_session_get(params.get("session_id"))
 
     qcmds = _load_cfg().get("quick_commands", {})
     if name in qcmds:
@@ -1425,7 +1425,7 @@ def _(rid, params: dict) -> dict:
     try:
         from toolsets import get_all_toolsets, get_toolset_info
 
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         enabled = (
             set(getattr(session["agent"], "enabled_toolsets", []) or [])
             if session
@@ -1456,7 +1456,7 @@ def _(rid, params: dict) -> dict:
     try:
         from model_tools import get_toolset_for_tool, get_tool_definitions
 
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         enabled = (
             getattr(session["agent"], "enabled_toolsets", None)
             if session
@@ -1532,7 +1532,7 @@ def _(rid, params: dict) -> dict:
         )
         save_config(cfg)
 
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         info = (
             _reset_session_agent(params.get("session_id", ""), session)
             if session
@@ -1568,7 +1568,7 @@ def _(rid, params: dict) -> dict:
     try:
         from toolsets import get_all_toolsets, get_toolset_info
 
-        session = _sessions.get(params.get("session_id", ""))
+        session = _safe_session_get(params.get("session_id"))
         enabled = (
             set(getattr(session["agent"], "enabled_toolsets", []) or [])
             if session

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -155,6 +155,29 @@ _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
+
+def _coerce_session_id(value: Any) -> str:
+    """Coerce session_id to a safe, hashable lookup key.
+
+    JSON-RPC clients might send malformed types (e.g. list/dict) for
+    ``params.session_id``. Directly using that value in ``_sessions.get()``
+    would raise ``TypeError`` and can crash a handler.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception:
+        return ""
+
+
+def _safe_session_get(session_id_value: Any) -> dict | None:
+    """Session lookup that never crashes on malformed session_id types."""
+    sid = _coerce_session_id(session_id_value)
+    return _sessions.get(sid)
+
 try:
     _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
 except (ValueError, TypeError):
@@ -2273,7 +2296,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
 
 def _sess_nowait(params, rid):
-    s = _sessions.get(params.get("session_id") or "")
+    s = _safe_session_get(params.get("session_id"))
     return (s, None) if s else (None, _err(rid, 4001, "session not found"))
 
 
@@ -2303,7 +2326,7 @@ def _completion_cwd(params: dict | None = None) -> str:
     params = params or {}
     raw = (
         params.get("cwd")
-        or _sessions.get(params.get("session_id") or "", {}).get("cwd")
+        or (_safe_session_get(params.get("session_id")) or {}).get("cwd")
         # A session bound to another profile resolves its workspace from THAT
         # profile's config before falling back to the launch profile's env var.
         or _profile_configured_cwd(_profile_home(params.get("profile")))
@@ -10471,7 +10494,7 @@ def _respond(rid, params, key, *, allow_expired=False):
 @method("config.set")
 def _(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
-    session = _sessions.get(params.get("session_id", ""))
+    session = _safe_session_get(params.get("session_id"))
 
     if key == "model":
         try:


### PR DESCRIPTION
## Summary
Some TUI JSON-RPC handlers do direct `_sessions.get(params["session_id"])`.
If a client sends an unhashable value (e.g. list/dict), Python raises `TypeError`
before the handler’s error handling runs, crashing the request.

Add a small coercion helper (`_coerce_session_id`) and route affected session
lookups through `_safe_session_get()` so malformed session_id types never crash
the JSON-RPC methods.
