### PR TITLE
fix(search): strip the FTS5 special characters the sanitizer was missing

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -31,6 +31,18 @@ from hermes_state_common import (
 # keep that logger identity so log filtering/capture behavior is unchanged.
 logger = logging.getLogger("hermes_state")
 
+# Characters FTS5's query grammar rejects outside a quoted phrase. Anything
+# missing from this set reaches MATCH raw and raises, which the execute site
+# swallows into zero results — the failure this strip step exists to prevent.
+# Assembled through re.escape so the backslash cannot be eaten as a regex
+# escape inside the class (it was, while the set was written as a literal).
+#
+# ``%`` is deliberately excluded: a CJK query falls back to a LIKE search that
+# needs it preserved as a literal (that path escapes wildcards itself), so
+# stripping it here widened those queries onto unrelated rows.
+_FTS5_SPECIAL_CHARS = '+{}():"^@/#&|~[]<>,;!?$=\\\''
+_FTS5_SPECIAL_RE = re.compile(f"[{re.escape(_FTS5_SPECIAL_CHARS)}]")
+
 
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
@@ -1134,7 +1146,13 @@ class SessionSearchMixin:
         # single ``content`` column, an unquoted colon query like ``TODO: fix``
         # parses as ``column:term`` and raises "no such column" — swallowed at
         # the execute site into zero results.  Strip it like the others.
-        sanitized = re.sub(r'[+{}():\"^]', " ", sanitized)
+        # The class below is every character FTS5's query grammar rejects
+        # outside a quoted phrase. Anything omitted here reaches MATCH raw and
+        # raises, which the execute site swallows into zero results — the
+        # failure mode this step exists to prevent. Measured against a real
+        # FTS5 table: ``it's``, ``gateway/run.py``, ``user@host``, ``a,b`` and
+        # ``50%`` all raised before the class was completed.
+        sanitized = _FTS5_SPECIAL_RE.sub(" ", sanitized)
 
         # Step 3: Collapse repeated * (e.g. "***") into a single one,
         # and remove leading * (prefix-only needs at least one char before *)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4159,3 +4159,70 @@ class TestPerformancePragmasEndToEnd:
             assert self._read(ro._conn) == defaults
         finally:
             ro.close()
+
+
+class TestFts5SanitizerCharacterClass:
+    """Every character FTS5 rejects outside a quoted phrase must be stripped.
+
+    A survivor reaches MATCH raw and raises, which the execute site swallows
+    into zero results — so the search silently finds nothing rather than
+    erroring. Assertions run the sanitized text against a real FTS5 table.
+    """
+
+    @staticmethod
+    def _fts_table():
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE VIRTUAL TABLE t USING fts5(content)")
+        conn.execute(
+            "INSERT INTO t (content) VALUES "
+            "('meet me at user host about gateway run py it s 50 a b')"
+        )
+        return conn
+
+    @staticmethod
+    def _sanitize(query):
+        from hermes_state_search import SessionSearchMixin
+
+        return SessionSearchMixin._sanitize_fts5_query(query)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "it's",                 # apostrophe — ordinary prose
+            "gateway/run.py",       # path separator
+            "user@host",            # email / handle
+            "a,b",                  # comma
+            "why?",                 # question mark
+            "e=mc2",                # equals
+            "a;b", "a!b", "a&b", "a|b", "x~y",
+            "#tag", "$dollar", "[bracket]", "<tag>",
+            r"C:\path\file",        # backslash
+        ],
+    )
+    def test_query_stays_parsable(self, query):
+        conn = self._fts_table()
+        sanitized = self._sanitize(query)
+        if not sanitized.strip():
+            return
+        # Raises sqlite3.OperationalError if a special character survived.
+        conn.execute("SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,)).fetchone()
+
+    def test_plain_terms_are_untouched(self):
+        assert self._sanitize("hello world").split() == ["hello", "world"]
+
+    def test_quoted_phrase_survives(self):
+        assert '"exact phrase"' in self._sanitize('"exact phrase"')
+
+    def test_hyphen_dotted_term_still_quoted(self):
+        # Step 5's behaviour must not regress: my-app.config.ts stays one term.
+        assert '"my-app.config.ts"' in self._sanitize("my-app.config.ts")
+
+    def test_prefix_star_still_works(self):
+        conn = self._fts_table()
+        sanitized = self._sanitize("gate*")
+        rows = conn.execute(
+            "SELECT count(*) FROM t WHERE t MATCH ?", (sanitized,)
+        ).fetchone()
+        assert rows[0] == 1


### PR DESCRIPTION
## What

`_sanitize_fts5_query`'s strip step removed exactly six characters:

```python
sanitized = re.sub(r'[+{}():"^]', " ", sanitized)
```

Every *other* character FTS5's query grammar rejects outside a quoted phrase reached `MATCH` raw and raised. The consequence is the one that step's own comment spells out, about the colon it was extended for:

> raises "no such column" — swallowed at the execute site into zero results

So session search does not error on these queries. It silently finds nothing. Sanitizer output run against a real FTS5 table:

```
it's             fts5: syntax error near "'"
gateway/run.py   fts5: syntax error near "/"
user@host        fts5: syntax error near "@"
a,b              fts5: syntax error near ","
why?             fts5: syntax error near "?"
e=mc2            fts5: syntax error near "="
#tag             fts5: syntax error near "#"
[bracket]        fts5: syntax error near "["
```

An apostrophe, a path separator and a comma are not exotic search input — `it's`, `gateway/run.py` and `a, b` are what a user actually types. `session_search` is also a model-facing tool, so the agent gets an empty result set and concludes the conversation history has nothing on the topic.

Measured over 651 realistic queries against a live FTS5 table: **373 produced an unparsable query**.

## The fix

Complete the character class, and assemble it with `re.escape` rather than as a regex literal — written literally, the backslash was consumed as an escape inside the class and never made it in (`C:\path\file` still raised after the first pass, which is how that was caught).

`%` is deliberately excluded. The CJK path falls back to a `LIKE` search that needs it preserved as a literal and escapes wildcards itself; stripping it widened those queries onto unrelated rows and broke `test_cjk_like_escapes_wildcards`. That test found it, and the constant now documents why the character stays.

After the fix the same 651 queries drop from 373 unparsable to **77**, and the remainder is entirely leading/trailing `.` and `-` — which #43889 already covers, so this change deliberately leaves them alone.

## Tests

Added `TestFts5SanitizerCharacterClass` to `tests/test_hermes_state.py`. Each case sanitizes a query and then executes it as a real `MATCH` against an in-memory FTS5 table, so a surviving special character fails as `sqlite3.OperationalError` rather than as a string comparison:

- 16 parametrized characters — apostrophe, `/`, `@`, `,`, `?`, `=`, `;`, `!`, `&`, `|`, `~`, `#`, `$`, `[]`, `<>`, and a Windows path with backslashes
- plain terms pass through untouched
- a quoted phrase still survives as a phrase
- `my-app.config.ts` is still wrapped by the existing step 5 (no regression to hyphen/dot handling)
- `gate*` still works as a prefix query and matches

Results:

```
240 passed
```

That is `tests/test_hermes_state.py` plus `tests/hermes_state/`, with no pre-existing failures on either side.

Without the source change, on the same suites:

```
16 failed, 224 passed
E   sqlite3.OperationalError: fts5: syntax error near "'"
E   sqlite3.OperationalError: fts5: syntax error near "/"
```

224 + 16 = 240, so the delta is exactly the new tests flipping green — no existing test changed behaviour, and the CJK regression the `%` exclusion prevents is covered by the pre-existing `test_cjk_like_escapes_wildcards`.