### PR TITLE
fix(gateway): bound lifecycle scans of binary paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -253,28 +253,28 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     return None
 
 
-def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
-    """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
+def _read_referenced_script(path: Path) -> tuple[Optional[str], bool, bool]:
+    """Return ``(text, unsafe, remote_fallback_allowed)`` using bounded reads."""
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except (OSError, ValueError):
-        # OSError: unreadable / missing / over-long paths. ValueError: an
-        # embedded NUL byte in *path* itself — a binary's decoded bytes
-        # tokenized into a bogus script path by the recursion (#77703). A
-        # guarded read must never crash the guard, so treat either as
-        # "nothing to scan" (mirrors the resolve() ValueError guard below).
-        return None, False
+    except ValueError:
+        # POSIX paths cannot contain NUL. Such candidates only come from
+        # tokenizing binary content and must not reach a remote reader either.
+        return None, False, False
+    except OSError:
+        # A path that cannot be opened locally may live on a remote backend.
+        return None, False, True
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
-            return None, True
+            return None, True, False
         # Read a bounded chunk first — even for oversized files, the first
         # chunk tells us if this is a binary (NUL bytes) that should be
         # skipped as "nothing to scan" rather than failing closed (#76762).
         data = os.read(descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1)
     except OSError:
-        return None, False
+        return None, False, False
     finally:
         os.close(descriptor)
     # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
@@ -284,10 +284,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
     # executed by the user is not a referenced *shell script*.
     if b"\x00" in data:
-        return None, False
+        return None, False, False
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
-        return None, True
-    return data.decode("utf-8", errors="replace"), False
+        return None, True, False
+    return data.decode("utf-8", errors="replace"), False, False
 
 
 def _contains_unsafe_gateway_action(
@@ -326,12 +326,30 @@ def _contains_unsafe_gateway_action(
         if resolved in visited:
             continue
         visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
+        script_text, unsafe, remote_fallback_allowed = _read_referenced_script(
+            script_path
+        )
         if unsafe:
             return True
-        if script_text is None and read_remote_script is not None:
+        if (
+            script_text is None
+            and remote_fallback_allowed
+            and read_remote_script is not None
+        ):
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+            # Apply the local reader's binary and size policy to remote
+            # content before recursive tokenization. This prevents a remote
+            # executable from feeding machine code or unbounded text into the
+            # lifecycle regex/path walk.
+            if script_text and "\x00" in script_text:
+                continue
+            if (
+                script_text
+                and len(script_text.encode("utf-8", errors="replace"))
+                > _MAX_REFERENCED_SCRIPT_BYTES
+            ):
+                return True
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's
@@ -392,7 +410,7 @@ def _read_script_for_scanning(script_path: str) -> str:
     sentinel, while missing/unreadable paths remain empty so ordinary scheduler
     path validation can report them.
     """
-    script_text, unsafe = _read_referenced_script(_resolve_script_path(script_path))
+    script_text, unsafe, _ = _read_referenced_script(_resolve_script_path(script_path))
     if unsafe:
         return "hermes gateway restart"
     return script_text or ""

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -705,9 +705,12 @@ class TestLifecycleGuardModule:
 
         from cron.lifecycle_guard import _read_referenced_script
 
-        text, unsafe = _read_referenced_script(Path("/tmp/hermes\x00binary"))
+        text, unsafe, remote_fallback_allowed = _read_referenced_script(
+            Path("/tmp/hermes\x00binary")
+        )
         assert text is None
         assert unsafe is False
