### PR TITLE
feat(signal): add allow_dms config key to disable direct messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1550,6 +1550,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["cron_continuable_surface"] = platform_cfg["cron_continuable_surface"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "allow_dms" in platform_cfg:
+                    bridged["allow_dms"] = platform_cfg["allow_dms"]
                 if "send_read_receipts" in platform_cfg:
                     bridged["send_read_receipts"] = platform_cfg["send_read_receipts"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -279,6 +279,13 @@ class SignalAdapter(BasePlatformAdapter):
         else:
             self.require_mention = os.getenv("SIGNAL_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes", "on")
 
+        # DM filter — set via config.yaml: signal.allow_dms: false  (default: true)
+        _adms_cfg = extra.get("allow_dms")
+        if _adms_cfg is not None:
+            self.allow_dms = bool(_adms_cfg)
+        else:
+            self.allow_dms = True
+
         # DM allowlist — mirrors SIGNAL_ALLOWED_USERS checked by run.py.
         # Stored here so the reaction hooks can skip unauthorized senders
         # (reactions fire before run.py's auth gate, so without this check
@@ -612,6 +619,11 @@ class SignalAdapter(BasePlatformAdapter):
         # Build chat info
         chat_id = sender if not is_group else f"group:{group_id}"
         chat_type = "group" if is_group else "dm"
+
+        # DM filter — drop direct messages when allow_dms is false in config
+        if not is_group and not self.allow_dms:
+            logger.debug("Signal: ignoring DM (allow_dms=false)")
+            return
 
         # Extract text and render mentions
         text = data_message.get("message", "")

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1333,3 +1333,117 @@ class TestRecentSentTimestampRing:
         adapter._track_sent_timestamp({"timestamp": 3})
         # Both 1 and 2 should be evicted on TTL, only 3 remains
         assert list(adapter._recent_sent_timestamps.keys()) == [3]
+
+
+# ---------------------------------------------------------------------------
+# allow_dms config key
+# ---------------------------------------------------------------------------
+
+def _make_group_envelope(sender: str, group_id: str, text: str = "hello") -> dict:
+    """Build a minimal signal-cli group envelope."""
+    return {
+        "envelope": {
+            "sourceNumber": sender,
+            "sourceName": "Test User",
+            "sourceUuid": "aaaaaaaa-0000-0000-0000-000000000002",
+            "timestamp": 1700000001000,
+            "dataMessage": {
+                "timestamp": 1700000001000,
+                "message": text,
+                "expiresInSeconds": 0,
+                "viewOnce": False,
+                "attachments": [],
+                "groupInfo": {
+                    "groupId": group_id,
+                    "type": "DELIVER",
+                },
+            },
+        }
+    }
+
+
+class TestSignalAllowDms:
+    """allow_dms config key — DM suppression and group passthrough."""
+
+    def test_allow_dms_defaults_to_true(self, monkeypatch):
+        """allow_dms is True when not present in config.extra."""
+        adapter = _make_signal_adapter(monkeypatch)
+        assert adapter.allow_dms is True
+
+    def test_allow_dms_false_in_config(self, monkeypatch):
+        """allow_dms is False when config.extra sets allow_dms: false."""
+        adapter = _make_signal_adapter(monkeypatch, allow_dms=False)
+        assert adapter.allow_dms is False
+
+    def test_allow_dms_true_in_config(self, monkeypatch):
+        """allow_dms is True when config.extra explicitly sets allow_dms: true."""
+        adapter = _make_signal_adapter(monkeypatch, allow_dms=True)
+        assert adapter.allow_dms is True
+
+    @pytest.mark.asyncio
+    async def test_allow_dms_false_suppresses_dm(self, monkeypatch):
+        """When allow_dms=false, DMs must not reach handle_message."""
+        adapter = _make_signal_adapter(monkeypatch, allow_dms=False)
+        adapter._rpc, _ = _stub_rpc(None)
+        dispatched = []
+
+        async def fake_handle(event):
+            dispatched.append(event)
+
+        adapter.handle_message = fake_handle
+
+        envelope = _make_dm_envelope(sender="+15559876543", attachments=[], text="hi")
+        await adapter._handle_envelope(envelope)
+
+        assert dispatched == [], (
+            "DM should be silently dropped when allow_dms=false, "
+            f"but got {len(dispatched)} event(s)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_allow_dms_false_still_delivers_group_message(self, monkeypatch):
+        """When allow_dms=false, group messages must still reach handle_message."""
+        group_id = "groupAABBCCDDEEFF=="
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            allow_dms=False,
+            group_allowed=group_id,
+        )
+        adapter._rpc, _ = _stub_rpc(None)
+        dispatched = []
+
+        async def fake_handle(event):
+            dispatched.append(event)
+
+        adapter.handle_message = fake_handle
+
+        envelope = _make_group_envelope(
+            sender="+15559876543",
+            group_id=group_id,
+            text="hey group",
+        )
+        await adapter._handle_envelope(envelope)
+
+        assert len(dispatched) == 1, (
+            "Group message should be delivered even when allow_dms=false, "
+            f"but got {len(dispatched)} event(s)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_allow_dms_true_delivers_dm(self, monkeypatch):
+        """Default behaviour: DMs reach handle_message when allow_dms=true."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, _ = _stub_rpc(None)
+        dispatched = []
+
+        async def fake_handle(event):
+            dispatched.append(event)
+
+        adapter.handle_message = fake_handle
+
+        envelope = _make_dm_envelope(sender="+15559876543", attachments=[], text="hello")
+        await adapter._handle_envelope(envelope)
+
+        assert len(dispatched) == 1, (
+            f"DM should be delivered when allow_dms=true, but got {len(dispatched)} event(s)"
+        )

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -228,6 +228,7 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
+| **Bot responds to DMs but should be group-only** | Set `allow_dms: false` under `signal:` in `config.yaml` (`hermes config set signal.allow_dms false`) |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |
 
 ---
@@ -256,3 +257,12 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | `SIGNAL_GROUP_ALLOWED_USERS` | No | — | Group IDs to monitor, or `*` for all (omit to disable groups) |
 | `SIGNAL_ALLOW_ALL_USERS` | No | `false` | Allow any user to interact (skip allowlist) |
 | `SIGNAL_HOME_CHANNEL` | No | — | Default delivery target for cron jobs |
+
+
+## Platform config keys
+
+These are set via `hermes config set` (or directly in `config.yaml` under `signal:`) rather than environment variables.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `allow_dms` | `true` | Set to `false` to block all direct messages — users in `SIGNAL_ALLOWED_USERS` can still use allowed group chats |


### PR DESCRIPTION
## What does this PR do?

Adds `signal.allow_dms` as a platform config key (read via `config.extra`, matching the existing `require_mention` pattern). When set to `false`, the Signal adapter silently drops all incoming direct messages while continuing to process group messages normally — enabling group-only mode without code changes.

This is a clean rebase of #66184 onto current main, addressing the formatting-churn feedback from the triage review. The diff now contains only the targeted changes.

Previous attempts: #56987 (closed — used env var, policy violation), #66184 (superseded by this PR — contained unrelated formatting churn).

## Related Issue

Fixes #56987

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/signal.py` — reads `allow_dms` from `config.extra` in `__init__` after the `require_mention` block; drops DMs early in the message handler when `self.allow_dms` is `false`
- `gateway/config.py` — bridges `signal.allow_dms` from the `signal:` yaml section into `config.extra`, alongside the existing `require_mention` bridge
- `tests/gateway/test_signal.py` — 5 new tests: default value (`True`), explicit `false`/`true` config, DM suppression, group passthrough, and DM delivery with default config
- `website/docs/user-guide/messaging/signal.md` — new troubleshooting row and "Platform config keys" section documenting `allow_dms`

## How to Test

1. Set `signal.allow_dms: false` in `~/.hermes/config.yaml` (or run `hermes config set signal.allow_dms false`)
2. Restart the gateway: `hermes gateway restart`
3. Send a direct message to the bot from a phone in `SIGNAL_ALLOWED_USERS` — bot should not respond
4. Send a message in an allowed group — bot should respond normally
5. Remove the key or set `allow_dms: true` and verify DMs work again (default behaviour unchanged)

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (VM)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Gateway log when a DM arrives with `allow_dms: false`:

