### PR TITLE
fix(compression): estimate Codex Responses wire payloads

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -862,6 +862,7 @@ class HermesACPAgent(acp.Agent):
                 state.history,
                 system_prompt=getattr(agent, "_cached_system_prompt", "") or "",
                 tools=getattr(agent, "tools", None) or None,
+                api_mode=getattr(agent, "api_mode", None),
             )
         except Exception:
             logger.debug("Could not estimate ACP native context usage", exc_info=True)
@@ -2275,6 +2276,7 @@ class HermesACPAgent(acp.Agent):
                 state.history,
                 system_prompt=system_prompt,
                 tools=tools,
+                api_mode=getattr(agent, "api_mode", None),
             )
         except Exception:
             logger.debug("Could not estimate ACP context usage", exc_info=True)
@@ -2368,7 +2370,10 @@ class HermesACPAgent(acp.Agent):
             _sys_prompt = getattr(agent, "_cached_system_prompt", "") or ""
             _tools = getattr(agent, "tools", None) or None
             approx_tokens = estimate_request_tokens_rough(
-                state.history, system_prompt=_sys_prompt, tools=_tools
+                state.history,
+                system_prompt=_sys_prompt,
+                tools=_tools,
+                api_mode=getattr(agent, "api_mode", None),
             )
             original_session_db = getattr(agent, "_session_db", None)
 
@@ -2396,6 +2401,7 @@ class HermesACPAgent(acp.Agent):
                 state.history,
                 system_prompt=_sys_prompt_after,
                 tools=_tools_after,
