### PR TITLE
fix(agent): stop Copilot MoA aggregators from losing premium model access

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1717,7 +1717,20 @@ class MoAChatCompletions:
         max_tokens: Any = agg_kwargs.get("max_tokens")
         tools: Any = agg_kwargs.get("tools")
         extra_body: Any = agg_kwargs.get("extra_body")
+        extra_headers: Any = agg_kwargs.get("extra_headers")
         agg_runtime = _slot_runtime(aggregator)
+        _agent = getattr(self, "_agent", None)
+        from agent.auxiliary_client import _normalize_aux_provider
+
+        if (
+            _agent is not None
+            and getattr(_agent, "_is_user_initiated_turn", False)
+            and _normalize_aux_provider(str(agg_runtime.get("provider") or ""))
+            in ("copilot", "copilot-acp")
+        ):
+            extra_headers = dict(extra_headers or {})
+            extra_headers["x-initiator"] = "user"
+            _agent._is_user_initiated_turn = False
         try:
             from agent.agent_runtime_helpers import (
                 plan_cache_sections_for_destination,
@@ -1737,7 +1750,6 @@ class MoAChatCompletions:
             # Prepared-aggregator facades built via __new__ have no _agent;
             # getattr(self._agent, ...) raises and bool(None-agent) would
             # force False and suppress the planner's config fallback (#76085).
-            _agent = getattr(self, "_agent", None)
             _cache_disabled = (
                 getattr(_agent, "_cache_disabled", None)
                 if _agent is not None
@@ -1817,6 +1829,7 @@ class MoAChatCompletions:
             max_tokens=max_tokens,
             tools=tools,
             extra_body=agg_extra_body,
+            extra_headers=extra_headers,
             # Prepared requests must retain the acting aggregator's reasoning
             # policy exactly as the direct create() path does (#64187).
             reasoning_config=_aggregator_reasoning_config(aggregator),

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -20,6 +20,7 @@ from typing import Any
 from agent.auxiliary_client import call_llm
 from agent.message_content import flatten_message_text
 from agent.transports import get_transport
+from utils import base_url_host_matches
 
 logger = logging.getLogger(__name__)
 
@@ -1723,9 +1724,14 @@ class MoAChatCompletions:
         from agent.auxiliary_client import _normalize_aux_provider
 
         raw_provider = str(agg_runtime.get("provider") or "").strip()
+        resolved_base_url = str(agg_runtime.get("base_url") or "")
         is_http_copilot = (
             not raw_provider.lower().startswith("custom:")
             and _normalize_aux_provider(raw_provider) == "copilot"
+            and (
+                base_url_host_matches(resolved_base_url, "githubcopilot.com")
+                or base_url_host_matches(resolved_base_url, "models.github.ai")
+            )
         )
         if (
             _agent is not None

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1725,8 +1725,9 @@ class MoAChatCompletions:
         if (
             _agent is not None
             and getattr(_agent, "_is_user_initiated_turn", False)
-            and _normalize_aux_provider(str(agg_runtime.get("provider") or ""))
-            in ("copilot", "copilot-acp")
+            and _normalize_aux_provider(
+                str(agg_runtime.get("provider") or "")
+            ) == "copilot"
         ):
             extra_headers = dict(extra_headers or {})
             extra_headers["x-initiator"] = "user"

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1722,12 +1722,15 @@ class MoAChatCompletions:
         _agent = getattr(self, "_agent", None)
         from agent.auxiliary_client import _normalize_aux_provider
 
+        raw_provider = str(agg_runtime.get("provider") or "").strip()
+        is_http_copilot = (
+            not raw_provider.lower().startswith("custom:")
+            and _normalize_aux_provider(raw_provider) == "copilot"
+        )
         if (
             _agent is not None
             and getattr(_agent, "_is_user_initiated_turn", False)
-            and _normalize_aux_provider(
-                str(agg_runtime.get("provider") or "")
-            ) == "copilot"
+            and is_http_copilot
         ):
             extra_headers = dict(extra_headers or {})
             extra_headers["x-initiator"] = "user"

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -876,7 +876,20 @@ def test_prepared_copilot_aggregator_marks_only_first_call_user_initiated(
     assert agent._is_user_initiated_turn is False
 
 
-def test_prepared_non_copilot_aggregator_preserves_request_headers(monkeypatch):
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "openrouter",
+        "custom:copilot",
+        "custom:github-copilot",
+        "copilot-acp",
+        "github-copilot-acp",
+        "copilot-acp-agent",
+    ],
+)
+def test_prepared_non_http_copilot_aggregator_preserves_request_headers(
+    monkeypatch, provider
+):
     from agent import moa_loop
 
     captured = {}
@@ -898,7 +911,7 @@ def test_prepared_non_copilot_aggregator_preserves_request_headers(monkeypatch):
     facade._call_prepared_aggregator(
         {
             "messages": [{"role": "user", "content": "question"}],
-            "aggregator": {"provider": "openrouter", "model": "aggregator"},
+            "aggregator": {"provider": provider, "model": "aggregator"},
             "aggregator_temperature": None,
         },
         {"extra_headers": request_headers},

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -830,7 +830,7 @@ def test_prepared_aggregator_preserves_reasoning_config(monkeypatch):
     assert captured["reasoning_config"] == expected_reasoning
 
 
-@pytest.mark.parametrize("provider", ["copilot", "github-copilot", "copilot-acp"])
+@pytest.mark.parametrize("provider", ["copilot", "github-copilot"])
 def test_prepared_copilot_aggregator_marks_only_first_call_user_initiated(
     monkeypatch, provider
 ):

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -830,9 +830,15 @@ def test_prepared_aggregator_preserves_reasoning_config(monkeypatch):
     assert captured["reasoning_config"] == expected_reasoning
 
 
-@pytest.mark.parametrize("provider", ["copilot", "github-copilot"])
+@pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("copilot", "https://api.githubcopilot.com"),
+        ("github-copilot", "https://models.github.ai/inference"),
+    ],
+)
 def test_prepared_copilot_aggregator_marks_only_first_call_user_initiated(
-    monkeypatch, provider
+    monkeypatch, provider, base_url
 ):
     from agent import moa_loop
 
@@ -842,7 +848,11 @@ def test_prepared_copilot_aggregator_marks_only_first_call_user_initiated(
     monkeypatch.setattr(
         moa_loop,
         "_slot_runtime",
-        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+        lambda slot: {
+            "provider": slot["provider"],
+            "model": slot["model"],
+            "base_url": base_url,
+        },
     )
     monkeypatch.setattr(
         moa_loop,
@@ -877,18 +887,20 @@ def test_prepared_copilot_aggregator_marks_only_first_call_user_initiated(
 
 
 @pytest.mark.parametrize(
-    "provider",
+    ("provider", "base_url"),
     [
-        "openrouter",
-        "custom:copilot",
-        "custom:github-copilot",
-        "copilot-acp",
-        "github-copilot-acp",
-        "copilot-acp-agent",
+        ("openrouter", "https://openrouter.ai/api/v1"),
+        ("custom:copilot", "https://custom.example/v1"),
+        ("custom:github-copilot", "https://custom.example/v1"),
+        ("copilot", "https://custom.example/v1"),
+        ("github-copilot", "https://custom.example/v1"),
+        ("copilot-acp", ""),
+        ("github-copilot-acp", ""),
+        ("copilot-acp-agent", ""),
     ],
 )
 def test_prepared_non_http_copilot_aggregator_preserves_request_headers(
-    monkeypatch, provider
+    monkeypatch, provider, base_url
 ):
     from agent import moa_loop
 
@@ -899,7 +911,11 @@ def test_prepared_non_http_copilot_aggregator_preserves_request_headers(
     monkeypatch.setattr(
         moa_loop,
         "_slot_runtime",
-        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+        lambda slot: {
+            "provider": slot["provider"],
+            "model": slot["model"],
+            "base_url": base_url,
+        },
     )
     monkeypatch.setattr(
         moa_loop,

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -830,6 +830,84 @@ def test_prepared_aggregator_preserves_reasoning_config(monkeypatch):
     assert captured["reasoning_config"] == expected_reasoning
 
 
+@pytest.mark.parametrize("provider", ["copilot", "github-copilot", "copilot-acp"])
+def test_prepared_copilot_aggregator_marks_only_first_call_user_initiated(
+    monkeypatch, provider
+):
+    from agent import moa_loop
+
+    calls = []
+    agent = SimpleNamespace(_is_user_initiated_turn=True)
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+    monkeypatch.setattr(
+        moa_loop,
+        "call_llm",
+        lambda **kwargs: calls.append(kwargs) or _response("aggregator acted"),
+    )
+
+    facade = moa_loop.MoAChatCompletions("review", agent=agent)
+    prepared = {
+        "messages": [{"role": "user", "content": "question"}],
+        "aggregator": {"provider": provider, "model": "claude-sonnet-4.6"},
+        "aggregator_temperature": None,
+    }
+    request_headers = {"x-trace-id": "keep", "x-initiator": "agent"}
+
+    facade._call_prepared_aggregator(
+        prepared,
+        {"extra_headers": request_headers},
+    )
+    facade._call_prepared_aggregator(
+        prepared,
+        {"extra_headers": request_headers},
+    )
+
+    assert calls[0]["extra_headers"] == {
+        "x-trace-id": "keep",
+        "x-initiator": "user",
+    }
+    assert calls[1]["extra_headers"] == request_headers
+    assert request_headers == {"x-trace-id": "keep", "x-initiator": "agent"}
+    assert agent._is_user_initiated_turn is False
+
+
+def test_prepared_non_copilot_aggregator_preserves_request_headers(monkeypatch):
+    from agent import moa_loop
+
+    captured = {}
+    agent = SimpleNamespace(_is_user_initiated_turn=True)
+    request_headers = {"x-trace-id": "keep"}
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {"provider": slot["provider"], "model": slot["model"]},
+    )
+    monkeypatch.setattr(
+        moa_loop,
+        "call_llm",
+        lambda **kwargs: captured.update(kwargs) or _response("aggregator acted"),
+    )
+
+    facade = moa_loop.MoAChatCompletions("review", agent=agent)
+    facade._call_prepared_aggregator(
+        {
+            "messages": [{"role": "user", "content": "question"}],
+            "aggregator": {"provider": "openrouter", "model": "aggregator"},
+            "aggregator_temperature": None,
+        },
+        {"extra_headers": request_headers},
+    )
+
+    assert captured["extra_headers"] == request_headers
+    assert agent._is_user_initiated_turn is True
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

This PR ensures that an official GitHub Copilot HTTP model acting as an MoA aggregator receives `x-initiator: user` on the first API call of each user turn. It preserves caller headers and scopes attribution to resolved official Copilot endpoints so custom providers, Copilot ACP, and tool-loop follow-ups retain their existing behavior.

### Bug Cause

The outer MoA runtime uses `base_url=moa://local`, so the main conversation loop's Copilot URL guard never injects the user initiator header. The prepared aggregator path then resolved the real acting model but forwarded only selected request fields, dropping caller `extra_headers` and never synthesizing first-turn attribution for the inner Copilot request.

### Reproduction Steps

1. Configure an MoA preset with an official GitHub Copilot HTTP provider and a premium Claude or Gemini aggregator model.
2. Submit a new user turn using that preset.
3. Inspect the aggregator transport request.

Expected: the first acting aggregator request contains `x-initiator: user`, while later tool-loop requests remain agent-attributed.

Before fix: the aggregator request contains no user initiator header, so Copilot can throttle or reject premium model access as agent traffic.

### Fix

The prepared aggregator path now forwards caller `extra_headers` without mutating the caller dictionary. On the first acting-model call, it overrides `x-initiator` to `user` only when both the normalized provider and resolved hostname identify an official Copilot HTTP endpoint. Hostname-boundary checks cover `githubcopilot.com` and `models.github.ai`, while custom provider namespaces, provider-plugin overrides resolving to other hosts, Copilot ACP aliases, and non-Copilot providers remain unchanged. Regression tests cover first-call consumption, follow-up attribution, header preservation, aliases, official hosts, custom hosts, and ACP exclusions.

## Related Issue

Fixes #79425

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py` - forward prepared aggregator headers and add endpoint-scoped first-turn Copilot attribution.
- `tests/run_agent/test_moa_loop_mode.py` - cover official Copilot hosts, aliases, one-shot turn state, caller header preservation, custom provider overrides, non-Copilot providers, and ACP exclusions.

## How to Test

1. Configure an MoA preset with a Copilot HTTP aggregator and submit a new user turn.
2. Verify the first aggregator request carries `x-initiator: user`.
3. Verify a tool-loop follow-up retains agent attribution and custom or ACP providers receive no injected header.
4. Run the automated regression suite:

```bash
scripts/run_tests.sh \
  tests/run_agent/test_moa_loop_mode.py \
  tests/test_copilot_initiator.py \
  tests/test_base_url_hostname.py \
  tests/agent/test_auxiliary_client.py \
  -q
```

Result: 233 passed, 0 failed, no flaky retries.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A because this restores an existing request-attribution contract
- [x] `cli-config.yaml.example` update is N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses the existing platform-independent hostname matcher
- [x] Tool description and schema updates are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - transport-level regression with automated test coverage.
