### PR TITLE
feat(feishu): implement create_handoff_thread for session handoff / cron continuable threads

### DIFF
--- a/contributors/emails/29206394@users.noreply.github.com
+++ b/contributors/emails/29206394@users.noreply.github.com
@@ -1,0 +1,2 @@
+moxian
+# feat(feishu) create_handoff_thread PR #79373

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1925,6 +1925,54 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    async def create_handoff_thread(
+        self,
+        parent_chat_id: str,
+        name: str,
+    ) -> Optional[str]:
+        """Create a fresh thread for a session handoff.
+
+        Used by the gateway's handoff watcher (``/handoff``) and the cron
+        scheduler's continuable-thread path (``attach_to_session``).
+
+        Feishu has no dedicated thread/topic-creation primitive usable as a
+        send target: the only valid way to address a thread is the reply API
+        anchored at the thread's root message (``reply_in_thread=true``; a
+        ``receive_id_type="thread_id"`` create is rejected by the API with
+        99992402 — #78975). Feishu surfaces any reply chain as a "topic" in
+        both DMs and groups, so we mirror Slack's seed-anchor pattern
+        (``plugins/platforms/slack/adapter.py``): post an anchor message
+        (``Hermes — <name>``) and return its ``message_id``. Follow-up sends
+        carry ``reply_to=<anchor>`` (or ``metadata["thread_id"]=<anchor>``
+        for anchorless cron sends — see ``_send_raw_message``), which the
+        adapter's send path already routes via the reply API with
+        ``reply_in_thread=true``.
+
+        Returns ``None`` when the anchor post fails — the caller falls back
+        to the origin-DM mirror (base contract, see
+        ``gateway/platforms/base.py``). Never raises.
+        """
+        if not self._client:
+            return None
+        try:
+            anchor_text = f"Hermes — {str(name or 'session').strip()[:80]}"
+            result = await self.send(parent_chat_id, anchor_text)
+            if result.success and result.message_id:
+                return str(result.message_id)
+            logger.warning(
+                "[Feishu] create_handoff_thread: anchor send failed for %s",
+                parent_chat_id,
+            )
+            return None
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] create_handoff_thread failed for %s: %s",
+                parent_chat_id,
+                exc,
+                exc_info=True,
+            )
+            return None
+
     async def send(
         self,
         chat_id: str,
@@ -4814,18 +4862,23 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
+        # Anchorless thread/continuable-cron send: ``metadata["thread_id"]``
+        # is the thread's root message id (the anchor posted by
+        # ``create_handoff_thread``). Feishu addresses threads only via the
+        # reply API with ``reply_in_thread=true`` — there is no
+        # ``receive_id_type="thread_id"`` on message.create (the API rejects
+        # it with 99992402, #78975). Reply to the anchor to land in the
+        # topic instead of the main chat.
         _thread_id = (metadata or {}).get("thread_id")
         if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
+            body = self._build_reply_message_body(
                 content=payload,
+                msg_type=msg_type,
+                reply_in_thread=True,
                 uuid_value=str(uuid.uuid4()),
             )
-            request = self._build_create_message_request("thread_id", body)
+            request = self._build_reply_message_request(_thread_id, body)
+            return await self._run_blocking(self._client.im.v1.message.reply, request)
         else:
             receive_id = chat_id
             receive_id_type = "chat_id"

--- a/tests/gateway/test_feishu_handoff_thread.py
+++ b/tests/gateway/test_feishu_handoff_thread.py
@@ -1,0 +1,140 @@
+"""Tests for Feishu adapter create_handoff_thread + thread routing.
+
+Covers:
+- create_handoff_thread: seed-anchor pattern (Feishu surfaces any reply
+  chain as a "topic" in DMs and groups, so the anchor message_id is the
+  thread handle — mirrors Slack).
+- _send_raw_message anchorless thread routing: metadata["thread_id"] must
+  go through the reply API with reply_in_thread=true, NOT message.create
+  with receive_id_type="thread_id" (rejected by the Feishu API with
+  99992402 — #78975).
+- Degradation contract: every failure path returns None so callers
+  (scheduler ``_open_continuable_cron_thread``, gateway ``_process_handoff``)
+  fall back to the origin-DM mirror without failing the delivery.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    return FeishuAdapter(PlatformConfig())
+
+
+class TestCreateHandoffThread(unittest.TestCase):
+    def test_anchor_message_and_returns_message_id(self):
+        adapter = _make_adapter()
+        adapter._client = Mock()
+
+        async def _fake_send(chat_id, content):
+            self.assertIn("Hermes —", content)
+            return SendResult(success=True, message_id="om_anchor123")
+
+        with patch.object(adapter, "send", side_effect=_fake_send):
+            result = asyncio.run(adapter.create_handoff_thread("oc_dm", "daily-review"))
+
+        self.assertEqual(result, "om_anchor123")
+
+    def test_anchor_send_failure_returns_none(self):
+        adapter = _make_adapter()
+        adapter._client = Mock()
+
+        async def _fake_send(chat_id, content):
+            return SendResult(success=False, error="[230002] cannot send")
+
+        with patch.object(adapter, "send", side_effect=_fake_send):
+            result = asyncio.run(adapter.create_handoff_thread("oc_dm", "x"))
+
+        self.assertIsNone(result)
+
+    def test_no_client_returns_none(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        result = asyncio.run(adapter.create_handoff_thread("oc_x", "x"))
+        self.assertIsNone(result)
+
+    def test_exception_inside_is_swallowed_to_none(self):
+        adapter = _make_adapter()
+        adapter._client = Mock()
+
+        async def _boom(chat_id, content):
+            raise RuntimeError("network down")
+
+        with patch.object(adapter, "send", side_effect=_boom):
+            result = asyncio.run(adapter.create_handoff_thread("oc_x", "x"))
+
+        self.assertIsNone(result)
+
+
+class TestAnchorlessThreadRouting(unittest.TestCase):
+    """#78975 regression: metadata['thread_id'] must route via the reply
+    API (reply_in_thread=true), never message.create with the invalid
+    receive_id_type='thread_id'."""
+
+    def _run_send_raw(self, metadata):
+        adapter = _make_adapter()
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["api"] = "reply"
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_routed"),
+                )
+
+            def create(self, request):
+                captured["api"] = "create"
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_created"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter._send_raw_message(
+                    chat_id="oc_chat",
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to=None,
+                    metadata=metadata,
+                )
+            )
+
+        return adapter, captured, result
+
+    def test_thread_id_routes_via_reply_api_with_reply_in_thread(self):
+        _, captured, result = self._run_send_raw({"thread_id": "om_anchor1"})
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["api"], "reply")
+        self.assertEqual(captured["request"].message_id, "om_anchor1")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    def test_no_thread_metadata_uses_create_with_chat_id(self):
+        _, captured, result = self._run_send_raw(None)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["api"], "create")
+        self.assertEqual(captured["request"].receive_id_type, "chat_id")
+        self.assertEqual(captured["request"].request_body.receive_id, "oc_chat")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_feishu_handoff_thread.py
+++ b/tests/gateway/test_feishu_handoff_thread.py
@@ -8,9 +8,23 @@ Covers:
   go through the reply API with reply_in_thread=true, NOT message.create
   with receive_id_type="thread_id" (rejected by the Feishu API with
   99992402 — #78975).
+- send() end-to-end: the real path scheduler/DeliveryRouter uses for
+  continuable cron deliveries (metadata={"thread_id": <anchor>}).
+- Reply-failure fallback semantics in _feishu_send_with_retry: with a
+  thread anchor present, a failed reply must NOT fall back to a top-level
+  create (that would spawn a new topic outside the thread); without a
+  thread, the existing create fallback stays.
 - Degradation contract: every failure path returns None so callers
   (scheduler ``_open_continuable_cron_thread``, gateway ``_process_handoff``)
   fall back to the origin-DM mirror without failing the delivery.
+
+Real-data notes (verified 2026-08-05 from the live state.db):
+- Feishu DM reply chains produce thread-keyed sessions keyed on the
+  anchor (root) message id:
+      session_key = agent:main:feishu:dm:oc_5449fd7cd1cab7e6df3e74cb81b4666e:om_x100b6ba5dc1a40a8c2acad0bace48b3
+      thread_id   = om_x100b6ba5dc1a40a8c2acad0bace48b3   (om_ prefix = message id)
+- Message ids are om_-prefixed; chat ids are oc_-prefixed (both p2p and
+  group). These shapes are used in the fixtures below.
 """
 
 import asyncio
@@ -21,11 +35,47 @@ from unittest.mock import AsyncMock, Mock, patch
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
 
+# Real-shape identifiers observed in production (see docstring).
+_ANCHOR_MSG_ID = "om_x100b6ba5dc1a40a8c2acad0bace48b3"
+_P2P_CHAT_ID = "oc_5449fd7cd1cab7e6df3e74cb81b4666e"
+_GROUP_CHAT_ID = "oc_bb98679627588183ff7ab339347e6d62"
+
 
 def _make_adapter():
     from plugins.platforms.feishu.adapter import FeishuAdapter
 
     return FeishuAdapter(PlatformConfig())
+
+
+def _install_message_api(adapter, captured, *, reply_returns=None, create_returns=None):
+    """Wire a fake im.v1.message API capturing requests; each method returns
+    a success SendResult-shaped response unless overridden."""
+
+    def _ok(message_id):
+        return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id=message_id))
+
+    class _MessageAPI:
+        def reply(self, request):
+            captured["api"] = "reply"
+            captured["request"] = request
+            if callable(reply_returns):
+                return reply_returns(request)
+            return _ok("om_replied")
+
+        def create(self, request):
+            captured["api"] = "create"
+            captured["request"] = request
+            if callable(create_returns):
+                return create_returns(request)
+            return _ok("om_created")
+
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
 
 
 class TestCreateHandoffThread(unittest.TestCase):
