### PR TITLE
fix(agent): recover tool_call arguments that arrived wrapped

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -221,6 +221,31 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
+    # Repair pass 0b: the payload is well-formed JSON that arrived wrapped.
+    # Two shapes reach here intact and were being discarded as unrepairable:
+    # a markdown fence around the object (```json … ```), and a complete
+    # object followed by prose. Both are ordinary model behaviour, and both
+    # carry the arguments the model actually chose — falling through to "{}"
+    # runs the tool with no arguments instead.
+    _unfenced = re.sub(
+        r"^\s*```[A-Za-z0-9_+-]*\s*\n?|\n?\s*```\s*$", "", raw_stripped,
+    ).strip()
+    for _candidate in (_unfenced, raw_stripped):
+        if not _candidate:
+            continue
+        try:
+            _parsed, _end = json.JSONDecoder().raw_decode(_candidate)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+        _reserialised = json.dumps(_parsed, separators=(",", ":"))
+        logger.warning(
+            "Recovered wrapped tool_call arguments for %s (dropped %d "
+            "surrounding character(s))",
+            tool_name,
+            len(raw_stripped) - _end,
+        )
+        return _reserialised
+
     # Attempt common JSON repairs
     fixed = raw_stripped
     # 1. Strip trailing commas before } or ]

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -61,3 +61,45 @@ class TestRepairToolCallArguments:
     # -- Stage 4: control-char escape fallback --
 
 
+
+
+class TestWrappedArgumentRecovery:
+    """A complete JSON payload that merely arrived wrapped must be recovered.
+
+    Both shapes below are ordinary model behaviour and carry the arguments the
+    model actually chose; falling through to "{}" runs the tool with no
+    arguments instead of the requested ones.
+    """
+
+    @staticmethod
+    def _repair(raw):
+        from agent.message_sanitization import _repair_tool_call_arguments
+
+        return _repair_tool_call_arguments(raw, "write_file")
+
+    def test_markdown_fenced_payload_is_recovered(self):
+        out = self._repair('```json\n{"path": "a.txt", "content": "hi"}\n```')
+        assert json.loads(out) == {"path": "a.txt", "content": "hi"}
+
+    def test_bare_fence_without_language_is_recovered(self):
+        out = self._repair('```\n{"path": "a.txt"}\n```')
+        assert json.loads(out) == {"path": "a.txt"}
+
+    def test_trailing_prose_after_the_object_is_dropped(self):
+        out = self._repair('{"path": "a.txt"} — writing that file now')
+        assert json.loads(out) == {"path": "a.txt"}
+
+    def test_leading_and_trailing_whitespace_only(self):
+        out = self._repair('  \n {"path": "a.txt"}  \n ')
+        assert json.loads(out) == {"path": "a.txt"}
+
+    def test_wellformed_payload_is_unchanged_semantically(self):
+        payload = {
+            "path": r"C:\Users\me\a.txt",
+            "content": "line1\nline2 🌍",
+        }
+        out = self._repair(json.dumps(payload))
+        assert json.loads(out) == payload
+
+    def test_still_empty_object_when_nothing_parses(self):
+        assert json.loads(self._repair("{path: 'a.txt'")) == {}


### PR DESCRIPTION
## What

`_repair_tool_call_arguments` is a repair ladder for the malformed argument JSON local models emit — its docstring names truncated JSON, trailing commas and Python `None`, and it falls back to `"{}"` only when nothing parses, "better than crashing the session."

Two shapes were reaching that fallback while carrying a **complete, valid payload**:

```
in='```json\n{"path": "a.txt"}\n```'      out='{}'
in='{"path": "a.txt"} trailing text'      out='{}'
```

Both are ordinary model behaviour — a fenced object, or an object followed by an explanatory sentence — and both hold exactly the arguments the model chose. Discarding them runs the tool with **no arguments at all**, so the call fails on a missing required parameter (`write_file` with no `path`, `terminal` with no `command`) and the turn is spent on a confusing error instead of the requested action. The log line even says `Unrepairable tool_call arguments … replaced with empty object` for a payload that parses fine once unwrapped.

Found by fuzzing the function: 14 well-formed and 13 malformed argument strings, checking that the result parses and that a well-formed payload survives unchanged. These two were the only recoverable inputs being thrown away.

## The fix

One pass added before the existing character-surgery repairs: strip a surrounding markdown fence, then take the leading JSON value with `json.JSONDecoder().raw_decode()`, which covers the trailing-prose case in the same step. The recovery is logged like every other repair in this function, including how many surrounding characters were dropped.

Ordering keeps the change inert for everything that already worked:

- well-formed input never reaches it — pass 0 (`json.loads(..., strict=False)`) returns first
- input that genuinely does not parse falls through to the existing repairs and, failing those, still ends at `"{}"`

Verified on the same fuzz corpus: the two wrapped cases now return `{"path":"a.txt"}`, every other input's output is byte-identical to before, and 0/14 well-formed payloads are damaged.

## Tests

Added `TestWrappedArgumentRecovery` to `tests/run_agent/test_repair_tool_call_arguments.py`:

- a ```` ```json ```` fenced object is recovered with both keys intact
- a bare ```` ``` ```` fence with no language tag is recovered
- prose after a complete object is dropped, the object is kept
- surrounding whitespace only is handled
- a well-formed payload with a Windows path, a newline and an emoji round-trips semantically unchanged
- input that still does not parse continues to yield `{}`

Results:

```
28 passed
```

That is this file plus `test_streaming_tool_call_repair.py`, `test_repair_tool_call_name.py` and `tests/agent/test_canon_args_memo_parity.py`, with no pre-existing failures.

Without the source change, on the same files:

```
3 failed, 25 passed
E   AssertionError: assert {} == {'content': 'hi', 'path': 'a.txt'}
E   AssertionError: assert {} == {'path': 'a.txt'}
```

25 + 3 = 28, so the delta is exactly the new tests flipping green. `tests/run_agent/test_dict_tool_call_args.py`, `test_dropped_tool_call_recovery.py` and `test_message_sequence_repair.py` also pass (19) unchanged, and `scripts/check-windows-footguns.py` is clean on both files.