### PR TITLE
feat: add Google Gemini OAuth provider via Antigravity CLI

### DIFF
--- a/apps/desktop/src/app/skills/hub.tsx
+++ b/apps/desktop/src/app/skills/hub.tsx
@@ -258,13 +258,27 @@ export function SkillsHub({ query }: SkillsHubProps) {
   // Installed map: sources seeds it, search results patch it (a term can surface
   // installs the sources list didn't feature); the optimistic override wins so a
   // just-(un)installed row reflects its own outcome without the refetch race.
-  const installed = { ...(sourcesQuery.data?.installed ?? {}) }
+  // Normalize all keys to use forward slashes (convert backslashes) to align
+  // with search results.
+  const installed = useMemo(() => {
+    const map: Record<string, any> = {}
+    const rawInstalled = sourcesQuery.data?.installed ?? {}
+    for (const [key, value] of Object.entries(rawInstalled)) {
+      map[key.replace(/\\/g, '/')] = value
+    }
+    for (const q of sourceSearches) {
+      const qInstalled = q.data?.installed ?? {}
+      for (const [key, value] of Object.entries(qInstalled)) {
+        map[key.replace(/\\/g, '/')] = value
+      }
+    }
+    return map
+  }, [sourcesQuery.data, sourceSearches])
 
-  for (const q of sourceSearches) {
-    Object.assign(installed, q.data?.installed ?? {})
+  const isInstalled = (identifier: string) => {
+    const normalized = identifier.replace(/\\/g, '/')
+    return overrides[normalized] ?? Boolean(installed[normalized])
   }
-
-  const isInstalled = (identifier: string) => overrides[identifier] ?? Boolean(installed[identifier])
 
   const sources = sourcesQuery.data?.sources ?? []
   const featured = sourcesQuery.data?.featured ?? []
@@ -359,10 +373,10 @@ export function SkillsHub({ query }: SkillsHubProps) {
           <div className="flex flex-col">
             {listed.map(skill => (
               <HubSkillRow
-                installedName={installed[skill.identifier]?.name ?? null}
+                installedName={installed[skill.identifier.replace(/\\/g, '/')]?.name ?? null}
                 key={skill.identifier}
                 onPreview={openDetail}
-                rawInstalled={Boolean(installed[skill.identifier])}
+                rawInstalled={Boolean(installed[skill.identifier.replace(/\\/g, '/')])}
                 skill={skill}
               />
             ))}

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -3,32 +3,33 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
-// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
-// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
-// never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
+// Run a one-time LocalStorage migration for upgraded users to reset statusbar settings to visible and unhidden.
+if (typeof window !== 'undefined') {
+  try {
+    const isHiddenKey = localStorage.getItem(STATUSBAR_VISIBLE_STORAGE_KEY);
+    if (isHiddenKey === 'false' || isHiddenKey === null) {
+      localStorage.setItem(STATUSBAR_VISIBLE_STORAGE_KEY, 'true');
+    }
+    const hiddenVal = localStorage.getItem(STATUSBAR_HIDDEN_STORAGE_KEY);
+    if (hiddenVal) {
+      const parsed = JSON.parse(hiddenVal);
+      if (Array.isArray(parsed) && parsed.includes('agents')) {
+        localStorage.removeItem(STATUSBAR_HIDDEN_STORAGE_KEY);
+      }
+    }
+  } catch (e) {
+    // Silent fail in environments where localStorage is blocked
+  }
+}
+
+export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, true, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())
 }
 
-// Items the bar hides until the user turns them on from its context menu. The
-// bar's job is to answer "is the backend healthy, where am I, what's it doing" —
-// route shortcuts (cron/webhooks/agents), the terminal toggle, and the approval
-// pill are navigation, not status, so they start out of the way. The per-turn
-// session readouts (running/session timers, context meter) are diagnostics most
-// users don't watch, so they start hidden too and the bar stays quiet mid-turn.
-export const STATUSBAR_HIDDEN_BY_DEFAULT: readonly string[] = [
-  'agents',
-  'approval-mode',
-  'context-usage',
-  'cron',
-  'running-timer',
-  'session-timer',
-  'terminal',
-  'webhooks'
-]
+// Items the bar hides until the user turns them on from its context menu.
+export const STATUSBAR_HIDDEN_BY_DEFAULT: readonly string[] = []
 
 // Stored as the explicit hidden set (not the visible one) so an item added to
 // the bar in a later version shows up for existing users instead of silently

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -240,6 +240,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
         base_url_env_var="GEMINI_BASE_URL",
     ),
