### PR TITLE
fix(cron): validate skill names at cronjob create/update time

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -615,3 +615,170 @@ class TestGithubExemptionAbuse:
         assert _scan_cron_prompt(
             "generate a keypair and explain id_rsa vs id_ed25519"
         ) == ""
+
+
+# =========================================================================
+# Skill-name validation at create/update (complements #77362's fire-time
+# hard-abort: a typo in skills=[...] should fail fast at the API boundary,
+# not weeks later when the job fires)
+# =========================================================================
+
+class TestCronSkillValidation:
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "scripts").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    @staticmethod
+    def _mock_skill_view(monkeypatch, ok_names=()):
+        import tools.skills_tool as st
+
+        def fake_view(name):
+            if name in ok_names:
+                return json.dumps({"success": True, "content": "skill body"})
+            return json.dumps({"success": False, "error": f"Skill '{name}' not found"})
+
+        monkeypatch.setattr(st, "skill_view", fake_view)
+
+    @staticmethod
+    def _mock_bundles(monkeypatch, bundle_names=()):
+        import agent.skill_bundles as sb
+        monkeypatch.setattr(
+            sb,
+            "resolve_bundle_command_key",
+            lambda cmd: f"/{cmd}" if cmd in bundle_names else None,
+        )
+
+    def test_create_rejects_unknown_skill(self, monkeypatch):
+        self._mock_bundles(monkeypatch)
+        self._mock_skill_view(monkeypatch)
+
+        result = json.loads(
+            cronjob(action="create", schedule="every 1h", skills=["bogus-skill"])
+        )
+
+        assert result["success"] is False
+        assert "Unknown skill(s): bogus-skill" in result["error"]
+        # nothing persisted
+        assert json.loads(cronjob(action="list"))["count"] == 0
+
+    def test_create_rejects_unknown_skill_alongside_resolvable(self, monkeypatch):
+        self._mock_bundles(monkeypatch)
+        self._mock_skill_view(monkeypatch, ok_names={"good-skill"})
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 1h",
+                skills=["good-skill", "bogus-skill"],
+            )
+        )
+
+        assert result["success"] is False
+        assert "bogus-skill" in result["error"]
+        assert "good-skill" not in result["error"].split("Unknown skill(s): ")[1].split(" — ")[0]
+
+    def test_create_accepts_resolvable_skill(self, monkeypatch):
+        self._mock_bundles(monkeypatch)
+        self._mock_skill_view(monkeypatch, ok_names={"good-skill"})
+
+        result = json.loads(
+            cronjob(action="create", schedule="every 1h", skills=["good-skill"])
+        )
+
+        assert result["success"] is True
+        assert result["job"]["skills"] == ["good-skill"]
+
+    def test_create_accepts_bundle_name_without_skill(self, monkeypatch):
+        # Bundles shadow skill slugs at fire time — a bundle hit is valid even
+        # when no skill with that name exists (skill_view would fail).
+        self._mock_bundles(monkeypatch, bundle_names={"my-bundle"})
+        self._mock_skill_view(monkeypatch)
+
+        result = json.loads(
+            cronjob(action="create", schedule="every 1h", skills=["my-bundle"])
+        )
+
+        assert result["success"] is True
+
+    def test_create_no_agent_skips_skill_validation(self, monkeypatch):
+        # no_agent jobs never assemble a prompt — attached skills are inert
+        # and must not be gated. skill_view raising proves it is never called.
+        import tools.skills_tool as st
+        monkeypatch.setattr(
+            st, "skill_view",
+            lambda name: (_ for _ in ()).throw(AssertionError("skill_view called")),
+        )
+
+        from hermes_constants import get_hermes_home
+        (get_hermes_home() / "scripts" / "probe.sh").write_text("#!/bin/sh\necho ok\n")
+
+        result = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 1h",
+                no_agent=True,
+                script="probe.sh",
+                skills=["bogus-skill"],
+            )
+        )
+
+        assert result["success"] is True
+
+    def test_update_rejects_unknown_skill(self, monkeypatch):
+        created = json.loads(cronjob(action="create", prompt="x", schedule="every 1h"))
+        job_id = created["job_id"]
+        self._mock_bundles(monkeypatch)
+        self._mock_skill_view(monkeypatch)
+
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, skills=["bogus-skill"])
+        )
+
+        assert result["success"] is False
+        assert "Unknown skill(s): bogus-skill" in result["error"]
+        # stored job untouched
+        job = json.loads(cronjob(action="list"))["jobs"][0]
+        assert job["skills"] == []
+
+    def test_update_accepts_resolvable_skill(self, monkeypatch):
+        created = json.loads(cronjob(action="create", prompt="x", schedule="every 1h"))
+        job_id = created["job_id"]
+        self._mock_bundles(monkeypatch)
+        self._mock_skill_view(monkeypatch, ok_names={"good-skill"})
+
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, skills=["good-skill"])
+        )
+
+        assert result["success"] is True
+        job = json.loads(cronjob(action="list"))["jobs"][0]
+        assert job["skills"] == ["good-skill"]
+
+    def test_update_skips_validation_for_no_agent_job(self, monkeypatch):
+        from hermes_constants import get_hermes_home
+        (get_hermes_home() / "scripts" / "probe.sh").write_text("#!/bin/sh\necho ok\n")
+        created = json.loads(
+            cronjob(
+                action="create",
+                schedule="every 1h",
+                no_agent=True,
+                script="probe.sh",
+            )
+        )
+        job_id = created["job_id"]
+        import tools.skills_tool as st
+        monkeypatch.setattr(
+            st, "skill_view",
+            lambda name: (_ for _ in ()).throw(AssertionError("skill_view called")),
+        )
+
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, skills=["bogus-skill"])
+        )
+
+        assert result["success"] is True

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -401,6 +401,48 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
     return normalized
 
 
