### PR TITLE
fix(config): redact secrets from config inspection output

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4216,6 +4216,15 @@ _SECRET_CONFIG_KEYS = frozenset({
 })
 
 
+def _is_secret_config_key(key: str) -> bool:
+    """Return whether a config mapping key conventionally carries a secret."""
+    normalized = key.lower().replace("-", "_")
+    return (
+        normalized in _SECRET_CONFIG_KEYS
+        or normalized.endswith(("_api_key", "_token", "_secret", "_password", "_passwd", "_private_key"))
+    )
+
+
 def redact_config_value(value: Any, _depth: int = 0) -> Any:
     """Return a copy of ``value`` with credential-shaped keys masked for display.
 
@@ -4227,7 +4236,7 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     redactor, and opaque tokens (e.g. Cloudflare ``cfut_...``) don't match the
     vendor-prefix regexes either, so structural key-name masking is required.
     """
-    from agent.redact import mask_secret
+    from agent.redact import mask_secret, redact_sensitive_text
 
     # Defensive bound on recursion depth for pathological/cyclic configs.
     if _depth > 20:
@@ -4235,13 +4244,18 @@ def redact_config_value(value: Any, _depth: int = 0) -> Any:
     if isinstance(value, dict):
         out = {}
         for k, v in value.items():
-            if isinstance(k, str) and k.lower() in _SECRET_CONFIG_KEYS and isinstance(v, str) and v:
+            if isinstance(k, str) and _is_secret_config_key(k) and isinstance(v, str) and v:
                 out[k] = mask_secret(v)
             else:
                 out[k] = redact_config_value(v, _depth + 1)
         return out
     if isinstance(value, list):
         return [redact_config_value(v, _depth + 1) for v in value]
+    if isinstance(value, str):
+        # Catch recognizable credentials even when stored under a custom key.
+        # force=True makes config inspection safe independently of the normal
+        # runtime redaction toggle.
+        return redact_sensitive_text(value, force=True)
     return value
 
 
@@ -5056,6 +5070,15 @@ def get_config_value(key: str, *, as_json: bool = False):
         print(f"Config key not set: {key}", file=sys.stderr)
         sys.exit(1)
 
+    # Configuration inspection is an unconditional secret boundary. Unlike
+    # ordinary tool/chat output, it must remain safe even when the operator
+    # disables runtime redaction, because arbitrary MCP env/header values can
+    # contain credentials that are not recognizable by token-prefix regexes.
+    if _is_env_config_key(key):
+        from agent.redact import mask_secret
+        value = mask_secret(value)
+    else:
+        value = redact_config_value(value)
     print(_format_config_get_value(value, as_json=as_json))
 
 

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -424,6 +424,96 @@ class TestSecretRedactionInDisplay:
         # Exact-match only — substrings like token_count must NOT be masked.
         assert out == cfg
 
+    def test_redact_config_value_masks_secret_suffixes_and_mcp_headers(self):
+        """MCP env suffixes and authorization headers are display secrets."""
+        from hermes_cli.config import redact_config_value
+
+        cfg = {
+            "env": {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "real-token",
+                "GITHUB_HOST": "https://api.github.com",
+            },
+            "headers": {"Authorization": "Bearer real-secret"},
+        }
+
+        out = redact_config_value(cfg)
+
+        assert "real-token" not in str(out)
+        assert "real-secret" not in str(out)
+        assert out["env"]["GITHUB_HOST"] == "https://api.github.com"
+
+    def test_config_get_redacts_secret_values_in_mcp_servers(self, _isolated_hermes_home, capsys):
+        """config get must not print MCP credentials in YAML output."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  github:\n"
+            "    command: github-mcp-server\n"
+            "    env:\n"
+            "      GITHUB_PERSONAL_ACCESS_TOKEN: real-github-token\n"
+            "      GITHUB_HOST: https://api.github.com\n"
+        )
+
+        args = argparse.Namespace(config_command="get", key="mcp_servers", json=False)
+        config_command(args)
+
+        output = capsys.readouterr().out
+        assert "real-github-token" not in output
+        assert "GITHUB_HOST: https://api.github.com" in output
+
+    def test_config_get_json_redacts_nested_mcp_credentials(self, _isolated_hermes_home, capsys):
+        """--json must redact the same nested MCP credentials as YAML output."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  proxmox:\n"
+            "    headers:\n"
+            "      Authorization: Bearer real-secret\n"
+        )
+
+        args = argparse.Namespace(config_command="get", key="mcp_servers", json=True)
+        config_command(args)
+
+        output = capsys.readouterr().out
+        assert "real-secret" not in output
+        assert "Authorization" in output
+
+    def test_config_get_redacts_recognizable_secret_under_custom_key(self, _isolated_hermes_home, capsys):
+        """Known token patterns are redacted even under non-secret keys."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "custom:\n"
+            "  value: ghp_abcdefghijklmnopqrstuvwxyz123456\n"
+        )
+
+        args = argparse.Namespace(config_command="get", key="custom", json=False)
+        config_command(args)
+
+        output = capsys.readouterr().out
+        assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in output
+
+    def test_config_get_redacts_env_secret_scalar(self, _isolated_hermes_home, capsys):
+        """Direct secret env-key reads must not print the resolved value."""
+        (_isolated_hermes_home / ".env").write_text("GITHUB_TOKEN=real-github-token\n")
+
+        args = argparse.Namespace(config_command="get", key="GITHUB_TOKEN", json=False)
+        config_command(args)
+
+        output = capsys.readouterr().out
+        assert "real-github-token" not in output
+
+    def test_config_get_redacts_even_when_runtime_redaction_is_disabled(self, _isolated_hermes_home, capsys):
+        """Config inspection remains safe when normal output redaction is off."""
+        (_isolated_hermes_home / "config.yaml").write_text(
+            "mcp_servers:\n"
+            "  custom:\n"
+            "    env:\n"
+            "      CUSTOM_PASSWORD: short-password\n"
+        )
+        with patch.dict(os.environ, {"HERMES_REDACT_SECRETS": "false"}):
+            args = argparse.Namespace(config_command="get", key="mcp_servers", json=False)
+            config_command(args)
+
+        output = capsys.readouterr().out
+        assert "short-password" not in output
+
     def test_set_echo_masks_secret_value(self, _isolated_hermes_home, capsys):
         secret = "cfut_ANOTHERSECRET0987654321zyxwvu"
         set_config_value("model.api_key", secret)


### PR DESCRIPTION
## Summary
- redact credential-shaped values from `hermes config get` output
- apply protection to YAML and JSON output, including nested MCP configuration
- keep configuration inspection safe when normal runtime redaction is disabled

## Testing
- `./scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py -v` (88 passed)
- `python3 -m compileall -q hermes_cli/config.py`

## Security
Configuration inspection is an unconditional redaction boundary; credentials are never printed from nested config structures.