### PR TITLE
fix(memory): accept JSON-encoded operations string in batch path

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -998,6 +998,15 @@ def memory_tool(
 
     # --- Batch path -------------------------------------------------------
     if operations:
+        # Some providers (esp. open-weight models via agent-loop path) emit the
+        # operations array as a JSON-encoded string. Normalize it here — the
+        # agent-loop path skips model_tools.coerce_tool_args, so this is the
+        # only guard. Mirrors todo_tool #14185 defensive coercion.
+        if isinstance(operations, str):
+            try:
+                operations = json.loads(operations)
+            except (json.JSONDecodeError, TypeError):
+                return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
         gate_result = _apply_batch_write_gate(target, operations)


### PR DESCRIPTION
## Problem

The memory tool's batch path (`operations` array) rejects JSON-encoded strings:

```python
if not isinstance(operations, list):
    return tool_error("operations must be a list of ...")
```

In the agent-loop path, tool arguments bypass `coerce_tool_args`, so some providers — especially open-weight models — emit `operations` as a JSON-encoded **string** rather than a parsed array. Result: hard error ("must be a list"), batch write never happens.

## Fix

Normalize the string at the top of the batch path, mirroring the defensive coercion already merged for `todo_tool` (#14185, 0be10607d9):

```python
if isinstance(operations, str):
    try:
        operations = json.loads(operations)
    except (json.JSONDecodeError, TypeError):
        return tool_error(...)
```

1 file, +9 lines. All downstream logic unchanged. Invalid JSON falls through to the existing friendly error path.

## Verification

- 167 (0.19.0 baseline) functional matrix 5/5:
  1. JSON-string ops → parsed, apply_batch executes
  2. Native list ops → unchanged behavior
  3. Garbage JSON string → friendly error, no crash
  4. todo garbage string → friendly error
  5. todo JSON-list → written correctly
- Mac runtime probe (live, zero side-effects): JSON-string `operations` containing a non-existent marker now executes the batch path (all-or-nothing "no entry matched" response) instead of "must be a list".

## Related

- Symmetric to todo_tool defensive coercion #14185
- Distinct from schema-level validation #64311 / #66099 (different problem)