+        assert remote_fallback_allowed is False
 
     def test_remote_read_fallback_binary_does_not_crash_guard(self):
         """#77703: in the gateway the referenced-script walk carries a
@@ -735,6 +738,117 @@ class TestLifecycleGuardModule:
             read_remote_script=_remote_read,
         )
         assert result is False
+
+    def test_local_binary_does_not_fall_back_to_remote_reader(self, tmp_path):
+        """A local NUL-bearing executable is present, not remotely missing."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        executable = tmp_path / "large-tool"
+        executable.write_bytes(b"\x7fELF\x00" + b"x" * (1024 * 1024))
+        remote_reads = []
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            str(executable),
+            read_remote_script=lambda path: (
+                remote_reads.append(path) or "hermes gateway restart"
+            ),
+        )
+
+        assert result is False
+        assert remote_reads == []
+
+    def test_missing_local_script_still_uses_remote_reader(self, tmp_path):
+        """Remote backends still scan scripts that are absent on the host."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        missing_script = tmp_path / "remote" / "restart.sh"
+        remote_reads = []
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            str(missing_script),
+            read_remote_script=lambda path: (
+                remote_reads.append(path) or "hermes gateway restart"
+            ),
+        )
+
+        assert result is True
+        assert remote_reads == [str(missing_script)]
+
+    def test_nul_bearing_candidate_neither_crashes_nor_uses_remote_reader(self):
+        """Binary-tokenization junk cannot name a real local or remote path."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        remote_reads = []
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "sh foo\x00bar.sh",
+            cwd="/tmp",
+            read_remote_script=lambda path: remote_reads.append(path) or "",
+        )
+
+        assert result is False
+        assert remote_reads == []
+
+    def test_post_open_read_failure_does_not_use_remote_reader(
+        self, tmp_path, monkeypatch
+    ):
+        """An opened local path must never be reclassified as remotely missing."""
+        from cron import lifecycle_guard
+
+        script = tmp_path / "tool"
+        script.write_text("#!/bin/sh\n")
+        remote_reads = []
+
+        def fail_read(_descriptor, _size):
+            raise OSError("simulated read failure")
+
+        monkeypatch.setattr(lifecycle_guard.os, "read", fail_read)
+
+        result = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script(
+            str(script),
+            read_remote_script=lambda path: (
+                remote_reads.append(path) or "hermes gateway restart"
+            ),
+        )
+
+        assert result is False
+        assert remote_reads == []
+
+    def test_remote_binary_content_is_not_scanned_as_a_script(self, tmp_path):
+        """Remote readers apply the same NUL-bearing binary policy as local reads."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        missing_binary = tmp_path / "remote" / "tool"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            str(missing_binary),
+            read_remote_script=lambda _path: b"\x7fELF\x00hermes gateway restart".decode(),
+        )
+
+        assert result is False
+
+    def test_oversized_remote_script_fails_closed(self, tmp_path):
+        """Remote readers cannot feed unbounded text into recursive scanning."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        missing_script = tmp_path / "remote" / "large.sh"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            str(missing_script),
+            read_remote_script=lambda _path: "x" * (1024 * 1024 + 1),
+        )
+
+        assert result is True
 
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
@@ -841,7 +955,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         import tools.terminal_tool as tt
 
         # Path only exists on the remote backend; locally it is absent, so the
-        # guard must fall back to env.execute('cat ...') to scan it.
+        # guard must use a bounded env.execute read to scan it.
         script = "/remote/workspace/remote.sh"
         calls = []
 
@@ -850,7 +964,10 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
             cwd = str(tmp_path)
             def execute(self, command, **kwargs):
                 calls.append(command)
-                if "cat" in command and "/remote/workspace/remote.sh" in command:
+                if (
+                    "head -c 1048577 --" in command
+                    and "/remote/workspace/remote.sh" in command
+                ):
                     return {"output": "#!/bin/bash\\nhermes gateway restart\\n", "returncode": 0}
                 return {"output": "", "returncode": 0}
 
@@ -862,7 +979,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
-        assert any("cat" in c for c in calls)
+        assert any("head -c 1048577 --" in c for c in calls)
 
 
 class TestCronCreateLifecycleBlockExtra:

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -11,6 +11,24 @@ def teardown_function():
     terminal_tool._reset_cached_sudo_passwords()
 
 
