### PR TITLE
fix(feishu): render clarify prompts as interactive card buttons with text fallback

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1536,6 +1536,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Clarify button state (clarify_id → {choices, session_key, message_id, chat_id})
+        self._clarify_state: Dict[str, Dict[str, Any]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -2175,6 +2177,177 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_update_prompt failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt as an interactive card with one button per choice.
+
+        Multi-choice mode (``choices`` non-empty): renders an interactive card
+        with one button per option plus a final "✏️ Other (type answer)"
+        button.  Button callbacks resolve the pending clarify via
+        ``tools.clarify_gateway.resolve_gateway_clarify``; picking "Other"
+        flips the entry into text-capture mode so the next message becomes
+        the response.
+
+        Open-ended mode (``choices`` empty): falls through to the base
+        plain-text render — the question is sent as a text message and the
+        gateway's text-intercept resolves it.
+
+        If sending the interactive card fails (e.g. the Feishu app lacks the
+        interactive-card capability), we fall back to a plain text numbered
+        list (base behavior) so the user can still reply with a number.  The
+        card body deliberately uses plain text lines instead of markdown
+        ordered-list syntax (``1. ...``): Feishu's ``md`` renderer does not
+        support list syntax and swallows the option lines, which is exactly
+        the "选项内容消失" bug this override fixes (see GitHub issue #9816).
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            if choices:
+                # Multi-select clarifies are NOT button-friendly on Feishu
+                # (buttons resolve immediately, one pick at a time), so keep
+                # the base text-fallback behavior for them.
+                _is_multi = False
+                try:
+                    from tools import clarify_gateway as _cg
+                    with _cg._lock:
+                        _entry = _cg._entries.get(clarify_id)
+                    _is_multi = bool(_entry and getattr(_entry, "multi_select", False))
+                except Exception:
+                    _is_multi = False
+
+                if _is_multi:
+                    return await super().send_clarify(
+                        chat_id=chat_id,
+                        question=question,
+                        choices=choices,
+                        clarify_id=clarify_id,
+                        session_key=session_key,
+                        metadata=metadata,
+                    )
+
+                card = self._build_clarify_card(
+                    question=question,
+                    choices=list(choices),
+                    clarify_id=clarify_id,
+                )
+                payload = json.dumps(card, ensure_ascii=False)
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="interactive",
+                    payload=payload,
+                    reply_to=None,
+                    metadata=metadata,
+                )
+                result = self._finalize_send_result(response, "clarify card send failed")
+                if result.success:
+                    self._clarify_state[clarify_id] = {
+                        "session_key": session_key,
+                        "message_id": result.message_id or "",
+                        "chat_id": chat_id,
+                        "choices": list(choices),
+                    }
+                    return result
+                logger.warning(
+                    "[Feishu] clarify card send failed (%s); falling back to plain text list",
+                    result.error,
+                )
+
+            # Fallback / open-ended: plain-text numbered list.  Send as a
+            # ``text`` message (not ``post``/md) so Feishu renders the option
+            # lines verbatim — the md renderer swallows list syntax.
+            text = f"❓ {question}"
+            if choices:
+                lines = [text, ""]
+                for i, choice in enumerate(choices, start=1):
+                    lines.append(f"  {i}. {choice}")
+                lines.append("")
+                lines.append(
+                    "Reply with the number, the option text, or your own answer."
+                )
+                text = "\n".join(lines)
+            from tools.clarify_gateway import mark_awaiting_text
+            mark_awaiting_text(clarify_id)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": text}, ensure_ascii=False),
+                reply_to=None,
+                metadata=metadata,
+            )
+            return self._finalize_send_result(response, "clarify text send failed")
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_clarify_card(*, question: str, choices: List[str], clarify_id: str) -> Dict[str, Any]:
+        """Build a Feishu interactive card for a multi-choice clarify prompt.
+
+        The body renders each option as a plain text line (NOT markdown
+        ordered-list syntax — Feishu's md renderer swallows ``1. ...`` lines,
+        see GitHub issue #9816).  Buttons carry short numeric labels (1, 2,
+        3, …, Other) so long option text stays readable in the body and the
+        button row stays compact on mobile.
+        """
+        def _btn(label: str, value: dict, btn_type: str = "default") -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": value,
+            }
+
+        actions = [
+            _btn(str(idx), {
+                "hermes_clarify_action": clarify_id,
+                "choice_index": idx - 1,
+            })
+            for idx in range(1, len(choices) + 1)
+        ]
+        actions.append(_btn("✏️ Other", {
+            "hermes_clarify_action": clarify_id,
+            "choice_index": -1,
+        }))
+
+        option_lines = "\n".join(
+            f"{idx}. {choice}" for idx, choice in enumerate(choices, start=1)
+        )
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "❓ Please choose", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"**{question}**\n\n{option_lines}"},
+                {"tag": "action", "actions": actions},
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"✅ Answered: {choice}", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"Answered by **{user_name}**"},
+            ],
+        }
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
@@ -2714,11 +2887,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if clarify_action:
+            return self._handle_clarify_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2870,6 +3053,117 @@ class FeishuAdapter(BasePlatformAdapter):
             card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
             response.card = card
         return response
