### PR TITLE
fix(tui): serialize source preparation across launches

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1783,9 +1783,10 @@ def _tui_need_rebuild(root: Path) -> bool:
     """True when ``dist/entry.js`` is missing or older than TUI inputs.
 
     The TUI bundle is self-contained. Rebuilding it on every launch adds a
-    visible cold-start tax on slow Termux CPUs, while a simple mtime freshness
-    check still rebuilds immediately after source updates, dependency updates,
-    or local edits. Set ``HERMES_TUI_FORCE_BUILD=1`` to force the old behaviour.
+    visible cold-start tax and lets concurrent launches mutate the same output,
+    while a simple mtime freshness check still rebuilds immediately after
+    source updates, dependency updates, or local edits. Set
+    ``HERMES_TUI_FORCE_BUILD=1`` to force the old behaviour.
     """
     force = (os.environ.get("HERMES_TUI_FORCE_BUILD") or "").strip().lower()
     if force in {"1", "true", "yes", "on"}:
@@ -1933,7 +1934,9 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     sys.exit(1)
 
 
-def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
+def _make_tui_argv(
+    tui_dir: Path, tui_dev: bool, *, _preparation_locked: bool = False
+) -> tuple[list[str], Path]:
     """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR prebuilt or esbuild)."""
     _ensure_tui_node()
 
@@ -1994,12 +1997,18 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
 
+    if not _preparation_locked:
+        from hermes_cli.tui_preparation_lock import tui_preparation_lock
+
+        with tui_preparation_lock(_workspace_root(tui_dir)):
+            return _make_tui_argv(tui_dir, tui_dev, _preparation_locked=True)
+
     # No prebuilt bundle available (or --dev, which never uses one) — we're
     # about to npm install/build from source, so the workspace must exist.
     if not ext_dir:
         _ensure_tui_workspace(tui_dir)
 
-    # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
+    # 2. Normal flow: npm install/build if stale, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
     #    Existing desktop behaviour runs npm from the workspace root.  Termux
     #    scopes the install to ui-tui so launch does not pull desktop/web
@@ -2118,12 +2127,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             return [str(tsx), "src/entry.tsx"], tui_dir
         return [npm, "start"], tui_dir
 
-    # Desktop/dev launches retain the historical "always rebuild" behaviour.
-    # Termux cold starts use the freshness check because esbuild startup is
-    # expensive on old mobile CPUs.
-    should_build = True
-    if termux_startup:
-        should_build = did_install or termux_need_rebuild
+    should_build = did_install or _tui_need_rebuild(tui_dir)
 
     if should_build:
         npm = _node_bin("npm")

--- a/hermes_cli/tui_preparation_lock.py
+++ b/hermes_cli/tui_preparation_lock.py
@@ -1,0 +1,59 @@
+"""Cross-process serialization for source TUI dependency and bundle preparation."""
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+@contextmanager
+def tui_preparation_lock(workspace_root: Path) -> Iterator[None]:
+    """Serialize install/build mutations for one source TUI workspace."""
+    lock_path = (
+        workspace_root
+        / "node_modules"
+        / ".cache"
+        / "hermes"
+        / "tui-preparation.lock"
+    )
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "a+b")
+    except OSError:
+        yield
+        return
+
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    except (ImportError, OSError):
+        handle.close()
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        if os.name == "nt":
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        else:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+        handle.close()

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -17,13 +17,13 @@ def main_mod():
 def _touch_ink(root: Path) -> None:
     ink = root / "node_modules" / "@hermes" / "ink" / "package.json"
     ink.parent.mkdir(parents=True, exist_ok=True)
-    ink.write_text("{}")
+    ink.write_text("{}", encoding="utf-8")
 
 
 def _touch_tui_entry(root: Path) -> None:
     entry = root / "dist" / "entry.js"
     entry.parent.mkdir(parents=True, exist_ok=True)
-    entry.write_text("console.log('tui')")
+    entry.write_text("console.log('tui')", encoding="utf-8")
 
 
 def _assert_utf8_replace_capture(kwargs: dict) -> None:
@@ -62,7 +62,7 @@ def test_make_tui_argv_uses_bundled_tui_when_workspace_missing(
 
     bundled_entry = tmp_path / "bundled" / "entry.js"
     bundled_entry.parent.mkdir(parents=True)
-    bundled_entry.write_text("// bundled TUI")
+    bundled_entry.write_text("// bundled TUI", encoding="utf-8")
     monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled_entry)
 
     def which(name: str) -> str | None:
