### PR TITLE
feat(slack): add per-channel thread mention requirements

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1022,12 +1022,6 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
-#   slack:
-#     extra:
-#       # Thread replies in these channels require an explicit @mention even
-#       # when the thread would otherwise auto-engage. Top-level messages are
-#       # unaffected. Env fallback: SLACK_REQUIRE_MENTION_CHANNEL_THREADS.
-#       require_mention_channel_threads: ["C0123456789"]
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1022,6 +1022,12 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
+#   slack:
+#     extra:
+#       # Thread replies in these channels require an explicit @mention even
+#       # when the thread would otherwise auto-engage. Top-level messages are
+#       # unaffected. Env fallback: SLACK_REQUIRE_MENTION_CHANNEL_THREADS.
+#       require_mention_channel_threads: ["C0123456789"]
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5666,6 +5666,20 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return
 
+            if (
+                is_thread_reply
+                and channel_id in self._slack_require_mention_channel_threads()
+                and not is_mentioned
+                and not force_process
+            ):
+                logger.debug(
+                    "[Slack] Ignoring thread reply without mention "
+                    "(require_mention_channel_threads): channel=%s thread_ts=%s",
+                    channel_id,
+                    event_thread_ts,
+                )
+                return
+
             if force_process:
                 pass  # Explicit internal routing path (reaction trigger).
             elif (
@@ -8403,6 +8417,17 @@ class SlackAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("require_mention_channels")
         if raw is None:
             raw = os.getenv("SLACK_REQUIRE_MENTION_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        if isinstance(raw, str) and raw.strip():
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        return set()
+
+    def _slack_require_mention_channel_threads(self) -> set:
+        """Return channel IDs where thread replies require a bot @mention."""
+        raw = self.config.extra.get("require_mention_channel_threads")
+        if raw is None:
+            raw = os.getenv("SLACK_REQUIRE_MENTION_CHANNEL_THREADS", "")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         if isinstance(raw, str) and raw.strip():

--- a/tests/test_slack_require_mention_channel_threads.py
+++ b/tests/test_slack_require_mention_channel_threads.py
@@ -1,0 +1,180 @@
+import asyncio
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_adapter(extra=None):
+    config = PlatformConfig(extra=extra or {})
+    adapter = SlackAdapter(config)
+    adapter._bot_user_id = "UBOT"
+    adapter._team_bot_user_ids["T1"] = "UBOT"
+    adapter._has_active_session_for_thread = lambda **_: False
+
+    async def no_thread_context(**_):
+        return ""
+
+    async def no_parent_text(**_):
+        return ""
+
+    async def user_name(*_, **__):
+        return "Sebastian"
+
+    adapter._fetch_thread_context = no_thread_context
+    adapter._fetch_thread_parent_text = no_parent_text
+    adapter._resolve_user_name = user_name
+    return adapter
+
+
+def slack_event(text, ts="100.000", thread_ts=None):
+    event = {
+        "type": "message",
+        "channel": "C123",
+        "channel_type": "channel",
+        "team": "T1",
+        "user": "U123",
+        "text": text,
+        "ts": ts,
+    }
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    return event
+
+
+def capture_messages(adapter):
+    handled = []
+
+    async def capture(event):
+        handled.append(event)
+
+    adapter.handle_message = capture
+    return handled
+
+
+def test_require_mention_channel_threads_parses_env_yaml_list_and_csv(monkeypatch):
+    monkeypatch.delenv("SLACK_REQUIRE_MENTION_CHANNEL_THREADS", raising=False)
+    assert make_adapter()._slack_require_mention_channel_threads() == set()
+
+    monkeypatch.setenv(
+        "SLACK_REQUIRE_MENTION_CHANNEL_THREADS", " CENV1, CENV2, , CENV1 "
+    )
+    assert make_adapter()._slack_require_mention_channel_threads() == {
+        "CENV1",
+        "CENV2",
+    }
+
+    assert make_adapter(
+        {"require_mention_channel_threads": [" C123 ", "", "C456"]}
+    )._slack_require_mention_channel_threads() == {"C123", "C456"}
+    assert make_adapter(
+        {"require_mention_channel_threads": " C789, C012, , C789 "}
+    )._slack_require_mention_channel_threads() == {"C789", "C012"}
+
+
+def test_unmentioned_thread_reply_in_listed_channel_is_ignored_before_wake_checks():
+    adapter = make_adapter(
+        {
+            "allowed_channels": ["C123"],
+            "require_mention_channel_threads": ["C123"],
+            "reply_in_thread": True,
+        }
+    )
+    adapter._bot_message_ts.add("101.000")
+    adapter._mentioned_threads.add("101.000")
+    adapter._has_active_session_for_thread = lambda **_: True
+
+    async def mentioned_parent(**_):
+        return "<@UBOT> please follow up"
+
+    adapter._fetch_thread_parent_text = mentioned_parent
+    handled = capture_messages(adapter)
+
+    run(
+        adapter._handle_slack_message(
+            slack_event("follow-up", ts="102.000", thread_ts="101.000")
+        )
+    )
+
+    assert handled == []
+
+
+def test_mentioned_thread_reply_in_listed_channel_proceeds():
+    adapter = make_adapter(
+        {
+            "allowed_channels": ["C123"],
+            "require_mention_channel_threads": ["C123"],
+            "reply_in_thread": True,
+        }
+    )
+    handled = capture_messages(adapter)
+
+    run(
+        adapter._handle_slack_message(
+            slack_event("<@UBOT> follow up", ts="102.000", thread_ts="101.000")
+        )
+    )
+
+    assert len(handled) == 1
+    assert handled[0].text == "follow up"
+
+
+def test_unmentioned_top_level_message_in_listed_channel_is_unchanged():
+    adapter = make_adapter(
+        {
+            "allowed_channels": ["C123"],
+            "require_mention": False,
+            "require_mention_channel_threads": ["C123"],
+            "reply_in_thread": True,
+        }
+    )
+    handled = capture_messages(adapter)
+
+    run(adapter._handle_slack_message(slack_event("top-level update")))
+
+    assert len(handled) == 1
+    assert handled[0].text == "top-level update"
+
+
+def test_unmentioned_thread_reply_in_non_listed_channel_is_unchanged():
+    adapter = make_adapter(
+        {
+            "allowed_channels": ["C123"],
+            "require_mention_channel_threads": ["C456"],
+            "reply_in_thread": True,
+        }
+    )
+    adapter._has_active_session_for_thread = lambda **_: True
+    handled = capture_messages(adapter)
+
+    run(
+        adapter._handle_slack_message(
+            slack_event("follow-up", ts="102.000", thread_ts="101.000")
+        )
+    )
+
+    assert len(handled) == 1
+    assert handled[0].text == "follow-up"
+
+
+def test_listed_channel_gate_wins_over_free_response_for_thread_replies():
+    adapter = make_adapter(
+        {
+            "allowed_channels": ["C123"],
+            "free_response_channels": ["C123"],
+            "require_mention_channel_threads": ["C123"],
+            "reply_in_thread": True,
+        }
+    )
+    handled = capture_messages(adapter)
+
+    run(
+        adapter._handle_slack_message(
+            slack_event("follow-up", ts="102.000", thread_ts="101.000")
+        )
+    )
+
+    assert handled == []

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -344,6 +344,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `SLACK_ALLOW_ALL_USERS` | Allow any Slack user to trigger the bot (dev only). |
 | `SLACK_ALLOW_BOTS` | Accept messages from other Slack bots: `none` (default), `mentions`, or `all`. The bot always ignores its own messages. |
 | `SLACK_THREAD_REQUIRE_MENTION` | Require an explicit @mention for Slack thread replies while preserving top-level free-response channels |
+| `SLACK_REQUIRE_MENTION_CHANNEL_THREADS` | Comma-separated Slack channel IDs where thread replies require an explicit @mention even in auto-engaging threads |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |
 | `GOOGLE_CHAT_PROJECT_ID` | GCP project hosting the Pub/Sub topic (falls back to `GOOGLE_CLOUD_PROJECT`) |

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -570,6 +570,12 @@ slack:
   # Env: SLACK_REQUIRE_MENTION_CHANNELS.
   require_mention_channels: ""
 
+  # Per-channel thread-only force-mention override. Thread replies in
+  # listed channels require an explicit @mention even when the thread
+  # would otherwise auto-engage. Top-level messages are unaffected.
+  # Comma-separated IDs or a list. Env: SLACK_REQUIRE_MENTION_CHANNEL_THREADS.
+  require_mention_channel_threads: ""
+
   # Custom mention patterns that trigger the bot
   # (in addition to the default @mention detection)
   mention_patterns:
@@ -605,6 +611,7 @@ The gating options compose — each answers a different question:
 | `require_mention` | Do **top-level channel messages** need an @mention? | `true` | All channels |
 | `free_response_channels` | Which channels are exempt from `require_mention`? | none | Listed channels |
 | `require_mention_channels` | Which channels ALWAYS need an @mention, even when `require_mention` is `false` or the channel is free-response? Wins over both. | none | Listed channels |
+| `require_mention_channel_threads` | Which channels require an @mention for THREAD replies even in auto-engaging threads? | none | Listed channels / threads |
 | `thread_require_mention` | Do **thread replies** need an @mention, even when top-level messages don't? Mentioned threads are not remembered. | `false` | Threads only |
 | `strict_mention` | Does **every** channel message (top-level and thread) need a fresh @mention? Disables all auto-follow: mentioned-thread memory, bot-reply follow-ups, active-session resume. | `false` | All channels + threads |
 | `ignore_other_user_mentions` | Should a message that **opens by @mentioning someone else** (`@rasha can you take this?`) be skipped? Overrides free-response and thread auto-follow; mid-sentence references still reach the bot. | `false` | Channels + group DMs |


### PR DESCRIPTION
## What does this PR do?

Adds `require_mention_channel_threads`, a per-channel Slack configuration option that requires an explicit bot `@mention` for thread replies in selected channels.

The gate applies before Slack’s thread auto-engagement checks, so an unmentioned reply cannot wake Hermes through mentioned-thread memory, an active agent session, a bot-authored thread root, or a parent-message mention.

Top-level messages, 1:1 DMs, and channels not listed in this option retain their existing behavior. An internally forced routing event also retains its existing bypass.

Configuration can be supplied through:

- `platforms.slack.extra.require_mention_channel_threads`
- `SLACK_REQUIRE_MENTION_CHANNEL_THREADS`

The YAML configuration takes precedence over the environment variable.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_slack_require_mention_channel_threads()` in `plugins/platforms/slack/adapter.py` to parse YAML lists, YAML comma-separated strings, and the environment fallback.
- Added an early thread-reply gate in `_handle_slack_message()` before all existing auto-engagement paths.
- Added `tests/test_slack_require_mention_channel_threads.py` covering:
  - unset, environment, YAML-list, and CSV parsing;
  - YAML precedence over the environment;
  - blocked unmentioned replies in listed channels;
  - allowed mentioned replies;
  - unchanged top-level behavior;
  - unchanged behavior in non-listed channels;
  - precedence over `free_response_channels`.
- Documented the YAML option in `website/docs/user-guide/messaging/slack.md`.
- Documented `SLACK_REQUIRE_MENTION_CHANNEL_THREADS` in `website/docs/reference/environment-variables.md`.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh \
     tests/test_slack_require_mention_channel_threads.py \
     tests/test_slack_thread_require_mention.py
   ```

2. Confirm an unmentioned thread reply in a listed channel is ignored even when an existing Slack wake path would otherwise engage the bot.
3. Confirm an explicit bot mention in that thread is processed.
4. Confirm top-level messages and thread replies in non-listed channels retain their existing behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I have not updated `cli-config.yaml.example` — N/A because it has no Slack configuration block
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] I've considered cross-platform impact; the change uses existing platform-independent Slack configuration and message-routing paths
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

```text
=== Summary: 2 files, 11 tests passed, 0 failed (100% complete) in 2.5s (20 workers) ===
```


