### PR TITLE
feat: add interactive task workspace start

### DIFF
--- a/hermes_cli/interactive_workspace.py
+++ b/hermes_cli/interactive_workspace.py
@@ -1,0 +1,689 @@
+"""Native interactive browser-session start for a Project-linked Kanban task.
+
+This is deliberately an edge service rather than a model tool.  It composes the
+existing Project, Kanban workspace and Session stores without claiming a task or
+creating an autonomous run.  The durable task event is both the lifecycle
+receipt and the idempotency record used after browser retries or process restarts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import subprocess
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+from hermes_state import SessionDB
+
+from hermes_cli import kanban_db as kdb
+from hermes_cli import projects_db as pdb
+from hermes_cli import web_git
+
+
+_ID_RE = re.compile(r"^[A-Za-z0-9_.:/-]{1,240}$")
+_START_LOCKS: dict[str, threading.Lock] = {}
+_START_LOCKS_GUARD = threading.Lock()
+_PREFLIGHT_CONFIG = Path(".hermes/workspace-start.json")
+_MAX_PREFLIGHT_OUTPUT = 2_000
+
+
+class InteractiveWorkspaceError(RuntimeError):
+    """Bounded, owner-visible workspace-start failure."""
+
+    def __init__(self, code: str, message: str, *, details: Optional[dict] = None):
+        super().__init__(message)
+        self.code = code
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class InteractiveWorkspaceRequest:
+    project_id: str
+    task_id: str
+    workstream_id: str
+    idempotency_key: str
+    write_scope: str
+    profile_name: str = ""
+
+
+@dataclass(frozen=True)
+class InteractiveWorkspaceResult:
+    project_id: str
+    task_id: str
+    workstream_id: str
+    session_id: str
+    repo_root: str
+    workspace_path: str
+    branch: str
+    base_ref: str
+    preflight_status: str
+    preflight_summary: str
+    reused: bool = False
+
+
+@dataclass(frozen=True)
+class InteractiveWorkspaceConnectedResult:
+    project_id: str
+    task_id: str
+    workstream_id: str
+    session_id: str
+    reused: bool = False
+
+
+@dataclass(frozen=True)
+class _PreparedWorktree:
+    repo_root: Path
+    path: Path
+    branch: str
+    base_ref: str
+    created_worktree: bool
+    created_branch: bool
+
+
+def _start_lock(key: str) -> threading.Lock:
+    with _START_LOCKS_GUARD:
+        return _START_LOCKS.setdefault(key, threading.Lock())
+
+
+@contextmanager
+def _cross_process_start_lock(lock_path: Path):
+    """Serialize one start intent across dashboard processes.
+
+    The file is only an inode anchor; the kernel owns lock liveness, so a
+    crashed process cannot leave a stale logical lock behind. The process-local
+    lock remains the first layer because POSIX ``flock`` alone does not
+    serialize sibling threads reliably.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        lock_path.parent.chmod(0o700)
+    except OSError:
+        pass
+    with lock_path.open("a+b") as lock_file:
+        try:
+            lock_path.chmod(0o600)
+        except OSError:
+            pass
+        if os.name == "posix":
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        else:
+            # Match Hermes' existing Windows cross-process lock strategy.
+            import portalocker
+
+            portalocker.lock(lock_file, portalocker.LOCK_EX)
+            try:
+                yield
+            finally:
+                portalocker.unlock(lock_file)
+
+
+@contextmanager
+def _serialized_start(lock_key: str):
+    digest = hashlib.sha256(lock_key.encode("utf-8")).hexdigest()
+    lock_path = (
+        Path(get_hermes_home())
+        / "runtime"
+        / "interactive-workspace-locks"
+        / f"{digest}.lock"
+    )
+    with _start_lock(lock_key):
+        with _cross_process_start_lock(lock_path):
+            yield
+
+
+def _clean_identifier(name: str, value: str) -> str:
+    clean = str(value or "").strip()
+    if not _ID_RE.fullmatch(clean):
+        raise InteractiveWorkspaceError("invalid_request", f"invalid {name}")
+    return clean
+
+
+def _run_git(cwd: Path, args: list[str], *, timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise InteractiveWorkspaceError("git_failed", f"git {' '.join(args[:2])} failed: {exc}") from exc
+
+
+def _git_ok(cwd: Path, args: list[str], *, timeout: int = 60) -> str:
+    result = _run_git(cwd, args, timeout=timeout)
+    if result.returncode != 0:
+        reason = (result.stderr or result.stdout or "git failed").strip()
+        raise InteractiveWorkspaceError("git_failed", reason[:500])
+    return result.stdout.strip()
+
+
+def _git_branch(path: Path) -> str:
+    return _git_ok(path, ["branch", "--show-current"])
+
+
+def _validate_repo(repo_root: Path) -> Path:
+    root = repo_root.expanduser().resolve()
+    actual = _git_ok(root, ["rev-parse", "--show-toplevel"])
+    if Path(actual).resolve() != root:
+        raise InteractiveWorkspaceError("project_repo_invalid", "project primary path is not a git root")
+    return root
+
+
+def _fetch_and_resolve_base(repo_root: Path) -> str:
+    fetch = _run_git(repo_root, ["fetch", "--prune", "origin"], timeout=120)
+    if fetch.returncode != 0:
+        reason = (fetch.stderr or fetch.stdout or "git fetch failed").strip()
+        raise InteractiveWorkspaceError("fetch_failed", reason[:500])
+
+    upstream = _run_git(
+        repo_root,
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+    )
+    candidates: list[str] = []
+    if upstream.returncode == 0 and upstream.stdout.strip().startswith("origin/"):
+        candidates.append(upstream.stdout.strip())
+    symbolic = _run_git(repo_root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])
+    if symbolic.returncode == 0:
+        candidates.append(symbolic.stdout.strip().replace("refs/remotes/", "", 1))
+    candidates.extend(["origin/main", "origin/master"])
+    for candidate in dict.fromkeys(candidates):
+        if _run_git(repo_root, ["rev-parse", "--verify", f"{candidate}^{{commit}}"]).__dict__.get("returncode") == 0:
+            return candidate
+    raise InteractiveWorkspaceError("base_not_found", "no fetched origin default branch is available")
+
+
+def _branch_checkout_paths(repo_root: Path, branch: str) -> list[Path]:
+    listing = _git_ok(repo_root, ["worktree", "list", "--porcelain"])
+    paths: list[Path] = []
+    current_path: Optional[Path] = None
+    wanted = f"refs/heads/{branch}"
+    for line in listing.splitlines():
+        if line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree ")).resolve()
+        elif line == f"branch {wanted}" and current_path is not None:
+            paths.append(current_path)
+    return paths
+
+
+def _prepare_worktree(repo_root: Path, target: Path, branch: str) -> _PreparedWorktree:
+    repo_root = _validate_repo(repo_root)
+    branch_check = _run_git(repo_root, ["check-ref-format", "--branch", branch])
+    if branch_check.returncode != 0:
+        raise InteractiveWorkspaceError("branch_invalid", "task branch is not a valid git branch")
+
+    allowed_root = (repo_root / ".worktrees").resolve()
+    target = target.expanduser().resolve(strict=False)
+    try:
+        target.relative_to(allowed_root)
+    except ValueError as exc:
+        raise InteractiveWorkspaceError(
+            "workspace_path_unsafe",
+            f"task worktree must live under {allowed_root}",
+        ) from exc
+
+    base_ref = _fetch_and_resolve_base(repo_root)
+    existing_branch = (
+        _run_git(
+            repo_root,
+            ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        ).returncode
+        == 0
+    )
+    before_paths = _branch_checkout_paths(repo_root, branch) if existing_branch else []
+    if target.exists() and target not in before_paths:
+        raise InteractiveWorkspaceError(
+            "workspace_collision",
+            f"workspace path is occupied: {target}",
+        )
+    if before_paths and target not in before_paths:
+        raise InteractiveWorkspaceError(
+            "workspace_collision",
+            f"branch {branch} is already bound to {before_paths[0]}",
+        )
+    created_worktree = not target.exists() and not before_paths
+
+    try:
+        added = web_git.worktree_add(
+            str(repo_root),
+            {
+                "name": target.name,
+                "directoryName": target.name,
+                "branch": branch,
+                "base": base_ref,
+            },
+        )
+    except RuntimeError as exc:
+        raise InteractiveWorkspaceError(
+            "worktree_create_failed",
+            str(exc)[:500],
+        ) from exc
+
+    canonical_path = Path(str(added["path"])).resolve()
+    canonical_root = Path(str(added["repoRoot"])).resolve()
+    if canonical_root != repo_root or canonical_path != target:
+        raise InteractiveWorkspaceError(
+            "workspace_collision",
+            f"branch {branch} is already bound to {canonical_path}",
+        )
+    return _PreparedWorktree(
+        repo_root,
+        canonical_path,
+        str(added["branch"]),
+        base_ref,
+        created_worktree,
+        created_worktree and not existing_branch,
+    )
+
+
+def _cleanup_new_worktree(prepared: _PreparedWorktree) -> str:
+    if not prepared.created_worktree:
+        return "not_created"
+    status = _run_git(prepared.path, ["status", "--porcelain"])
+    if status.returncode != 0 or status.stdout.strip():
+        return "dirty_preserved"
+    _run_git(prepared.repo_root, ["worktree", "unlock", str(prepared.path)])
+    removed = _run_git(prepared.repo_root, ["worktree", "remove", str(prepared.path)], timeout=120)
+    if removed.returncode != 0:
+        return "remove_failed"
+    if prepared.created_branch:
+        deleted = _run_git(prepared.repo_root, ["branch", "-D", prepared.branch])
+        if deleted.returncode != 0:
+            return "branch_delete_failed"
+    return "removed"
+
+
+def _preflight_environment(request: InteractiveWorkspaceRequest, prepared: _PreparedWorktree) -> dict[str, str]:
+    try:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env(scrub_secrets=True, inherit_profile_home=True)
+    except Exception:
+        env = {name: value for name, value in os.environ.items() if name in {"HOME", "PATH", "LANG", "LC_ALL"}}
+    env.update(
+        {
+            "HERMES_WORKSPACE_ROOT": str(prepared.path),
+            "HERMES_WORKSPACE_SCOPE": request.write_scope,
+            "HERMES_PROJECT_ID": request.project_id,
+            "HERMES_TASK_ID": request.task_id,
+            "HERMES_WORKSTREAM_ID": request.workstream_id,
+        }
+    )
+    return env
+
+
+def _run_preflight(
+    request: InteractiveWorkspaceRequest,
+    prepared: _PreparedWorktree,
+) -> tuple[str, str]:
+    config_path = prepared.path / _PREFLIGHT_CONFIG
+    if not config_path.is_file():
+        return "not_configured", "Repository has no .hermes/workspace-start.json preflight."
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        spec = config["preflight"]
+        command = spec["command"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise InteractiveWorkspaceError("preflight_config_invalid", f"invalid workspace preflight config: {exc}") from exc
+    if not isinstance(command, list) or not command or not all(isinstance(part, str) and part for part in command):
+        raise InteractiveWorkspaceError("preflight_config_invalid", "preflight command must be a non-empty argv list")
+    required = spec.get("required_inputs") or []
+    if "write_scope" in required and not request.write_scope.strip():
+        raise InteractiveWorkspaceError("write_scope_required", "repository preflight requires a write scope")
+    try:
+        timeout = max(5, min(300, int(spec.get("timeout_seconds", 120))))
+    except (TypeError, ValueError):
+        raise InteractiveWorkspaceError("preflight_config_invalid", "preflight timeout must be an integer")
+
+    env = _preflight_environment(request, prepared)
+    value_map = {
+        "workspace_path": str(prepared.path),
+        "write_scope": request.write_scope,
+        "project_id": request.project_id,
+        "task_id": request.task_id,
+        "workstream_id": request.workstream_id,
+    }
+    aliases = spec.get("env") or {}
+    if not isinstance(aliases, dict):
+        raise InteractiveWorkspaceError("preflight_config_invalid", "preflight env must be an object")
+    for env_name, source_name in aliases.items():
+        if not isinstance(env_name, str) or not re.fullmatch(r"[A-Z][A-Z0-9_]{0,79}", env_name):
+            raise InteractiveWorkspaceError("preflight_config_invalid", "preflight env name is invalid")
+        if source_name not in value_map:
+            raise InteractiveWorkspaceError("preflight_config_invalid", f"unsupported preflight env source: {source_name}")
+        env[env_name] = value_map[source_name]
+
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(prepared.path),
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise InteractiveWorkspaceError("preflight_failed", f"workspace preflight failed: {exc}") from exc
+    summary = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part.strip())
+    summary = summary[:_MAX_PREFLIGHT_OUTPUT]
+    if result.returncode != 0:
+        raise InteractiveWorkspaceError(
+            "preflight_failed",
+            f"workspace preflight exited {result.returncode}: {summary or 'no output'}",
+            details={"preflight_status": "failed", "preflight_summary": summary},
+        )
+    return "passed", summary or "Preflight passed."
+
+
+def _new_session_id() -> str:
+    return f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{secrets.token_hex(3)}"
+
+
+def _result_from_event(payload: dict[str, Any], *, reused: bool) -> InteractiveWorkspaceResult:
+    return InteractiveWorkspaceResult(
+        project_id=str(payload["project_id"]),
+        task_id=str(payload["task_id"]),
+        workstream_id=str(payload["workstream_id"]),
+        session_id=str(payload["session_id"]),
+        repo_root=str(payload["repo_root"]),
+        workspace_path=str(payload["workspace_path"]),
+        branch=str(payload["branch"]),
+        base_ref=str(payload.get("base_ref") or ""),
+        preflight_status=str(payload.get("preflight_status") or "unknown"),
+        preflight_summary=str(payload.get("preflight_summary") or ""),
+        reused=reused,
+    )
+
+
+def _existing_success(
+    conn,
+    request: InteractiveWorkspaceRequest,
+    session_db: SessionDB,
+) -> Optional[InteractiveWorkspaceResult]:
+    for event in reversed(kdb.list_events(conn, request.task_id)):
+        payload = event.payload or {}
+        if event.kind != "interactive_workspace_prepared" or payload.get("idempotency_key") != request.idempotency_key:
+            continue
+        expected_intent = {
+            "project_id": request.project_id,
+            "task_id": request.task_id,
+            "workstream_id": request.workstream_id,
+            "write_scope": request.write_scope,
+        }
+        mismatched = [
+            field
+            for field, expected in expected_intent.items()
+            if str(payload.get(field) or "") != expected
+        ]
+        if mismatched:
+            raise InteractiveWorkspaceError(
+                "idempotency_mismatch",
+                "idempotency key is already bound to a different start intent",
+                details={"mismatched_fields": mismatched},
+            )
+        result = _result_from_event(payload, reused=True)
+        row = session_db.get_session(result.session_id)
+        if row is None:
+            raise InteractiveWorkspaceError("stale_start_receipt", "the prior start session no longer exists")
+        path = Path(result.workspace_path)
+        if not path.is_dir() or _git_branch(path) != result.branch or str(row.get("cwd") or "") != result.workspace_path:
+            raise InteractiveWorkspaceError("stale_start_receipt", "the prior start workspace no longer matches its receipt")
+        return result
+    return None
+
+
+def _failure_payload(
+    request: InteractiveWorkspaceRequest,
+    exc: InteractiveWorkspaceError,
+    prepared: Optional[_PreparedWorktree],
+    cleanup: str,
+) -> dict[str, Any]:
+    return {
+        "project_id": request.project_id,
+        "task_id": request.task_id,
+        "workstream_id": request.workstream_id,
+        "idempotency_key": request.idempotency_key,
+        "code": exc.code,
+        "message": str(exc)[:500],
+        "workspace_path": str(prepared.path) if prepared else None,
+        "branch": prepared.branch if prepared else None,
+        "preflight_status": exc.details.get("preflight_status", "not_run"),
+        "preflight_summary": str(exc.details.get("preflight_summary") or "")[:_MAX_PREFLIGHT_OUTPUT],
+        "cleanup": cleanup,
+    }
+
+
+def start_interactive_task_workspace(request: InteractiveWorkspaceRequest) -> InteractiveWorkspaceResult:
+    """Prepare and persist one idempotent interactive session for a native task."""
+    request = InteractiveWorkspaceRequest(
+        project_id=_clean_identifier("project_id", request.project_id),
+        task_id=_clean_identifier("task_id", request.task_id),
+        workstream_id=_clean_identifier("workstream_id", request.workstream_id),
+        idempotency_key=_clean_identifier("idempotency_key", request.idempotency_key),
+        write_scope=str(request.write_scope or "").strip()[:500],
+        profile_name=str(request.profile_name or "").strip()[:100],
+    )
+    lock_key = f"{request.project_id}\0{request.task_id}\0{request.idempotency_key}"
+    with _serialized_start(lock_key):
+        with pdb.connect_closing() as project_conn:
+            project = pdb.get_project(project_conn, request.project_id)
+        if project is None or project.archived:
+            raise InteractiveWorkspaceError("project_not_found", f"project not found: {request.project_id}")
+        repo_value = str(project.primary_path or "").strip()
+        if not repo_value:
+            raise InteractiveWorkspaceError("project_repo_missing", "project has no primary repository")
+        board = str(project.board_slug or kdb.DEFAULT_BOARD)
+
+        prepared: Optional[_PreparedWorktree] = None
+        session_db = SessionDB()
+        session_id: Optional[str] = None
+        try:
+            with kdb.connect_closing(board=board) as conn:
+                task = kdb.get_task(conn, request.task_id)
+                if task is None:
+                    raise InteractiveWorkspaceError("task_not_found", f"task not found: {request.task_id}")
+                if str(task.project_id or "") != request.project_id:
+                    raise InteractiveWorkspaceError(
+                        "project_task_mismatch",
+                        f"task {request.task_id} does not belong to project {request.project_id}",
+                    )
+                if task.workspace_kind != "worktree":
+                    raise InteractiveWorkspaceError("task_workspace_invalid", "interactive coding task must use a worktree workspace")
+                existing = _existing_success(conn, request, session_db)
+                if existing is not None:
+                    return existing
+
+                repo_root = Path(repo_value)
+                target = Path(task.workspace_path) if task.workspace_path else repo_root / ".worktrees" / task.id
+                branch = str(task.branch_name or f"{project.slug}/{task.id}")
+                prepared = _prepare_worktree(repo_root, target, branch)
+                preflight_status, preflight_summary = _run_preflight(request, prepared)
+
+                session_id = _new_session_id()
+                session_db.create_session(
+                    session_id,
+                    source="dashboard",
+                    session_key=session_id,
+                    cwd=str(prepared.path),
+                    profile_name=request.profile_name or None,
+                    git_repo_root=str(prepared.repo_root),
+                )
+                session_db.update_session_cwd(
+                    session_id,
+                    str(prepared.path),
+                    git_branch=prepared.branch,
+                    git_repo_root=str(prepared.repo_root),
+                    replace_git_meta=True,
+                )
+                payload = {
+                    "project_id": request.project_id,
+                    "task_id": request.task_id,
+                    "workstream_id": request.workstream_id,
+                    "idempotency_key": request.idempotency_key,
+                    "write_scope": request.write_scope,
+                    "session_id": session_id,
+                    "repo_root": str(prepared.repo_root),
+                    "workspace_path": str(prepared.path),
+                    "branch": prepared.branch,
+                    "base_ref": prepared.base_ref,
+                    "preflight_status": preflight_status,
+                    "preflight_summary": preflight_summary,
+                    "execution_mode": "interactive",
+                    "task_claimed": False,
+                    "run_created": False,
+                }
+                kdb.bind_workspace_and_append_task_event(
+                    conn,
+                    task.id,
+                    prepared.path,
+                    prepared.branch,
+                    "interactive_workspace_prepared",
+                    payload,
+                )
+                return _result_from_event(payload, reused=False)
+        except InteractiveWorkspaceError as exc:
+            cleanup = _cleanup_new_worktree(prepared) if prepared else "not_created"
+            if session_id:
+                try:
+                    session_db.delete_session_if_empty(session_id)
+                except Exception:
+                    pass
+            try:
+                with kdb.connect_closing(board=board) as failure_conn:
+                    if kdb.get_task(failure_conn, request.task_id) is not None:
+                        kdb.append_task_event(
+                            failure_conn,
+                            request.task_id,
+                            "interactive_session_start_failed",
+                            _failure_payload(request, exc, prepared, cleanup),
+                        )
+            except Exception:
+                pass
+            raise
+        except Exception as raw_exc:
+            cleanup = _cleanup_new_worktree(prepared) if prepared else "not_created"
+            if session_id:
+                try:
+                    session_db.delete_session_if_empty(session_id)
+                except Exception:
+                    pass
+            exc = InteractiveWorkspaceError("start_persistence_failed", f"interactive start failed: {raw_exc}")
+            try:
+                with kdb.connect_closing(board=board) as failure_conn:
+                    if kdb.get_task(failure_conn, request.task_id) is not None:
+                        kdb.append_task_event(
+                            failure_conn,
+                            request.task_id,
+                            "interactive_session_start_failed",
+                            _failure_payload(request, exc, prepared, cleanup),
+                        )
+            except Exception:
+                pass
+            raise exc from raw_exc
+        finally:
+            session_db.close()
+
+
+def mark_interactive_task_session_connected(
+    request: InteractiveWorkspaceRequest,
+    session_id: str,
+) -> InteractiveWorkspaceConnectedResult:
+    """Persist the first browser-observed PTY frame for a prepared session."""
+    request = InteractiveWorkspaceRequest(
+        project_id=_clean_identifier("project_id", request.project_id),
+        task_id=_clean_identifier("task_id", request.task_id),
+        workstream_id=_clean_identifier("workstream_id", request.workstream_id),
+        idempotency_key=_clean_identifier("idempotency_key", request.idempotency_key),
+        write_scope=str(request.write_scope or "").strip()[:500],
+        profile_name=str(request.profile_name or "").strip()[:100],
+    )
+    clean_session_id = _clean_identifier("session_id", session_id)
+    lock_key = f"{request.project_id}\0{request.task_id}\0{request.idempotency_key}"
+    with _serialized_start(lock_key):
+        with pdb.connect_closing() as project_conn:
+            project = pdb.get_project(project_conn, request.project_id)
+        if project is None or project.archived:
+            raise InteractiveWorkspaceError("project_not_found", f"project not found: {request.project_id}")
+        board = str(project.board_slug or kdb.DEFAULT_BOARD)
+        session_db = SessionDB()
+        try:
+            with kdb.connect_closing(board=board) as conn:
+                task = kdb.get_task(conn, request.task_id)
+                if task is None:
+                    raise InteractiveWorkspaceError("task_not_found", f"task not found: {request.task_id}")
+                if str(task.project_id or "") != request.project_id:
+                    raise InteractiveWorkspaceError(
+                        "project_task_mismatch",
+                        f"task {request.task_id} does not belong to project {request.project_id}",
+                    )
+                prepared = _existing_success(conn, request, session_db)
+                if prepared is None:
+                    raise InteractiveWorkspaceError(
+                        "workspace_not_prepared",
+                        "interactive workspace has no matching prepared receipt",
+                    )
+                if prepared.session_id != clean_session_id:
+                    raise InteractiveWorkspaceError(
+                        "session_intent_mismatch",
+                        "session does not match the prepared workspace receipt",
+                    )
+                for event in reversed(kdb.list_events(conn, request.task_id)):
+                    payload = event.payload or {}
+                    if (
+                        event.kind == "interactive_session_connected"
+                        and payload.get("idempotency_key") == request.idempotency_key
+                        and payload.get("session_id") == clean_session_id
+                    ):
+                        return InteractiveWorkspaceConnectedResult(
+                            request.project_id,
+                            request.task_id,
+                            request.workstream_id,
+                            clean_session_id,
+                            reused=True,
+                        )
+                kdb.append_task_event(
+                    conn,
+                    request.task_id,
+                    "interactive_session_connected",
+                    {
+                        "project_id": request.project_id,
+                        "task_id": request.task_id,
+                        "workstream_id": request.workstream_id,
+                        "idempotency_key": request.idempotency_key,
+                        "session_id": clean_session_id,
+                        "execution_mode": "interactive",
+                        "consumer_evidence": "browser_pty_first_frame",
+                        "task_claimed": False,
+                        "run_created": False,
+                    },
+                )
+                return InteractiveWorkspaceConnectedResult(
+                    request.project_id,
+                    request.task_id,
+                    request.workstream_id,
+                    clean_session_id,
+                )
+        finally:
+            session_db.close()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3975,6 +3975,52 @@ def _append_event(
     )
 
 
