### PR TITLE
fix(state): repair bare-marker final replies left by the #78148 fallback replay

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -431,10 +431,44 @@ def _is_stale_tool_call_marker_message(msg: Dict[str, Any]) -> bool:
     return bool(_STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip()))
 
 
+def _is_bare_marker_final_reply(msg: Dict[str, Any]) -> bool:
+    """True when ``msg`` is an assistant FINAL reply whose entire content is
+    a bare bracketed marker (e.g. ``[memory]``) with no ``tool_calls``.
+
+    This is the second half of the #78148 contamination: the loop cached the
+    stray marker from a tool-call turn and, when the following turn came
+    back empty, replayed it as the "final response". Persisted that way it
+    has no ``tool_calls``, so the per-message signature above never matches
+    it, yet it teaches the model the marker on every resume just the same.
+    Callers must only act on this when an earlier marker+tool_calls turn
+    exists in the same conversation — that pairing is what separates the
+    replayed fallback from a deliberate one-word answer.
+    """
+    if not isinstance(msg, dict):
+        return False
+    if msg.get("role") != "assistant":
+        return False
+    if msg.get("tool_calls"):
+        return False
+    content = msg.get("content")
+    if not isinstance(content, str):
+        return False
+    return bool(_STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip()))
+
+
 def _strip_stale_tool_call_markers(
     messages: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     """Clear bare protocol-marker content persisted before the #78148 fix.
+
+    Two shapes are repaired:
+
+    1. Marker content sitting alongside a real ``tool_calls`` payload.
+    2. A later FINAL assistant reply that is nothing but the same bare
+       marker with no ``tool_calls`` — the cached fallback replayed as the
+       answer on the next turn. Only cleared when an earlier
+       marker+tool_calls turn exists in this conversation, so a genuine
+       one-word reply is never touched.
 
     Replaying "[memory]" as if the model had actually answered teaches the
     model, by example, to keep emitting the same marker in later turns — the
@@ -444,8 +478,13 @@ def _strip_stale_tool_call_markers(
     rows pass through unchanged.
     """
     repaired = 0
+    seen_marker_tool_turn = False
     for msg in messages:
         if _is_stale_tool_call_marker_message(msg):
+            msg["content"] = ""
+            seen_marker_tool_turn = True
+            repaired += 1
+        elif seen_marker_tool_turn and _is_bare_marker_final_reply(msg):
             msg["content"] = ""
             repaired += 1
     if repaired:
@@ -8578,6 +8617,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         left in the ``messages`` table by sessions persisted before the
         #78148 fix in ``agent.conversation_loop``.
 
+        Both contamination shapes are covered: marker content sitting next
+        to a real ``tool_calls`` payload, and a later bare-marker FINAL
+        reply (no ``tool_calls``) that the loop persisted when it replayed
+        the cached marker as the answer. The final-reply shape only counts
+        when a marker+tool_calls turn precedes it in the same session.
+
         ``_strip_stale_tool_call_markers`` already repairs this in memory on
         every session load (see ``_rows_to_conversation``), so running this
         is optional — but for long-lived sessions the same rows get
@@ -8607,14 +8652,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
 
         def _find_affected(conn) -> List[int]:
+            # Single ordered scan catches both contamination shapes in one
+            # pass: a marker+tool_calls row, and a LATER bare-marker final
+            # reply in the same session (the cached fallback replayed as the
+            # answer, persisted without tool_calls). Ordering matters because
+            # the final-reply shape is only contamination when a marker
+            # tool-call turn precedes it, and because this same UPDATE blanks
+            # the marker+tool_calls content that future scans use as the
+            # evidence.
             cursor = conn.execute(
-                "SELECT id, content FROM messages "
-                "WHERE role = 'assistant' AND tool_calls IS NOT NULL AND tool_calls != ''"
+                "SELECT id, session_id, content, tool_calls FROM messages "
+                "WHERE role = 'assistant' ORDER BY session_id, id"
             )
             affected: List[int] = []
+            sessions_with_marker_turn: set = set()
             for row in cursor.fetchall():
                 content = row["content"]
-                if isinstance(content, str) and _STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip()):
+                if not (
+                    isinstance(content, str)
+                    and _STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip())
+                ):
+                    continue
+                if row["tool_calls"]:
+                    sessions_with_marker_turn.add(row["session_id"])
+                    affected.append(row["id"])
+                elif row["session_id"] in sessions_with_marker_turn:
                     affected.append(row["id"])
             return affected
 

