### PR TITLE
Coerce null name/command on command.dispatch and slash.exec

### DIFF
--- a/tests/tui_gateway/test_command_dispatch_null_name.py
+++ b/tests/tui_gateway/test_command_dispatch_null_name.py
@@ -1,0 +1,61 @@
+"""command.dispatch / slash.exec must tolerate JSON-null string fields.
+
+``dict.get("name", "")`` returns None when the key is present with a null
+value. A bare ``.lstrip`` / ``.strip`` then raises AttributeError.
+
+``command.dispatch`` runs inline (not in ``_LONG_HANDLERS``), so that crash
+can tear down the TUI gateway stdin/WS reader loop. ``slash.exec`` is
+pool-wrapped but still returns a cleaner empty-command error when coerced.
+"""
+
+from __future__ import annotations
+
+from tui_gateway import server
+
+
+def test_command_dispatch_tolerates_null_name(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {}})
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+
+    resp = server.dispatch(
+        {
+            "id": "1",
+            "method": "command.dispatch",
+            "params": {"name": None, "arg": None, "session_id": "missing"},
+        }
+    )
+    # Must not raise — returns a structured unknown-command / not-found error.
+    assert isinstance(resp, dict)
+    assert "error" in resp or "result" in resp
+
+
+def test_command_dispatch_null_name_does_not_crash_inline():
+    """Regression: AttributeError must not escape dispatch() for null name."""
+    try:
+        resp = server.dispatch(
+            {
+                "id": "2",
+                "method": "command.dispatch",
+                "params": {"name": None},
+            }
+        )
+    except AttributeError as exc:
+        raise AssertionError(f"null name crashed inline dispatch: {exc}") from exc
+    assert isinstance(resp, dict)
+
+
+def test_slash_exec_null_command_returns_empty_error(monkeypatch):
+    sid = "slash-null"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+    try:
+        resp = server.handle_request(
+            {
+                "id": "3",
+                "method": "slash.exec",
+                "params": {"session_id": sid, "command": None},
+            }
+        )
+        assert resp["error"]["code"] == 4004
+        assert "empty" in resp["error"]["message"].lower()
+    finally:
+        server._sessions.pop(sid, None)

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -431,7 +431,10 @@ def _(rid, params: dict) -> dict:
 
 @method("command.dispatch")
 def _(rid, params: dict) -> dict:
-    name, arg = params.get("name", "").lstrip("/"), params.get("arg", "")
+    # JSON null for name/arg makes ``.get(..., "")`` return None (key present),
+    # and a bare ``.lstrip`` would crash this inline RPC on the reader thread.
+    name = str(params.get("name") or "").lstrip("/")
+    arg = str(params.get("arg") or "")
     resolved = _resolve_name(name)
     if resolved != name:
         name = resolved
@@ -1076,7 +1079,9 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
 
-    cmd = params.get("command", "").strip()
+    # Same null-key pitfall as command.dispatch: present-but-null ``command``
+    # must not AttributeError on ``.strip()``.
+    cmd = str(params.get("command") or "").strip()
     if not cmd:
         return _err(rid, 4004, "empty command")
 


### PR DESCRIPTION
## Summary
- `dict.get("name", "")` returns `None` when the key is present with JSON `null`, so a bare `.lstrip()` / `.strip()` raises `AttributeError`.
- `command.dispatch` runs **inline** (not in `_LONG_HANDLERS`), so that crash can tear down the stdin/WS reader loop.
- Coerce via `str(... or "")` on `command.dispatch` (`name`/`arg`) and the same guard on `slash.exec` (`command`).

