### PR TITLE
Reject non-string code without crashing

### DIFF
--- a/tests/tools/test_execute_code_nonstrings.py
+++ b/tests/tools/test_execute_code_nonstrings.py
@@ -1,0 +1,20 @@
+"""execute_code must reject non-string code without AttributeError."""
+
+from __future__ import annotations
+
+import json
+
+from tools.code_execution_tool import execute_code
+
+
+def test_non_string_code_returns_error_not_attribute_error():
+    for bad in (42, ["print(1)"], {"code": "x"}, None, ""):
+        result = json.loads(execute_code(code=bad))
+        assert "error" in result, bad
+        assert "No code provided" in result["error"]
+
+
+def test_blank_code_returns_error():
+    result = json.loads(execute_code(code="   "))
+    assert "error" in result
+    assert "No code provided" in result["error"]

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1284,14 +1284,19 @@ def execute_code(
     Returns:
         JSON string with execution results.
     """
+    # Strict providers may send int/list fillers; bare ``.strip()`` after a
+    # truthiness check AttributeErrors (null/"" already fail ``not code``).
+    # Require a real non-empty string — do not str()-coerce fillers into a script.
+    # Validate before the sandbox-availability gate so a bad payload gets a clear
+    # "No code provided" instead of a misleading sandbox-unavailable error.
+    if not isinstance(code, str) or not code.strip():
+        return tool_error("No code provided.")
+
     if not SANDBOX_AVAILABLE:
         return tool_error(
             "execute_code sandbox is unavailable in this environment. "
             "Use normal tool calls (terminal, read_file, write_file, ...) instead."
         )
-
-    if not code or not code.strip():
-        return tool_error("No code provided.")
 
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config, _docker_has_host_access


### PR DESCRIPTION
## Summary
- `execute_code` validated with `if not code or not code.strip()`.
- Null/blank already fail; int/list values are truthy and raise `AttributeError` on `.strip()` mid-tool.
- Require a real non-empty string (do not `str()`-coerce fillers into a script).
- Validate before the sandbox-availability gate so bad payloads get a clear "No code provided" instead of a misleading sandbox-unavailable error.

