### PR TITLE
fix(curator): re-anchor never-used built-in skill clock on first curator run

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -310,7 +310,10 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
     with a baseline record the first time they're seen so their inactivity
     clock starts NOW rather than at epoch — a long-unused built-in is therefore
     archived only after a fresh ``archive_after_days`` of non-use, not on the
-    first pass after the flag flips on.
+    first pass after the flag flips on. A built-in whose record predates the
+    curator (pure telemetry: never used, no activity) gets its clock
+    re-anchored the first time it is seen here, so pre-seeded built-ins aren't
+    all marked stale on the first run (#79295).
 
     Returns a counter dict describing what changed.
     """
@@ -344,6 +347,25 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
         # (e.g. a newly-eligible built-in): anchor its clock to now and defer.
         if not row.get("_persisted", True):
             _u.seed_record_if_missing(name)
+            counts["seeded"] += 1
+            continue
+
+        # A bundled built-in whose only record is pure telemetry (never used,
+        # no activity) carries a created_at that predates the first curator
+        # run — telemetry writes the record the moment the skill is seeded,
+        # which can be long before ``curator.prune_builtins`` is enabled.
+        # Anchoring the clock there marks a fresh built-in stale on the first
+        # pass. On first sight, re-anchor created_at to now (stamping
+        # first_seen_at) so the clock starts from this run; the skill then
+        # ages normally and is pruned only after a full window of non-use.
+        # Fixes #79295.
+        if (
+            row.get("provenance") == "bundled"
+            and int(row.get("use_count", 0) or 0) == 0
+            and not _parse_iso(row.get("last_activity_at"))
+            and not row.get("first_seen_at")
+        ):
+            _u.reanchor_clock(name)
             counts["seeded"] += 1
             continue
 

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -274,6 +274,100 @@ def test_prune_builtins_never_touches_hub_skills(curator_env, monkeypatch):
     assert (skills_dir / "hubskill").exists()
 
 
+def test_prune_builtins_reanchors_preseeded_never_used_builtin(curator_env, monkeypatch):
+    """A pre-seeded built-in record must not mark the skill stale on the first
+    curator run.
+
+    Telemetry writes a usage record the moment a built-in is seeded — possibly
+    weeks before the first curator run with ``curator.prune_builtins`` on. That
+    record has use_count 0, no activity, and a created_at older than
+    stale_after_days; anchoring the inactivity clock there marks every fresh
+    built-in stale on the first pass. The curator re-anchors created_at to now
+    on first sight instead, so the clock starts from this run (#79295).
+    """
+    u = curator_env["usage"]
+    c = curator_env["curator"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "bundled-helper")
+    (skills_dir / ".bundled_manifest").write_text(
+        "bundled-helper:abc\n", encoding="utf-8"
+    )
+    _enable_prune_builtins(curator_env, monkeypatch)
+
+    # Pure-telemetry record batch-created before the first curator run.
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["bundled-helper"] = u._empty_record()
+    data["bundled-helper"]["created_at"] = super_old
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["marked_stale"] == 0
+    assert counts["archived"] == 0
+    rec = u.get_record("bundled-helper")
+    assert rec["state"] == "active"
+    # Clock was re-anchored to this run, not left at the telemetry timestamp.
+    assert rec["first_seen_at"] is not None
+    reanchored = datetime.fromisoformat(rec["created_at"])
+    assert reanchored > datetime.fromisoformat(super_old)
+    assert reanchored > datetime.now(timezone.utc) - timedelta(minutes=5)
+
+
+def test_prune_builtins_reanchored_builtin_still_ages_out(curator_env, monkeypatch):
+    """Re-anchoring is one-shot: after first sight, the re-anchored clock keeps
+    ticking, so a still-unused built-in goes stale after a full stale window
+    instead of being deferred forever."""
+    u = curator_env["usage"]
+    c = curator_env["curator"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "bundled-helper")
+    (skills_dir / ".bundled_manifest").write_text(
+        "bundled-helper:abc\n", encoding="utf-8"
+    )
+    _enable_prune_builtins(curator_env, monkeypatch)
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["bundled-helper"] = u._empty_record()
+    data["bundled-helper"]["created_at"] = super_old
+    u.save_usage(data)
+
+    t0 = datetime.now(timezone.utc)
+    assert c.apply_automatic_transitions(now=t0)["marked_stale"] == 0
+
+    # A month later (past stale_after_days=30) with still no use: stale.
+    counts = c.apply_automatic_transitions(now=t0 + timedelta(days=31))
+    assert counts["marked_stale"] == 1
+    assert u.get_record("bundled-helper")["state"] == "stale"
+
+
+def test_prune_builtins_used_builtin_still_marked_stale(curator_env, monkeypatch):
+    """The never-used re-anchor must not shield built-ins that were actually
+    used long ago — their activity anchor governs and they age out normally."""
+    u = curator_env["usage"]
+    c = curator_env["curator"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "bundled-used")
+    (skills_dir / ".bundled_manifest").write_text(
+        "bundled-used:abc\n", encoding="utf-8"
+    )
+    _enable_prune_builtins(curator_env, monkeypatch)
+
+    # Last used 45 days ago: inside the stale window (>30d) but well before
+    # the archive window (90d) — an unequivocal stale candidate.
+    old = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+    data = u.load_usage()
+    data["bundled-used"] = u._empty_record()
+    data["bundled-used"]["created_at"] = old
+    data["bundled-used"]["last_used_at"] = old
+    data["bundled-used"]["use_count"] = 1
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["marked_stale"] == 1
+    assert u.get_record("bundled-used")["state"] == "stale"
+
+
 # ---------------------------------------------------------------------------
 # run_curator_review orchestration
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -651,6 +651,10 @@ def _empty_record() -> Dict[str, Any]:
         "patch_count": 0,
         "last_patched_at": None,
         "created_at": _now_iso(),
+        # When the curator first anchored this skill's inactivity clock.
+        # Written on first sight (seed or re-anchor) so later runs don't
+        # re-anchor a record whose clock already started (see reanchor_clock).
+        "first_seen_at": None,
         "state": STATE_ACTIVE,
         "pinned": False,
         "archived_at": None,
@@ -730,7 +734,11 @@ def seed_record_if_missing(skill_name: str) -> None:
             data = load_usage()
             if isinstance(data.get(skill_name), dict):
                 return
-            data[skill_name] = _empty_record()
+            rec = _empty_record()
+            # Stamp first sight so a later run knows the clock was already
+            # anchored here and doesn't re-anchor it (see reanchor_clock).
+            rec["first_seen_at"] = _now_iso()
+            data[skill_name] = rec
             save_usage(data)
     except Exception as e:
         logger.debug("skill_usage.seed_record_if_missing(%s) failed: %s", skill_name, e, exc_info=True)
@@ -762,6 +770,31 @@ def _mutate(skill_name: str, mutator, *, require_curation_eligible: bool = False
             save_usage(data)
     except Exception as e:
         logger.debug("skill_usage._mutate(%s) failed: %s", skill_name, e, exc_info=True)
+
+
+def reanchor_clock(skill_name: str) -> None:
+    """Anchor a skill's curator inactivity clock to now, exactly once.
+
+    A bundled built-in can carry a pure-telemetry record (``use_count`` 0, no
+    activity) whose ``created_at`` predates the curator's first sight of the
+    skill — e.g. records batch-created when skills were seeded, before
+    ``curator.prune_builtins`` was ever enabled. Anchoring the clock there
+    would mark a fresh built-in stale on the very first curator run. This
+    resets ``created_at`` to now and stamps ``first_seen_at`` so the clock
+    measures non-use from first curation — matching the no-record first-sight
+    behavior of :func:`seed_record_if_missing` — and the ``first_seen_at``
+    stamp keeps later runs from re-anchoring (the clock then ticks normally
+    and the skill ages out after a full stale window of non-use). No-op when
+    no record exists.
+    """
+    if not skill_name:
+        return
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["created_at"] = _now_iso()
+        rec["first_seen_at"] = _now_iso()
+
+    _mutate(skill_name, _apply)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #79295 — when `curator.prune_builtins: true` is enabled on an existing install, the first curator run marks **all** bundled built-in skills as stale (71 in the report, 65 of them never used), because pre-existing telemetry records anchor the inactivity clock at timestamps from before the curator ever ran.

This restores the design guarantee that *a built-in's inactivity clock starts from the first curator sight* — also when a pure-telemetry record already exists for it.

## Root Cause

`apply_automatic_transitions()` only anchored the clock for built-ins with **no** persisted record (the `_persisted` first-sight check). But telemetry (`tools/skill_usage.py::bump_use` / `_empty_record`) writes a usage record the moment a built-in is seeded — weeks before the first curator run. For those records `_persisted=True`, so the first-sight protection never ran, and with `use_count: 0`, `last_used_at: null`, `created_at` from before the first run, the anchor fell back to the old `created_at` → older than `stale_after_days` → marked stale on the first pass.

## Change

- **`tools/skill_usage.py`**
  - New record field `first_seen_at` — stamped when the curator first anchors a skill's inactivity clock, so the re-anchor happens exactly once.
  - `seed_record_if_missing()` now stamps `first_seen_at` on the no-record path.
  - New `reanchor_clock(skill_name)` helper — resets `created_at` to now and stamps `first_seen_at`.
- **`agent/curator.py`** — `apply_automatic_transitions()` now also defers and re-anchors a bundled built-in whose record is pure telemetry (never used, no activity, not yet seen by the curator). The `first_seen_at` stamp makes this one-shot: from the next run the re-anchored `created_at` ticks normally, so a still-unused built-in still ages out after a full stale window — `prune_builtins` keeps working.

Used the codebase's provenance distinction (`row["provenance"] == "bundled"`, from `provenance()` / `is_bundled()`) rather than inferring from `created_by`, since `created_by` is a curator-management policy marker, not an authorship fact (see `_is_curator_managed_record`).

## Verification

- New tests in `tests/agent/test_curator.py`:
  - `test_prune_builtins_reanchors_preseeded_never_used_builtin` — the issue scenario: pre-seeded old telemetry record is **not** marked stale; `created_at` is re-anchored and `first_seen_at` stamped.
  - `test_prune_builtins_reanchored_builtin_still_ages_out` — re-anchor is one-shot: a later run past `stale_after_days` still marks the unused built-in stale (pruning is not defeated).
  - `test_prune_builtins_used_builtin_still_marked_stale` — a built-in actually used long ago still ages out normally; the re-anchor only shields never-used records.
- `pytest tests/agent/test_curator.py -q` → **26 passed**
- `pytest tests/tools/test_skill_usage.py -q` → **19 passed**

## Closes

Closes #79295
