### PR TITLE
fix(cron): guard against None completed counter in mark_job_run

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1733,7 +1733,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         and completed > 0
                     )
                     if not preclaimed_oneshot:
-                        completed += 1
+                        completed = (completed or 0) + 1
                         repeat["completed"] = completed
 
                     # Check if we've hit the repeat limit


### PR DESCRIPTION
## What

Fix a `TypeError` in `cron/jobs.py::mark_job_run` when the repeat-completed counter is `None`.

## Why

`completed` can be `None` on the first run of a repeating job (the value is read from the job record and may be unset). The old code did `completed += 1`, which raises `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'` and breaks the repeat-count tracking for that job.

## How

Coalesce to `0` before incrementing: `completed = (completed or 0) + 1`.
