### PR TITLE
fix(mattermost): scope typing indicator to thread when metadata carries a root

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -430,10 +430,22 @@ class MattermostAdapter(BasePlatformAdapter):
     async def send_typing(
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Send a typing indicator."""
+        """Send a typing indicator.
+
+        When metadata carries a thread anchor (``thread_id`` / ``root_id``),
+        scope the typing bubble to that thread — Mattermost's user_typing
+        WebSocket event accepts a ``parent_id`` so clients only render the
+        bubble inside the matching thread panel instead of the channel-wide
+        composer footer.
+        """
+        payload: Dict[str, Any] = {"channel_id": chat_id}
+        if isinstance(metadata, dict):
+            root = metadata.get("thread_id") or metadata.get("root_id")
+            if root:
+                payload["parent_id"] = str(root)
         await self._api_post(
             f"users/{self._bot_user_id}/typing",
-            {"channel_id": chat_id},
+            payload,
         )
 
     async def edit_message(

--- a/tests/gateway/test_mattermost_typing.py
+++ b/tests/gateway/test_mattermost_typing.py
@@ -1,0 +1,87 @@
+"""Tests for Mattermost adapter typing indicator (thread-scope aware)."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(*, bot_user_id: str = "bot_xyz"):
+    """Build a MattermostAdapter wired up enough to invoke send_typing."""
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={"url": "https://mm.example.com"},
+    )
+    adapter = MattermostAdapter(config)
+    adapter._bot_user_id = bot_user_id
+    adapter._session = MagicMock()
+    adapter._api_post = AsyncMock(return_value={})
+    return adapter
+
+
+class TestSendTyping:
+    @pytest.mark.asyncio
+    async def test_channel_level_typing_has_no_parent_id(self):
+        """No metadata → bubble appears in the channel composer footer."""
+        adapter = _make_adapter()
+        await adapter.send_typing("channel_1")
+        adapter._api_post.assert_awaited_once_with(
+            "users/bot_xyz/typing",
+            {"channel_id": "channel_1"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_id_metadata_scopes_to_thread(self):
+        """metadata.thread_id → parent_id keeps the bubble inside the thread."""
+        adapter = _make_adapter()
+        await adapter.send_typing("channel_1", metadata={"thread_id": "root_post_42"})
+        adapter._api_post.assert_awaited_once_with(
+            "users/bot_xyz/typing",
+            {"channel_id": "channel_1", "parent_id": "root_post_42"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_root_id_metadata_also_scopes_to_thread(self):
+        """Some callers spell it root_id — accept that too."""
+        adapter = _make_adapter()
+        await adapter.send_typing("channel_1", metadata={"root_id": "root_post_99"})
+        adapter._api_post.assert_awaited_once_with(
+            "users/bot_xyz/typing",
+            {"channel_id": "channel_1", "parent_id": "root_post_99"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_id_takes_precedence_over_root_id(self):
+        """When both are present (unlikely) thread_id wins."""
+        adapter = _make_adapter()
+        await adapter.send_typing(
+            "channel_1",
+            metadata={"thread_id": "thread_winner", "root_id": "root_loser"},
+        )
+        adapter._api_post.assert_awaited_once_with(
+            "users/bot_xyz/typing",
+            {"channel_id": "channel_1", "parent_id": "thread_winner"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_thread_id_omits_parent_id(self):
+        """Falsy thread_id (None / '' / 0) shouldn't pollute the payload."""
+        adapter = _make_adapter()
+        await adapter.send_typing("channel_1", metadata={"thread_id": ""})
+        adapter._api_post.assert_awaited_once_with(
+            "users/bot_xyz/typing",
+            {"channel_id": "channel_1"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_dict_metadata_is_ignored(self):
+        """Defensive: unrelated metadata types shouldn't crash send_typing."""
+        adapter = _make_adapter()
+        await adapter.send_typing("channel_1", metadata="not-a-dict")  # type: ignore[arg-type]
+        adapter._api_post.assert_awaited_once_with(
+            "users/bot_xyz/typing",
+            {"channel_id": "channel_1"},
+        )


### PR DESCRIPTION
## What does this PR do?

`send_typing()` always posted only `channel_id`, so the bot's typing bubble surfaced in the channel composer footer even when the conversation was happening inside a thread. Mattermost's `user_typing` WebSocket action accepts a `parent_id`; when the typing metadata carries `thread_id` / `root_id` (the keys the base typing-keepalive loop already passes through), include it so the bubble renders in the right thread panel.

## Related Issue

No existing issue found (searched open and closed issues/PRs). Related: #36498 (Mattermost adapter test coverage).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`: `send_typing` forwards `parent_id` from metadata `thread_id`/`root_id` when present.
- `tests/gateway/test_mattermost_typing.py` (new): channel-level typing (no `parent_id`), `thread_id` and `root_id` keys, key precedence, empty `thread_id` guard, non-dict metadata safety.

## Test plan

- `python -m pytest tests/gateway/test_mattermost_typing.py tests/gateway/test_mattermost.py -q` — 30 passed
- `python -m py_compile plugins/platforms/mattermost/adapter.py`
- Running in production on our self-hosted Mattermost workspace since July.