+def _validate_cron_skills(skill_names: List[str]) -> Optional[str]:
+    """Validate declared cron skill names at the API boundary.
+
+    The scheduler resolves each declared skill at fire time — bundle expansion
+    first (bundles shadow skill slugs), then ``skill_view()`` — and skips any
+    name that resolves to neither. A typo in ``skills=[...]`` therefore used to
+    surface only when the job fired (contextless run, or a hard abort once ALL
+    skills fail — #77362), potentially weeks after creation. Fail fast at
+    create/update time instead, mirroring the scheduler's resolution order.
+
+    Returns an error string listing the unresolvable names, else None.
+    """
+    if not skill_names:
+        return None
+
+    from agent.skill_bundles import resolve_bundle_command_key
+    from agent.skill_utils import normalize_skill_lookup_name
+    from tools.skills_tool import skill_view
+
+    unknown: List[str] = []
+    for name in skill_names:
+        raw = str(name).strip()
+        if not raw:
+            continue
+        # Bundles shadow skill slugs at fire time; a bundle hit is valid even
+        # if no skill with that name exists.
+        if resolve_bundle_command_key(raw.lstrip("/")):
+            continue
+        try:
+            loaded = json.loads(skill_view(normalize_skill_lookup_name(raw)))
+        except (json.JSONDecodeError, TypeError):
+            loaded = {}
+        if not loaded.get("success"):
+            unknown.append(raw)
+
+    if not unknown:
+        return None
+    return (
+        f"Unknown skill(s): {', '.join(unknown)} — not an installed skill or bundle. "
+        "The scheduler skips unresolvable skills at fire time, so the job would run "
+        "without them. Fix the name (see skills_list) or remove it from skills=[...]."
+    )
 
 
 def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash: bool = False) -> Optional[str]:
@@ -755,6 +797,12 @@ def cronjob(
                     )
             elif not prompt and not canonical_skills:
                 return tool_error("create requires either prompt or at least one skill", success=False)
+            # no_agent jobs never assemble a prompt, so attached skills are
+            # inert — don't gate them on resolvability.
+            if canonical_skills and not _no_agent:
+                skills_error = _validate_cron_skills(canonical_skills)
+                if skills_error:
+                    return tool_error(skills_error, success=False)
             if prompt:
                 scan_error = _scan_cron_prompt(prompt)
                 if scan_error:
@@ -924,6 +972,13 @@ def cronjob(
                 updates["deliver"] = _normalize_deliver_param(deliver)
             if skills is not None or skill is not None:
                 canonical_skills = _canonical_skills(skill, skills)
+                # Skip the resolvability gate when the effective job is
+                # no_agent — its skills are inert (never assembled).
+                eff_no_agent = bool(no_agent) if no_agent is not None else bool(job.get("no_agent"))
+                if canonical_skills and not eff_no_agent:
+                    skills_error = _validate_cron_skills(canonical_skills)
+                    if skills_error:
+                        return tool_error(skills_error, success=False)
                 updates["skills"] = canonical_skills
                 updates["skill"] = canonical_skills[0] if canonical_skills else None
             if model is not None:


### PR DESCRIPTION
## Summary

`cronjob(action="create")` and `cronjob(action="update")` accepted any string in `skills=[...]` without resolving it. A typo is silently persisted and only surfaces when the job fires — the scheduler skips the unresolvable skill (or, with #77446, hard-aborts when ALL skills fail). Depending on the schedule, that is days or weeks later, and the job looks healthy in `list` the whole time.

This PR fails fast at the API boundary: create/update now resolve each declared skill **the same way the scheduler does at fire time** — bundle expansion first (bundles shadow skill slugs), then `skill_view()` — and reject names that match neither, listing the offenders.

Complements #77362 / #77446 (fire-time hard-abort): that change is the last line of defense, this one catches the typo at the source.

## Behavior

| Case | Result |
|---|---|
| `create` with `skills=["bogus"]` | `success: false`, error lists unknown name(s), nothing persisted |
| `update` with `skills=["bogus"]` | same error, stored job untouched |
| Bundle name, no same-named skill | accepted (mirrors fire-time shadowing) |
| `no_agent=True` job with skills | accepted — its skills are never assembled into a prompt |
| `cron/jobs.py create_job(skills=[...])` | unchanged — programmatic callers (curator skill-ref rewrites) keep working with stale names by design |

## Repro (before this patch)

```python
cronjob(action="create", schedule="0 9 * * 3", skills=["__definitely-bogus-skill-xyz"])
# → {"success": true, ...} — job persisted; contextless run or abort only at fire time
```

## Test plan

- 8 new tests in `tests/tools/test_cronjob_tools.py`: reject-on-create (single + mixed good/bad), accept resolvable, bundle-without-skill accepted, `no_agent` create/update skip (asserts `skill_view` is never called), stored job untouched on rejected update.
- `pytest tests/tools/test_cronjob_tools.py` → **76 passed**.
- Full `tests/tools/` + cron skill-injection/no_agent files, diffed against clean `main`: **zero new failures**.