### PR TITLE
Clamp session.list / spawn_tree.list limit before slicing

### DIFF
--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -69,3 +69,46 @@ def test_session_list_surfaces_all_user_facing_sources(monkeypatch):
     assert "tool-1" not in ids
 
 
+def test_session_list_clamps_negative_limit(monkeypatch):
+    """Negative limit must not reverse-slice (``rows[:-n]``) the result set."""
+    rows = [
+        {"id": f"s{i}", "source": "cli", "started_at": i}
+        for i in range(10)
+    ]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=-3)
+    sessions = resp["result"]["sessions"]
+    # Clamped to 1 — never drops the tail via negative slicing.
+    assert len(sessions) == 1
+    # Stub returns rows in insertion order; first surviving row is s0.
+    assert sessions[0]["id"] == "s0"
+
+
+def test_session_list_clamps_huge_limit(monkeypatch):
+    """Huge limits must not request unbounded DB fetches."""
+    rows = [{"id": "only", "source": "cli", "started_at": 1}]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=99999)
+    assert "error" not in resp
+    # fetch_limit = max(clamped_limit * 2, 200) with clamp=500 → 1000
+    assert db.calls[0]["limit"] == 1000
+
+
+def test_session_list_invalid_limit_falls_back(monkeypatch):
+    rows = [{"id": "a", "source": "cli", "started_at": 1}]
+    db = _StubDB(rows)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.list",
+        "params": {"limit": "not-a-number"},
+    })
+    assert "error" not in resp
+    assert len(resp["result"]["sessions"]) == 1
+
+

--- a/tests/tui_gateway/test_spawn_tree_list_limit_clamp.py
+++ b/tests/tui_gateway/test_spawn_tree_list_limit_clamp.py
@@ -1,0 +1,69 @@
+"""spawn_tree.list must clamp ``limit`` before slicing entries.
+
+A negative limit is a valid Python slice (``entries[:-n]``) and would
+silently drop the newest snapshots from the result. Huge limits can also
+inflate memory when scanning many snapshot files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tui_gateway import server
+
+
+def _seed_snapshots(tmp_path: Path, count: int) -> Path:
+    session_dir = tmp_path / "spawn-trees" / "default"
+    session_dir.mkdir(parents=True)
+    for i in range(count):
+        p = session_dir / f"snap-{i:03d}.json"
+        p.write_text(
+            f'{{"session_id": "default", "finished_at": {i}, "subagents": []}}',
+            encoding="utf-8",
+        )
+    return session_dir
+
+
+def test_spawn_tree_list_clamps_negative_limit(tmp_path, monkeypatch):
+    _seed_snapshots(tmp_path, 5)
+    monkeypatch.setattr(server, "_spawn_trees_root", lambda: tmp_path / "spawn-trees")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "spawn_tree.list",
+            "params": {"session_id": "default", "limit": -2},
+        }
+    )
+    assert "error" not in resp
+    assert len(resp["result"]["entries"]) == 1
+
+
+def test_spawn_tree_list_clamps_huge_limit(tmp_path, monkeypatch):
+    _seed_snapshots(tmp_path, 3)
+    monkeypatch.setattr(server, "_spawn_trees_root", lambda: tmp_path / "spawn-trees")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "spawn_tree.list",
+            "params": {"session_id": "default", "limit": 99999},
+        }
+    )
+    assert "error" not in resp
+    assert len(resp["result"]["entries"]) == 3
+
+
+def test_spawn_tree_list_invalid_limit_falls_back(tmp_path, monkeypatch):
+    _seed_snapshots(tmp_path, 2)
+    monkeypatch.setattr(server, "_spawn_trees_root", lambda: tmp_path / "spawn-trees")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "spawn_tree.list",
+            "params": {"session_id": "default", "limit": "nope"},
+        }
+    )
+    assert "error" not in resp
+    assert len(resp["result"]["entries"]) == 2

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -176,7 +176,14 @@ def _(rid, params: dict) -> dict:
             # their own source.
             deny = frozenset({"kanban", "tool"})
 
-            limit = int(params.get("limit", 200) or 200)
+            # Clamp before slicing: a negative limit is a valid Python slice
+            # (``rows[:-n]`` drops the tail) and would silently return the
+            # wrong set. Huge limits also force oversized DB fetches.
+            try:
+                limit = int(params.get("limit", 200) or 200)
+            except (TypeError, ValueError):
+                limit = 200
+            limit = max(1, min(limit, 500))
             # Over-fetch modestly so per-source filtering doesn't leave us
             # short; the compression-tip projection in ``list_sessions_rich``
             # can also merge rows.
@@ -2980,7 +2987,12 @@ def _(rid, params: dict) -> dict:
 @method("spawn_tree.list")
 def _(rid, params: dict) -> dict:
     session_id = str(params.get("session_id") or "").strip()
-    limit = int(params.get("limit") or 50)
+    # Same negative-slice hazard as session.list — clamp before ``[:limit]``.
+    try:
+        limit = int(params.get("limit") or 50)
+    except (TypeError, ValueError):
+        limit = 50
+    limit = max(1, min(limit, 500))
     cross_session = bool(params.get("cross_session"))
 
     if cross_session:


### PR DESCRIPTION
## Summary
- `session.list` and `spawn_tree.list` sliced with the raw JSON-RPC `limit`.
- A negative limit is valid Python (`rows[:-n]`) and silently drops the newest entries from the resume picker / spawn-tree listing.
- Huge limits also inflate DB fetches and snapshot scans.
- Clamp both to `1..500` and fall back to defaults on non-int values.
