### PR TITLE
fix(agent): stop repeated MoA aggregation from dropping custom provider overrides

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -351,7 +351,8 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     query + config read) that used to run serially per create() call before
     the parallel fan-out could start — the dominant source of MoA cold-start
     latency (#66793). The TTL bounds credential staleness (key rotation,
-    base_url edits) instead of caching for the process lifetime.
+    base_url edits) instead of caching for the process lifetime. Callers get a
+    request-local copy so consuming kwargs cannot mutate the cached snapshot.
     """
     provider = str(slot.get("provider") or "").strip()
     model = str(slot.get("model") or "").strip()
@@ -362,7 +363,7 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     if entry is not None:
         stamped_at, cached = entry
         if now - stamped_at < _RUNTIME_CACHE_TTL_SECONDS:
-            return cached
+            return dict(cached)
     out: dict[str, Any] = {"provider": provider, "model": model}
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -388,7 +389,7 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
         return out
     with _runtime_cache_lock:
         _runtime_cache[cache_key] = (now, out)
-    return out
+    return dict(out)
 
 
 def _merge_slot_extra_body(

--- a/tests/agent/test_moa_cold_start_cache_66793.py
+++ b/tests/agent/test_moa_cold_start_cache_66793.py
@@ -154,6 +154,55 @@ def test_slot_runtime_is_cached_across_create_calls(monkeypatch, tmp_path):
     assert calls["n"] == 3, f"expected 3 slot resolutions, got {calls['n']}"
 
 
+def test_cached_slot_runtime_keeps_extra_body_across_aggregator_calls(
+    monkeypatch, tmp_path
+):
+    """A cache hit must retain custom-provider request overrides."""
+    import agent.moa_loop as moa
+
+    moa._runtime_cache.clear()
+    moa._preset_cache.clear()
+
+    def resolve_with_extra_body(*_args, **_kwargs):
+        return {
+            "base_url": "https://custom.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+            "request_overrides": {
+                "extra_body": {"provider_required": True},
+            },
+        }
+
+    import hermes_cli.runtime_provider as rt_mod
+    monkeypatch.setattr(rt_mod, "resolve_runtime_provider", resolve_with_extra_body)
+    import hermes_cli.config as cfg_mod
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("moa: {}\n")
+    monkeypatch.setattr(cfg_mod, "get_config_path", lambda: cfg_file)
+    monkeypatch.setattr(cfg_mod, "load_config", lambda: _make_preset_config())
+
+    captured_calls = []
+
+    def capture_call(**kwargs):
+        captured_calls.append(kwargs)
+        return _fake_response()
+
+    monkeypatch.setattr(moa, "call_llm", capture_call)
+
+    cc = moa.MoAChatCompletions("demo")
+    for _ in range(2):
+        cc.create(messages=[{"role": "user", "content": "hi"}])
+
+    aggregator_calls = [
+        call for call in captured_calls if call.get("task") == "moa_aggregator"
+    ]
+    assert len(aggregator_calls) == 2
+    assert [call["extra_body"] for call in aggregator_calls] == [
+        {"provider_required": True},
+        {"provider_required": True},
+    ]
+
+
 def test_slot_runtime_cache_expires_after_ttl(monkeypatch):
     """A stale runtime entry (key rotation window) must re-resolve after
     the TTL — the original PR cached for the process lifetime, pinning

--- a/tests/agent/test_moa_cold_start_cache_66793.py
+++ b/tests/agent/test_moa_cold_start_cache_66793.py
@@ -177,7 +177,7 @@ def test_cached_slot_runtime_keeps_extra_body_across_aggregator_calls(
     monkeypatch.setattr(rt_mod, "resolve_runtime_provider", resolve_with_extra_body)
     import hermes_cli.config as cfg_mod
     cfg_file = tmp_path / "config.yaml"
-    cfg_file.write_text("moa: {}\n")
+    cfg_file.write_text("moa: {}\n", encoding="utf-8")
     monkeypatch.setattr(cfg_mod, "get_config_path", lambda: cfg_file)
     monkeypatch.setattr(cfg_mod, "load_config", lambda: _make_preset_config())
 


### PR DESCRIPTION
## What does this PR do?

This PR keeps custom-provider `extra_body` overrides intact across repeated MoA aggregator calls within the runtime cache TTL. It isolates the cached runtime snapshot from request-local kwargs so consuming one request cannot alter later requests.

### Bug Cause

`agent/moa_loop.py::_slot_runtime()` stored a mutable runtime dictionary in `_runtime_cache` and returned the same object to callers. The prepared aggregator consumed `extra_body` with `pop()`, which removed that field from the cached object. Subsequent cache hits therefore omitted the provider override.

### Reproduction Steps

1. Configure a custom provider with a non-empty `extra_body`.
2. Use the provider and model as the MoA aggregator.
3. Execute two aggregation calls for the same provider and model within 300 seconds.
4. Inspect the request body sent for each aggregator call.

Expected: both aggregator requests include the configured `extra_body`.

Before fix: the first request includes the override, while the second cache-backed request sends `extra_body=None`.

### Fix

Return a request-local top-level copy from `_slot_runtime()` after fresh resolution and on every cache hit. The cache retains its canonical snapshot while existing consumers remain free to pop or merge kwargs for an individual request. A behavioral regression test executes two complete aggregation calls and verifies that both receive the provider-required `extra_body`.

## Related Issue

Fixes #79287

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py` - return request-local copies without exposing the mutable runtime cache snapshot.
- `tests/agent/test_moa_cold_start_cache_66793.py` - cover repeated aggregator calls with cached custom-provider request overrides and use an explicit UTF-8 fixture encoding.

## How to Test

1. Configure a custom provider with `extra_body` and select it as the MoA aggregator.
2. Run two aggregator calls for the same provider and model within the runtime cache TTL.
3. Confirm both provider requests contain the configured fields.
4. Run the automated MoA suites:

```bash
scripts/run_tests.sh tests/agent/test_moa_*.py tests/run_agent/test_moa_loop_mode.py -q
```

Result: 66 tests passed, 0 failed, with no flaky retries.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; no user-facing behavior or configuration changed
- [x] I've updated `cli-config.yaml.example` - N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; production logic is platform-independent and the test fixture uses explicit UTF-8
- [x] I've updated tool descriptions/schemas - N/A; no tool behavior changed

## Screenshots / Logs

```text
13 files, 66 tests passed, 0 failed
```