+def append_task_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    kind: str,
+    payload: Optional[dict] = None,
+) -> None:
+    """Append a durable non-run task lifecycle event.
+
+    Interactive surfaces sometimes need to record native task-adjacent state
+    without claiming the task or manufacturing a worker run.  Keep that write
+    on the same event ledger every Kanban consumer already reads, and retain the
+    delegated-child mutation guard used by the rest of the public write API.
+    """
+    _assert_not_delegated_child_mutation()
+    if get_task(conn, task_id) is None:
+        raise ValueError(f"task not found: {task_id}")
+    clean_kind = str(kind or "").strip()
+    if not clean_kind:
+        raise ValueError("event kind is required")
+    with write_txn(conn):
+        _append_event(conn, task_id, clean_kind, payload)
+
+
+def bind_workspace_and_append_task_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    workspace_path: Path | str,
+    branch_name: str,
+    kind: str,
+    payload: Optional[dict] = None,
+) -> None:
+    """Atomically bind a task workspace and append its non-run receipt."""
+    _assert_not_delegated_child_mutation()
+    if get_task(conn, task_id) is None:
+        raise ValueError(f"task not found: {task_id}")
+    clean_kind = str(kind or "").strip()
+    if not clean_kind:
+        raise ValueError("event kind is required")
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ?, branch_name = ? WHERE id = ?",
+            (str(workspace_path), str(branch_name), task_id),
+        )
+        _append_event(conn, task_id, clean_kind, payload)
+
+
 def _end_run(
     conn: sqlite3.Connection,
     task_id: str,

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -592,6 +592,24 @@ def _unique_dir(base: str) -> str:
     return candidate
 
 
+def _worktree_directory_name(options: dict) -> str:
+    """Resolve an optional exact internal directory name, otherwise slugify UX text."""
+    exact = str(options.get("directoryName") or "").strip()
+    if exact:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,119}", exact):
+            raise RuntimeError("Invalid worktree directory name.")
+        return exact
+    return _slugify(options.get("name") or f"work-{os.urandom(4).hex()}")
+
+
+def _worktree_for_branch(root: str, branch: str) -> Optional[dict]:
+    """Return the canonical worktree already owning ``branch``, if any."""
+    for worktree in worktree_list(root):
+        if worktree.get("branch") == branch:
+            return worktree
+    return None
+
+
 def worktree_add(cwd: str, options: dict) -> dict:
     _ensure_repo(cwd)
     root = _main_root(cwd)