+
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Handle a clarify card button click: resolve the pending clarify.
+
+        Mirrors the update-prompt flow: validates the operator and chat,
+        schedules the resolve on the event loop, and returns a synchronous
+        callback response that swaps the card to an "Answered: <choice>" state.
+        Picking the "Other" button (``choice_index == -1``) flips the entry
+        into text-capture mode so the next message resolves it instead.
+        """
+        clarify_id = str(action_value.get("hermes_clarify_action", "") or "")
+        choice_index = action_value.get("choice_index")
+        if not clarify_id or choice_index is None:
+            logger.debug("[Feishu] Clarify card action missing clarify_id/choice_index, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        state = self._clarify_state.get(clarify_id)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Clarify callback chat mismatch for %s (expected=%s, got=%s)",
+                clarify_id,
+                expected_chat_id,
+                callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        choices = state.get("choices") or []
+
+        try:
+            idx = int(choice_index)
+        except (TypeError, ValueError):
+            idx = -1
+
+        if 0 <= idx < len(choices):
+            choice_text = str(choices[idx])
+        else:
+            choice_text = None  # "Other" (or out-of-range) → text capture
+
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_clarify(
+                clarify_id=clarify_id,
+                choice_text=choice_text,
+                user_name=user_name,
+                open_id=open_id,
+                chat_id=callback_chat_id,
+            ),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_clarify_card(
+                choice=choice_text or "Other (type answer)",
+                user_name=user_name,
+            )
+            response.card = card
+        return response
+
+    async def _resolve_clarify(
+        self,
+        *,
+        clarify_id: str,
+        choice_text: Optional[str],
+        user_name: str,
+        open_id: str = "",
+        chat_id: str = "",
+    ) -> None:
+        """Resolve a pending clarify from a card button click.
+
+        ``choice_text`` of None means the user picked "Other" — flip the entry
+        into text-capture mode so the next typed message becomes the response.
+        """
+        from tools.clarify_gateway import mark_awaiting_text, resolve_gateway_clarify
+
+        state = self._clarify_state.pop(clarify_id, None)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return
+
+        if choice_text is None:
+            mark_awaiting_text(clarify_id)
+            logger.info("[Feishu] Clarify %s: user chose 'Other', awaiting text", clarify_id)
+            return
+
+        ok = resolve_gateway_clarify(clarify_id, choice_text)
+        logger.info(
+            "[Feishu] Clarify %s resolved by %s -> %r (ok=%s)",
+            clarify_id,
+            open_id or user_name or "<unknown>",
+            choice_text,
+            ok,
+        )
 
     async def _resolve_approval(
         self,

--- a/tests/gateway/test_feishu_clarify_buttons.py
+++ b/tests/gateway/test_feishu_clarify_buttons.py
@@ -1,0 +1,346 @@
+"""Tests for Feishu interactive card clarify buttons + plain-text fallback.
+
+Covers:
+- send_clarify sends an interactive card with one button per choice + Other
+- send_clarify stores clarify state for callback routing
+- send_clarify falls back to plain text when the card send fails (B plan:
+  the md renderer swallows ordered-list syntax, so the fallback sends a
+  ``text`` message instead of ``post``/md)
+- _handle_clarify_card_action resolves the pending clarify via
+  tools.clarify_gateway
+- picking "Other" flips the entry into text-capture mode
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Feishu mock so FeishuAdapter can be imported without lark-oapi
+# ---------------------------------------------------------------------------
+def _ensure_feishu_mocks():
+    """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig  # noqa: E402
+import plugins.platforms.feishu.adapter as feishu_module  # noqa: E402
+from plugins.platforms.feishu.adapter import FeishuAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> FeishuAdapter:
+    """Create a FeishuAdapter with mocked internals."""
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_clarify_1",
+) -> SimpleNamespace:
+    """Create a mock Feishu card action callback data object."""
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(
+                tag="button",
+                value=action_value,
+            ),
+        ),
+    )
+
+
+def _close_submitted_coro(coro, _loop):
+    """Close scheduled coroutines in sync-handler tests to avoid unawaited warnings."""
+    coro.close()
+    return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+
+# ===========================================================================
+# send_clarify — interactive card with buttons (A plan)
+# ===========================================================================
+
+class TestFeishuClarifyCard:
+    """Test send_clarify sends an interactive card with choice buttons."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_cl_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="你想选哪个方案？",
+                choices=["方案A", "方案B", "方案C"],
+                clarify_id="cl_abc123",
+                session_key="agent:main:feishu:dm:oc_12345",
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_cl_001"
+
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        # Question in the markdown body
+        body = card["elements"][0]["content"]
+        assert "你想选哪个方案？" in body
+        # Option text is rendered as plain lines (no md ordered-list syntax)
+        assert "1. 方案A" in body
+        assert "2. 方案B" in body
+        assert "3. 方案C" in body
+
+        # Buttons: one per choice + Other
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 4
+        values = [a["value"] for a in actions]
+        assert values[0] == {"hermes_clarify_action": "cl_abc123", "choice_index": 0}
+        assert values[1] == {"hermes_clarify_action": "cl_abc123", "choice_index": 1}
+        assert values[2] == {"hermes_clarify_action": "cl_abc123", "choice_index": 2}
+        assert values[3] == {"hermes_clarify_action": "cl_abc123", "choice_index": -1}
+
+    @pytest.mark.asyncio
+    async def test_stores_clarify_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_cl_002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_clarify(
+                chat_id="oc_12345",
+                question="Q?",
+                choices=["X", "Y"],
+                clarify_id="cl_store1",
+                session_key="my-session-key",
+            )
+
+        state = adapter._clarify_state.get("cl_store1")
+        assert state is not None
+        assert state["session_key"] == "my-session-key"
+        assert state["message_id"] == "msg_cl_002"
+        assert state["chat_id"] == "oc_12345"
+        assert state["choices"] == ["X", "Y"]
+
+
+# ===========================================================================
+# send_clarify — plain-text fallback (B plan: md swallows lists)
+# ===========================================================================
+
+class TestFeishuClarifyTextFallback:
+    """Test send_clarify falls back to a text message when the card fails."""
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_plain_text_on_card_failure(self):
+        adapter = _make_adapter()
+
+        fail_response = SimpleNamespace(
+            success=lambda: False,
+            data=SimpleNamespace(message_id=""),
+        )
+        # First call (interactive card) fails → second call (text) succeeds
+        mock_send = AsyncMock(side_effect=[fail_response, fail_response])
+
+        with patch.object(adapter, "_feishu_send_with_retry", mock_send):
+            with patch("tools.clarify_gateway.mark_awaiting_text") as mock_mark:
+                result = await adapter.send_clarify(
+                    chat_id="oc_12345",
+                    question="选择困难？",
+                    choices=["A", "B"],
+                    clarify_id="cl_fb1",
+                    session_key="sess",
+                )
+
+        assert result.success is False  # text send also "failed" in this mock
+        # Second send must be msg_type="text" (not post/md) so the option
+        # lines render verbatim instead of being swallowed by the md renderer.
+        text_kwargs = mock_send.call_args_list[1][1]
+        assert text_kwargs["msg_type"] == "text"
+        text_payload = json.loads(text_kwargs["payload"])
+        assert "❓ 选择困难？" in text_payload["text"]
+        assert "1. A" in text_payload["text"]
+        assert "2. B" in text_payload["text"]
+        mock_mark.assert_called_once_with("cl_fb1")
+
+    @pytest.mark.asyncio
+    async def test_open_ended_question_uses_text_directly(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_cl_open"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            with patch("tools.clarify_gateway.mark_awaiting_text"):
+                result = await adapter.send_clarify(
+                    chat_id="oc_12345",
+                    question="随便说点啥",
+                    choices=None,
+                    clarify_id="cl_open1",
+                    session_key="sess",
+                )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "text"
+        payload = json.loads(kwargs["payload"])
+        assert payload["text"] == "❓ 随便说点啥"
+
+
+# ===========================================================================
+# _handle_clarify_card_action — callback routing
+# ===========================================================================
+
+class TestFeishuClarifyCardAction:
+    """Test card button clicks resolve the pending clarify."""
+
+    def test_resolves_choice(self):
+        adapter = _make_adapter()
+        adapter._clarify_state["cl_abc"] = {
+            "session_key": "sess-abc",
+            "message_id": "msg_abc",
+            "chat_id": "oc_12345",
+            "choices": ["方案A", "方案B", "方案C"],
+        }
+
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "cl_abc", "choice_index": 1},
+        )
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=_close_submitted_coro) as mock_submit:
+            with patch("tools.clarify_gateway.resolve_gateway_clarify", return_value=True) as mock_resolve:
+                with patch.object(adapter, "_allow_group_message", return_value=True):
+                    adapter._handle_clarify_card_action(
+                        event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+                    )
+
+        mock_submit.assert_called_once()
+        # The scheduled coroutine resolves with the choice text at index 1
+        scheduled = mock_submit.call_args[0][1]
+        assert scheduled is not None
+
+        # Verify _resolve_clarify pops state and calls resolve_gateway_clarify
+        with patch("tools.clarify_gateway.resolve_gateway_clarify", return_value=True) as mock_resolve2:
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(
+                adapter._resolve_clarify(
+                    clarify_id="cl_abc",
+                    choice_text="方案B",
+                    user_name="Norbert",
+                )
+            )
+        mock_resolve2.assert_called_once_with("cl_abc", "方案B")
+        assert "cl_abc" not in adapter._clarify_state
+
+    def test_other_button_marks_awaiting_text(self):
+        adapter = _make_adapter()
+        adapter._clarify_state["cl_other"] = {
+            "session_key": "sess-other",
+            "message_id": "msg_other",
+            "chat_id": "oc_12345",
+            "choices": ["A", "B"],
+        }
+
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "cl_other", "choice_index": -1},
+        )
+
+        with patch.object(adapter, "_submit_on_loop", side_effect=_close_submitted_coro):
+            with patch.object(adapter, "_allow_group_message", return_value=True):
+                adapter._handle_clarify_card_action(
+                    event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+                )
+
+        with patch("tools.clarify_gateway.mark_awaiting_text") as mock_mark:
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(
+                adapter._resolve_clarify(
+                    clarify_id="cl_other",
+                    choice_text=None,  # Other → text capture
+                    user_name="Norbert",
+                )
+            )
+        mock_mark.assert_called_once_with("cl_other")
+        assert "cl_other" not in adapter._clarify_state
+
+    def test_unknown_clarify_is_ignored(self):
+        adapter = _make_adapter()
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "cl_ghost", "choice_index": 0},
+        )
+        with patch.object(adapter, "_submit_on_loop") as mock_submit:
+            adapter._handle_clarify_card_action(
+                event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+            )
+        mock_submit.assert_not_called()
+
+    def test_unauthorized_click_is_rejected(self):
+        adapter = _make_adapter()
+        adapter._clarify_state["cl_auth"] = {
+            "session_key": "sess-auth",
+            "message_id": "msg_auth",
+            "chat_id": "oc_12345",
+            "choices": ["A"],
+        }
+        data = _make_card_action_data(
+            {"hermes_clarify_action": "cl_auth", "choice_index": 0},
+            open_id="ou_intruder",
+        )
+        with patch.object(adapter, "_submit_on_loop") as mock_submit:
+            with patch.object(adapter, "_allow_group_message", return_value=False):
+                adapter._handle_clarify_card_action(
+                    event=data.event, action_value=data.event.action.value, loop=MagicMock(),
+                )
+        mock_submit.assert_not_called()
+        assert "cl_auth" in adapter._clarify_state  # state preserved


