### PR TITLE
fix(pricing): apply OpenAI's 2026-07-30 GPT-5.6 Terra/Luna price cut

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -148,9 +148,13 @@ _UTC_NOW = lambda: datetime.now(timezone.utc)
 _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # ── OpenAI GPT-5.6 series (Sol/Terra/Luna) ───────────────────────────
     # Announced in limited preview 2026-06-26; GA 2026-07-09 at the same
-    # rates (Sol $5/$30, Terra $2.50/$15, Luna $1/$6 per 1M in/out). Cache
-    # writes are billed at 1.25x the uncached input rate; cache reads get the
-    # standard 90% discount (0.10x input, confirmed: Sol $0.50/M cached).
+    # rates. Sol $5/$30 per 1M in/out. Terra and Luna were repriced on
+    # 2026-07-30 ("Advancing the price-performance frontier with GPT-5.6"):
+    # Terra $2.50/$15 -> $2/$12 (-20%), Luna $1/$6 -> $0.20/$1.20 (-80%);
+    # Sol unchanged. The cut applies across serving partners (the
+    # announcement notes the AWS rollout began the same day). Cache
+    # writes are billed at 1.25x the uncached input rate; cache reads get
+    # the standard 90% discount (0.10x input, confirmed: Sol $0.50/M cached).
     # Note: "Sol Fast mode" ($12.5/$75, up to 750 tok/s via Cerebras) is a
     # separate serving tier, not covered by these entries. The "-pro"
     # variants (high-effort modes, GA alongside base tiers) bill at the