@@ -601,6 +619,13 @@ def worktree_add(cwd: str, options: dict) -> dict:
     if options.get("existingBranch"):
         if not existing:
             raise RuntimeError("Branch name is required.")
+        checked_out = _worktree_for_branch(root, existing)
+        if checked_out:
+            return {
+                "path": checked_out["path"],
+                "branch": existing,
+                "repoRoot": root,
+            }
         if existing == _default_branch(root):
             _git_ok(root, ["switch", existing])
             return {"path": root, "branch": existing, "repoRoot": root}
@@ -608,8 +633,15 @@ def worktree_add(cwd: str, options: dict) -> dict:
         _git_ok(root, ["worktree", "add", target, existing])
         return {"path": target, "branch": existing, "repoRoot": root}
 
-    slug = _slugify(options.get("name") or f"work-{os.urandom(4).hex()}")
+    slug = _worktree_directory_name(options)
     branch = _sanitize_branch(options.get("branch") or "") or f"hermes/{slug}"
+    checked_out = _worktree_for_branch(root, branch)
+    if checked_out:
+        return {
+            "path": checked_out["path"],
+            "branch": branch,
+            "repoRoot": root,
+        }
     target = _unique_dir(os.path.join(root, ".worktrees", slug))
     args = ["worktree", "add", "-b", branch, target]
     if options.get("base"):
@@ -625,7 +657,19 @@ def worktree_add(cwd: str, options: dict) -> dict:
     code, _, err = _git(root, args)
     if code != 0:
         if "already exists" in (err or "").lower():