+                api_mode=getattr(agent, "api_mode", None),
             )
             return (
                 f"Context compressed: {original_count} -> {new_count} messages\n"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,7 @@ from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
+    estimate_request_tokens_rough,
     get_model_context_length,
     estimate_messages_tokens_rough,
     estimate_tokens_rough,
@@ -3112,7 +3113,7 @@ class ContextCompressor(ContextEngine):
         # Nothing to reclaim until there are messages outside the protected tail.
         if len(messages) <= self.protect_last_n + self._protect_head_size(messages) + 1:
             return messages, 0
-        before = sum(_estimate_msg_budget_tokens(m) for m in messages)
+        before = estimate_request_tokens_rough(messages, api_mode=self.api_mode)
         if before < self._proactive_prune_rearm_tokens:
             return messages, 0
         # Capability gate BEFORE the expensive 3-pass scan: a bound store that
@@ -3140,7 +3141,9 @@ class ContextCompressor(ContextEngine):
         # Measured-savings gate (prompt-cache hysteresis): only commit when
         # the prune reclaims a meaningful batch of tokens. Estimated on the
         # real before/after messages so dedup + arg truncation count too.
-        after = sum(_estimate_msg_budget_tokens(m) for m in pruned_msgs)
+        after = estimate_request_tokens_rough(
+            pruned_msgs, api_mode=self.api_mode,
+        )
         reclaimed = max(0, before - after)
         if reclaimed < self.proactive_prune_min_reclaim_tokens:
             return messages, 0

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3494,6 +3494,7 @@ def compress_context(
             compressed,
             system_prompt=new_system_prompt or "",
             tools=agent.tools or None,
+            api_mode=getattr(agent, "api_mode", None),
         )
         agent.context_compressor.last_compression_rough_tokens = _compressed_est
         agent.context_compressor.last_prompt_tokens = -1

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1897,7 +1897,10 @@ def run_conversation(
         # messages walk inside estimate_request_tokens_rough. Tools added
         # separately (compression needs them: 50+ tools = 20-30K tokens).
         # total_chars is a rough (~) proxy — verbose log + hook metric only.
-        approx_tokens = estimate_messages_tokens_rough(api_messages)
+        approx_tokens = estimate_request_tokens_rough(
+            api_messages,
+            api_mode=getattr(agent, "api_mode", None),
+        )
         request_pressure_tokens = approx_tokens + (
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
@@ -4399,7 +4402,11 @@ def run_conversation(
                         # the true request (msgs + tools + system), not the tool-blind message count.
                         messages, active_system_prompt = agent._compress_context(
                             messages, system_message,
-                            approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                            approx_tokens=estimate_request_tokens_rough(
+                                api_messages,
+                                tools=agent.tools or None,
+                                api_mode=getattr(agent, "api_mode", None),
+                            ),
                             task_id=effective_task_id,
                         )
                         conversation_history = conversation_history_after_compression(
@@ -4658,7 +4665,11 @@ def run_conversation(
                     # true request (msgs + tools + system), not the tool-blind message count.
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                        approx_tokens=estimate_request_tokens_rough(
+                            api_messages,
+                            tools=agent.tools or None,
+                            api_mode=getattr(agent, "api_mode", None),
+                        ),
                         task_id=effective_task_id,
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
@@ -4755,7 +4766,9 @@ def run_conversation(
                         # messages.  Use the smaller budget and apply a small
                         # safety margin.  Do not alter context_length.
                         request_input_estimate = estimate_request_tokens_rough(
-                            api_messages, tools=agent.tools or None,
+                            api_messages,
+                            tools=agent.tools or None,
+                            api_mode=getattr(agent, "api_mode", None),
                         )
                         local_available_out = old_ctx - request_input_estimate
                         if local_available_out > 0:
@@ -4959,7 +4972,11 @@ def run_conversation(
                     # _should_force_overflow_recovery. (approx_tokens stays for the status display.)
                     messages, active_system_prompt = agent._compress_context(
                         messages, system_message,
-                        approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
+                        approx_tokens=estimate_request_tokens_rough(
+                            api_messages,
+                            tools=agent.tools or None,
+                            api_mode=getattr(agent, "api_mode", None),
+                        ),
                         task_id=effective_task_id,
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
@@ -6449,7 +6466,9 @@ def run_conversation(
                     # estimate misses, which can skip compression
                     # past the configured threshold (#14695).
                     _real_tokens = estimate_request_tokens_rough(
-                        messages, tools=agent.tools or None
+                        messages,
+                        tools=agent.tools or None,
+                        api_mode=getattr(agent, "api_mode", None),
                     )
 
                 if (

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3274,8 +3274,9 @@ def estimate_request_tokens_rough(
     *,
     system_prompt: str = "",
     tools: Optional[List[Dict[str, Any]]] = None,
+    api_mode: Optional[str] = None,
 ) -> int:
-    """Rough token estimate for a full chat-completions request.
+    """Rough token estimate for a full provider request.
 
     Includes the major payload buckets Hermes sends to providers:
     system prompt, conversation messages, and tool schemas.  With 50+
@@ -3286,8 +3287,43 @@ def estimate_request_tokens_rough(
     total = 0
     if system_prompt:
         total += estimate_tokens_rough(system_prompt)
+    elif (
+        api_mode == "codex_responses"
+        and messages
+        and isinstance(messages[0], dict)
+        and messages[0].get("role") == "system"
+    ):
+        total += estimate_tokens_rough(str(messages[0].get("content") or "").strip())
     if messages:
-        total += estimate_messages_tokens_rough(messages)
+        estimated_messages = messages
+        if api_mode == "codex_responses" and all(
+            isinstance(message, dict) for message in messages
+        ):
+            try:
+                from agent.codex_responses_adapter import (
+                    _chat_messages_to_responses_input,
+                )
+                from agent.turn_context import substitute_api_content
+
+                api_messages = [message.copy() for message in messages]
+                for message in api_messages:
+                    substitute_api_content(message)
+                estimated_messages = _chat_messages_to_responses_input(api_messages)
+                wire_shadows = []
+                for item in estimated_messages:
+                    shadow = item.copy()
+                    if shadow.get("type") == "reasoning":
+                        shadow.pop("encrypted_content", None)
+                    elif (
+                        shadow.get("type") == "function_call_output"
+                        and isinstance(shadow.get("output"), list)
+                    ):
+                        shadow["content"] = shadow.pop("output")
+                    wire_shadows.append(shadow)
+                estimated_messages = wire_shadows
+            except Exception:
+                estimated_messages = messages
+        total += estimate_messages_tokens_rough(estimated_messages)
     if tools:
         total += _estimate_tools_tokens_rough(tools)
     return total

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -669,6 +669,7 @@ def build_turn_context(
                 messages,
                 system_prompt=active_system_prompt or "",
                 tools=agent.tools or None,
+                api_mode=getattr(agent, "api_mode", None),
             )
             # Post-compression target size: don't summarise a thread already
             # below what compaction would reduce it to.
@@ -748,6 +749,7 @@ def build_turn_context(
             messages,
             system_prompt=active_system_prompt or "",
             tools=agent.tools or None,
+            api_mode=getattr(agent, "api_mode", None),
         )
         _compressor = agent.context_compressor
         # getattr guard: minimal compressor doubles (SimpleNamespace in the
@@ -912,6 +914,7 @@ def build_turn_context(
                     messages,
                     system_prompt=active_system_prompt or "",
                     tools=agent.tools or None,
+                    api_mode=getattr(agent, "api_mode", None),
                 )
                 if not _compression_made_progress(
                     _orig_len, len(messages), _orig_tokens, _preflight_tokens

--- a/cli.py
+++ b/cli.py
@@ -11042,6 +11042,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self.conversation_history,
                 system_prompt=_sys_prompt,
                 tools=_tools,
+                api_mode=getattr(self.agent, "api_mode", None),
             )
             report = summarize_compress_preview(
                 self.conversation_history,
@@ -11086,6 +11087,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     original_history,
                     system_prompt=_sys_prompt,
                     tools=_tools,
+                    api_mode=getattr(self.agent, "api_mode", None),
                 )
                 if partial:
                     print(f"🗜️  Summarizing up to here: compressing {len(head)} of "
@@ -11171,6 +11173,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self.conversation_history,
                     system_prompt=_sys_prompt,
                     tools=_tools,
+                    api_mode=getattr(self.agent, "api_mode", None),
                 )
                 summary = summarize_manual_compression(
                     original_history,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16479,13 +16479,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Token source priority:
         # 1. Actual API-reported prompt_tokens from the last turn
         #    (stored in session_entry.last_prompt_tokens)
-        # 2. Rough char-based estimate (str(msg)//4). Overestimates
-        #    by 30-50% on code/JSON-heavy sessions, but that just
-        #    means hygiene fires a bit early — safe and harmless.
+        # 2. Rough transcript estimate. Responses history is projected through
+        #    its wire adapter so persisted private replay state does not trigger
+        #    compression by itself. System/tool overhead is unavailable before
+        #    the hygiene agent is built; the live turn's lower-threshold
+        #    preflight remains the full-request safety net.
         # -----------------------------------------------------------------
         if history and len(history) >= 4:
             from agent.model_metadata import (
                 estimate_messages_tokens_rough,
+                estimate_request_tokens_rough,
                 get_model_context_length_async,
             )
 
@@ -16508,6 +16511,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _hyg_provider = None
             _hyg_base_url = None
             _hyg_api_key = None
+            _hyg_api_mode = None
             _hyg_configured_model = None
             _hyg_configured_provider = None
             _hyg_configured_base_url = None
@@ -16592,6 +16596,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _hyg_provider = _hyg_runtime.get("provider") or _hyg_provider
                     _hyg_base_url = _hyg_runtime.get("base_url") or _hyg_base_url
                     _hyg_api_key = _hyg_runtime.get("api_key") or _hyg_api_key
+                    _hyg_api_mode = _hyg_runtime.get("api_mode") or _hyg_api_mode
                 except Exception:
                     pass
 
@@ -16660,15 +16665,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _approx_tokens = _stored_tokens
                     _token_source = "actual"
                 else:
-                    _approx_tokens = estimate_messages_tokens_rough(history)
+                    _approx_tokens = estimate_request_tokens_rough(
+                        history,
+                        api_mode=_hyg_api_mode,
+                    )
                     _token_source = "estimated"
-                    # Note: rough estimates overestimate by 30-50% for code/JSON-heavy
-                    # sessions, but that just means hygiene fires a bit early — which
-                    # is safe and harmless.  The 85% threshold already provides ample
-                    # headroom (agent's own compressor runs at 50%).  A previous 1.4x
-                    # multiplier tried to compensate by inflating the threshold, but
-                    # 85% * 1.4 = 119% of context — which exceeds the model's limit
-                    # and prevented hygiene from ever firing for ~200K models (GLM-5).
+                    # Remaining rough estimates can overcount code/JSON, but
+                    # the 85% threshold still provides headroom (the agent's
+                    # own compressor runs at 50%). A previous 1.4x multiplier
+                    # inflated the threshold to 119% of context and prevented
+                    # hygiene from firing for ~200K models (GLM-5).
 
                 # Hard safety valve: force compression if message count is
                 # extreme, regardless of token estimates.  This breaks the

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3998,7 +3998,10 @@ class GatewaySlashCommandsMixin:
                 _sys_prompt = getattr(tmp_agent, "_cached_system_prompt", "") or ""
                 _tools = getattr(tmp_agent, "tools", None) or None
                 approx_tokens = estimate_request_tokens_rough(
-                    msgs, system_prompt=_sys_prompt, tools=_tools
+                    msgs,
+                    system_prompt=_sys_prompt,
+                    tools=_tools,
+                    api_mode=getattr(tmp_agent, "api_mode", None),
                 )
 
                 compressor = tmp_agent.context_compressor
@@ -4111,7 +4114,10 @@ class GatewaySlashCommandsMixin:
                     committed=True,
                 )
                 new_tokens = estimate_request_tokens_rough(
-                    compressed, system_prompt=_sys_prompt, tools=_tools
+                    compressed,
+                    system_prompt=_sys_prompt,
+                    tools=_tools,
+                    api_mode=getattr(tmp_agent, "api_mode", None),
                 )
                 summary = summarize_manual_compression(
                     msgs,

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -29,7 +29,12 @@ def _threshold_tokens(context_length: int, threshold_percent: float) -> int:
     return max(int(context_length * threshold_percent), MINIMUM_CONTEXT_LENGTH)
 
 
-def _estimate_tokens(agent: Any, messages: Optional[List[dict]]) -> Optional[int]:
+def _estimate_tokens(
+    agent: Any,
+    messages: Optional[List[dict]],
+    *,
+    api_mode: Optional[str] = None,
+) -> Optional[int]:
     cc = getattr(agent, "context_compressor", None)
     if cc is None:
         return None
@@ -50,6 +55,7 @@ def _estimate_tokens(agent: Any, messages: Optional[List[dict]]) -> Optional[int
                     messages,
                     system_prompt=system_prompt,
                     tools=tools or None,
+                    api_mode=api_mode or getattr(agent, "api_mode", None),
                 )
             )
         except Exception:
@@ -118,7 +124,7 @@ def merge_preflight_compression_warning(
     if not new_ctx:
         return
 
-    estimate = _estimate_tokens(agent, messages)
+    estimate = _estimate_tokens(agent, messages, api_mode=result.api_mode)
     if estimate is None:
         return
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -266,17 +266,19 @@ class TestSessionOps:
         state.agent.context_compressor = MagicMock(context_length=100_000)
         state.agent._cached_system_prompt = "system"
         state.agent.tools = [{"type": "function", "function": {"name": "demo"}}]
+        state.agent.api_mode = "codex_responses"
 
         with patch(
             "agent.model_metadata.estimate_request_tokens_rough",
             return_value=25_000,
-        ):
+        ) as estimate:
             update = agent._build_usage_update(state)
 
         assert isinstance(update, UsageUpdate)
         assert update.session_update == "usage_update"
         assert update.size == 100_000
         assert update.used == 25_000
+        assert estimate.call_args.kwargs["api_mode"] == "codex_responses"
 
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -10,7 +10,9 @@ Coverage levels:
   Persistent cache       — save/load, corruption, update, provider isolation
 """
 
+import ast
 import time
+from pathlib import Path
 
 import pytest
 import yaml
@@ -147,6 +149,106 @@ class TestEstimateMessagesTokensRough:
 
 
 class TestEstimateRequestTokensRough:
+    def test_all_agent_backed_callers_propagate_api_mode(self):
+        root = Path(__file__).resolve().parents[2]
+        calls = []
+        for path in root.rglob("*.py"):
+            if "tests" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = (
+                    node.func.id
+                    if isinstance(node.func, ast.Name)
+                    else node.func.attr
+                    if isinstance(node.func, ast.Attribute)
+                    else None
+                )
+                if name != "estimate_request_tokens_rough":
+                    continue
+                calls.append((path.relative_to(root), node))
+
+        assert len(calls) == 31
+        without_api_mode = [
+            (path, node.lineno)
+            for path, node in calls
+            if not any(keyword.arg == "api_mode" for keyword in node.keywords)
+        ]
+        assert [path for path, _ in without_api_mode] == [
+            Path("gateway/slash_commands.py"),
+        ]
+
+    def test_codex_responses_estimates_projected_wire_messages(self):
+        visible = "v" * 40_000
+        baseline = [{"role": "assistant", "content": "ok"}]
+
+        def codex_estimate(messages, **kwargs):
+            return estimate_request_tokens_rough(
+                messages, api_mode="codex_responses", **kwargs
+            )
+
+        inflated = [{
+            **baseline[0],
+            "reasoning": "r" * 40_000,
+            "reasoning_content": "c" * 40_000,
+            "display_metadata": {"internal": "m" * 40_000},
+        }]
+        assert codex_estimate(inflated) == codex_estimate(baseline)
+
+        replay_only = [{
+            "role": "assistant",
+            "content": "",
+            "codex_message_items": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": visible}],
+            }],
+        }]
+        assert codex_estimate(
+            [{**replay_only[0], "content": visible}]
+        ) == codex_estimate(replay_only)
+
+        def encrypted(size):
+            return [{
+                **baseline[0],
+                "codex_reasoning_items": [{
+                    "type": "reasoning",
+                    "encrypted_content": "e" * size,
+                }],
+            }]
+        assert codex_estimate(encrypted(40_000)) == codex_estimate(encrypted(80_000))
+
+        api_content = [{"role": "user", "content": "stored", "api_content": visible}]
+        wire_content = [{"role": "user", "content": visible}]
+        assert codex_estimate(api_content) == codex_estimate(wire_content)
+
+        with_system_message = [
+            {"role": "system", "content": visible},
+            {"role": "user", "content": "hello"},
+        ]
+        assert codex_estimate(with_system_message) == codex_estimate(
+            with_system_message[1:], system_prompt=visible
+        )
+
+        tool_image = [{
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": [{
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{'a' * 40_000}"},
+            }],
+        }]
+        assert 1_500 <= codex_estimate(tool_image) < 2_000
+
+        malformed = ["m" * 40_000]
+        assert codex_estimate(malformed) == estimate_request_tokens_rough(malformed)
+
+        assert estimate_request_tokens_rough(inflated) > estimate_request_tokens_rough(
+            baseline
+        )
+
     def test_caches_tools_estimate(self):
         messages = [{"role": "user", "content": "hello"}]
         tools = [

--- a/tests/agent/test_proactive_tool_result_pruning.py
+++ b/tests/agent/test_proactive_tool_result_pruning.py
@@ -16,6 +16,7 @@ from agent.context_compressor import (
     _PRUNED_TOOL_PLACEHOLDER,
     _estimate_msg_budget_tokens,
 )
+from agent.model_metadata import estimate_request_tokens_rough
 
 LARGE_WINDOW = 1_000_000
 
@@ -141,6 +142,67 @@ def test_rearms_only_after_reclaimed_token_runway():
     assert sum(map(_estimate_msg_budget_tokens, regrown)) >= rearm_tokens
     rearmed, n3 = c.prune_tool_results_only(regrown, current_tokens=1_000_000)
     assert n3 >= 2
+    assert rearmed is not regrown
+
+
+def test_codex_private_replay_does_not_rearm_without_visible_growth():
+    c = _compressor(
+        api_mode="codex_responses",
+        proactive_prune_tokens=48_000,
+        proactive_prune_min_result_chars=8_000,
+    )
+    first, first_count = c.prune_tool_results_only(
+        _build(8, big_indices={0, 1, 2, 6, 7}), current_tokens=120_000,
+    )
+    assert first_count >= 3
+    runway = c._proactive_prune_rearm_tokens
+
+    grown = first + [
+        _assistant_call("call_8"),
+        _tool_msg("call_8", "ok"),
+        _assistant_call("call_9"),
+        _tool_msg("call_9", "ok"),
+    ]
+    private_replay = {
+        "role": "assistant",
+        "content": "ok",
+        "codex_reasoning_items": [{
+            "type": "reasoning",
+            "encrypted_content": "e" * 240_000,
+        }],
+    }
+    visible_baseline = grown + [{"role": "assistant", "content": "ok"}]
+    replayed = grown + [private_replay]
+    raw_delta = (
+        sum(map(_estimate_msg_budget_tokens, replayed))
+        - sum(map(_estimate_msg_budget_tokens, visible_baseline))
+    )
+    projected_delta = (
+        estimate_request_tokens_rough(replayed, api_mode=c.api_mode)
+        - estimate_request_tokens_rough(visible_baseline, api_mode=c.api_mode)
+    )
+    assert raw_delta == 60_012
+    assert projected_delta == 6
+    assert sum(map(_estimate_msg_budget_tokens, replayed)) >= runway
+    projected = estimate_request_tokens_rough(replayed, api_mode=c.api_mode)
+    assert projected < runway
+
+    blocked, blocked_count = c.prune_tool_results_only(
+        replayed, current_tokens=1_000_000,
+    )
+    assert blocked is replayed
+    assert blocked_count == 0
+
+    visible_growth = {
+        "role": "user",
+        "content": "v" * ((runway - projected + 32) * 4),
+    }
+    regrown = replayed + [visible_growth]
+    assert estimate_request_tokens_rough(regrown, api_mode=c.api_mode) >= runway
+    rearmed, rearmed_count = c.prune_tool_results_only(
+        regrown, current_tokens=1_000_000,
+    )
+    assert rearmed_count >= 2
     assert rearmed is not regrown
 
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.context_compressor import ContextCompressor
+from agent.model_metadata import estimate_request_tokens_rough
 from agent.turn_context import TurnContext, build_turn_context
 from hermes_state import SessionDB
 
@@ -208,6 +209,49 @@ def test_returns_turn_context_with_user_message_appended():
     assert ctx.active_system_prompt == "SYSTEM"
 
 
+def test_responses_preflight_uses_wire_estimate_for_compression_decision():
+    agent = _FakeAgent()
+    agent.api_mode = "codex_responses"
+    agent.compression_enabled = True
+    decision_tokens = []
+    threshold = 100
+    agent.context_compressor = types.SimpleNamespace(
+        protect_first_n=0,
+        protect_last_n=0,
+        threshold_tokens=threshold,
+        last_prompt_tokens=0,
+        should_compress=lambda tokens: (
+            decision_tokens.append(tokens) or tokens >= threshold
+        ),
+        should_compress_info=lambda _tokens: (False, None),
+        should_defer_preflight_to_real_usage=lambda _tokens: False,
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+    agent._compress_context = MagicMock()
+    history = [
+        {
+            "role": "assistant",
+            "content": "ok",
+            "reasoning": "r" * 120_000,
+        }
+    ]
+
+    ctx = _build(agent, conversation_history=history)
+
+    wire_tokens = estimate_request_tokens_rough(
+        ctx.messages,
+        system_prompt=ctx.active_system_prompt or "",
+        api_mode="codex_responses",
+    )
+    rough_tokens = estimate_request_tokens_rough(
+        ctx.messages,
+        system_prompt=ctx.active_system_prompt or "",
+    )
+    assert wire_tokens < threshold < rough_tokens
+    assert decision_tokens == [wire_tokens]
+    agent._compress_context.assert_not_called()
+
+
 # ── Trivial-prompt prefetch gate (PR #25350 salvage) ─────────────────────────
 #
 # The prologue is the ONLY place the per-turn synchronous
@@ -363,9 +407,6 @@ def test_between_turns_refresh_adds_late_tool_when_servers_registered():
 
     assert "mcp_x_tool" in agent.valid_tool_names
     assert any(t["function"]["name"] == "mcp_x_tool" for t in agent.tools)
-
-
-
 
 
 

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -60,11 +60,15 @@ def test_manual_compress_explains_when_token_estimate_rises(capsys):
     shell.agent.compression_enabled = True
     shell.agent._cached_system_prompt = ""
     shell.agent.tools = None
+    shell.agent.api_mode = "codex_responses"
     shell.agent.session_id = shell.session_id  # no-op: no split
     shell.agent._compress_context.return_value = (compressed, "")
     shell.agent._compression_skipped_due_to_lock = False
 
-    def _estimate(messages, **_kwargs):
+    estimate_modes = []
+
+    def _estimate(messages, **kwargs):
+        estimate_modes.append(kwargs.get("api_mode"))
         if messages == history:
             return 100
         if messages == compressed:
@@ -78,6 +82,7 @@ def test_manual_compress_explains_when_token_estimate_rises(capsys):
     assert "✅ Compressed: 4 → 3 messages" in output
     assert "Approx request size: ~100 → ~120 tokens" in output
     assert "denser summaries" in output
+    assert estimate_modes == ["codex_responses", "codex_responses"]
 
 
 def test_manual_compress_syncs_session_id_after_split():

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -80,6 +80,7 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     agent_instance.close = MagicMock()
     agent_instance._cached_system_prompt = ""
     agent_instance.tools = None
+    agent_instance.api_mode = "codex_responses"
     agent_instance.compression_enabled = False
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
@@ -87,7 +88,10 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     # Explicit non-lock-skip: MagicMock getattr would return a truthy mock.
     agent_instance._compression_skipped_due_to_lock = False
 
-    def _estimate(messages, **_kwargs):
+    estimate_modes = []
+
+    def _estimate(messages, **kwargs):
+        estimate_modes.append(kwargs.get("api_mode"))
         return 100 if messages == history else 60
 
     with (
@@ -102,6 +106,7 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     assert "Compressed:" in result
     agent_instance._compress_context.assert_called_once()
     assert agent_instance._compress_context.call_args.kwargs.get("force") is True
+    assert estimate_modes == ["codex_responses", "codex_responses"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -215,6 +215,146 @@ class TestTokenEstimation:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("history", "expect_hygiene"),
+    [
+        pytest.param(
+            [
+                {"role": "user", "content": "Earlier request"},
+                {
+                    "role": "assistant",
+                    "content": "Visible answer",
+                    "reasoning_content": "r" * 40_000,
+                    "codex_reasoning_items": [
+                        {
+                            "type": "reasoning",
+                            "encrypted_content": "e" * 1_000_000,
+                        }
+                    ],
+                },
+                {"role": "user", "content": "Follow-up"},
+                {"role": "assistant", "content": "Visible reply"},
+            ],
+            False,
+            id="private-replay-state-fits-wire",
+        ),
+        pytest.param(
+            [
+                {"role": "user", "content": "x" * 1_000_000},
+                {"role": "assistant", "content": "Earlier answer"},
+                {"role": "user", "content": "Follow-up"},
+                {"role": "assistant", "content": "Visible reply"},
+            ],
+            True,
+            id="visible-wire-content-is-oversize",
+        ),
+    ],
+)
+async def test_responses_session_hygiene_uses_projected_wire_history(
+    monkeypatch, tmp_path, history, expect_hygiene
+):
+    """Responses hygiene must ignore private replay weight, not visible input."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        instances = 0
+
+        def __init__(self, **kwargs):
+            type(self).instances += 1
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._last_compaction_in_place = False
+            self.context_compressor = SimpleNamespace()
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            self.session_id = f"{self.session_id}_compressed"
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    adapter = HygieneCaptureAdapter()
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")
+        }
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-responses-hygiene",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+        last_prompt_tokens=0,
+    )
+    runner.session_store.load_transcript.return_value = history
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "gpt-5-codex",
+        {
+            "api_key": "fake",
+            "api_mode": "codex_responses",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+        },
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    async def _context_length(*_args, **_kwargs):
+        return 282_353  # int(282_353 * 0.85) == 240_000
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async",
+        _context_length,
+    )
+
+    event = MessageEvent(
+        text="Continue",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="12345",
+        ),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert FakeCompressAgent.instances == int(expect_hygiene)
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch, tmp_path):
     """Regression for #21301: the hygiene agent is built without a session_db,
     so _compress_context cannot rotate. When it neither rotates NOR compacts

--- a/tests/hermes_cli/test_context_switch_guard.py
+++ b/tests/hermes_cli/test_context_switch_guard.py
@@ -64,6 +64,37 @@ def test_merge_appends_to_existing_warning(monkeypatch):
     assert "preflight compression" in result.warning_message
 
 
+def test_responses_switch_warning_uses_target_wire_shape(monkeypatch):
+    cc = _compressor(monkeypatch)
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        context_compressor=cc,
+        compression_enabled=True,
+        base_url="",
+        api_key="",
+        _cached_system_prompt="",
+        tools=None,
+        session_prompt_tokens=0,
+    )
+    messages = [
+        {"role": "assistant", "content": "ok", "reasoning": "r" * 100_000}
+        for _ in range(25)
+    ]
+
+    chat_result = _result()
+    merge_preflight_compression_warning(chat_result, agent=agent, messages=messages)
+    assert "preflight compression" in chat_result.warning_message
+
+    responses_result = _result()
+    responses_result.api_mode = "codex_responses"
+    merge_preflight_compression_warning(
+        responses_result,
+        agent=agent,
+        messages=messages,
+    )
+    assert not responses_result.warning_message
+
+
 
 
 def test_custom_provider_context_avoids_false_shrink_warning(monkeypatch):

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1069,6 +1069,9 @@ class TestToolResultPreflightCompression:
         agent.compression_enabled = True
         agent.context_compressor.context_length = 200_000
         agent.context_compressor.threshold_tokens = 130_000
+        # Keep the post-response gate on its real-usage branch so this test
+        # isolates the next loop's fully assembled pre-API request estimate.
+        agent.context_compressor.last_prompt_tokens = 1
 
         tc = SimpleNamespace(
             id="tc1", type="function",
@@ -1086,16 +1089,15 @@ class TestToolResultPreflightCompression:
 
         # First provider request is small. The tool result pushes the fully
         # assembled request over threshold; rebuilding after compression only
-        # trims it from 150K to 148K. Raw-message estimation is much smaller,
-        # which previously made the no-op pass look successful and allowed two
-        # more immediate summaries.
+        # trims it from 150K to 148K. Comparing any other request shape could
+        # make the no-op pass look successful and allow more immediate summaries.
         assembled_estimates = iter(
             [1_000, 150_000, 148_000, 148_000, 148_000]
         )
 
         with (
             patch(
-                "agent.conversation_loop.estimate_messages_tokens_rough",
+                "agent.conversation_loop.estimate_request_tokens_rough",
                 side_effect=lambda *_a, **_k: next(assembled_estimates),
             ),
             patch("run_agent.handle_function_call", return_value="x" * 100_000),

--- a/tests/run_agent/test_overflow_overhead_aware_tokens.py
+++ b/tests/run_agent/test_overflow_overhead_aware_tokens.py
@@ -155,8 +155,10 @@ class TestHTTP413OverheadAwareTokens:
 
         estimate_calls = []
 
-        def _capture_estimate(messages, tools=None):
-            estimate_calls.append({"messages": messages, "tools": tools})
+        def _capture_estimate(messages, tools=None, api_mode=None):
+            estimate_calls.append(
+                {"messages": messages, "tools": tools, "api_mode": api_mode}
+            )
             return _SENTINEL_TOKENS
 
         with (
@@ -182,6 +184,7 @@ class TestHTTP413OverheadAwareTokens:
             "during 413 recovery. All calls: "
             + str([c["tools"] for c in estimate_calls])
         )
+        assert all(c["api_mode"] == agent.api_mode for c in handler_calls_with_tools)
 
 
 # ---------------------------------------------------------------------------
@@ -249,8 +252,10 @@ class TestContextOverflowOverheadAwareTokens:
 
         estimate_calls = []
 
-        def _capture_estimate(messages, tools=None):
-            estimate_calls.append({"messages": messages, "tools": tools})
+        def _capture_estimate(messages, tools=None, api_mode=None):
+            estimate_calls.append(
+                {"messages": messages, "tools": tools, "api_mode": api_mode}
+            )
             return _SENTINEL_TOKENS
 
         with (
@@ -275,6 +280,7 @@ class TestContextOverflowOverheadAwareTokens:
             "during context-overflow recovery. All calls: "
             + str([c["tools"] for c in estimate_calls])
         )
+        assert all(c["api_mode"] == agent.api_mode for c in handler_calls_with_tools)
 
     def test_prompt_too_long_variant_passes_overhead_aware_tokens(self, agent):
         """Anthropic 'prompt is too long' error also routes to context_overflow handler."""
@@ -376,8 +382,10 @@ class TestLongContextTierOverheadAwareTokens:
 
         estimate_calls = []
 
-        def _capture_estimate(messages, tools=None):
-            estimate_calls.append({"messages": messages, "tools": tools})
+        def _capture_estimate(messages, tools=None, api_mode=None):
+            estimate_calls.append(
+                {"messages": messages, "tools": tools, "api_mode": api_mode}
+            )
             return _SENTINEL_TOKENS
 
         with (
@@ -402,3 +410,4 @@ class TestLongContextTierOverheadAwareTokens:
             "during long-context-tier recovery. All calls: "
             + str([c["tools"] for c in estimate_calls])
         )
+        assert all(c["api_mode"] == agent.api_mode for c in handler_calls_with_tools)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -688,6 +688,90 @@ def test_run_conversation_codex_plain_text(monkeypatch):
     assert result["messages"][-1]["content"] == "OK"
 
 
+def test_codex_pre_api_pressure_uses_projected_wire_history(monkeypatch):
+    """Private Responses replay state must not cause false-early compaction."""
+    agent = _build_agent(monkeypatch)
+    agent.context_compressor.threshold_tokens = 240_000
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: _codex_message_response("OK"),
+    )
+
+    visible = "v" * 40_000
+    history = [
+        {"role": "user", "content": "Earlier request"},
+        {
+            "role": "assistant",
+            "content": visible,
+            "reasoning_content": "r" * 40_000,
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "e" * 900_000,
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": visible}],
+                }
+            ],
+        },
+    ]
+    compression_calls = []
+
+    def _compress(messages, system_message, **kwargs):
+        compression_calls.append(kwargs["approx_tokens"])
+        return [
+            {"role": "user", "content": "Earlier request"},
+            {"role": "assistant", "content": "Summary"},
+            {"role": "user", "content": "Continue"},
+        ], system_message
+
+    monkeypatch.setattr(agent, "_compress_context", _compress)
+
+    result = agent.run_conversation("Continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert compression_calls == []
+
+
+def test_codex_pre_api_pressure_still_compresses_true_wire_oversize(monkeypatch):
+    """A genuinely oversized Responses request remains a positive control."""
+    agent = _build_agent(monkeypatch)
+    agent.context_compressor.threshold_tokens = 240_000
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: _codex_message_response("OK"),
+    )
+
+    history = [
+        {"role": "user", "content": "x" * 1_000_000},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
+    compression_calls = []
+
+    def _compress(messages, system_message, **kwargs):
+        compression_calls.append(kwargs["approx_tokens"])
+        return [
+            {"role": "user", "content": "Earlier request"},
+            {"role": "assistant", "content": "Summary"},
+            {"role": "user", "content": "Continue"},
+        ], system_message
+
+    monkeypatch.setattr(agent, "_compress_context", _compress)
+
+    result = agent.run_conversation("Continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert compression_calls
+    assert compression_calls[0] >= 240_000
+
+
 def test_codex_preflight_defangs_harmony_tokens_before_and_after_middleware(monkeypatch):
     """Both mutable request boundaries must reject literal Harmony wire tokens."""
     agent = _build_agent(monkeypatch)
@@ -1981,7 +2065,6 @@ def test_duplicate_detection_uses_commentary_when_hidden_reasoning_changes(monke
     reasoning_items = interim_msgs[0].get("codex_reasoning_items")
     if reasoning_items:
         assert reasoning_items[0].get("id") == "rs_second"
-
 
 
 

--- a/tests/tui_gateway/test_compress_lock_skip.py
+++ b/tests/tui_gateway/test_compress_lock_skip.py
@@ -58,12 +58,13 @@ def test_compress_session_history_raises_on_lock_skip():
 
     history = _make_history()
     agent = _make_lock_skip_agent("pid=99999:tid=1:agent=1:nonce=abc")
+    agent.api_mode = "codex_responses"
     session = _make_session(agent, history)
 
     with (
         patch(
             "agent.model_metadata.estimate_request_tokens_rough", return_value=100
-        ),
+        ) as estimate,
         pytest.raises(CompressionLockHeld) as exc_info,
     ):
         _compress_session_history(session)
@@ -72,6 +73,7 @@ def test_compress_session_history_raises_on_lock_skip():
     # The history must be untouched by the lock-skip.
     assert session["history"] == history
     assert session["history_version"] == 1
+    assert estimate.call_args.kwargs["api_mode"] == "codex_responses"
 
 
 # ── Consumer 1: session.compress RPC ───────────────────────────────────
@@ -168,5 +170,4 @@ def test_mirror_slash_side_effects_reports_lock_skip():
     assert "pid=6161" in output
     assert "No changes from compression" not in output
     assert "live session sync failed" not in output
-
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2487,7 +2487,10 @@ def _(rid, params: dict) -> dict:
         _tools = getattr(_agent, "tools", None) or None
         before_tokens = (
             estimate_request_tokens_rough(
-                before_messages, system_prompt=_sys_prompt, tools=_tools
+                before_messages,
+                system_prompt=_sys_prompt,
+                tools=_tools,
+                api_mode=getattr(_agent, "api_mode", None),
             )
             if before_count
             else 0
@@ -2524,6 +2527,7 @@ def _(rid, params: dict) -> dict:
                     messages,
                     system_prompt=_sys_prompt_after,
                     tools=_tools_after,
+                    api_mode=getattr(_agent, "api_mode", None),
                 )
                 if after_count
                 else 0

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -997,7 +997,10 @@ def _(rid, params: dict) -> dict:
             _tools = getattr(_agent, "tools", None) or None
             before_tokens = (
                 estimate_request_tokens_rough(
-                    before_messages, system_prompt=_sys_prompt, tools=_tools
+                    before_messages,
+                    system_prompt=_sys_prompt,
+                    tools=_tools,
+                    api_mode=getattr(_agent, "api_mode", None),
                 )
                 if before_count
                 else 0
@@ -1021,6 +1024,7 @@ def _(rid, params: dict) -> dict:
                     after_messages,
                     system_prompt=_sys_prompt_after,
                     tools=_tools_after,
+                    api_mode=getattr(_agent, "api_mode", None),
                 )
                 if after_count
                 else 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4681,7 +4681,10 @@ def _compress_session_history(
         _sys_prompt = getattr(agent, "_cached_system_prompt", "") or ""
         _tools = getattr(agent, "tools", None) or None
         approx_tokens = estimate_request_tokens_rough(
-            history, system_prompt=_sys_prompt, tools=_tools
+            history,
+            system_prompt=_sys_prompt,
+            tools=_tools,
+            api_mode=getattr(agent, "api_mode", None),
         )
     # Pass system_message=None so AIAgent._compress_context rebuilds the
     # system prompt cleanly via _build_system_prompt(None). Passing the
@@ -12557,7 +12560,10 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             _tools = getattr(agent, "tools", None) or None
             _before_tokens = (
                 estimate_request_tokens_rough(
-                    _before_messages, system_prompt=_sys_prompt, tools=_tools
+                    _before_messages,
+                    system_prompt=_sys_prompt,
+                    tools=_tools,
+                    api_mode=getattr(agent, "api_mode", None),
                 )
                 if _before_count
                 else 0
@@ -12582,7 +12588,10 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             _tools_after = getattr(agent, "tools", None) or _tools
             _after_tokens = (
                 estimate_request_tokens_rough(
-                    _after_messages, system_prompt=_sys_prompt_after, tools=_tools_after
+                    _after_messages,
+                    system_prompt=_sys_prompt_after,
+                    tools=_tools_after,
+                    api_mode=getattr(agent, "api_mode", None),
                 )
                 if _after_messages
                 else 0


### PR DESCRIPTION
## Summary

- project persisted Codex Responses history through the actual Responses input adapter before rough token estimation
- exclude opaque encrypted reasoning weight while preserving visible messages, tool outputs, images, system instructions, and tool-schema overhead
- propagate the target/current API mode through all 28 agent-backed compression and context-usage call sites
- keep non-Responses estimation behavior unchanged

## Why

Persisted Codex sessions retain private replay metadata such as encrypted reasoning items. Counting the raw persisted dictionaries can greatly overstate the request sent on the wire, causing premature repeated compression and prompt-cache churn even when the real Responses payload fits.

## Validation

- approved three-commit source stack and final squash have the same stable patch-id: `573b3b9d025fe39ce78c9b1884662e809e1719dc`
- focused independent review: 177 tests passed across model metadata, turn context, context switching, gateway hygiene/manual compression, Codex loop, 413, and overflow paths
- final candidate validation: 247 tests passed across 18 directly related files
- Ruff, `py_compile`, and `git diff --check` pass