@@ -174,25 +178,25 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "openai",
         "gpt-5.6-terra",
     ): PricingEntry(
-        input_cost_per_million=Decimal("2.50"),
-        output_cost_per_million=Decimal("15.00"),
-        cache_read_cost_per_million=Decimal("0.25"),
-        cache_write_cost_per_million=Decimal("3.125"),
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("12.00"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        cache_write_cost_per_million=Decimal("2.50"),
         source="official_docs_snapshot",
-        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-2026-07",
+        source_url="https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/",
+        pricing_version="openai-gpt-5.6-2026-07-30",
     ),
     (
         "openai",
         "gpt-5.6-luna",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.00"),
-        output_cost_per_million=Decimal("6.00"),
-        cache_read_cost_per_million=Decimal("0.10"),
-        cache_write_cost_per_million=Decimal("1.25"),
+        input_cost_per_million=Decimal("0.20"),
+        output_cost_per_million=Decimal("1.20"),
+        cache_read_cost_per_million=Decimal("0.02"),
+        cache_write_cost_per_million=Decimal("0.25"),
         source="official_docs_snapshot",
-        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-2026-07",
+        source_url="https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/",
+        pricing_version="openai-gpt-5.6-2026-07-30",
     ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -105,9 +105,13 @@ _UTC_NOW = lambda: datetime.now(timezone.utc)
 _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # ── OpenAI GPT-5.6 series (Sol/Terra/Luna) ───────────────────────────
     # Announced in limited preview 2026-06-26; GA 2026-07-09 at the same
-    # rates (Sol $5/$30, Terra $2.50/$15, Luna $1/$6 per 1M in/out). Cache
-    # writes are billed at 1.25x the uncached input rate; cache reads get the
-    # standard 90% discount (0.10x input, confirmed: Sol $0.50/M cached).
+    # rates. Sol $5/$30 per 1M in/out. Terra and Luna were repriced on
+    # 2026-07-30 ("Advancing the price-performance frontier with GPT-5.6"):
+    # Terra $2.50/$15 -> $2/$12 (-20%), Luna $1/$6 -> $0.20/$1.20 (-80%);
+    # Sol unchanged. The cut applies across serving partners (the
+    # announcement notes the AWS rollout began the same day). Cache
+    # writes are billed at 1.25x the uncached input rate; cache reads get
+    # the standard 90% discount (0.10x input, confirmed: Sol $0.50/M cached).
     # Note: "Sol Fast mode" ($12.5/$75, up to 750 tok/s via Cerebras) is a
     # separate serving tier, not covered by these entries. The "-pro"
     # variants (high-effort modes, GA alongside base tiers) bill at the
@@ -131,25 +135,25 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "openai",
         "gpt-5.6-terra",
     ): PricingEntry(
-        input_cost_per_million=Decimal("2.50"),
-        output_cost_per_million=Decimal("15.00"),
-        cache_read_cost_per_million=Decimal("0.25"),
-        cache_write_cost_per_million=Decimal("3.125"),
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("12.00"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        cache_write_cost_per_million=Decimal("2.50"),
         source="official_docs_snapshot",
-        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-2026-07",
+        source_url="https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/",
+        pricing_version="openai-gpt-5.6-2026-07-30",
     ),
     (
         "openai",
         "gpt-5.6-luna",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.00"),
-        output_cost_per_million=Decimal("6.00"),
-        cache_read_cost_per_million=Decimal("0.10"),
-        cache_write_cost_per_million=Decimal("1.25"),
+        input_cost_per_million=Decimal("0.20"),
+        output_cost_per_million=Decimal("1.20"),
+        cache_read_cost_per_million=Decimal("0.02"),
+        cache_write_cost_per_million=Decimal("0.25"),
         source="official_docs_snapshot",
-        source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
-        pricing_version="openai-gpt-5.6-2026-07",
+        source_url="https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/",
+        pricing_version="openai-gpt-5.6-2026-07-30",
     ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,20 +1,47 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
     CanonicalUsage,
-    format_cost_label,
+    _OFFICIAL_DOCS_PRICING,
     estimate_usage_cost,
+    format_cost_label,
     get_pricing_entry,
     normalize_usage,
     resolve_billing_route,
 )
-from decimal import Decimal
 
 
 
 
 
 
+
+
+def test_gpt_56_terra_luna_july_30_reprice():
+    """Terra/Luna carry the 2026-07-30 repriced rates; Sol is unchanged.
+
+    OpenAI cut Luna 80% ($1/$6 -> $0.20/$1.20) and Terra 20%
+    ($2.50/$15 -> $2/$12) on 2026-07-30. Pin the new rates, the cache
+    multiplier structure (read = 0.1x input, write = 1.25x input), and
+    that the "-pro" aliases keep resolving to the repriced base entries.
+    """
+    expected = {
+        "gpt-5.6-sol": (Decimal("5.00"), Decimal("30.00")),
+        "gpt-5.6-terra": (Decimal("2.00"), Decimal("12.00")),
+        "gpt-5.6-luna": (Decimal("0.20"), Decimal("1.20")),
+    }
+    for model, (rate_in, rate_out) in expected.items():
+        entry = get_pricing_entry(model, provider="openai")
+        assert entry is not None, model
+        assert entry.input_cost_per_million == rate_in, model
+        assert entry.output_cost_per_million == rate_out, model
+        assert entry.cache_read_cost_per_million == rate_in * Decimal("0.1"), model
+        assert entry.cache_write_cost_per_million == rate_in * Decimal("1.25"), model
+        # "-pro" variants bill at the same per-token rates as the base tier.
+        assert _OFFICIAL_DOCS_PRICING[("openai", f"{model}-pro")] is _OFFICIAL_DOCS_PRICING[
+            ("openai", model)
+        ], model
 
 
 def test_normalize_usage_reads_deepseek_native_cache_hit_tokens():

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,7 +1,9 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
     CanonicalUsage,
+    _OFFICIAL_DOCS_PRICING,
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
@@ -13,6 +15,32 @@ from agent.usage_pricing import (
 
 
 
+
+
+def test_gpt_56_terra_luna_july_30_reprice():
+    """Terra/Luna carry the 2026-07-30 repriced rates; Sol is unchanged.
+
+    OpenAI cut Luna 80% ($1/$6 -> $0.20/$1.20) and Terra 20%
+    ($2.50/$15 -> $2/$12) on 2026-07-30. Pin the new rates, the cache
+    multiplier structure (read = 0.1x input, write = 1.25x input), and
+    that the "-pro" aliases keep resolving to the repriced base entries.
+    """
+    expected = {
+        "gpt-5.6-sol": (Decimal("5.00"), Decimal("30.00")),
+        "gpt-5.6-terra": (Decimal("2.00"), Decimal("12.00")),
+        "gpt-5.6-luna": (Decimal("0.20"), Decimal("1.20")),
+    }
+    for model, (rate_in, rate_out) in expected.items():
+        entry = get_pricing_entry(model, provider="openai")
+        assert entry is not None, model
+        assert entry.input_cost_per_million == rate_in, model
+        assert entry.output_cost_per_million == rate_out, model
+        assert entry.cache_read_cost_per_million == rate_in * Decimal("0.1"), model
+        assert entry.cache_write_cost_per_million == rate_in * Decimal("1.25"), model
+        # "-pro" variants bill at the same per-token rates as the base tier.
+        assert _OFFICIAL_DOCS_PRICING[("openai", f"{model}-pro")] is _OFFICIAL_DOCS_PRICING[
+            ("openai", model)
+        ], model
 
 
 def test_normalize_usage_reads_deepseek_native_cache_hit_tokens():


### PR DESCRIPTION
## Problem

OpenAI repriced two GPT-5.6 tiers on 2026-07-30 ([Advancing the price-performance frontier with GPT-5.6](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/)): **Luna $1/$6 → $0.20/$1.20 per MTok (−80%)** and **Terra $2.50/$15 → $2/$12 (−20%)**. Sol is unchanged. The snapshot rows still carry launch rates, so every Terra/Luna session since the cut over-reports estimated cost — Luna by 5x, which matters now that the cut makes Luna a natural default for high-volume subagent/background work.

## Change

- Terra/Luna entries updated to the new rates with the same cache multiplier structure (0.1x read, 1.25x write, matching the announcement's cached pricing).
- `pricing_version` bumped to `openai-gpt-5.6-2026-07-30` and `source_url` points at the reprice announcement.
- `-pro` aliases inherit automatically (they alias the base entries — asserted in the test).
- The announcement notes the cut applies across serving partners (AWS rollout began the same day), so snapshot-based consumers stay consistent regardless of endpoint.

## Verification

`pytest tests/agent/test_usage_pricing.py` — 12 passed. The new test pins all three tiers' rates, the cache multiplier structure, and the -pro alias identity, so the next reprice fails visibly instead of silently drifting.