### PR TITLE
feat(webhook): verify Todoist X-Todoist-Hmac-SHA256 signatures

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1028,7 +1028,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, Todoist, GitLab, Svix, generic HMAC-SHA256)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
@@ -1061,6 +1061,14 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return _hmac_str_equal(gh_sig, expected)
+
+        # Todoist: X-Todoist-Hmac-SHA256 = base64(HMAC-SHA256(client_secret, body))
+        td_sig = request.headers.get("X-Todoist-Hmac-SHA256", "")
+        if td_sig:
+            expected = base64.b64encode(
+                hmac.new(secret.encode(), body, hashlib.sha256).digest()
+            ).decode()
+            return _hmac_str_equal(td_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -99,6 +99,13 @@ def _github_signature(body: bytes, secret: str) -> str:
     ).hexdigest()
 
 
+def _todoist_signature(body: bytes, secret: str) -> str:
+    """Compute X-Todoist-Hmac-SHA256 (base64 HMAC-SHA256) for *body* using *secret*."""
+    return base64.b64encode(
+        hmac.new(secret.encode(), body, hashlib.sha256).digest()
+    ).decode()
+
+
 def _generic_signature(body: bytes, secret: str) -> str:
     """Compute X-Webhook-Signature (plain HMAC-SHA256 hex) for *body*."""
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
@@ -147,6 +154,7 @@ class TestValidateSignature:
         hostile = "ské-not-a-valid-signature"
         for header in (
             "X-Hub-Signature-256",
+            "X-Todoist-Hmac-SHA256",
             "X-Gitlab-Token",
             "X-Webhook-Signature",
         ):
@@ -154,6 +162,36 @@ class TestValidateSignature:
             # Must return False, never raise.
             assert adapter._validate_signature(req, body, secret) is False
 
+
+    def test_validate_todoist_valid_signature_accepts(self):
+        """A correctly computed X-Todoist-Hmac-SHA256 validates."""
+        adapter = _make_adapter()
+        body = b'{"event_name": "item:completed"}'
+        secret = "todoist-client-secret"
+        req = _mock_request(
+            headers={"X-Todoist-Hmac-SHA256": _todoist_signature(body, secret)}
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_todoist_wrong_secret_rejects(self):
+        """A signature computed with a different secret is rejected."""
+        adapter = _make_adapter()
+        body = b'{"event_name": "item:completed"}'
+        req = _mock_request(
+            headers={"X-Todoist-Hmac-SHA256": _todoist_signature(body, "other-secret")}
+        )
+        assert adapter._validate_signature(req, body, "todoist-client-secret") is False
+
+    def test_validate_todoist_tampered_body_rejects(self):
+        """A valid signature over a different body is rejected."""
+        adapter = _make_adapter()
+        secret = "todoist-client-secret"
+        signed_body = b'{"event_name": "item:completed"}'
+        req = _mock_request(
+            headers={"X-Todoist-Hmac-SHA256": _todoist_signature(signed_body, secret)}
+        )
+        tampered = b'{"event_name": "item:deleted"}'
+        assert adapter._validate_signature(req, tampered, secret) is False
 
     def test_non_ascii_svix_signature_rejected(self):
         """The Svix branch also runs its `v1,<sig>` comparison through the

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -455,6 +455,7 @@ The webhook adapter includes multiple layers of security:
 The adapter validates incoming webhook signatures using the appropriate method for each source:
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
+- **Todoist**: `X-Todoist-Hmac-SHA256` header — base64-encoded HMAC-SHA256 of the body, keyed with the app's client secret
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.


### PR DESCRIPTION
## What does this PR do?

Adds Todoist to the providers recognised by webhook signature validation. Todoist signs each delivery with base64(HMAC-SHA256(client_secret, body)) in the `X-Todoist-Hmac-SHA256` header. `_validate_signature()` does not recognise that header today, so a Todoist route with a secret configured is always rejected with 401; the only way to receive Todoist events is to disable validation with `INSECURE_NO_AUTH`, which is not a real option on an internet-facing endpoint.

The new branch verifies the header through the same hardened constant-time comparison helper the other providers use, keyed with the route secret (the Todoist app's client secret). It sits after GitHub and before GitLab in the provider chain and changes nothing for requests that do not carry the header.

## Related Issue

No existing issue; I searched open and merged issues and PRs for Todoist and found nothing related to webhook signatures.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/webhook.py`: new Todoist branch in `_validate_signature()`; docstring updated.
- `tests/gateway/test_webhook_adapter.py`: `_todoist_signature()` helper and three tests (valid signature accepts, wrong secret rejects, tampered body rejects); the Todoist header is also added to the existing non-ASCII header hardening test.
- `website/docs/user-guide/messaging/webhooks.md`: documented the header in the HMAC signature validation section.

## How to Test

1. Configure a webhook route whose `secret` is your Todoist app's client secret, and register the route URL as the webhook callback in the Todoist App Console.
2. Trigger a subscribed event (complete a task, for example); the delivery validates and dispatches instead of returning 401.
3. Automated: `pytest tests/gateway/test_webhook_adapter.py -q`.

This exact validation branch has been running on my own gateway for live Todoist deliveries.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the full `tests/gateway/` suite via `scripts/run_tests.sh` locally; remaining directories are untouched by this change and left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
