### PR TITLE
fix(models): add SiliconFlow to PROVIDER_TO_MODELS_DEV mapping

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -188,6 +188,8 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "perplexity": "perplexity",
     "cohere": "cohere",
     "ollama-cloud": "ollama-cloud",
+    "siliconflow": "siliconflow",
+    "siliconflow-cn": "siliconflow-cn",
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)


### PR DESCRIPTION
The models.dev catalog contains SiliconFlow provider data (49 models for siliconflow, 47 for siliconflow-cn) but PROVIDER_TO_MODELS_DEV had no entry mapping the Hermes provider slugs to their models.dev IDs. Users who configure a custom SiliconFlow endpoint get an empty model picker and no capability lookups.

Add the two missing entries.

Fixes #79325