### PR TITLE
refactor(cli): extract TUI hooks into CLITUIHooksMixin + goal loop into goals.py (cli.py god-file slice R5)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -54,6 +54,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
+from hermes_cli.cli_tui_hooks_mixin import CLITUIHooksMixin
 from agent.interrupt_compat import request_hard_interrupt
 
 # prompt_toolkit for fixed input area TUI
@@ -4202,7 +4203,7 @@ class _VoiceInputMessage:
         return self.text
 
 
-class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
+class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, CLITUIHooksMixin):
     """
     Interactive CLI for the Hermes Agent.
     
@@ -14824,89 +14825,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             pass
         return style_dict
 
-    def _apply_tui_skin_style(self) -> bool:
-        """Refresh prompt_toolkit styling for a running interactive TUI."""
-        if not getattr(self, "_app", None) or not getattr(self, "_tui_style_base", None):
-            return False
-        self._app.style = PTStyle.from_dict(self._build_tui_style_dict())
-        self._invalidate(min_interval=0.0)
-        return True
-
-    # --- Protected TUI extension hooks for wrapper CLIs ---
-
-    def _get_extra_tui_widgets(self) -> list:
-        """Return extra prompt_toolkit widgets to insert into the TUI layout.
-
-        Wrapper CLIs can override this to inject widgets (e.g. a mini-player,
-        overlay menu) into the layout without overriding ``run()``.  Widgets
-        are inserted between the spacer and the status bar.
-        """
-        return []
-
-    def _register_extra_tui_keybindings(self, kb, *, input_area) -> None:
-        """Register extra keybindings on the TUI ``KeyBindings`` object.
-
-        Wrapper CLIs can override this to add keybindings (e.g. transport
-        controls, modal shortcuts) without overriding ``run()``.
-
-        Parameters
-        ----------
-        kb : KeyBindings
-            The active keybinding registry for the prompt_toolkit application.
-        input_area : TextArea
-            The main input widget, for wrappers that need to inspect or
-            manipulate user input from a keybinding handler.
-        """
-
-    def _build_tui_layout_children(
-        self,
-        *,
-        sudo_widget,
-        secret_widget,
-        approval_widget,
-        slash_confirm_widget=None,
-        clarify_widget,
-        model_picker_widget=None,
-        spinner_widget=None,
-        spacer,
-        status_bar,
-        input_rule_top,
-        image_bar,
-        input_area,
-        input_rule_bot,
-        voice_status_bar,
-        completions_menu,
-    ) -> list:
-        """Assemble the ordered list of children for the root ``HSplit``.
-
-        Wrapper CLIs typically override ``_get_extra_tui_widgets`` instead of
-        this method.  Override this only when you need full control over widget
-        ordering.
-        """
-        return [
-            item for item in [
-                Window(height=0),
-                sudo_widget,
-                secret_widget,
-                approval_widget,
-                slash_confirm_widget,
-                clarify_widget,
-                model_picker_widget,
-                spinner_widget,
-                spacer,
-                *self._get_extra_tui_widgets(),
-                getattr(self, "_pet_widget", None),
-                getattr(self, "_stash_panel_widget", None),
-                status_bar,
-                input_rule_top,
-                image_bar,
-                input_area,
-                input_rule_bot,
-                voice_status_bar,
-                completions_menu,
-            ] if item is not None
-        ]
-
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         if not self._claim_active_session("cli"):
@@ -17863,95 +17781,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 # Main Entry Point
 # ============================================================================
 
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
-    """Drive a kanban goal_mode worker through the Ralph-style goal loop.
-
-    Called from the quiet single-query path AFTER the worker's first turn,
-    only when ``HERMES_KANBAN_GOAL_MODE`` is set (dispatcher-spawned
-    goal_mode card). Wires the worker's ``run_conversation`` and the kanban
-    DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
-    caller — a broken goal loop must never wedge a worker, the dispatcher's
-    claim TTL / crash detection is the backstop.
-    """
-    import os as _os
-
-    task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    if not task_id:
-        return
-
-    from hermes_cli import kanban_db as _kb
-    from hermes_cli.goals import run_kanban_goal_loop as _run_loop, DEFAULT_MAX_TURNS as _DEF_TURNS
-
-    # Resolve goal text from the card (title + body = the acceptance
-    # criteria the judge evaluates against).
-    conn = _kb.connect()
-    try:
-        task = _kb.get_task(conn, task_id)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-    if task is None:
-        return
-
-    goal_parts = [task.title or ""]
-    if task.body:
-        goal_parts.append(task.body)
-    goal_text = "\n\n".join(p for p in goal_parts if p).strip()
-    if not goal_text:
-        return
-
-    max_turns = task.goal_max_turns or _DEF_TURNS
-
-    def _run_turn(prompt: str) -> str:
-        result = cli.agent.run_conversation(
-            user_message=prompt,
-            conversation_history=cli.conversation_history,
-        )
-        # Keep session_id in sync if mid-run compression rotated it.
-        if (
-            getattr(cli.agent, "session_id", None)
-            and cli.agent.session_id != cli.session_id
-        ):
-            cli.session_id = cli.agent.session_id
-        resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
-        if resp:
-            print(resp)
-        return resp or ""
-
-    def _task_status() -> "str | None":
-        c = _kb.connect()
-        try:
-            t = _kb.get_task(c, task_id)
-            return t.status if t is not None else None
-        finally:
-            try:
-                c.close()
-            except Exception:
-                pass
-
-    def _block(reason: str) -> None:
-        c = _kb.connect()
-        try:
-            _kb.block_task(c, task_id, reason=reason)
-        finally:
-            try:
-                c.close()
-            except Exception:
-                pass
-
-    _run_loop(
-        task_id=task_id,
-        goal_text=goal_text,
-        run_turn=_run_turn,
-        task_status_fn=_task_status,
-        block_fn=_block,
-        max_turns=max_turns,
-        first_response=first_response or "",
-        log=lambda m: logger.info("%s", m),
-    )
-
 
 def main(
     query: str = None,
@@ -18413,6 +18242,7 @@ def main(
                         # normal worker and every non-kanban `-q` run.
                         if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
                             try:
+                                from hermes_cli.goals import _run_kanban_goal_loop_q
                                 _run_kanban_goal_loop_q(cli, response)
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)

--- a/hermes_cli/cli_tui_hooks_mixin.py
+++ b/hermes_cli/cli_tui_hooks_mixin.py
@@ -1,0 +1,106 @@
+"""Protected TUI extension hooks for wrapper CLIs (cli.py god-file slice R5).
+
+Hosts the four protected TUI extension hooks lifted out of ``cli.py``'s
+``HermesCLI`` class so wrapper CLIs can extend the interactive TUI without
+overriding ``run()``:
+
+  - _apply_tui_skin_style
+  - _get_extra_tui_widgets
+  - _register_extra_tui_keybindings
+  - _build_tui_layout_children
+
+``HermesCLI`` inherits ``CLITUIHooksMixin``; every ``self.<hook>`` call
+resolves unchanged via the MRO — behavior-neutral. The mixin touches only
+``self`` state (getattr-guarded) plus prompt_toolkit, and never imports
+``cli`` at module level (no import cycle).
+"""
+
+from prompt_toolkit.layout import Window
+from prompt_toolkit.styles import Style as PTStyle
+
+
+class CLITUIHooksMixin:
+    """Protected TUI extension hooks wrapper CLIs override without touching run()."""
+
+    def _apply_tui_skin_style(self) -> bool:
+        """Refresh prompt_toolkit styling for a running interactive TUI."""
+        if not getattr(self, "_app", None) or not getattr(self, "_tui_style_base", None):
+            return False
+        self._app.style = PTStyle.from_dict(self._build_tui_style_dict())
+        self._invalidate(min_interval=0.0)
+        return True
+
+    # --- Protected TUI extension hooks for wrapper CLIs ---
+
+    def _get_extra_tui_widgets(self) -> list:
+        """Return extra prompt_toolkit widgets to insert into the TUI layout.
+
+        Wrapper CLIs can override this to inject widgets (e.g. a mini-player,
+        overlay menu) into the layout without overriding ``run()``.  Widgets
+        are inserted between the spacer and the status bar.
+        """
+        return []
+
+    def _register_extra_tui_keybindings(self, kb, *, input_area) -> None:
+        """Register extra keybindings on the TUI ``KeyBindings`` object.
+
+        Wrapper CLIs can override this to add keybindings (e.g. transport
+        controls, modal shortcuts) without overriding ``run()``.
+
+        Parameters
+        ----------
+        kb : KeyBindings
+            The active keybinding registry for the prompt_toolkit application.
+        input_area : TextArea
+            The main input widget, for wrappers that need to inspect or
+            manipulate user input from a keybinding handler.
+        """
+
+    def _build_tui_layout_children(
+        self,
+        *,
+        sudo_widget,
+        secret_widget,
+        approval_widget,
+        slash_confirm_widget=None,
+        clarify_widget,
+        model_picker_widget=None,
+        spinner_widget=None,
+        spacer,
+        status_bar,
+        input_rule_top,
+        image_bar,
+        input_area,
+        input_rule_bot,
+        voice_status_bar,
+        completions_menu,
+    ) -> list:
+        """Assemble the ordered list of children for the root ``HSplit``.
+
+        Wrapper CLIs typically override ``_get_extra_tui_widgets`` instead of
+        this method.  Override this only when you need full control over widget
+        ordering.
+        """
+        return [
+            item for item in [
+                Window(height=0),
+                sudo_widget,
+                secret_widget,
+                approval_widget,
+                slash_confirm_widget,
+                clarify_widget,
+                model_picker_widget,
+                spinner_widget,
+                spacer,
+                *self._get_extra_tui_widgets(),
+                getattr(self, "_pet_widget", None),
+                getattr(self, "_stash_panel_widget", None),
+                status_bar,
+                input_rule_top,
+                image_bar,
+                input_area,
+                input_rule_bot,
+                voice_status_bar,
+                completions_menu,
+            ] if item is not None
+        ]

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1805,3 +1805,92 @@ __all__ = [
     "judge_goal",
     "run_kanban_goal_loop",
 ]
+
+
+def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
+    """Drive a kanban goal_mode worker through the Ralph-style goal loop.
+
+    Called from the quiet single-query path AFTER the worker's first turn,
+    only when ``HERMES_KANBAN_GOAL_MODE`` is set (dispatcher-spawned
+    goal_mode card). Wires the worker's ``run_conversation`` and the kanban
+    DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
+    caller — a broken goal loop must never wedge a worker, the dispatcher's
+    claim TTL / crash detection is the backstop.
+    """
+    import os as _os
+
+    task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task_id:
+        return
+
+    from hermes_cli import kanban_db as _kb
+
+    # Resolve goal text from the card (title + body = the acceptance
+    # criteria the judge evaluates against).
+    conn = _kb.connect()
+    try:
+        task = _kb.get_task(conn, task_id)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    if task is None:
+        return
+
+    goal_parts = [task.title or ""]
+    if task.body:
+        goal_parts.append(task.body)
+    goal_text = "\n\n".join(p for p in goal_parts if p).strip()
+    if not goal_text:
+        return
+
+    max_turns = task.goal_max_turns or DEFAULT_MAX_TURNS
+
+    def _run_turn(prompt: str) -> str:
+        result = cli.agent.run_conversation(
+            user_message=prompt,
+            conversation_history=cli.conversation_history,
+        )
+        # Keep session_id in sync if mid-run compression rotated it.
+        if (
+            getattr(cli.agent, "session_id", None)
+            and cli.agent.session_id != cli.session_id
+        ):
+            cli.session_id = cli.agent.session_id
+        resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
+        if resp:
+            print(resp)
+        return resp or ""
+
+    def _task_status() -> "str | None":
+        c = _kb.connect()
+        try:
+            t = _kb.get_task(c, task_id)
+            return t.status if t is not None else None
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+    def _block(reason: str) -> None:
+        c = _kb.connect()
+        try:
+            _kb.block_task(c, task_id, reason=reason)
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+    run_kanban_goal_loop(
+        task_id=task_id,
+        goal_text=goal_text,
+        run_turn=_run_turn,
+        task_status_fn=_task_status,
+        block_fn=_block,
+        max_turns=max_turns,
+        first_response=first_response or "",
+        log=lambda m: logger.info("%s", m),
+    )

--- a/tests/cli/test_cli_tui_hooks_seam.py
+++ b/tests/cli/test_cli_tui_hooks_seam.py
@@ -1,0 +1,203 @@
+"""Seam tests for the CLITUIHooksMixin extraction (cli.py god-file slice R5).
+
+Verifies that the four protected TUI extension hooks moved into
+``hermes_cli/cli_tui_hooks_mixin.py`` remain reachable through ``HermesCLI``
+with identical identity (MRO resolution), no back-import cycle, and the
+behavioral contract wrapper CLIs depend on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import cli as cli_mod
+from cli import HermesCLI
+from hermes_cli.cli_tui_hooks_mixin import CLITUIHooksMixin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+HOOK_NAMES = (
+    "_apply_tui_skin_style",
+    "_get_extra_tui_widgets",
+    "_register_extra_tui_keybindings",
+    "_build_tui_layout_children",
+)
+
+
+def _stub():
+    """Isolate the mixin without paying HermesCLI.__init__ cost (house pattern)."""
+    return object.__new__(CLITUIHooksMixin)
+
+
+def _layout_kwargs(**overrides):
+    kwargs = {
+        "sudo_widget": "sudo",
+        "secret_widget": "secret",
+        "approval_widget": "approval",
+        "slash_confirm_widget": "slash-confirm",
+        "clarify_widget": "clarify",
+        "model_picker_widget": "model-picker",
+        "spinner_widget": "spinner",
+        "spacer": "spacer",
+        "status_bar": "status",
+        "input_rule_top": "top-rule",
+        "image_bar": "image-bar",
+        "input_area": "input-area",
+        "input_rule_bot": "bottom-rule",
+        "voice_status_bar": "voice-status",
+        "completions_menu": "completions-menu",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+class TestSeamIdentity:
+    @pytest.mark.parametrize("name", HOOK_NAMES)
+    def test_method_identity(self, name):
+        assert getattr(HermesCLI, name) is getattr(CLITUIHooksMixin, name)
+
+    def test_mixin_in_mro_after_house_mixins(self):
+        mro = HermesCLI.__mro__
+        assert CLITUIHooksMixin in mro
+        house = (
+            cli_mod.CLIAgentSetupMixin,
+            cli_mod.CLICommandsMixin,
+            cli_mod.CLIBillingMixin,
+        )
+        positions = [mro.index(m) for m in house] + [mro.index(CLITUIHooksMixin)]
+        assert positions == sorted(positions), "house mixins precede CLITUIHooksMixin"
+
+    def test_patch_binding_through_seam(self, monkeypatch):
+        monkeypatch.setattr(
+            CLITUIHooksMixin, "_build_tui_layout_children", lambda self, **kw: ["fake-child"]
+        )
+        inst = object.__new__(HermesCLI)
+        assert inst._build_tui_layout_children() == ["fake-child"]
+
+
+class TestNoBackImport:
+    def test_module_imports_without_cli(self):
+        code = (
+            "import sys\n"
+            "sys.modules['cli'] = None\n"
+            "import hermes_cli.cli_tui_hooks_mixin as m\n"
+            "assert m.CLITUIHooksMixin.__name__ == 'CLITUIHooksMixin'\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, cwd=REPO_ROOT
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+    def test_import_order_permutation(self):
+        code = (
+            "import hermes_cli.cli_tui_hooks_mixin\n"
+            "import cli\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, cwd=REPO_ROOT
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout
+
+
+class TestSkinStyleHook:
+    def test_apply_tui_skin_style_false_without_app(self):
+        assert _stub()._apply_tui_skin_style() is False
+
+    def test_apply_tui_skin_style_true_updates_running_app(self, monkeypatch):
+        inst = _stub()
+        invalidate_calls = []
+        inst._app = type("App", (), {"style": "old-style"})()
+        inst._tui_style_base = {"accent": "#fff"}
+        inst._build_tui_style_dict = lambda: {"x": 1}
+        inst._invalidate = lambda min_interval=0.25: invalidate_calls.append(min_interval)
+
+        seen = {}
+
+        class FakePTStyle:
+            @classmethod
+            def from_dict(cls, style_dict):
+                seen["dict"] = style_dict
+                return "NEW-STYLE"
+
+        monkeypatch.setattr("hermes_cli.cli_tui_hooks_mixin.PTStyle", FakePTStyle)
+        assert inst._apply_tui_skin_style() is True
+        assert seen["dict"] == {"x": 1}
+        assert inst._app.style == "NEW-STYLE"
+        assert invalidate_calls == [0.0]
+
+
+class TestLayoutChildrenHook:
+    def test_children_order_with_none_filtering(self):
+        inst = _stub()
+        children = inst._build_tui_layout_children(
+            **_layout_kwargs(
+                slash_confirm_widget=None,
+                model_picker_widget=None,
+                spinner_widget=None,
+            )
+        )
+        # Stub has no _pet_widget / _stash_panel_widget attrs -> slots vanish.
+        assert children[1:] == [
+            "sudo", "secret", "approval", "clarify",
+            "spacer", "status", "top-rule", "image-bar",
+            "input-area", "bottom-rule", "voice-status", "completions-menu",
+        ]
+
+    def test_extra_widgets_interpolated_between_spacer_and_status(self):
+        class _WrapperStub(CLITUIHooksMixin):
+            def _get_extra_tui_widgets(self):
+                return ["radio-menu", "mini-player"]
+
+        inst = _WrapperStub()
+        children = inst._build_tui_layout_children(**_layout_kwargs())
+        spacer_idx = children.index("spacer")
+        assert children[spacer_idx + 1 : spacer_idx + 3] == ["radio-menu", "mini-player"]
+        assert children[spacer_idx + 3] == "status"
+
+    def test_none_filter_removes_optional_slots(self):
+        inst = _stub()
+        children = inst._build_tui_layout_children(**_layout_kwargs())
+        assert "slash-confirm" in children and "model-picker" in children and "spinner" in children
+        filtered = inst._build_tui_layout_children(
+            **_layout_kwargs(
+                slash_confirm_widget=None,
+                model_picker_widget=None,
+                spinner_widget=None,
+            )
+        )
+        assert "slash-confirm" not in filtered
+        assert "model-picker" not in filtered
+        assert "spinner" not in filtered
+
+
+class TestKeybindingHook:
+    def test_register_extra_keybindings_default_noop(self):
+        from prompt_toolkit.key_binding import KeyBindings
+
+        inst = _stub()
+        kb = KeyBindings()
+        assert inst._register_extra_tui_keybindings(kb, input_area=None) is None
+        assert kb.bindings == []
+
+    def test_override_is_dispatched(self):
+        class _BindingStub(CLITUIHooksMixin):
+            def __init__(self):
+                self.seen = None
+
+            def _register_extra_tui_keybindings(self, kb, *, input_area):
+                self.seen = (kb, input_area)
+
+        from prompt_toolkit.key_binding import KeyBindings
+
+        inst = _BindingStub()
+        kb = KeyBindings()
+        inst._register_extra_tui_keybindings(kb, input_area="AREA")
+        assert inst.seen == (kb, "AREA")

--- a/tests/cli/test_goals_leaf.py
+++ b/tests/cli/test_goals_leaf.py
@@ -1,0 +1,165 @@
+"""Tests for _run_kanban_goal_loop_q, the kanban goal-loop leaf moved from
+cli.py into hermes_cli/goals.py (cli.py god-file slice R5, C3).
+
+Covers the env-gated leaf behavior (HERMES_KANBAN_TASK guard, task/body
+resolution, run_turn session sync, run_kanban_goal_loop wiring, block path)
+and the main() gate's lazy-import seam back into cli.py.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import goals
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _FakeConn:
+    def close(self):
+        pass
+
+
+def _make_cli(session_id="s1", agent_session_id="s1", run_result=None):
+    def _run_conversation(**kwargs):
+        return run_result if run_result is not None else {"final_response": "FINAL"}
+
+    agent = SimpleNamespace(
+        session_id=agent_session_id, run_conversation=_run_conversation
+    )
+    return SimpleNamespace(agent=agent, session_id=session_id, conversation_history=[])
+
+
+def _task(title="Goal", body="Body", max_turns=5):
+    return SimpleNamespace(title=title, body=body, goal_max_turns=max_turns, status="ready")
+
+
+@pytest.fixture(autouse=True)
+def _clean_task_env(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+
+class TestLeafBehavior:
+    def test_no_task_env_returns_without_touching_db(self, monkeypatch):
+        def _boom(*a, **k):
+            raise AssertionError("kanban_db must not be touched")
+
+        monkeypatch.setattr("hermes_cli.kanban_db.connect", _boom)
+        assert goals._run_kanban_goal_loop_q(_make_cli(), "resp") is None
+
+    def test_missing_task_returns_without_loop(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t1")
+        monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+        monkeypatch.setattr("hermes_cli.kanban_db.get_task", lambda conn, tid: None)
+        calls = []
+        monkeypatch.setattr(goals, "run_kanban_goal_loop", lambda **kw: calls.append(kw))
+        assert goals._run_kanban_goal_loop_q(_make_cli(), "resp") is None
+        assert calls == []
+
+    def test_empty_goal_text_returns_without_loop(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t1")
+        monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.get_task", lambda conn, tid: _task(title="", body=None)
+        )
+        calls = []
+        monkeypatch.setattr(goals, "run_kanban_goal_loop", lambda **kw: calls.append(kw))
+        assert goals._run_kanban_goal_loop_q(_make_cli(), "resp") is None
+        assert calls == []
+
+    def test_loop_wires_callbacks_and_syncs_session(self, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t1")
+        monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.get_task", lambda conn, tid: _task(max_turns=7)
+        )
+        cli = _make_cli(session_id="s1", agent_session_id="s2")
+        seen = {}
+
+        def fake_loop(**kwargs):
+            seen.update(kwargs)
+            seen["run_turn_resp"] = kwargs["run_turn"]("prompt-1")
+            seen["status"] = kwargs["task_status_fn"]()
+            kwargs["log"]("hello")
+            return {"outcome": "done"}
+
+        monkeypatch.setattr(goals, "run_kanban_goal_loop", fake_loop)
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.block_task", lambda conn, task_id, reason: None
+        )
+
+        # The leaf ends in a bare call; the caller error-swallows and ignores
+        # the return value, so the function itself returns None.
+        assert goals._run_kanban_goal_loop_q(cli, "first-resp") is None
+        assert seen["task_id"] == "t1"
+        assert seen["goal_text"] == "Goal\n\nBody"
+        assert seen["max_turns"] == 7
+        assert seen["first_response"] == "first-resp"
+        assert seen["run_turn_resp"] == "FINAL"
+        assert seen["status"] == "ready"
+        # mid-run compression rotation syncs cli.session_id from the agent.
+        assert cli.session_id == "s2"
+        out = capsys.readouterr().out
+        assert "FINAL" in out
+
+    def test_max_turns_falls_back_to_module_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t1")
+        monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.get_task", lambda conn, tid: _task(max_turns=None)
+        )
+        seen = {}
+        monkeypatch.setattr(goals, "run_kanban_goal_loop", lambda **kw: seen.update(kw))
+        goals._run_kanban_goal_loop_q(_make_cli(), "x")
+        assert seen["max_turns"] == goals.DEFAULT_MAX_TURNS
+
+    def test_block_fn_calls_kanban_db_block_task(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t1")
+        monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: _FakeConn())
+        monkeypatch.setattr("hermes_cli.kanban_db.get_task", lambda conn, tid: _task())
+        blocked = []
+        monkeypatch.setattr(
+            "hermes_cli.kanban_db.block_task",
+            lambda conn, task_id, reason: blocked.append((task_id, reason)),
+        )
+
+        def fake_loop(**kwargs):
+            kwargs["block_fn"]("stuck forever")
+            return None
+
+        monkeypatch.setattr(goals, "run_kanban_goal_loop", fake_loop)
+        goals._run_kanban_goal_loop_q(_make_cli(), "x")
+        assert blocked == [("t1", "stuck forever")]
+
+
+class TestEnvGatedInvocationSeam:
+    def test_main_gate_lazy_imports_moved_leaf(self):
+        import cli as cli_mod
+
+        src = inspect.getsource(cli_mod.main)
+        assert "HERMES_KANBAN_GOAL_MODE" in src
+        assert "from hermes_cli.goals import _run_kanban_goal_loop_q" in src
+        assert "def _run_kanban_goal_loop_q" not in inspect.getsource(cli_mod)
+        assert not hasattr(cli_mod, "_run_kanban_goal_loop_q")
+        assert callable(goals._run_kanban_goal_loop_q)
+
+    def test_cli_imports_under_goal_mode_env(self):
+        code = (
+            "import os\n"
+            "os.environ['HERMES_KANBAN_GOAL_MODE'] = '1'\n"
+            "import cli\n"
+            "import hermes_cli.goals as g\n"
+            "assert callable(g._run_kanban_goal_loop_q)\n"
+            "print('OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, cwd=REPO_ROOT
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

cli.py god-file slice **R5**: extract the TUI-hooks cluster + the goal-loop leaf from `cli.py` into `hermes_cli/cli_tui_hooks_mixin.py` (class `CLITUIHooksMixin`) and `hermes_cli/goals.py`. Part of the repo-wide large-file decomposition (tracker #78647).

## What changed and why

- **TUI hooks** (window 14827–14908, 4 methods) moved **83/83 bytes byte-exact** into `cli_tui_hooks_mixin.py`; `CLITUIHooksMixin` appended last to `HermesCLI` bases; **no `run()` edits** (call sites @17086/@17095–17111 resolve through the MRO)
- **Goal-loop leaf** (window 17866–17953) moved into `hermes_cli/goals.py` — **3 sanctioned edits only** (dropped lazy self-import, `_run_loop`→`run_kanban_goal_loop`, `_DEF_TURNS`→`DEFAULT_MAX_TURNS`); env-gated call site intact (gate @18414, call @18416, `HERMES_KANBAN_GOAL_MODE`)
- **Double-blind**: 2 analysts → consensus (R5-CONSENSUS.md; house naming `CLITUIHooksMixin`) → implementer → 2 blind re-reviewers (pass A: APPROVED 0C/0I/2M; pass B: APPROVED 0C/0I/1M-observation)

## Testing

- `test_cli_tui_hooks_seam.py` + `test_goals_leaf.py`: **23 passed** (identity asserts, MRO-position asserts, no-back-import subprocess, goal-loop env-gated invocation)
- Import-order permutations clean (cli-first, hooks-first, entry/ws)
- ruff clean · git diff --check clean · LF-only · DCO signed

## Coordination / interlock

- **Epic:** Part of #78647 · **Target:** Part of #55136
- **Sibling PRs:** the 3 other cli.py wave-1 slices — disjoint windows
- **Dedup:** no existing PR extracts TUI hooks or the goal loop (open-PR sweep clean for R5)

Part of #78647
Part of #55136
