### PR TITLE
fix(desktop): avoid first-run onboarding on active-runtime probe timeouts

### DIFF
--- a/apps/desktop/electron/active-runtime-state.test.ts
+++ b/apps/desktop/electron/active-runtime-state.test.ts
@@ -20,7 +20,7 @@ test('hasValidBootstrapMarker rejects missing, wrong-schema, and too-short marke
 })
 
 test('classifyActiveRuntime uses a healthy active runtime even when the bootstrap marker is missing', () => {
-  assert.deepEqual(classifyActiveRuntime(null, 1, true), {
+  assert.deepEqual(classifyActiveRuntime(null, 1, 'usable'), {
     hasValidMarker: false,
     shouldUseActiveRuntime: true,
     usabilityReason: 'usable'
@@ -28,7 +28,7 @@ test('classifyActiveRuntime uses a healthy active runtime even when the bootstra
 })
 
 test('classifyActiveRuntime uses a healthy active runtime even when the marker is stale or malformed', () => {
-  assert.deepEqual(classifyActiveRuntime({ schemaVersion: 999, pinnedCommit: 'abc1234' }, 1, true), {
+  assert.deepEqual(classifyActiveRuntime({ schemaVersion: 999, pinnedCommit: 'abc1234' }, 1, 'usable'), {
     hasValidMarker: false,
     shouldUseActiveRuntime: true,
     usabilityReason: 'usable'
@@ -36,10 +36,18 @@ test('classifyActiveRuntime uses a healthy active runtime even when the marker i
 })
 
 test('classifyActiveRuntime refuses an unusable runtime even if a valid marker exists', () => {
-  assert.deepEqual(classifyActiveRuntime(VALID_MARKER, 1, false), {
+  assert.deepEqual(classifyActiveRuntime(VALID_MARKER, 1, 'unusable'), {
     hasValidMarker: true,
     shouldUseActiveRuntime: false,
     usabilityReason: 'unusable'
+  })
+})
+
+test('classifyActiveRuntime keeps an existing install on the local-runtime path when the probe only times out', () => {
+  assert.deepEqual(classifyActiveRuntime(VALID_MARKER, 1, 'probe-timeout'), {
+    hasValidMarker: true,
+    shouldUseActiveRuntime: true,
+    usabilityReason: 'probe-timeout'
   })
 })
 
@@ -47,7 +55,7 @@ test('a CLI-installed runtime with no marker launches instead of re-running boot
   // The reported symptom (#60721): install.sh / install.ps1 produced a healthy
   // repo+venv, no desktop-managed marker was ever written, and every launch
   // dropped the user back into the first-run installer.
-  const state = classifyActiveRuntime(null, 1, true)
+  const state = classifyActiveRuntime(null, 1, 'usable')
 
   assert.equal(state.shouldUseActiveRuntime, true, 'a usable runtime must launch')
   assert.equal(state.hasValidMarker, false, 'marker provenance stays honest')
@@ -56,5 +64,5 @@ test('a CLI-installed runtime with no marker launches instead of re-running boot
 test('a repair that deleted the marker does not strand a healthy install', () => {
   // #72166: the repair handler clears the marker unconditionally. Runtime
   // usability, not marker presence, must decide the next boot.
-  assert.equal(classifyActiveRuntime(null, 1, true).shouldUseActiveRuntime, true)
+  assert.equal(classifyActiveRuntime(null, 1, 'usable').shouldUseActiveRuntime, true)
 })

--- a/apps/desktop/electron/active-runtime-state.ts
+++ b/apps/desktop/electron/active-runtime-state.ts
@@ -1,3 +1,5 @@
+export type ActiveRuntimeUsability = 'usable' | 'probe-timeout' | 'unusable'
+
 export interface BootstrapMarkerLike {
   pinnedCommit?: unknown
   schemaVersion?: unknown
@@ -6,7 +8,7 @@ export interface BootstrapMarkerLike {
 export interface ActiveRuntimeState {
   hasValidMarker: boolean
   shouldUseActiveRuntime: boolean
-  usabilityReason: 'usable' | 'unusable'
+  usabilityReason: ActiveRuntimeUsability
 }
 
 export function hasValidBootstrapMarker(
@@ -38,11 +40,11 @@ export function hasValidBootstrapMarker(
 export function classifyActiveRuntime(
   marker: BootstrapMarkerLike | null | undefined,
   schemaVersion: number,
-  runtimeUsable: boolean
+  runtimeUsability: ActiveRuntimeUsability
 ): ActiveRuntimeState {
   const hasValidMarker = hasValidBootstrapMarker(marker, schemaVersion)
 
-  if (!runtimeUsable) {
+  if (runtimeUsability === 'unusable') {
     return {
       hasValidMarker,
       shouldUseActiveRuntime: false,
@@ -53,6 +55,6 @@ export function classifyActiveRuntime(
   return {
     hasValidMarker,
     shouldUseActiveRuntime: true,
-    usabilityReason: 'usable'
+    usabilityReason: runtimeUsability
   }
 }

--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -15,8 +15,11 @@ import { test } from 'vitest'
 import {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
+  execProbeStatus,
   hermesRuntimeImportProbe,
   PROBE_TIMEOUT_MS,
+  probeHermesCliImportStatus,
+  probeHermesCliStatus,
   resolveProbeTimeoutMs,
   shouldTrustHermesOverride,
   verifyHermesCli
@@ -49,6 +52,12 @@ test('canImportHermesCli returns false when binary does not exist', () => {
   assert.equal(canImportHermesCli(ghost), false)
 })
 
+test('probeHermesCliImportStatus reports failure when path is falsy', () => {
+  assert.equal(probeHermesCliImportStatus(''), 'failure')
+  assert.equal(probeHermesCliImportStatus(null), 'failure')
+  assert.equal(probeHermesCliImportStatus(undefined), 'failure')
+})
+
 test('hermes runtime import probe checks config dependencies', () => {
   const probe = hermesRuntimeImportProbe()
   assert.match(probe, /\bimport yaml\b/)
@@ -77,6 +86,12 @@ test('verifyHermesCli returns false when command is falsy', () => {
 test('verifyHermesCli returns false when binary does not exist', () => {
   const ghost = path.join(os.tmpdir(), 'hermes-probes-ghost-' + Date.now() + '.exe')
   assert.equal(verifyHermesCli(ghost), false)
+})
+
+test('probeHermesCliStatus reports failure when command is falsy', () => {
+  assert.equal(probeHermesCliStatus(''), 'failure')
+  assert.equal(probeHermesCliStatus(null), 'failure')
+  assert.equal(probeHermesCliStatus(undefined), 'failure')
 })
 
 test('verifyHermesCli returns true when --version exits 0', () => {
@@ -108,6 +123,20 @@ test('verifyHermesCli swallows timeouts (does not throw)', () => {
   // (because the binary is missing) returns false rather than
   // propagating. Same code path the timeout case takes.
   assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
+})
+
+test('execProbeStatus reports timeout after both attempts exhaust the budget', () => {
+  const status = execProbeStatus(
+    NODE_BIN,
+    ['-e', 'setTimeout(() => process.exit(0), 200)'],
+    {
+      stdio: 'ignore',
+      timeout: 10,
+      windowsHide: true
+    }
+  )
+
+  assert.equal(status, 'timeout')
 })
 
 test('default probe timeout is 15s (not the old 5s death-loop value)', () => {

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -35,6 +35,8 @@
 
 import { execFileSync } from 'node:child_process'
 
+type ProbeStatus = 'success' | 'timeout' | 'failure'
+
 /** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
 const DEFAULT_PROBE_TIMEOUT_MS = 15_000
 
@@ -84,6 +86,38 @@ function isTimeoutError(err: unknown): boolean {
   return false
 }
 
+function execProbeStatus(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string
+    env?: NodeJS.ProcessEnv
+    stdio: 'ignore'
+    timeout: number
+    shell?: boolean
+    windowsHide?: boolean
+  }
+): ProbeStatus {
+  try {
+    execFileSync(command, args, options)
+
+    return 'success'
+  } catch (err) {
+    if (!isTimeoutError(err)) {
+      return 'failure'
+    }
+  }
+
+  // One cold-cache / AV miss should not force hermes-setup --update (#61764).
+  try {
+    execFileSync(command, args, options)
+
+    return 'success'
+  } catch (err) {
+    return isTimeoutError(err) ? 'timeout' : 'failure'
+  }
+}
+
 /**
  * Run execFileSync; on timeout only, retry once before failing.
  * Non-timeout failures (ENOENT, non-zero exit) fail immediately.
@@ -102,14 +136,16 @@ function execProbeSync(
 ): void {
   try {
     execFileSync(command, args, options)
+
+    return
   } catch (err) {
     if (!isTimeoutError(err)) {
       throw err
     }
-
-    // One cold-cache / AV miss should not force hermes-setup --update (#61764).
-    execFileSync(command, args, options)
   }
+
+  // One cold-cache / AV miss should not force hermes-setup --update (#61764).
+  execFileSync(command, args, options)
 }
 
 /**
@@ -121,6 +157,19 @@ function execProbeSync(
  */
 function hermesRuntimeImportProbe() {
   return 'import yaml; import dotenv; import hermes_cli.config'
+}
+
+function probeHermesCliImportStatus(pythonPath: string, opts: { env?: Record<string, string> } = {}): ProbeStatus {
+  if (!pythonPath) {
+    return 'failure'
+  }
+
+  return execProbeStatus(pythonPath, ['-c', hermesRuntimeImportProbe()], {
+    env: { ...process.env, ...(opts.env || {}) },
+    stdio: 'ignore',
+    timeout: PROBE_TIMEOUT_MS,
+    windowsHide: true
+  })
 }
 
 /**
@@ -142,19 +191,8 @@ function hermesRuntimeImportProbe() {
  * @returns {boolean}
  */
 function canImportHermesCli(pythonPath: string, opts: { env?: Record<string, string> } = {}) {
-  if (!pythonPath) {
-    return false
-  }
-
   try {
-    execProbeSync(pythonPath, ['-c', hermesRuntimeImportProbe()], {
-      env: { ...process.env, ...(opts.env || {}) },
-      stdio: 'ignore',
-      timeout: PROBE_TIMEOUT_MS,
-      windowsHide: true
-    })
-
-    return true
+    return probeHermesCliImportStatus(pythonPath, opts) === 'success'
   } catch {
     return false
   }
@@ -190,20 +228,22 @@ function shouldTrustHermesOverride(hermesOverride?: string) {
   return typeof hermesOverride === 'string' && hermesOverride.trim().length > 0
 }
 
-function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
+function probeHermesCliStatus(hermesCommand: string, opts?: { shell?: boolean }): ProbeStatus {
   if (!hermesCommand) {
-    return false
+    return 'failure'
   }
 
-  try {
-    execProbeSync(hermesCommand, ['--version'], {
-      stdio: 'ignore',
-      timeout: PROBE_TIMEOUT_MS,
-      shell: Boolean(opts?.shell),
-      windowsHide: true
-    })
+  return execProbeStatus(hermesCommand, ['--version'], {
+    stdio: 'ignore',
+    timeout: PROBE_TIMEOUT_MS,
+    shell: Boolean(opts?.shell),
+    windowsHide: true
+  })
+}
 
-    return true
+function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
+  try {
+    return probeHermesCliStatus(hermesCommand, opts) === 'success'
   } catch {
     return false
   }
@@ -212,9 +252,12 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
 export {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
+  execProbeStatus,
   execProbeSync,
   hermesRuntimeImportProbe,
   PROBE_TIMEOUT_MS,
+  probeHermesCliImportStatus,
+  probeHermesCliStatus,
   resolveProbeTimeoutMs,
   shouldTrustHermesOverride,
   verifyHermesCli

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,7 +30,7 @@ import {
 } from 'electron'
 import nodePty from 'node-pty'
 
-import { classifyActiveRuntime } from './active-runtime-state'
+import { type ActiveRuntimeUsability, classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -41,6 +41,7 @@ import {
   canImportHermesCli,
   execProbeSync,
   PROBE_TIMEOUT_MS,
+  probeHermesCliImportStatus,
   shouldTrustHermesOverride,
   verifyHermesCli
 } from './backend-probes'
@@ -3914,18 +3915,24 @@ function readBootstrapMarker() {
 // or a DMG launch over a prior CLI install satisfies this WITHOUT the desktop
 // ever having written the bootstrap marker -- so we must be able to recognise
 // "already installed" off the filesystem alone, not just the marker.
-function isActiveRuntimeUsable() {
+function activeRuntimeUsability(): ActiveRuntimeUsability {
   const venvPython = getVenvPython(VENV_ROOT)
 
-  return (
-    isHermesSourceRoot(ACTIVE_HERMES_ROOT) &&
-    fileExists(venvPython) &&
-    canImportHermesCli(venvPython, {
-      env: {
-        PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
-      }
-    })
-  )
+  if (!(isHermesSourceRoot(ACTIVE_HERMES_ROOT) && fileExists(venvPython))) {
+    return 'unusable'
+  }
+
+  const probeStatus = probeHermesCliImportStatus(venvPython, {
+    env: {
+      PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+    }
+  })
+
+  if (probeStatus === 'timeout') {
+    return 'probe-timeout'
+  }
+
+  return probeStatus === 'success' ? 'usable' : 'unusable'
 }
 
 function activeRuntimeState() {
@@ -3934,7 +3941,16 @@ function activeRuntimeState() {
   // update`, which moves HEAD legitimately. The marker only attests "a
   // desktop-managed bootstrap ran here at least once"; runtime usability is
   // what decides whether we can actually launch.
-  return classifyActiveRuntime(readBootstrapMarker(), BOOTSTRAP_MARKER_SCHEMA_VERSION, isActiveRuntimeUsable())
+  const runtimeUsability = activeRuntimeUsability()
+
+  if (runtimeUsability === 'probe-timeout') {
+    rememberLog(
+      `[bootstrap] Active Hermes runtime probe timed out after ${PROBE_TIMEOUT_MS}ms; ` +
+        'trusting the existing install instead of routing to first-run bootstrap.'
+    )
+  }
+
+  return classifyActiveRuntime(readBootstrapMarker(), BOOTSTRAP_MARKER_SCHEMA_VERSION, runtimeUsability)
 }
 
 function writeBootstrapMarker(payload) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,7 @@ import {
 } from 'electron'
 import nodePty from 'node-pty'
 
-import { classifyActiveRuntime } from './active-runtime-state'
+import { type ActiveRuntimeUsability, classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -41,6 +41,7 @@ import {
   canImportHermesCli,
   execProbeSync,
   PROBE_TIMEOUT_MS,
+  probeHermesCliImportStatus,
   shouldTrustHermesOverride,
   verifyHermesCli
 } from './backend-probes'
@@ -3616,18 +3617,24 @@ function readBootstrapMarker() {
 // or a DMG launch over a prior CLI install satisfies this WITHOUT the desktop
 // ever having written the bootstrap marker -- so we must be able to recognise
 // "already installed" off the filesystem alone, not just the marker.
-function isActiveRuntimeUsable() {
+function activeRuntimeUsability(): ActiveRuntimeUsability {
   const venvPython = getVenvPython(VENV_ROOT)
 
-  return (
-    isHermesSourceRoot(ACTIVE_HERMES_ROOT) &&
-    fileExists(venvPython) &&
-    canImportHermesCli(venvPython, {
-      env: {
-        PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
-      }
-    })
-  )
+  if (!(isHermesSourceRoot(ACTIVE_HERMES_ROOT) && fileExists(venvPython))) {
+    return 'unusable'
+  }
+
+  const probeStatus = probeHermesCliImportStatus(venvPython, {
+    env: {
+      PYTHONPATH: [ACTIVE_HERMES_ROOT, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+    }
+  })
+
+  if (probeStatus === 'timeout') {
+    return 'probe-timeout'
+  }
+
+  return probeStatus === 'success' ? 'usable' : 'unusable'
 }
 
 function activeRuntimeState() {
@@ -3636,7 +3643,16 @@ function activeRuntimeState() {
   // update`, which moves HEAD legitimately. The marker only attests "a
   // desktop-managed bootstrap ran here at least once"; runtime usability is
   // what decides whether we can actually launch.
-  return classifyActiveRuntime(readBootstrapMarker(), BOOTSTRAP_MARKER_SCHEMA_VERSION, isActiveRuntimeUsable())
+  const runtimeUsability = activeRuntimeUsability()
+
+  if (runtimeUsability === 'probe-timeout') {
+    rememberLog(
+      `[bootstrap] Active Hermes runtime probe timed out after ${PROBE_TIMEOUT_MS}ms; ` +
+        'trusting the existing install instead of routing to first-run bootstrap.'
+    )
+  }
+
+  return classifyActiveRuntime(readBootstrapMarker(), BOOTSTRAP_MARKER_SCHEMA_VERSION, runtimeUsability)
 }
 
 function writeBootstrapMarker(payload) {


### PR DESCRIPTION
## Summary
- treat active-runtime import probe timeouts as an inconclusive result instead of "runtime missing"
- keep the desktop on the existing local-runtime path when the active install is structurally present but the probe exhausts its timeout budget
- add timeout-aware probe tests and active-runtime classification coverage so healthy installs do not fall into first-run bootstrap

## Testing
- npx vitest run --project electron electron/backend-probes.test.ts electron/active-runtime-state.test.ts electron/windows-hermes-path.test.ts
- npx tsc -p tsconfig.electron.json --noEmit

## Notes
- `npm run typecheck` still fails in `src/components/assistant-ui/thread/message-reactions.tsx` because of a pre-existing `frimousse` type-resolution problem unrelated to this change.