### PR TITLE
fix(honcho): fall back to peer search when workspace search returns empty

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1167,6 +1167,7 @@ class HonchoSessionManager:
         char_budget = max(200, int(max_tokens) * 4)
         limit = max(3, min(20, char_budget // 300))
 
+        messages: list = []
         try:
             messages = self.honcho.search(
                 q,
@@ -1175,8 +1176,11 @@ class HonchoSessionManager:
             )
         except Exception as e:
             logger.debug("Honcho message search failed (peer_perspective=%s): %s", peer_id, e)
-            # Fall back to peer-authored search if the perspective filter is
-            # unsupported by the running Honcho version.
+
+        if not messages:
+            # Fall back to peer-authored search when the perspective filter is
+            # unsupported by the running Honcho version OR returns nothing
+            # (observed on self-hosted v3.0.11: filter accepted, HTTP 200, []).
             try:
                 peer_obj = self._get_or_create_peer(peer_id)
                 messages = peer_obj.search(q, limit=limit)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -181,6 +181,28 @@ class TestPeerLookupHelpers:
         # user-stated facts from assistant-derived ones.
         assert "[assistant" in result
 
+    def test_search_context_falls_back_to_peer_search_on_empty_results(self):
+        """An empty workspace search (HTTP 200, no rows) also triggers the
+        peer-authored fallback, not just raised exceptions.
+
+        Regression test: self-hosted Honcho v3 accepts the peer_perspective
+        filter but can return [] (e.g. membership joined_at windows), which
+        previously surfaced as "No relevant context found." every time.
+        """
+        mgr, session = self._make_cached_manager()
+        honcho_client = MagicMock()
+        honcho_client.search.return_value = []
+        peer = MagicMock()
+        peer.search.return_value = [
+            SimpleNamespace(content="I founded neuralancer in 2019", peer_id="robert", session_id="s-old", id="m1"),
+        ]
+        mgr._get_or_create_peer = MagicMock(return_value=peer)
+        with patch.object(HonchoSessionManager, "honcho", new_callable=lambda: property(lambda s: honcho_client)):
+            result = mgr.search_context(session.key, "neuralancer")
+
+        assert "neuralancer in 2019" in result
+        peer.search.assert_called_once()
+
 
     def test_create_conclusion_defaults_to_user_target(self):
         mgr, session = self._make_cached_manager()


### PR DESCRIPTION
## Summary

- `HonchoSessionManager.search_context` only fell back to peer-authored search when the workspace search **raised an exception**. Against self-hosted Honcho v3, the `peer_perspective` filter can return HTTP 200 with **zero rows** — e.g. because membership `joined_at` windows exclude older messages (upstream: plastic-labs/honcho#940, and any client that re-adds peers on boot resets those windows). The fallback never fired, so `honcho_search` surfaced "No relevant context found." even when matching messages existed.
- The fallback now fires on an **empty result set** as well. The exception path is unchanged.
- Adds a regression test covering the empty-result path.

Fixes #79299

## Test plan

- [x] `pytest tests/honcho_plugin/test_session.py` — 55 passed (including the new regression test)
- [x] E2E against a live self-hosted Honcho v3.0.11: before the patch `search_context` returned empty for queries with known matches; after the patch it returns ranked message excerpts from the real server.