### PR TITLE
fix(memory): stop skipping provider recall on mid-task workflow commands

### DIFF
--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -48,11 +48,16 @@ logger = logging.getLogger(__name__)
 # The alternation is anchored and may only be followed by whitespace or
 # punctuation, so words that merely START with a trivial word ("k8s", "yolo",
 # "note", "hindsight") do NOT match, while trailing-punctuation variants
-# ("hi!", "hey.", "thanks :)", "done???") do.
+# ("hi!", "hey.", "thanks :)") do.
+#
+# Workflow commands ("continue", "next", "do it", "proceed", "go ahead",
+# "done", "lgtm") are deliberately NOT here: they are common mid-task turns
+# where the agent is about to do more work and provider memory is exactly
+# what it needs. Only pure acknowledgements and greetings skip prefetch.
 TRIVIAL_PROMPT_RE = re.compile(
     r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
     r'hi|hey|hello|yo|sup|'
-    r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)'
+    r'got it|cool|nice|great|k)'
     r'[\s!?.:;,"' + "'" + r'~\u2018\u2019\u201c\u201d\u2014\u2013\u2026()\[\]{}<>*&^%$#@!+=`\u00a0]*$',
     re.IGNORECASE,
 )

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1147,8 +1147,17 @@ class TestTrivialPromptClassifier:
         from agent.memory_provider import is_trivial_prompt
 
         for t in ("hi", "HI!", "hey.", "hello", "yo", "sup~", "thanks :)",
-                  "done???", "ok", "yes.", "k", "", "   ", "/help", "lgtm"):
+                  "ok", "yes.", "k", "got it", "", "   ", "/help"):
             assert is_trivial_prompt(t), f"expected trivial: {t!r}"
+
+    def test_workflow_commands_are_not_trivial(self):
+        from agent.memory_provider import is_trivial_prompt
+
+        # Mid-task workflow commands need provider memory, so they must NOT
+        # be gated out as trivial even though they are short.
+        for t in ("continue", "next", "do it", "proceed", "go ahead",
+                  "done", "done???", "lgtm"):
+            assert not is_trivial_prompt(t), f"expected non-trivial: {t!r}"
 
     def test_substantive_and_prefix_collisions_pass_through(self):
         from agent.memory_provider import is_trivial_prompt

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -788,8 +788,13 @@ class TestTrivialPromptHeuristic:
         return provider
 
     def test_classifier_catches_common_trivial_forms(self):
-        for t in ("ok", "OK", " ok ", "y", "yes", "sure", "thanks", "lgtm", "/help", "", "   "):
+        for t in ("ok", "OK", " ok ", "y", "yes", "sure", "thanks", "/help", "", "   "):
             assert HonchoMemoryProvider._is_trivial_prompt(t), f"expected trivial: {t!r}"
+
+    def test_classifier_passes_workflow_commands(self):
+        """Mid-task workflow words need memory context, so they must not skip."""
+        for t in ("continue", "next", "do it", "proceed", "go ahead", "done", "lgtm"):
+            assert not HonchoMemoryProvider._is_trivial_prompt(t), f"expected non-trivial: {t!r}"
 
     def test_classifier_catches_greetings(self):
         """Greeting words must register as trivial so context injection is skipped."""


### PR DESCRIPTION
## What does this PR do?

The shared trivial-prompt classifier (`TRIVIAL_PROMPT_RE` in `agent/memory_provider.py`) gated memory-provider prefetch and injection for bare workflow commands: `continue`, `go ahead`, `do it`, `proceed`, `done`, `next`, `lgtm`. Those are the exact mid-task turns where the agent is about to do more work and provider memory is most useful, so a user replying "continue" got a turn with zero external memory context while the same intent as a sentence got full recall.

This drops the workflow commands from the alternation and keeps only greetings and pure acknowledgements (hi, thanks, ok, sure, got it, ...). One edit covers every layer because the regex is the single source of truth: the core prefetch gate (`agent/turn_context.py`, `run_agent.py`) uses `is_trivial_prompt`, and Honcho aliases the same regex as `_TRIVIAL_PROMPT_RE`.

## Related Issue

Fixes #79343

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/memory_provider.py`: remove `continue|go ahead|do it|proceed|done|next|lgtm` from `TRIVIAL_PROMPT_RE`, keep `got it|cool|nice|great|k` and the greeting/ack groups, and document why workflow commands are excluded.
- `tests/agent/test_memory_provider.py`: move "done???"/"lgtm" out of the trivial list, add `test_workflow_commands_are_not_trivial` covering all seven removed words.
- `tests/honcho_plugin/test_session.py`: drop "lgtm" from the trivial forms, add `test_classifier_passes_workflow_commands`.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_memory_provider.py tests/honcho_plugin/test_session.py -q`
   - 114 passed, 0 failed
2. Sanity: `is_trivial_prompt("continue")` / `("next")` / `("lgtm")` now return False, `("hi")` / `("thanks")` / `("got it")` still return True.
3. With a memory provider enabled, replying "continue" mid-task now runs the normal prefetch path instead of skipping it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the memory/honcho suites above and they pass. Full `pytest tests/ -q` not re-run here. Change is isolated to one regex plus its tests.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A (comment above the regex only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure regex change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```shell
# Before: workflow commands skipped memory recall
>>> is_trivial_prompt("continue"), is_trivial_prompt("next"), is_trivial_prompt("lgtm")
(True, True, True)

# After: only greetings and pure acknowledgements skip
>>> is_trivial_prompt("continue"), is_trivial_prompt("next"), is_trivial_prompt("lgtm")
(False, False, False)
>>> is_trivial_prompt("hi"), is_trivial_prompt("thanks"), is_trivial_prompt("got it")
(True, True, True)
```
