### PR TITLE
fix(discord): add isolated inline fallback for auto-thread failures

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6597,6 +6597,7 @@ class BasePlatformAdapter(ABC):
         role_authorized: bool = False,
         auto_thread_created: bool = False,
         auto_thread_initial_name: Optional[str] = None,
+        prospective_thread_id: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform.
 
@@ -6660,6 +6661,7 @@ class BasePlatformAdapter(ABC):
             role_authorized=role_authorized,
             auto_thread_created=auto_thread_created,
             auto_thread_initial_name=auto_thread_initial_name,
+            prospective_thread_id=str(prospective_thread_id) if prospective_thread_id else None,
         )
         # In-process transport provenance is deliberately not serialized by
         # SessionSource.to_dict(). The live receiving adapter is authoritative

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1875,7 +1875,7 @@ class SessionStore:
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=legacy_key is None and not source.prospective_thread_id,
             raise_on_lookup_error=raise_on_lookup_error,
         )
         migrated_legacy = False
@@ -1937,7 +1937,7 @@ class SessionStore:
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=legacy_key is None and not source.prospective_thread_id,
         )
         migrated_legacy = False
         if (

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -386,6 +386,7 @@ _GATE_ENV_KEYS = (
     "DISCORD_IGNORED_CHANNELS",
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_AUTO_THREAD_FAILURE_MODE",
     "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
     "DISCORD_ALLOW_ALL_USERS",
     "DISCORD_ALLOW_BOTS",
@@ -6229,6 +6230,14 @@ class DiscordAdapter(BasePlatformAdapter):
         """This adapter's DISCORD_NO_THREAD_CHANNELS list (per-profile)."""
         return self._gate_csv_set(self._gate_raw("no_thread_channels", "DISCORD_NO_THREAD_CHANNELS"))
 
+    def _get_auto_thread_failure_mode(self) -> str:
+        """Return this adapter's safe normalized auto-thread failure policy."""
+        configured = self._gate_raw(
+            "auto_thread_failure_mode", "DISCORD_AUTO_THREAD_FAILURE_MODE"
+        )
+        mode = str(configured or "error").strip().lower()
+        return "inline" if mode == "inline" else "error"
+
     def _get_allowed_users(self) -> set:
         """This adapter's DISCORD_ALLOWED_USERS entries (per-profile, cleaned)."""
         raw = self._gate_raw("allow_from", "DISCORD_ALLOWED_USERS")
@@ -7641,6 +7650,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.auto_thread_failure_mode: error (default) or isolated inline fallback
 
         thread_id = None
         parent_channel_id = None
@@ -7725,6 +7735,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
+        auto_thread_failed = False
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
@@ -7749,25 +7760,34 @@ class DiscordAdapter(BasePlatformAdapter):
                     # Fixes #51057.
                     self._dedup.is_duplicate(str(thread.id))
                 else:
-                    # Auto-threading is the configured routing target for this
-                    # message; if it fails we must NOT silently fall back to an
-                    # inline parent-channel reply (#20243). That breaks
-                    # thread-first Discord workflows by dumping a new task into
-                    # a shared channel. Surface a short visible error so the
-                    # user can retry once Discord recovers, and skip agent
-                    # invocation for this message.
-                    try:
-                        await message.channel.send(
-                            "⚠️ Hermes could not create a Discord thread for "
-                            "this message, so the request was not processed. Please retry."
-                        )
-                    except Exception as notify_error:
-                        logger.warning(
-                            "[%s] Failed to notify user of auto-thread failure: %s",
-                            self.name,
-                            notify_error,
-                        )
-                    return False
+                    if self._get_auto_thread_failure_mode() == "error":
+                        # Auto-threading is the configured routing target for
+                        # this message. Fail closed by default so thread-first
+                        # workflows never spill a request into a shared channel.
+                        try:
+                            await message.channel.send(
+                                "\u26a0\ufe0f Hermes could not create a Discord thread for "
+                                "this message, so the request was not processed. Please retry."
+                            )
+                        except Exception as notify_error:
+                            logger.warning(
+                                "[%s] Failed to notify user of auto-thread failure: %s",
+                                self.name,
+                                notify_error,
+                            )
+                        return False
+
+                    # Explicit inline mode preserves parent-channel delivery,
+                    # while prospective_thread_id gives this failed attempt a
+                    # fresh isolated session instead of reusing parent history.
+                    logger.warning(
+                        "[%s] Discord auto-thread creation failed for message %s "
+                        "in channel %s; continuing in the parent channel",
+                        self.name,
+                        getattr(message, "id", "unknown"),
+                        getattr(message.channel, "id", "unknown"),
+                    )
+                    auto_thread_failed = True
 
         referenced_attachments = []
         reference = getattr(message, "reference", None)
@@ -7847,6 +7867,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 getattr(auto_threaded_channel, "_hermes_auto_thread_initial_name", None)
                 or self._derive_auto_thread_name(message.content or "")
             ) if auto_threaded_channel is not None else None,
+            prospective_thread_id=str(message.id) if auto_thread_failed else None,
         )
 
         # Build media URLs -- download image attachments to local cache so the
