### PR TITLE
feat(mattermost): add reaction lifecycle (eyes / check / x)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -278,6 +278,23 @@ class MattermostAdapter(BasePlatformAdapter):
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
+    async def _api_delete(self, path: str) -> bool:
+        """DELETE /api/v4/{path}. Returns True on 2xx."""
+        import aiohttp
+        url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
+        try:
+            async with self._session.delete(
+                url, headers=self._headers()
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM API DELETE %s → %s: %s", path, resp.status, body[:200])
+                    return False
+                return True
+        except aiohttp.ClientError as exc:
+            logger.error("MM API DELETE %s network error: %s", path, exc)
+            return False
+
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
     ) -> Optional[str]:
@@ -1001,6 +1018,61 @@ class MattermostAdapter(BasePlatformAdapter):
 
         await self.handle_message(msg_event)
 
+    # ------------------------------------------------------------------
+    # Message reactions (👀 on receive, ✅/❌ on completion)
+    # ------------------------------------------------------------------
+
+    # Opt into the shared reaction-ack flow (base.on_processing_complete):
+    # swap the 👀 progress reaction for a ✅/❌ result. Mattermost reactions
+    # are additive per user, so the base remove-then-add sequencing applies
+    # unchanged. Values are Mattermost emoji names, not unicode glyphs.
+    _ACK_EMOJI = "eyes"
+    _OK_EMOJI = "white_check_mark"
+    _FAIL_EMOJI = "x"
+
+    def _reactions_enabled(self) -> bool:
+        """Check if message reactions are enabled via env."""
+        return os.getenv("MATTERMOST_REACTIONS", "true").lower() not in {"false", "0", "no"}
+
+    async def _add_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+        """React to a post with ``emoji``. Soft-fails (False), never raises.
+
+        ``chat_id`` is unused: Mattermost reactions address the post alone.
+        """
+        if not message_id or not self._bot_user_id or self._session is None:
+            return False
+        result = await self._api_post(
+            "reactions",
+            {
+                "user_id": self._bot_user_id,
+                "post_id": message_id,
+                "emoji_name": emoji,
+            },
+        )
+        return bool(result)
+
+    async def _remove_reaction(self, chat_id: str, message_id: str) -> bool:
+        """Remove the bot's 👀 progress reaction from a post. Soft-fails.
+
+        The base reaction-ack flow only ever removes the in-progress marker,
+        and Mattermost's DELETE route is addressed by emoji name, so this
+        targets ``_ACK_EMOJI`` directly.
+        """
+        if not message_id or not self._bot_user_id or self._session is None:
+            return False
+        return await self._api_delete(
+            f"users/{self._bot_user_id}/posts/{message_id}/reactions/{self._ACK_EMOJI}"
+        )
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add an in-progress 👀 reaction when the bot starts handling a message."""
+        if not self._reactions_enabled():
+            return
+        chat_id = getattr(event.source, "chat_id", None)
+        message_id = getattr(event, "message_id", None)
+        if chat_id and message_id:
+            await self._add_reaction(chat_id, message_id, self._ACK_EMOJI)
+
 
 
 
@@ -1252,6 +1324,8 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+    if "reactions" in mattermost_cfg and not os.getenv("MATTERMOST_REACTIONS"):
+        os.environ["MATTERMOST_REACTIONS"] = str(mattermost_cfg["reactions"]).lower()
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_REACTIONS
+    description: "React to incoming messages with 👀 while processing and ✅/❌ on completion (default true)."
+    prompt: "Enable reactions? (true/false)"
+    password: false

--- a/tests/gateway/test_mattermost_reactions.py
+++ b/tests/gateway/test_mattermost_reactions.py
@@ -1,0 +1,224 @@
+"""Tests for Mattermost adapter message reactions (👀 / ✅ / ❌).
+
+The completion-side swap runs through the shared reaction-ack flow in
+``BasePlatformAdapter.on_processing_complete`` — the adapter opts in via the
+``_ACK_EMOJI`` / ``_OK_EMOJI`` / ``_FAIL_EMOJI`` class attributes and the
+base-shaped ``_add_reaction`` / ``_remove_reaction`` primitives.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+
+def _make_adapter(*, bot_user_id: str = "bot_xyz"):
+    """Build a MattermostAdapter wired up enough to invoke reaction methods."""
+    from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={"url": "https://mm.example.com"},
+    )
+    adapter = MattermostAdapter(config)
+    adapter._bot_user_id = bot_user_id
+    adapter._session = MagicMock()  # truthy session so guards pass
+    adapter._api_post = AsyncMock(return_value={"id": "reaction_1"})
+    adapter._api_delete = AsyncMock(return_value=True)
+    return adapter
+
+
+def _make_event(post_id: str = "post_abc", chat_id: str = "chan_1") -> MessageEvent:
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=SimpleNamespace(chat_id=chat_id),
+        raw_message={"id": post_id} if post_id else None,
+        message_id=post_id or None,
+    )
+
+
+class TestOptIn:
+    def test_ack_emoji_class_attributes(self):
+        """The adapter opts into the base reaction-ack flow via class attrs."""
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        assert MattermostAdapter._ACK_EMOJI == "eyes"
+        assert MattermostAdapter._OK_EMOJI == "white_check_mark"
+        assert MattermostAdapter._FAIL_EMOJI == "x"
+
+
+class TestReactionsEnabled:
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        assert adapter._reactions_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "FALSE", "No"])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", value)
+        adapter = _make_adapter()
+        assert adapter._reactions_enabled() is False
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", ""])
+    def test_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", value)
+        adapter = _make_adapter()
+        assert adapter._reactions_enabled() is True
+
+
+class TestOnProcessingStart:
+    @pytest.mark.asyncio
+    async def test_adds_eyes_reaction(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        await adapter.on_processing_start(_make_event("post_abc"))
+        adapter._api_post.assert_awaited_once_with(
+            "reactions",
+            {"user_id": "bot_xyz", "post_id": "post_abc", "emoji_name": "eyes"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_disabled_skips_call(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "false")
+        adapter = _make_adapter()
+        await adapter.on_processing_start(_make_event("post_abc"))
+        adapter._api_post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_message_id_skips_call(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        await adapter.on_processing_start(_make_event(""))
+        adapter._api_post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sourceless_event_skips_call(self, monkeypatch):
+        """Events whose source carries no chat_id (e.g. synthetic events from
+        other surfaces) must not trigger a 👀 the completion side could never
+        remove."""
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source="user_1",  # plain string: no chat_id attribute
+            raw_message=None,
+            message_id="post_abc",
+        )
+        await adapter.on_processing_start(event)
+        adapter._api_post.assert_not_awaited()
+
+
+class TestOnProcessingComplete:
+    """Completion runs the inherited base reaction-ack flow end to end."""
+
+    @pytest.mark.asyncio
+    async def test_success_swaps_eyes_for_check(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        await adapter.on_processing_complete(
+            _make_event("post_abc"), ProcessingOutcome.SUCCESS
+        )
+        adapter._api_delete.assert_awaited_once_with(
+            "users/bot_xyz/posts/post_abc/reactions/eyes"
+        )
+        adapter._api_post.assert_awaited_once_with(
+            "reactions",
+            {
+                "user_id": "bot_xyz",
+                "post_id": "post_abc",
+                "emoji_name": "white_check_mark",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure_swaps_eyes_for_x(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        await adapter.on_processing_complete(
+            _make_event("post_abc"), ProcessingOutcome.FAILURE
+        )
+        adapter._api_delete.assert_awaited_once_with(
+            "users/bot_xyz/posts/post_abc/reactions/eyes"
+        )
+        adapter._api_post.assert_awaited_once_with(
+            "reactions",
+            {"user_id": "bot_xyz", "post_id": "post_abc", "emoji_name": "x"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_only_removes_eyes(self, monkeypatch):
+        """CANCELLED should only clear the in-progress marker, no final stamp."""
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        await adapter.on_processing_complete(
+            _make_event("post_abc"), ProcessingOutcome.CANCELLED
+        )
+        adapter._api_delete.assert_awaited_once_with(
+            "users/bot_xyz/posts/post_abc/reactions/eyes"
+        )
+        adapter._api_post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disabled_skips_all_calls(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "false")
+        adapter = _make_adapter()
+        await adapter.on_processing_complete(
+            _make_event("post_abc"), ProcessingOutcome.SUCCESS
+        )
+        adapter._api_post.assert_not_awaited()
+        adapter._api_delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_chat_id_skips_all_calls(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        adapter = _make_adapter()
+        await adapter.on_processing_complete(
+            _make_event("post_abc", chat_id=""), ProcessingOutcome.SUCCESS
+        )
+        adapter._api_post.assert_not_awaited()
+        adapter._api_delete.assert_not_awaited()
+
+
+class TestReactionHelpers:
+    @pytest.mark.asyncio
+    async def test_add_reaction_returns_false_without_bot_id(self):
+        adapter = _make_adapter(bot_user_id="")
+        assert await adapter._add_reaction("chan_1", "post_abc", "eyes") is False
+        adapter._api_post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_remove_reaction_returns_false_without_bot_id(self):
+        adapter = _make_adapter(bot_user_id="")
+        assert await adapter._remove_reaction("chan_1", "post_abc") is False
+        adapter._api_delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_add_reaction_returns_false_on_api_failure(self):
+        adapter = _make_adapter()
+        adapter._api_post = AsyncMock(return_value={})  # _api_post returns {} on failure
+        assert await adapter._add_reaction("chan_1", "post_abc", "eyes") is False
+
+
+class TestApplyYamlConfigReactions:
+    def test_reactions_yaml_to_env(self, monkeypatch):
+        monkeypatch.delenv("MATTERMOST_REACTIONS", raising=False)
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        _apply_yaml_config({}, {"reactions": False})
+        import os
+
+        assert os.environ["MATTERMOST_REACTIONS"] == "false"
+
+    def test_env_takes_precedence_over_yaml(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_REACTIONS", "true")
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        _apply_yaml_config({}, {"reactions": False})
+        import os
+
+        assert os.environ["MATTERMOST_REACTIONS"] == "true"


### PR DESCRIPTION
## What does this PR do?

Brings Mattermost to parity with Discord/Telegram/Matrix/photon: the bot reacts 👀 to a message when it starts processing, then swaps it for ✅ on success or ❌ on failure.

The completion-side swap rides the shared reaction-ack flow that #74230 promoted into `base.on_processing_complete` — the adapter opts in via the `_ACK_EMOJI` / `_OK_EMOJI` / `_FAIL_EMOJI` class attributes and provides the base-shaped `_add_reaction(chat_id, message_id, emoji)` / `_remove_reaction(chat_id, message_id)` primitives (`chat_id` is accepted but unused: Mattermost reactions address the post alone). Mattermost reactions are additive per user, so the base remove-then-add sequencing applies unchanged, and CANCELLED leaves the message unreacted. Emoji values are Mattermost emoji names rather than unicode glyphs.

Toggle with the `MATTERMOST_REACTIONS` env var or the `mattermost.reactions` config.yaml key (default true).

## Related Issue

Related: #74230 (the shared base flow this builds on), #74105 (Matrix analog of thread-scoped processing reactions), #36498 (Mattermost adapter test coverage). Not a duplicate of #49724 (inbound user-reaction events) or the agent-facing reaction tools in #47593 — this is the processing-status ack flow the other adapters already have.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`: `_ACK_EMOJI`/`_OK_EMOJI`/`_FAIL_EMOJI` opt-in, base-shaped `_add_reaction`/`_remove_reaction` primitives, `on_processing_start` override (the base has no start-side default), `_api_delete` REST helper alongside `_api_get/post/put`, `mattermost.reactions` yaml→env bridge.
- `plugins/platforms/mattermost/plugin.yaml`: document `MATTERMOST_REACTIONS` in `optional_env`.
- `tests/gateway/test_mattermost_reactions.py` (new, 25 tests): opt-in attributes, all three outcome paths through the inherited base hook, env toggle, guard behavior for sourceless/id-less events, helper soft-fail guards, yaml→env bridge.

## Test plan

- `python -m pytest tests/gateway/test_mattermost_reactions.py tests/gateway/test_mattermost.py -q` — 48 passed
- `python -m py_compile plugins/platforms/mattermost/adapter.py`
- Running in production on our self-hosted Mattermost workspace since July.