+def test_remote_lifecycle_script_read_is_bounded():
+    commands = []
+
+    class FakeEnvironment:
+        def execute(self, command):
+            commands.append(command)
+            return {"returncode": 0, "output": "script text"}
+
+    result = terminal_tool._read_remote_script_bounded(
+        FakeEnvironment(),
+        "/remote/script.sh",
+        max_bytes=7,
+    )
+
+    assert result == "script text"
+    assert commands == ["head -c 8 -- /remote/script.sh"]
+
+
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -81,6 +81,24 @@ from tools.tool_backend_helpers import (
 )
 
 
+def _read_remote_script_bounded(
+    env: Any,
+    script_path: str,
+    *,
+    max_bytes: int,
+) -> Optional[str]:
+    """Read at most ``max_bytes + 1`` from a remote terminal environment."""
+    try:
+        result = env.execute(
+            f"head -c {max_bytes + 1} -- {shlex.quote(script_path)}"
+        )
+        if result.get("returncode", -1) == 0:
+            return result.get("output", "")
+    except Exception:
+        pass
+    return None
+
+
 def _safe_parse_import_env(
     name: str,
     default: Any,
@@ -2532,7 +2550,7 @@ def terminal_tool(
 
                 For local backends the script path is on the host filesystem. For
                 SSH/Modal/Daytona the same path is remote; the local read misses, so we
-                fall back to ``env.execute('cat ...')``.
+                fall back to a bounded read through ``env.execute``.
                 """
                 if env is None:
                     return None
@@ -2556,19 +2574,14 @@ def terminal_tool(
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
                     pass
-                # Remote / sandboxed backend: read via the environment's shell.
-                try:
-                    result = env.execute(f"cat {shlex.quote(script_path)}")
-                    if result.get("returncode", -1) == 0:
-                        output = result.get("output", "")
-                        if output and "\x00" in output:
-                            # Binary content from a remote `cat`: skip for the
-                            # same reason as the local branch above (#77703).
-                            return None
-                        return output
-                except Exception:
-                    pass
-                return None
+                # Remote / sandboxed backend: read a bounded prefix via the
+                # environment's shell. The guard detects NUL and oversized
+                # text before recursive scanning.
+                return _read_remote_script_bounded(
+                    env,
+                    script_path,
+                    max_bytes=1024 * 1024,
+                )
 
             if contains_gateway_lifecycle_command_or_referenced_script(
                 command,


### PR DESCRIPTION
## Summary

- distinguish missing referenced scripts from local binaries before remote fallback
- skip NUL-bearing local and remote binary content instead of recursively tokenizing it
- handle NUL-bearing candidate paths without raising `ValueError` or calling the remote reader
- cap remote script reads at 1 MiB + 1 byte and fail closed on oversized text
- preserve remote scanning for scripts that are genuinely absent on the host

## Why this is still needed after #77703

#77703 prevents the eventual `ValueError` and skips NUL-bearing output, but the remote fallback still uses an unbounded `cat`. For a local executable larger than 1 MiB, `_read_script_in_env()` skips its bounded local branch and then cats the same file through the environment. The NUL check only runs after the entire binary has been captured.

This PR fixes that remaining memory/hang path by distinguishing `missing` from `present but binary`, and by bounding genuinely remote reads. In production, a 273 MB Rust debug ELF drove the gateway to multi-GB memory use and stalled it before the executable ran.

## Root cause

`_read_referenced_script()` returned `None` both when a local path was missing and when it had positively identified a NUL-bearing binary. The caller interpreted both states as remotely missing and invoked `read_remote_script`. Path-based executables could therefore be read again and fed into the lifecycle regex/path walk.

The tri-state result now permits remote fallback only when `os.open()` could not open the path. Once a local path has opened, binary detection or a later read failure cannot reclassify it as remotely missing.

## Tests

- `uv run --extra dev pytest -q tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_terminal_tool.py tests/cron` — 493 passed
- `uv run --extra dev ruff check cron/lifecycle_guard.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_terminal_tool.py` — passed
- `python -m py_compile` for all modified Python files — passed
- real 273 MB `target/debug/solana-deploy` lifecycle-guard harness — allowed in 0.004s with no remote callback

One pre-existing cron test warning remains: `_send_to_platform` coroutine was never awaited.

Fixes #78800
Related: #76762, #77703, #78942
