### PR TITLE
Ignore non-string workdir values in scheduler tick

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -53,6 +53,20 @@ from agent.interrupt_compat import request_hard_interrupt
 logger = logging.getLogger(__name__)
 
 
+def _resolve_job_workdir(raw: Any) -> Optional[str]:
+    """Return a stripped workdir string from a job record, or None.
+
+    Malformed jobs.json (e.g. ``workdir: 42``) must not crash the scheduler
+    tick — non-string values are treated as absent.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        return None
+    stripped = raw.strip()
+    return stripped or None
+
+
 def _set_cron_session_title(session_db, session_id, base_title):
     """Robustly title a finished cron session before it is closed.
 
@@ -2812,7 +2826,7 @@ def run_job(
         # paths. For no_agent jobs this is passed as the subprocess cwd so the
         # Python process cwd is NEVER mutated — avoiding the global-side-effect
         # bug where os.chdir() leaks into concurrent gateway sessions (#69396).
-        _job_workdir = (job.get("workdir") or "").strip() or None
+        _job_workdir = _resolve_job_workdir(job.get("workdir"))
         if _job_workdir and not Path(_job_workdir).is_dir():
             logger.warning(
                 "Job '%s': configured workdir %r no longer exists — running without it",
@@ -3048,7 +3062,7 @@ def run_job(
     # letting set_session_vars handle the _SESSION_CWD ContextVar set/clear
     # via its existing machinery (clear_session_vars calls clear_session_cwd
     # internally). This avoids a separate import/set/clear dance (#69396).
-    _job_workdir = (job.get("workdir") or "").strip() or None
+    _job_workdir = _resolve_job_workdir(job.get("workdir"))
     if _job_workdir and not Path(_job_workdir).is_dir():
         logger.warning(
             "Job '%s': configured workdir %r no longer exists — running without it",
@@ -4225,8 +4239,8 @@ def tick(
         # That alone only keeps workdir jobs from overlapping EACH OTHER;
         # run_job's _terminal_cwd_lock is what additionally stops a concurrently
         # firing workdir-less parallel-pool job from observing the override.
-        sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
-        parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
+        sequential_jobs = [j for j in due_jobs if _resolve_job_workdir(j.get("workdir"))]
+        parallel_jobs = [j for j in due_jobs if not _resolve_job_workdir(j.get("workdir"))]
 
         _results: list = []
         _all_futures: list = []

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -251,3 +251,48 @@ class TestRunJobTerminalCwd:
         # And after run_job completes, it's still the sentinel (nothing
         # overwrote or cleared it).
         assert os.environ["TERMINAL_CWD"] == before
+
+
+# ---------------------------------------------------------------------------
+# scheduler._resolve_job_workdir — malformed stored values
+# ---------------------------------------------------------------------------
+
+class TestSchedulerWorkdirTypeGuard:
+    def test_non_string_workdir_treated_as_absent(self):
+        from cron.scheduler import _resolve_job_workdir
+
+        assert _resolve_job_workdir(42) is None
+        assert _resolve_job_workdir(True) is None
+        assert _resolve_job_workdir([]) is None
+
+    def test_string_workdir_stripped(self, tmp_path):
+        from cron.scheduler import _resolve_job_workdir
+
+        path = str(tmp_path)
+        assert _resolve_job_workdir(f"  {path}  ") == path
+
+    def test_tick_partitions_malformed_workdir_without_crashing(self, tmp_path, monkeypatch):
+        """A non-string workdir must not crash tick() job partitioning."""
+        from unittest.mock import patch
+
+        import cron.scheduler as sched
+
+        lock_dir = tmp_path / "cron"
+        lock_dir.mkdir()
+        lock_file = lock_dir / ".tick.lock"
+
+        jobs = [
+            {"id": "job-a", "name": "a", "deliver": "local", "workdir": 42},
+            {"id": "job-b", "name": "b", "deliver": "local"},
+        ]
+
+        with patch("cron.scheduler._get_lock_paths", return_value=(lock_dir, lock_file)), \
+             patch("cron.scheduler.get_due_jobs", return_value=jobs), \
+             patch("cron.scheduler.advance_next_runs"), \
+             patch("cron.scheduler.run_job", return_value=(True, "out", "resp", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None), \
+             patch("cron.scheduler.mark_job_run"):
+            result = sched.tick(verbose=False)
+
+        assert result == 2


### PR DESCRIPTION
## Summary
- Malformed `jobs.json` can store `workdir` as a non-string (e.g. `42`).
- The scheduler tick partitioned jobs with `(workdir or "").strip()`, which raises `AttributeError` and crashes the entire tick.
- Add `_resolve_job_workdir()` to treat non-string values as absent and route all workdir reads through it (tick partitioning + `run_job`).

