### PR TITLE
fix(signal): let sendTyping finish under Signal's 8s typing cadence

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4692,19 +4692,26 @@ class BasePlatformAdapter(ABC):
         for Slack's Assistant API where ``assistant_threads_setStatus`` disables
         the compose box — pausing lets the user type ``/approve`` or ``/deny``.
 
-        Each ``send_typing`` call is bounded by a ~1.5s timeout so a slow
-        network round-trip can't stall the refresh cadence.  Telegram- and
-        Discord-side typing expire after ~5s; if any individual send_typing
-        takes longer than the refresh interval, the bubble would die and
-        stay dead until that call returns.  Abandoning the slow call lets
-        the next tick fire a fresh send_typing on schedule — as long as
-        one of them succeeds within the 5s platform-side window, the bubble
-        stays visible across provider stalls / upstream API timeouts.
+        Each ``send_typing`` call is bounded by a per-tick timeout
+        (``interval - 0.25s``, floored at 0.25s) so a slow network
+        round-trip can't stall the refresh cadence.  Telegram- and
+        Discord-side typing expire after ~5s with the default 2s
+        interval; if any individual send_typing takes longer than the
+        refresh interval, the bubble would die and stay dead until that
+        call returns.  Abandoning the slow call lets the next tick fire
+        a fresh send_typing on schedule — as long as one of them
+        succeeds within the platform-side window, the bubble stays
+        visible across provider stalls / upstream API timeouts.
+
+        The timeout scales with ``interval`` (not a hard 1.5s cap) so
+        platforms that refresh more slowly — e.g. Signal at 8s — can
+        finish a multi-second signal-cli ``sendTyping`` RPC instead of
+        having every attempt cancelled before it lands (#78972).
         """
         # Bound each send_typing round-trip so the refresh cadence isn't
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
-        _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        _send_typing_timeout = max(0.25, interval - 0.25)
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1078,7 +1078,15 @@ class SignalAdapter(BasePlatformAdapter):
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
 
-        logger.info("[Signal] Sending response (%d chars) to %s", len(plain_text), chat_id)
+        # DEBUG only — base._process_message_background already logs the
+        # outbound at INFO with the pre-markdown length. Logging again at
+        # INFO with the post-markdown length made every reply look like a
+        # double-send in gateway.log (#78972).
+        logger.debug(
+            "[Signal] Sending response (%d chars plain) to %s",
+            len(plain_text),
+            chat_id,
+        )
         result = await self._rpc("send", params)
 
         if result is not None:
@@ -1123,11 +1131,12 @@ class SignalAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator.
 
-        base.py's ``_keep_typing`` refresh loop calls this every ~2s while
-        the agent is processing. If signal-cli returns NETWORK_FAILURE for
-        this recipient (offline, unroutable, group membership lost, etc.)
-        the unmitigated behaviour is: a WARNING log every 2 seconds for as
-        long as the agent keeps running. Instead we:
+        base.py's ``_keep_typing`` refresh loop (Signal default interval:
+        ``TYPING_INTERVAL`` / 8s) calls this while the agent is processing.
+        If signal-cli returns NETWORK_FAILURE for this recipient (offline,
+        unroutable, group membership lost, etc.) the unmitigated behaviour
+        is: a WARNING log on every refresh for as long as the agent keeps
+        running. Instead we:
 
         - silence the WARNING after the first consecutive failure (subsequent
           attempts log at DEBUG) so transport issues are still visible once
@@ -1510,6 +1519,28 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Typing Indicators
     # ------------------------------------------------------------------
+
+    async def _keep_typing(
+        self,
+        chat_id: str,
+        interval: float = TYPING_INTERVAL,
+        metadata=None,
+        stop_event: asyncio.Event | None = None,
+    ) -> None:
+        """Refresh Signal typing on the Signal-native cadence.
+
+        ``base._process_message_background`` calls ``_keep_typing`` without
+        an ``interval`` kwarg, so the default here (``TYPING_INTERVAL``,
+        8s) is what actually runs.  Pairing that longer refresh with
+        base's scaled per-tick timeout lets slow signal-cli ``sendTyping``
+        RPCs complete instead of being cancelled at 1.5s (#78972).
+        """
+        await super()._keep_typing(
+            chat_id,
+            interval=interval,
+            metadata=metadata,
+            stop_event=stop_event,
+        )
 
     async def _stop_typing_indicator(self, chat_id: str) -> None:
         """Stop a typing indicator loop for a chat."""

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -15,10 +15,12 @@ call returns — exactly when the user most needs the "yes, still working"
 signal.
 
 The fix: bound each ``send_typing`` with ``asyncio.wait_for``. If a
-send_typing takes longer than the per-tick budget (default 1.5s when
-interval=2.0), abandon it and let the next scheduled tick fire a fresh
-call. As long as any one of them succeeds within the ~5s platform window,
-the bubble stays visible across provider stalls.
+send_typing takes longer than the per-tick budget (``interval - 0.25s``,
+e.g. 1.75s when interval=2.0), abandon it and let the next scheduled
+tick fire a fresh call. As long as any one of them succeeds within the
+~5s platform window, the bubble stays visible across provider stalls.
+The budget scales with ``interval`` so slower platforms (Signal @ 8s)
+are not cancelled by a hard 1.5s cap (#78972).
 """
 
 import asyncio
@@ -234,3 +236,36 @@ class TestKeepTypingTimeoutPerTick:
             ("discord-chat", True),
         ]
         assert "discord-chat" not in adapter._typing_paused
+
+    @pytest.mark.asyncio
+    async def test_typing_timeout_scales_with_interval(self, monkeypatch):
+        """Per-tick budget must grow with interval so slow platforms
+        (Signal @ 8s) can finish a multi-second sendTyping RPC (#78972)."""
+        adapter = _StubAdapter()
+        completed = []
+
+        async def two_second_send_typing(chat_id, metadata=None):
+            await asyncio.sleep(2.0)
+            completed.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", two_second_send_typing)
+        adapter.stop_typing = MagicMock(return_value=asyncio.sleep(0))
+
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="signal-chat",
+                interval=8.0,
+                stop_event=stop_event,
+            )
+        )
+        # First tick starts immediately; 2s RPC must finish under the
+        # interval-scaled budget (~7.75s) before we stop the loop.
+        await asyncio.sleep(2.5)
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert completed == ["signal-chat"], (
+            f"2s send_typing with interval=8 should complete under the "
+            f"scaled timeout, got completed={completed}"
+        )

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -733,13 +733,14 @@ class TestSignalStopTyping:
 # ---------------------------------------------------------------------------
 
 class TestSignalTypingBackoff:
-    """When base.py's _keep_typing refresh loop calls send_typing every ~2s
-    and the recipient is unreachable (NETWORK_FAILURE), the adapter must:
+    """When base.py's _keep_typing refresh loop calls send_typing on the
+    Signal cadence (TYPING_INTERVAL) and the recipient is unreachable
+    (NETWORK_FAILURE), the adapter must:
 
     - log WARNING only for the first failure (subsequent failures use DEBUG
       via log_failures=False on the _rpc call)
     - after 3 consecutive failures, skip the RPC entirely during an
-      exponential cooldown window instead of hammering signal-cli every 2s
+      exponential cooldown window instead of hammering signal-cli every tick
     - reset counters on a successful sendTyping
     - reset counters when _stop_typing_indicator() is called for the chat
     """
@@ -789,6 +790,115 @@ class TestSignalTypingBackoff:
         await adapter.send_typing("+155****4567")
         await adapter.send_typing("+155****4567")
         assert call_count["n"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Signal typing start path + dual-log false positive (#78972)
+# ---------------------------------------------------------------------------
+
+class TestSignalTypingStartAndSendLogging:
+    """Regression for #78972:
+
+    - Signal must drive ``_keep_typing`` at ``TYPING_INTERVAL`` (8s) so the
+      scaled per-tick timeout can finish a multi-second signal-cli
+      ``sendTyping`` RPC instead of cancelling it at 1.5s.
+    - Final delivery logs once at INFO from base; Signal's post-markdown
+      send log is DEBUG so gateway.log no longer looks like a double-send.
+    """
+
+    @pytest.mark.asyncio
+    async def test_keep_typing_defaults_to_signal_interval(self, monkeypatch):
+        import inspect
+        from gateway.platforms.signal import TYPING_INTERVAL
+
+        adapter = _make_signal_adapter(monkeypatch)
+        sig = inspect.signature(adapter._keep_typing)
+        assert sig.parameters["interval"].default == TYPING_INTERVAL
+
+    @pytest.mark.asyncio
+    async def test_slow_send_typing_completes_under_signal_interval(
+        self, monkeypatch
+    ):
+        """A 2s sendTyping must land when Signal uses its 8s refresh cadence."""
+        adapter = _make_signal_adapter(monkeypatch)
+        completed = []
+
+        async def slow_send_typing(chat_id, metadata=None):
+            await asyncio.sleep(2.0)
+            completed.append(chat_id)
+
+        monkeypatch.setattr(adapter, "send_typing", slow_send_typing)
+        adapter.stop_typing = AsyncMock()
+
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing(
+                chat_id="+155****4567",
+                stop_event=stop_event,
+            )
+        )
+        await asyncio.sleep(2.5)
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert completed == ["+155****4567"]
+
+    @pytest.mark.asyncio
+    async def test_final_delivery_single_send_rpc_not_dual_log(
+        self, monkeypatch, caplog
+    ):
+        """One ``send`` RPC for the final reply — dual INFO lines were a
+        logging artifact (base + Signal), not a double delivery."""
+        import logging
+
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource, build_session_key
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.client = object()  # pretend connected
+        mock_rpc, captured = _stub_rpc({"timestamp": 42})
+
+        async def rpc(method, params, rpc_id=None, **kwargs):
+            return await mock_rpc(method, params, rpc_id=rpc_id)
+
+        adapter._rpc = rpc
+
+        async def handler(_event):
+            await asyncio.sleep(0.05)
+            return "Hello **world**"
+
+        adapter.set_message_handler(handler)
+
+        source = SessionSource(
+            platform=Platform.SIGNAL,
+            chat_id="+155****9999",
+            chat_type="dm",
+            user_id="+155****9999",
+            user_name="tester",
+        )
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m1",
+        )
+
+        with caplog.at_level(logging.INFO):
+            await adapter._process_message_background(
+                event, build_session_key(source)
+            )
+
+        send_calls = [c for c in captured if c["method"] == "send"]
+        assert len(send_calls) == 1
+        assert send_calls[0]["params"]["message"] == "Hello world"
+
+        sending_info = [
+            r for r in caplog.records
+            if r.levelno == logging.INFO and "Sending response" in r.getMessage()
+        ]
+        # Only base's pre-markdown INFO line — Signal's post-markdown line
+        # is DEBUG now.
+        assert len(sending_info) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Signal typing indicators never appeared while Hermes processed a reply, even though `typing_indicator` defaults to on and the adapter implements `sendTyping`.

Root cause: `BasePlatformAdapter._keep_typing` hard-capped each `send_typing` call at **1.5s**. Slow signal-cli RPCs were cancelled by `asyncio.wait_for` before they landed, so no Hermes→Signal typing traffic reached the daemon. Signal already defined `TYPING_INTERVAL = 8.0` (matching the docs) but never used it — base always spawned the loop at the default 2s interval, so the 1.5s cap always applied.

This PR:
1. Scales the per-tick typing timeout with `interval` (`max(0.25, interval - 0.25)` instead of `min(1.5, …)`).
2. Overrides Signal `_keep_typing` so the unused 8s `TYPING_INTERVAL` is the actual default when base starts the refresh loop.
3. Demotes Signal’s duplicate “Sending response” INFO log to DEBUG. The reporter’s “double send” paired `gateway.platforms.base` + `gateway.platforms.signal` lines were one `send` RPC logged twice (pre-markdown vs post-markdown lengths), not two deliveries.

## Related Issue

Fixes #78972

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — remove the hard 1.5s `send_typing` timeout cap; budget is now `interval - 0.25s`
- `gateway/platforms/signal.py` — default `_keep_typing` to `TYPING_INTERVAL` (8s); demote post-markdown send log to DEBUG
- `tests/gateway/test_keep_typing_timeout.py` — assert a 2s `send_typing` completes under `interval=8`
- `tests/gateway/test_signal.py` — Signal interval default, slow-typing completion, and single-INFO / single-`send` RPC regression

## How to Test

1. **Unit (no signal-cli):**
   ```bash
   scripts/run_tests.sh tests/gateway/test_keep_typing_timeout.py tests/gateway/test_signal.py -q
   ```
2. **Pre-fix repro (mental model / script):** mock `_rpc` so `sendTyping` sleeps 2s; under the old 1.5s cap the coroutine is cancelled (`completed=0`). With this PR and Signal’s 8s interval on a turn longer than the RPC, `sendTyping` completes.
3. **Live Signal (optional):** send a DM/group message that takes several seconds to answer; confirm the typing bubble appears, and that a normal final reply produces one INFO “Sending response” line (not a base+signal pair).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin) via unit/integration mocks; no live signal-cli UI check

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