@@ -34,13 +84,14 @@ class TestCreateHandoffThread(unittest.TestCase):
         adapter._client = Mock()
 
         async def _fake_send(chat_id, content):
+            self.assertEqual(chat_id, _P2P_CHAT_ID)
             self.assertIn("Hermes —", content)
-            return SendResult(success=True, message_id="om_anchor123")
+            return SendResult(success=True, message_id=_ANCHOR_MSG_ID)
 
         with patch.object(adapter, "send", side_effect=_fake_send):
-            result = asyncio.run(adapter.create_handoff_thread("oc_dm", "daily-review"))
+            result = _run(adapter.create_handoff_thread(_P2P_CHAT_ID, "daily-review"))
 
-        self.assertEqual(result, "om_anchor123")
+        self.assertEqual(result, _ANCHOR_MSG_ID)
 
     def test_anchor_send_failure_returns_none(self):
         adapter = _make_adapter()
@@ -50,14 +101,28 @@ class TestCreateHandoffThread(unittest.TestCase):
             return SendResult(success=False, error="[230002] cannot send")
 
         with patch.object(adapter, "send", side_effect=_fake_send):
-            result = asyncio.run(adapter.create_handoff_thread("oc_dm", "x"))
+            result = _run(adapter.create_handoff_thread(_P2P_CHAT_ID, "x"))
+
+        self.assertIsNone(result)
+
+    def test_anchor_send_success_without_message_id_returns_none(self):
+        """SendResult may report success but carry no message_id (defensive:
+        never return a non-message-id as a thread handle)."""
+        adapter = _make_adapter()
+        adapter._client = Mock()
+
+        async def _fake_send(chat_id, content):
+            return SendResult(success=True, message_id=None)
+
+        with patch.object(adapter, "send", side_effect=_fake_send):
+            result = _run(adapter.create_handoff_thread(_P2P_CHAT_ID, "x"))
 
         self.assertIsNone(result)
 
     def test_no_client_returns_none(self):
         adapter = _make_adapter()
         adapter._client = None
