### PR TITLE
fix(auth): let explicit pool status resets survive the on-disk cooldown merge

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -757,7 +757,12 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        cleared_status_ids: Optional[List[str]] = None,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -765,6 +770,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                cleared_status_ids=cleared_status_ids,
             )
 
     def _is_terminal_auth_failure(
@@ -2302,7 +2308,9 @@ class CredentialPool:
                     new_entries.append(entry)
             if count:
                 self._entries = new_entries
-                self._persist()
+                self._persist(
+                    cleared_status_ids=[entry.id for entry in new_entries]
+                )
             return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1609,6 +1609,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    cleared_status_ids: Optional[Iterable[str]] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1626,9 +1627,12 @@ def write_credential_pool(
     snapshot cannot erase a cooldown/quarantine another process just wrote.
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
-    merge does not resurrect them from the on-disk copy.
+    merge does not resurrect them from the on-disk copy. Pass
+    ``cleared_status_ids`` when the caller intentionally reset credential
+    status, so the newer-on-disk guard does not undo that explicit reset.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
+    cleared_statuses = {rid for rid in (cleared_status_ids or ()) if rid}
     with _auth_store_lock():
         auth_store = _load_auth_store()
         pool = auth_store.get("credential_pool")
@@ -1653,7 +1657,9 @@ def write_credential_pool(
             if isinstance(entry, dict) and entry.get("id")
         }
         merged: List[Dict[str, Any]] = [
-            _merge_disk_cooldown_state(
+            entry
+            if isinstance(entry, dict) and entry.get("id") in cleared_statuses
+            else _merge_disk_cooldown_state(
                 entry, existing_by_id.get(entry.get("id")), provider_id
             )
             if isinstance(entry, dict)

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -288,3 +288,28 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+def test_explicit_pool_reset_clears_newer_disk_cooldown(classic_env):
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    exhausted = _pool_entry(
+        last_status="exhausted",
+        last_status_at=time.time(),
+        last_error_code=429,
+    )
+    _write(classic_env / "auth.json", _make_auth_store(pool={
+        "openrouter": [exhausted],
+    }))
+    pool = CredentialPool(
+        "openrouter",
+        [PooledCredential.from_dict("openrouter", exhausted)],
+    )
+
+    assert pool.reset_statuses() == 1
+
+    data = json.loads((classic_env / "auth.json").read_text())
+    persisted = data["credential_pool"]["openrouter"][0]
+    assert persisted.get("last_status") is None
+    assert persisted.get("last_status_at") is None
+    assert persisted.get("last_error_code") is None


### PR DESCRIPTION
## What does this PR do?

When a pooled credential is exhausted, `write_credential_pool()` deliberately merges the on-disk cooldown state back into whatever snapshot it is writing, so a process holding a stale in-memory copy cannot erase a cooldown another process just recorded. That guard is correct for normal writes, but it also defeats intentional resets: `CredentialPool.reset_statuses()` clears the exhaustion in memory and persists, then the merge immediately restores the cooldown from the on-disk copy. The reset never sticks and the entry stays benched until its TTL expires.

This PR adds a `cleared_status_ids` parameter to `write_credential_pool()`. Entries named there skip the cooldown merge for that one write; every other caller is unchanged, so accidental erasure stays impossible. `reset_statuses()` passes the ids of the entries it just cleared.

## Related Issue

No existing issue; I searched open and merged issues and PRs for the symptom and found nothing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: `write_credential_pool()` accepts `cleared_status_ids`; entries named there bypass `_merge_disk_cooldown_state()` for that write.
- `agent/credential_pool.py`: `_persist()` forwards `cleared_status_ids`; `reset_statuses()` passes the ids of the entries it cleared.
- `tests/hermes_cli/test_auth_profile_fallback.py`: regression test proving an explicit reset clears a cooldown that is newer on disk.

## How to Test

1. Get a pool entry marked exhausted so the cooldown is persisted in `auth.json` (any 429 will do).
2. Call `CredentialPool.reset_statuses()` (the pool status reset path in the CLI).
3. Without this fix, the persisted entry still shows `last_status: exhausted` afterwards because the merge restored it; with the fix, `last_status`, `last_status_at` and `last_error_code` are cleared on disk. The new regression test `test_explicit_pool_reset_clears_newer_disk_cooldown` covers exactly this sequence.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the full `tests/hermes_cli/` and `tests/agent/` suites via `scripts/run_tests.sh` locally; remaining directories are untouched by this change and left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