@@ -148,11 +148,11 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     """
     tui_dir = tmp_path / "ui-tui"
     tui_dir.mkdir()
-    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "package.json").write_text("{}", encoding="utf-8")
     # Simulate curl-install layout: tui_dir has its own lockfile
-    (tui_dir / "package-lock.json").write_text("{}")
+    (tui_dir / "package-lock.json").write_text("{}", encoding="utf-8")
     # Parent also has lockfile (but _workspace_root prefers tui_dir's own)
-    (tmp_path / "package-lock.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
 
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
     monkeypatch.setenv("PREFIX", "/usr")
@@ -176,3 +176,39 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+def test_make_tui_argv_reuses_fresh_desktop_bundle(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(
+        main_mod,
+        "_tui_need_rebuild",
+        lambda root: not (root / "dist" / "entry.js").is_file(),
+    )
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    build_calls = 0
+
+    def fake_run(cmd, cwd=None, **_kwargs):
+        nonlocal build_calls
+        if cmd[1:] == ["run", "build"]:
+            build_calls += 1
+            _touch_tui_entry(tui_dir)
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert build_calls == 1

--- a/tests/hermes_cli/test_tui_preparation_lock.py
+++ b/tests/hermes_cli/test_tui_preparation_lock.py
@@ -1,0 +1,37 @@
+import threading
+from pathlib import Path
+
+from hermes_cli.tui_preparation_lock import tui_preparation_lock
+
+
+def test_tui_preparation_lock_serializes_threads(tmp_path: Path) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    entered = threading.Event()
+    release = threading.Event()
+    order: list[str] = []
+
+    def first() -> None:
+        with tui_preparation_lock(tui_dir):
+            order.append("first-enter")
+            entered.set()
+            assert release.wait(timeout=5)
+            order.append("first-exit")
+
+    def second() -> None:
+        assert entered.wait(timeout=5)
+        with tui_preparation_lock(tui_dir):
+            order.append("second-enter")
+
+    first_thread = threading.Thread(target=first)
+    second_thread = threading.Thread(target=second)
+    first_thread.start()
+    second_thread.start()
+    assert entered.wait(timeout=5)
+    release.set()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert order == ["first-enter", "first-exit", "second-enter"]


### PR DESCRIPTION
## What does this PR do?

Serializes source-based TUI dependency installation and bundle generation across concurrent `hermes --tui` launches, then reuses a fresh bundle instead of rebuilding it on every desktop launch.

Three simultaneous cold resumes can currently enter the same `npm install` / `npm run build` workspace. One process may observe a transient `dist/entry.js`, exit cleanly before starting `tui_gateway`, and leave the user at a shell prompt even though the Hermes session itself is healthy.

The fix keeps the prebuilt-bundle fast path unchanged, protects source preparation with a per-workspace file lock, and rechecks dependency/build freshness after acquiring the lock. POSIX uses `flock`; Windows uses `msvcrt.locking`, with best-effort fallback on unsupported filesystems.

## Related Issue

No linked issue. This was reproduced from three concurrent cold TUI session restores; one printed the session resume summary and returned to the shell without starting its gateway.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a cross-platform, per-workspace TUI preparation lock.
- Recheck install/build freshness while holding the lock.
- Reuse fresh desktop bundles while retaining `HERMES_TUI_FORCE_BUILD=1`.
- Cover serialized preparation and fresh-bundle reuse behavior.

## How to Test

1. Start multiple `hermes --tui --resume <session>` processes concurrently from a source install with stale or missing TUI dependencies.
2. Confirm preparation runs serially and every process reaches the TUI/gateway.
3. Run:

   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_tui_npm_install.py \
     tests/hermes_cli/test_tui_preparation_lock.py \
     tests/hermes_cli/test_tui_resume_flow.py
   ```

   Result: 11 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test wrapper and all selected tests pass.
- [x] I've added tests for the bug fix.
- [x] I've tested on NixOS Linux.

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and the force-build escape hatch are documented in code.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] Architecture/workflow documentation update is N/A.
- [x] Cross-platform impact was considered; the lock has POSIX and Windows implementations.
- [x] Tool descriptions/schemas update is N/A.

## Screenshots / Logs

Observed failed launch:

```text
Installing TUI dependencies…

Resume this session with:
  hermes --tui --resume 20260802_162921_75bee0

Session:        20260802_162921_75bee0
Messages:       102
<returned to shell; no tui_gateway process started>
```
