### PR TITLE
fix(desktop): lay DisclosureRow trailing slot in flow to prevent timer-title overlap (#79330)

### DIFF
--- a/apps/desktop/src/components/chat/disclosure-row.tsx
+++ b/apps/desktop/src/components/chat/disclosure-row.tsx
@@ -14,11 +14,10 @@ import { cn } from '@/lib/utils'
 //     title text, NOT the full row — and reaches just past the chevron with
 //     `-mx-1.5 px-1.5` so it reads as a soft hit-target rather than a slab
 //     stretching to the message edge.
-//   - `trailing` overlays the right edge (absolute) and must stay
-//     non-interactive (e.g. a duration timer) — an opacity-0-but-clickable
-//     control there steals clicks from the caret. Interactive controls go in
-//     `action`, which lays out *in flow* at the far right so it never sits on
-//     top of the caret's hit-target, no matter how long the title is.
+//   - `trailing` is laid out in flow at the far right (ml-auto), matching the
+//     `action` slot's pattern, so it occupies real width and the title's
+//     FadeText correctly detects overflow. It is pointer-events-none so it
+//     cannot steal clicks from the caret. Interactive controls go in `action`.
 export function DisclosureRow({
   action,
   children,
@@ -68,7 +67,7 @@ export function DisclosureRow({
         </span>
       )}
       {trailing && (
-        <span className="absolute right-1 top-0 flex h-(--conversation-line-height) items-center">{trailing}</span>
+        <span className="pointer-events-none ml-auto flex h-(--conversation-line-height) shrink-0 items-center self-start pl-1.5 pr-1">{trailing}</span>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

The `trailing` slot in `DisclosureRow` was absolutely positioned (`right-1 top-0`), taking zero layout width. This caused the `ActivityTimerText` (live elapsed-time timer on pending tool rows) to paint directly over the row title text when the timer grew to `M:SS` format (~1 min mark), producing overlapping glyphs with no fade-out.

Fixes #79330

## Root Cause

`DisclosureRow` has two right-edge slots:
- `action` — laid out **in flow** (`ml-auto + shrink-0`), takes real width, title fades correctly
- `trailing` — laid out with **absolute positioning** (`absolute right-1 top-0`), takes zero width, title has no overflow signal

The only consumer of `trailing` is the pending tool row in `fallback.tsx`, which passes `<ActivityTimerText seconds={elapsed} />`. `ActivityTimerText` uses `StableText` with `w-[1ch]` cells, so its footprint grows in fixed steps as the timer digits increase. When `formatElapsed()` switches from `Ns` (2 chars) to `M:SS` (4 chars) at the 1-minute mark, the 4-character timer overlaps the last characters of the title.

## Fix

Change `trailing` from absolute to in-flow layout, matching the existing `action` slot pattern:

```diff
- <span className="absolute right-1 top-0 flex h-(--conversation-line-height) items-center">
+ <span className="pointer-events-none ml-auto flex h-(--conversation-line-height) shrink-0 items-center self-start pl-1.5 pr-1">
```

- `ml-auto + shrink-0` — occupies real width, pushes to the right edge (same as `action`)
- `pointer-events-none` — preserves the non-interactive contract (prevents stealing clicks from the caret)
- `pl-1.5 pr-1` — preserves the horizontal inset the old `right-1` anchor provided

With the slot occupying real width, the title's `FadeText` measures itself as overflowing and fades out at any timer size.

## Test Plan

- [ ] Pending tool row with short timer (`9s`) — no overlap (same as before)
- [ ] Pending tool row with `M:SS` timer (`1:33`) — title fades, no glyph overlap
- [ ] Hover on row — caret still visible and clickable (pointer-events-none doesn't interfere)
- [ ] Expanded tool group — trailing timer still positioned correctly