### PR TITLE
fix(file-ops): stop flagging valid UTF-8 as binary when byte-truncated sample

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,29 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_truncated_multibyte_sample_not_flagged(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # read_file samples with `head -c 1000`, which slices by BYTE. When
+        # byte 1000 cuts inside a multi-byte UTF-8 char, errors="replace"
+        # decoding yields exactly one synthetic trailing U+FFFD. That is a
+        # truncation artifact — the file itself is valid UTF-8 and must still
+        # read as text (CJK text hits this constantly: 3 bytes/char).
+        truncated_sample = ("火箭发动机液氧甲烷" * 60) + "火\ufffd"
+        assert ops._is_likely_binary("notes.txt", truncated_sample) is False
+
+    def test_real_byte_truncation_utf8_not_binary(self, tmp_path):
+        # E2E: reproduce read_file's sampling semantics on a real CJK file —
+        # take the first 1000 BYTES and decode with errors="replace" exactly
+        # like the terminal backend does. Byte 1000 lands mid-character here
+        # (3 bytes/char), so decoding yields a trailing U+FFFD that is a
+        # truncation artifact; the file itself is valid UTF-8 and must still
+        # read as text.
+        p = tmp_path / "中文.md"
+        p.write_text("液氧甲烷火箭发动机试车" * 100, encoding="utf-8")
+        sample = p.read_bytes()[:1000].decode("utf-8", errors="replace")
+        # Precondition: byte truncation really does produce a trailing U+FFFD
+        # on this file — otherwise the assertion below is vacuous.
+        assert sample.endswith("\ufffd")
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        assert ops._is_likely_binary(str(p), sample) is False

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,7 +903,15 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            # Exception: the sample is produced by `head -c 1000`, which
+            # slices by BYTE. When byte 1000 lands inside a multi-byte UTF-8
+            # character (common for CJK text, 3 bytes/char), decoding with
+            # errors="replace" yields exactly one synthetic trailing U+FFFD.
+            # That char is a truncation artifact, not evidence of binary
+            # content — strip it before deciding, so valid UTF-8 files whose
+            # first 1000 bytes end mid-character still read as text. A real
+            # U+FFFD anywhere else in the sample still flags the file binary.
+            if "\ufffd" in content_sample[:1000].rstrip("\ufffd"):
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')


### PR DESCRIPTION
## Problem

`read_file` and `read_file_raw` sample files with ``head -c 1000``, which slices by **byte**. When byte 1000 lands inside a multi-byte UTF-8 character (common for CJK text: 3 bytes/char), the terminal backend decodes the truncated stream with `errors="replace"`, producing exactly one synthetic trailing U+FFFD.

`_is_likely_binary` then sees the U+FFFD and flags the file as binary:

```
if "\ufffd" in content_sample[:1000]:
    return True
```

Result: read_file refuses to read perfectly valid UTF-8 markdown files — in practice, most Chinese-language documents. Reproduced on a 66 KB Chinese meeting transcript: first-1000-bytes sample decodes to a trailing U+FFFD, whole file is valid UTF-8, yet read_file returns "Binary file - cannot display as text". In a directory of 4 CJK markdown files, 3 hit the false positive (75%).

## Fix

Strip the trailing U+FFFD before the check — it is a truncation artifact of the byte-based sample, not evidence of binary content:

```python
if "\ufffd" in content_sample[:1000].rstrip("\ufffd"):
    return True
```

The read-edit-write corruption guard is preserved: a real U+FFFD anywhere else in the sample (e.g. a latin-1 file decoded lossily) still flags the file binary.

## Tests

Two regression tests added to `TestReadNonUtf8IsBinary`:

- `test_truncated_multibyte_sample_not_flagged` — sample with a trailing U+FFFD (simulating the truncation artifact) is not binary
- `test_real_byte_truncation_utf8_not_binary` — E2E: real CJK file, first 1000 bytes decoded with `errors="replace"` exactly like the terminal backend, preconditions asserted (trailing U+FFFD produced), then confirmed not flagged binary

Existing test `test_replacement_char_sample_flagged_binary` (U+FFFD in the middle of the sample → binary) still passes.

Full suite for the two touched test files: 60 passed, 8 failed — the 8 failures are pre-existing Windows-environment issues (umask permission bits, symlink semantics) unrelated to this change.