### PR TITLE
Reject non-string question without crashing

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -35,6 +35,24 @@ class TestClarifyToolBasics:
         assert "error" in result
         assert "not available" in result["error"].lower()
 
+    def test_non_string_question_returns_error_not_attribute_error(self):
+        """Int/list question must not AttributeError on ``.strip()``."""
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            raise AssertionError("callback must not run for invalid question")
+
+        for bad in (42, ["pick one"], {"q": "y"}):
+            result = json.loads(clarify_tool(question=bad, callback=mock_callback))
+            assert "error" in result, bad
+            assert "required" in result["error"].lower()
+
+    def test_null_and_blank_question_still_rejected(self):
+        result_null = json.loads(clarify_tool(question=None, callback=lambda *a, **k: "x"))
+        result_blank = json.loads(clarify_tool(question="   ", callback=lambda *a, **k: "x"))
+        assert "error" in result_null
+        assert "error" in result_blank
+        assert "required" in result_null["error"].lower()
+        assert "required" in result_blank["error"].lower()
+
 
 class TestClarifyToolChoicesValidation:
     """Tests for choices parameter validation."""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -136,7 +136,10 @@ def clarify_tool(
     Returns:
         JSON string with the user's response.
     """
-    if not question or not question.strip():
+    # Strict providers may send int/list fillers; bare ``.strip()`` after a
+    # truthiness check AttributeErrors (null/"" already fail the ``not question``
+    # short-circuit). Require a real non-empty string — do not str()-coerce.
+    if not isinstance(question, str) or not question.strip():
         return tool_error("Question text is required.")
 
     question = question.strip()


### PR DESCRIPTION
## Summary
- `clarify_tool` validated questions with `if not question or not question.strip()`.
- Null/blank already fail the truthiness check, but int/list values are truthy and raise `AttributeError` on `.strip()` mid-tool.
- Require a real non-empty string (do not `str()`-coerce fillers into UI text) — same posture as choices validation.

