### PR TITLE
fix(agent): expose resumed todos to pre-llm hooks

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1060,6 +1060,7 @@ def build_turn_context(
             turn_id=turn_id,
             user_message=original_user_message,
             conversation_history=list(messages),
+            todos=agent._todo_store.read(),
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -149,6 +149,9 @@ class _FakeTodoStore:
     def has_items(self):
         return True
 
+    def read(self):
+        return []
+
 
 class _FakeGuardrails:
     def reset_for_turn(self):

--- a/tests/agent/test_gateway_turn_sidecar.py
+++ b/tests/agent/test_gateway_turn_sidecar.py
@@ -28,6 +28,9 @@ class _FakeTodoStore:
     def has_items(self):
         return True
 
+    def read(self):
+        return []
+
 
 class _FakeGuardrails:
     def reset_for_turn(self):

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -20,8 +20,14 @@ from hermes_state import SessionDB
 
 
 class _FakeTodoStore:
+    def __init__(self):
+        self.items = []
+
     def has_items(self):
-        return True
+        return bool(self.items)
+
+    def read(self):
+        return [item.copy() for item in self.items]
 
     def _hydrate(self, *_a, **_k):
         pass
@@ -284,6 +290,31 @@ def test_applies_agent_side_effects():
     # task/turn ids assigned on the agent.
     assert agent._current_task_id
     assert agent._current_turn_id
+
+
+def test_resume_hydration_reaches_pre_llm_hook_before_agent_work():
+    agent = _FakeAgent()
+    hydrated = [
+        {"id": "resume", "content": "continue prior work", "status": "in_progress"}
+    ]
+
+    def _hydrate(_history):
+        agent._todo_store.items = [item.copy() for item in hydrated]
+
+    agent._hydrate_todo_store = _hydrate
+    observed = {}
+
+    def _hook(name, **kwargs):
+        if name == "pre_llm_call":
+            observed.update(kwargs)
+        return []
+
+    with patch("hermes_cli.lifecycle.invoke_hook", side_effect=_hook):
+        _build(agent, conversation_history=[{"role": "user", "content": "prior"}])
+
+    assert observed["session_id"] == "sess-1"
+    assert observed["todos"] == hydrated
+    assert observed["todos"] is not agent._todo_store.items
 
 
 


### PR DESCRIPTION
## Summary

Expose the session TodoStore snapshot to `pre_llm_call` observers.

A resumed gateway turn hydrates the TodoStore from conversation history before the hook runs, but plugins previously received no todo snapshot. Session-bound UI observers therefore could not reconstruct active work until the model called the `todo` tool again.

## Change

- add a defensive `todos` snapshot to the existing `pre_llm_call` payload
- add a regression proving resumed history is hydrated before observers run
- keep existing hook semantics and avoid exposing the mutable TodoStore

## Verification

- `python -m pytest tests/agent/test_turn_context.py tests/hermes_cli/test_plugins.py -q` — 47 passed
- `git diff --check` — pass

Made with [Orca](https://github.com/stablyai/orca) 🐋
