### PR TITLE
fix(terminal): guard against NUL bytes in referenced script scanning

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2544,6 +2544,12 @@ def terminal_tool(
                         metadata = local_path.stat()
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
+                            # Binary (ELF/Mach-O/PE/etc.) is not a shell script;
+                            # scanning its decoded bytes would tokenize machine
+                            # code and feed NUL-containing junk paths into the
+                            # recursion (#76762). Mirror _read_referenced_script.
+                            if b"\x00" in data:
+                                return None
                             if len(data) <= 1024 * 1024:
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
@@ -2552,7 +2558,14 @@ def terminal_tool(
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        output = result.get("output", "")
+                        # Binary content (ELF/Mach-O/PE) read through `cat`
+                        # carries NUL bytes; scanning it would tokenize machine
+                        # code into junk paths and crash the recursion with
+                        # "embedded null byte" (#76762). Mirror the local path.
+                        if "\x00" in output:
+                            return None
+                        return output
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## Summary

Fixes the "embedded null byte" crash in the terminal tool's lifecycle guard. When a terminal command references a binary (e.g. `venv/bin/python`), the guard's **fallback script reader** (`_read_script_in_env` in `tools/terminal_tool.py`) read the file as text without filtering binaries. The ELF got decoded as text, machine code was tokenized into junk paths, and the recursion hit `os.open(path)` with an embedded NUL → `ValueError: embedded null byte` on every terminal-tool call.

The primary reader (`_read_referenced_script` in `cron/lifecycle_guard.py`) already returns `None` for files containing NUL bytes (#76762) — this PR mirrors that behavior in the fallback path, which was missed.

## Changes

Two fix sites in `_read_script_in_env`:

1. **Local read path** — return `None` when the bytes contain a NUL byte (`if b"\x00" in data: return None`), mirroring `_read_referenced_script`.
2. **`cat` fallback path** — the local read is *skipped* for files >1MB (`st_size <= 1024*1024` guard), so a large binary falls through to `env.execute("cat ...")` whose output carries **live NUL bytes** (0x00 is valid UTF-8; `errors="replace"` does NOT strip it). Added `if "\x00" in output: return None` before returning.

## Repro

Any terminal command referencing a binary path crashes the guard:
```bash
~/.hermes/hermes-agent/venv/bin/python -m pip install foo
# ValueError: embedded null byte — guard crashes before the command runs
```

Workarounds existed (run via a separate `.py` file, avoid `$VAR` paths in scripts, split compound commands) but the root cause is the unfiltered binary read.

## Test plan

- [x] Reproduced the crash on current `main` with `venv/bin/python`-referencing commands
- [x] Applied both fixes; the same commands now pass the guard and execute normally
- [x] Verified no behavior change for legit script scanning (text files still scanned)

Closes #77988