-            _git_ok(root, ["worktree", "add", target, branch])
+            code, _, retry_err = _git(root, ["worktree", "add", target, branch])
+            if code != 0:
+                # A concurrent identical request may have won after our first
+                # branch lookup. Recover that canonical worktree instead of
+                # creating a duplicate or surfacing a false failure.
+                checked_out = _worktree_for_branch(root, branch)
+                if checked_out:
+                    return {
+                        "path": checked_out["path"],
+                        "branch": branch,
+                        "repoRoot": root,
+                    }
+                raise RuntimeError(retry_err.strip() or "git worktree add failed")
         else:
             raise RuntimeError(err.strip() or "git worktree add failed")
     return {"path": target, "branch": branch, "repoRoot": root}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13631,6 +13631,140 @@ def _config_profile_scope(profile: Optional[str]):
         reset_hermes_home_override(token)
 
 
+class InteractiveWorkspaceStartBody(BaseModel):
+    project_id: str
+    task_id: str
+    workstream_id: str
+    idempotency_key: str
+    write_scope: str = ""
+
+
+class InteractiveWorkspaceConnectedBody(InteractiveWorkspaceStartBody):
+    session_id: str
+
+
+@app.post("/api/workspaces/interactive/start")
+async def start_interactive_workspace(
+    body: InteractiveWorkspaceStartBody,
+    profile: Optional[str] = Query(default=None),
+):
+    """Prepare a native task worktree and a persisted resumable chat session.
+
+    This endpoint never claims the task and never creates a Kanban run.  The
+    blocking git/preflight/SQLite composition runs in the thread pool, with the
+    requested profile override installed inside that worker's context.
+    """
+    from dataclasses import asdict
+
+    from hermes_cli.interactive_workspace import (
+        InteractiveWorkspaceError,
+        InteractiveWorkspaceRequest,
+        start_interactive_task_workspace,
+    )
+
+    requested_profile = (profile or "").strip()
+
+    def _start():
+        with _config_profile_scope(requested_profile):
+            return start_interactive_task_workspace(
+                InteractiveWorkspaceRequest(
+                    project_id=body.project_id,
+                    task_id=body.task_id,
+                    workstream_id=body.workstream_id,
+                    idempotency_key=body.idempotency_key,
+                    write_scope=body.write_scope,
+                    profile_name=requested_profile,
+                )
+            )
+
+    try:
+        result = await run_in_threadpool(_start)
+    except InteractiveWorkspaceError as exc:
+        if exc.code in {"project_not_found", "task_not_found"}:
+            status = 404
+        elif exc.code in {
+            "project_task_mismatch",
+            "idempotency_mismatch",
+            "workspace_collision",
+            "branch_collision",
+            "stale_start_receipt",
+        }:
+            status = 409
+        elif exc.code in {
+            "fetch_failed",
+            "base_not_found",
+            "preflight_failed",
+            "preflight_config_invalid",
+            "write_scope_required",
+        }:
+            status = 422
+        else:
+            status = 400
+        raise HTTPException(
+            status_code=status,
+            detail={
+                "code": exc.code,
+                "message": str(exc),
+                "details": exc.details,
+            },
+        ) from exc
+    return {"ok": True, **asdict(result)}
+
+
+@app.post("/api/workspaces/interactive/connected")
+async def mark_interactive_workspace_connected(
+    body: InteractiveWorkspaceConnectedBody,
+    profile: Optional[str] = Query(default=None),
+):
+    """Record the first PTY frame observed by the authenticated browser."""
+    from dataclasses import asdict
+
+    from hermes_cli.interactive_workspace import (
+        InteractiveWorkspaceError,
+        InteractiveWorkspaceRequest,
+        mark_interactive_task_session_connected,
+    )
+
+    requested_profile = (profile or "").strip()
+
+    def _mark_connected():
+        with _config_profile_scope(requested_profile):
+            return mark_interactive_task_session_connected(
+                InteractiveWorkspaceRequest(
+                    project_id=body.project_id,
+                    task_id=body.task_id,
+                    workstream_id=body.workstream_id,
+                    idempotency_key=body.idempotency_key,
+                    write_scope=body.write_scope,
+                    profile_name=requested_profile,
+                ),
+                body.session_id,
+            )
+
+    try:
+        result = await run_in_threadpool(_mark_connected)
+    except InteractiveWorkspaceError as exc:
+        status = 404 if exc.code in {
+            "project_not_found",
+            "task_not_found",
+            "workspace_not_prepared",
+        } else 409 if exc.code in {
+            "project_task_mismatch",
+            "idempotency_mismatch",
+            "session_intent_mismatch",
+            "stale_start_receipt",
+        } else 400
+        raise HTTPException(
+            status_code=status,
+            detail={
+                "code": exc.code,
+                "message": str(exc),
+                "details": exc.details,
+            },
+        ) from exc
+    return {"ok": True, **asdict(result)}
+
+
 app.include_router(_skills_routes.router)
 from hermes_cli.web_routers.skills import (  # noqa: E402,F401 — legacy re-exports; tests call these via web_server.<name>
     get_skills,
@@ -15664,13 +15798,12 @@ async def pty_ws(ws: WebSocket) -> None:
     # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
     # client and close cleanly rather than pretending the feature works.
     if not _PTY_BRIDGE_AVAILABLE:
-        await ws.send_text(
-            "\r\n\x1b[31mChat unavailable: the embedded terminal requires a "
-            "POSIX PTY, which native Windows Python doesn't provide.\x1b[0m\r\n"
-            "\x1b[33mInstall Hermes inside WSL2 to use the dashboard's /chat "
-            "tab — the rest of the dashboard works here.\x1b[0m\r\n"
+        await ws.close(
+            code=1011,
+            reason=_ws_close_reason(
+                "embedded chat requires a POSIX PTY; use Hermes inside WSL2"
+            ),
         )
-        await ws.close(code=1011)
         return
 
     # --- spawn PTY ------------------------------------------------------
@@ -15707,13 +15840,11 @@ async def pty_ws(ws: WebSocket) -> None:
         argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)
     except HTTPException as exc:
         # Unknown/invalid profile from _resolve_profile_dir.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
-        await ws.close(code=1011)
+        await ws.close(code=1011, reason=_ws_close_reason(str(exc.detail)))
         return
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
+        await ws.close(code=1011, reason=_ws_close_reason(str(exc)))
         return
 
 
@@ -15733,12 +15864,10 @@ async def pty_ws(ws: WebSocket) -> None:
         try:
             bridge = _spawn()
         except PtyUnavailableError as exc:
-            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-            await ws.close(code=1011)
+            await ws.close(code=1011, reason=_ws_close_reason(str(exc)))
             return
         except (FileNotFoundError, OSError) as exc:
-            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
-            await ws.close(code=1011)
+            await ws.close(code=1011, reason=_ws_close_reason(str(exc)))
             return
         await _legacy_pump(ws, bridge)
         return
@@ -15749,12 +15878,10 @@ async def pty_ws(ws: WebSocket) -> None:
             attach_token, spawn=_spawn
         )
     except PtyUnavailableError as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
+        await ws.close(code=1011, reason=_ws_close_reason(str(exc)))
         return
     except (FileNotFoundError, OSError, RegistryFull) as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
+        await ws.close(code=1011, reason=_ws_close_reason(str(exc)))
         return
 
     await session.attach(ws)

