### PR TITLE
feat(pricing): price Bedrock vendor-prefixed models via the vendor table; add Claude Fable 5 / Opus 5

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -222,6 +222,38 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openrouter.ai/anthropic/claude-opus-4.8-fast",
         pricing_version="anthropic-pricing-2026-05",
     ),
+    # ── Anthropic Claude 5 (Opus 5 / Fable 5) ────────────────────────────
+    # Opus 5 keeps the $5/$25 Opus list price. Fable 5 (Mythos tier) lists
+    # at $10/$50 — exactly 2x the Opus line — with the same 0.1x-read /
+    # 1.25x-write cache multiplier structure. Both also ship on Bedrock as
+    # cross-region inference profiles (global./us. + vendor prefix), priced
+    # identically; the bedrock vendor-table fallback in
+    # _lookup_official_docs_pricing resolves those onto these rows.
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
+    (
+        "anthropic",
+        "claude-fable-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
     # ── Anthropic Claude Sonnet 5 ────────────────────────────────────────
     # Launched 2026-06-30. Introductory pricing ($2/$10 per MTok) runs
     # through 2026-08-31, after which it reverts to $3/$15 (matching
@@ -1180,6 +1212,18 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
         normalized = _normalize_bedrock_model_name(model)
         if normalized != model:
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
+            if entry:
+                return entry
+        # Bedrock serves third-party foundation models under vendor-prefixed
+        # ids (``anthropic.claude-*``, ``openai.gpt-*``, ...) and its
+        # on-demand rates mirror the vendor's list price (every existing
+        # ("bedrock", "anthropic.claude-*") row is identical to its
+        # ("anthropic", ...) sibling). Fall back to the vendor's own table so
+        # a model priced for its first-party API prices on Bedrock without a
+        # duplicate row per model per region-profile.
+        vendor, _, bare_model = normalized.partition(".")
+        if vendor and bare_model:
+            entry = _OFFICIAL_DOCS_PRICING.get((vendor, bare_model))
             if entry:
                 return entry
     return None

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -179,6 +179,38 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openrouter.ai/anthropic/claude-opus-4.8-fast",
         pricing_version="anthropic-pricing-2026-05",
     ),
