### PR TITLE
refactor(gateway): extract thread-metadata mixin from run.py (shard s4)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2257,6 +2257,7 @@ from gateway.session_state import (
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.thread_metadata_mixin import GatewayThreadMetadataMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -2264,7 +2265,6 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     _prefix_within_utf16_limit,
-    _reply_anchor_for_event,
     build_auto_tts_output_path,
     merge_pending_message_event,
     utf16_len,
@@ -5637,7 +5637,7 @@ class TurnRunner:
 
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(GatewayThreadMetadataMixin, GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
 
@@ -20417,62 +20417,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return {}
 
-    def _thread_metadata_for_source(
-        self,
-        source,
-        reply_to_message_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
-        """Build the metadata dict platforms need for thread-aware replies."""
-        metadata = self._thread_metadata_for_target(
-            getattr(source, "platform", None),
-            getattr(source, "chat_id", None),
-            getattr(source, "thread_id", None),
-            chat_type=getattr(source, "chat_type", None),
-            reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
-        )
-        if getattr(source, "platform", None) == Platform.SLACK:
-            team_id = getattr(source, "scope_id", None)
-            if team_id:
-                metadata = dict(metadata or {})
-                metadata["slack_team_id"] = str(team_id)
-        return metadata
-
-    def _thread_metadata_for_target(
-        self,
-        platform: Optional[Platform],
-        chat_id: Optional[str],
-        thread_id: Optional[str],
-        *,
-        chat_type: Optional[str] = None,
-        reply_to_message_id: Optional[str] = None,
-        adapter: Optional[Any] = None,
-    ) -> Optional[Dict[str, Any]]:
-        """Build thread metadata for synthetic sends that only have routing state."""
-        if thread_id is None:
-            return None
-        metadata: Dict[str, Any] = {"thread_id": thread_id}
-        if self._is_telegram_dm_topic_target(
-            platform,
-            chat_id,
-            thread_id,
-            chat_type=chat_type,
-            adapter=adapter,
-        ):
-            metadata["telegram_dm_topic_reply_fallback"] = True
-            # Telegram DM topic lanes need direct_messages_topic_id in metadata
-            # so synthetic/queued messages (goal continuations, status notices)
-            # route to the correct topic even when reply anchor is unavailable.
-            tid = str(thread_id)
-            if tid and tid not in {"", "1"}:
-                metadata["direct_messages_topic_id"] = tid
-            if reply_to_message_id is not None:
-                metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
-        if platform == Platform.SLACK and reply_to_message_id is not None:
-            # Slack's reply_in_thread=false path uses message_id to distinguish
-            # real existing threads from synthetic top-level session keys.
-            metadata["message_id"] = str(reply_to_message_id)
-        return metadata
-
     @staticmethod
     def _is_telegram_dm_topic_target(
         platform: Optional[Platform],
@@ -20504,11 +20448,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     return isinstance(topic_info, dict)
         return False
-
-    @staticmethod
-    def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
-        """Return the platform-specific reply anchor for GatewayRunner sends."""
-        return _reply_anchor_for_event(event)
 
 
     # ------------------------------------------------------------------

--- a/gateway/thread_metadata_mixin.py
+++ b/gateway/thread_metadata_mixin.py
@@ -1,0 +1,88 @@
+"""Thread-metadata helpers for ``GatewayRunner``.
+
+Extracted from ``gateway/run.py`` (god-file decomposition campaign, Wave 1
+mixin lifts). This mixin holds the thread-metadata cluster: building the
+platform-specific metadata dicts that thread-aware replies need
+(``_thread_metadata_for_source`` / ``_thread_metadata_for_target``) and the
+``_reply_anchor_for_event`` passthrough.
+
+Behavior-neutral: every method is lifted verbatim from ``GatewayRunner``.
+``self.*`` calls resolve unchanged via the MRO (``_is_telegram_dm_topic_target``
+stays on ``GatewayRunner`` — covered by the open threads-mixin extraction).
+The module-level ``logger`` is ``logging.getLogger("gateway.run")`` so log
+records keep the exact name (``"gateway.run"``), matching the sibling mixins'
+convention.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+
+logger = logging.getLogger("gateway.run")
+
+
+class GatewayThreadMetadataMixin:
+    def _thread_metadata_for_source(
+        self,
+        source,
+        reply_to_message_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build the metadata dict platforms need for thread-aware replies."""
+        metadata = self._thread_metadata_for_target(
+            getattr(source, "platform", None),
+            getattr(source, "chat_id", None),
+            getattr(source, "thread_id", None),
+            chat_type=getattr(source, "chat_type", None),
+            reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
+        )
+        if getattr(source, "platform", None) == Platform.SLACK:
+            team_id = getattr(source, "scope_id", None)
+            if team_id:
+                metadata = dict(metadata or {})
+                metadata["slack_team_id"] = str(team_id)
+        return metadata
+
+    def _thread_metadata_for_target(
+        self,
+        platform: Optional[Platform],
+        chat_id: Optional[str],
+        thread_id: Optional[str],
+        *,
+        chat_type: Optional[str] = None,
+        reply_to_message_id: Optional[str] = None,
+        adapter: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Build thread metadata for synthetic sends that only have routing state."""
+        if thread_id is None:
+            return None
+        metadata: Dict[str, Any] = {"thread_id": thread_id}
+        if self._is_telegram_dm_topic_target(
+            platform,
+            chat_id,
+            thread_id,
+            chat_type=chat_type,
+            adapter=adapter,
+        ):
+            metadata["telegram_dm_topic_reply_fallback"] = True
+            # Telegram DM topic lanes need direct_messages_topic_id in metadata
+            # so synthetic/queued messages (goal continuations, status notices)
+            # route to the correct topic even when reply anchor is unavailable.
+            tid = str(thread_id)
+            if tid and tid not in {"", "1"}:
+                metadata["direct_messages_topic_id"] = tid
+            if reply_to_message_id is not None:
+                metadata["telegram_reply_to_message_id"] = str(reply_to_message_id)
+        if platform == Platform.SLACK and reply_to_message_id is not None:
+            # Slack's reply_in_thread=false path uses message_id to distinguish
+            # real existing threads from synthetic top-level session keys.
+            metadata["message_id"] = str(reply_to_message_id)
+        return metadata
+
+    @staticmethod
+    def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
+        """Return the platform-specific reply anchor for GatewayRunner sends."""
+        return _reply_anchor_for_event(event)

--- a/tests/gateway/test_thread_metadata_mixin.py
+++ b/tests/gateway/test_thread_metadata_mixin.py
@@ -1,0 +1,144 @@
+"""Regression tests for the thread-metadata mixin lifted out of ``gateway/run.py``.
+
+Covers the pure helpers extracted into ``gateway/thread_metadata_mixin.py``
+(god-file decomposition campaign, shard s4, cluster c16):
+
+* ``_thread_metadata_for_target`` — thread-metadata dict construction for
+  synthetic sends (DM-topic fallback keys, Slack message_id).
+* ``_thread_metadata_for_source`` — source-event wrapper that adds the Slack
+  ``slack_team_id`` key.
+* ``_reply_anchor_for_event`` — static passthrough to the module-level helper.
+
+``_is_telegram_dm_topic_target`` stays on ``GatewayRunner`` (covered by the
+open threads-mixin extraction PR), so the harness stubs it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import _reply_anchor_for_event as _module_reply_anchor
+from gateway.thread_metadata_mixin import GatewayThreadMetadataMixin
+
+
+class _ThreadMetadataHarness(GatewayThreadMetadataMixin):
+    """Bare harness: only the staying ``_is_telegram_dm_topic_target`` is stubbed."""
+
+    def __init__(self, dm_topic_target: bool = False):
+        self._dm_topic_target = dm_topic_target
+
+    def _is_telegram_dm_topic_target(
+        self,
+        platform,
+        chat_id,
+        thread_id,
+        *,
+        chat_type=None,
+        adapter=None,
+    ) -> bool:
+        return self._dm_topic_target
+
+
+class TestThreadMetadataForTarget:
+    def test_none_thread_id_returns_none(self):
+        h = _ThreadMetadataHarness()
+        assert h._thread_metadata_for_target(Platform.SLACK, "c1", None) is None
+
+    def test_plain_thread_id(self):
+        h = _ThreadMetadataHarness()
+        meta = h._thread_metadata_for_target(Platform.SLACK, "c1", "42")
+        assert meta == {"thread_id": "42"}
+
+    def test_telegram_dm_topic_fallback_keys(self):
+        h = _ThreadMetadataHarness(dm_topic_target=True)
+        meta = h._thread_metadata_for_target(
+            Platform.TELEGRAM, "c1", "77", chat_type="dm", reply_to_message_id="9"
+        )
+        assert meta["thread_id"] == "77"
+        assert meta["telegram_dm_topic_reply_fallback"] is True
+        assert meta["direct_messages_topic_id"] == "77"
+        assert meta["telegram_reply_to_message_id"] == "9"
+
+    def test_telegram_dm_topic_ignores_trivial_thread_ids(self):
+        # thread ids "1"/"" are the general topic — never treated as a DM lane id.
+        h = _ThreadMetadataHarness(dm_topic_target=True)
+        meta = h._thread_metadata_for_target(Platform.TELEGRAM, "c1", "1", chat_type="dm")
+        assert meta["telegram_dm_topic_reply_fallback"] is True
+        assert "direct_messages_topic_id" not in meta
+
+    def test_slack_reply_anchor_message_id(self):
+        h = _ThreadMetadataHarness()
+        meta = h._thread_metadata_for_target(Platform.SLACK, "c1", "42", reply_to_message_id="5")
+        assert meta["message_id"] == "5"
+
+    def test_slack_without_reply_to_keeps_plain_metadata(self):
+        h = _ThreadMetadataHarness()
+        meta = h._thread_metadata_for_target(Platform.SLACK, "c1", "42")
+        assert meta == {"thread_id": "42"}
+
+
+class TestThreadMetadataForSource:
+    def _source(self, **kwargs):
+        defaults = dict(
+            platform=Platform.SLACK,
+            chat_id="c1",
+            thread_id="42",
+            chat_type=None,
+            message_id="7",
+            scope_id="T123",
+        )
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def test_slack_team_id_added_from_scope_id(self):
+        h = _ThreadMetadataHarness()
+        meta = h._thread_metadata_for_source(self._source())
+        assert meta["thread_id"] == "42"
+        assert meta["slack_team_id"] == "T123"
+
+    def test_slack_without_scope_id_keeps_plain_metadata(self):
+        h = _ThreadMetadataHarness()
+        source = self._source(scope_id=None)
+        meta = h._thread_metadata_for_source(source)
+        assert "slack_team_id" not in meta
+        assert meta["thread_id"] == "42"
+
+    def test_non_slack_platform_no_team_id(self):
+        h = _ThreadMetadataHarness()
+        source = self._source(platform=Platform.TELEGRAM, scope_id="T123")
+        meta = h._thread_metadata_for_source(source)
+        assert "slack_team_id" not in meta
+
+    def test_reply_to_message_id_defaults_to_source_message_id(self):
+        h = _ThreadMetadataHarness()
+        meta = h._thread_metadata_for_source(self._source())
+        # slack path adds message_id from the reply anchor
+        assert meta["message_id"] == "7"
+
+
+class TestReplyAnchorForEvent:
+    def test_passthrough_matches_module_helper(self):
+        # A bare event with only a message_id — module helper falls through to it.
+        event = SimpleNamespace(
+            source=None,
+            raw_message=None,
+            message_id="msg-1",
+            reply_to_message_id=None,
+        )
+        assert (
+            GatewayThreadMetadataMixin._reply_anchor_for_event(event)
+            == _module_reply_anchor(event)
+            == "msg-1"
+        )
+
+    def test_slack_no_thread_response_returns_none(self):
+        event = SimpleNamespace(
+            source=SimpleNamespace(platform=Platform.SLACK, thread_id=None, chat_type=None),
+            raw_message={"_hermes_no_thread_response": True},
+            message_id="msg-1",
+            reply_to_message_id=None,
+        )
+        assert GatewayThreadMetadataMixin._reply_anchor_for_event(event) is None


### PR DESCRIPTION
## Godfile kill — gateway/run.py shard s4

Extracts the thread_metadata_mixin into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 236 added / 63 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069
#79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701
#78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715
#78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729
#78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743
#78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757
#78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771
#78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785
#78786 #78787 #78788 #78789 #78790

Part of #54962

Part of #78721
Part of #78722
Part of #78723
Part of #78724
Part of #78725
Part of #78726
Part of #78727
Part of #78728
Part of #78729
Part of #78731
Part of #78732
Part of #78733
Part of #78734
Part of #78735
Part of #78736
Part of #78737
Part of #78738
Part of #78739
Part of #78740
Part of #78741
Part of #78742
Part of #78743
Part of #78744
Part of #78745
Part of #78746
Part of #78747
Part of #78748
Part of #78749
Part of #78750
Part of #78751
Part of #78752
Part of #78753
Part of #78754
Part of #78755
Part of #78756
Part of #78757
Part of #78758
Part of #78759
Part of #78760
Part of #78761
Part of #78762
Part of #78763
Part of #78764
Part of #78765
Part of #78766
Part of #78767
Part of #78768
Part of #78769
Part of #78770
Part of #78771
Part of #78772
Part of #78773
Part of #78774
Part of #78775
Part of #78776
Part of #78777
Part of #78778
Part of #78779
Part of #78780
Part of #78781
Part of #78782
Part of #78783
Part of #78784
Part of #78785
Part of #78786
Part of #78787
Part of #78788
Part of #78789
Part of #78790
Part of #78791

Part of #78647
Part of #79890