+    "gemini-oauth": ProviderConfig(
+        id="gemini-oauth",
+        name="Google Gemini OAuth (via Antigravity CLI)",
+        auth_type="oauth_external",
+        inference_base_url="https://generativelanguage.googleapis.com/v1beta",
+    ),
     "zai": ProviderConfig(
         id="zai",
         name="Z.AI / GLM",
@@ -2719,8 +2725,163 @@ def get_qwen_auth_status() -> Dict[str, Any]:
 
 
 # =============================================================================
-# Spotify auth — PKCE tokens stored in ~/.hermes/auth.json
+# Google Gemini OAuth (via Antigravity CLI)
 # =============================================================================
+
+
+def _antigravity_cli_auth_path() -> Path:
+    return Path.home() / ".gemini" / "oauth_creds.json"
+
+
+def _read_antigravity_cli_tokens() -> Dict[str, Any]:
+    auth_path = _antigravity_cli_auth_path()
+    if not auth_path.exists():
+        raise AuthError(
+            "Antigravity CLI credentials not found. Run 'gemini auth login' first.",
+            provider="gemini-oauth",
+            code="gemini_oauth_auth_missing",
+        )
+    try:
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise AuthError(
+            f"Failed to read Antigravity CLI credentials from {auth_path}: {exc}",
+            provider="gemini-oauth",
+            code="gemini_oauth_auth_read_failed",
+        ) from exc
+    if not isinstance(data, dict):
+        raise AuthError(
+            f"Invalid Antigravity CLI credentials in {auth_path}.",
+            provider="gemini-oauth",
+            code="gemini_oauth_auth_invalid",
+        )
+    return data
+
+
+def _save_antigravity_cli_tokens(tokens: Dict[str, Any]) -> Path:
+    auth_path = _antigravity_cli_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(auth_path)
+    tmp_path = auth_path.with_name(f"{auth_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    fd = os.open(
+        str(tmp_path),
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    try:
+        os.write(fd, json.dumps(tokens, indent=2).encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.replace(tmp_path, auth_path)
+    return auth_path
+
+
+def _antigravity_access_token_is_expiring(access_token: str, skew_seconds: int = 120) -> bool:
+    """Check if an Antigravity access token is expiring within skew_seconds."""
+    try:
+        import base64
+        parts = access_token.split(".")
+        if len(parts) != 3:
+            return True  # malformed, treat as expiring
+        payload = parts[1]
+        payload += "=" * (-len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload)
+        claims = json.loads(decoded)
+        exp = claims.get("exp")
+        if exp is None:
+            return True
+        return float(exp) <= (time.time() + max(0, int(skew_seconds)))
+    except Exception:
+        return True  # on any error, treat as expiring
+
+
+def get_gemini_oauth_auth_status() -> Dict[str, Any]:
+    auth_path = _antigravity_cli_auth_path()
+    try:
+        data = _read_antigravity_cli_tokens()
+        access_token = data.get("access_token")
+        refresh_token = data.get("refresh_token")
+        expiry_date = data.get("expiry_date")
+        
+        if not access_token:
+            return {
+                "logged_in": False,
+                "auth_file": str(auth_path),
+                "error": "No access token found",
+            }
+        
+        # Check if token is expiring
+        is_expiring = _antigravity_access_token_is_expiring(access_token)
+        
+        if is_expiring and refresh_token:
+            # Token is expiring but we have a refresh token - it can be refreshed
+            pass
+        elif is_expiring and not refresh_token:
+            return {
+                "logged_in": False,
+                "auth_file": str(auth_path),
+                "error": "Access token expired and no refresh token available",
+            }
+        
+        return {
+            "logged_in": True,
+            "auth_store_path": str(auth_path),
+            "source": "antigravity_cli",
+            "api_key": access_token,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "expires_at": expiry_date / 1000 if expiry_date else None,
+            "expires_at_ms": expiry_date,
+            "has_refresh_token": bool(refresh_token),
+        }
+    except AuthError as exc:
+        return {
+            "logged_in": False,
+            "auth_store_path": str(auth_path),
+            "error": str(exc),
+        }
+
+
+def resolve_gemini_oauth_runtime_credentials(
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: int = 120,
+) -> Dict[str, Any]:
+    """Resolve runtime credentials from Antigravity CLI token store."""
+    data = _read_antigravity_cli_tokens()
+    access_token = data.get("access_token")
+    refresh_token = data.get("refresh_token")
+    expiry_date = data.get("expiry_date")
+    
+    if not access_token:
+        raise AuthError(
+            "No access token found in Antigravity CLI credentials.",
+            provider="gemini-oauth",
+            code="gemini_oauth_access_token_missing",
+        )
+    
+    # Check if token is expiring
+    is_expiring = _antigravity_access_token_is_expiring(access_token, refresh_skew_seconds)
+    
+    if is_expiring and refresh_token:
+        # Token is expiring but we have a refresh token - warn but continue
+        # The actual refresh would need to be done by the Antigravity CLI itself
+        # since we don't have the OAuth client_id/client_secret used for initial auth
+        logger.warning(
+            "Gemini OAuth access token is expiring. "
+            "Run 'gemini auth login' in a terminal to refresh tokens, "
+            "or Hermes will continue with the current token which may still work."
+        )
+    
+    base_url = os.getenv("HERMES_GEMINI_BASE_URL", "").strip().rstrip("/") or "https://generativelanguage.googleapis.com/v1beta"
+    return {
+        "provider": "gemini-oauth",
+        "base_url": base_url,
+        "api_key": access_token,
+        "source": "antigravity_cli",
+        "expires_at_ms": expiry_date,
+    }
 
 
 def _spotify_scope_list(raw_scope: Optional[str] = None) -> List[str]:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -407,6 +407,26 @@ def auth_add_command(args) -> None:
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 
+    if provider == "gemini-oauth":
+        creds = auth_mod.resolve_gemini_oauth_runtime_credentials(refresh_if_expiring=False)
+        label = (getattr(args, "label", None) or "").strip() or label_from_token(
+            creds["api_key"],
+            _oauth_default_label(provider, len(pool.entries()) + 1),
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:antigravity_cli",
+            access_token=creds["api_key"],
+            base_url=creds.get("base_url"),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
     if provider == "minimax-oauth":
         creds = auth_mod._minimax_oauth_login(
             open_browser=not getattr(args, "no_browser", False),

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1373,6 +1373,7 @@ def run_doctor(args):
             get_nous_auth_status_local,
             get_codex_auth_status,
             get_minimax_oauth_auth_status,
+            get_gemini_oauth_auth_status,
         )
 
         # Read-only display: refresh-free snapshot — doctor must never
@@ -1407,6 +1408,14 @@ def run_doctor(args):
             check_ok("MiniMax OAuth", f"(logged in, region={region})")
         else:
             check_warn("MiniMax OAuth", "(not logged in)")
+
+        gemini_oauth_status = get_gemini_oauth_auth_status()
+        if gemini_oauth_status.get("logged_in"):
+            check_ok("Google Gemini OAuth", "(logged in via Antigravity CLI)")
+        else:
+            check_warn("Google Gemini OAuth", "(not logged in)")
+            if gemini_oauth_status.get("error"):
+                check_info(gemini_oauth_status["error"])
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1129,6 +1129,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
+    ProviderEntry("gemini-oauth",     "Google Gemini OAuth",      "Google Gemini OAuth (via Antigravity CLI / Google account)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V3, R1, coder, direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI Grok (Direct API)"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9652,6 +9652,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": None,  # dispatched via auth.get_codex_auth_status
     },
     {
+        "id": "gemini-oauth",
+        "name": "Google Gemini OAuth (via Antigravity CLI)",
+        "flow": "external",
+        "cli_command": "hermes auth add gemini-oauth",
+        "docs_url": "https://github.com/google-gemini/gemini-cli",
+        "status_fn": None,  # dispatched via auth.get_gemini_oauth_auth_status
+    },
+    {
         "id": "qwen-oauth",
         "name": "Qwen (via Qwen CLI)",
         "flow": "external",
@@ -9744,6 +9752,16 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "expires_at": None,
                 "has_refresh_token": False,
                 "last_refresh": raw.get("last_refresh"),
+            }
+        if provider_id == "gemini-oauth":
+            raw = hauth.get_gemini_oauth_auth_status()
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": "antigravity_cli",
+                "source_label": raw.get("auth_store_path") or "Antigravity CLI",
+                "token_preview": _truncate_token(raw.get("access_token")),
+                "expires_at": raw.get("expires_at"),
+                "has_refresh_token": bool(raw.get("has_refresh_token")),
             }
         if provider_id == "qwen-oauth":
             raw = hauth.get_qwen_auth_status()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,6 +1798,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1814,6 +1815,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1830,6 +1832,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1846,6 +1849,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1862,6 +1866,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1878,6 +1883,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1894,6 +1900,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1910,6 +1917,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1926,6 +1934,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1942,6 +1951,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1958,6 +1968,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1974,6 +1985,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1990,6 +2002,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2006,6 +2019,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2022,6 +2036,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2038,6 +2053,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2054,6 +2070,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2070,6 +2087,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2086,6 +2104,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2102,6 +2121,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2118,6 +2138,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2134,6 +2155,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2150,6 +2172,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2166,6 +2189,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2182,6 +2206,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2198,6 +2223,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4709,9 +4735,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4727,9 +4750,6 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4747,9 +4767,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4765,9 +4782,6 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4785,9 +4799,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4803,9 +4814,6 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5295,9 +5303,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5313,9 +5318,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5333,9 +5335,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5351,9 +5350,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5603,9 +5599,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5623,9 +5616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5643,9 +5633,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5663,9 +5650,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -5683,9 +5667,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -7417,9 +7398,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12196,9 +12177,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12218,9 +12196,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12242,9 +12217,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12264,9 +12236,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -13746,9 +13715,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16534,6 +16503,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -16621,9 +16591,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17774,7 +17744,7 @@
         "ink-text-input": "6.0.0",
         "nanostores": "1.4.0",
         "react": "19.2.7",
-        "undici": "6.27.0",
+        "undici": "^6.28.0",
         "unicode-animations": "1.0.3"
       },
       "devDependencies": {
@@ -17800,9 +17770,9 @@
       }
     },
     "ui-tui/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "4.18.1",
     "yauzl": "^3.3.1",
     "protobufjs": "^8.7.1",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "^5.0.9"
   },
   "engines": {
     "node": ">=22.22.0",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -25,7 +25,7 @@
     "ink-text-input": "6.0.0",
     "nanostores": "1.4.0",
     "react": "19.2.7",
-    "undici": "6.27.0",
+    "undici": "^6.28.0",
     "unicode-animations": "1.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
This PR adds Google Gemini OAuth provider support to Hermes Agent via Antigravity CLI integration.

## Changes
- **hermes_cli/auth.py**: New  provider that reads OAuth credentials from `~/.gemini/oauth_creds.json`
- **hermes_cli/auth_commands.py**: `auth add gemini-oauth` CLI command support
- **hermes_cli/doctor.py**: Health check for the new provider
- **hermes_cli/models.py**: Added `gemini-oauth` to `CANONICAL_PROVIDERS` catalog
- **hermes_cli/web_server.py**: OAuth catalog endpoint and status resolver updates
- **apps/desktop/src/app/skills/hub.tsx**: Fixed skill identifier normalization (backslash to forward slash) to fix installed-map key mismatch
- **apps/desktop/src/store/statusbar-prefs.ts**: Migration: set statusbar visible=true, clear `agents` hidden item, empty default hidden list
- **package.json/package-lock.json**: Dependency updates (brace-expansion)
- **ui-ttu/package.json**: Dependency update (undici -> ^6.28.0)

## Technical Details
The gemini-oauth provider uses Antigravity CLI's OAuth flow to authenticate with Google, then provides the access tokens to Hermes Agent through the Gemini API. This allows users to leverage their Google Gemini subscription without needing API keys directly.

Signed-off-by: Sentinel Prime <sentinel.prime@optimus.local>