### PR TITLE
fix(doctor): detect vulnerable SQLite engine (WAL-reset bug) hidden behind pysqlite3

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1298,6 +1298,46 @@ def run_doctor(args):
         except Exception:
             pass
 
+    # SQLite engine version guard (WAL-reset corruption bug, SQLite 3.7.0-3.51.2;
+    # safe builds are >= 3.51.3). Hermes resolves `import sqlite3` to `pysqlite3`
+    # when that package is present in the venv (it shadows the stdlib), so the
+    # version that actually matters is whatever is statically linked into
+    # pysqlite3's _sqlite3 extension -- NOT the managed Python's SQLite. A
+    # `hermes update` can silently revert pysqlite3 to a vulnerable build, and
+    # without this guard the user has no way to see it.
+    _section("SQLite Engine Version")
+    try:
+        import sqlite3
+
+        _sql_version = sqlite3.sqlite_version
+        _sql_backend = sqlite3.__file__ or "unknown"
+        _vparts = tuple(int(x) for x in _sql_version.split(".")[:3] if x.isdigit())
+        _vuln = _vparts < (3, 51, 3)
+        if _vuln:
+            check_warn(
+                f"SQLite engine is {_sql_version} (WAL-reset corruption bug, "
+                f"affects 3.7.0-3.51.2)",
+                f"(backend: {_sql_backend})",
+            )
+            if should_fix:
+                check_info(
+                    "Auto-fix not available: the active backend is pysqlite3, "
+                    "which statically links SQLite. Rebuild it against the "
+                    "official amalgamation >= 3.51.3, or run "
+                    "'hermes update' again after a safe build is published."
+                )
+            issues.append(
+                f"Vulnerable SQLite {_sql_version} (WAL-reset bug) — backend: "
+                f"{_sql_backend}"
+            )
+        else:
+            check_ok(
+                f"SQLite engine {_sql_version} (safe, >= 3.51.3)",
+                f"(backend: {_sql_backend})",
+            )
+    except Exception as e:
+        check_warn(f"Could not determine SQLite engine version: {e}")
+
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
 


### PR DESCRIPTION
## Summary
- Adds a **SQLite Engine Version** section to `hermes doctor` that reports the *active* SQLite engine and version.
- Hermes resolves `import sqlite3` to `pysqlite3` when that package is present in the venv (it shadows the stdlib). The version that matters is therefore the one **statically linked into pysqlite3's `_sqlite3` extension**, not the managed Python's SQLite.
- Flags SQLite **3.7.0–3.51.2** (WAL-reset corruption bug; safe builds are **>= 3.51.3**) with a clear warning, and notes that auto-fix is unavailable because the backend is a statically-linked extension that `hermes update` can silently revert.

## Why this is the real fix
The WAL-reset vulnerability is invisible today: `hermes update` can revert `pysqlite3` to a vulnerable build and the user gets no signal — `doctor` never looked at the engine version, only at WAL file size. This guard makes the condition observable, which is the prerequisite for any repair path.

## Test plan
- [x] `py_compile` passes.
- [x] Version logic verified: `3.51.1`/`3.50.4`/`3.47.1` → vuln; `3.51.3`/`3.53.4` → safe.
- [x] On a safe install (managed Python 3.11.15 links SQLite 3.53.4; pysqlite3 rebuilt to 3.53.4) doctor prints `SQLite engine 3.53.4 (safe, >= 3.51.3)`.
- [ ] CI lint/tests (cosmetic, single-file, no new deps).

## Risk
- Low: read-only check, no behavior change to any repair path.
- Single-file change to `doctor.py`.

## Note on #79291
The original issue described a `repair_vulnerable_runtime` silent-skip against managed Python builds linking SQLite 3.50.4. In current `main` the managed Python is **3.11.15 linking SQLite 3.53.4** (already safe), and that repair function is not present in this tree — the issue's root-cause section was inaccurate for the current code. This PR delivers the actionable part that *is* still valid: make the engine version observable so a future regression (e.g. `hermes update` reverting `pysqlite3`) is caught instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)