### PR TITLE
fix(providers): emit top-level reasoning_effort for Aliyun MaaS OpenAI-compatible endpoint

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1287,6 +1287,9 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         or base_url_host_matches(agent.base_url, "moonshot.cn")
     )
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
+    # Aliyun MaaS OpenAI-compatible endpoint (token-plan.<region>.maas.aliyuncs.com).
+    # Top-level reasoning_effort emission — see chat_completions.build_kwargs().
+    _is_aliyun_maas = base_url_host_matches(agent._base_url_lower, "maas.aliyuncs.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
     # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
@@ -1403,6 +1406,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         is_nvidia_nim=_is_nvidia,
         is_kimi=_is_kimi,
         is_tokenhub=_is_tokenhub,
+        is_aliyun_maas=_is_aliyun_maas,
         is_lmstudio=_is_lmstudio,
         is_custom_provider=agent.provider == "custom",
         ollama_num_ctx=agent._ollama_num_ctx,
@@ -2242,6 +2246,21 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             agent._resolve_lmstudio_summary_reasoning_effort()
             if _is_lmstudio_summary else None
         )
+        # Aliyun MaaS: top-level reasoning_effort, mirroring
+        # ChatCompletionsTransport.build_kwargs(). _supports_reasoning_extra_body()
+        # is False for this route, so the generic extra_body["reasoning"] branch
+        # below is skipped and the summary call would otherwise run at the
+        # provider default (xhigh) regardless of the configured effort.
+        _aliyun_reasoning_effort: str | None = None
+        if base_url_host_matches(agent._base_url_lower, "maas.aliyuncs.com"):
+            _ali_cfg = agent.reasoning_config if isinstance(agent.reasoning_config, dict) else {}
+            if _ali_cfg.get("enabled") is False:
+                _aliyun_reasoning_effort = "none"
+            else:
+                _ali_e = str(_ali_cfg.get("effort") or "").strip().lower()
+                if _ali_e == "ultra":
+                    _ali_e = "max"
+                _aliyun_reasoning_effort = _ali_e or None
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
             if agent.reasoning_config is not None:
                 summary_extra_body["reasoning"] = agent.reasoning_config
@@ -2272,6 +2291,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
             if _lm_reasoning_effort is not None:
                 summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+            if _aliyun_reasoning_effort is not None:
+                summary_kwargs["reasoning_effort"] = _aliyun_reasoning_effort
 
             # Merge the profile's canonical body even when routing is unset:
             # profiles may always emit required metadata such as Portal tags.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2425,6 +2425,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
                 if _lm_reasoning_effort is not None:
                     summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+                if _aliyun_reasoning_effort is not None:
+                    summary_kwargs["reasoning_effort"] = _aliyun_reasoning_effort
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -384,6 +384,9 @@ class ChatCompletionsTransport(ProviderTransport):
             is_nvidia_nim: bool
             is_kimi: bool
             is_tokenhub: bool
+            is_aliyun_maas: bool — Aliyun MaaS OpenAI-compatible endpoint
+                (token-plan.*.maas.aliyuncs.com / compatible-mode/v1):
+                top-level reasoning_effort, no extra_body.reasoning
             is_lmstudio: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
@@ -496,6 +499,26 @@ class ChatCompletionsTransport(ProviderTransport):
                     if _e in {"low", "medium", "high"}:
                         _tokenhub_effort = _e
                 api_kwargs["reasoning_effort"] = _tokenhub_effort