### PR DESCRIPTION
## What

Feishu's `md` renderer swallows ordered-list syntax, so clarify prompts sent as a numbered markdown list lose their options entirely (see #9816). This PR renders clarify as an **interactive card with one button per choice** (plus a final "Other (type answer)" button that flips the entry into text-capture mode), and **falls back to plain text** when the card send fails (e.g. app lacks the interactive-card capability).

## Why

- Fixes the options-disappear bug on Feishu — users can't answer multiple-choice questions because the options are never rendered.
- Keeps open-ended clarifies on the base plain-text path (unchanged).
- Multi-select clarifies stay on the base text-fallback path (buttons resolve immediately, one pick at a time).

## How

- `FeishuAdapter.send_clarify()`: builds an interactive card with one button per choice, stores clarify state for callback routing, resolves pending clarifies via `tools.clarify_gateway.resolve_gateway_clarify`.
- Button callbacks are routed through the existing card-action handler.
- Card body deliberately uses plain text lines instead of markdown ordered-list syntax — Feishu's md renderer does not support list syntax and swallows option lines.

## Tests

- `tests/gateway/test_feishu_clarify_buttons.py` — 8 tests covering card send, state storage, plain-text fallback on send failure, callback resolution, and "Other" text-capture mode.
- All pass: 8 passed

Closes #9816
