### PR TITLE
fix(clarify): reject all-empty choices instead of degrading to open-ended

### DIFF
--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -52,6 +52,38 @@ class TestClarifyToolChoicesValidation:
 
         assert len(choices_passed) == MAX_CHOICES
 
+    def test_all_empty_choices_returns_error(self):
+        """All-empty choices must return a tool error, not silently degrade.
+
+        LLMs sometimes emit choices as placeholder empty strings
+        (["", "", "", ""]). Degrading to an open-ended question makes the
+        options disappear on every surface; the model should be told to
+        retry with real option text instead.
+        """
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            raise AssertionError("callback must not run for empty choices")
+
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["", "", "", ""],
+            callback=mock_callback,
+        ))
+        assert "error" in result
+        assert "every entry is empty" in result["error"]
+
+    def test_empty_string_choices_returns_error(self):
+        """A single empty-string choice is also rejected."""
+        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+            raise AssertionError("callback must not run for empty choices")
+
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=[""],
+            callback=mock_callback,
+        ))
+        assert "error" in result
+        assert "every entry is empty" in result["error"]
+
 
     def test_choices_converted_to_strings(self):
         """Non-string choices should be converted to strings."""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -154,7 +154,20 @@ def clarify_tool(
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
         if not choices:
-            choices = None  # empty list → open-ended
+            # The model explicitly passed a choices array but every entry
+            # flattened to empty (common failure mode: ["", "", "", ""] or
+            # [{"description": ""}]). Silently degrading to an open-ended
+            # question makes the options disappear on every surface (CLI
+            # panel, desktop app, messaging platforms) — the user sees a
+            # bare question with no selectable choices and no way to know
+            # options were intended. Returning an error makes the model
+            # retry the call with real option text (or omit choices
+            # entirely for a genuine open-ended question).
+            return tool_error(
+                "choices was provided but every entry is empty. "
+                "Provide 1-4 non-empty option strings, or omit the "
+                "choices parameter for an open-ended question."
+            )
 
     if callback is None:
         return tool_error("Clarify tool is not available in this execution context.")


### PR DESCRIPTION
## What

When the model calls `clarify` with a `choices` array whose entries are all empty (a real failure mode: `["", "", "", ""]` or `[{"description": ""}]`), the tool silently collapses it to an open-ended question (`choices = None`).

## Why

The silent degradation makes the intended options **disappear on every surface** — CLI panel, desktop app, Telegram/Discord/Feishu buttons. The user sees a bare question with no selectable choices and no way to know options were intended. This surfaces as "the agent asked a question but never showed the options."

## How

Return a `tool_error` when `choices` was explicitly provided but every entry flattened to empty, so the model retries the call with real option text — or omits `choices` entirely for a genuine open-ended question (that path still works: `choices=None` → open-ended).

## Tests

- `tests/tools/test_clarify_tool.py`:
  - `test_all_empty_choices_returns_error` — `["", "", "", ""]` → error, callback never runs
  - `test_empty_string_choices_returns_error` — `[""]` → error, callback never runs
- All clarify tests pass: `50 passed` (core) + `30 passed` (feishu buttons + core)
