### PR TITLE
fix(gateway): preserve compressed session in queued follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7660,16 +7660,83 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _q_state.conversation.queued_events = kept
         return removed
 
-    def _goal_still_active_for_session(self, session_id: str) -> bool:
-        """Best-effort fresh DB check before running a queued continuation."""
+    def _goal_still_active_for_session(
+        self,
+        session_id: str,
+        *,
+        previous_session_id: Optional[str] = None,
+    ) -> Optional[bool]:
+        """Return active/inactive, or ``None`` when goal state is unreadable.
+
+        Compression migrates active goals to the continuation session. If that
+        migration did not complete, retry its atomic move here before deciding
+        whether an already-queued continuation is stale. Never run the
+        continuation against the closed parent session.
+        """
         if not session_id:
             return False
         try:
-            from hermes_cli.goals import GoalManager
-            return GoalManager(session_id=session_id).is_active()
+            from hermes_cli.goals import load_goal, migrate_goal_to_session
+
+            state = load_goal(session_id, raise_on_error=True)
+            if state is not None:
+                return state.status == "active"
+            if previous_session_id and previous_session_id != session_id:
+                previous_state = load_goal(
+                    previous_session_id,
+                    raise_on_error=True,
+                )
+                if previous_state is not None and previous_state.status == "active":
+                    migrate_goal_to_session(
+                        previous_session_id,
+                        session_id,
+                        reason="queued-followup",
+                    )
+                    state = load_goal(session_id, raise_on_error=True)
+                    if state is not None:
+                        return state.status == "active"
+                    previous_state = load_goal(
+                        previous_session_id,
+                        raise_on_error=True,
+                    )
+                    if previous_state is not None and previous_state.status == "active":
+                        return None
+            return False
         except Exception as exc:
             logger.debug("goal continuation: active-state recheck failed: %s", exc)
-            return False
+            return None
+
+    def _defer_goal_continuation_recheck(
+        self,
+        session_key: str,
+        adapter: Any,
+        pending_event: "MessageEvent",
+    ) -> None:
+        """Preserve a queued goal while its DB state cannot be read safely."""
+        metadata = pending_event.metadata
+        if not isinstance(metadata, dict):
+            metadata = {}
+            pending_event.metadata = metadata
+        retry_count = int(metadata.get("_goal_state_rechecks", 0))
+        if retry_count < 1:
+            metadata["_goal_state_rechecks"] = retry_count + 1
+            self._enqueue_fifo(session_key, pending_event, adapter)
+            logger.warning(
+                "Deferring goal continuation for session %s — goal state is temporarily unavailable",
+                session_key or "?",
+            )
+            return
+
+        # A persistent DB failure must not create a hot drain loop. Keep the
+        # event in the runner FIFO so the next real session activity retries it.
+        self._session_state(session_key).conversation.queued_events.insert(
+            0,
+            pending_event,
+        )
+        logger.warning(
+            "Parking goal continuation for session %s until goal state is readable",
+            session_key or "?",
+        )
 
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
@@ -17946,7 +18013,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # here makes the guard fire only on a DIFFERENT process's writes.
             # Fail-safe inside the helper.
             await self._refresh_agent_cache_message_count(
-                session_key, session_entry.session_id
+                session_key,
+                session_entry.session_id,
+                previous_session_id=_run_start_session_id,
             )
 
             # Intentional silence is a delivery decision, not a transcript
@@ -22891,7 +22960,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._evict_cached_agent(session_key)
 
     async def _refresh_agent_cache_message_count(
-        self, session_key: str, session_id: Optional[str]
+        self,
+        session_key: str,
+        session_id: Optional[str],
+        *,
+        previous_session_id: Optional[str] = None,
+        expected_agent: Any = None,
     ) -> None:
         """Re-baseline a cached agent's stored message_count after THIS turn.
 
@@ -22921,7 +22995,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         — the snapshot is intentionally left untouched.  Overwriting it with
         the current session's count would corrupt the original conversation's
         baseline and cause the next switch back to fire the cross-process
-        guard spuriously.  Fail-safe: the legacy 3-tuple shape (no
+        guard spuriously. A completed turn may legitimately rotate its own
+        cached agent from ``previous_session_id`` to ``session_id`` during
+        compression. In that case, advance the tuple only when the cached
+        agent itself now reports the child id (and, when supplied, is the exact
+        ``expected_agent``). This preserves warm-prefix reuse without weakening
+        stale/dead-session eviction. Fail-safe: the legacy 3-tuple shape (no
         ``session_id``) is still re-baselined as before.
         """
         if self._session_db is None or not session_id:
