### PR TITLE
fix(mcp): separate tool errors from transport breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -101,6 +101,45 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_application_tool_errors_do_not_open_server_transport_breaker(
+    monkeypatch, tmp_path,
+):
+    """A healthy RPC-level refusal must not disable sibling server tools."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_invalid(*args, **kwargs):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "invalid arguments"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_invalid)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "invalid_tool", 10.0)
+        attempts = mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 2
+
+        for _ in range(attempts):
+            parsed = json.loads(handler({"invalid": True}))
+            assert "invalid arguments" in parsed.get("error", "")
+
+        assert call_count["n"] == attempts
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+        assert "srv" not in mcp_tool._server_breaker_opened_at
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
     """After a tripped breaker's cooldown elapses, the *next* call must
     actually execute against the session (half-open probe). When the

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5045,15 +5045,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # The RPC round-trip completed, so the server transport is healthy.
+            # A CallToolResult with isError=True is an application-level tool
+            # refusal (invalid arguments, missing resource, etc.), not evidence
+            # that every tool on this MCP server is unreachable. Keep returning
+            # the tool error to the caller, but close the server-wide transport
+            # breaker. Missing sessions and raised transport exceptions still
+            # bump the breaker in their dedicated paths below.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Intent
Keep one tool-level validation or business error from disabling every tool on an otherwise healthy MCP server.

## Behavior
A completed `tools/call` RPC now closes the server transport breaker even when the MCP result has `isError=true`. Missing sessions and raised transport exceptions retain the existing breaker behavior.

## Verification
- `scripts/run_tests.sh tests/tools/test_mcp_circuit_breaker.py -q` (8 passed)
- `scripts/run_tests.sh tests/tools/test_mcp_tool.py tests/tools/test_mcp_tool_session_expired.py -q` (103 passed)
- Ruff on both changed files