### PR TITLE
feat(plugins): add generic footer + usage_extra lifecycle hooks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11390,6 +11390,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if self._print_nous_credits_block():
             self._print_usage_cta()
 
+        # usage_extra lifecycle hook — let plugins append an extra section
+        # after the account/credits blocks (e.g. a per-provider quota summary).
+        # Observer-only: each plugin returns a string block; we print non-empty
+        # ones. Fail-open: any exception is logged and skipped.
+        try:
+            from hermes_cli.lifecycle import has_hook as _has_usage_extra_hook
+            from hermes_cli.lifecycle import invoke_hook as _invoke_usage_extra
+            if _has_usage_extra_hook("usage_extra"):
+                _usage_blocks = _invoke_usage_extra(
+                    "usage_extra",
+                    provider=provider,
+                    base_url=base_url,
+                    api_key=api_key,
+                    session_id=getattr(self, "session_id", None)
+                    or getattr(agent, "session_id", None),
+                )
+                for _block in _usage_blocks:
+                    _text = str(_block).strip() if _block is not None else ""
+                    if _text:
+                        print()
+                        print(_text)
+        except Exception as _usage_extra_err:
+            logger.debug("usage_extra hook failed: %s", _usage_extra_err)
+
         if self.verbose:
             logging.getLogger().setLevel(logging.DEBUG)
             for noisy in ('openai', 'openai._base_client', 'httpx', 'httpcore', 'asyncio', 'hpack', 'grpc', 'modal'):

