### PR TITLE
fix: parse bare-array /models responses in custom endpoint probe

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4349,8 +4349,11 @@ def probe_api_models(
         try:
             with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
+                # Together AI and some other providers return a bare JSON array
+                # ([{"id": ...}, ...]) instead of the OpenAI envelope
+                # ({"data": [{"id": ...}, ...]}). _payload_items handles both.
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": [m.get("id", "") for m in _payload_items(data)],
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
                     "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -219,6 +219,30 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
         assert probe["used_fallback"] is False
 
+    def test_probe_api_models_parses_bare_array_response(self):
+        """Together AI returns ``[{"id": ...}, ...]`` (no ``data`` envelope).
+
+        Regression: the parser used to call ``data.get("data", [])`` on the
+        payload, raising ``AttributeError`` on a list, which the broad
+        ``except Exception`` swallowed — reporting the endpoint unreachable.
+        """
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'[{"id": "moonshotai/Kimi-K3"}, {"id": "deepseek-ai/DeepSeek-V4-Pro"}]'
+
+        with patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()):
+            probe = probe_api_models("sk-test", "https://api.together.xyz/v1")
+
+        assert probe["models"] == ["moonshotai/Kimi-K3", "deepseek-ai/DeepSeek-V4-Pro"]
+        assert probe["probed_url"] == "https://api.together.xyz/v1/models"
+        assert probe["used_fallback"] is False
+
 
 class TestGithubReasoningEfforts:
     def test_gpt5_supports_minimal_to_high(self):


### PR DESCRIPTION
## Summary

Adding a Together AI custom endpoint (`https://api.together.xyz/v1`) prints a spurious warning:

> Note: could not reach this custom endpoint's model listing at `https://api.together.xyz/v1/models`. Hermes will still save `<model>`, but the endpoint should expose `/models` for verification.

…even though the API key is valid and `GET /v1/models` returns HTTP 200.

## Root cause

`probe_api_models` parsed the catalog with `data.get("data", [])`, expecting the OpenAI envelope `{"data": [{"id": ...}]}`. Together AI (and some other providers) return a **bare JSON array** `[{"id": ...}, ...]`. Calling `.get` on a `list` raises `AttributeError`, which the broad `except Exception: continue` swallowed — so the probe reported `models: None` and the endpoint was misreported as unreachable.

## Fix

Reuse the existing `_payload_items` helper, which already handles both the bare-array and envelope shapes, instead of calling `data.get("data", [])` directly.

## Test plan

- Added `test_probe_api_models_parses_bare_array_response` (regression test with a bare-array payload).
- `tests/hermes_cli/test_model_validation.py`: 30 passed.
- Verified live against `https://api.together.xyz/v1`: probe now returns 2129 models (previously `None`).