### PR TITLE
chore: map zhjay@stu.xjtu.edu.cn to ZHJay

### DIFF
--- a/contributors/emails/zhjay@stu.xjtu.edu.cn
+++ b/contributors/emails/zhjay@stu.xjtu.edu.cn
@@ -1,0 +1,2 @@
+ZHJay
+# PRs for #77472 security cluster


### PR DESCRIPTION
## What / Why

Adds the `contributors/emails/` mapping for my commit author email so `Check contributors` can attribute my commits.

Without it that job fails, and it is a required `needs:` of the `all-checks-pass` aggregate — so it fails before any test runs. That currently blocks all seven PRs I have open against #77472:

| PR | branch |
|---|---|
| #77520 | `fix/transcript-artifact-file-modes` |
| #77655 | `fix/at-rest-remaining-transcript-sites` |
| #77579 | `fix/browser-profile-media-cache-modes` |
| #77717 | `fix/shutdown-flush-managed-mode` |
| #78379 | `fix/redact-preserves-json-delimiters` |
| #78395 | `fix/bound-request-dump-growth` |
| #78408 | `fix/trajectory-cwd-git-guard` |

Measured on `upstream/main` at `1be70d635`:

```
all 7 branches, author email:            zhjay@stu.xjtu.edu.cn
contributors/emails/ entries on main:    751 files, 0 matching
grep zhjay scripts/release.py:           0
```

Landing this first makes the other seven attributable; it is otherwise independent of them.

## Changes Made

- `contributors/emails/zhjay@stu.xjtu.edu.cn` — new, 2 lines: the login plus a comment naming the cluster.

One file per email, per the directory's own convention. `scripts/add_contributor.py` and its docstring both say the legacy `AUTHOR_MAP` in `scripts/release.py` is frozen and must not be appended to, so this goes in the conflict-free directory instead.

## How to Test

Generated with the repo's own script rather than by hand, so the filename and content follow whatever it enforces:

```
$ python3 scripts/add_contributor.py zhjay@stu.xjtu.edu.cn ZHJay "PRs for #77472 security cluster"
added: contributors/emails/zhjay@stu.xjtu.edu.cn -> ZHJay
```

Re-running it prints `present` and exits 0 (idempotent), and it refuses with exit 1 if an email already maps to a different login, so a typo cannot silently reassign someone else's commits.

The check this satisfies, from `.github/workflows/contributor-check.yml`:

```
if [ -f "contributors/emails/${email}" ]; then
  continue  # mapped via the contributors directory
fi
```

Note: the script requires Python 3.10+ (`str | None` annotations). On 3.9 it fails with `TypeError: unsupported operand type(s) for |`. Not a change in this PR, just what I hit.

## Platforms Tested

- [x] macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

No code paths change, so there is nothing platform-specific to exercise.

## Related Issue

Unblocks CI attribution for the seven PRs listed above, which address #77472.
