### PR TITLE
Reject non-string content/old_text without crashing

### DIFF
--- a/tests/tools/test_memory_nonstrings_content.py
+++ b/tests/tools/test_memory_nonstrings_content.py
@@ -1,0 +1,57 @@
+"""memory tool must reject non-string content/old_text without crashing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.memory_tool import MemoryStore, memory_tool
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return MemoryStore(memory_char_limit=2000, user_char_limit=1000)
+
+
+def test_add_rejects_non_string_content(store):
+    result = store.add("memory", ["not", "a", "string"])
+    assert result["success"] is False
+    assert "must be a string" in result["error"]
+    assert store.memory_entries == []
+
+
+def test_replace_rejects_non_string_old_text(store):
+    store.add("memory", "keep me")
+    result = store.replace("memory", 42, "replacement")
+    assert result["success"] is False
+    assert "old_text must be a string" in result["error"]
+    assert store.memory_entries == ["keep me"]
+
+
+def test_remove_rejects_non_string_old_text(store):
+    store.add("memory", "keep me")
+    result = store.remove("memory", ["keep"])
+    assert result["success"] is False
+    assert "old_text must be a string" in result["error"]
+    assert store.memory_entries == ["keep me"]
+
+
+def test_batch_rejects_non_string_content(store):
+    result = store.apply_batch(
+        "memory",
+        [{"action": "add", "content": 123}],
+    )
+    assert result["success"] is False
+    assert "content must be a string" in result["error"]
+    assert store.memory_entries == []
+
+
+def test_memory_tool_add_non_string_returns_tool_error(store):
+    """Dispatcher path: model JSON int content must not AttributeError."""
+    result = json.loads(
+        memory_tool(action="add", content=99, store=store)
+    )
+    assert result["success"] is False
+    assert "must be a string" in result["error"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -389,6 +389,10 @@ class MemoryStore:
 
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
+        # Strict providers may send JSON null (already caught upstream) or a
+        # non-string filler; bare ``.strip()`` AttributeErrors mid-tool.
+        if not isinstance(content, str):
+            return {"success": False, "error": "Content must be a string."}
         content = content.strip()
         if not content:
             return {"success": False, "error": "Content cannot be empty."}
@@ -448,6 +452,10 @@ class MemoryStore:
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
+        if not isinstance(old_text, str):
+            return {"success": False, "error": "old_text must be a string."}
+        if not isinstance(new_content, str):
+            return {"success": False, "error": "new_content must be a string."}
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
@@ -519,6 +527,8 @@ class MemoryStore:
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
+        if not isinstance(old_text, str):
+            return {"success": False, "error": "old_text must be a string."}
         old_text = old_text.strip()
         if not old_text:
             return {"success": False, "error": "old_text cannot be empty."}
@@ -580,6 +590,11 @@ class MemoryStore:
         for i, op in enumerate(operations):
             act = (op or {}).get("action")
             new_content = (op or {}).get("content")
+            if act in {"add", "replace"} and new_content is not None and not isinstance(new_content, str):
+                return {
+                    "success": False,
+                    "error": f"Operation {i + 1}: content must be a string.",
+                }
             if act in {"add", "replace"} and new_content:
                 scan_error = _scan_memory_content(new_content)
                 if scan_error:
@@ -599,9 +614,17 @@ class MemoryStore:
             for i, op in enumerate(operations):
                 op = op or {}
                 act = op.get("action")
-                content = (op.get("content") or "").strip()
-                old_text = (op.get("old_text") or "").strip()
+                raw_content = op.get("content")
+                raw_old = op.get("old_text")
                 pos = f"Operation {i + 1} ({act or 'unknown'})"
+                # Present-but-null is fine (treated as empty); non-strings must
+                # not AttributeError on ``.strip()`` mid-batch.
+                if raw_content is not None and not isinstance(raw_content, str):
+                    return self._batch_error(target, f"{pos}: content must be a string.")
+                if raw_old is not None and not isinstance(raw_old, str):
+                    return self._batch_error(target, f"{pos}: old_text must be a string.")
+                content = (raw_content or "").strip()
+                old_text = (raw_old or "").strip()
 
                 if act == "add":
                     if not content:


### PR DESCRIPTION
## Summary
- `MemoryStore.add` / `replace` / `remove` and `apply_batch` called `.strip()` on raw model args.
- Strict providers sometimes send int/list fillers for string fields; that raises `AttributeError` mid-tool instead of a clean error.
- `target: null` was already handled in `memory_tool`; extend the same defensive posture to `content` / `old_text` (require real strings; null still means empty).

