### PR TITLE
refactor(gateway): extract supervision mixin from run.py (shard s3)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2257,6 +2257,7 @@ from gateway.session_state import (
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.supervision_mixin import GatewaySupervisionMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -5637,7 +5638,7 @@ class TurnRunner:
 
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(GatewaySupervisionMixin, GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
 
@@ -11455,99 +11456,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # handoff for the rest of the process life).
     _SUPERVISED_HEALTHY_SECS = 300
 
-    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0, on_spawn=None):
-        """Launch a long-lived background task with task-level supervision.
-
-        Complements upstream's per-iteration inner-loop try/except (which only
-        guards a single loop-body) by covering what that CANNOT: an exception
-        raised in the watcher's OUTER ``while self._running:`` loop or its
-        pre-try setup region, plus task-level death generally. A bare
-        ``asyncio.create_task`` drops such an exception on the floor — no log,
-        no restart, the watcher silently gone. This retains the handle in
-        ``self._background_tasks``, logs any crash, and restarts with capped
-        exponential backoff up to ``_MAX_SUPERVISED_RESTARTS`` failures in rapid
-        succession (each within ``_SUPERVISED_HEALTHY_SECS`` of its restart).
-        The counter resets after any run that stayed healthy for at least
-        ``_SUPERVISED_HEALTHY_SECS`` — so a long-lived daemon that crashes
-        occasionally over days is never permanently abandoned.
-
-        ``on_spawn`` (optional) is invoked with the freshly-created task on
-        every spawn, INCLUDING internal backoff respawns. Callers that also
-        track the live handle elsewhere (e.g. ``self._reconnect_watcher_task``
-        for ``_ensure_reconnect_watcher_running``) MUST pass it — otherwise the
-        supervisor's own respawn creates a new task without updating that
-        external handle, so ``_ensure_...`` later sees the stale/done handle
-        and spawns a SECOND concurrent watcher (double reconnect attempts).
-        """
-        if getattr(self, "_background_tasks", None) is None:
-            self._background_tasks = set()
-
-        # Monotonic spawn timestamp captured per spawn: the ``_done`` callback
-        # uses it to distinguish a rapid crash-loop from a healthy-run-then-crash.
-        _started = time.monotonic()
-
-        # Deliberately do NOT pass name= to create_task — some test doubles mock
-        # create_task with a signature that rejects the name kwarg.
-        task = asyncio.create_task(coro_factory())
-        self._background_tasks.add(task)
-        if on_spawn is not None:
-            # Record the live handle NOW so an external tracker (e.g.
-            # _reconnect_watcher_task) always points at the current task, not a
-            # dead one left behind by a prior supervised respawn.
-            try:
-                on_spawn(task)
-            except Exception:  # pragma: no cover - defensive; a tracker must never kill the spawn
-                logger.debug("on_spawn callback for %s raised", name, exc_info=True)
-
-        def _done(t):
-            self._background_tasks.discard(t)
-            if t.cancelled():
-                return
-            exc = t.exception()
-            if exc is None:
-                # Clean return == deliberate shutdown or a self-disabling watcher
-                # (e.g. a gated no-op that returns synchronously). Respawning here
-                # would busy-spin such a watcher — so NEVER restart on clean exit.
-                return
-            logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
-            if restart and self._running:
-                ran_for = time.monotonic() - _started
-                if ran_for >= self._SUPERVISED_HEALTHY_SECS:
-                    # Ran healthily for a while before crashing — this is a
-                    # FRESH failure, not part of a rapid crash-loop. Reset the
-                    # consecutive counter so a daemon that crashes a handful of
-                    # times over days is never permanently abandoned.
-                    effective_attempt = 0
-                else:
-                    effective_attempt = _attempt
-                if effective_attempt >= self._MAX_SUPERVISED_RESTARTS:
-                    logger.error(
-                        "Supervised task %s died %d times in rapid succession "
-                        "(each within %ds of restart) — giving up restarts",
-                        name,
-                        effective_attempt,
-                        self._SUPERVISED_HEALTHY_SECS,
-                    )
-                    return
-                backoff = min(60, 2 ** min(effective_attempt, 6))
-
-                async def _respawn():
-                    await asyncio.sleep(backoff)
-                    if self._running:
-                        self._spawn_supervised(
-                            coro_factory,
-                            name,
-                            restart=restart,
-                            _attempt=effective_attempt + 1,
-                            on_spawn=on_spawn,
-                        )
-
-                respawn_task = asyncio.create_task(_respawn())
-                self._background_tasks.add(respawn_task)
-                respawn_task.add_done_callback(self._background_tasks.discard)
-
-        task.add_done_callback(_done)
-        return task
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.

--- a/gateway/supervision_mixin.py
+++ b/gateway/supervision_mixin.py
@@ -1,0 +1,120 @@
+"""Supervised long-lived background task support for ``GatewayRunner``.
+
+Extracted from ``gateway/run.py`` (god-file decomposition campaign, Wave 1
+mixin lift). This mixin holds the task-level supervision cluster:
+``_spawn_supervised`` (with its nested ``_done`` / ``_respawn`` callbacks),
+which launches long-lived background watchers with capped-exponential-backoff
+restart supervision.
+
+Behavior-neutral: the method is lifted verbatim from ``GatewayRunner``.
+``self.*`` calls resolve unchanged via the MRO. The class constants
+``_MAX_SUPERVISED_RESTARTS`` and ``_SUPERVISED_HEALTHY_SECS`` remain defined
+on ``GatewayRunner`` (MRO resolves them); ``self._background_tasks`` and
+``self._running`` are instance state. The module-level ``logger`` is
+``logging.getLogger("gateway.run")`` so log records keep the exact name
+(``"gateway.run"``), matching the sibling mixins' convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger("gateway.run")
+
+
+class GatewaySupervisionMixin:
+    def _spawn_supervised(self, coro_factory, name, *, restart=True, _attempt=0, on_spawn=None):
+        """Launch a long-lived background task with task-level supervision.
+
+        Complements upstream's per-iteration inner-loop try/except (which only
+        guards a single loop-body) by covering what that CANNOT: an exception
+        raised in the watcher's OUTER ``while self._running:`` loop or its
+        pre-try setup region, plus task-level death generally. A bare
+        ``asyncio.create_task`` drops such an exception on the floor — no log,
+        no restart, the watcher silently gone. This retains the handle in
+        ``self._background_tasks``, logs any crash, and restarts with capped
+        exponential backoff up to ``_MAX_SUPERVISED_RESTARTS`` failures in rapid
+        succession (each within ``_SUPERVISED_HEALTHY_SECS`` of its restart).
+        The counter resets after any run that stayed healthy for at least
+        ``_SUPERVISED_HEALTHY_SECS`` — so a long-lived daemon that crashes
+        occasionally over days is never permanently abandoned.
+
+        ``on_spawn`` (optional) is invoked with the freshly-created task on
+        every spawn, INCLUDING internal backoff respawns. Callers that also
+        track the live handle elsewhere (e.g. ``self._reconnect_watcher_task``
+        for ``_ensure_reconnect_watcher_running``) MUST pass it — otherwise the
+        supervisor's own respawn creates a new task without updating that
+        external handle, so ``_ensure_...`` later sees the stale/done handle
+        and spawns a SECOND concurrent watcher (double reconnect attempts).
+        """
+        if getattr(self, "_background_tasks", None) is None:
+            self._background_tasks = set()
+
+        # Monotonic spawn timestamp captured per spawn: the ``_done`` callback
+        # uses it to distinguish a rapid crash-loop from a healthy-run-then-crash.
+        _started = time.monotonic()
+
+        # Deliberately do NOT pass name= to create_task — some test doubles mock
+        # create_task with a signature that rejects the name kwarg.
+        task = asyncio.create_task(coro_factory())
+        self._background_tasks.add(task)
+        if on_spawn is not None:
+            # Record the live handle NOW so an external tracker (e.g.
+            # _reconnect_watcher_task) always points at the current task, not a
+            # dead one left behind by a prior supervised respawn.
+            try:
+                on_spawn(task)
+            except Exception:  # pragma: no cover - defensive; a tracker must never kill the spawn
+                logger.debug("on_spawn callback for %s raised", name, exc_info=True)
+
+        def _done(t):
+            self._background_tasks.discard(t)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is None:
+                # Clean return == deliberate shutdown or a self-disabling watcher
+                # (e.g. a gated no-op that returns synchronously). Respawning here
+                # would busy-spin such a watcher — so NEVER restart on clean exit.
+                return
+            logger.error("Supervised task %s died: %r", name, exc, exc_info=exc)
+            if restart and self._running:
+                ran_for = time.monotonic() - _started
+                if ran_for >= self._SUPERVISED_HEALTHY_SECS:
+                    # Ran healthily for a while before crashing — this is a
+                    # FRESH failure, not part of a rapid crash-loop. Reset the
+                    # consecutive counter so a daemon that crashes a handful of
+                    # times over days is never permanently abandoned.
+                    effective_attempt = 0
+                else:
+                    effective_attempt = _attempt
+                if effective_attempt >= self._MAX_SUPERVISED_RESTARTS:
+                    logger.error(
+                        "Supervised task %s died %d times in rapid succession "
+                        "(each within %ds of restart) — giving up restarts",
+                        name,
+                        effective_attempt,
+                        self._SUPERVISED_HEALTHY_SECS,
+                    )
+                    return
+                backoff = min(60, 2 ** min(effective_attempt, 6))
+
+                async def _respawn():
+                    await asyncio.sleep(backoff)
+                    if self._running:
+                        self._spawn_supervised(
+                            coro_factory,
+                            name,
+                            restart=restart,
+                            _attempt=effective_attempt + 1,
+                            on_spawn=on_spawn,
+                        )
+
+                respawn_task = asyncio.create_task(_respawn())
+                self._background_tasks.add(respawn_task)
+                respawn_task.add_done_callback(self._background_tasks.discard)
+
+        task.add_done_callback(_done)
+        return task

--- a/tests/gateway/test_supervision_mixin.py
+++ b/tests/gateway/test_supervision_mixin.py
@@ -1,0 +1,179 @@
+"""Regression tests for ``GatewaySupervisionMixin._spawn_supervised``.
+
+Wave 1 god-file extraction (shard s3, cluster c2): the task-level
+supervision logic moved verbatim from ``GatewayRunner`` into
+``gateway/supervision_mixin.py``. These tests pin the supervision contract
+that must survive the move:
+
+1. Tasks are tracked in ``self._background_tasks`` (lazily initialized) and
+   discarded when they finish.
+2. A crashed task that the gateway is still running is respawned with capped
+   exponential backoff, up to ``_MAX_SUPERVISED_RESTARTS`` rapid failures.
+3. ``on_spawn`` is invoked on EVERY spawn (initial + internal respawns) so
+   external live-handle trackers (e.g. ``_reconnect_watcher_task``) never go
+   stale.
+4. A run that lasted at least ``_SUPERVISED_HEALTHY_SECS`` resets the
+   consecutive-failure counter (a healthy-then-crashed daemon is never
+   abandoned).
+5. Clean returns and crashes while the gateway is stopping never respawn.
+
+The mixin is exercised on a bare ``object.__new__`` instance with stub
+state, following the pattern used by the original ``_compile_mention_patterns``
+test seam — no ``GatewayRunner`` construction needed.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import gateway.supervision_mixin as supervision_mixin
+from gateway.supervision_mixin import GatewaySupervisionMixin
+
+# Real asyncio.sleep captured before the tests patch module-level asyncio.sleep
+# to collapse backoff delays (the mixin references asyncio.sleep at call time).
+_REAL_SLEEP = asyncio.sleep
+
+
+def _make_runner(*, running=True, max_restarts=2, healthy_secs=300.0):
+    runner = object.__new__(GatewaySupervisionMixin)
+    runner._background_tasks = None
+    runner._running = running
+    runner._MAX_SUPERVISED_RESTARTS = max_restarts
+    runner._SUPERVISED_HEALTHY_SECS = healthy_secs
+    return runner
+
+
+async def _drive_until_idle(runner, max_iterations=400):
+    """Yield to the loop until the supervisor's task set drains."""
+    for _ in range(max_iterations):
+        if not runner._background_tasks:
+            return
+        await _REAL_SLEEP(0.01)
+    raise AssertionError("supervisor task set did not drain")
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch):
+    """Collapse the backoff sleep to a loop-yielding no-op."""
+
+    async def _fast_sleep(delay):
+        await _REAL_SLEEP(0)
+
+    monkeypatch.setattr(supervision_mixin.asyncio, "sleep", _fast_sleep)
+    yield
+
+
+def test_spawn_tracks_task_and_discards_on_clean_return():
+    """A clean-returning watcher is tracked, then discarded, never respawned."""
+
+    async def main():
+        runner = _make_runner()
+        spawns = []
+
+        async def watcher():
+            return None
+
+        task = runner._spawn_supervised(watcher, "clean_watcher", on_spawn=spawns.append)
+        assert task in runner._background_tasks  # tracked immediately
+        await _drive_until_idle(runner)
+        assert len(spawns) == 1  # initial spawn only, no respawn on clean exit
+        assert task.done() and not task.cancelled()
+        assert runner._background_tasks == set()
+
+    asyncio.run(main())
+
+
+def test_crash_respawns_with_backoff_and_gives_up_at_cap():
+    """Rapid crash-loop respawns until _MAX_SUPERVISED_RESTARTS, then stops."""
+
+    async def main():
+        runner = _make_runner(max_restarts=2)
+        spawns = []
+
+        async def always_crash():
+            raise RuntimeError("watcher exploded")
+
+        runner._spawn_supervised(always_crash, "crash_watcher", on_spawn=spawns.append)
+        await _drive_until_idle(runner)
+        # initial + respawn at _attempt=1 + respawn at _attempt=2, then give up
+        assert len(spawns) == 3
+        assert runner._background_tasks == set()
+
+    asyncio.run(main())
+
+
+def test_healthy_run_resets_restart_counter():
+    """A run lasting >= _SUPERVISED_HEALTHY_SECS resets the rapid-failure count."""
+
+    async def main():
+        runner = _make_runner(max_restarts=1, healthy_secs=0.01)
+        spawns = []
+        calls = {"n": 0}
+
+        async def crash_after_healthy_delay():
+            calls["n"] += 1
+            if calls["n"] == 2:  # second run is "healthy" (runs >= 0.01s)
+                await _REAL_SLEEP(0.05)
+            raise RuntimeError("watcher exploded")
+
+        runner._spawn_supervised(
+            crash_after_healthy_delay, "healthy_crash_watcher", on_spawn=spawns.append
+        )
+        await _drive_until_idle(runner)
+        # Without the health reset: crash(0) -> respawn(1) -> crash(1) gives up
+        # at cap=1 (2 spawns). With the reset, spawn(1) is treated as fresh
+        # (attempt 0 again), so the give-up is deferred one more cycle (3 spawns).
+        assert len(spawns) == 3
+        assert runner._background_tasks == set()
+
+    asyncio.run(main())
+
+
+def test_no_respawn_when_gateway_stopped():
+    """A crash while self._running is False never respawns."""
+
+    async def main():
+        runner = _make_runner(running=False)
+        spawns = []
+
+        async def always_crash():
+            raise RuntimeError("watcher exploded")
+
+        runner._spawn_supervised(always_crash, "stopped_watcher", on_spawn=spawns.append)
+        await _drive_until_idle(runner)
+        assert len(spawns) == 1  # initial spawn only
+        assert runner._background_tasks == set()
+
+    asyncio.run(main())
+
+
+def test_on_spawn_receives_live_task_handle_on_every_spawn():
+    """on_spawn fires on internal respawns too, with a live (not done) task."""
+
+    async def main():
+        runner = _make_runner(max_restarts=1)
+        seen = []
+
+        async def flaky():
+            raise RuntimeError("flaky watcher")
+
+        def record(handle):
+            # The mixin calls on_spawn right after create_task, before the
+            # loop ever runs the coroutine — the handle must still be live.
+            seen.append(handle.done())
+
+        runner._spawn_supervised(flaky, "flaky_watcher", on_spawn=record)
+        await _drive_until_idle(runner)
+        assert len(seen) == 2  # initial + one respawn (cap=1)
+        assert seen == [False, False]  # every handle live at spawn time
+
+    asyncio.run(main())
+
+
+def test_spawn_supervised_resolves_via_gateway_runner_mro():
+    """GatewayRunner must still expose _spawn_supervised through the mixin."""
+    from gateway.run import GatewayRunner
+
+    assert issubclass(GatewayRunner, GatewaySupervisionMixin)
+    assert callable(GatewayRunner._spawn_supervised)


