### PR TITLE
x_search : reject non-string query and tolerate null dates

### DIFF
--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -312,3 +312,29 @@ def test_x_search_not_degraded_when_no_filters_active(monkeypatch):
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
 
+
+def test_x_search_non_string_query_returns_error_not_attribute_error():
+    """Int/list query must not AttributeError on ``.strip()``."""
+    from tools.x_search_tool import x_search_tool
+
+    for bad in (42, ["elon"], {"q": "xai"}):
+        result = json.loads(x_search_tool(query=bad))
+        assert "error" in result, bad
+        assert "query is required" in result["error"]
+
+
+def test_x_search_null_from_date_does_not_crash(monkeypatch):
+    """Present-but-null optional dates must not crash ``_validate_date_range``."""
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr(
+        "requests.post",
+        lambda *a, **k: _FakeResponse({"output_text": "ok", "citations": []}),
+    )
+
+    result = json.loads(
+        x_search_tool(query="xai", from_date=None, to_date=None)
+    )
+    assert result["success"] is True
+

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -297,8 +297,18 @@ def x_search_tool(
     enable_image_understanding: bool = False,
     enable_video_understanding: bool = False,
 ) -> str:
-    if not query or not query.strip():
+    # Strict providers may send int/list fillers; bare ``.strip()`` after a
+    # truthiness check AttributeErrors (null/"" already fail ``not query``).
+    # Require a real non-empty string — do not str()-coerce fillers into a search.
+    if not isinstance(query, str) or not query.strip():
         return tool_error("query is required for x_search")
+
+    # Optional date fields: present-but-null / non-string must not crash
+    # ``_validate_date_range``'s ``.strip()`` — treat as unset.
+    if not isinstance(from_date, str):
+        from_date = ""
+    if not isinstance(to_date, str):
+        to_date = ""
 
     try:
         api_key, base_url, source = _resolve_xai_bearer()


### PR DESCRIPTION
## Summary
- `x_search_tool` validated query with `if not query or not query.strip()`.
- Null/blank already fail; int/list values are truthy and raise `AttributeError` on `.strip()` mid-tool.
- Require a real non-empty string for `query` (do not `str()`-coerce fillers into a search).
- Optional `from_date` / `to_date`: present-but-null or non-string must not crash `_validate_date_range` — treat as unset.