@@ -22947,22 +23026,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and len(cached) > 2
                 and cached[0] is not _AGENT_PENDING_SENTINEL
             ):
+                if expected_agent is not None and cached[0] is not expected_agent:
+                    return
                 # If the snapshot was taken for a different session_id
                 # (same session_key, different conversation), leave the
                 # snapshot alone — the current session_id's count belongs
                 # to a different DB row (#54947).
                 _snapshot_sid = cached[3] if len(cached) > 3 else None
-                if _snapshot_sid is not None and _snapshot_sid != session_id:
+                _legitimate_rotation = (
+                    _snapshot_sid is not None
+                    and previous_session_id is not None
+                    and previous_session_id != session_id
+                    and _snapshot_sid == previous_session_id
+                    and getattr(cached[0], "session_id", None) == session_id
+                )
+                if (
+                    _snapshot_sid is not None
+                    and _snapshot_sid != session_id
+                    and not _legitimate_rotation
+                ):
                     return
-                if cached[2] != _live:
-                    if _snapshot_sid is None:
+                if cached[2] != _live or _legitimate_rotation:
+                    if _snapshot_sid is None and not _legitimate_rotation:
                         # Legacy 3-tuple: preserve the original 3-element
                         # shape so existing entries stay compatible with
                         # callers that index ``cached[2]`` directly.
                         _cache[session_key] = (cached[0], cached[1], _live)
                     else:
                         _cache[session_key] = (
-                            cached[0], cached[1], _live, _snapshot_sid,
+                            cached[0],
+                            cached[1],
+                            _live,
+                            session_id if _legitimate_rotation else _snapshot_sid,
                         )
 
     def _set_pending_turn_sidecar_notes(self, session_key: str, notes: List[str]) -> None:
@@ -25421,6 +25516,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # new message).
 
                 updated_history = result.get("messages", history)
+                # Compression may rotate the session while the first turn runs.
+                # Every queued follow-up operation must target that live child,
+                # not the now-closed parent supplied to the outer call.
+                followup_session_id = result.get("session_id") or session_id
                 next_source = source
                 next_message = pending
                 next_message_id = None
