### PR TITLE
feat(slack): add configurable link unfurl controls

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1022,6 +1022,12 @@ platform_toolsets:
 #         priority_mode: prepend
 #         priority:
 #           - my_plugin_command
+#   slack:
+#     extra:
+#       # Suppress automatic link-preview cards without removing clickable links.
+#       # Omit either key to preserve Slack's default for that preview type.
+#       unfurl_links: false
+#       unfurl_media: false
 #   webhook:
 #     extra:
 #       # Route scripts default to a 30 second timeout. Scripts must live under

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -79,6 +79,21 @@ _HERMES_SLACK_USER_AGENT_PREFIX = f"HermesAgent/{_HERMES_VERSION}"
 _SLACK_ERROR_BODY_LIMIT_BYTES = 8 * 1024
 
 
+def _slack_unfurl_kwargs(extra: Optional[Dict[str, Any]]) -> Dict[str, bool]:
+    """Return explicitly configured Slack link-preview controls.
+
+    Omitting a key preserves Slack's existing default.  Passing ``False``
+    suppresses only the automatic preview while leaving the link text and URL
+    in the message untouched.
+    """
+    settings = extra or {}
+    return {
+        key: settings[key]
+        for key in ("unfurl_links", "unfurl_media")
+        if isinstance(settings.get(key), bool)
+    }
+
+
 async def _read_error_text_limited(
     response: Any,
     *,
@@ -2543,6 +2558,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
+                    **_slack_unfurl_kwargs(self.config.extra),
                 }
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks
@@ -8703,6 +8719,7 @@ async def _standalone_send(
                 "channel": chat_id,
                 "text": text_to_send,
                 "mrkdwn": True,
+                **_slack_unfurl_kwargs(pconfig.extra),
             }
             if thread_id:
                 post_kwargs["thread_ts"] = thread_id
@@ -8816,7 +8833,12 @@ async def _standalone_send(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
-            payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
+            payload = {
+                "channel": chat_id,
+                "text": formatted,
+                "mrkdwn": True,
+                **_slack_unfurl_kwargs(pconfig.extra),
+            }
             if thread_id:
                 payload["thread_ts"] = thread_id
             for tok in tokens:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1092,6 +1092,30 @@ class TestStandaloneSendUserDmResolution:
         assert session.post.call_count == 1
         assert "chat.postMessage" in session.post.call_args.args[0]
 
+    @pytest.mark.asyncio
+    async def test_channel_delivery_honors_unfurl_config(self):
+        _slack_mod._slack_dm_cache.clear()
+        post_resp = self._mock_resp({"ok": True, "ts": "123.456"})
+        session = self._mock_session(post_resp)
+        config = PlatformConfig(
+            enabled=True,
+            token="«redacted:xox…»",
+            extra={"unfurl_links": False, "unfurl_media": False},
+        )
+
+        with patch.object(_slack_mod.aiohttp, "ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(
+                config,
+                "C123",
+                "[Hermes](https://example.com/hermes)",
+            )
+
+        assert result["success"] is True
+        payload = session.post.call_args.kwargs["json"]
+        assert payload["text"] == "<https://example.com/hermes|Hermes>"
+        assert payload["unfurl_links"] is False
+        assert payload["unfurl_media"] is False
+
 
     @pytest.mark.asyncio
     async def test_user_id_media_delivery_resolves_dm_before_upload(self, tmp_path):

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -66,6 +66,20 @@ class TestSendMessageBlocks:
         assert "blocks" not in kwargs
         assert kwargs["text"]  # plain text still sent
 
+    @pytest.mark.asyncio
+    async def test_unfurl_config_suppresses_previews_without_changing_link_text(self):
+        adapter, client = _make_adapter(
+            {"unfurl_links": False, "unfurl_media": False}
+        )
+        content = "[Hermes](https://example.com/hermes)"
+
+        await adapter.send("C1", content)
+
+        kwargs = client.chat_postMessage.await_args.kwargs
+        assert kwargs["text"] == "<https://example.com/hermes|Hermes>"
+        assert kwargs["unfurl_links"] is False
+        assert kwargs["unfurl_media"] is False
+
 
     @pytest.mark.asyncio
     async def test_enabled_but_unrenderable_falls_back_to_text(self):

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -410,6 +410,12 @@ platforms:
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
 
+      # Control Slack's automatic link-preview cards without changing or
+      # removing clickable links from message text. Omit either key to keep
+      # Slack's default behavior for that preview type.
+      unfurl_links: false
+      unfurl_media: false
+
       # Render agent messages as Slack Block Kit blocks (default: false).
       # When true, the final agent message is sent with structured blocks —
       # section headers, dividers, true nested lists (via rich_text), and
@@ -452,6 +458,8 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
+| `platforms.slack.extra.unfurl_links` | Slack default | Set to `false` to suppress automatic previews for linked web pages while preserving clickable links. |
+| `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |


### PR DESCRIPTION
## What does this PR do?

Adds opt-in Slack link-preview controls that suppress automatic unfurl cards without removing or changing clickable links. The settings are independent so users can control text-link and media previews separately, and omitted settings preserve Slack's existing defaults.

The controls apply to both normal gateway responses and standalone Slack deliveries used by cron jobs. This covers the digest/briefing use case where several useful links otherwise produce a large stack of preview cards, especially on mobile.

## Related Issue

- #34302 - This supersedes and extends that conflicting implementation by targeting the current Slack platform plugin and covering standalone cron delivery in addition to normal gateway responses.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `platforms.slack.extra.unfurl_links` and `platforms.slack.extra.unfurl_media` handling in `plugins/platforms/slack/adapter.py`.
- Applied configured unfurl controls to normal gateway responses and standalone text posts used by cron delivery, including text sent alongside media.
- Added behavior tests proving previews can be suppressed while Slack-formatted links remain intact and clickable.
- Documented both settings in the Slack messaging guide and `cli-config.yaml.example`.

## How to Test

1. Configure `platforms.slack.extra.unfurl_links: false` and `platforms.slack.extra.unfurl_media: false`.
2. Send a normal Slack response and a standalone cron delivery containing Markdown links; confirm the message retains clickable linked text and Slack adds no automatic preview cards.
3. Run `scripts/run_tests.sh` and `uv run ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py tests/gateway/test_slack_block_kit_adapter.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — this is a send-side Slack API payload change covered by adapter tests.
