### PR TITLE
fix(gateway): preserve idle compaction gap on cached turns

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -656,12 +656,19 @@ def build_turn_context(
     # a large stale context on every turn. This fires on elapsed wall-clock time
     # rather than size, so it complements (does not replace) the token-threshold
     # preflight below. ``_last_activity_ts`` is the last time this turn loop did
-    # work; nothing has touched it yet this turn, so it measures the gap since
-    # the previous turn finished. The cheap gap pre-check gates the (more
-    # expensive) token estimate, mirroring ``_should_run_preflight_estimate``.
+    # work; nothing has touched it yet this turn in CLI/TUI, so it measures the
+    # gap since the previous turn finished. Gateway cached-agent reuse resets
+    # ``_last_activity_ts`` at fresh-turn start for the inactivity watchdog, so
+    # that path stashes the pre-reset gap on ``_idle_gap_at_turn_start`` and we
+    # consume it once here. The cheap gap pre-check gates the (more expensive)
+    # token estimate, mirroring ``_should_run_preflight_estimate``.
     _idle_after = getattr(agent, "compression_idle_compact_after_seconds", 0)
     if agent.compression_enabled and _idle_after > 0 and messages:
-        _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
+        _idle_gap = getattr(agent, "_idle_gap_at_turn_start", None)
+        if _idle_gap is not None:
+            agent._idle_gap_at_turn_start = None
+        else:
+            _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
         if _idle_gap >= _idle_after:
             _compressor = agent.context_compressor
             _idle_tokens = estimate_request_tokens_rough(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23204,7 +23204,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if interrupt_depth == 0:
             from agent.session_activity import ActivityProvenance
 
-            agent._last_activity_ts = time.time()
+            prev_activity_ts = getattr(agent, "_last_activity_ts", None)
+            now = time.time()
+            agent._idle_gap_at_turn_start = (
+                max(0.0, now - float(prev_activity_ts))
+                if prev_activity_ts is not None
+                else None
+            )
+            agent._last_activity_ts = now
             agent._last_activity_desc = "starting new turn (cached)"
             agent._last_activity_provenance = ActivityProvenance.UNKNOWN
             # Reset the SessionDB flush cursor so the new turn's messages are

--- a/tests/agent/test_idle_compaction_lock_and_guards.py
+++ b/tests/agent/test_idle_compaction_lock_and_guards.py
@@ -112,6 +112,29 @@ def test_idle_compaction_status_emitted_by_default(tmp_path: Path) -> None:
     ), f"expected idle status line, got: {events}"
 
 
+def test_gateway_cached_turn_uses_stashed_idle_gap(tmp_path: Path) -> None:
+    """Gateway fresh-turn watchdog reset must not suppress idle compaction."""
+    from gateway.run import GatewayRunner
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "IDLE_GATEWAY_STASH"
+    db.create_session(sid, source="gateway")
+    agent = _prep_idle_agent(db, sid, idle_after=60, idle_gap=3600.0)
+    history = _history()
+
+    with patch("gateway.run.time") as mock_time:
+        mock_time.time.return_value = time.time()
+        GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=0)
+
+    assert agent._last_activity_ts is not None
+    assert agent._idle_gap_at_turn_start is not None
+
+    _run_prologue(agent, history)
+
+    agent.context_compressor.compress.assert_called_once()
+    assert agent._idle_gap_at_turn_start is None
+
+
 def test_idle_compaction_defers_to_held_compression_lock(tmp_path: Path) -> None:
     """An idle-triggered compress racing another path must sit the round out.
 
@@ -183,7 +206,6 @@ def test_idle_compaction_respects_anti_thrash_breaker(tmp_path: Path) -> None:
     compressor.compress.assert_not_called()
     assert agent.session_id == sid
     assert len(ctx.messages) == len(_history()) + 1
-
 
 
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -727,6 +727,10 @@ class TestCachedAgentInactivityReset:
         assert agent._last_activity_ts > old_ts, (
             "Stale idle time should be cleared so the new turn gets a fresh window"
         )
+        assert agent._idle_gap_at_turn_start == _FAKE_NOW - old_ts, (
+            "Fresh cached turns must stash the pre-reset idle gap so "
+            "idle-compaction can still see gateway resume time"
+        )
 
 
     def test_fresh_turn_resets_provenance(self):
@@ -750,6 +754,7 @@ class TestCachedAgentInactivityReset:
 
         agent = self._fake_agent(stale_seconds=1200.0)
         old_ts = agent._last_activity_ts
+        agent._idle_gap_at_turn_start = 123.0
 
         GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=1)
 
@@ -757,6 +762,7 @@ class TestCachedAgentInactivityReset:
             "_last_activity_ts must not be reset on interrupt-recursive turns "
             "(interrupt_depth>0) — the watchdog needs the accumulated idle time"
         )
+        assert agent._idle_gap_at_turn_start == 123.0
 
     def test_interrupt_turn_preserves_desc(self):
         """interrupt_depth=1: desc preserved — it is semantically paired with ts."""
@@ -1061,4 +1067,3 @@ class TestCrossProcessInvalidationDefersCleanup:
         # Stale entry was popped, hard-teardown path never used.
         assert "telegram:s1" not in runner._agent_cache
         runner._cleanup_agent_resources.assert_not_called()
-


### PR DESCRIPTION
## Summary
- preserve the pre-reset idle gap on cached gateway agents before the watchdog refreshes `_last_activity_ts`
- consume that stashed gap once in the idle-compaction preflight so gateway resumes can still trigger idle compaction
- add focused regression coverage for the gateway cache reset and the end-to-end idle-compaction path

## Problem
On current `main`, gateway fresh turns reset `agent._last_activity_ts` in `GatewayRunner._init_cached_agent_for_turn()` before `agent.turn_context.build_turn_context()` runs the idle-compaction check. That means `compression.idle_compact_after_seconds` always sees a near-zero idle gap in gateway mode, so the feature is effectively dead for long-lived Discord/Slack/etc. sessions.

## Fix
- In `gateway/run.py`, stash the pre-reset idle gap on `_idle_gap_at_turn_start` for fresh cached turns (`interrupt_depth == 0`) before refreshing the watchdog timestamp.
- In `agent/turn_context.py`, prefer that stashed gap for the idle-compaction decision and clear it after one use so interrupt-recursive turns cannot re-trigger from stale state.

CLI/TUI behavior stays unchanged because they never set the gateway-only stash.

## Testing
- `.venv/bin/pytest tests/gateway/test_agent_cache.py tests/agent/test_idle_compaction_lock_and_guards.py -q`

Fixes #79357
