### PR TITLE
Raft : tolerate malformed port and max_body_bytes in config

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -56,6 +56,16 @@ DEFAULT_PATH = "/wake"
 DEFAULT_RUNTIME_SESSION = "default"
 DEFAULT_MAX_BODY_BYTES = 16_384
 DEFAULT_ACTIVITY_QUEUE_CAP = 500
+
+
+def _coerce_int(value: object, *, default: int) -> int:
+    """Parse config/env ints; malformed values must not crash adapter init."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
 ACTIVITY_CONTENT_CAP = 4096
 ACTIVITY_EVENT_SCHEMA = "raft-activity.v1"
 ACTIVITY_DRAIN_SCHEMA = "raft-activity-drain.v1"
@@ -450,15 +460,16 @@ class RaftAdapter(BasePlatformAdapter):
         super().__init__(config, Platform("raft"))
         extra = config.extra or {}
         self._host: str = str(extra.get("host", DEFAULT_HOST))
-        self._port: int = int(extra.get("port", DEFAULT_PORT))
+        self._port: int = _coerce_int(extra.get("port", DEFAULT_PORT), default=DEFAULT_PORT)
         self._path: str = _path_value(extra.get("path", DEFAULT_PATH))
         self._bridge_token: str = str(extra.get("bridge_token", ""))
         self._runtime_session: str = str(
             extra.get("runtime_session", DEFAULT_RUNTIME_SESSION)
             or DEFAULT_RUNTIME_SESSION
         )
-        self._max_body_bytes: int = int(
-            extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES)
+        self._max_body_bytes: int = _coerce_int(
+            extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES),
+            default=DEFAULT_MAX_BODY_BYTES,
         )
         self._runner = None
         self._bridge_process: Optional[subprocess.Popen] = None

--- a/tests/plugins/test_raft_config_int_guard.py
+++ b/tests/plugins/test_raft_config_int_guard.py
@@ -1,0 +1,35 @@
+"""Raft adapter must tolerate malformed port / max_body_bytes in config.extra."""
+
+from __future__ import annotations
+
+from gateway.config import PlatformConfig
+from plugins.platforms.raft.adapter import (
+    DEFAULT_MAX_BODY_BYTES,
+    DEFAULT_PORT,
+    RaftAdapter,
+)
+
+
+def _make_config(**extra):
+    data = {
+        "bridge_token": "bridge-secret",
+        "runtime_session": "default",
+        "port": DEFAULT_PORT,
+    }
+    data.update(extra)
+    return PlatformConfig(enabled=True, extra=data)
+
+
+def test_malformed_port_falls_back_to_default():
+    adapter = RaftAdapter(_make_config(port="not-a-port"))
+    assert adapter._port == DEFAULT_PORT
+
+
+def test_malformed_max_body_bytes_falls_back_to_default():
+    adapter = RaftAdapter(_make_config(max_body_bytes="nope"))
+    assert adapter._max_body_bytes == DEFAULT_MAX_BODY_BYTES
+
+
+def test_valid_port_from_extra_is_honored():
+    adapter = RaftAdapter(_make_config(port=8088))
+    assert adapter._port == 8088


### PR DESCRIPTION
## Summary
- `RaftAdapter.__init__` used unguarded `int()` on `extra.port` and `extra.max_body_bytes`.
- Malformed config (`port: "abc"`, `max_body_bytes: "nope"`) raises `ValueError` during construction and takes the platform down.
- Add `_coerce_int()` with defaults — same posture as Teams `_coerce_port` and the IRC/A2A port guard family.
