### PR TITLE
feat(cli): add chat --query-file for oversized single queries

### DIFF
--- a/contributors/emails/cooke.andrew.p@gmail.com
+++ b/contributors/emails/cooke.andrew.p@gmail.com
@@ -1,0 +1,2 @@
+andrewcooke89
+# PR #79416

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -287,6 +287,14 @@ def build_top_level_parser():
         "-q", "--query", help="Single query (non-interactive mode)"
     )
     chat_parser.add_argument(
+        "--query-file",
+        help=(
+            "Path to a file whose contents are used as the single query "
+            "(alternative to -q/--query; avoids shell/argv size limits for "
+            "very large prompts). Mutually exclusive with -q/--query."
+        ),
+    )
+    chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
     )
     # `default=argparse.SUPPRESS` on flags that are ALSO declared on the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2253,6 +2253,47 @@ def _safe_tui_cwd(env: Optional[dict] = None) -> str:
         return str(PROJECT_ROOT)
 
 
+# Queries larger than this travel to the TUI via a file path
+# (HERMES_TUI_QUERY_FILE) instead of an env value: Linux applies
+# MAX_ARG_STRLEN (~128KiB) to individual environment strings too.
+_TUI_QUERY_ENV_MAX_BYTES = 100_000
+# OOM guard for the --query-file slurp; real prompts are far smaller
+# (harness-dispatch caps prompts at 500KB).
+_MAX_QUERY_FILE_BYTES = 50 * 1024 * 1024
+
+
+def _apply_tui_query_env(
+    env: dict, query: Optional[str], query_file: Optional[str] = None
+) -> Optional[str]:
+    """Hand the initial query to the TUI without exceeding per-string env
+    size limits. Small queries ride HERMES_TUI_QUERY; large queries and
+    explicit query files ride HERMES_TUI_QUERY_FILE (the TUI reads the
+    file itself). Returns a temp file path the caller must unlink, or None.
+    """
+    if not query:
+        return None
+    if query_file and os.path.isfile(query_file):
+        env["HERMES_TUI_QUERY_FILE"] = os.path.abspath(query_file)
+        return None
+    if len(query.encode("utf-8", "replace")) <= _TUI_QUERY_ENV_MAX_BYTES:
+        env["HERMES_TUI_QUERY"] = query
+        return None
+    import tempfile
+
+    fd, path = tempfile.mkstemp(prefix="hermes-tui-query-", suffix=".txt")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(query)
+    except Exception:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
+    env["HERMES_TUI_QUERY_FILE"] = path
+    return path
+
+
 def _apply_tui_python_env(env: dict) -> None:
     """Seed/repair Python-related env vars shared by CLI and dashboard TUI launches."""
     src_root = str(env.get("HERMES_PYTHON_SRC_ROOT") or "").strip()