@@ -25432,12 +25531,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_message_type = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
-                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
-                        logger.info(
-                            "Discarding stale goal continuation for session %s — goal is no longer active",
-                            session_key or "?",
+                    if self._is_goal_continuation_event(pending_event):
+                        goal_active = self._goal_still_active_for_session(
+                            followup_session_id,
+                            previous_session_id=session_id,
                         )
-                        return result
+                        if goal_active is None:
+                            self._defer_goal_continuation_recheck(
+                                session_key,
+                                adapter,
+                                pending_event,
+                            )
+                            return result
+                        if not goal_active:
+                            logger.info(
+                                "Discarding stale goal continuation for session %s — goal is no longer active",
+                                session_key or "?",
+                            )
+                            return result
                     # Resolve the follow-up's session key BEFORE preparing the
                     # inbound text: _prepare_inbound_message_text buffers native
                     # image paths under the key it is given, and the recursive
@@ -25500,17 +25611,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # prefix #46237 was merged to preserve.  The existing
                 # re-baseline in _handle_message_with_agent only runs after the
                 # whole _run_agent chain unwinds — too late for the in-band
-                # follow-up.  Use the same (session_key, session_id) the
-                # recursive call runs under so the snapshot matches exactly
-                # what the follow-up's guard will consult.  Fail-safe in helper.
-                await self._refresh_agent_cache_message_count(session_key, session_id)
+                # follow-up.  Re-baseline the completed turn's cache entry
+                # against the live session returned by that turn.  If the
+                # pending event resolves to a different session key, the
+                # recursive call handles that key separately.  Fail-safe in
+                # helper.
+                await self._refresh_agent_cache_message_count(
+                    session_key,
+                    followup_session_id,
+                    previous_session_id=session_id,
+                    expected_agent=agent_holder[0],
+                )
 
                 followup_result = await self._run_agent(
                     message=next_message,
                     context_prompt=context_prompt,
                     history=updated_history,
                     source=next_source,
-                    session_id=session_id,
+                    session_id=followup_session_id,
                     session_key=next_session_key,
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -533,16 +533,20 @@ def _get_session_db() -> Optional[Any]:
     return db
 
 
-def load_goal(session_id: str) -> Optional[GoalState]:
+def load_goal(session_id: str, *, raise_on_error: bool = False) -> Optional[GoalState]:
     """Load the goal for a session, or None if none exists."""
     if not session_id:
         return None
     db = _get_session_db()
     if db is None:
+        if raise_on_error:
+            raise RuntimeError("goal database is unavailable")
         return None
     try:
         raw = db.get_meta(_meta_key(session_id))
     except Exception as exc:
+        if raise_on_error:
+            raise
         logger.debug("GoalManager: get_meta failed: %s", exc)
         return None
     if not raw:
@@ -550,6 +554,8 @@ def load_goal(session_id: str) -> Optional[GoalState]:
     try:
         return GoalState.from_json(raw)
     except Exception as exc:
+        if raise_on_error:
+            raise
         logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
         return None
 
@@ -594,16 +600,26 @@ def migrate_goal_to_session(old_session_id: str, new_session_id: str, *, reason:
     if not old_session_id or not new_session_id or old_session_id == new_session_id:
         return False
     try:
-        state = load_goal(old_session_id)
+        db = _get_session_db()
+        if db is None:
+            return False
+        source_key = _meta_key(old_session_id)
+        destination_key = _meta_key(new_session_id)
+        source_raw = db.get_meta(source_key)
+        if not source_raw:
+            return False
+        state = GoalState.from_json(source_raw)
         if state is None or getattr(state, "status", None) == "cleared":
             return False
-        # Don't clobber a goal already set on the child (e.g. a resumed
-        # lineage that re-established its own goal).
-        if load_goal(new_session_id) is not None:
+        cleared_state = GoalState.from_json(source_raw)
+        cleared_state.status = "cleared"
+        if not db.move_meta_if_destination_absent(
+            source_key,
+            destination_key,
+            expected_source_value=source_raw,
+            source_replacement_value=cleared_state.to_json(),
+        ):
             return False
-        save_goal(new_session_id, state)
-        # Archive the parent's row so it isn't double-counted as active.
-        clear_goal(old_session_id)
         logger.debug(
             "GoalManager: migrated goal %s -> %s (%s)",
             old_session_id, new_session_id, reason or "rotation",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8718,6 +8718,59 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
         self._execute_write(_do)
 
+    def move_meta_if_destination_absent(
+        self,
+        source_key: str,
+        destination_key: str,
+        *,
+        expected_source_value: str,
+        source_replacement_value: str,
+    ) -> bool:
+        """Atomically copy one meta value and replace its source value.
+
+        The move succeeds only when the source still matches the caller's
+        snapshot and the destination is still absent. ``BEGIN IMMEDIATE``
+        serializes the check and both writes, preventing a concurrent control
+        action from being overwritten between the destination check and copy.
+        Any write failure rolls the whole transaction back.
+        """
+        if not source_key or not destination_key or source_key == destination_key:
+            return False
+
+        def _do(conn):
+            source_row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (source_key,),
+            ).fetchone()
+            if source_row is None:
+                return False
+            source_value = (
+                source_row["value"]
+                if isinstance(source_row, sqlite3.Row)
+                else source_row[0]
+            )
+            if source_value != expected_source_value:
+                return False
+            if conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ?",
+                (destination_key,),
+            ).fetchone() is not None:
+                return False
+
+            conn.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+                (destination_key, expected_source_value),
+            )
+            updated = conn.execute(
+                "UPDATE state_meta SET value = ? WHERE key = ? AND value = ?",
+                (source_replacement_value, source_key, expected_source_value),
+            )
+            if updated.rowcount != 1:
+                raise RuntimeError("meta source changed during atomic move")
+            return True
+
+        return self._execute_write(_do)
+
     def retag_kanban_worker_sessions(self, workspaces_root: str) -> int:
         """Retag legacy kanban worker rows from ``cli`` to ``kanban``.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -10,6 +10,7 @@ Verifies that the agent cache correctly:
 """
 
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -971,6 +972,64 @@ class TestAgentCacheMessageCountRebaseline:
         assert self._guard_would_reuse(runner, "telegram:s1", "s1") is True
         with runner._agent_cache_lock:
             assert runner._agent_cache["telegram:s1"][0] is agent
+
+    @pytest.mark.asyncio
+    async def test_compression_rotation_advances_cached_agent_to_child(self, tmp_path):
+        """A cached agent that performed parent -> child compression stays warm."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("parent", source="telegram")
+        db.create_session("child", source="telegram", parent_session_id="parent")
+        runner = self._runner_with_db(db)
+        agent = SimpleNamespace(session_id="child")
+        session_key = "telegram:rotated"
+
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = (agent, "sig", 0, "parent")
+
+        db.append_message("child", role="user", content="u")
+        db.append_message("child", role="assistant", content="a")
+        await runner._refresh_agent_cache_message_count(
+            session_key,
+            "child",
+            previous_session_id="parent",
+            expected_agent=agent,
+        )
+
+        child_row = db.get_session("child")
+        with runner._agent_cache_lock:
+            cached = runner._agent_cache[session_key]
+        assert cached[0] is agent
+        assert cached[2] == child_row["message_count"]
+        assert cached[3] == "child"
+        assert self._guard_would_reuse(runner, session_key, "child") is True
+
+    @pytest.mark.asyncio
+    async def test_rotation_rebaseline_rejects_stale_parent_agent(self, tmp_path):
+        """A dead-parent/self-heal artifact must still reach the eviction guard."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("parent", source="telegram")
+        db.create_session("child", source="telegram", parent_session_id="parent")
+        runner = self._runner_with_db(db)
+        stale_agent = SimpleNamespace(session_id="parent")
+        session_key = "telegram:stale-parent"
+        original = (stale_agent, "sig", 0, "parent")
+
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = original
+
+        await runner._refresh_agent_cache_message_count(
+            session_key,
+            "child",
+            previous_session_id="parent",
+            expected_agent=stale_agent,
+        )
+
+        with runner._agent_cache_lock:
+            assert runner._agent_cache[session_key] == original
 
 
 class TestCrossProcessInvalidationDefersCleanup:

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -51,18 +51,28 @@ class CaptureAdapter(BasePlatformAdapter):
 
 class CaptureQueuedNativeImageAgent:
     calls = []
+    session_ids = []
+    rotate_to_session_id: str | None = None
+    omit_first_session_id = False
 
     def __init__(self, **kwargs):
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.session_id = kwargs.get("session_id")
+        type(self).session_ids.append(self.session_id)
 
     def run_conversation(self, message, conversation_history=None, task_id=None):
         type(self).calls.append(message)
-        return {
+        if len(type(self).calls) == 1 and type(self).rotate_to_session_id:
+            self.session_id = type(self).rotate_to_session_id
+        result = {
             "final_response": f"done-{len(type(self).calls)}",
             "messages": [],
             "api_calls": 1,
         }
+        if not (len(type(self).calls) == 1 and type(self).omit_first_session_id):
+            result["session_id"] = self.session_id
+        return result
 
 
 def _make_runner(adapter):
@@ -76,6 +86,7 @@ def _make_runner(adapter):
     runner._provider_routing = {}
     runner._fallback_model = None
     runner._session_db = None
+    runner.session_store = SimpleNamespace(_entries={})
     runner._running_agents = {}
     runner._session_run_generation = {}
     runner.hooks = SimpleNamespace(loaded_hooks=False)
@@ -93,13 +104,16 @@ def _make_runner(adapter):
 @pytest.mark.asyncio
 async def test_queued_followup_uses_pending_event_session_key_for_native_images(monkeypatch, tmp_path):
     CaptureQueuedNativeImageAgent.calls = []
+    CaptureQueuedNativeImageAgent.session_ids = []
+    CaptureQueuedNativeImageAgent.rotate_to_session_id = None
+    CaptureQueuedNativeImageAgent.omit_first_session_id = False
 
     fake_dotenv = types.ModuleType("dotenv")
-    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
-    fake_run_agent.AIAgent = CaptureQueuedNativeImageAgent
+    setattr(fake_run_agent, "AIAgent", CaptureQueuedNativeImageAgent)
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     gateway_run = importlib.import_module("gateway.run")
@@ -149,3 +163,215 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "initial_session_id",
+        "rotated_session_id",
+        "omit_first_session_id",
+        "expected_session_id",
+        "expected_session_ids",
+    ),
+    [
+        (
+            "parent-session",
+            "continuation-session",
+            False,
+            "continuation-session",
+            ["parent-session", "continuation-session"],
+        ),
+        (
+            "parent-session",
+            None,
+            True,
+            "parent-session",
+            ["parent-session", "parent-session"],
+        ),
+    ],
+    ids=["rotated-session", "missing-session-id"],
+)
+async def test_queued_followup_uses_session_id_returned_by_prior_turn(
+    monkeypatch,
+    tmp_path,
+    initial_session_id,
+    rotated_session_id,
+    omit_first_session_id,
+    expected_session_id,
+    expected_session_ids,
+):
+    CaptureQueuedNativeImageAgent.calls = []
+    CaptureQueuedNativeImageAgent.session_ids = []
+    CaptureQueuedNativeImageAgent.rotate_to_session_id = rotated_session_id
+    CaptureQueuedNativeImageAgent.omit_first_session_id = omit_first_session_id
+
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", CaptureQueuedNativeImageAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    session_key = "agent:main:telegram:dm:42"
+    cache_refreshes = []
+
+    async def capture_cache_refresh(
+        refreshed_session_key,
+        refreshed_session_id,
+        *,
+        previous_session_id=None,
+        expected_agent=None,
+    ):
+        cache_refreshes.append(
+            (
+                refreshed_session_key,
+                refreshed_session_id,
+                previous_session_id,
+                getattr(expected_agent, "session_id", None),
+            )
+        )
+
+    runner._refresh_agent_cache_message_count = capture_cache_refresh
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+    )
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="follow up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-2",
+    )
+
+    result = await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id=initial_session_id,
+        session_key=session_key,
+    )
+
+    assert result["session_id"] == expected_session_id
+    assert CaptureQueuedNativeImageAgent.session_ids == expected_session_ids
+    assert cache_refreshes == [
+        (
+            session_key,
+            expected_session_id,
+            initial_session_id,
+            expected_session_id,
+        )
+    ]
+
+
+def test_goal_recheck_recovers_active_goal_from_rotated_parent(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    try:
+        goals.GoalManager(session_id="parent-session").set("ship the fix")
+        runner = _make_runner(CaptureAdapter())
+
+        assert runner._goal_still_active_for_session(
+            "continuation-session",
+            previous_session_id="parent-session",
+        )
+        assert goals.GoalManager(session_id="continuation-session").is_active()
+        assert not goals.GoalManager(session_id="parent-session").is_active()
+    finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_queued_goal_recheck_uses_rotated_and_parent_session_ids(
+    monkeypatch,
+    tmp_path,
+):
+    CaptureQueuedNativeImageAgent.calls = []
+    CaptureQueuedNativeImageAgent.session_ids = []
+    CaptureQueuedNativeImageAgent.rotate_to_session_id = "continuation-session"
+    CaptureQueuedNativeImageAgent.omit_first_session_id = False
+
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", CaptureQueuedNativeImageAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    checked_session_ids = []
+
+    def capture_goal_recheck(session_id, *, previous_session_id=None):
+        checked_session_ids.append((session_id, previous_session_id))
+        return True
+
+    runner._goal_still_active_for_session = capture_goal_recheck
+    session_key = "agent:main:telegram:dm:42"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+    )
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="[Continuing toward your standing goal]\nGoal: ship the fix",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="goal-queued-1",
+    )
+
+    await runner._run_agent(
+        message="first turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="parent-session",
+        session_key=session_key,
+    )
+
+    assert checked_session_ids == [("continuation-session", "parent-session")]
+    assert CaptureQueuedNativeImageAgent.session_ids == [
+        "parent-session",
+        "continuation-session",
+    ]
+
+
+def test_unknown_goal_state_is_requeued_once_then_parked():
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    session_key = "agent:main:telegram:dm:42"
+    event = MessageEvent(
+        text="[Continuing toward your standing goal]\nGoal: ship the fix",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="42",
+            chat_type="dm",
+        ),
+    )
+
+    runner._defer_goal_continuation_recheck(session_key, adapter, event)
+    assert adapter._pending_messages.pop(session_key) is event
+    assert event.metadata["_goal_state_rechecks"] == 1
+
+    runner._defer_goal_continuation_recheck(session_key, adapter, event)
+    assert session_key not in adapter._pending_messages
+    assert runner._session_state(session_key).conversation.queued_events == [event]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -271,6 +271,59 @@ class TestMigrateGoalToSession:
         assert migrate_goal_to_session("p3", "c3") is False
         assert load_goal("c3").goal == "child already has one"
 