-        result = asyncio.run(adapter.create_handoff_thread("oc_x", "x"))
+        result = _run(adapter.create_handoff_thread(_P2P_CHAT_ID, "x"))
         self.assertIsNone(result)
 
     def test_exception_inside_is_swallowed_to_none(self):
@@ -68,72 +133,208 @@ class TestCreateHandoffThread(unittest.TestCase):
             raise RuntimeError("network down")
 
         with patch.object(adapter, "send", side_effect=_boom):
-            result = asyncio.run(adapter.create_handoff_thread("oc_x", "x"))
+            result = _run(adapter.create_handoff_thread(_P2P_CHAT_ID, "x"))
 
         self.assertIsNone(result)
 
 
-class TestAnchorlessThreadRouting(unittest.TestCase):
-    """#78975 regression: metadata['thread_id'] must route via the reply
-    API (reply_in_thread=true), never message.create with the invalid
-    receive_id_type='thread_id'."""
+class TestSendEndToEnd(unittest.TestCase):
+    """send() — the real entry the scheduler/DeliveryRouter uses for
+    continuable cron deliveries (metadata={"thread_id": <anchor>}, no
+    reply_to)."""
 
-    def _run_send_raw(self, metadata):
-        adapter = _make_adapter()
-        captured = {}
-
-        class _MessageAPI:
-            def reply(self, request):
-                captured["api"] = "reply"
-                captured["request"] = request
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(message_id="om_routed"),
-                )
-
-            def create(self, request):
-                captured["api"] = "create"
-                captured["request"] = request
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(message_id="om_created"),
-                )
-
-        adapter._client = SimpleNamespace(
-            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
-        )
-
+    @staticmethod
+    def _direct_patch():
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
-            result = asyncio.run(
-                adapter._send_raw_message(
-                    chat_id="oc_chat",
-                    msg_type="text",
-                    payload='{"text":"hi"}',
-                    reply_to=None,
-                    metadata=metadata,
-                )
+        return patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct)
+
+    def test_send_with_thread_id_metadata_routes_to_reply_in_thread(self):
+        adapter = _make_adapter()
+        captured = {}
+        _install_message_api(adapter, captured)
+        with self._direct_patch():
+            result = _run(
+                adapter.send(_P2P_CHAT_ID, "daily ledger", metadata={"thread_id": _ANCHOR_MSG_ID})
             )
