### PR TITLE
fix(cli): catch BaseException when flushing in single-query signal handler

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -656,11 +656,16 @@ def _prepare_deferred_agent_startup() -> None:
 
 
 def _flush_logging_and_stdio() -> None:
-    """Best-effort ``logging.shutdown()`` + stdout/stderr flush before ``os._exit``."""
+    """Best-effort ``logging.shutdown()`` + stdout/stderr flush before ``os._exit``.
+
+    Catch ``BaseException`` on the stdio flush: a second Ctrl+C during flush is a
+    ``KeyboardInterrupt`` (not ``Exception``) and would otherwise escape the
+    kanban ``os._exit`` path as an ignored-exception traceback.
+    """
     with suppress(Exception):
         logging.shutdown()
     for _stream in (sys.stdout, sys.stderr):
-        with suppress(Exception):
+        with suppress(BaseException):
             _stream.flush()
 
 

--- a/cli.py
+++ b/cli.py
@@ -18303,7 +18303,7 @@ def main(
             for _stream in (sys.stdout, sys.stderr):
                 try:
                     _stream.flush()
-                except Exception:
+                except BaseException:
                     pass
             os._exit(0)
         raise KeyboardInterrupt()

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -1,3 +1,4 @@
+import signal
 from types import SimpleNamespace
 
 import pytest
@@ -131,6 +132,70 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
         "summary",
         ("finalize", "single-query-session"),
     ]
+
+
+def test_kanban_signal_handler_ignores_base_exception_from_stream_flush(monkeypatch):
+    """A second interrupt during shutdown must not escape before ``os._exit``."""
+
+    import cli as cli_mod
+
+    installed_handlers = {}
+    flush_calls = []
+
+    class ExitCalled(BaseException):
+        pass
+
+    class InterruptingStream:
+        def __init__(self, name):
+            self.name = name
+
+        def flush(self):
+            flush_calls.append(self.name)
+            raise KeyboardInterrupt()
+
+    class _Console:
+        def print(self, *_args, **_kwargs):
+            pass
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = _Console()
+            self.session_id = "kanban-session"
+            self.agent = None
+
+        def _claim_active_session(self, _surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, _query, images=None):
+            installed_handlers[signal.SIGTERM](signal.SIGTERM, None)
+            raise AssertionError("signal handler returned instead of exiting")
+
+    def capture_handler(signum, handler):
+        installed_handlers[signum] = handler
+
+    def fake_exit(code):
+        assert code == 0
+        assert flush_calls == ["stdout", "stderr"]
+        raise ExitCalled()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-regression")
+    monkeypatch.setenv("HERMES_SIGTERM_GRACE", "0")
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_arm_exit_watchdog_on_shutdown_signal", lambda: None)
+    monkeypatch.setattr(signal, "signal", capture_handler)
+    monkeypatch.setattr(signal, "alarm", lambda _seconds: None, raising=False)
+    monkeypatch.setattr(cli_mod.logging, "shutdown", lambda: None)
+    monkeypatch.setattr(cli_mod.sys, "stdout", InterruptingStream("stdout"))
+    monkeypatch.setattr(cli_mod.sys, "stderr", InterruptingStream("stderr"))
+    monkeypatch.setattr(cli_mod.os, "_exit", fake_exit)
+
+    with pytest.raises(ExitCalled):
+        cli_mod.main(query="hello", quiet=False, toolsets="terminal")
 
 
 def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):


### PR DESCRIPTION
## Problem

Exiting Hermes single-query mode with Ctrl+C can print a noisy traceback:

```
^CException ignored in: <module 'threading' from '.../threading.py'>
Traceback (most recent call last):
  File ".../threading.py", line 1541, in _shutdown
  File ".../cli.py", line 18235, in _signal_handler_q
    _stream.flush()
KeyboardInterrupt:
```

The process still exits cleanly — this is purely cosmetic noise that makes users think something crashed.

## Root cause

`_signal_handler_q`'s cleanup path flushes stdout/stderr inside `except Exception:`. `KeyboardInterrupt` subclasses `BaseException`, not `Exception`, so a second Ctrl+C landing while the flush runs escapes the handler and surfaces in `threading._shutdown()` while the interpreter is already unwinding. The comment on this path explicitly states it "never raises" — the implementation contradicts that contract.

## Fix

`except Exception:` → `except BaseException:` on the flush guard. One line, honors the documented "never raises" intent.

## Related

Part of #10764 (same symptom class — KeyboardInterrupt noise on repeated Ctrl+C at exit). #10765/#11149 cover the TUI browser-cleanup join location; this covers the single-query signal-handler location, which none of those touch.