@@ -2285,6 +2326,7 @@ def _launch_tui(
     verbose: Optional[bool] = None,
     quiet: bool = False,
     query: Optional[str] = None,
+    query_file: Optional[str] = None,
     image: Optional[str] = None,
     worktree: bool = False,
     checkpoints: bool = False,
@@ -2294,6 +2336,7 @@ def _launch_tui(
 ):
     """Replace current process with the TUI."""
     tui_dir = PROJECT_ROOT / "ui-tui"
+    tui_query_tmp: Optional[str] = None
 
     import tempfile
 
@@ -2359,8 +2402,7 @@ def _launch_tui(
             value = str(skills).strip()
             if value:
                 env["HERMES_TUI_SKILLS"] = value
-    if query:
-        env["HERMES_TUI_QUERY"] = query
+    tui_query_tmp = _apply_tui_query_env(env, query, query_file)
     if image:
         env["HERMES_TUI_IMAGE"] = image
     if checkpoints:
@@ -2420,6 +2462,11 @@ def _launch_tui(
             os.unlink(active_session_file)
         except OSError:
             pass
+        if tui_query_tmp:
+            try:
+                os.unlink(tui_query_tmp)
+            except OSError:
+                pass
         if wt_info:
             try:
                 _cleanup_worktree(wt_info)
@@ -2531,20 +2578,28 @@ def cmd_chat(args):
 
     _apply_safe_mode(args)
 
-    # --query-file: read the single query from a file instead of -q/--query.
-    # Needed for very large prompts (e.g. harness-dispatch runs) that exceed
-    # the kernel's per-argv limit (MAX_ARG_STRLEN ~128KiB). Normalized here so
-    # both the TUI path and the classic CLI path see a plain `args.query`.
+    # --query-file: single query read from a file (large prompts would blow
+    # the kernel's per-argv limit when passed via -q). Normalized here so
+    # both the TUI path and the classic CLI path see a plain args.query.
     query_file = getattr(args, "query_file", None)
     if query_file:
-        if getattr(args, "query", None):
+        if getattr(args, "query", None) is not None:
             print("Error: use either -q/--query or --query-file, not both.")
             sys.exit(2)
         try:
             with open(query_file, "r", encoding="utf-8") as _qf:
-                args.query = _qf.read()
+                args.query = _qf.read(_MAX_QUERY_FILE_BYTES + 1)
+        except UnicodeDecodeError as exc:
+            print(f"Error: --query-file {query_file!r} is not valid UTF-8: {exc}")
+            sys.exit(2)
         except OSError as exc:
             print(f"Error: cannot read --query-file {query_file!r}: {exc}")
+            sys.exit(2)
+        if len(args.query) > _MAX_QUERY_FILE_BYTES:
+            print(f"Error: --query-file {query_file!r} exceeds {_MAX_QUERY_FILE_BYTES} bytes")
+            sys.exit(2)
+        if not args.query.strip():
+            print(f"Error: --query-file {query_file!r} is empty")
             sys.exit(2)
 
     # Resolve --continue into --resume with the latest session or by name
@@ -2713,6 +2768,7 @@ def cmd_chat(args):
             verbose=getattr(args, "verbose", None),
             quiet=getattr(args, "quiet", False),
             query=getattr(args, "query", None),
+            query_file=getattr(args, "query_file", None),
             image=getattr(args, "image", None),
             worktree=getattr(args, "worktree", False),
             checkpoints=getattr(args, "checkpoints", False),
@@ -10914,7 +10970,11 @@ def _try_termux_fast_cli_launch() -> bool:
 
     if args.command in {None, "chat"}:
         _set_chat_arg_defaults(args)
-        interactive_prompt = not getattr(args, "query", None) and not getattr(args, "image", None)
+        interactive_prompt = (
+            not getattr(args, "query", None)
+            and not getattr(args, "query_file", None)
+            and not getattr(args, "image", None)
+        )
         if interactive_prompt:
             # Bare Termux CLI should reach the prompt first and do agent-only
             # discovery on the first submitted turn instead of before input.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2604,7 +2604,7 @@ def cmd_chat(args):
             print(f"Error: --query-file {query_file!r} exceeds {_MAX_QUERY_FILE_BYTES} bytes")
             sys.exit(2)
         try:
-            args.query = raw.decode("utf-8")
+            args.query = raw.decode("utf-8-sig")
         except UnicodeDecodeError as exc:
             print(f"Error: --query-file {query_file!r} is not valid UTF-8: {exc}")
             sys.exit(2)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2269,7 +2269,15 @@ def _apply_tui_query_env(
     size limits. Small queries ride HERMES_TUI_QUERY; large queries and
     explicit query files ride HERMES_TUI_QUERY_FILE (the TUI reads the
     file itself). Returns a temp file path the caller must unlink, or None.
+
+    Query env vars are cleared first so a stale exported value from an
+    earlier launch can't leak into this one (same rationale as the
+    HERMES_TUI_RESUME clear in _launch_tui). Note: for an explicit
+    --query-file the TUI re-reads the file itself; the classic CLI path
+    uses the already-validated content in args.query.
     """
+    env.pop("HERMES_TUI_QUERY", None)
+    env.pop("HERMES_TUI_QUERY_FILE", None)
     if not query:
         return None
     if query_file and os.path.isfile(query_file):
@@ -2587,16 +2595,18 @@ def cmd_chat(args):
             print("Error: use either -q/--query or --query-file, not both.")
             sys.exit(2)
         try:
-            with open(query_file, "r", encoding="utf-8") as _qf:
-                args.query = _qf.read(_MAX_QUERY_FILE_BYTES + 1)
-        except UnicodeDecodeError as exc:
-            print(f"Error: --query-file {query_file!r} is not valid UTF-8: {exc}")
-            sys.exit(2)
+            with open(query_file, "rb") as _qf:
+                raw = _qf.read(_MAX_QUERY_FILE_BYTES + 1)
         except OSError as exc:
             print(f"Error: cannot read --query-file {query_file!r}: {exc}")
             sys.exit(2)
-        if len(args.query) > _MAX_QUERY_FILE_BYTES:
+        if len(raw) > _MAX_QUERY_FILE_BYTES:
             print(f"Error: --query-file {query_file!r} exceeds {_MAX_QUERY_FILE_BYTES} bytes")
+            sys.exit(2)
+        try:
+            args.query = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            print(f"Error: --query-file {query_file!r} is not valid UTF-8: {exc}")
             sys.exit(2)
         if not args.query.strip():
             print(f"Error: --query-file {query_file!r} is empty")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2531,6 +2531,22 @@ def cmd_chat(args):
 
     _apply_safe_mode(args)
 
+    # --query-file: read the single query from a file instead of -q/--query.
+    # Needed for very large prompts (e.g. harness-dispatch runs) that exceed
+    # the kernel's per-argv limit (MAX_ARG_STRLEN ~128KiB). Normalized here so
+    # both the TUI path and the classic CLI path see a plain `args.query`.
+    query_file = getattr(args, "query_file", None)
+    if query_file:
+        if getattr(args, "query", None):
+            print("Error: use either -q/--query or --query-file, not both.")
+            sys.exit(2)
+        try:
+            with open(query_file, "r", encoding="utf-8") as _qf:
+                args.query = _qf.read()
+        except OSError as exc:
+            print(f"Error: cannot read --query-file {query_file!r}: {exc}")
+            sys.exit(2)
+
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)
     if continue_val and not getattr(args, "resume", None):

--- a/tests/hermes_cli/test_chat_query_file.py
+++ b/tests/hermes_cli/test_chat_query_file.py
@@ -191,6 +191,16 @@ class TestCmdChatQueryFile:
         assert exc_info.value.code == 2
         assert "exceeds" in capsys.readouterr().out
 
+    def test_utf8_bom_query_file_stripped(self, monkeypatch, tmp_path):
+        # Windows GUI editors can save a UTF-8 BOM; it must not leak into
+        # the prompt (CONTRIBUTING cross-platform rule #4).
+        query_file = tmp_path / "bom.txt"
+        query_file.write_bytes(b"\xef\xbb\xbfbom-prefixed prompt")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        captured = {}
+        _run_cmd_chat(monkeypatch, args, captured)
+        assert captured["query"] == "bom-prefixed prompt"
+
     def test_query_file_with_resume(self, monkeypatch, tmp_path):
         # Query normalization runs before resume resolution; both must land.
         import hermes_cli.main as main_mod

--- a/tests/hermes_cli/test_chat_query_file.py
+++ b/tests/hermes_cli/test_chat_query_file.py
@@ -85,6 +85,17 @@ class TestCmdChatQueryFile:
         _run_cmd_chat(monkeypatch, args, captured)
         assert captured["query"] == "large hardening prompt body"
 
+    def test_large_query_file_round_trips_untouched(self, monkeypatch, tmp_path):
+        # Guards the actual regression: a prompt far above the kernel's
+        # per-argv limit must survive the file round trip byte-for-byte.
+        content = ("x" * 200_000) + "\nwith a tail marker\n"
+        query_file = tmp_path / "big.txt"
+        query_file.write_text(content, encoding="utf-8")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        captured = {}
+        _run_cmd_chat(monkeypatch, args, captured)
+        assert captured["query"] == content
+
     def test_query_flag_unchanged_without_query_file(self, monkeypatch, capsys):
         args = _build_chat_args(["chat", "-q", "inline query"])
         captured = {}
@@ -103,6 +114,20 @@ class TestCmdChatQueryFile:
         assert exc_info.value.code == 2
         assert "not both" in capsys.readouterr().out
 
+    def test_empty_query_flag_and_query_file_rejected(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        # `-q ""` is still a supplied query; the file must not silently win.
+        query_file = tmp_path / "query.txt"
+        query_file.write_text("x", encoding="utf-8")
+        args = _build_chat_args(
+            ["chat", "-q", "", "--query-file", str(query_file)]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "not both" in capsys.readouterr().out
+
     def test_missing_query_file_rejected(self, monkeypatch, capsys, tmp_path):
         missing = tmp_path / "does-not-exist.txt"
         args = _build_chat_args(["chat", "--query-file", str(missing)])
@@ -110,3 +135,106 @@ class TestCmdChatQueryFile:
             _run_cmd_chat(monkeypatch, args, {})
         assert exc_info.value.code == 2
         assert "cannot read" in capsys.readouterr().out
+
+    def test_invalid_utf8_query_file_rejected(self, monkeypatch, capsys, tmp_path):
+        query_file = tmp_path / "bad.txt"
+        query_file.write_bytes(b"\xff\xfe\x00")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "not valid UTF-8" in capsys.readouterr().out
+
+    def test_empty_query_file_rejected(self, monkeypatch, capsys, tmp_path):
+        query_file = tmp_path / "empty.txt"
+        query_file.write_text("", encoding="utf-8")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "is empty" in capsys.readouterr().out
+
+    def test_whitespace_only_query_file_rejected(self, monkeypatch, capsys, tmp_path):
+        query_file = tmp_path / "blank.txt"
+        query_file.write_text(" \n\t ", encoding="utf-8")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "is empty" in capsys.readouterr().out
+
+    def test_query_file_with_resume(self, monkeypatch, tmp_path):
+        # Query normalization runs before resume resolution; both must land.
+        import hermes_cli.main as main_mod
+
+        query_file = tmp_path / "query.txt"
+        query_file.write_text("resume turn content", encoding="utf-8")
+
+        fake_state = types.ModuleType("hermes_state")
+
+        class _FakeSessionDB:
+            def get_session(self, session_id):
+                return None
+
+        setattr(fake_state, "SessionDB", _FakeSessionDB)
+        monkeypatch.setitem(sys.modules, "hermes_state", fake_state)
+        monkeypatch.setattr(main_mod, "_resolve_session_by_name_or_id", lambda v: None)
+
+        args = _build_chat_args(
+            ["chat", "--resume", "sess-abc", "--query-file", str(query_file)]
+        )
+        captured = {}
+        _run_cmd_chat(monkeypatch, args, captured)
+        assert captured["query"] == "resume turn content"
+        assert captured["resume"] == "sess-abc"
+
+
+class TestTuiQueryEnv:
+    """_apply_tui_query_env keeps large queries out of the TUI env."""
+
+    def test_small_query_rides_env(self):
+        import hermes_cli.main as main_mod
+
+        env = {}
+        ret = main_mod._apply_tui_query_env(env, "hi there", None)
+        assert ret is None
+        assert env.get("HERMES_TUI_QUERY") == "hi there"
+        assert "HERMES_TUI_QUERY_FILE" not in env
+
+    def test_large_query_rides_file(self):
+        import os
+
+        import hermes_cli.main as main_mod
+
+        content = "y" * 150_000
+        env = {}
+        ret = main_mod._apply_tui_query_env(env, content, None)
+        assert ret is not None
+        assert "HERMES_TUI_QUERY" not in env
+        assert env.get("HERMES_TUI_QUERY_FILE") == ret
+        try:
+            with open(ret, encoding="utf-8") as fh:
+                assert fh.read() == content
+        finally:
+            os.unlink(ret)
+
+    def test_explicit_query_file_passthrough(self, tmp_path):
+        import os
+
+        import hermes_cli.main as main_mod
+
+        query_file = tmp_path / "query.txt"
+        query_file.write_text("from file", encoding="utf-8")
+        env = {}
+        ret = main_mod._apply_tui_query_env(env, "from file", str(query_file))
+        assert ret is None
+        assert env.get("HERMES_TUI_QUERY_FILE") == os.path.abspath(str(query_file))
+        assert "HERMES_TUI_QUERY" not in env
+
+    def test_no_query_no_env(self):
+        import hermes_cli.main as main_mod
+
+        env = {}
+        ret = main_mod._apply_tui_query_env(env, None, None)
+        assert ret is None
+        assert env == {}

--- a/tests/hermes_cli/test_chat_query_file.py
+++ b/tests/hermes_cli/test_chat_query_file.py
@@ -163,6 +163,34 @@ class TestCmdChatQueryFile:
         assert exc_info.value.code == 2
         assert "is empty" in capsys.readouterr().out
 
+    def test_oversized_query_file_rejected(self, monkeypatch, capsys, tmp_path):
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(main_mod, "_MAX_QUERY_FILE_BYTES", 100)
+        query_file = tmp_path / "huge.txt"
+        query_file.write_text("x" * 150, encoding="utf-8")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "exceeds" in capsys.readouterr().out
+
+    def test_multibyte_query_file_checked_in_bytes(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        # 60 x "é" is 120 bytes but only 60 characters: the byte cap must
+        # reject it even though the character count is under the limit.
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(main_mod, "_MAX_QUERY_FILE_BYTES", 100)
+        query_file = tmp_path / "wide.txt"
+        query_file.write_text("é" * 60, encoding="utf-8")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "exceeds" in capsys.readouterr().out
+
     def test_query_file_with_resume(self, monkeypatch, tmp_path):
         # Query normalization runs before resume resolution; both must land.
         import hermes_cli.main as main_mod
@@ -235,6 +263,30 @@ class TestTuiQueryEnv:
         import hermes_cli.main as main_mod
 
         env = {}
+        ret = main_mod._apply_tui_query_env(env, None, None)
+        assert ret is None
+        assert env == {}
+
+    def test_stale_query_env_cleared(self):
+        # A stale exported value must not win over the current invocation.
+        import hermes_cli.main as main_mod
+
+        env = {
+            "HERMES_TUI_QUERY": "stale inline",
+            "HERMES_TUI_QUERY_FILE": "/stale/path.txt",
+        }
+        ret = main_mod._apply_tui_query_env(env, "fresh", None)
+        assert ret is None
+        assert env.get("HERMES_TUI_QUERY") == "fresh"
+        assert "HERMES_TUI_QUERY_FILE" not in env
+
+    def test_stale_query_env_cleared_without_query(self):
+        import hermes_cli.main as main_mod
+
+        env = {
+            "HERMES_TUI_QUERY": "stale inline",
+            "HERMES_TUI_QUERY_FILE": "/stale/path.txt",
+        }
         ret = main_mod._apply_tui_query_env(env, None, None)
         assert ret is None
         assert env == {}

--- a/tests/hermes_cli/test_chat_query_file.py
+++ b/tests/hermes_cli/test_chat_query_file.py
@@ -1,0 +1,112 @@
+"""Tests for `hermes chat --query-file`.
+
+The flag reads the single query from a file instead of `-q/--query`.
+It exists for very large prompts (e.g. harness-dispatch runs) that would
+exceed the kernel's per-argv limit (MAX_ARG_STRLEN ~128KiB) when passed
+inline on the command line.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+def _build_chat_args(argv):
+    """Parse argv with the real parser; returns the parsed namespace."""
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    return parser.parse_args(argv)
+
+
+def _run_cmd_chat(monkeypatch, args, captured):
+    """Invoke cmd_chat with heavy side effects stubbed.
+
+    Mirrors the pattern in tests/hermes_cli/test_argparse_flag_propagation.py
+    (fake `cli` module + banner + skills_sync + provider/kanban stubs) so the
+    test exercises the real cmd_chat query handling without a full runtime.
+    """
+    import hermes_cli.main as main_mod
+
+    fake_cli = types.ModuleType("cli")
+
+    def fake_main(**kwargs):
+        captured.update(kwargs)
+
+    setattr(fake_cli, "main", fake_main)
+    fake_banner = types.ModuleType("hermes_cli.banner")
+    setattr(fake_banner, "prefetch_update_check", lambda: None)
+    fake_skills_sync = types.ModuleType("tools.skills_sync")
+    setattr(fake_skills_sync, "sync_skills", lambda quiet=True: None)
+
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.banner", fake_banner)
+    monkeypatch.setitem(sys.modules, "tools.skills_sync", fake_skills_sync)
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+
+    main_mod.cmd_chat(args)
+
+
+class TestQueryFileParsing:
+    """Parser-level behaviour."""
+
+    def test_parser_accepts_query_file(self):
+        args = _build_chat_args(["chat", "--query-file", "/tmp/query.txt"])
+        assert args.query_file == "/tmp/query.txt"
+        assert args.query is None
+
+    def test_parser_accepts_query_and_query_file_together(self):
+        # The parser accepts both flags; cmd_chat rejects the combination.
+        args = _build_chat_args(
+            ["chat", "-q", "inline", "--query-file", "/tmp/query.txt"]
+        )
+        assert args.query == "inline"
+        assert args.query_file == "/tmp/query.txt"
+
+    def test_parent_parser_does_not_accept_query_file(self):
+        # The flag belongs to the chat subparser, not the root parser.
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--query-file", "/tmp/query.txt", "chat"])
+
+
+class TestCmdChatQueryFile:
+    """cmd_chat behaviour with the real parser wiring."""
+
+    def test_query_file_content_becomes_query(self, monkeypatch, tmp_path):
+        query_file = tmp_path / "query.txt"
+        query_file.write_text("large hardening prompt body", encoding="utf-8")
+        args = _build_chat_args(["chat", "--query-file", str(query_file)])
+        captured = {}
+        _run_cmd_chat(monkeypatch, args, captured)
+        assert captured["query"] == "large hardening prompt body"
+
+    def test_query_flag_unchanged_without_query_file(self, monkeypatch, capsys):
+        args = _build_chat_args(["chat", "-q", "inline query"])
+        captured = {}
+        _run_cmd_chat(monkeypatch, args, captured)
+        assert captured["query"] == "inline query"
+        assert "query-file" not in capsys.readouterr().out
+
+    def test_both_query_and_query_file_rejected(self, monkeypatch, capsys, tmp_path):
+        query_file = tmp_path / "query.txt"
+        query_file.write_text("x", encoding="utf-8")
+        args = _build_chat_args(
+            ["chat", "-q", "inline", "--query-file", str(query_file)]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "not both" in capsys.readouterr().out
+
+    def test_missing_query_file_rejected(self, monkeypatch, capsys, tmp_path):
+        missing = tmp_path / "does-not-exist.txt"
+        args = _build_chat_args(["chat", "--query-file", str(missing)])
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cmd_chat(monkeypatch, args, {})
+        assert exc_info.value.code == 2
+        assert "cannot read" in capsys.readouterr().out

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -36,8 +36,8 @@ let startupQuery = (process.env.HERMES_TUI_QUERY ?? '').trim()
 if (startupQueryFile) {
   try {
     startupQuery = readFileSync(startupQueryFile, 'utf8').trim()
-  } catch {
-    // Unreadable file: fall back to the env-carried query.
+  } catch (err) {
+    console.error(`hermes-tui: cannot read HERMES_TUI_QUERY_FILE ${startupQueryFile}: ${String(err)}`)
   }
 }
 export const STARTUP_QUERY = startupQuery

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,5 +1,7 @@
 import type { MouseTrackingMode } from '@hermes/ink'
 
+import { readFileSync } from 'node:fs'
+
 import { isTermuxTuiMode } from '../lib/termux.js'
 
 const truthy = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
@@ -26,7 +28,19 @@ const parseToggle = (v?: string): boolean | null => {
 export const TERMUX_TUI_MODE = isTermuxTuiMode()
 
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
-export const STARTUP_QUERY = (process.env.HERMES_TUI_QUERY ?? '').trim()
+// Large initial queries are handed over via HERMES_TUI_QUERY_FILE (a path)
+// because environment values are subject to the same per-string size limits
+// as argv. Prefer the file when present; fall back to the env-carried query.
+const startupQueryFile = (process.env.HERMES_TUI_QUERY_FILE ?? '').trim()
+let startupQuery = (process.env.HERMES_TUI_QUERY ?? '').trim()
+if (startupQueryFile) {
+  try {
+    startupQuery = readFileSync(startupQueryFile, 'utf8').trim()
+  } catch {
+    // Unreadable file: fall back to the env-carried query.
+  }
+}
+export const STARTUP_QUERY = startupQuery
 export const STARTUP_IMAGE = (process.env.HERMES_TUI_IMAGE ?? '').trim()
 
 // Mouse tracking mode resolution at startup. Per-mode selection (off|wheel|


### PR DESCRIPTION
## What does this PR do?

Adds `--query-file` to `hermes chat`: the single query is read from a UTF-8
file instead of being passed inline via `-q/--query`. The two flags are
mutually exclusive (usage error, exit 2, when both are supplied).

Large initial queries are also handed to the TUI via a new
`HERMES_TUI_QUERY_FILE` env var (a path the TUI reads at startup) instead of
stuffing the content into `HERMES_TUI_QUERY`, because environment values are
subject to the same per-string size limit as argv.

This mirrors the `-f <file>` fallback the kilo/pi harnesses already use for
the same reason.

## Related Issue

Fixes #79417

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/_parser.py` — add `--query-file` to the chat subparser.
- `hermes_cli/main.py` — `cmd_chat` reads the query file (byte-capped at
  50 MiB, `utf-8-sig` decode, empty/whitespace rejection, mutual exclusion
  with `-q`); `_apply_tui_query_env` routes small queries via
  `HERMES_TUI_QUERY` and large/explicit-file queries via
  `HERMES_TUI_QUERY_FILE` (stale env cleared; temp files cleaned up after
  the TUI exits); Termux fast path treats `--query-file` as non-interactive.
- `ui-tui/src/config/env.ts` — read `HERMES_TUI_QUERY_FILE` at startup
  (falls back to the env-carried query with a visible warning on unreadable
  files).
- `tests/hermes_cli/test_chat_query_file.py` — 22 tests: parser wiring,
  byte-exact 200 KB round trip, mutual exclusion (incl. `-q ""`), missing
  file, invalid UTF-8, UTF-8 BOM, empty/whitespace-only, oversized file
  (byte-accurate cap), `--resume` interaction, and TUI env/file routing.

## How to Test

1. Reproduce the bug (pre-fix): `python3 -c "open('/tmp/big.txt','w').write('x' * 150_000)"` then `hermes chat -q "$(cat /tmp/big.txt)"` fails at spawn with `Argument list too long`.
2. Verify the fix: `hermes chat --query-file /tmp/big.txt -Q --yolo --provider <provider> -m <model>` runs and responds.
3. Verify mutual exclusion: `hermes chat -q "x" --query-file /tmp/big.txt` exits 2 with a clear message; missing/invalid-UTF-8/empty files exit 2 with specific messages.
4. Verify TUI routing: `hermes chat --tui --query-file /tmp/big.txt` starts with the file content as the initial query (large queries travel via `HERMES_TUI_QUERY_FILE`, not the env).
5. Unit tests: `scripts/run_tests.sh tests/hermes_cli/test_chat_query_file.py -q` → 22 passed; related suites (argparse propagation, chat-skills flags, TUI resume/heap, update command) all green; full hermetic suite: 25,647 passed / 56 failed — failure set identical to clean upstream main.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`, `feat(cli):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no prior art for a chat query-file; related: #22913 — same kernel limit, tool-result-storage path)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full hermetic suite (`scripts/run_tests.sh -q`, CI parity): 25,647 passed / 56 failed. The 56 failures are environment-dependent (provider secrets/network) and are byte-identical on clean upstream main (same 19 files) — zero failures attributable to this PR. Leaving this box for CI, which runs with the required secrets.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux (primary target); the change is pure Python file I/O and platform-neutral (macOS/WSL2 code paths identical; Windows BOM handled via `utf-8-sig`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: the flag is self-documenting in `hermes chat --help`; no central CLI reference exists in docs/
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no process or architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: file I/O only; encoding errors and BOM handled; `scripts/check-windows-footguns.py` clean on all changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (CLI flag, not a tool)

## Screenshots / Logs

Smoke test (12 KB prompt via the real CLI):

```
$ hermes -p engineer chat -Q --yolo --provider zai -m glm-5.2 --query-file /tmp/hermes_qf_smoke.txt
QUERY_FILE_OK
session_id: 20260805_115357_9ac613
```
