### PR TITLE
fix(aux): filter text-only models from the vision picker

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4407,6 +4407,31 @@ def _configure_vision_backend() -> None:
     _print_info("  Skipped vision configuration")
 
 
+def _filter_vision_capable_models(provider_slug: str, models: list) -> list:
+    """Drop models the models.dev catalog marks as text-only.
+
+    Vision configuration must not offer models that cannot accept image
+    input — selecting one configures fine and then 404s on every image
+    ("No endpoints found that support image input"). The lookup fails
+    open: models missing from the catalog, or whose lookup raises, are
+    kept, because unknown capability must not hide a working model.
+    """
+    try:
+        from agent.models_dev import get_model_capabilities
+    except Exception:
+        return list(models)
+
+    capable = []
+    for model in models:
+        try:
+            meta = get_model_capabilities(provider_slug, model)
+        except Exception:
+            meta = None
+        if meta is None or meta.supports_vision:
+            capable.append(model)
+    return capable
+
+
 def _configure_vision_provider_model(config: dict, vision_cfg: dict) -> None:
     """Provider + model picker for vision, mirroring the ``/model`` surface.
 
@@ -4465,7 +4490,14 @@ def _configure_vision_provider_model(config: dict, vision_cfg: dict) -> None:
 
     chosen = providers[pidx]
     slug = chosen.get("slug")
-    models = list(chosen.get("models", []))
+    models = _filter_vision_capable_models(slug, list(chosen.get("models", [])))
+
+    if not models and chosen.get("models"):
+        _print_warning(
+            f"  None of the curated {chosen.get('name') or slug} models are "
+            "known to support image input — every listed model is text-only. "
+            "You can still type a custom model id, or cancel."
+        )
 
     model_choices = list(models) + ["Type a custom model id…"]
     midx = _prompt_choice(

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -523,6 +523,100 @@ def test_vision_picker_custom_endpoint(tmp_path, monkeypatch):
     save_env.assert_called_once_with("OPENAI_API_KEY", "sk-secret")
 
 
+def test_vision_picker_filters_text_only_models():
+    """#78884: the vision picker must not offer models the models.dev
+    catalog marks as text-only. Known-capable (supports_vision=True) and
+    uncatalogued (None) models stay; the custom-id option stays last."""
+    import hermes_cli.tools_config as tc
+
+    rows = [
+        {
+            "slug": "nous",
+            "name": "Nous",
+            "models": [
+                "openai/gpt-5.6-sol-pro",      # supports_vision=True  → kept
+                "deepseek/deepseek-v4-flash",  # supports_vision=False → filtered
+                "vendor/uncatalogued",         # None (fail open)      → kept
+            ],
+        }
+    ]
+
+    def _caps(provider, model):
+        if model == "openai/gpt-5.6-sol-pro":
+            return SimpleNamespace(supports_vision=True)
+        if model == "deepseek/deepseek-v4-flash":
+            return SimpleNamespace(supports_vision=False)
+        return None
+
+    picked = []
+
+    def _pick(question, choices, default=0):
+        picked.append(choices)
+        return 0  # first provider, then first (vision-capable) model
+
+    config = {"auxiliary": {"vision": {}}}
+    with (
+        patch("hermes_cli.inventory.build_aux_picker_rows", return_value=rows),
+        patch("agent.models_dev.get_model_capabilities", side_effect=_caps),
+        patch.object(tc, "_prompt_choice", side_effect=_pick),
+        patch.object(tc, "save_config"),
+    ):
+        tc._configure_vision_provider_model(config, config["auxiliary"]["vision"])
+
+    assert len(picked) == 2  # provider prompt, then model prompt
+    assert picked[1] == [
+        "openai/gpt-5.6-sol-pro",
+        "vendor/uncatalogued",
+        "Type a custom model id…",
+    ]
+    assert config["auxiliary"]["vision"]["provider"] == "nous"
+    assert config["auxiliary"]["vision"]["model"] == "openai/gpt-5.6-sol-pro"
+
+
+def test_vision_picker_warns_when_all_curated_models_text_only():
+    """#78884: if every curated model for the chosen provider is known
+    text-only, warn loudly but keep the custom-id escape hatch."""
+    import hermes_cli.tools_config as tc
+
+    rows = [
+        {
+            "slug": "deepseek",
+            "name": "DeepSeek",
+            "models": ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v3"],
+        }
+    ]
+
+    def _caps(provider, model):
+        return SimpleNamespace(supports_vision=False)
+
+    picked = []
+
+    def _pick(question, choices, default=0):
+        picked.append(choices)
+        return 0  # first provider; custom-id row is the only model row left
+
+    warnings = []
+
+    def _warn(msg):
+        warnings.append(msg)
+
+    config = {"auxiliary": {"vision": {}}}
+    with (
+        patch("hermes_cli.inventory.build_aux_picker_rows", return_value=rows),
+        patch("agent.models_dev.get_model_capabilities", side_effect=_caps),
+        patch.object(tc, "_prompt_choice", side_effect=_pick),
+        patch.object(tc, "_prompt", return_value="my/custom-vision-model"),
+        patch.object(tc, "_print_warning", side_effect=_warn),
+        patch.object(tc, "save_config"),
+    ):
+        tc._configure_vision_provider_model(config, config["auxiliary"]["vision"])
+
+    assert picked[1] == ["Type a custom model id…"]
+    assert warnings, "expected a warning when every curated model is text-only"
+    assert config["auxiliary"]["vision"]["provider"] == "deepseek"
+    assert config["auxiliary"]["vision"]["model"] == "my/custom-vision-model"
+
+
 
 
 # ─── provider_readiness_status ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
The vision configuration picker (`hermes` → configure vision backend → "Pick a provider and model") offers models that cannot accept image input. Selecting one configures fine and then every `vision_analyze`, `browser_vision`, or image-bearing message fails with a silent 404: `No endpoints found that support image input`.

## Root Cause
`_configure_vision_provider_model` in `hermes_cli/tools_config.py` lists every curated model from `build_aux_picker_rows()` with no capability check. The models.dev catalog already carries the answer (`ModelCapabilities.supports_vision`), but the picker never consults it.

## Change
- New `_filter_vision_capable_models()` helper: drops models the models.dev catalog marks as `supports_vision == False` (known text-only). **Fail-open**: models missing from the catalog, or whose lookup raises, are kept — unknown capability must not hide a working model.
- `_configure_vision_provider_model` now runs the model list through the filter before rendering the picker. If every curated model for the chosen provider is known text-only, a clear warning is shown; the "Type a custom model id…" escape hatch stays available and cancel still works.
- Lazy import with try/except mirrors the existing `inventory._apply_capabilities` pattern.

## Verification
- `tests/hermes_cli/test_tools_config.py` + `tests/hermes_cli/test_aux_picker_inventory.py`: **33 passed** (31 pre-existing + 2 new).
- New tests cover: text-only filtered / capable+uncatalogued kept / custom-id option stays last; and the all-text-only warning path with custom id persistence.

Closes #78884