+
+        # Aliyun MaaS OpenAI-compatible endpoint (token-plan.*.maas.aliyuncs.com,
+        # /compatible-mode/v1): top-level reasoning_effort. The endpoint does
+        # NOT understand OpenRouter-style extra_body.reasoning, and Hermes'
+        # _supports_reasoning_extra_body() gate returns False for custom
+        # providers, so reasoning_config was silently dropped and qwen3.8-max
+        # defaulted to xhigh thinking (budget ~131k). Pass the effort through
+        # verbatim (the endpoint maps high/max→xhigh, minimal→low,
+        # none→disabled); only emit when the user actually configured one so
+        # the provider default is preserved otherwise.
+        if params.get("is_aliyun_maas", False):
+            _ali_cfg = reasoning_config if isinstance(reasoning_config, dict) else {}
+            if _ali_cfg.get("enabled") is False:
+                api_kwargs["reasoning_effort"] = "none"
+            else:
+                _ali_effort = str(_ali_cfg.get("effort") or "").strip().lower()
+                if _ali_effort == "ultra":
+                    _ali_effort = "max"
+                if _ali_effort:
+                    api_kwargs["reasoning_effort"] = _ali_effort
 
         # LM Studio: top-level reasoning_effort. Only emit when the model
         # declares reasoning support via /api/v1/models capabilities (gated

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -170,3 +170,82 @@ class TestCustomOllamaParity:
             reasoning_config={"enabled": False, "effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+
+
+class TestAliyunMaasParity:
+    """Aliyun MaaS OpenAI-compatible endpoint: top-level reasoning_effort.
+
+    Aliyun MaaS (token-plan.<region>.maas.aliyuncs.com /compatible-mode/v1)
+    only understands a top-level ``reasoning_effort`` field — it does NOT
+    read OpenRouter-style ``extra_body.reasoning``. ``_supports_reasoning_extra_body()``
+    returns False for custom providers, so without this branch the configured
+    reasoning_config was silently dropped and reasoning models (e.g.
+    qwen3.8-max-preview, default xhigh / ~131k budget) ran at full thinking
+    depth regardless of the user's setting. This is the legacy flag path
+    (no provider profile), same shape as Kimi / Tencent TokenHub.
+    """
+
+    def test_effort_emitted_top_level(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.8-max-preview",
+            messages=_simple_messages(),
+            tools=None,
+            base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            reasoning_config={"enabled": True, "effort": "medium"},
+            is_aliyun_maas=True,
+            supports_reasoning=False,
+        )
+        assert kw["reasoning_effort"] == "medium"
+        # Must NOT go into extra_body — the endpoint ignores that shape.
+        assert "reasoning" not in (kw.get("extra_body") or {})
+
+    def test_no_config_preserves_provider_default(self, transport):
+        """Unset reasoning_config emits nothing (endpoint default applies)."""
+        kw = transport.build_kwargs(
+            model="qwen3.8-max-preview",
+            messages=_simple_messages(),
+            tools=None,
+            base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            reasoning_config=None,
+            is_aliyun_maas=True,
+            supports_reasoning=False,
+        )
+        assert "reasoning_effort" not in kw
+
+    def test_disabled_maps_to_none(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.8-max-preview",
+            messages=_simple_messages(),
+            tools=None,
+            base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            reasoning_config={"enabled": False},
+            is_aliyun_maas=True,
+            supports_reasoning=False,
+        )
+        assert kw["reasoning_effort"] == "none"
+
+    def test_ultra_normalizes_to_max(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.8-max-preview",
+            messages=_simple_messages(),
+            tools=None,
+            base_url="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+            reasoning_config={"enabled": True, "effort": "ultra"},
+            is_aliyun_maas=True,
+            supports_reasoning=False,
+        )
+        assert kw["reasoning_effort"] == "max"
+
+    def test_not_emitted_for_other_custom_providers(self, transport):
+        """The branch is base_url-gated upstream; verify no leakage when the
+        flag is absent (e.g. a generic custom provider)."""
+        kw = transport.build_kwargs(
+            model="qwen3.8-max-preview",
+            messages=_simple_messages(),
+            tools=None,
+            base_url="https://example.com/v1",
+            reasoning_config={"enabled": True, "effort": "medium"},
+            is_custom_provider=True,
+            supports_reasoning=False,
+        )
+        assert "reasoning_effort" not in kw


### PR DESCRIPTION
## What does this PR do?

The Aliyun MaaS OpenAI-compatible endpoint (`token-plan.<region>.maas.aliyuncs.com/compatible-mode/v1`) only reads a **top-level** `reasoning_effort` field — it does not understand OpenRouter-style `extra_body.reasoning`.

Since `_supports_reasoning_extra_body()` returns `False` for custom providers (the base_url whitelist only covers openrouter/nous/vercel/github/lmstudio/ollama), the user's configured `reasoning_config` (via `/reasoning` or `agent.reasoning_effort`) was **silently dropped** on this route. Reasoning models such as `qwen3.8-max-preview` (default `xhigh`, ~131k thinking budget) then ran at full thinking depth regardless of the configured level, inflating latency dramatically.

This adds an `is_aliyun_maas` branch on the legacy flag path, mirroring the existing Kimi and Tencent TokenHub top-level `reasoning_effort` branches:

| reasoning_config | emitted `reasoning_effort` |
|---|---|
| `{"enabled": false}` | `"none"` |
| effort `ultra` | `"max"` (normalized) |
| effort set (low/medium/high/xhigh/max) | passed through verbatim |
| `None` / unset | **nothing emitted** (provider default preserved) |

The iteration-limit summary call path (which bypasses the transport and calls `chat.completions.create()` directly) is mirrored with the same logic, so summary calls honor the configured level too.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py` — new `is_aliyun_maas` branch emitting top-level `reasoning_effort` (plus docstring flag documentation)
- `agent/chat_completion_helpers.py` — detect `maas.aliyuncs.com` via `base_url_host_matches`, pass `is_aliyun_maas` into the legacy-path `build_kwargs` call, and mirror the emission in the summary-call path
- `tests/providers/test_transport_parity.py` — `TestAliyunMaasParity` (5 cases): top-level emission, no-config default preservation, disabled→none, ultra→max, no leakage for other custom providers

## How to Test

1. Configure a custom provider pointing at an Aliyun MaaS OpenAI-compatible endpoint with a reasoning model (e.g. `qwen3.8-max-preview`), set `agent.reasoning_effort: medium`
2. `pytest tests/providers/test_transport_parity.py -q` → 15 passed
3. Live-endpoint verification with the same coding prompt:
   - without the parameter (endpoint default xhigh): thinking ~2184 chars, **25.1s**
   - with `reasoning_effort=medium`: thinking ~523 chars, **16.1s**

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (relevant subset; two pre-existing failures in `test_auxiliary_client.py` and `test_flux3_video_tool.py` verified unrelated — they fail identically with this change stashed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring for the new flag) — no config keys added, no architecture change