--- a/tests/test_stale_tool_call_marker_session_repair.py
+++ b/tests/test_stale_tool_call_marker_session_repair.py
@@ -84,6 +84,68 @@ class TestStripStaleToolCallMarkers:
         assert out == messages
 
 
+class TestStripBareMarkerFinalReplies:
+    """The replayed-fallback shape: a bare marker persisted as a FINAL
+    assistant reply (no tool_calls) on the turn after a marker+tool_calls
+    turn. Cleared only when that earlier marker turn exists."""
+
+    def test_clears_final_reply_marker_after_marker_tool_turn(self):
+        messages = [
+            {"role": "user", "content": "do the full task"},
+            {
+                "role": "assistant",
+                "content": "[memory]",
+                "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "ok", "tool_call_id": "1"},
+            # Next turn came back empty, cached marker replayed as the answer.
+            {"role": "assistant", "content": "[memory]"},
+        ]
+        out = _strip_stale_tool_call_markers(messages)
+        assert out[1]["content"] == ""
+        assert out[3]["content"] == ""
+
+    def test_final_reply_marker_without_prior_marker_turn_is_kept(self):
+        # No marker+tool_calls turn anywhere: a bare "[memory]" final reply
+        # is not the contamination signature, leave it alone.
+        messages = [
+            {"role": "user", "content": "what did you just do?"},
+            {"role": "assistant", "content": "[memory]"},
+        ]
+        out = _strip_stale_tool_call_markers(messages)
+        assert out[1]["content"] == "[memory]"
+
+    def test_final_reply_marker_before_marker_turn_is_kept(self):
+        # Ordering matters: only a replay AFTER a marker tool turn counts.
+        messages = [
+            {"role": "assistant", "content": "[memory]"},
+            {
+                "role": "assistant",
+                "content": "[memory]",
+                "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+            },
+        ]
+        out = _strip_stale_tool_call_markers(messages)
+        assert out[0]["content"] == "[memory]"
+        assert out[1]["content"] == ""
+
+    def test_marker_sentence_final_reply_is_kept(self):
+        # Real user-facing content that merely mentions the marker must
+        # survive even in a contaminated session (fullmatch, not substring).
+        messages = [
+            {
+                "role": "assistant",
+                "content": "[memory]",
+                "tool_calls": [{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "ok", "tool_call_id": "1"},
+            {"role": "assistant", "content": "[memory] is not configured"},
+        ]
+        out = _strip_stale_tool_call_markers(messages)
+        assert out[0]["content"] == ""
+        assert out[2]["content"] == "[memory] is not configured"
+
+
 class TestGetMessagesAsConversationStripsStaleMarkers:
     """The load-on-read wiring: get_messages_as_conversation must actually
     call _strip_stale_tool_call_markers, so a session polluted with a stale
@@ -258,5 +320,112 @@ class TestPurgeStaleToolCallMarkers:
                 report = db.purge_stale_tool_call_markers(dry_run=False)
                 assert report["rows_affected"] == 0
                 assert report["row_ids"] == []
+            finally:
+                db.close()
+
+
+class TestBareMarkerFinalReplyEndToEnd:
+    """Load-on-read and purge coverage for the replayed-fallback shape: the
+    bare "[memory]" FINAL reply (no tool_calls) persisted on the turn after
+    a marker+tool_calls turn."""
+
+    def _seed_replayed_fallback_db(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="do the full task")
+        db.append_message(
+            "s1", role="assistant", content="[memory]",
+            tool_calls=[{"id": "1", "function": {"name": "skill_manage", "arguments": "{}"}}],
+        )
+        db.append_message("s1", role="tool", content="ok", tool_call_id="1")
+        # Next turn came back empty, cached marker replayed as the answer.
+        db.append_message("s1", role="assistant", content="[memory]")
+
+    def test_resume_clears_both_marker_shapes(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_replayed_fallback_db(db)
+
+                conv = db.get_messages_as_conversation("s1")
+                contents = [m.get("content") for m in conv if m.get("role") == "assistant"]
+
+                assert "[memory]" not in contents
+            finally:
+                db.close()
+
+    def test_purge_clears_both_marker_shapes_in_one_run(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_replayed_fallback_db(db)
+
+                report = db.purge_stale_tool_call_markers(dry_run=False)
+                assert report["rows_affected"] == 2
+
+                rows = db._conn.execute(
+                    "SELECT content FROM messages WHERE role = 'assistant'"
+                ).fetchall()
+                assert [r["content"] for r in rows] == ["", ""]
+
+                # Idempotent: a second run must find nothing, including via
+                # the now-blanked marker+tool_calls evidence row.
+                second = db.purge_stale_tool_call_markers(dry_run=False)
+                assert second["rows_affected"] == 0
+            finally:
+                db.close()
+
+    def test_purge_keeps_final_reply_marker_without_prior_marker_turn(self):
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                db.create_session(session_id="s1", source="cli")
+                db.append_message("s1", role="user", content="what did you just do?")
+                db.append_message("s1", role="assistant", content="[memory]")
+
+                report = db.purge_stale_tool_call_markers(dry_run=False)
+                assert report["rows_affected"] == 0
+
+                row = db._conn.execute(
+                    "SELECT content FROM messages WHERE role = 'assistant'"
+                ).fetchone()
+                assert row["content"] == "[memory]"
+            finally:
+                db.close()
+
+    def test_purge_scopes_final_reply_detection_per_session(self):
+        # A marker tool turn in one session must not condemn a deliberate
+        # one-word reply in another.
+        import tempfile
+        from pathlib import Path
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            try:
+                self._seed_replayed_fallback_db(db)
+                db.create_session(session_id="s2", source="cli")
+                db.append_message("s2", role="user", content="what did you just do?")
+                db.append_message("s2", role="assistant", content="[memory]")
+
+                report = db.purge_stale_tool_call_markers(dry_run=False)
+                assert report["rows_affected"] == 2
+
+                row = db._conn.execute(
+                    "SELECT content FROM messages WHERE session_id = 's2' "
+                    "AND role = 'assistant'"
+                ).fetchone()
+                assert row["content"] == "[memory]"
             finally:
                 db.close()


### PR DESCRIPTION
## What does this PR do?

The #78148 repair work (load-on-read strip in `_strip_stale_tool_call_markers`, permanent rewrite in `purge_stale_tool_call_markers`) only matches assistant rows whose bare marker content sits next to a real `tool_calls` payload. The actual poisoning row is the second shape: the loop cached that marker as the fallback and, when the next turn came back empty, replayed it as the FINAL response, persisted with no `tool_calls`. Those rows pass both repairs untouched, so already-contaminated sessions keep teaching the model the marker on every resume and `clean-markers` can never remove them.

This covers the second shape in both paths:

- Load repair also clears an assistant final reply whose content fullmatches the bare-marker regex, but only when an earlier marker+tool_calls turn exists in the same conversation. That pairing is what separates the replayed fallback from a deliberate one-word answer.
- Purge now does a single ordered scan per session and collects both shapes in the same run. Ordering matters because the UPDATE blanks the marker+tool_calls content that serves as the evidence, so a second run must not depend on it (an idempotency test pins this).

Tool calls, tool results, and genuine replies ("[memory] is not configured", a bare marker with no prior marker turn, a bare marker in a different session) are all left exactly as they are.

## Related Issue

Fixes #79350

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: add `_is_bare_marker_final_reply`, extend `_strip_stale_tool_call_markers` with the prior-marker-turn tracking, rewrite `purge_stale_tool_call_markers._find_affected` as one ordered per-session scan covering both shapes, update both docstrings.
- `tests/test_stale_tool_call_marker_session_repair.py`: 8 new tests, unit level (strip ordering, no-prior-turn kept, marker-sentence kept) and end to end (resume clears both shapes, purge clears both in one run and stays idempotent, per-session scoping, no-prior-turn purge keeps the row).

## How to Test

1. `scripts/run_tests.sh tests/test_stale_tool_call_marker_session_repair.py -q`
   - 22 passed, 0 failed
2. `scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_state/ tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_session_recovery.py -q`
   - 237 passed, 2 failed. Both failures are `TestCursesBrowse` cases that need the `_curses` module this Windows Python does not ship, and they fail identically on upstream/main.
3. Manual: seed a session with marker+tool_calls, tool result, then a bare "[memory]" final reply. Resume it and both rows come back blank. `hermes sessions clean-markers` reports 2 rows and a second run reports 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the state/session suites above and they pass. Full `pytest tests/ -q` not re-run here. Change is isolated to hermes_state repair logic plus its tests.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstrings updated in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure Python/SQLite change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```shell
# Before: only the tool_calls row is repaired, the replayed final reply survives
[{'role': 'assistant', 'content': '', 'tool_calls': [...]},
 {'role': 'tool', 'content': 'ok', ...},
 {'role': 'assistant', 'content': '[memory]'}]   # still teaching the marker

# After: both shapes cleared, tool_calls payload untouched
[{'role': 'assistant', 'content': '', 'tool_calls': [...]},
 {'role': 'tool', 'content': 'ok', ...},
 {'role': 'assistant', 'content': ''}]
```
