### PR TITLE
fix(mcp): HTTP transport broken on mcp >= 1.24.0 / 2.x

### DIFF
--- a/tests/agent/test_mcp_http_availability.py
+++ b/tests/agent/test_mcp_http_availability.py
@@ -1,0 +1,102 @@
+"""HTTP MCP transport must not be gated on a symbol the SDK has removed.
+
+mcp >= 1.24.0 dropped the deprecated ``streamablehttp_client`` alias in favour
+of ``streamable_http_client``. ``_MCP_HTTP_AVAILABLE`` is set only from the
+deprecated import, so on a current SDK every HTTP MCP server is parked at
+startup with:
+
+    MCP server '<name>' requires HTTP transport but
+    mcp.client.streamable_http is not available. Upgrade the mcp package.
+
+which is the opposite of the actual cause -- upgrading is what triggers it, and
+the module imports fine. ``_run_http`` raises on that flag before it can reach
+its own ``_MCP_NEW_HTTP`` branch, which is fully implemented and works.
+
+Each case runs in its own interpreter. Deciding these flags means importing
+``tools.mcp_tool`` against a stubbed ``mcp`` package, and doing that in-process
+leaves the real modules swapped out for anything that imports later in the same
+pytest session -- which silently broke ~20 unrelated MCP tests when this file
+was first written in-process.
+"""
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PROBE = textwrap.dedent(
+    """
+    import sys, types
+
+    def _stub(**attrs):
+        m = types.ModuleType("mcp.client.streamable_http")
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        return m
+
+    names = set(sys.argv[1].split(",")) - {""}
+    mcp = types.ModuleType("mcp")
+    mcp.ClientSession = object
+    mcp.StdioServerParameters = object
+    client = types.ModuleType("mcp.client")
+    stdio = types.ModuleType("mcp.client.stdio")
+    stdio.stdio_client = lambda *a, **k: None
+    sse = types.ModuleType("mcp.client.sse")
+    sse.sse_client = lambda *a, **k: None
+    sys.modules.update({
+        "mcp": mcp,
+        "mcp.client": client,
+        "mcp.client.stdio": stdio,
+        "mcp.types": types.ModuleType("mcp.types"),
+        "mcp.client.sse": sse,
+        "mcp.client.streamable_http": _stub(
+            **{n: (lambda *a, **k: None) for n in names}
+        ),
+    })
+
+    import tools.mcp_tool as m
+    print(f"{bool(m._MCP_HTTP_AVAILABLE)},{bool(m._MCP_NEW_HTTP)}")
+    """
+)
+
+
+def _flags(*exported):
+    """Import tools.mcp_tool in a fresh interpreter with these SDK symbols."""
+    proc = subprocess.run(
+        [sys.executable, "-c", PROBE, ",".join(exported)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"probe failed:\n{proc.stdout}\n{proc.stderr}"
+    http_available, new_http = proc.stdout.strip().splitlines()[-1].split(",")
+    return http_available == "True", new_http == "True"
+
+
+def test_new_sdk_only_still_enables_http():
+    """mcp >= 1.24.0 exports only the NEW name. This is the regression."""
+    http_available, new_http = _flags("streamable_http_client")
+    assert new_http is True
+    assert http_available is True, (
+        "HTTP transport reported unavailable on a current mcp SDK — every "
+        "HTTP MCP server would be parked at startup"
+    )
+
+
+def test_old_sdk_only_still_enables_http():
+    """Older SDKs export only the deprecated name; must keep working."""
+    http_available, new_http = _flags("streamablehttp_client")
+    assert new_http is False
+    assert http_available is True
+
+
+def test_both_names_enable_http():
+    http_available, new_http = _flags("streamablehttp_client", "streamable_http_client")
+    assert new_http is True
+    assert http_available is True
+
+
+def test_neither_name_disables_http():
+    """No HTTP client at all — the flag must still go False, honestly."""
+    http_available, new_http = _flags()
+    assert new_http is False
+    assert http_available is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -232,6 +232,11 @@ try:
         _MCP_NEW_HTTP = True
     except ImportError:
         _MCP_NEW_HTTP = False
+    # HTTP transport is available if EITHER entry point imports. mcp >= 1.24.0
+    # removed the deprecated ``streamablehttp_client``, so gating only on it
+    # disables HTTP MCP servers on a current SDK even though ``_run_http`` has a
+    # working ``_MCP_NEW_HTTP`` branch it can never reach.
+    _MCP_HTTP_AVAILABLE = _MCP_HTTP_AVAILABLE or _MCP_NEW_HTTP
     try:
         from mcp.types import LATEST_PROTOCOL_VERSION
     except ImportError:
@@ -3013,9 +3018,15 @@ class MCPServerTask:
             # http_client is provided, so we wrap in async-with.
             try:
                 async with httpx.AsyncClient(**client_kwargs) as http_client:
-                    async with streamable_http_client(url, http_client=http_client) as (
-                        read_stream, write_stream, _get_session_id,
-                    ):
+                    # Take the streams positionally instead of unpacking a fixed
+                    # arity. The deprecated ``streamablehttp_client`` yields
+                    # (read, write, get_session_id); ``streamable_http_client``
+                    # yields (read, write) -- its annotation is
+                    # ``AsyncGenerator[TransportStreams, None]``. Unpacking three
+                    # raises "not enough values to unpack (expected 3, got 2)"
+                    # as soon as the transport is entered.
+                    async with streamable_http_client(url, http_client=http_client) as _streams:
+                        read_stream, write_stream = _streams[0], _streams[1]
                         async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
                             # Bound the handshake (#59349) — see stdio path.
                             self.initialize_result = await asyncio.wait_for(


### PR DESCRIPTION
## What does this PR do?

Fixes HTTP/StreamableHTTP MCP servers failing to connect on mcp >= 1.24.0.
Two faults in the same path; the first hides the second, so both are needed.

1. `_MCP_HTTP_AVAILABLE` is set only from `from mcp.client.streamable_http
   import streamablehttp_client`. That alias was removed in mcp 1.24.0, so the
   flag is False and `_run_http` raises "requires HTTP transport but
   mcp.client.streamable_http is not available. Upgrade the mcp package" —
   the opposite of the cause. `_MCP_NEW_HTTP` is already detected two lines
   below and `_run_http` already has a complete `if _MCP_NEW_HTTP:` branch,
   but it can never be reached.

2. That branch unpacks three values from `streamable_http_client`, which on
   mcp 2.0.0 yields two (`AsyncGenerator[TransportStreams, None]`). With (1)
   fixed the connection instead dies with "not enough values to unpack
   (expected 3, got 2)" as an ExceptionGroup from the transport TaskGroup.

Taking the streams positionally keeps both SDK generations working — the arity
has differed across versions (cf. #76855, which reports the 3-tuple shape on
1.26.0), so pinning either arity breaks the other.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: set `_MCP_HTTP_AVAILABLE` if **either** entry point imports
- `tools/mcp_tool.py`: take the streams positionally from `streamable_http_client`
- `tests/agent/test_mcp_http_availability.py`: 4 tests for the flag across
  new-SDK-only, old-SDK-only, both, and neither (subprocess-isolated, since
  stubbing `mcp` in-process leaks into later tests in the same session)

## How to Test

1. On mcp >= 1.24.0, configure any HTTP MCP server. Before: parked at startup
   with the "upgrade the mcp package" message. After: connects.
2. `pytest tests/agent/test_mcp_http_availability.py -q` → 4 passed.
   `test_new_sdk_only_still_enables_http` fails without the change.
3. Verified against a live StreamableHTTP server on mcp 2.0.0 using
   `_run_http`'s own call shape (explicit `http_client=`):
   3-tuple unpack → ExceptionGroup; positional → connected, 10 tools discovered.

## Checklist

### Code
- [x] I've read the [Contributing Guide]
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (nearest is #76855, closed unmerged)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Python 3.12, mcp 2.0.0