### PR TITLE
fix(cron): catch ValueError from os.open() on NUL-containing paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable / special files.  ValueError: embedded NUL
+        # byte in path (e.g. binary junk from a >1 MB executable read by
+        # _read_script_in_env, #78833).
         return None, False
     try:
         metadata = os.fstat(descriptor)


### PR DESCRIPTION
The lifecycle guard crashes with ValueError: embedded null byte when a terminal command references a >1MB executable. The crash chain:

1. _read_script_in_env in terminal_tool.py reads the binary with cat, returning raw bytes decoded as text with embedded NUL characters
2. The lifecycle guard tokenizes the binary junk into paths containing NUL bytes
3. _read_referenced_script calls os.open() on the NUL-containing path, which raises ValueError
4. The except clause only catches OSError, so the ValueError crashes the entire terminal tool invocation

#76762 fixed this for Path.resolve() by catching both OSError and ValueError, but os.open() ~30 lines below was missed. Apply the same fix: catch ValueError alongside OSError and return None, False (not unsafe, nothing to scan).

Fixes #78833