### PR TITLE
Coerce non-string snapshot fields in model drift guard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -53,6 +53,19 @@ from agent.interrupt_compat import request_hard_interrupt
 logger = logging.getLogger(__name__)
 
 
+def _job_text(raw: Any) -> str:
+    """Return a stripped string from a job field, or ``\"\"`` if non-string.
+
+    Hand-edited ``jobs.json`` can store snapshot/pin fields as non-strings
+    (e.g. ``provider_snapshot: 1``). Calling ``.strip()`` on those raises
+    ``AttributeError`` and aborts the job mid-run. Non-strings are treated
+    as absent so the drift guard stays back-compat quiet.
+    """
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip()
+
+
 def _set_cron_session_title(session_db, session_id, base_title):
     """Robustly title a finished cron session before it is closed.
 
@@ -3403,10 +3416,10 @@ def run_job(
         # unpinned cron jobs there, so the guard is skipped for that axis.
         if cron_model_drift_guard_enabled(_cfg):
             _drift: list[str] = []
-            _provider_snapshot = (job.get("provider_snapshot") or "").strip().lower()
+            _provider_snapshot = _job_text(job.get("provider_snapshot")).lower()
             if (
                 _provider_snapshot
-                and not (job.get("provider") or "").strip()
+                and not _job_text(job.get("provider"))
                 and not _cron_default_provider
             ):
                 _current_provider = str(
@@ -3416,10 +3429,10 @@ def run_job(
                     _drift.append(
                         f"provider '{_provider_snapshot}' -> '{_current_provider}'"
                     )
-            _model_snapshot = (job.get("model_snapshot") or "").strip().lower()
+            _model_snapshot = _job_text(job.get("model_snapshot")).lower()
             if (
                 _model_snapshot
-                and not (job.get("model") or "").strip()
+                and not _job_text(job.get("model"))
                 and not _cron_default_model
             ):
                 _current_model = str(primary_model_for_drift or "").strip().lower()

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -153,6 +153,27 @@ class TestProviderDriftGuard:
         assert error is None
         assert agent_constructed is True
 
+    def test_non_string_snapshot_does_not_crash(self, tmp_path):
+        """Hand-edited jobs.json with a non-string snapshot must not AttributeError."""
+        job = _base_job(provider_snapshot=42, model_snapshot=True)
+        success, output, final_response, error, agent_constructed = \
+            _run_with_current_provider(job, "nous", tmp_path)
+
+        # Treated as absent → back-compat run, no crash.
+        assert success is True
+        assert error is None
+        assert agent_constructed is True
+
+
+def test_job_text_rejects_non_strings():
+    from cron.scheduler import _job_text
+
+    assert _job_text(None) == ""
+    assert _job_text(42) == ""
+    assert _job_text(True) == ""
+    assert _job_text(["openrouter"]) == ""
+    assert _job_text("  openrouter  ") == "openrouter"
+
 
 class TestCreateJobSnapshot:
     """create_job captures provider_snapshot for unpinned agent jobs only."""


### PR DESCRIPTION
## Summary
- Hand-edited `jobs.json` can store `provider_snapshot` / `model_snapshot` as non-strings.
- The #44585 drift guard called `.strip()` on them and raised `AttributeError` mid-run.
- Route those reads through `_job_text()` so non-strings are treated as absent (back-compat quiet), matching how current-provider resolution already uses `str()`.