--- a/tests/hermes_cli/test_interactive_workspace.py
+++ b/tests/hermes_cli/test_interactive_workspace.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import queue
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_state import SessionDB
+from hermes_cli import kanban_db as kdb
+from hermes_cli import projects_db as pdb
+from hermes_cli.interactive_workspace import (
+    InteractiveWorkspaceError,
+    InteractiveWorkspaceRequest,
+    mark_interactive_task_session_connected,
+    start_interactive_task_workspace,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _cross_process_lock_probe(lock_path: str, acquired, hold_seconds: float) -> None:
+    from hermes_cli.interactive_workspace import _cross_process_start_lock
+
+    with _cross_process_start_lock(Path(lock_path)):
+        acquired.put(time.monotonic())
+        time.sleep(hold_seconds)
+
+
+def _fixture_repo(tmp_path: Path, *, preflight_exit: int = 0) -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "clone", str(remote), str(repo)], check=True, capture_output=True)
+    _git(repo, "checkout", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Hermes Test")
+    (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+    hook_dir = repo / ".hermes"
+    hook_dir.mkdir()
+    (hook_dir / "preflight.py").write_text(
+        "import os, sys\n"
+        "required = ['HERMES_WORKSPACE_ROOT', 'HERMES_WORKSPACE_SCOPE', "
+        "'HERMES_PROJECT_ID', 'HERMES_TASK_ID', 'GOLIATH_ROOT', 'GOLIATH_WRITE_SCOPE']\n"
+        "missing = [name for name in required if not os.environ.get(name)]\n"
+        "print('PREFLIGHT_OK' if not missing else 'MISSING:' + ','.join(missing))\n"
+        f"sys.exit({preflight_exit} if not missing else 9)\n",
+        encoding="utf-8",
+    )
+    (hook_dir / "workspace-start.json").write_text(
+        json.dumps(
+            {
+                "preflight": {
+                    "command": ["python3", ".hermes/preflight.py"],
+                    "required_inputs": ["write_scope"],
+                    "timeout_seconds": 30,
+                    "env": {
+                        "GOLIATH_ROOT": "workspace_path",
+                        "GOLIATH_WRITE_SCOPE": "write_scope",
+                    },
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "README.md", ".hermes")
+    _git(repo, "commit", "-m", "fixture")
+    _git(repo, "push", "-u", "origin", "main")
+    subprocess.run(
+        ["git", "--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+    return repo, remote
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setattr("hermes_state.DEFAULT_DB_PATH", home / "state.db")
+    token = set_hermes_home_override(home)
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _seed_task(home: Path, repo: Path) -> tuple[str, str, str, Path]:
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(
+            conn,
+            name="Fixture Project",
+            slug="fixture-project",
+            primary_path=str(repo),
+            folders=[str(repo)],
+            board_slug="default",
+        )
+    kdb.create_board(
+        "default",
+        name="Fixture",
+        default_workdir=str(repo),
+        project_id=project_id,
+    )
+    with kdb.connect_closing(board="default") as conn:
+        task_id = kdb.create_task(
+            conn,
+            title="Interactive fixture",
+            created_by="test",
+            workspace_kind="worktree",
+            branch_name="feat/interactive-fixture",
+            project_id=project_id,
+            initial_status="running",
+            board="default",
+        )
+        task = kdb.get_task(conn, task_id)
+        assert task is not None
+        assert task.workspace_path
+        target = Path(task.workspace_path)
+    return project_id, task_id, "W-fixture", target
+
+
+def _request(project_id: str, task_id: str, workstream_id: str) -> InteractiveWorkspaceRequest:
+    return InteractiveWorkspaceRequest(
+        project_id=project_id,
+        task_id=task_id,
+        workstream_id=workstream_id,
+        idempotency_key=f"{project_id}:{task_id}:{workstream_id}:v1",
+        write_scope="fixture subsystem",
+        profile_name="fixture-profile",
+    )
+
+
+def test_start_persists_task_worktree_session_preflight_and_idempotent_event(
+    tmp_path: Path, isolated_home: Path
+):
+    repo, _remote = _fixture_repo(tmp_path)
+    project_id, task_id, workstream_id, target = _seed_task(isolated_home, repo)
+
+    request = _request(project_id, task_id, workstream_id)
+    first = start_interactive_task_workspace(request)
+    second = start_interactive_task_workspace(request)
+    connected = mark_interactive_task_session_connected(request, first.session_id)
+    connected_retry = mark_interactive_task_session_connected(request, first.session_id)
+    changed_intent = InteractiveWorkspaceRequest(
+        project_id=project_id,
+        task_id=task_id,
+        workstream_id="W-other",
+        idempotency_key=_request(project_id, task_id, workstream_id).idempotency_key,
+        write_scope="fixture subsystem",
+        profile_name="fixture-profile",
+    )
+    with pytest.raises(InteractiveWorkspaceError) as mismatch:
+        start_interactive_task_workspace(changed_intent)
+
+    assert first.reused is False
+    assert second.reused is True
+    assert second.session_id == first.session_id
+    assert connected.session_id == first.session_id
+    assert connected.reused is False
+    assert connected_retry.reused is True
+    assert mismatch.value.code == "idempotency_mismatch"
+    assert first.project_id == project_id
+    assert first.task_id == task_id
+    assert first.workstream_id == workstream_id
+    assert Path(first.workspace_path) == target
+    assert first.branch == "feat/interactive-fixture"
+    assert first.preflight_status == "passed"
+    assert "PREFLIGHT_OK" in first.preflight_summary
+    assert _git(target, "branch", "--show-current") == first.branch
+    assert _git(target, "rev-parse", "HEAD") == _git(repo, "rev-parse", "origin/main")
+
+    db = SessionDB(db_path=isolated_home / "state.db")
+    try:
+        stored = db.get_session(first.session_id)
+        assert stored is not None
+        assert stored["cwd"] == str(target)
+        assert stored["git_branch"] == first.branch
+        assert stored["git_repo_root"] == str(repo)
+        assert stored["profile_name"] == "fixture-profile"
+        assert stored["message_count"] == 0
+    finally:
+        db.close()
+
+    with kdb.connect_closing(board="default") as conn:
+        task = kdb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert kdb.list_runs(conn, task_id) == []
+        events = kdb.list_events(conn, task_id)
+        starts = [event for event in events if event.kind == "interactive_workspace_prepared"]
+        connected_events = [event for event in events if event.kind == "interactive_session_connected"]
+        assert len(starts) == 1
+        assert len(connected_events) == 1
+        payload = starts[0].payload
+        assert payload["session_id"] == first.session_id
+        assert payload["project_id"] == project_id
+        assert payload["workstream_id"] == workstream_id
+        assert payload["workspace_path"] == str(target)
+        assert payload["preflight_status"] == "passed"
+
+
+def test_cross_process_start_lock_serializes_identical_intents(tmp_path: Path):
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Queue()
+    lock_path = tmp_path / "interactive-start.lock"
+    first = context.Process(
+        target=_cross_process_lock_probe,
+        args=(str(lock_path), acquired, 0.5),
+    )
+    second = context.Process(
+        target=_cross_process_lock_probe,
+        args=(str(lock_path), acquired, 0.0),
+    )
+
+    first.start()
+    first_acquired = acquired.get(timeout=5)
+    second.start()
+    with pytest.raises(queue.Empty):
+        acquired.get(timeout=0.15)
+    first.join(timeout=5)
+    assert first.exitcode == 0
+    second_acquired = acquired.get(timeout=5)
+    second.join(timeout=5)
+    assert second.exitcode == 0
+    assert second_acquired - first_acquired >= 0.4
+
+
+def test_project_task_mismatch_fails_before_workspace_or_session(
+    tmp_path: Path, isolated_home: Path
+):
+    repo, _remote = _fixture_repo(tmp_path)
+    project_id, task_id, workstream_id, target = _seed_task(isolated_home, repo)
+    with pdb.connect_closing() as conn:
+        wrong_project_id = pdb.create_project(
+            conn,
+            name="Wrong Project",
+            slug="wrong-project",
+            primary_path=str(repo),
+            folders=[str(repo)],
+            board_slug="default",
+        )
+
+    with pytest.raises(InteractiveWorkspaceError, match="does not belong") as exc_info:
+        start_interactive_task_workspace(_request(wrong_project_id, task_id, workstream_id))
+
+    assert exc_info.value.code == "project_task_mismatch"
+    assert not target.exists()
+    db = SessionDB(db_path=isolated_home / "state.db")
+    try:
+        assert db.list_sessions_rich(limit=20) == []
+    finally:
+        db.close()
+
+
+def test_preflight_failure_is_persisted_and_cleans_only_new_worktree(
+    tmp_path: Path, isolated_home: Path
+):
+    repo, _remote = _fixture_repo(tmp_path, preflight_exit=7)
+    project_id, task_id, workstream_id, target = _seed_task(isolated_home, repo)
+
+    with pytest.raises(InteractiveWorkspaceError, match="preflight") as exc_info:
+        start_interactive_task_workspace(_request(project_id, task_id, workstream_id))
+
+    assert exc_info.value.code == "preflight_failed"
+    assert not target.exists()
+    assert _git(repo, "branch", "--list", "feat/interactive-fixture") == ""
+    db = SessionDB(db_path=isolated_home / "state.db")
+    try:
+        assert db.list_sessions_rich(limit=20) == []
+    finally:
+        db.close()
+
+    with kdb.connect_closing(board="default") as conn:
+        failures = [event for event in kdb.list_events(conn, task_id) if event.kind == "interactive_session_start_failed"]
+        assert len(failures) == 1
+        assert failures[0].payload["code"] == "preflight_failed"
+        assert failures[0].payload["preflight_status"] == "failed"

--- a/tests/hermes_cli/test_web_interactive_workspace.py
+++ b/tests/hermes_cli/test_web_interactive_workspace.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.interactive_workspace import (
+    InteractiveWorkspaceConnectedResult,
+    InteractiveWorkspaceError,
+    InteractiveWorkspaceResult,
+)
+
+
+@pytest.fixture
+def client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    result = TestClient(app)
+    result.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return result
+
+
+def _payload() -> dict[str, str]:
+    return {
+        "project_id": "p_fixture",
+        "task_id": "t_fixture",
+        "workstream_id": "W1.1",
+        "idempotency_key": "p_fixture:t_fixture:W1.1:v1",
+        "write_scope": "dashboard frontend",
+    }
+
+
+def test_interactive_workspace_endpoint_returns_persisted_receipt(client, monkeypatch):
+    import hermes_cli.interactive_workspace as workspace
+
+    captured = []
+
+    def fake_start(request):
+        captured.append(request)
+        return InteractiveWorkspaceResult(
+            project_id=request.project_id,
+            task_id=request.task_id,
+            workstream_id=request.workstream_id,
+            session_id="20260805_120000_ab12cd",
+            repo_root="/repo",
+            workspace_path="/repo/.worktrees/t_fixture",
+            branch="feat/browser-session",
+            base_ref="origin/main",
+            preflight_status="passed",
+            preflight_summary="PREFLIGHT_OK",
+            reused=False,
+        )
+
+    monkeypatch.setattr(workspace, "start_interactive_task_workspace", fake_start)
+
+    response = client.post("/api/workspaces/interactive/start", json=_payload())
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "project_id": "p_fixture",
+        "task_id": "t_fixture",
+        "workstream_id": "W1.1",
+        "session_id": "20260805_120000_ab12cd",
+        "repo_root": "/repo",
+        "workspace_path": "/repo/.worktrees/t_fixture",
+        "branch": "feat/browser-session",
+        "base_ref": "origin/main",
+        "preflight_status": "passed",
+        "preflight_summary": "PREFLIGHT_OK",
+        "reused": False,
+    }
+    assert len(captured) == 1
+    assert captured[0].profile_name == ""
+
+
+def test_interactive_workspace_endpoint_maps_native_conflict(client, monkeypatch):
+    import hermes_cli.interactive_workspace as workspace
+
+    def fail(_request):
+        raise InteractiveWorkspaceError(
+            "project_task_mismatch",
+            "task does not belong to project",
+        )
+
+    monkeypatch.setattr(workspace, "start_interactive_task_workspace", fail)
+
+    response = client.post("/api/workspaces/interactive/start", json=_payload())
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "project_task_mismatch"
+
+
+def test_interactive_workspace_connected_endpoint_records_consumer_evidence(
+    client, monkeypatch
+):
+    import hermes_cli.interactive_workspace as workspace
+
+    captured = []
+
+    def fake_connected(request, session_id):
+        captured.append((request, session_id))
+        return InteractiveWorkspaceConnectedResult(
+            project_id=request.project_id,
+            task_id=request.task_id,
+            workstream_id=request.workstream_id,
+            session_id=session_id,
+        )
+
+    monkeypatch.setattr(
+        workspace,
+        "mark_interactive_task_session_connected",
+        fake_connected,
+    )
+    response = client.post(
+        "/api/workspaces/interactive/connected",
+        json={**_payload(), "session_id": "20260805_120000_ab12cd"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "project_id": "p_fixture",
+        "task_id": "t_fixture",
+        "workstream_id": "W1.1",
+        "session_id": "20260805_120000_ab12cd",
+        "reused": False,
+    }
+    assert captured[0][1] == "20260805_120000_ab12cd"
+
+
+def test_interactive_workspace_endpoint_requires_dashboard_auth(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    from hermes_cli.web_server import app
+
+    response = TestClient(app).post("/api/workspaces/interactive/start", json=_payload())
+
+    assert response.status_code == 401

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3569,6 +3569,7 @@ class TestPtyWebSocket:
 
 
     def test_unavailable_platform_closes_with_message(self, monkeypatch):
+        from starlette.websockets import WebSocketDisconnect
         from hermes_cli.pty_bridge import PtyUnavailableError
 
         def _raise(argv, **kwargs):
@@ -3584,10 +3585,11 @@ class TestPtyWebSocket:
 
         monkeypatch.setattr(ws_mod.PtyBridge, "spawn", classmethod(lambda cls, *a, **k: _raise(*a, **k)))
 
-        with self.client.websocket_connect(self._url()) as conn:
-            # Expect a final text frame with the error message, then close.
-            msg = conn.receive_text()
-            assert "pty missing" in msg or "unavailable" in msg.lower() or "pty" in msg.lower()
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with self.client.websocket_connect(self._url()) as conn:
+                conn.receive_text()
+        assert exc_info.value.code == 1011
+        assert "pty missing" in exc_info.value.reason.lower()
 
 
 

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -75,6 +75,29 @@ def test_stage_commit_roundtrip_clears_changes(client, repo):
 
 
 
+def test_worktree_add_recovers_existing_branch_idempotently(client, repo):
+    payload = {
+        "path": str(repo),
+        "name": "browser-retry",
+        "branch": "feature/browser-retry",
+    }
+
+    first = client.post("/api/git/worktree/add", json=payload)
+    second = client.post("/api/git/worktree/add", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json() == first.json()
+    worktrees = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert worktrees.count("branch refs/heads/feature/browser-retry") == 1
+
+
 def test_worktree_add_initializes_plain_folder(client, tmp_path):
     folder = tmp_path / "plain-project"
     folder.mkdir()

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -90,6 +90,15 @@ export const de: Translations = {
     statusOverview: "Statusübersicht",
     system: "System",
     webUi: "Web UI",
+    workspaceStart: {
+      preparing: "Hermes bereitet Worktree, Preflight und Session vor …",
+      failed:
+        "Der Task-Workspace konnte nicht vorbereitet werden. Es wurde kein Run gestartet.",
+      retry: "Workspace-Start erneut versuchen",
+      failurePrefix: "Workspace-Start fehlgeschlagen",
+      evidenceFailurePrefix:
+        "Chat verbunden, aber der Verbindungsnachweis konnte nicht gespeichert werden",
+    },
   },
 
   status: {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -97,6 +97,14 @@ export const en: Translations = {
     currentProfileOption: "this dashboard ({name})",
     managingProfileBanner:
       "Managing profile \u201c{name}\u201d \u2014 config, keys, skills, MCPs, model, and new chats apply to that profile.",
+    workspaceStart: {
+      preparing: "Preparing task worktree, preflight, and session...",
+      failed: "The task workspace could not be prepared. No run was started.",
+      retry: "Retry workspace start",
+      failurePrefix: "Workspace start failed",
+      evidenceFailurePrefix:
+        "Chat connected, but workspace evidence could not be recorded",
+    },
   },
 
   status: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -115,6 +115,14 @@ export interface Translations {
     managingProfile?: string;
     currentProfileOption?: string;
     managingProfileBanner?: string;
+    /** Optional — untranslated locales use the English workspace-start copy. */
+    workspaceStart?: {
+      preparing: string;
+      failed: string;
+      retry: string;
+      failurePrefix: string;
+      evidenceFailurePrefix: string;
+    };
   };
 
   // ── Status page ──

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -84,6 +84,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  "/api/workspaces/interactive",
   // A named profile keeps its own pairing whitelist, and its gateway only
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.
@@ -334,8 +335,69 @@ function appendSessionFilters(url: string, options: SessionQueryOptions): string
   return appendProfileParam(next, options.profile);
 }
 
+export interface InteractiveWorkspaceStartRequest {
+  project_id: string;
+  task_id: string;
+  workstream_id: string;
+  idempotency_key: string;
+  write_scope: string;
+}
+
+export interface InteractiveWorkspaceStartResponse {
+  ok: true;
+  project_id: string;
+  task_id: string;
+  workstream_id: string;
+  session_id: string;
+  repo_root: string;
+  workspace_path: string;
+  branch: string;
+  base_ref: string;
+  preflight_status: "passed" | "not_configured";
+  preflight_summary: string;
+  reused: boolean;
+}
+
+export interface InteractiveWorkspaceConnectedRequest
+  extends InteractiveWorkspaceStartRequest {
+  session_id: string;
+}
+
+export interface InteractiveWorkspaceConnectedResponse {
+  ok: true;
+  project_id: string;
+  task_id: string;
+  workstream_id: string;
+  session_id: string;
+  reused: boolean;
+}
+
 export const api = {
   buildWsUrl,
+  startInteractiveWorkspace: (
+    request: InteractiveWorkspaceStartRequest,
+    profile = getManagementProfile(),
+  ) =>
+    fetchJSON<InteractiveWorkspaceStartResponse>(
+      appendProfileParam("/api/workspaces/interactive/start", profile),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      },
+    ),
+  markInteractiveWorkspaceConnected: (
+    request: InteractiveWorkspaceConnectedRequest,
+    profile = getManagementProfile(),
+  ) =>
+    fetchJSON<InteractiveWorkspaceConnectedResponse>(
+      appendProfileParam("/api/workspaces/interactive/connected", profile),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      },
+    ),
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   /**
    * Identity probe for the dashboard auth gate (Phase 7).

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location-search">{location.search}</output>;
+}
 
 class FakeFitAddon {
   fit() {}
@@ -97,11 +102,22 @@ vi.mock("@/i18n", () => ({
         closeModelTools: "Close model tools",
         modelToolsSheetSubtitle: "Tools",
         modelToolsSheetTitle: "Model",
+        workspaceStart: {
+          preparing: "Hermes bereitet Worktree, Preflight und Session vor …",
+          failed:
+            "Der Task-Workspace konnte nicht vorbereitet werden. Es wurde kein Run gestartet.",
+          retry: "Workspace-Start erneut versuchen",
+          failurePrefix: "Workspace-Start fehlgeschlagen",
+          evidenceFailurePrefix:
+            "Chat verbunden, aber der Verbindungsnachweis konnte nicht gespeichert werden",
+        },
       },
     },
   }),
 }));
 vi.mock("@/lib/dashboard-auth-reload", () => ({
+  attemptDashboardTokenReloadOnce: vi.fn(() => false),
+  clearDashboardTokenReloadAttempt: vi.fn(),
   maybeReloadForLoopbackWsAuthFailure,
 }));
 
@@ -224,5 +240,167 @@ describe("ChatPage", () => {
     });
 
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
+  });
+
+  it("prepares a task workspace before opening the exact persisted session", async () => {
+    let resolveFetch!: (response: Response) => void;
+    const responsePromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(() => responsePromise);
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter
+        initialEntries={[
+          "/chat?profile=goliath-main&start_project=p_fixture&start_task=t_fixture&start_workstream=W1.1&start_key=p_fixture%3At_fixture%3AW1.1%3Av1&write_scope=dashboard",
+        ]}
+      >
+        <ChatPage isActive />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(container.textContent).toContain(
+      "Hermes bereitet Worktree, Preflight und Session vor …",
+    );
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "/api/workspaces/interactive/start?profile=goliath-main",
+    );
+    expect(JSON.parse(String(init?.body))).toEqual({
+      project_id: "p_fixture",
+      task_id: "t_fixture",
+      workstream_id: "W1.1",
+      idempotency_key: "p_fixture:t_fixture:W1.1:v1",
+      write_scope: "dashboard",
+    });
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          project_id: "p_fixture",
+          task_id: "t_fixture",
+          workstream_id: "W1.1",
+          session_id: "20260805_120000_ab12cd",
+          repo_root: "/repo",
+          workspace_path: "/repo/.worktrees/t_fixture",
+          branch: "feat/browser-session",
+          base_ref: "origin/main",
+          preflight_status: "passed",
+          preflight_summary: "PREFLIGHT_OK",
+          reused: false,
+        }),
+        text: async () => "",
+      } as Response);
+      await responsePromise;
+    });
+
+    await vi.waitFor(() =>
+      expect(container?.textContent).not.toContain(
+        "Hermes bereitet Worktree, Preflight und Session vor …",
+      ),
+    );
+    expect(container?.textContent).not.toContain("Workspace-Start fehlgeschlagen:");
+    await vi.waitFor(() =>
+      expect(
+        container?.querySelector('[data-testid="location-search"]')?.textContent,
+      ).toContain("resume=20260805_120000_ab12cd"),
+    );
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(FakeWebSocket.instances[0].url).toContain(
+      "resume=20260805_120000_ab12cd",
+    );
+    expect(FakeWebSocket.instances[0].url).toContain("profile=goliath-main");
+    await act(async () => {
+      FakeWebSocket.instances[0].onmessage?.({
+        data: "\r\n\u001b[31mChat unavailable: pty failed\u001b[0m\r\n",
+      });
+      await Promise.resolve();
+    });
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes("/api/workspaces/interactive/connected"),
+      ),
+    ).toHaveLength(0);
+    await act(async () => {
+      FakeWebSocket.instances[0].onmessage?.({ data: "PTY ready" });
+      FakeWebSocket.instances[0].onmessage?.({ data: "second frame" });
+      await Promise.resolve();
+    });
+    await vi.waitFor(() =>
+      expect(
+        fetchMock.mock.calls.filter(([url]) =>
+          String(url).includes("/api/workspaces/interactive/connected"),
+        ),
+      ).toHaveLength(1),
+    );
+    const [connectedUrl, connectedInit] = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("/api/workspaces/interactive/connected"),
+    )!;
+    expect(connectedUrl).toBe(
+      "/api/workspaces/interactive/connected?profile=goliath-main",
+    );
+    expect(JSON.parse(String(connectedInit?.body))).toMatchObject({
+      project_id: "p_fixture",
+      task_id: "t_fixture",
+      workstream_id: "W1.1",
+      idempotency_key: "p_fixture:t_fixture:W1.1:v1",
+      session_id: "20260805_120000_ab12cd",
+    });
+  });
+
+  it("shows localized, keyboard-reachable workspace failure recovery", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            detail: {
+              code: "preflight_failed",
+              message: "Preflight fehlgeschlagen",
+            },
+          }),
+          {
+            status: 422,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    );
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter
+        initialEntries={[
+          "/chat?profile=goliath-main&start_project=p_fixture&start_task=t_fixture&start_workstream=W1.1&start_key=p_fixture%3At_fixture%3AW1.1%3Av1&write_scope=dashboard",
+        ]}
+      >
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain("Workspace-Start fehlgeschlagen:"),
+    );
+    expect(container.textContent).toContain(
+      "Der Task-Workspace konnte nicht vorbereitet werden. Es wurde kein Run gestartet.",
+    );
+    const retry = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Workspace-Start erneut versuchen",
+    );
+    expect(retry).toBeDefined();
+    expect(retry?.disabled).toBe(false);
+    retry?.focus();
+    expect(document.activeElement).toBe(retry);
+    expect(FakeWebSocket.instances).toHaveLength(0);
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -289,6 +289,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     title: string | null;
   }>({ scope: "", title: null });
   const { t } = useI18n();
+  const workspaceStartCopy = t.app.workspaceStart ?? {
+    preparing: "Preparing task worktree, preflight, and session...",
+    failed: "The task workspace could not be prepared. No run was started.",
+    retry: "Retry workspace start",
+    failurePrefix: "Workspace start failed",
+    evidenceFailurePrefix:
+      "Chat connected, but workspace evidence could not be recorded",
+  };
   const closeMobilePanel = useCallback(() => setMobilePanelOpenRaw(false), []);
   const modelToolsLabel = useMemo(
     () => `${t.app.modelToolsSheetTitle} ${t.app.modelToolsSheetSubtitle}`,
@@ -321,10 +329,34 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // Profile-scoped chat: spawn the PTY under the globally selected
   // management profile. Changing it remounts the terminal (key below /
   // effect dep) so the user explicitly starts a fresh scoped session.
-  const { profile: scopedProfile } = useProfileScope();
+  const { profile: managementProfile } = useProfileScope();
+  const explicitProfile = searchParams.get("profile")?.trim() ?? "";
+  const chatProfile = explicitProfile || managementProfile;
+  const startProject = searchParams.get("start_project")?.trim() ?? "";
+  const startTask = searchParams.get("start_task")?.trim() ?? "";
+  const startWorkstream = searchParams.get("start_workstream")?.trim() ?? "";
+  const startKey = searchParams.get("start_key")?.trim() ?? "";
+  const startScope = searchParams.get("write_scope")?.trim() ?? "";
+  const hasWorkspaceStartIntent = Boolean(
+    startProject || startTask || startWorkstream || startKey || startScope,
+  );
+  const workspaceStartBlocked = hasWorkspaceStartIntent && !resumeParam;
+  const [workspaceStartAttempt, setWorkspaceStartAttempt] = useState(0);
+  const [workspaceStartState, setWorkspaceStartState] = useState<
+    "idle" | "starting" | "failed"
+  >(() => (workspaceStartBlocked ? "starting" : "idle"));
+  const workspaceStartReceiptRef = useRef<{
+    project_id: string;
+    task_id: string;
+    workstream_id: string;
+    idempotency_key: string;
+    write_scope: string;
+    session_id: string;
+  } | null>(null);
+  const workspaceConnectedReportedRef = useRef<string | null>(null);
   const channel = useMemo(
-    () => generateChannelId(`${resumeParam ?? ""}\0${scopedProfile}`),
-    [resumeParam, scopedProfile],
+    () => generateChannelId(`${resumeParam ?? ""}\0${chatProfile}`),
+    [resumeParam, chatProfile],
   );
   const titleScope = `${channel}\0${reconnectNonce}`;
   const sessionTitle =
@@ -333,6 +365,90 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     (title: string | null) => setSessionTitleState({ scope: titleScope, title }),
     [titleScope],
   );
+
+  useEffect(() => {
+    if (!workspaceStartBlocked) return;
+
+    let cancelled = false;
+    const missing = [
+      ["project", startProject],
+      ["task", startTask],
+      ["workstream", startWorkstream],
+      ["idempotency key", startKey],
+    ]
+      .filter(([, value]) => !value)
+      .map(([name]) => name);
+
+    void Promise.resolve()
+      .then(() => {
+        if (missing.length) {
+          throw new Error(`Workspace start is missing: ${missing.join(", ")}`);
+        }
+        return api.startInteractiveWorkspace(
+          {
+            project_id: startProject,
+            task_id: startTask,
+            workstream_id: startWorkstream,
+            idempotency_key: startKey,
+            write_scope: startScope,
+          },
+          chatProfile,
+        );
+      })
+      .then((result) => {
+        if (cancelled) return;
+        workspaceStartReceiptRef.current = {
+          project_id: startProject,
+          task_id: startTask,
+          workstream_id: startWorkstream,
+          idempotency_key: startKey,
+          write_scope: startScope,
+          session_id: result.session_id,
+        };
+        workspaceConnectedReportedRef.current = null;
+        setBanner(null);
+        setWorkspaceStartState("idle");
+        setSearchParams(
+          (current) => {
+            const next = new URLSearchParams(current);
+            for (const name of [
+              "start_project",
+              "start_task",
+              "start_workstream",
+              "start_key",
+              "write_scope",
+            ]) {
+              next.delete(name);
+            }
+            next.set("resume", result.session_id);
+            if (chatProfile) next.set("profile", chatProfile);
+            return next;
+          },
+          { replace: true },
+        );
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setWorkspaceStartState("failed");
+        setBanner(`${workspaceStartCopy.failurePrefix}: ${message}`);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    workspaceStartBlocked,
+    workspaceStartAttempt,
+    startProject,
+    startTask,
+    startWorkstream,
+    startKey,
+    startScope,
+    chatProfile,
+    workspaceStartCopy.failurePrefix,
+    setSearchParams,
+  ]);
 
   useEffect(() => {
     if (!isActive) {
@@ -350,7 +466,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let cancelled = false;
 
     api
-      .getSessionDetail(resumeParam, scopedProfile)
+      .getSessionDetail(resumeParam, chatProfile)
       .then((session) => {
         if (cancelled) return;
         handleSessionTitleChange(normalizeSessionTitle(session.title));
@@ -362,7 +478,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [resumeParam, scopedProfile, handleSessionTitleChange]);
+  }, [resumeParam, chatProfile, handleSessionTitleChange]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -370,7 +486,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let cancelled = false;
 
     api
-      .getSessionLatestDescendant(resumeParam, scopedProfile)
+      .getSessionLatestDescendant(resumeParam, chatProfile)
       .then((res) => {
         if (cancelled || !res.session_id || res.session_id === resumeParam) {
           return;
@@ -387,7 +503,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [resumeParam, scopedProfile, searchParams, setSearchParams]);
+  }, [resumeParam, chatProfile, searchParams, setSearchParams]);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");
@@ -476,6 +592,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // mounted, hidden ChatPage from opening `/api/pty` on every dashboard
     // page. Sticky, so switching away from /chat keeps the PTY alive.
     if (!hasActivated) return;
+    if (workspaceStartBlocked) return;
 
     const host = hostRef.current;
     if (!host) return;
@@ -610,7 +727,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       void (async () => {
         const paths: string[] = [];
         for (const file of files) {
-          const uploaded = await uploadChatImage(file, scopedProfile);
+          const uploaded = await uploadChatImage(file, chatProfile);
           if (imageUploadDisposed) return;
           paths.push(uploaded.path);
         }
@@ -978,7 +1095,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).
-      if (scopedProfile) params.profile = scopedProfile;
+      if (chatProfile) params.profile = chatProfile;
       const url = await api.buildWsUrl("/api/pty", params);
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
@@ -1059,6 +1176,31 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           : decoder.decode(new Uint8Array(ev.data as ArrayBuffer), {
               stream: true,
             });
+      // Mixed-clock compatibility: older dashboard servers sent startup
+      // failures as ordinary ANSI terminal frames before closing with 1011.
+      // Render those bytes, but never treat them as PTY-process evidence.
+      const isLegacyStartupFailure =
+        text.includes("Chat unavailable:") ||
+        text.includes("Chat failed to start:");
+      const receipt = workspaceStartReceiptRef.current;
+      if (
+        text &&
+        !isLegacyStartupFailure &&
+        receipt &&
+        receipt.session_id === resumeParam &&
+        workspaceConnectedReportedRef.current !== receipt.session_id
+      ) {
+        workspaceConnectedReportedRef.current = receipt.session_id;
+        void api
+          .markInteractiveWorkspaceConnected(receipt, chatProfile)
+          .catch((err: unknown) => {
+            workspaceConnectedReportedRef.current = null;
+            const message = err instanceof Error ? err.message : String(err);
+            setBanner(
+              `${workspaceStartCopy.evidenceFailurePrefix}: ${message}`,
+            );
+          });
+      }
       // Gate hydration on the payload actually written to xterm. The
       // sanitizer can turn a nonempty erase-only / all-newline / partial-CSI
       // resume frame into "" (pty-resume-sanitizer.ts); keying off raw `text`
@@ -1134,8 +1276,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         return;
       }
       if (ev.code === 1011) {
-        // Server already wrote an ANSI error frame.
         setPtyState("closed");
+        if (ev.reason) {
+          setBanner(`Chat failed to start: ${ev.reason}`);
+        }
         return;
       }
       // Keep-alive close-code contract (web_server.pty_ws + pty_session):
@@ -1275,8 +1419,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     channel,
     clearReconnectTimer,
     resumeParam,
-    scopedProfile,
+    chatProfile,
+    workspaceStartBlocked,
     reconnectNonce,
+    workspaceStartCopy.evidenceFailurePrefix,
   ]);
 
   // When the user returns to the chat tab (isActive: false → true), the
@@ -1480,14 +1626,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             <div className="border-b border-current/10 px-1 py-2">
               <ChatSidebar
                 channel={channel}
-                profile={scopedProfile}
+                profile={chatProfile}
                 onDashboardNewSessionRequest={startFreshDashboardChat}
                 onSessionTitleChange={handleSessionTitleChange}
               />
             </div>
             <ChatSessionList
               activeSessionId={resumeParam}
-              profile={scopedProfile}
+              profile={chatProfile}
               onPicked={closeMobilePanel}
               onNewChat={startFreshDashboardChat}
             />
@@ -1523,6 +1669,32 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             ref={hostRef}
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
+
+          {workspaceStartBlocked && (
+            <div
+              className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 bg-black/80 px-6 text-center"
+              role="status"
+              aria-live="polite"
+            >
+              <div className="text-sm tracking-wide text-white/90">
+                {workspaceStartState === "failed"
+                  ? workspaceStartCopy.failed
+                  : workspaceStartCopy.preparing}
+              </div>
+              {workspaceStartState === "failed" && (
+                <Button
+                  onClick={() => {
+                    setBanner(null);
+                    setWorkspaceStartState("starting");
+                    setWorkspaceStartAttempt((value) => value + 1);
+                  }}
+                  prefix={<RotateCcw className="h-4 w-4" />}
+                >
+                  {workspaceStartCopy.retry}
+                </Button>
+              )}
+            </div>
+          )}
 
           {showReconnectOverlay && (
             <div className="absolute inset-x-3 top-3 z-20 flex justify-center sm:inset-x-auto sm:right-3 sm:justify-end">
@@ -1613,7 +1785,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             <div className="shrink-0">
               <ChatSidebar
                 channel={channel}
-                profile={scopedProfile}
+                profile={chatProfile}
                 onDashboardNewSessionRequest={startFreshDashboardChat}
                 onSessionTitleChange={handleSessionTitleChange}
               />
@@ -1623,7 +1795,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             <div className="min-h-0 flex-1 overflow-hidden">
               <ChatSessionList
                 activeSessionId={resumeParam}
-                profile={scopedProfile}
+                profile={chatProfile}
                 onNewChat={startFreshDashboardChat}
               />
             </div>

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -119,6 +119,27 @@ The **Chat** tab embeds the full Hermes TUI (the same interface you get from `he
 
 **Resume an existing session:** from the **Sessions** tab, click the play icon (▶) next to any session. That jumps to `/chat?resume=<id>` and launches the TUI with `--resume`, loading the full history.
 
+**Open a Project task in an isolated browser workspace:** a trusted same-dashboard link may provide `start_project`, `start_task`, `start_workstream`, `start_key`, and `write_scope` on `/chat` (plus `profile` for a non-default profile). After the dashboard's normal auth and request guards pass, the Chat page posts that bounded intent to Hermes. Hermes verifies the native Project/Task relationship, fetches the Project repository's origin, creates or reuses the Task's declared worktree and branch, runs the repository preflight, persists a Session whose CWD is that worktree, and resumes exactly that Session in the browser TUI. Retries with the same key and same intent reuse the receipt; changed intent under the same key fails closed. Starts are serialized across dashboard processes. This path does not assign the Task or create a Kanban Run.
+
+Repositories can declare the optional preflight at `.hermes/workspace-start.json`:
+
+```json
+{
+  "schema_version": 1,
+  "preflight": {
+    "command": ["bash", "scripts/worktree-preflight.sh"],
+    "required_inputs": ["write_scope"],
+    "timeout_seconds": 120,
+    "env": {
+      "PROJECT_ROOT": "workspace_path",
+      "PROJECT_WRITE_SCOPE": "write_scope"
+    }
+  }
+}
+```
+
+`command` is an argument array, never a shell string. `required_inputs` accepts only `write_scope`; every `env` key is a safe environment-variable name and every value is one of the supported aliases `workspace_path`, `write_scope`, `project_id`, `task_id`, or `workstream_id`. Hermes supplies a minimal scrubbed environment, bounds runtime/output, and removes a newly created worktree and branch if preparation fails. A prepared receipt is not connection proof: the native Task receives `interactive_session_connected` only after the exact browser Session emits a non-error PTY frame.
+
 **Session switcher (right rail):** the Chat tab carries its own ChatGPT-style conversation list in a thin right rail beside the terminal, so you can swap conversations without leaving the page. The rail stacks the model picker on top and the session list directly below it; the terminal takes up most of the screen. The list shows your most recent sessions for the active profile — title (falling back to a message preview), relative last-active time, message count, and the source channel for non-CLI sessions. Click any row to resume it in place (the terminal respawns with that conversation's history); the active session is highlighted. **New chat** starts a fresh session, and a refresh control re-pulls the list. The rail is read-only for switching — delete, rename, export, and bulk cleanup still live on the **Sessions** tab. On narrow screens it folds into a slide-over panel.
 
 **Prerequisites:**
@@ -127,7 +148,7 @@ The **Chat** tab embeds the full Hermes TUI (the same interface you get from `he
 - `ptyprocess` — installed by the `pty` extra (`cd ~/.hermes/hermes-agent && uv pip install -e ".[web,pty]"`, or `[all]` covers both)
 - POSIX kernel (Linux, macOS, or WSL2).  The `/chat` terminal pane specifically needs a POSIX PTY — native Windows Python has no equivalent, so on a native Windows install the rest of the dashboard (sessions, jobs, metrics, config editor) works but the `/chat` tab will show a banner telling you to use WSL2 for that feature.
 
-Close the browser tab and the PTY is reaped cleanly on the server. Re-opening spawns a fresh session.
+Legacy one-socket chats are reaped when the browser disconnects. Keep-alive chats use their attach token to retain the PTY for a bounded reattach window; an explicit process exit still ends the Session.
 
 To point [Hermes Desktop](#connecting-hermes-desktop-to-a-remote-backend) at a dashboard running on another machine instead of its own bundled backend, see the remote-backend section below.
 


### PR DESCRIPTION
## Owner outcome

A browser launch can now prepare a Project-linked Task workspace and open the exact persisted Hermes session in a real PTY. The flow creates a fresh Git worktree from the configured base, runs the repository preflight, persists the session with the worktree as CWD, and then resumes it in the dashboard.

## Contract

- Adds `POST /api/workspaces/interactive/start` and `/connected` with explicit profile scoping.
- Validates Project/Task/repository linkage and repository-owned `.hermes/workspace-start.json`.
- Serializes same-key starts across processes and durably reuses one receipt/session.
- Cleans up only resources owned by a failed start; Task assignment/status and Kanban runs remain untouched.
- Records bounded prepared/connected task events without overwriting originating-session semantics.
- Emits connected evidence only after a real PTY frame; startup failures remain visible and fail closed.
- Adds English/German workspace preparation, failure and keyboard-reachable retry copy.

## Verification

- 148 focused Python tests passed (interactive workspace, web endpoints, git and PTY server paths).
- 3 ChatPage tests passed; TypeScript typecheck and production build passed.
- Exact staged tree `a1f0e110f183f227f6a458a8a934ad5ddcb45615` was independently materialized and produced the same results.
- Unmocked candidate-pair browser proof reached a clean worktree, passed the real repository preflight, created one exact-CWD session, rendered a PTY frame and reused the same session on retry. A real exit-7 preflight left no worktree, session, run or connected evidence.

## Cross-repo integration

The Goliath owner projection/link consumer is reviewed separately and is merged/released only after this Hermes capability. No public listener, credential, provider/model, schema migration or autonomous task/run lifecycle is introduced.
