### PR TITLE
feat(hooks): expose chat_id/chat_name/user_name/chat_type to pre_llm_call

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1165,6 +1165,10 @@ def build_turn_context(
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            chat_id=getattr(agent, "_chat_id", None) or "",
+            chat_name=getattr(agent, "_chat_name", None) or "",
+            user_name=getattr(agent, "_user_name", None) or "",
+            chat_type=getattr(agent, "_chat_type", None) or "",
         )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -365,6 +365,59 @@ def test_between_turns_refresh_adds_late_tool_when_servers_registered():
     assert any(t["function"]["name"] == "mcp_x_tool" for t in agent.tools)
 
 
+# ── pre_llm_call source metadata forwarding (#79214) ────────────────────────
+#
+# Unified sessions (cross-platform session sharing) receive messages from
+# different platforms/chat types in the same conversation. The pre_llm_call
+# plugin hook must carry per-message source metadata (chat_id, chat_name,
+# user_name, chat_type) so plugins can apply per-channel behavior. These
+# assert the prologue forwards the four agent attributes to invoke_hook.
+
+
+def _capture_pre_llm_call_kwargs(agent, **agent_overrides):
+    for name, value in agent_overrides.items():
+        setattr(agent, name, value)
+
+    captured: dict = {}
+
+    def _fake_invoke_hook(*_args, **_kwargs):
+        captured.update(_kwargs)
+        return []
+
+    with patch("hermes_cli.lifecycle.invoke_hook", side_effect=_fake_invoke_hook):
+        _build(agent)
+
+    return captured
+
+
+def test_pre_llm_call_forwards_chat_and_user_metadata():
+    agent = _FakeAgent()
+    captured = _capture_pre_llm_call_kwargs(
+        agent,
+        _chat_id="chat-42",
+        _chat_name="Project Ops",
+        _user_name="Alice",
+        _chat_type="group",
+    )
+
+    assert captured["chat_id"] == "chat-42"
+    assert captured["chat_name"] == "Project Ops"
+    assert captured["user_name"] == "Alice"
+    assert captured["chat_type"] == "group"
+
+
+def test_pre_llm_call_metadata_defaults_to_empty_string_when_absent():
+    """Agent attributes are absent on CLI agents — must not raise and must
+    default to '' so plugins can treat the fields as always-present."""
+    agent = _FakeAgent()
+    captured = _capture_pre_llm_call_kwargs(agent)
+
+    assert captured["chat_id"] == ""
+    assert captured["chat_name"] == ""
+    assert captured["user_name"] == ""
+    assert captured["chat_type"] == ""
+
+
 class _TitlingAgent:
     """Only what ``_maybe_title_session_at_turn_start`` reads off an agent."""
 


### PR DESCRIPTION
## Summary

The `pre_llm_call` hook currently passes `platform` and `sender_id` to plugins but not `chat_id`, `chat_name`, `user_name`, or `chat_type`. Agents running in unified sessions (cross-platform session sharing) receive messages from different platforms and chat types — DM, group, channel, thread — in the same conversation. Without per-message source metadata, the agent cannot distinguish a DM from a group chat or identify the sender by display name.

## Changes

4 new kwargs added to the existing `invoke_hook("pre_llm_call", ...)` call in `agent/turn_context.py`:

```python
chat_id=getattr(agent, "_chat_id", None) or "",
chat_name=getattr(agent, "_chat_name", None) or "",
user_name=getattr(agent, "_user_name", None) or "",
chat_type=getattr(agent, "_chat_type", None) or "",
```

Same `getattr` pattern as the existing `sender_id` (`agent._user_id`). The attributes are confirmed present at `agent/agent_init.py:597-600`.

- **4 new kwargs on an existing hook** — no new hook, no breaking change (plugins that don't read them are unaffected via `**kwargs`)
- **No cache impact** — `pre_llm_call` is ephemeral (injected into user message, not system prompt)

## Tests

Added 2 regression tests to `tests/agent/test_turn_context.py`:
- metadata forwarded when set on the agent (chat_id/chat_name/user_name/chat_type)
- defaults to `''` when absent (CLI agents) — no raise, always-present fields

All 10 tests in the file pass.

Closes #79214