### PR TITLE
Coerce handoff.request platform against non-string JSON

### DIFF
--- a/tests/tui_gateway/test_handoff_platform_text_coerce.py
+++ b/tests/tui_gateway/test_handoff_platform_text_coerce.py
@@ -1,0 +1,71 @@
+"""handoff.request must tolerate non-string ``platform`` on the inline reader path."""
+
+from __future__ import annotations
+
+import threading
+
+from tui_gateway import server
+
+
+def _install_session(sid: str):
+    ready = threading.Event()
+    ready.set()
+    server._sessions[sid] = {
+        "agent": object(),
+        "agent_ready": ready,
+        "session_key": sid,
+        "running": False,
+        "history_lock": threading.Lock(),
+    }
+
+
+def test_handoff_request_rejects_null_platform():
+    sid = "handoff-null"
+    _install_session(sid)
+    try:
+        resp = server.dispatch(
+            {
+                "id": "1",
+                "method": "handoff.request",
+                "params": {"session_id": sid, "platform": None},
+            }
+        )
+        assert resp["error"]["code"] == 4023
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_handoff_request_list_platform_does_not_crash():
+    """List platform must not AttributeError on the inline reader path."""
+    sid = "handoff-list"
+    _install_session(sid)
+    try:
+        resp = server.dispatch(
+            {
+                "id": "2",
+                "method": "handoff.request",
+                "params": {"session_id": sid, "platform": ["telegram"]},
+            }
+        )
+        # Coerced str(list) is not a valid Platform name — expect 4024, not a crash.
+        assert "error" in resp, resp
+        assert resp["error"]["code"] == 4024
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_handoff_request_int_platform_does_not_crash():
+    sid = "handoff-int"
+    _install_session(sid)
+    try:
+        resp = server.dispatch(
+            {
+                "id": "3",
+                "method": "handoff.request",
+                "params": {"session_id": sid, "platform": 42},
+            }
+        )
+        assert "error" in resp, resp
+        assert resp["error"]["code"] == 4024
+    finally:
+        server._sessions.pop(sid, None)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1151,7 +1151,9 @@ def _(rid, params: dict) -> dict:
             "session busy — wait for the current turn to finish, then retry the handoff",
         )
 
-    platform_name = (params.get("platform", "") or "").strip().lower()
+    # Inline RPC: non-string platform (JSON null already falsy; list/int is
+    # truthy) must not AttributeError on .strip() and tear down the reader.
+    platform_name = str(params.get("platform") or "").strip().lower()
     if not platform_name:
         return _err(rid, 4023, "platform required")
 


### PR DESCRIPTION
## Summary
- `handoff.request` runs inline; bare `(params.get("platform") or "").strip()` AttributeErrors on list/int `platform` before validation and can tear down the stdin/WS reader.
- Coerce with `str(... or "")` before `.strip().lower()`.
- Regression tests: null → 4023, list/int → 4024 without crash.