@@ -9879,8 +9900,8 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     The DiscordAdapter reads its runtime configuration via ``os.getenv()``
     throughout the connect / handle code paths (``DISCORD_ALLOWED_USERS``,
     ``DISCORD_REQUIRE_MENTION``, ``DISCORD_FREE_RESPONSE_CHANNELS``,
-    ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
-    ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
+    ``DISCORD_AUTO_THREAD``, ``DISCORD_AUTO_THREAD_FAILURE_MODE``,
+    ``DISCORD_REACTIONS``, ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
     ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
     ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``,
@@ -9960,6 +9981,22 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+    auto_thread_failure_mode_cfg = (
+        discord_cfg["auto_thread_failure_mode"]
+        if "auto_thread_failure_mode" in discord_cfg
+        else platform_extra_cfg.get("auto_thread_failure_mode")
+    )
+    if auto_thread_failure_mode_cfg is not None:
+        seeded_extra["auto_thread_failure_mode"] = str(
+            auto_thread_failure_mode_cfg
+        ).lower()
+        if (
+            not _skip_env_bridge
+            and not os.getenv("DISCORD_AUTO_THREAD_FAILURE_MODE")
+        ):
+            os.environ["DISCORD_AUTO_THREAD_FAILURE_MODE"] = seeded_extra[
+                "auto_thread_failure_mode"
+            ]
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     backfill_cfg = discord_cfg.get("missed_message_backfill")
@@ -10091,7 +10128,7 @@ def register(ctx) -> None:
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of ``config.yaml``
         # ``discord:`` keys (require_mention, free_response_channels,
-        # auto_thread, reactions, ignored_channels, allowed_channels,
+        # auto_thread, auto_thread_failure_mode, reactions, ignored_channels, allowed_channels,
         # no_thread_channels, allow_mentions.*, reply_to_mode,
         # thread_require_mention) into ``DISCORD_*`` env vars that the
         # adapter reads via ``os.getenv()``.  Replaces the hardcoded block

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6817,6 +6817,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 return thread
             except Exception as direct_error:
                 last_direct_error = direct_error
+                seed_msg = None
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -6833,6 +6834,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     return thread
                 except Exception as fallback_error:
                     last_fallback_error = fallback_error
+                    # The seed message announces "Thread created by Hermes"
+                    # *before* create_thread() is confirmed. When the thread
+                    # call then fails (commonly a Discord 429 on thread
+                    # creation), the announcement is left orphaned in the
+                    # channel with no thread behind it (#52422). The retry loop
+                    # runs this handler once per attempt, so each attempt's own
+                    # seed is cleaned up rather than only the last one.
+                    if seed_msg is not None:
+                        try:
+                            await seed_msg.delete()
+                        except Exception as cleanup_error:
+                            logger.debug(
+                                "[%s] Could not delete orphaned auto-thread seed message: %s",
+                                self.name,
+                                cleanup_error,
+                            )
                     if attempt == 0:
                         # Brief backoff before the second attempt — most failures
                         # in this path are transient connect errors that recover

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -5,17 +5,21 @@ Covers the fix for slash commands not being recognized when sent via
 """
 
 import asyncio
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
+from gateway.session import build_session_key
 from tests.e2e.conftest import (
     BOT_USER_ID,
+    CHANNEL_ID,
     E2E_MESSAGE_SETTLE_DELAY,
     get_response_text,
     make_discord_message,
     make_fake_dm_channel,
+    make_fake_text_channel,
     make_fake_thread,
 )
 
@@ -105,6 +109,112 @@ class TestAutoThreadingPreservesCommand:
         response = get_response_text(discord_adapter)
         assert response is not None
         assert "/new" in response
+
+    async def test_successful_auto_thread_routes_event_to_new_thread(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        """Successful auto-threading should build the event as a thread turn."""
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+        monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+
+        parent = make_fake_text_channel(channel_id=CHANNEL_ID, name="support")
+        fake_thread = make_fake_thread(thread_id=90002, name="help", parent=parent)
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> help me",
+            channel=parent,
+            mentions=[bot_user],
+        )
+        msg.create_thread = AsyncMock(return_value=fake_thread)
+
+        handled = await discord_adapter._handle_message(msg)
+
+        assert handled is True
+        msg.create_thread.assert_awaited_once()
+        discord_adapter.handle_message.assert_awaited_once()
+        event = discord_adapter.handle_message.await_args.args[0]
+        assert event.source.chat_id == "90002"
+        assert event.source.chat_type == "thread"
+        assert event.source.thread_id == "90002"
+        assert event.source.prospective_thread_id is None
+        assert event.source.parent_chat_id == str(CHANNEL_ID)
+        assert event.source.auto_thread_created is True
+        assert event.source.auto_thread_initial_name == "help me"
+
+    async def test_failed_auto_thread_continues_in_parent_without_failure_notice(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        """If auto-threading fails, the original request should still dispatch in the parent channel."""
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+        monkeypatch.setenv("DISCORD_AUTO_THREAD_FAILURE_MODE", "inline")
+        monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+
+        parent = make_fake_text_channel(channel_id=CHANNEL_ID, name="support")
+        parent.send = AsyncMock(side_effect=RuntimeError("seed message failed"))
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> help me",
+            channel=parent,
+            mentions=[bot_user],
+        )
+        msg.create_thread = AsyncMock(side_effect=RuntimeError("thread create failed"))
+
+        handled = await discord_adapter._handle_message(msg)
+
+        assert handled is True
+        assert msg.create_thread.await_count == 2
+        assert parent.send.await_count == 2
+        assert all(
+            "Hermes could not create a Discord thread" not in call.args[0]
+            for call in parent.send.await_args_list
+        )
+        discord_adapter.handle_message.assert_awaited_once()
+        event = discord_adapter.handle_message.await_args.args[0]
+        assert event.text == "help me"
+        assert event.source.chat_id == str(CHANNEL_ID)
+        assert event.source.chat_type == "group"
+        assert event.source.thread_id is None
+        assert event.source.parent_chat_id is None
+        assert event.source.prospective_thread_id == str(msg.id)
+        assert build_session_key(event.source) != build_session_key(
+            replace(event.source, prospective_thread_id=None)
+        )
+
+    async def test_failed_auto_thread_source_metadata_has_no_auto_thread(
+        self, discord_adapter, bot_user, monkeypatch
+    ):
+        """Failure fallback metadata must reflect that no thread was auto-created."""
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+        monkeypatch.setenv("DISCORD_AUTO_THREAD_FAILURE_MODE", "inline")
+        monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+        discord_adapter._text_batch_delay_seconds = 0
+        discord_adapter.handle_message = AsyncMock()
+
+        parent = make_fake_text_channel(channel_id=CHANNEL_ID, name="support")
+        parent.send = AsyncMock(side_effect=RuntimeError("seed message failed"))
+        msg = make_discord_message(
+            content=f"<@{BOT_USER_ID}> summarize this",
+            channel=parent,
+            mentions=[bot_user],
+        )
+        msg.create_thread = AsyncMock(side_effect=RuntimeError("thread create failed"))
+
+        handled = await discord_adapter._handle_message(msg)
+
+        assert handled is True
+        discord_adapter.handle_message.assert_awaited_once()
+        source = discord_adapter.handle_message.await_args.args[0].source
+        assert source.auto_thread_created is False
+        assert source.auto_thread_initial_name is None
+        assert source.prospective_thread_id == str(msg.id)
+        metadata = source.to_dict()
+        assert "auto_thread_created" not in metadata
+        assert "auto_thread_initial_name" not in metadata
+        assert metadata["thread_id"] is None
+        assert "parent_chat_id" not in metadata
+        assert metadata["prospective_thread_id"] == str(msg.id)
 
 
 class TestRepliedToMediaDispatch:

--- a/tests/gateway/test_discord_auto_thread_orphan_seed.py
+++ b/tests/gateway/test_discord_auto_thread_orphan_seed.py
@@ -1,0 +1,208 @@
+"""Tests for Discord auto-thread orphaned-seed-message cleanup.
+
+When auto-threading is enabled, ``_auto_create_thread()`` first tries
+``message.create_thread()``.  If that fails (commonly a Discord 429
+rate-limit on thread creation), it falls back to posting a seed
+announcement message ("🧵 Thread created by Hermes: ...") and creating
+the thread *from that message*.
+
+The bug: the seed announcement is posted **before** the fallback
+``create_thread()`` is confirmed to succeed.  When the fallback also
+fails (e.g. the rate-limit is still in effect), the announcement is left
+orphaned in the channel — so users see a "Thread created by Hermes"
+message with no thread behind it (#52422).
+
+Fix: on fallback failure, delete the orphaned seed message so the
+announcement only ever survives when a real thread exists.
+
+Retry-loop specific: ``_auto_create_thread`` retries the whole
+direct+fallback sequence twice (#20243), and **each attempt posts its own
+seed message**.  A cleanup that only removed the last seed would still
+leave one orphan behind, which is why the live 2026-08-03 failure showed
+*two* "Thread created by Hermes" notices.  The cleanup therefore lives in
+the per-attempt fallback handler, and the tests below assert every seed
+is deleted, not merely one.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+class _RateLimited(Exception):
+    """Stand-in for discord.HTTPException 429."""
+
+
+class _SeedMessage:
+    """Fake seed message returned by channel.send()."""
+
+    def __init__(self, create_thread_succeeds: bool, thread=None,
+                 delete_raises: bool = False):
+        self._create_thread_succeeds = create_thread_succeeds
+        self._thread = thread
+        self._delete_raises = delete_raises
+        self.deleted = False
+        self.create_thread = AsyncMock(side_effect=self._create_thread)
+        self.delete = AsyncMock(side_effect=self._delete)
+
+    async def _create_thread(self, *args, **kwargs):
+        if self._create_thread_succeeds:
+            return self._thread
+        raise _RateLimited("Too many requests. Retry in 222.97 seconds.")
+
+    async def _delete(self, *args, **kwargs):
+        if self._delete_raises:
+            raise _RateLimited("Too many requests. Retry in 5.00 seconds.")
+        self.deleted = True
+
+
+class _Channel:
+    """Channel whose send() hands out a distinct seed message per call.
+
+    Distinct objects matter: the retry loop posts one seed per attempt, so
+    reusing a single fake would let a fix that deletes only the final seed
+    pass while still orphaning the first one in production.
+    """
+
+    def __init__(self, *seed_messages):
+        self.id = 100
+        self.name = "general"
+        self.guild = SimpleNamespace(name="Test Server", id=1)
+        self.seeds = list(seed_messages)
+        self.send = AsyncMock(side_effect=list(seed_messages))
+
+
+class _Thread:
+    def __init__(self, thread_id=55555, parent=None):
+        self.id = thread_id
+        self.name = "thread"
+        self.parent = parent
+
+
+def _make_message(*, channel, content="hello bot", direct_create_succeeds=False,
+                  thread=None):
+    async def _create_thread(*args, **kwargs):
+        if direct_create_succeeds:
+            return thread
+        raise _RateLimited("Too many requests. Retry in 278.53 seconds.")
+
+    return SimpleNamespace(
+        id=42,
+        content=content,
+        channel=channel,
+        author=SimpleNamespace(id=7, display_name="Alice", name="Alice", bot=False),
+        created_at=datetime.now(timezone.utc),
+        type=discord_platform.discord.MessageType.default,
+        create_thread=AsyncMock(side_effect=_create_thread),
+    )
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    for var in ("DISCORD_AUTO_THREAD", "DISCORD_NO_THREAD_CHANNELS"):
+        monkeypatch.delenv(var, raising=False)
+    config = PlatformConfig(enabled=True, token="***")
+    a = DiscordAdapter(config)
+    a._client = SimpleNamespace(user=SimpleNamespace(id=999, bot=True))
+    return a
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_backoff(monkeypatch):
+    """Skip the 0.75s inter-attempt backoff so the suite stays fast."""
+    async def _instant(_seconds):
+        return None
+
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", _instant)
+
+
+class TestAutoThreadOrphanSeed:
+    @pytest.mark.asyncio
+    async def test_every_attempts_orphaned_seed_is_deleted(self, adapter):
+        """Both attempts 429 → two seeds posted, and BOTH deleted."""
+        first, second = (
+            _SeedMessage(create_thread_succeeds=False),
+            _SeedMessage(create_thread_succeeds=False),
+        )
+        channel = _Channel(first, second)
+        message = _make_message(channel=channel, direct_create_succeeds=False)
+
+        result = await adapter._auto_create_thread(message)
+
+        assert result is None, "must return None when both create paths fail"
+        assert channel.send.await_count == 2, (
+            "the retry loop posts one seed announcement per attempt"
+        )
+        assert first.deleted is True and second.deleted is True, (
+            "every orphaned seed announcement must be deleted — cleaning up "
+            "only the last one still leaves a 'Thread created' message with "
+            "no thread behind it (the live #52422 symptom was TWO notices)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_success_keeps_seed(self, adapter):
+        """Direct create 429s but fallback create succeeds → seed kept."""
+        thread = _Thread()
+        seed = _SeedMessage(create_thread_succeeds=True, thread=thread)
+        channel = _Channel(seed)
+        message = _make_message(channel=channel, direct_create_succeeds=False)
+
+        result = await adapter._auto_create_thread(message)
+
+        assert result is thread
+        channel.send.assert_awaited_once()
+        assert seed.deleted is False, "seed must survive when a real thread was created"
+
+    @pytest.mark.asyncio
+    async def test_direct_success_posts_no_seed(self, adapter):
+        """Direct create succeeds → no seed announcement, no fallback."""
+        thread = _Thread()
+        seed = _SeedMessage(create_thread_succeeds=True, thread=thread)
+        channel = _Channel(seed)
+        message = _make_message(
+            channel=channel, direct_create_succeeds=True, thread=thread
+        )
+
+        result = await adapter._auto_create_thread(message)
+
+        assert result is thread
+        channel.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_seed_send_failure_does_not_mask_the_original_error(self, adapter):
+        """If posting the seed itself fails there is nothing to delete.
+
+        Guards the ``seed_msg = None`` initialisation: without it the cleanup
+        branch would raise UnboundLocalError and replace a clean ``None``
+        return with a crash inside the failure path.
+        """
+        channel = _Channel()
+        channel.send = AsyncMock(side_effect=_RateLimited("cannot post"))
+        message = _make_message(channel=channel, direct_create_succeeds=False)
+
+        result = await adapter._auto_create_thread(message)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_delete_failure_is_swallowed(self, adapter):
+        """A failing cleanup must not mask the underlying thread failure."""
+        first, second = (
+            _SeedMessage(create_thread_succeeds=False, delete_raises=True),
+            _SeedMessage(create_thread_succeeds=False, delete_raises=True),
+        )
+        channel = _Channel(first, second)
+        message = _make_message(channel=channel, direct_create_succeeds=False)
+
+        result = await adapter._auto_create_thread(message)
+
+        assert result is None
+        assert first.delete.await_count == 1 and second.delete.await_count == 1
+        assert first.deleted is False and second.deleted is False

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -7,7 +7,8 @@ import sys
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.session import build_session_key
 
 
 def _ensure_discord_mock():
@@ -128,8 +129,7 @@ async def test_non_ignored_channel_processes_normally(adapter, monkeypatch):
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
     # Stub auto-thread creation so this test focuses on ignored-channel
-    # routing only — auto-thread failures now correctly skip agent invocation
-    # (#20243), which would otherwise mask the assertion below.
+    # routing only.
     adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
 
     message = make_message(channel=FakeTextChannel(channel_id=700), content="hello")
@@ -146,8 +146,7 @@ async def test_ignored_channels_empty_string_ignores_nothing(adapter, monkeypatc
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
     # Stub auto-thread creation so this test focuses on ignored-channel
-    # routing only — auto-thread failures now correctly skip agent invocation
-    # (#20243), which would otherwise mask the assertion below.
+    # routing only.
     adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
 
     message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
@@ -177,23 +176,52 @@ async def test_no_thread_channel_skips_auto_thread(adapter, monkeypatch):
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.source.chat_type == "group"
+    assert event.source.prospective_thread_id is None
 
 
-# ── auto-thread failure must not silently fall back to inline (#20243) ──
+# ── auto-thread failure policy (#20243) ──────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_auto_thread_failure_skips_agent_and_notifies_user(adapter, monkeypatch):
-    """Auto-thread creation failure must not trigger an inline parent-channel reply.
-
-    Before #20243, ``effective_channel = auto_threaded_channel or message.channel``
-    silently routed the response back to the parent channel when thread creation
-    failed, breaking thread-first Discord workflows. The fix surfaces a short
-    visible error to the parent channel and skips agent invocation entirely so
-    the user can retry.
-    """
+@pytest.mark.parametrize("failure_mode", [None, "error", "unexpected"])
+async def test_auto_thread_failure_defaults_safely_to_error(
+    adapter, monkeypatch, failure_mode
+):
+    """Default, explicit error, and unknown modes all fail closed."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    if failure_mode is None:
+        monkeypatch.delenv("DISCORD_AUTO_THREAD_FAILURE_MODE", raising=False)
+    else:
+        monkeypatch.setenv("DISCORD_AUTO_THREAD_FAILURE_MODE", failure_mode)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=None)
+
+    channel = FakeTextChannel(channel_id=800)
+    channel.send = AsyncMock()
+    message = make_message(channel=channel, content="hello")
+
+    handled = await adapter._handle_message(message)
+
+    assert handled is False
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_not_awaited()
+    channel.send.assert_awaited_once()
+    assert "request was not processed" in channel.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_failure_inline_dispatches_parent_with_prospective_scope(
+    adapter, monkeypatch
+):
+    """Inline mode dispatches once in the parent channel,
+    with the triggering message id used only as a session discriminator."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_FAILURE_MODE", "inline")
     monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
     monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
@@ -206,14 +234,21 @@ async def test_auto_thread_failure_skips_agent_and_notifies_user(adapter, monkey
     await adapter._handle_message(message)
 
     adapter._auto_create_thread.assert_awaited_once()
-    # Agent must NOT be invoked when the routing target failed.
-    adapter.handle_message.assert_not_awaited()
-    # User gets a visible explanation in the parent channel instead of a silent
-    # inline reply.
-    channel.send.assert_awaited_once()
-    sent_text = channel.send.await_args.args[0]
-    assert "could not create" in sent_text.lower()
-    assert "thread" in sent_text.lower()
+    adapter.handle_message.assert_awaited_once()
+    channel.send.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "800"
+    assert event.source.chat_type == "group"
+    assert event.source.thread_id is None
+    assert event.source.parent_chat_id is None
+    assert event.source.prospective_thread_id == "123"
+    ordinary_parent = SimpleNamespace(
+        **{
+            **event.source.__dict__,
+            "prospective_thread_id": None,
+        }
+    )
+    assert build_session_key(event.source) != build_session_key(ordinary_parent)
 
 
 # ── config.py bridging ───────────────────────────────────────────────
@@ -240,3 +275,25 @@ def test_config_bridges_ignored_channels(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_IGNORED_CHANNELS") == "111,222"
 
 
+def test_config_bridges_auto_thread_failure_mode(monkeypatch, tmp_path):
+    """discord.auto_thread_failure_mode bridges to its environment variable."""
+    import yaml
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        yaml.dump({"discord": {"auto_thread_failure_mode": "inline"}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_FAILURE_MODE", "")
+
+    from gateway.config import load_gateway_config
+
+    config = load_gateway_config()
+
+    import os
+
+    assert os.getenv("DISCORD_AUTO_THREAD_FAILURE_MODE") == "inline"
+    assert (
+        config.platforms[Platform.DISCORD].extra["auto_thread_failure_mode"]
+        == "inline"
+    )

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -615,6 +615,60 @@ class TestSlackWorkspaceSessionIsolation:
         )
 
 
+class TestProspectiveThreadRecovery:
+    def test_prospective_thread_recovery_never_uses_parent_peer_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        config = GatewayConfig()
+        parent_source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            chat_type="group",
+            user_id="user-1",
+        )
+        prospective_source = replace(
+            parent_source,
+            prospective_thread_id="msg-123",
+        )
+        parent_key = build_session_key(parent_source)
+        prospective_key = build_session_key(prospective_source)
+        assert prospective_key != parent_key
+
+        db.create_session(
+            "old-parent-session",
+            "discord",
+            user_id="user-1",
+            session_key=parent_key,
+            chat_id="channel-1",
+            chat_type="group",
+            thread_id=None,
+        )
+        db.append_message("old-parent-session", "user", "old parent turn")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with patch("hermes_state.SessionDB", return_value=db):
+            first_store = SessionStore(
+                sessions_dir=tmp_path / "routing-a",
+                config=config,
+            )
+            first_entry = first_store.get_or_create_session(prospective_source)
+
+        assert first_entry.session_id != "old-parent-session"
+        assert first_entry.session_key == prospective_key
+        db.append_message(first_entry.session_id, "user", "prospective turn")
+
+        with patch("hermes_state.SessionDB", return_value=db):
+            restarted = SessionStore(
+                sessions_dir=tmp_path / "routing-b",
+                config=config,
+            )
+            recovered = restarted.get_or_create_session(prospective_source)
+
+        assert recovered.session_id == first_entry.session_id
+        assert recovered.session_key == prospective_key
+
+
 class TestWhatsAppSessionKeyConsistency:
     """Regression: WhatsApp session keys must collapse JID/LID aliases to a
     single stable identity for both DM chat_ids and group participant_ids."""

--- a/tests/plugins/platforms/test_discord_gate_isolation.py
+++ b/tests/plugins/platforms/test_discord_gate_isolation.py
@@ -36,6 +36,7 @@ GATE_VARS = [
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
     "DISCORD_ALLOW_BOTS",
+    "DISCORD_AUTO_THREAD_FAILURE_MODE",
 ]
 
 
@@ -113,6 +114,14 @@ class TestTwoAdapterChannelIsolation:
         _snapshot(b, {"DISCORD_IGNORED_CHANNELS": "322"})
         assert a._get_ignored_channels() == {"311"}
         assert b._get_ignored_channels() == {"322"}
+
+    def test_auto_thread_failure_mode_reads_direct_extra(self):
+        """An adapter can resolve its failure policy from per-profile config."""
+        inline = _adapter({"auto_thread_failure_mode": "inline"})
+        error = _adapter({"auto_thread_failure_mode": "error"})
+
+        assert inline._get_auto_thread_failure_mode() == "inline"
+        assert error._get_auto_thread_failure_mode() == "error"
 
 
 class TestTwoAdapterUserRoleIsolation:
@@ -372,6 +381,42 @@ class TestYamlBridgeSeeding:
 
         assert a._get_allowed_channels() == {"111"}
         assert b._get_allowed_channels() == {"222"}
+
+    def test_auto_thread_failure_mode_isolated_between_multiplex_profiles(
+        self, monkeypatch
+    ):
+        """Profile A's inline policy must not override profile B's error policy."""
+        from agent import secret_scope
+        from plugins.platforms.discord.adapter import _apply_yaml_config
+
+        # Profile A loads first through the legacy unscoped path and bridges its
+        # value into process env.
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        seeded_a = _apply_yaml_config({}, {"auto_thread_failure_mode": "inline"})
+        assert os.environ["DISCORD_AUTO_THREAD_FAILURE_MODE"] == "inline"
+
+        # Profile B loads in an authoritative multiplex scope. Its policy must
+        # be carried by PlatformConfig.extra without mutating process env.
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            seeded_b = _apply_yaml_config(
+                {}, {"auto_thread_failure_mode": "error"}
+            )
+            b = _adapter(seeded_b)
+            b._snapshot_gate_env()
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert os.environ["DISCORD_AUTO_THREAD_FAILURE_MODE"] == "inline"
+        assert seeded_b["auto_thread_failure_mode"] == "error"
+        assert b._get_auto_thread_failure_mode() == "error"
+
+        # The first profile retains its own explicit inline behavior.
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        a = _adapter(seeded_a)
+        a._snapshot_gate_env()
+        assert a._get_auto_thread_failure_mode() == "inline"
 
 
 class TestTelegramGateIsolation:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -328,6 +328,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
+| `DISCORD_AUTO_THREAD_FAILURE_MODE` | Auto-thread creation failure behavior: `error` (safe default; warn and do not process) or `inline` (continue in the parent channel with a fresh isolated session). Unknown values use `error`. |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | When `true`, accept attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached and surfaced to the agent as a local path so it can inspect them via `terminal` / `read_file` / `ffprobe`. Default `false`. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | Maximum bytes per attachment the gateway will cache. Default `33554432` (32 MiB). Set to `0` for no cap (attachments are held in memory while being written). |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2131,11 +2131,13 @@ discord:
   require_mention: true          # Require @mention to respond in server channels
   free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
   auto_thread: true              # Auto-create threads on @mention in channels
+  auto_thread_failure_mode: error # error (safe default) or isolated inline fallback
 ```
 
 - `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
 - `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
+- `auto_thread_failure_mode` — `error` (default) sends a retry warning and does not process the request if thread creation fails. `inline` continues in the parent channel with a fresh isolated session. Unknown values use `error`.
 
 ## Security
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -301,6 +301,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
+| `DISCORD_AUTO_THREAD_FAILURE_MODE` | No | `"error"` | Behavior when Discord cannot create an auto-thread: `"error"` sends a retry warning and does not process the request; `"inline"` processes it in the parent channel with a fresh isolated session. Unknown values safely use `"error"`. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
@@ -336,6 +337,7 @@ discord:
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
+  auto_thread_failure_mode: error  # error (safe default) or isolated inline fallback
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
@@ -409,6 +411,19 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
 Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+
+#### `discord.auto_thread_failure_mode`
+
+**Type:** string (`error` or `inline`) — **Default:** `error`
+
+Controls what happens when `auto_thread` is enabled but Discord thread creation fails. The safe default, `error`, sends the existing “request was not processed” warning and stops before invoking the agent, preserving thread-first workflows. Set it to `inline` to continue processing in the parent channel instead. Each inline fallback uses the triggering message ID as a prospective thread scope, so it starts a fresh isolated session rather than reusing stale parent-channel history. No thread-failure warning is sent in `inline` mode. Unknown values are normalized to `error`.
+
+```yaml
+discord:
+  auto_thread_failure_mode: inline
+```
+
+The setting has no effect on successful auto-thread creation, existing threads or DMs, or channels that bypass threading through `free_response_channels` or `no_thread_channels`.
 
 #### `discord.reactions`
 


### PR DESCRIPTION
## Summary

- add `discord.auto_thread_failure_mode` with `error` as the backwards-compatible default and `inline` as an opt-in fallback
- keep failed-thread replies in the parent channel while isolating them in a fresh prospective session
- prevent prospective session recovery from adopting an unrelated parent-channel session
- keep failure-mode configuration isolated between multiplexed profiles
- delete the orphaned "Thread created by Hermes" seed message when thread creation fails (separate commit)

## Why

Fail-closed behaviour is correct for thread-first installations, but some deployments must not drop operational commands when Discord cannot create a thread. A plain inline fallback would reuse the long-lived parent-channel session, so the fallback needs a distinct session scope even though delivery stays in the parent channel.

## Behaviour

- `error` (default): warn and do not process — current behaviour, unchanged
- `inline`: process in the parent channel with `prospective_thread_id=message.id`
- unknown values normalise to `error`
- successful threads, DMs, and channels bypassing threading via `free_response_channels` / `no_thread_channels` are unaffected

## Second commit: orphaned seed cleanup

`_auto_create_thread` posts the seed announcement *before* the fallback `create_thread()` is confirmed. When that also fails, the announcement is left with no thread behind it. Because the retry loop added for #20243 runs the direct+fallback sequence twice, a persistent failure leaves **two** orphaned notices, not one. The cleanup therefore lives in the per-attempt fallback handler so every attempt's seed is removed; cleanup errors are logged at debug so they cannot mask the underlying failure.

This is the same bug targeted by `fix/discord-auto-thread-orphaned-seed`, re-derived against current `main` — that branch predates the retry loop and cleans up only a single seed.

## Test plan

Run against this branch:

```
python -m pytest -o addopts= -m "not integration" -q \
  tests/e2e/test_discord_adapter.py \
  tests/gateway/test_discord_channel_controls.py \
  tests/gateway/test_session.py \
  tests/gateway/test_config.py \
  tests/plugins/platforms/test_discord_gate_isolation.py \
  tests/gateway/test_discord_double_dispatch.py \
  tests/gateway/test_discord_free_response.py \
  tests/gateway/test_discord_auto_thread_orphan_seed.py \
  tests/gateway/test_*multiplex*.py
```

→ `250 passed`.

`tests/gateway/test_discord_slash_commands.py` passes on its own (`13 passed`) but shows 4 failures when collected alongside a large set of sibling Discord suites. That ordering sensitivity reproduces on unmodified `main` with this branch's changes reverted, so it is pre-existing and unrelated to this change.

Both new behaviours were checked red/green — reverting only the runtime files makes the new tests fail, and restoring them makes them pass.

Related to #20243 and #52422.