### PR TITLE
 Harden session.create cols against malformed JSON-RPC

### DIFF
--- a/tests/tui_gateway/test_session_create_cols_guard.py
+++ b/tests/tui_gateway/test_session_create_cols_guard.py
@@ -1,0 +1,85 @@
+"""session.create / terminal.resize must tolerate malformed ``cols``.
+
+``session.resume`` already wraps ``int(cols)`` in try/except. ``session.create``
+is an inline (non-_LONG_HANDLERS) RPC, so a bare ``int(...)`` raising
+ValueError/TypeError can tear down the TUI gateway stdin/WS reader loop.
+``terminal.resize`` has the same bare ``int`` sibling.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from tui_gateway import server
+
+
+def _stub_create_side_effects(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_resolve_session_source", lambda s=None: "tui")
+    monkeypatch.setattr(server, "_new_session_key", lambda: "key-test")
+    monkeypatch.setattr(server, "_coerce_seed_history", lambda _m: [])
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: "")
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda _cwd: {})
+    monkeypatch.setattr(server, "_profile_home", lambda _p: None)
+    monkeypatch.setattr(server, "_response_profile_name", lambda _p: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+
+
+def test_session_create_tolerates_non_int_cols(monkeypatch, tmp_path):
+    _stub_create_side_effects(monkeypatch, tmp_path)
+
+    resp = server.dispatch(
+        {
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": "wide"},
+        }
+    )
+    assert "error" not in resp, resp
+    sid = resp["result"]["session_id"]
+    assert server._sessions[sid]["cols"] == 80
+    server._sessions.pop(sid, None)
+
+
+def test_session_create_tolerates_list_cols(monkeypatch, tmp_path):
+    _stub_create_side_effects(monkeypatch, tmp_path)
+
+    resp = server.dispatch(
+        {
+            "id": "2",
+            "method": "session.create",
+            "params": {"cols": [120]},
+        }
+    )
+    assert "error" not in resp, resp
+    sid = resp["result"]["session_id"]
+    assert server._sessions[sid]["cols"] == 80
+    server._sessions.pop(sid, None)
+
+
+def test_terminal_resize_tolerates_non_int_cols(monkeypatch):
+    ready = threading.Event()
+    ready.set()
+    server._sessions["sid-r"] = {
+        "cols": 80,
+        "agent_ready": ready,
+        "session_key": "k",
+    }
+    try:
+        resp = server.handle_request(
+            {
+                "id": "3",
+                "method": "terminal.resize",
+                "params": {"session_id": "sid-r", "cols": "nope"},
+            }
+        )
+        assert "error" not in resp, resp
+        assert resp["result"]["cols"] == 80
+        assert server._sessions["sid-r"]["cols"] == 80
+    finally:
+        server._sessions.pop("sid-r", None)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -15,7 +15,12 @@ _profile_scoped = _registry.profile_scoped
 def _(rid, params: dict) -> dict:
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
-    cols = int(params.get("cols", 80))
+    # Mirror session.resume: malformed cols must not crash the inline
+    # stdin/WS reader thread (create is not in _LONG_HANDLERS).
+    try:
+        cols = int(params.get("cols", 80))
+    except (TypeError, ValueError):
+        cols = 80
     history = _coerce_seed_history(params.get("messages"))
     title = str(params.get("title") or "").strip()
     # When set, this is a branch: the new chat copies an existing conversation's
@@ -39,7 +44,7 @@ def _(rid, params: dict) -> dict:
     # profile must build its agent + persist against THAT profile's home/state.db,
     # not the dashboard's launch profile. Stored on the session so _start_agent_build
     # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
-    profile = (params.get("profile") or "").strip() or None
+    profile = str(params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
@@ -314,7 +319,7 @@ def _(rid, params: dict) -> dict:
         cols = 80
     # ``profile`` (app-global remote mode): resume a session that lives in another
     # local profile's state.db. None/own profile → the launch profile (unchanged).
-    profile = (params.get("profile") or "").strip() or None
+    profile = str(params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
     # Desktop hydrates persisted transcripts through the authenticated REST
     # route in parallel. Suppress the duplicate WebSocket transcript only when
@@ -3129,7 +3134,11 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    session["cols"] = int(params.get("cols", 80))
+    try:
+        cols = int(params.get("cols", 80))
+    except (TypeError, ValueError):
+        cols = 80
+    session["cols"] = cols
     return _ok(rid, {"cols": session["cols"]})
 
 


### PR DESCRIPTION
## Summary
- `session.resume` already wraps `int(cols)` in try/except; `session.create` did not.
- `session.create` runs inline (not in `_LONG_HANDLERS`), so a non-int `cols` (`"wide"`, `[]`, …) can raise and tear down the stdin/WS reader loop.
- Mirror the resume guard on create, and apply the same to `terminal.resize`.
- Coerce `profile` via `str(...)` on create/resume so a non-string value can't crash `.strip()`.
