### PR TITLE
fix(mattermost): handle slash commands in DM mention path

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -846,6 +846,15 @@ class MattermostAdapter(BasePlatformAdapter):
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
+        mention_patterns = [
+            f"@{self._bot_username}",
+            f"@{self._bot_user_id}",
+        ]
+        has_mention = any(
+            pattern.lower() in message_text.lower()
+            for pattern in mention_patterns
+        )
+
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):
         #   require_mention / MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
@@ -879,15 +888,6 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
-            mention_patterns = [
-                f"@{self._bot_username}",
-                f"@{self._bot_user_id}",
-            ]
-            has_mention = any(
-                pattern.lower() in message_text.lower()
-                for pattern in mention_patterns
-            )
-
             if require_mention and not is_free_channel and not has_mention:
                 logger.debug(
                     "Mattermost: skipping non-DM message without @mention (channel=%s)",
@@ -895,12 +895,15 @@ class MattermostAdapter(BasePlatformAdapter):
                 )
                 return
 
-            # Strip @mention from the message text so the agent sees clean input.
-            if has_mention:
-                for pattern in mention_patterns:
-                    message_text = re.sub(
-                        re.escape(pattern), "", message_text, flags=re.IGNORECASE
-                    ).strip()
+        # Strip a leading @mention from both channels and DMs so messages like
+        # "@alan-bot /status" are normalized to "/status" and can dispatch as
+        # Hermes slash commands. Only strip at the start; mentions in ordinary
+        # message bodies should remain intact.
+        if has_mention:
+            for pattern in mention_patterns:
+                message_text = re.sub(
+                    rf"^\s*{re.escape(pattern)}\s*", "", message_text, flags=re.IGNORECASE
+                ).strip()
 
         # Resolve sender info.
         sender_id = post.get("user_id", "")

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -393,6 +393,29 @@ class TestMattermostMentionBehavior:
             await self.adapter._handle_ws_event(self._make_event("hello", channel_id="chan_456"))
             assert self.adapter.handle_message.called
 
+    @pytest.mark.asyncio
+    async def test_dm_leading_mention_slash_command_is_normalized(self):
+        """DMs strip a leading bot mention so @bot /status dispatches as /status."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_REQUIRE_MENTION", None)
+            await self.adapter._handle_ws_event(
+                self._make_event("@hermes-bot /status", channel_type="D")
+            )
+            assert self.adapter.handle_message.called
+            msg = self.adapter.handle_message.call_args[0][0]
+            assert msg.text == "/status"
+            assert msg.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_mid_message_mention_is_preserved(self):
+        """Only leading mentions are stripped; ordinary body mentions remain."""
+        with patch.dict(os.environ, {"MATTERMOST_REQUIRE_MENTION": "false"}):
+            await self.adapter._handle_ws_event(
+                self._make_event("please ask @hermes-bot later")
+            )
+            assert self.adapter.handle_message.called
+            msg = self.adapter.handle_message.call_args[0][0]
+            assert msg.text == "please ask @hermes-bot later"
 
 # ---------------------------------------------------------------------------
 # File upload (send_image)


### PR DESCRIPTION
## What does this PR do?

In a Mattermost DM, a message like `@hermes /status` never dispatches as a Hermes slash command: mention stripping only ran inside the non-DM branch, so the DM path handed `@hermes /status` to the agent as plain text and the user got an LLM turn instead of the command. Users who @-mention the bot in DMs out of channel muscle memory hit this constantly.

The fix hoists mention detection out of the channel-only block and strips a **leading** mention in both DMs and channels before the message is classified. Stripping is now anchored to the start of the message — previously the channel path removed mentions anywhere in the body, which also mangled ordinary messages that reference the bot mid-sentence.

## Related Issue

No existing issue found (searched open and closed issues/PRs). Distinct from #37756, which wires Mattermost's native `/command` webhook bridge — this PR is about Hermes' own slash commands arriving as ordinary posts. Related: #36498 (Mattermost adapter test coverage).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`: hoist `mention_patterns` / `has_mention` out of the channel-only branch; strip only a leading mention, for DMs and channels alike.
- `tests/gateway/test_mattermost.py`: add `test_dm_leading_mention_slash_command_is_normalized` and `test_mid_message_mention_is_preserved`.

## Test plan

- `python -m pytest tests/gateway/test_mattermost.py -q` — 26 passed
- `python -m py_compile plugins/platforms/mattermost/adapter.py`
- Running in production on our self-hosted Mattermost workspace since July.
