### PR TITLE
fix(cli): recognize background process notification config

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1197,6 +1197,7 @@ DEFAULT_CONFIG = {
         # When false, commentary falls back to the reasoning channel and is
         # only visible when show_reasoning is enabled.
         "show_commentary": True,
+        "background_process_notifications": "all",
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         # NOTE: display.tool_progress_overrides is deprecated and no longer
         # seeded here — use display.platforms. A user-set value is still

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -457,6 +457,16 @@ class TestSchemaValidation:
 
 
 
+    def test_background_process_notifications_is_accepted(
+        self, _isolated_hermes_home, capsys
+    ):
+        set_config_value("display.background_process_notifications", "result")
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["display"]["background_process_notifications"] == "result"
+        assert "not a recognized config key" not in capsys.readouterr().out
+
     def test_desktop_macos_signing_identity_is_accepted(self, _isolated_hermes_home, capsys):
         """The documented TCC signing identity setting is part of the schema."""
         set_config_value("desktop.macos_signing_identity", "Hermes Local Signing")


### PR DESCRIPTION
## What does this PR do?

Registers the already-documented `display.background_process_notifications` setting in the CLI's canonical config schema.

Before this change, `hermes config set display.background_process_notifications result` saved the value but also warned that the setting was not a recognized config key. The gateway already consumes this setting and defaults it to `all`; this PR aligns `DEFAULT_CONFIG` with that existing behavior without changing gateway notification semantics.

## Related Issue

None. This is a small fork contribution for a reproduced schema-registration mismatch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `background_process_notifications: "all"` to `DEFAULT_CONFIG["display"]` in `hermes_cli/config_defaults.py`.
- Add a regression test in `tests/hermes_cli/test_set_config_value.py` proving the setting is persisted without an unrecognized-key warning.
- Leave gateway behavior, config versioning, and `cli-config.yaml.example` unchanged.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/gateway/test_background_process_notifications.py -q` (93 passed locally).
2. Run `scripts/run_tests.sh tests/gateway/test_config.py -q` (55 passed locally).
3. With a temporary `HERMES_HOME`, run `hermes config set display.background_process_notifications result`, verify no unrecognized-key warning appears, and verify `hermes config get display.background_process_notifications` returns `result`.
4. Run `ruff check .` and `python scripts/check-windows-footguns.py --all` (both passed locally).

The full local suite was also attempted. It did not complete green in this environment: 131 tests failed and 37 files had collection/import or timeout issues, primarily because optional integration dependencies were not installed and because of macOS/Linux environment differences. The focused CLI, gateway notification, and gateway config suites above pass; GitHub Actions is the authoritative full-suite result.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused and related suites pass; see the environment limitation above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no documentation behavior changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: the key and default were already documented there
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Manual verification after the fix:

```text
Set output: configuration saved without an unrecognized-key warning
Get output: result
Saved YAML:
display:
  background_process_notifications: result
```
