### PR TITLE
fix(godmode): normalize curly quotes in refusal detection

### DIFF
--- a/optional-skills/security/godmode/scripts/godmode_race.py
+++ b/optional-skills/security/godmode/scripts/godmode_race.py
@@ -165,8 +165,15 @@ HEDGE_PATTERNS = [
 ]
 
 
+def _normalize_apostrophes(text):
+    """Normalize curly quotes to ASCII so refusal/hedge regexes match model output.
+    Many models emit U+2019 (') for apostrophes, which missed patterns using ASCII '."""
+    return text.replace("\u2019", "'").replace("\u2018", "'").replace("\u201c", '"').replace("\u201d", '"')
+
+
 def is_refusal(content):
     """Check if response is a refusal."""
+    content = _normalize_apostrophes(content)
     for pattern in REFUSAL_PATTERNS:
         if pattern.search(content):
             return True
@@ -175,6 +182,7 @@ def is_refusal(content):
 
 def count_hedges(content):
     """Count hedge/disclaimer patterns in content."""
+    content = _normalize_apostrophes(content)
     count = 0
     for pattern in HEDGE_PATTERNS:
         if pattern.search(content):


### PR DESCRIPTION
## Summary

Fixes godmode's refusal detection (see issue #79336). `is_refusal` / `count_hedges` in `scripts/godmode_race.py` used regexes with ASCII apostrophes only, so refusals emitted with curly quotes (U+2019, e.g. "I can't help with that request") were misclassified as compliant. `auto_jailbreak()` could then report a refusing model as `strategy: none_needed` or score refusals as successful jailbreaks.

## Change

Added `_normalize_apostrophes()` (normalizes U+2018/U+2019/U+201C/U+201D to ASCII) and apply it at the top of `is_refusal` and `count_hedges` before pattern matching.

## Test Plan

- `py_compile` passes
- Curly-apostrophe soft refusals now score `-9999` / `refused=True` (previously `refused=False`)
- ASCII-apostrophe refusals still detected
- Genuine compliant responses unaffected

Closes #79336