+    # ── Anthropic Claude 5 (Opus 5 / Fable 5) ────────────────────────────
+    # Opus 5 keeps the $5/$25 Opus list price. Fable 5 (Mythos tier) lists
+    # at $10/$50 — exactly 2x the Opus line — with the same 0.1x-read /
+    # 1.25x-write cache multiplier structure. Both also ship on Bedrock as
+    # cross-region inference profiles (global./us. + vendor prefix), priced
+    # identically; the bedrock vendor-table fallback in
+    # _lookup_official_docs_pricing resolves those onto these rows.
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
+    (
+        "anthropic",
+        "claude-fable-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
     # ── Anthropic Claude Sonnet 5 ────────────────────────────────────────
     # Launched 2026-06-30. Introductory pricing ($2/$10 per MTok) runs
     # through 2026-08-31, after which it reverts to $3/$15 (matching
@@ -1114,6 +1146,18 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
         normalized = _normalize_bedrock_model_name(model)
         if normalized != model:
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
+            if entry:
+                return entry
+        # Bedrock serves third-party foundation models under vendor-prefixed
+        # ids (``anthropic.claude-*``, ``openai.gpt-*``, ...) and its
+        # on-demand rates mirror the vendor's list price (every existing
+        # ("bedrock", "anthropic.claude-*") row is identical to its
+        # ("anthropic", ...) sibling). Fall back to the vendor's own table so
+        # a model priced for its first-party API prices on Bedrock without a
+        # duplicate row per model per region-profile.
+        vendor, _, bare_model = normalized.partition(".")
+        if vendor and bare_model:
+            entry = _OFFICIAL_DOCS_PRICING.get((vendor, bare_model))
             if entry:
                 return entry
     return None

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from agent.usage_pricing import (
     CanonicalUsage,
+    _OFFICIAL_DOCS_PRICING,
     format_cost_label,
     estimate_usage_cost,
     get_pricing_entry,
@@ -187,6 +188,59 @@ def test_bedrock_current_gen_claude_rows_resolve():
             assert entry is not None, mid
             assert entry.input_cost_per_million == ref.input_cost_per_million, mid
             assert entry.output_cost_per_million == ref.output_cost_per_million, mid
+
+
+
+
+def test_bedrock_vendor_prefixed_models_fall_back_to_vendor_pricing():
+    """Bedrock ids without a ("bedrock", ...) row price via the vendor table.
+
+    Bedrock on-demand mirrors the vendor's list price (every existing
+    ("bedrock", "anthropic.claude-*") row equals its ("anthropic", ...)
+    sibling), so ``anthropic.claude-fable-5`` should resolve through the
+    ("anthropic", "claude-fable-5") row without a duplicate bedrock row —
+    including from ``us.``/``global.`` cross-region inference profiles.
+    """
+    url = "https://bedrock-runtime.us-east-1.amazonaws.com"
+    for vendor_model, bedrock_id in (
+        ("claude-fable-5", "anthropic.claude-fable-5"),
+        ("claude-opus-5", "anthropic.claude-opus-5"),
+    ):
+        vendor_ref = _OFFICIAL_DOCS_PRICING[("anthropic", vendor_model)]
+        for mid in (bedrock_id, f"us.{bedrock_id}", f"global.{bedrock_id}"):
+            entry = get_pricing_entry(mid, provider="bedrock", base_url=url)
+            assert entry is not None, mid
+            assert entry.input_cost_per_million == vendor_ref.input_cost_per_million, mid
+            assert entry.output_cost_per_million == vendor_ref.output_cost_per_million, mid
+            assert entry.cache_read_cost_per_million == vendor_ref.cache_read_cost_per_million, mid
+            assert entry.cache_write_cost_per_million == vendor_ref.cache_write_cost_per_million, mid
+    # Vendor fallback must NOT shadow an explicit ("bedrock", ...) row: the
+    # direct lookup wins first, so rows that intentionally diverge from the
+    # vendor table (if any appear) keep taking precedence.
+    explicit = get_pricing_entry("anthropic.claude-opus-4-8", provider="bedrock", base_url=url)
+    assert explicit is _OFFICIAL_DOCS_PRICING[("bedrock", "anthropic.claude-opus-4-8")]
+
+
+def test_anthropic_fable_5_and_opus_5_rows():
+    """Fable 5 (Mythos tier) is exactly 2x the Opus 5 list price.
+
+    Pin the rates and the cache multiplier structure (read = 0.1x input,
+    write = 1.25x input) so a future edit that breaks one row fails loudly.
+    """
+    fable = get_pricing_entry("claude-fable-5", provider="anthropic")
+    opus = get_pricing_entry("claude-opus-5", provider="anthropic")
+    assert fable is not None
+    assert opus is not None
+    assert fable.input_cost_per_million == Decimal("10.00")
+    assert fable.output_cost_per_million == Decimal("50.00")
+    assert opus.input_cost_per_million == Decimal("5.00")
+    assert opus.output_cost_per_million == Decimal("25.00")
+    for entry in (fable, opus):
+        assert entry.input_cost_per_million is not None
+        assert entry.cache_read_cost_per_million == entry.input_cost_per_million * Decimal("0.1")
+        assert entry.cache_write_cost_per_million == entry.input_cost_per_million * Decimal("1.25")
+    assert fable.input_cost_per_million == opus.input_cost_per_million * 2
+    assert fable.output_cost_per_million == opus.output_cost_per_million * 2
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,7 +1,9 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
     CanonicalUsage,
+    _OFFICIAL_DOCS_PRICING,
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
@@ -185,6 +187,59 @@ def test_bedrock_current_gen_claude_rows_resolve():
             assert entry is not None, mid
             assert entry.input_cost_per_million == ref.input_cost_per_million, mid
             assert entry.output_cost_per_million == ref.output_cost_per_million, mid
+
+
+
+
+def test_bedrock_vendor_prefixed_models_fall_back_to_vendor_pricing():
+    """Bedrock ids without a ("bedrock", ...) row price via the vendor table.
+
+    Bedrock on-demand mirrors the vendor's list price (every existing
+    ("bedrock", "anthropic.claude-*") row equals its ("anthropic", ...)
+    sibling), so ``anthropic.claude-fable-5`` should resolve through the
+    ("anthropic", "claude-fable-5") row without a duplicate bedrock row —
+    including from ``us.``/``global.`` cross-region inference profiles.
+    """
+    url = "https://bedrock-runtime.us-east-1.amazonaws.com"
+    for vendor_model, bedrock_id in (
+        ("claude-fable-5", "anthropic.claude-fable-5"),
+        ("claude-opus-5", "anthropic.claude-opus-5"),
+    ):
+        vendor_ref = _OFFICIAL_DOCS_PRICING[("anthropic", vendor_model)]
+        for mid in (bedrock_id, f"us.{bedrock_id}", f"global.{bedrock_id}"):
+            entry = get_pricing_entry(mid, provider="bedrock", base_url=url)
+            assert entry is not None, mid
+            assert entry.input_cost_per_million == vendor_ref.input_cost_per_million, mid
+            assert entry.output_cost_per_million == vendor_ref.output_cost_per_million, mid
+            assert entry.cache_read_cost_per_million == vendor_ref.cache_read_cost_per_million, mid
+            assert entry.cache_write_cost_per_million == vendor_ref.cache_write_cost_per_million, mid
+    # Vendor fallback must NOT shadow an explicit ("bedrock", ...) row: the
+    # direct lookup wins first, so rows that intentionally diverge from the
+    # vendor table (if any appear) keep taking precedence.
+    explicit = get_pricing_entry("anthropic.claude-opus-4-8", provider="bedrock", base_url=url)
+    assert explicit is _OFFICIAL_DOCS_PRICING[("bedrock", "anthropic.claude-opus-4-8")]
+
+
+def test_anthropic_fable_5_and_opus_5_rows():
+    """Fable 5 (Mythos tier) is exactly 2x the Opus 5 list price.
+
+    Pin the rates and the cache multiplier structure (read = 0.1x input,
+    write = 1.25x input) so a future edit that breaks one row fails loudly.
+    """
+    fable = get_pricing_entry("claude-fable-5", provider="anthropic")
+    opus = get_pricing_entry("claude-opus-5", provider="anthropic")
+    assert fable is not None
+    assert opus is not None
+    assert fable.input_cost_per_million == Decimal("10.00")
+    assert fable.output_cost_per_million == Decimal("50.00")
+    assert opus.input_cost_per_million == Decimal("5.00")
+    assert opus.output_cost_per_million == Decimal("25.00")
+    for entry in (fable, opus):
+        assert entry.input_cost_per_million is not None
+        assert entry.cache_read_cost_per_million == entry.input_cost_per_million * Decimal("0.1")
+        assert entry.cache_write_cost_per_million == entry.input_cost_per_million * Decimal("1.25")
+    assert fable.input_cost_per_million == opus.input_cost_per_million * 2
+    assert fable.output_cost_per_million == opus.output_cost_per_million * 2
 
 
 


### PR DESCRIPTION
## Problem

Bedrock sessions on models without a ("bedrock", ...) row in `_OFFICIAL_DOCS_PRICING` record token usage but report unknown estimated cost — the #50295 symptom class. Claude Fable 5 and Opus 5 both hit this today, and with Fable 5 increasingly common as a daily-driver model, whole days of Bedrock spend go unpriced.

## Fix (the class, not the instance)

Bedrock model ids are vendor-prefixed (`anthropic.claude-*`, `openai.gpt-*`) and Bedrock on-demand mirrors the vendor's list price — every existing ("bedrock", "anthropic.claude-*") row is byte-identical to its ("anthropic", ...) sibling (verified across all 7 pairs). So after the existing region-prefix normalization, `_lookup_official_docs_pricing` now falls back from ("bedrock", "<vendor>.<model>") to ("<vendor>", "<model>").

- Explicit bedrock rows still win (direct lookup runs first), so a future Bedrock-divergent rate can always be pinned with a dedicated row — tested.
- Any model priced for its first-party API now prices on Bedrock automatically (bare id, `us.`/`global.`/`eu.`/... cross-region profiles, dated version suffixes) with no duplicate rows.

Also adds the missing vendor rows: Claude Fable 5 (Mythos tier, $10/$50 per MTok — exactly 2x the Opus line) and Claude Opus 5 ($5/$25 Opus list), both with the standard 0.1x-read / 1.25x-write cache multipliers. Complementary to #43317 (direct-Anthropic Fable row): with this PR either row shape also covers Bedrock.

## Verification

- `pytest tests/agent/test_usage_pricing.py` — 13 passed (new: exact rates, 2x Fable/Opus ratio, cache multiplier structure, fallback from all three Bedrock id forms, explicit-row precedence).
- `pytest tests/agent -k 'pricing or usage or cost'` — 58 passed, 3 skipped.
- Cross-checked against real Bedrock invocation logs (2026-08-04, 10,070 InvokeModel calls, us-east-1): priced total matches hand-computed list-price spend.

Same commercial-list-snapshot caveat as the Opus 4.8/4.7 rows (3441b80f4f): the AWS Price List API still doesn't publish these SKUs machine-readably.