+    @pytest.mark.parametrize("child_status", ["paused", "cleared"])
+    def test_does_not_resurrect_terminal_child_goal(self, hermes_home, child_status):
+        from hermes_cli.goals import save_goal, load_goal, migrate_goal_to_session, GoalState
+
+        save_goal("race-parent", GoalState(goal="stale parent goal"))
+        save_goal(
+            "race-child",
+            GoalState(goal="child control won", status=child_status),
+        )
+
+        assert migrate_goal_to_session("race-parent", "race-child") is False
+        assert load_goal("race-child").status == child_status
+        assert load_goal("race-parent").status == "active"
+
+    def test_rolls_back_child_copy_when_parent_archive_fails(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import save_goal, load_goal, migrate_goal_to_session, GoalState
+
+        save_goal("rollback-parent", GoalState(goal="must survive"))
+        db = goals._get_session_db()
+
+        def install_failure_trigger(conn):
+            conn.execute(
+                """
+                CREATE TRIGGER fail_goal_parent_archive
+                BEFORE UPDATE ON state_meta
+                WHEN OLD.key = 'goal:rollback-parent'
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced parent archive failure');
+                END
+                """
+            )
+
+        db._execute_write(install_failure_trigger)
+
+        assert migrate_goal_to_session("rollback-parent", "rollback-child") is False
+        assert load_goal("rollback-child") is None
+        assert load_goal("rollback-parent").status == "active"
+
+
+def test_load_goal_can_surface_database_read_failures(monkeypatch):
+    from hermes_cli import goals
+
+    class BrokenGoalDB:
+        def get_meta(self, key):
+            raise RuntimeError(f"database locked while reading {key}")
+
+    monkeypatch.setattr(goals, "_get_session_db", lambda: BrokenGoalDB())
+
+    assert goals.load_goal("read-failure") is None
+    with pytest.raises(RuntimeError, match="database locked"):
+        goals.load_goal("read-failure", raise_on_error=True)
+
 
 class TestGoalManagerSubgoals:
     def test_add_subgoal(self, hermes_home):


### PR DESCRIPTION
## What changed

Queued follow-up turns now continue on the live session returned by the immediately preceding turn. Previously, when that turn compressed its transcript, the recursive follow-up reused the closed parent session and failed with `CompressionSessionClosedError`.

The effective session now drives:

- queued follow-up agent construction
- history/cache refresh after the completed turn
- recursive follow-up execution
- queued `/goal` activity checks

When an active goal must move from the compressed parent to its continuation, the state transfer is now one `BEGIN IMMEDIATE` transaction with source-value CAS and a destination-absent guard. A partial write rolls back, and a child pause/clear cannot be overwritten. If goal state is temporarily unreadable, the synthetic continuation is retried once and then parked in FIFO rather than silently discarded or hot-looped.

The cached-agent snapshot advances parent→child only when that same cached agent reports the returned child session, preserving warm-prefix reuse without weakening stale/dead-session eviction.

If a result omits `session_id`, behavior still falls back to the original session.

## Why

Compression closes the parent session and publishes a live continuation. Reusing the parent for a queued message risks a persistence failure even though storage, permissions, and the database are healthy. Goal migration also has to preserve user control and survive partial writes; otherwise a queued synthetic continuation can vanish during the same rotation boundary.

## Tests

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_agent_cache.py tests/gateway/test_queued_native_image_session_key.py tests/gateway/test_session_id_cache_coherence.py tests/gateway/test_first_turn_session_meta_rebaseline.py tests/gateway/test_goal_continuation_drain.py tests/hermes_cli/test_goals.py tests/gateway/test_compression_session_id_persistence.py tests/agent/test_compression_rotation_state.py tests/state/test_compression_lineage_guard.py tests/gateway/test_transcript_offset.py tests/gateway/test_queue_consumption.py -q` — 122 passed
- `ruff check gateway/run.py hermes_cli/goals.py hermes_state.py tests/gateway/test_queued_native_image_session_key.py tests/hermes_cli/test_goals.py`
- `git diff --check`

Regression coverage includes the rotated-session route, non-null-parent missing-result fallback, cache re-baselining, queued-goal call-site ID forwarding, real-DB migration, rollback after an injected archive failure, paused/cleared child preservation, strict read-error handling, and bounded retry/FIFO parking.