### PR DESCRIPTION
## Godfile kill — gateway/run.py shard s3

Extracts the supervision_mixin into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 303 added / 94 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069
#79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701
#78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715
#78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729
#78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743
#78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757
#78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771
#78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785
#78786 #78787 #78788 #78789 #78790

Part of #54962

Part of #78721
Part of #78722
Part of #78723
Part of #78724
Part of #78725
Part of #78726
Part of #78727
Part of #78728
Part of #78729
Part of #78731
Part of #78732
Part of #78733
Part of #78734
Part of #78735
Part of #78736
Part of #78737
Part of #78738
Part of #78739
Part of #78740
Part of #78741
Part of #78742
Part of #78743
Part of #78744
Part of #78745
Part of #78746
Part of #78747
Part of #78748
Part of #78749
Part of #78750
Part of #78751
Part of #78752
Part of #78753
Part of #78754
Part of #78755
Part of #78756
Part of #78757
Part of #78758
Part of #78759
Part of #78760
Part of #78761
Part of #78762
Part of #78763
Part of #78764
Part of #78765
Part of #78766
Part of #78767
Part of #78768
Part of #78769
Part of #78770
Part of #78771
Part of #78772
Part of #78773
Part of #78774
Part of #78775
Part of #78776
Part of #78777
Part of #78778
Part of #78779
Part of #78780
Part of #78781
Part of #78782
Part of #78783
Part of #78784
Part of #78785
Part of #78786
Part of #78787
Part of #78788
Part of #78789
Part of #78790
Part of #78791

Part of #78647
Part of #79890
