### PR TITLE
Tolerate malformed A2A_PORT without crashing adapter init

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -343,7 +343,12 @@ class A2AAdapter(BasePlatformAdapter):
         super().__init__(config=config, platform=platform)
 
         extra = getattr(config, "extra", {}) or {}
-        self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
+        # Mirror IRC_PORT (#40598): malformed A2A_PORT / extra.port must not
+        # ValueError during adapter construction and take the platform down.
+        try:
+            self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
+        except (ValueError, TypeError):
+            self.port = _DEFAULT_PORT
         self.host = security.resolve_bind_host()
         self.agent_name = _default_agent_name()
         self._advertised_toolsets = [

--- a/tests/plugins/test_a2a_port_int_guard.py
+++ b/tests/plugins/test_a2a_port_int_guard.py
@@ -1,0 +1,24 @@
+"""A2A adapter must tolerate malformed A2A_PORT / extra.port."""
+
+from __future__ import annotations
+
+from gateway.config import PlatformConfig
+from plugins.platforms.a2a.adapter import A2AAdapter, _DEFAULT_PORT
+
+
+def test_malformed_a2a_port_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("A2A_PORT", "not-a-port")
+    adapter = A2AAdapter(PlatformConfig(enabled=True))
+    assert adapter.port == _DEFAULT_PORT
+
+
+def test_malformed_extra_port_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("A2A_PORT", raising=False)
+    adapter = A2AAdapter(PlatformConfig(enabled=True, extra={"port": "nope"}))
+    assert adapter.port == _DEFAULT_PORT
+
+
+def test_valid_a2a_port_env_is_honored(monkeypatch):
+    monkeypatch.setenv("A2A_PORT", "9911")
+    adapter = A2AAdapter(PlatformConfig(enabled=True))
+    assert adapter.port == 9911


### PR DESCRIPTION
## Summary
- `A2AAdapter.__init__` used unguarded `int(os.getenv("A2A_PORT") or extra.port)`.
- Malformed env/config (`A2A_PORT=abc`, `extra.port: "nope"`) raises `ValueError` during construction and takes the platform down.
- Mirror the IRC_PORT try/except (#40598 family) and fall back to `_DEFAULT_PORT`.
