### PR TITLE
feat(kanban): add nullable recursive decomposition metadata

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -915,6 +915,12 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Recursive decomposition metadata is nullable on disk so legacy rows are
+    # never backfilled. A missing or NULL depth is the root-compatible depth 1.
+    depth: int = 1
+    plan_item_index: Optional[int] = None
+    recursion_enabled: Optional[bool] = None
+    recursion_trigger_chars: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1004,28 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            depth=(
+                int(row["depth"])
+                if "depth" in keys and row["depth"] is not None
+                else 1
+            ),
+            plan_item_index=(
+                int(row["plan_item_index"])
+                if "plan_item_index" in keys and row["plan_item_index"] is not None
+                else None
+            ),
+            recursion_enabled=(
+                bool(row["recursion_enabled"])
+                if "recursion_enabled" in keys
+                and row["recursion_enabled"] is not None
+                else None
+            ),
+            recursion_trigger_chars=(
+                int(row["recursion_trigger_chars"])
+                if "recursion_trigger_chars" in keys
+                and row["recursion_trigger_chars"] is not None
+                else None
             ),
         )
 
@@ -1176,7 +1204,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Recursive decomposition metadata. These columns intentionally remain
+    -- nullable so opening a legacy board never rewrites old rows.
+    depth                INTEGER,
+    plan_item_index      INTEGER,
+    recursion_enabled    INTEGER,
+    recursion_trigger_chars INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2202,6 +2236,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
+    # Recursive decomposition metadata is additive and nullable. Do not
+    # backfill depth: Task.from_row supplies the legacy-compatible value 1
+    # while the database preserves NULL for historical rows.
+    for name, definition in (
+        ("depth", "depth INTEGER"),
+        ("plan_item_index", "plan_item_index INTEGER"),
+        ("recursion_enabled", "recursion_enabled INTEGER"),
+        ("recursion_trigger_chars", "recursion_trigger_chars INTEGER"),
+    ):
+        if name not in cols:
+            _add_column_if_missing(conn, "tasks", name, definition)
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -2742,6 +2787,10 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    depth: Optional[int] = None,
+    plan_item_index: Optional[int] = None,
+    recursion_enabled: Optional[bool] = None,
+    recursion_trigger_chars: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2970,8 +3019,10 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        depth, plan_item_index, recursion_enabled,
+                        recursion_trigger_chars
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2994,6 +3045,14 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        int(depth) if depth is not None else None,
+                        int(plan_item_index) if plan_item_index is not None else None,
+                        int(bool(recursion_enabled))
+                        if recursion_enabled is not None else None,
+                        (
+                            int(recursion_trigger_chars)
+                            if recursion_trigger_chars is not None else None
+                        ),
                     ),
                 )
                 for pid in parents:
@@ -5780,11 +5839,16 @@ def decompose_triage_task(
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            depth = child.get("depth")
+            plan_item_index = child.get("plan_item_index")
+            recursion_enabled = child.get("recursion_enabled")
+            recursion_trigger_chars = child.get("recursion_trigger_chars")
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, depth, "
+                " plan_item_index, recursion_enabled, recursion_trigger_chars) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -5795,6 +5859,14 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    int(depth) if depth is not None else None,
+                    int(plan_item_index) if plan_item_index is not None else None,
+                    int(bool(recursion_enabled))
+                    if recursion_enabled is not None else None,
+                    (
+                        int(recursion_trigger_chars)
+                        if recursion_trigger_chars is not None else None
+                    ),
                 ),
             )
             _append_event(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4959,3 +4959,73 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_recursive_metadata_is_nullable_and_depth_defaults_without_backfill(tmp_path):
+    db_path = tmp_path / "legacy-kanban.db"
+    legacy = sqlite3.connect(db_path)
+    legacy.execute(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER
+        )
+        """
+    )
+    legacy.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old row', 'ready', 1)"
+    )
+    legacy.commit()
+    legacy.close()
+
+    with kb.connect(db_path) as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        row = conn.execute(
+            "SELECT depth, plan_item_index, recursion_enabled, "
+            "recursion_trigger_chars FROM tasks WHERE id = 'legacy'"
+        ).fetchone()
+        task = kb.get_task(conn, "legacy")
+
+    assert {
+        "depth",
+        "plan_item_index",
+        "recursion_enabled",
+        "recursion_trigger_chars",
+    } <= columns
+    assert tuple(row) == (None, None, None, None)
+    assert task is not None
+    assert task.depth == 1
+
+
+def test_recursive_metadata_is_written_for_new_tasks(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="recursive child",
+            depth=2,
+            plan_item_index=3,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.depth == 2
+    assert task.plan_item_index == 3
+    assert task.recursion_enabled is True
+    assert task.recursion_trigger_chars == 400


### PR DESCRIPTION
## Tracking issue

Sincera-Works/sermon-translate#1656 — Recursive decomposition: give each level its own 4k budget.

## Summary

- Add additive nullable `depth`, `plan_item_index`, `recursion_enabled`, and `recursion_trigger_chars` task columns.
- Keep historical rows physically NULL while exposing absent depth as `1` in the `Task` view.
- Accept metadata on task creation and decomposition child inserts without changing flat-mode defaults.

## Verification evidence

- `python3 -m pytest tests/hermes_cli/test_kanban_db.py -x -q` — 232 passed.
- `python3 -m pytest tests/hermes_cli/test_kanban_decompose.py -x -q` — 9 passed.
- `python3 -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` — passed.

## Rollback plan

Revert commit `152159bbe`; the migration is additive and nullable, so leaving the new columns in existing boards is harmless. The recursive path remains default-off until the downstream bridge enables it.
