### PR TITLE
Reject null/non-string batch goals without crashing

### DIFF
--- a/tests/tools/test_delegate_null_goal.py
+++ b/tests/tools/test_delegate_null_goal.py
@@ -1,0 +1,42 @@
+"""delegate_task batch goals must tolerate JSON-null / non-string values."""
+
+from __future__ import annotations
+
+import json
+
+from tests.tools.test_delegate import _make_mock_parent
+from tools.delegate_tool import delegate_task
+
+
+def test_batch_null_goal_returns_tool_error_not_attribute_error():
+    """``{"goal": null}`` must not AttributeError on ``.strip()``."""
+    result = json.loads(
+        delegate_task(
+            tasks=[{"goal": None}],
+            parent_agent=_make_mock_parent(),
+        )
+    )
+    assert "error" in result
+    assert "missing a 'goal'" in result["error"]
+
+
+def test_batch_non_string_goal_returns_tool_error():
+    result = json.loads(
+        delegate_task(
+            tasks=[{"goal": 42}],
+            parent_agent=_make_mock_parent(),
+        )
+    )
+    assert "error" in result
+    assert "missing a 'goal'" in result["error"]
+
+
+def test_batch_empty_string_goal_returns_tool_error():
+    result = json.loads(
+        delegate_task(
+            tasks=[{"goal": "   "}],
+            parent_agent=_make_mock_parent(),
+        )
+    )
+    assert "error" in result
+    assert "missing a 'goal'" in result["error"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2913,7 +2913,11 @@ def delegate_task(
             return tool_error(
                 f"Task {i} must be an object, got {type(task).__name__}."
             )
-        if not task.get("goal", "").strip():
+        # Present-but-null ``goal`` makes dict.get("goal", "") return None, so a
+        # bare ``.strip()`` AttributeErrors mid-tool. Require a non-empty string
+        # — same contract as the top-level ``goal`` path above.
+        goal_val = task.get("goal")
+        if not isinstance(goal_val, str) or not goal_val.strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
     overall_start = time.monotonic()


### PR DESCRIPTION
## Summary
- Batch `delegate_task` validated goals with `task.get("goal", "").strip()`.
- When the model sends `{"goal": null}`, `dict.get` returns `None` (key present), so `.strip()` raises `AttributeError` mid-tool instead of a clean tool error.
- Require a non-empty string — same contract as the top-level `goal` path. Also rejects int/list goals that would later crash on `goal[:40]` labeling.