--- a/docs/plugins/hook-taxonomy.md
+++ b/docs/plugins/hook-taxonomy.md
@@ -1,0 +1,123 @@
+# Hermes Plugin Hook Taxonomy
+
+This document is the canonical catalog of plugin lifecycle hooks: their
+contract, return-value semantics, and naming grammar. It is the reference
+used by the #64231 batch disposition of pending hook PRs and by plugin
+authors deciding which hook to register.
+
+Hook registration is additive and never breaks existing plugins. A plugin
+registers callbacks from `register(ctx)`:
+
+```python
+def register(ctx):
+    ctx.register_hook("footer", on_footer)
+    ctx.register_hook("usage_extra", on_usage_extra)
+```
+
+Every hook callback receives keyword arguments. Plugins should accept
+`**kwargs` so additive fields remain backward-compatible:
+
+```python
+def on_footer(**kwargs):
+    model = kwargs.get("model")
+    context_tokens = kwargs.get("context_tokens")
+```
+
+The plugin manager injects a schema-version field into every hook payload:
+
+```text
+telemetry_schema_version = "hermes.observer.v1"
+```
+
+Hook callbacks are fail-open. Hermes catches callback exceptions, logs a
+warning, and keeps the agent loop running. Call sites short-circuit via
+`has_hook(name)` so a hook with no registered callback costs nothing.
+
+This document covers **observer / render-extension** hooks (the footer and
+usage surfaces). Mutating-contract hooks (block signals, first-valid-wins
+middleware) are covered by their own design notes and share the same
+registration surface.
+
+## Naming grammar
+
+Hook names follow `<subsystem>_<noun>_<verb-past>` where possible, but the
+two render-extension hooks below use short, discoverable ids (`footer`,
+`usage_extra`) because they map 1:1 to a user-visible surface rather than a
+subsystem event. Both are observer-only: they return a string block that the
+call site appends; they never mutate the message or the runtime state.
+
+## Render-extension hooks (observer)
+
+These hooks let a plugin append an extra block to a rendered surface without
+any core special-casing of a feature. Both are fail-open and short-circuited
+when nothing is registered.
+
+### `footer`
+
+Fired after the runtime footer line is built, before it is appended to the
+final response in `gateway/run.py`. A plugin returns a string block that is
+appended after the footer line.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `model` | `str \| None` | Bare model id (same value the footer renders). |
+| `context_tokens` | `int` | Last-prompt token count. |
+| `context_length` | `int \| None` | Model context window length. |
+| `cwd` | `str` | Working directory (home-collapsed). |
+| `turn_seconds` | `float \| None` | Wall-clock turn duration. |
+| `platform_key` | `str \| None` | Gateway platform (discord/telegram/slack/…). |
+| `user_config` | `dict \| None` | Effective `~/.hermes/config.yaml`. |
+
+Return behavior: return a string block (may be multi-line). The call site
+joins non-empty blocks with blank lines after the footer line. Return `None`
+(or `""`) to contribute nothing.
+
+### `usage_extra`
+
+Fired at the end of the `/usage` command render in `cli.py`, after the
+account/credits blocks. A plugin returns an extra section appended after
+those blocks.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `provider` | `str \| None` | Active provider (if any). |
+| `base_url` | `str \| None` | Provider base URL. |
+| `api_key` | `str \| None` | Provider API key (present only in-process; do not log). |
+| `session_id` | `str \| None` | Current session id. |
+
+Return behavior: return a string block (may be multi-line). The call site
+prints non-empty blocks after the account/credits blocks. Return `None` (or
+`""`) to contribute nothing.
+
+## Example: per-provider quota block
+
+The `hermes-quota-plugin` (https://github.com/rarf/hermes-quota-plugin)
+registers both hooks. It reads a precomputed `quota_cache.json` (written by a
+scheduled refresh) so the footer never does network I/O on the hot path, and
+is fail-open per provider:
+
+```python
+def footer_segment(**kwargs):
+    if quota_cache_age_seconds() <= CACHE_MAX_AGE_S:
+        return _format_quota_block(read_quota_cache())
+    return None
+
+def register(ctx):
+    ctx.register_hook("footer", footer_segment)
+    ctx.register_hook("usage_extra", usage_extra)
+```
+
+## Acceptance criteria for new hooks
+
+A new hook is accepted when it satisfies the plugin-interface expansion ground
+rules:
+
+1. **Additive** — no change to existing plugin behavior; new hook id in
+   `VALID_HOOKS`.
+2. **Observer-first** — where observe/mutate is a choice, ship the observer
+   version first.
+3. **Fail-open** — a broken plugin cannot abort the response, `/usage`, or any
+   hot path.
+4. **No prompt-cache violation** — render-extension hooks append text only;
+   they never mutate past context or the system prompt.
+5. **Documented** — listed in this catalog with kwargs and return behavior.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17621,6 +17621,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
 
+            # footer lifecycle hook — let plugins append an extra block to the
+            # final message (e.g. a per-provider quota summary). Observer-only:
+            # each plugin returns a string block; we concatenate non-empty ones
+            # after the runtime footer line. Fail-open: any exception is logged
+            # and skipped so a broken plugin can never abort the response.
+            try:
+                from hermes_cli.lifecycle import has_hook as _has_footer_hook
+                from hermes_cli.lifecycle import invoke_hook as _invoke_footer_hook
+                if _has_footer_hook("footer"):
+                    _footer_blocks = _invoke_footer_hook(
+                        "footer",
+                        model=agent_result.get("model"),
+                        context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
+                        context_length=agent_result.get("context_length") or None,
+                        cwd=os.environ.get("TERMINAL_CWD", ""),
+                        turn_seconds=_turn_seconds,
+                        platform_key=_platform_config_key(source.platform),
+                        user_config=_load_gateway_config(),
+                    )
+                    _footer_extra = "\n\n".join(
+                        b for b in (str(b).strip() for b in _footer_blocks) if b
+                    )
+                    if _footer_extra and response and not agent_result.get("already_sent") and not _intentional_silence:
+                        response = f"{response}\n\n{_footer_extra}"
+            except Exception as _footer_hook_err:
+                logger.debug("footer hook failed: %s", _footer_hook_err)
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -226,6 +226,7 @@ VALID_HOOKS: Set[str] = {
     # ``usage_extra`` — fired at the end of the /usage command render. Kwargs:
     #     provider, base_url, api_key, session_id. A plugin returns an extra
     #   section (string) appended after the account/credits blocks.
+    # Catalog + kwargs + return behavior: docs/plugins/hook-taxonomy.md
     "footer",
     "usage_extra",
 }

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -212,6 +212,22 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Rendering extension hooks. Both are OBSERVERS: a plugin returns a string
+    # (or a dict with a ``text`` key) to append an extra block to a rendered
+    # surface. Return values are concatenated by the call site; a plugin that
+    # returns None contributes nothing. Call sites return early (no hook
+    # dispatch) when no plugin has registered the hook, so idle cost is zero.
+    #
+    # ``footer`` — fired after the runtime footer line is built, before it is
+    #   appended to the final response. Kwargs mirror build_footer_line:
+    #     model, context_tokens, context_length, cwd, turn_seconds,
+    #     platform_key, user_config. A plugin returns a block (e.g. a quota
+    #   summary) that is appended after the footer line.
+    # ``usage_extra`` — fired at the end of the /usage command render. Kwargs:
+    #     provider, base_url, api_key, session_id. A plugin returns an extra
+    #   section (string) appended after the account/credits blocks.
+    "footer",
+    "usage_extra",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/hermes_cli/test_footer_usage_extra_hooks.py
+++ b/tests/hermes_cli/test_footer_usage_extra_hooks.py
@@ -1,0 +1,86 @@
+"""Tests for the generic ``footer`` and ``usage_extra`` plugin lifecycle hooks.
+
+These hooks let a plugin append an extra block to the runtime footer (final
+message) and to the ``/usage`` command render, respectively. Both are
+observer-only: a plugin returns a string block; call sites concatenate
+non-empty blocks and skip the hook entirely when nothing is registered.
+"""
+
+import types
+
+from hermes_cli import plugins
+from hermes_cli.plugins import PluginManager, VALID_HOOKS
+
+
+def _fresh_manager(monkeypatch):
+    """Install a clean PluginManager singleton and return it."""
+    mgr = PluginManager()
+    monkeypatch.setattr(plugins, "get_plugin_manager", lambda: mgr)
+    return mgr
+
+
+def test_valid_hooks_include_footer_and_usage_extra():
+    assert "footer" in VALID_HOOKS
+    assert "usage_extra" in VALID_HOOKS
+
+
+def test_has_hook_false_when_nothing_registered(monkeypatch):
+    _fresh_manager(monkeypatch)
+    assert plugins.has_hook("footer") is False
+    assert plugins.has_hook("usage_extra") is False
+
+
+def test_footer_hook_returns_registered_blocks(monkeypatch):
+    mgr = _fresh_manager(monkeypatch)
+
+    def footer_block(**kwargs):
+        return "📊 quota:\n• anthropic: 54% (reset today 13:09)"
+
+    mgr._hooks.setdefault("footer", []).append(footer_block)
+
+    assert plugins.has_hook("footer") is True
+    results = plugins.invoke_hook("footer", model="gpt-5.4", context_tokens=10, context_length=100)
+    assert results == ["📊 quota:\n• anthropic: 54% (reset today 13:09)"]
+
+
+def test_usage_extra_hook_returns_registered_blocks(monkeypatch):
+    mgr = _fresh_manager(monkeypatch)
+
+    def usage_block(**kwargs):
+        return "📊 quota:\n• grok: Weekly 0% (reset today 18:00)"
+
+    mgr._hooks.setdefault("usage_extra", []).append(usage_block)
+
+    assert plugins.has_hook("usage_extra") is True
+    results = plugins.invoke_hook(
+        "usage_extra", provider="grok", base_url="x", api_key="y", session_id="s1"
+    )
+    assert results == ["📊 quota:\n• grok: Weekly 0% (reset today 18:00)"]
+
+
+def test_footer_hook_core_drops_none_keeps_text(monkeypatch):
+    mgr = _fresh_manager(monkeypatch)
+    mgr._hooks.setdefault("footer", []).extend(
+        [
+            lambda **kw: None,  # observer that contributes nothing
+            lambda **kw: "   \n  ",  # whitespace-only: returned by core,
+            # filtered at the call site via str().strip()
+            lambda **kw: "real block",
+        ]
+    )
+    results = plugins.invoke_hook("footer")
+    # Core invoke_hook only drops None; call sites strip() whitespace-only.
+    assert results == ["   \n  ", "real block"]
+
+
+def test_register_hook_accepts_new_hooks_without_warning(monkeypatch, caplog):
+    mgr = _fresh_manager(monkeypatch)
+    ctx = plugins.PluginContext.__new__(plugins.PluginContext)
+    ctx._manager = mgr
+    ctx.manifest = types.SimpleNamespace(name="quota")
+
+    ctx.register_hook("footer", lambda **kw: "fb")
+    ctx.register_hook("usage_extra", lambda **kw: "ue")
+
+    assert mgr.has_hook("footer") is True
+    assert mgr.has_hook("usage_extra") is True


### PR DESCRIPTION
## Summary

Adds two **observer-only** plugin lifecycle hooks so a plugin can append an extra block to the runtime footer (final message) and to the `/usage` command render — with zero core special-casing of any specific feature.

- `footer` — fired after the runtime footer line is built, before it is appended to the final response. A plugin returns a string block that is appended after the footer line.
- `usage_extra` — fired at the end of the `/usage` command render. A plugin returns an extra section appended after the account/credits blocks.

Both call sites short-circuit via `has_hook()` so idle cost is zero, and are fail-open (any hook error is logged and skipped — a broken plugin can never abort the response or `/usage`).

## Why

A working downstream plugin already depends on these hooks: **hermes-quota-plugin** (https://github.com/rarf/hermes-quota-plugin) appends a per-provider quota/rate-limit block to the footer and `/usage`, plus a `/quota` command. It carries its own fetchers + cache so it survives `hermes update`; the hooks only read a precomputed `quota_cache.json`, so they do **no network I/O on the hot path** and are fail-open (a broken provider yields an `unavailable_reason`, never fake zeros).

This is the concrete use case referenced in #64231 (lifecycle-event catalog / batch disposition of pending hook PRs) and #67798 (shared cross-surface lifecycle contract). The hooks belong in the shared runtime contract rather than gateway-only, so the quota block shows up identically wherever the footer renders.

## Test plan

- `tests/hermes_cli/test_footer_usage_extra_hooks.py` — new: `VALID_HOOKS` includes both hooks; `has_hook`/`invoke_hook` return registered blocks; `register_hook` accepts them without warning; core drops `None` returns.
- Existing footer / plugin / lifecycle / hooks-cli suites still green (`tests/gateway/test_runtime_footer.py`, `tests/hermes_cli/test_plugins.py`, `tests/hermes_cli/test_lifecycle.py`, `tests/hermes_cli/test_hooks_cli.py`) — 85 passed.

## Notes for maintainers

- Hooks are observer-style: return values are strings; call sites concatenate non-empty blocks. No mutation of the message.
- Kwargs for `footer` mirror `build_footer_line` (`model`, `context_tokens`, `context_length`, `cwd`, `turn_seconds`, `platform_key`, `user_config`).
- Kwargs for `usage_extra`: `provider`, `base_url`, `api_key`, `session_id`.
- Happy to fold this into the #64231 taxonomy batch or adjust the surface names if you prefer different hook ids.

Closes the `footer-hook` / `usage-extra-hook` work discussed in #64231.