### PR TITLE
Reject non-string shell.exec command before approval checks

### DIFF
--- a/tests/tui_gateway/test_shell_exec_command_type.py
+++ b/tests/tui_gateway/test_shell_exec_command_type.py
@@ -1,0 +1,74 @@
+"""shell.exec must reject non-string ``command`` before approval checks.
+
+``params.get("command", "")`` returns None when the key is present with JSON
+null (caught by the empty check). A list/int is truthy, reaches
+``detect_hardline_command``, and raises TypeError — which the ImportError-only
+catch does not swallow.
+"""
+
+from __future__ import annotations
+
+from tui_gateway import server
+
+
+def test_shell_exec_rejects_null_command():
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "shell.exec",
+            "params": {"command": None},
+        }
+    )
+    assert resp["error"]["code"] == 4004
+
+
+def test_shell_exec_rejects_list_command():
+    resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "shell.exec",
+            "params": {"command": ["echo", "hi"]},
+        }
+    )
+    assert resp["error"]["code"] == 4004
+    assert "string" in resp["error"]["message"].lower()
+
+
+def test_shell_exec_rejects_empty_string():
+    resp = server.handle_request(
+        {
+            "id": "3",
+            "method": "shell.exec",
+            "params": {"command": "   "},
+        }
+    )
+    assert resp["error"]["code"] == 4004
+    assert "empty" in resp["error"]["message"].lower()
+
+
+def test_cli_exec_tolerates_non_int_timeout(monkeypatch):
+    """Malformed timeout must not raise before the subprocess call."""
+    calls = {}
+
+    def fake_run(*args, **kwargs):
+        calls["timeout"] = kwargs.get("timeout")
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+    monkeypatch.setattr(server, "_cli_exec_blocked", lambda _argv: None)
+
+    resp = server.handle_request(
+        {
+            "id": "4",
+            "method": "cli.exec",
+            "params": {"argv": ["version"], "timeout": "nope"},
+        }
+    )
+    assert "error" not in resp, resp
+    assert calls["timeout"] == 240

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -382,6 +382,12 @@ def _(rid, params: dict) -> dict:
         # parent, this spawn otherwise flashes a console (#56747).
         from hermes_cli._subprocess_compat import windows_hide_flags
 
+        try:
+            timeout = int(params.get("timeout", 240) or 240)
+        except (TypeError, ValueError):
+            timeout = 240
+        timeout = max(1, min(timeout, 600))
+
         r = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
@@ -390,7 +396,7 @@ def _(rid, params: dict) -> dict:
             # the gateway thread on locale-mismatched Windows. See #53137.
             encoding="utf-8",
             errors="replace",
-            timeout=min(int(params.get("timeout", 240)), 600),
+            timeout=timeout,
             cwd=os.getcwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
@@ -1866,7 +1872,13 @@ def _(rid, params: dict) -> dict:
 
 @method("shell.exec")
 def _(rid, params: dict) -> dict:
-    cmd = params.get("command", "")
+    # Present-but-null yields None from get(); a list/int would reach
+    # detect_hardline_command and raise TypeError — the ImportError-only
+    # catch below would not swallow it. Require a real string.
+    raw = params.get("command", "")
+    if not isinstance(raw, str):
+        return _err(rid, 4004, "command must be a string")
+    cmd = raw.strip()
     if not cmd:
         return _err(rid, 4004, "empty command")
     try:


### PR DESCRIPTION
## Summary
- A list/int `command` is truthy, reaches `detect_hardline_command`, and raises `TypeError` — which the `ImportError`-only catch does not swallow.
- Require a real string (and treat blank/whitespace as empty).
- Also harden `cli.exec` timeout parsing so malformed values fall back to 240s instead of failing the whole call.