-
-        return adapter, captured, result
-
-    def test_thread_id_routes_via_reply_api_with_reply_in_thread(self):
-        _, captured, result = self._run_send_raw({"thread_id": "om_anchor1"})
 
         self.assertTrue(result.success)
         self.assertEqual(captured["api"], "reply")
-        self.assertEqual(captured["request"].message_id, "om_anchor1")
+        self.assertEqual(captured["request"].message_id, _ANCHOR_MSG_ID)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
-    def test_no_thread_metadata_uses_create_with_chat_id(self):
-        _, captured, result = self._run_send_raw(None)
+    def test_send_with_reply_to_and_thread_id_metadata(self):
+        """In-thread reply (user reply inside the topic): reply_to + thread_id
+        both present → reply API, reply_in_thread still true (parity with the
+        existing send_document test, test_feishu.py::test_send_document_reply_uses_thread_flag)."""
+        adapter = _make_adapter()
+        captured = {}
+        _install_message_api(adapter, captured)
+        with self._direct_patch():
+            result = _run(
+                adapter.send(
+                    _GROUP_CHAT_ID,
+                    "in-topic reply",
+                    reply_to=_ANCHOR_MSG_ID,
+                    metadata={"thread_id": _ANCHOR_MSG_ID},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["api"], "reply")
+        self.assertEqual(captured["request"].message_id, _ANCHOR_MSG_ID)
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    def test_send_without_thread_uses_create_with_chat_id(self):
+        adapter = _make_adapter()
+        captured = {}
+        _install_message_api(adapter, captured)
+        with self._direct_patch():
+            result = _run(adapter.send(_P2P_CHAT_ID, "plain message"))
 
         self.assertTrue(result.success)
         self.assertEqual(captured["api"], "create")
         self.assertEqual(captured["request"].receive_id_type, "chat_id")
-        self.assertEqual(captured["request"].request_body.receive_id, "oc_chat")
+        self.assertEqual(captured["request"].request_body.receive_id, _P2P_CHAT_ID)
+
+
+class TestAnchorlessThreadRouting(unittest.TestCase):
+    """#78975 regression at the _send_raw_message level: metadata['thread_id']
+    must route via the reply API (reply_in_thread=true), never message.create
+    with the invalid receive_id_type='thread_id'."""
+
+    def test_thread_id_routes_via_reply_api_with_reply_in_thread(self):
+        adapter = _make_adapter()
+        captured = {}
+        _install_message_api(adapter, captured)
+        with TestSendEndToEnd._direct_patch():
+            result = _run(
+                adapter._send_raw_message(
+                    chat_id=_P2P_CHAT_ID,
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to=None,
+                    metadata={"thread_id": _ANCHOR_MSG_ID},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["api"], "reply")
+        self.assertEqual(captured["request"].message_id, _ANCHOR_MSG_ID)
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    def test_empty_thread_id_metadata_falls_through_to_create(self):
+        """An empty/None thread_id value is falsy — must not attempt a
+        reply against it; falls through to the normal create path."""
+        adapter = _make_adapter()
+        captured = {}
+        _install_message_api(adapter, captured)
+        with TestSendEndToEnd._direct_patch():
+            result = _run(
+                adapter._send_raw_message(
+                    chat_id=_P2P_CHAT_ID,
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to=None,
+                    metadata={"thread_id": ""},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["api"], "create")
+        self.assertEqual(captured["request"].request_body.receive_id, _P2P_CHAT_ID)
+
+    def test_no_thread_metadata_uses_create_with_chat_id(self):
+        adapter = _make_adapter()
+        captured = {}
+        _install_message_api(adapter, captured)
+        with TestSendEndToEnd._direct_patch():
+            result = _run(
+                adapter._send_raw_message(
+                    chat_id=_P2P_CHAT_ID,
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to=None,
+                    metadata=None,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["api"], "create")
+        self.assertEqual(captured["request"].receive_id_type, "chat_id")
+        self.assertEqual(captured["request"].request_body.receive_id, _P2P_CHAT_ID)
+
+
+class TestReplyFallback(unittest.TestCase):
+    """_feishu_send_with_retry reply-failure semantics (#78975 interaction)."""
+
+    def test_reply_failure_with_thread_anchor_skips_top_level_fallback(self):
+        """Reply target withdrawn/missing (code 230011) inside a thread must
+        NOT fall back to a top-level create — that would spawn a NEW message
+        outside the thread (or, worse, a new topic). The failure propagates."""
+        adapter = _make_adapter()
+        calls = []
+
+        async def _fake_send_raw(**kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                success=lambda: False,
+                code=230011,
+                msg="reply target withdrawn",
+                raw=SimpleNamespace(content=b"{}"),
+            )
+
+        with patch.object(adapter, "_send_raw_message", side_effect=_fake_send_raw):
+            result = _run(
+                adapter._feishu_send_with_retry(
+                    chat_id=_P2P_CHAT_ID,
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to=_ANCHOR_MSG_ID,
+                    metadata={"thread_id": _ANCHOR_MSG_ID},
+                )
+            )
+
+        self.assertFalse(result.success())
+        # Exactly one attempt — no top-level fallback send.
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["reply_to"], _ANCHOR_MSG_ID)
+
+    def test_reply_failure_without_thread_falls_back_to_create(self):
+        """Without a thread anchor, a failed reply (230011) degrades to a
+        fresh message in the chat — existing behavior preserved."""
+        adapter = _make_adapter()
+        calls = []
+
+        async def _fake_send_raw(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=230011,
+                    msg="reply target withdrawn",
+                    raw=SimpleNamespace(content=b"{}"),
+                )
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(message_id="om_fallback"),
+            )
+
+        with patch.object(adapter, "_send_raw_message", side_effect=_fake_send_raw):
+            result = _run(
+                adapter._feishu_send_with_retry(
+                    chat_id=_P2P_CHAT_ID,
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to="om_withdrawn",
+                    metadata=None,
+                )
+            )
+
+        self.assertTrue(result.success())
+        self.assertEqual(len(calls), 2)
+        self.assertIsNone(calls[1]["reply_to"])  # second attempt is a bare create
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Implements `create_handoff_thread` for the Feishu adapter and fixes thread routing in `_send_raw_message`, so cron continuable threads (`attach_to_session`) and CLI→gateway session handoffs (`/handoff feishu`) work on Feishu instead of always falling back to the origin-DM mirror.

**`create_handoff_thread` — seed-anchor pattern (mirrors Slack's `plugins/platforms/slack/adapter.py`):**
Feishu has no thread/topic-creation primitive usable as a send target: the only valid way to address a thread is the reply API anchored at the thread's root message. Feishu surfaces any reply chain as a "topic" in both DMs and groups (verified: inbound `root_id`/`thread_id` parsing already resolves replies into thread-keyed sessions like `agent:main:feishu:dm:<chat>:<anchor>`). So we post a `Hermes — <name>` anchor message and return its `message_id` as the thread handle.

**`_send_raw_message` thread routing fix (#78975):**
`metadata["thread_id"]` previously built a `message.create` with `receive_id_type="thread_id"` — not a valid Feishu API value (rejected with 99992402), so cron deliveries to a Feishu DM thread failed 100% of the time. Now routes via the reply API with `reply_in_thread=true` (the same primitive the adapter already uses for `reply_to` + `thread_id` sends, covered by existing tests).

## Related Issue

- Fixes part of #78975 (Feishu cron delivery fails with [99992402] — thread routing)
- Related to #54656 (Feishu: no way to start a fresh session — thread/topic support)
- Related to #39526 (MEDIA via topic/thread reply)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - New `create_handoff_thread(parent_chat_id, name) -> Optional[str]`: posts anchor message, returns its `message_id` as thread handle; `None` on any failure (base contract, caller falls back to DM mirror; never raises)
  - `_send_raw_message`: anchorless thread sends (`metadata["thread_id"]`) now use the reply API + `reply_in_thread=true` instead of the invalid `receive_id_type="thread_id"` create
- `tests/gateway/test_feishu_handoff_thread.py` (new, 13 tests)

## How to Test

1. `python -m unittest tests.gateway.test_feishu_handoff_thread -v` — 13/13 pass
2. `python -m unittest discover -s tests/gateway -p "test_feishu*.py"` — 116 tests, no new failures vs baseline (3 failures / 9 errors are pre-existing bot-identity & comment-suite issues)
3. Live: schedule a cron job with `attach_to_session=true` from a Feishu DM thread (or run `/handoff feishu`) — delivery lands in the reply-chain topic, and replying in that topic continues the session with the brief in context

## Test Coverage (13 cases)

- **create_handoff_thread**: anchor success returns message_id (real-shape `om_` ids); anchor failure → None; success-without-message_id → None (defensive); no client → None; exception swallowed → None
- **send() end-to-end** (the scheduler/DeliveryRouter entry): `metadata={"thread_id": <anchor>}` → reply API + `reply_in_thread=true`; in-thread reply (`reply_to` + `thread_id`) → reply API; plain send → create with `chat_id`
- **_send_raw_message routing (#78975 regression)**: `thread_id` → reply API + `reply_in_thread=true`, never the invalid create; empty `thread_id` (falsy) falls through to create
- **reply-failure fallback**: failed reply (230011) with a thread anchor skips the top-level fallback (must not spawn a new topic); without an anchor, the existing create fallback is preserved
- Fixtures use real-shape identifiers from production (`om_` message ids, `oc_` chat ids) with documented state.db session-key evidence

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(feishu):`, `test(feishu):`, `chore:`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted suites green; full suite not run locally (venv lacks pytest); baseline unchanged
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings document the anchor contract and the #78975 constraint) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (no platform-specific constructs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A