### PR TITLE
fix(pet): prefer iterm mode over kitty for WezTerm

### DIFF
--- a/agent/pet/render.py
+++ b/agent/pet/render.py
@@ -73,9 +73,10 @@ def detect_terminal_graphics() -> str:
     if term_program in {"ghostty"}:
         return "kitty"
 
-    # WezTerm speaks both kitty and iterm; prefer kitty (richer placement).
+    # WezTerm speaks both kitty and iterm; kitty placement renders incorrectly
+    # in practice, so prefer iterm here (Ghostty keeps kitty above).
     if term_program == "wezterm" or os.environ.get("WEZTERM_PANE"):
-        return "kitty"
+        return "iterm"
 
     # iTerm2 inline images
     if term_program == "iterm.app" or os.environ.get("ITERM_SESSION_ID"):


### PR DESCRIPTION
## Problem

`detect_terminal_graphics()` maps WezTerm to the `kitty` render mode on the grounds that WezTerm speaks the kitty graphics protocol. In practice the pet mascot's kitty-protocol placement renders incorrectly in WezTerm (broken/garbled frames), while `iterm` mode (WezTerm also supports iTerm2 inline images) renders correctly. Ghostty, which shares the `kitty` branch, is unaffected — the pet renders correctly there.

Users hitting this had no way to fix it short of manually pinning `display.pet.render_mode: iterm` globally, which breaks the pet on any other terminal (e.g. Ghostty) also used on the same machine.

## Fix

One-line change to the WezTerm branch of `detect_terminal_graphics()`: return `iterm` instead of `kitty` when `TERM_PROGRAM=wezterm` or `WEZTERM_PANE` is set. Ghostty's branch is untouched.

## Testing

- `pytest tests/agent/test_pet_engine.py` — 7 passed (covers `detect_terminal_graphics()`, including the WezTerm env-var case)
- `pytest tests/hermes_cli/test_pet_toggle.py tests/agent/test_pet_generate.py tests/cli/test_cli_pet_pane.py tests/tui_gateway/test_pet_generate_rpc.py` — 8 passed, 11 skipped (pre-existing environment gates), 0 failed
- `ruff check agent/pet/render.py` — clean
- Manually verified: `hermes pets doctor` in WezTerm now reports `detected graphics: iterm` (previously `kitty`); pet renders correctly.

---
*This fix was drafted by a Hermes Agent session (Claude Sonnet 5) acting on behalf of the submitter.*
