### PR TITLE
fix(compression): reset in-place signal on aborted compaction to prevent history loss

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2899,6 +2899,14 @@ def compress_context(
             split_status="aborted",
             failure_class="explicit_interrupt",
         )
+        # An interrupted attempt did NOT compact in place. The run-level
+        # ``_last_compaction_in_place`` signal must be reset exactly like the
+        # other abort paths (lock-cancelled / fence-cancelled): a stale True
+        # from an EARLIER successful in-place compaction would make gateway /
+        # api_server consumers believe THIS attempt committed a boundary, and
+        # they would rewrite / archive the untouched transcript — permanently
+        # deleting the pre-compaction rows (#79391).
+        agent._last_compaction_in_place = False
         _existing_sp = getattr(agent, "_cached_system_prompt", None)
         if not _existing_sp:
             _existing_sp = agent._build_system_prompt(system_message)
@@ -2967,6 +2975,14 @@ def compress_context(
                         and "summary_generation_aborted"
                     ),
                 )
+                # No boundary was committed: an aborted summary attempt must
+                # not inherit a stale ``_last_compaction_in_place=True`` from
+                # an earlier successful in-place compaction. The run-level
+                # signal is what gateway/api_server consumers key their
+                # transcript rewrite on; leaving it stale would make them
+                # treat the untouched transcript as already-compacted and
+                # delete/overwrite the pre-compaction rows (#79391).
+                agent._last_compaction_in_place = False
                 return messages, _existing_sp
             finally:
                 _release_lock()

--- a/tests/run_agent/test_compression_abort_state_reset.py
+++ b/tests/run_agent/test_compression_abort_state_reset.py
@@ -132,4 +132,149 @@ class TestAbortPathsResetPerAttemptState:
             assert new_history is history
             db.close()
 
+    def test_explicit_interrupt_resets_run_level_in_place_signal(self):
+        """A hard interrupt after an earlier in-place success must not leave
+        ``_last_compaction_in_place=True`` behind (#79391).
+
+        Every other abort path (lock-cancelled, fence-cancelled) resets the
+        run-level signal so gateway/api_server consumers cannot mistake an
+        interrupted attempt for a committed in-place boundary and rewrite /
+        archive the untouched transcript — which physically deletes the
+        pre-compaction rows. The explicit_interrupt path was missing the same
+        reset, so a session that had compressed in place earlier the day
+        (stale True) lost its pre-compaction history when a later compression
+        was interrupted mid-summary by an incoming user message.
+        """
+        from unittest.mock import MagicMock, patch as mock_patch
+
+        from agent import auxiliary_client as aux
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            agent._cached_system_prompt = "system"
+
+            # Simulate an earlier successful in-place compaction: the run-level
+            # signal is True before this attempt starts (the exact stale state
+            # issue #79391 reports for a session compressed twice that day).
+            agent._last_compaction_in_place = True
+
+            compressor = MagicMock()
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+            compressor._last_compress_aborted = False
+            compressor._last_aux_model_failure_model = None
+            compressor._last_aux_model_failure_error = None
+            compressor._last_compression_made_progress = False
+            compressor._last_summary_fallback_used = False
+            compressor._summary_failure_cooldown_until = 0.0
+            compressor._cooldown_persist_failed = False
+            compressor._last_summary_dropped_count = 0
+            compressor._verify_compaction_cleared_threshold = False
+            compressor._ineffective_compression_count = 0
+            compressor._anti_thrash_recovery_deadline = 0.0
+            compressor._fallback_compression_streak = 0
+            compressor._consecutive_timeout_failures = 0
+            compressor._previous_summary = None
+            compressor._summary_has_user_turn = False
+            compressor._last_summary_auth_failure = False
+            compressor._last_summary_network_failure = False
+            compressor._last_aux_model_failure_model = None
+            compressor._summary_model_fallen_back = False
+            compressor.summary_model = None
+            compressor._compression_telemetry_seed = None
+            compressor._last_compression_telemetry = None
+            compressor._active_compression_telemetry = None
+
+            def _interrupted_compress(current, *_args, **_kwargs):
+                agent._hard_interrupt_requested.set()
+                raise aux.AuxiliaryExplicitCancellation()
+
+            compressor.compress.side_effect = _interrupted_compress
+            agent.context_compressor = compressor
+            agent._compression_feasibility_checked = True
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+            with mock_patch.dict(
+                os.environ, {"OPENROUTER_API_KEY": "test-key"}
+            ), mock_patch("agent.model_metadata.get_model_context_length", return_value=100000):
+                compressed, _sp = compress_context(
+                    agent, messages, "system", approx_tokens=100_000
+                )
+
+            # The interrupted attempt is a true no-op: transcript unchanged...
+            assert compressed == messages
+            # ...AND the run-level signal must NOT claim an in-place boundary
+            # was committed. A stale True would make gateway/api_server rewrite
+            # the untouched transcript as if it were already compacted.
+            assert agent._last_compaction_in_place is False
+            db.close()
+
+    def test_summary_abort_resets_run_level_in_place_signal(self):
+        """A summary-failure abort after an earlier in-place success must reset
+        ``_last_compaction_in_place`` too (#79391)."""
+        from unittest.mock import MagicMock, patch as mock_patch
+
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = _make_agent(db)
+            agent.compression_in_place = True
+            agent._cached_system_prompt = "system"
+            agent._last_compaction_in_place = True  # stale from earlier success
+
+            compressor = MagicMock()
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = "provider 429"
+            compressor._last_compress_aborted = True
+            compressor._last_aux_model_failure_model = None
+            compressor._last_aux_model_failure_error = None
+            compressor._last_compression_made_progress = False
+            compressor._last_summary_fallback_used = False
+            compressor._summary_failure_cooldown_until = 0.0
+            compressor._cooldown_persist_failed = False
+            compressor._last_summary_dropped_count = 0
+            compressor._verify_compaction_cleared_threshold = False
+            compressor._ineffective_compression_count = 0
+            compressor._anti_thrash_recovery_deadline = 0.0
+            compressor._fallback_compression_streak = 0
+            compressor._consecutive_timeout_failures = 0
+            compressor._previous_summary = None
+            compressor._summary_has_user_turn = False
+            compressor._last_summary_auth_failure = False
+            compressor._last_summary_network_failure = False
+            compressor._summary_model_fallen_back = False
+            compressor.summary_model = None
+            compressor._compression_telemetry_seed = None
+            compressor._last_compression_telemetry = None
+            compressor._active_compression_telemetry = None
+
+            def _aborted_compress(current, *_args, **_kwargs):
+                return list(current)  # no-op transcript
+
+            compressor.compress.side_effect = _aborted_compress
+            agent.context_compressor = compressor
+            agent._compression_feasibility_checked = True
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+            with mock_patch.dict(
+                os.environ, {"OPENROUTER_API_KEY": "test-key"}
+            ), mock_patch("agent.model_metadata.get_model_context_length", return_value=100000):
+                compressed, _sp = compress_context(
+                    agent, messages, "system", approx_tokens=100_000
+                )
+
+            assert compressed == messages
+            assert agent._last_compaction_in_place is False
+            db.close()
+
 


### PR DESCRIPTION
## 背景

修复 #79391：auto-compaction 被 `explicit_interrupt` 中断后，会话压缩前的历史被永久删除——无 summary、无 archive 行、消息 ID 出现硬缺口。

## 根因分析

`compress_context()` 中所有 abort/取消分支都会重置 `agent._last_compaction_in_place = False`（lock-cancelled、fence-cancelled），**唯独两条路径遗漏**：

1. `explicit_interrupt` 分支（用户发新消息中断压缩 summary streaming）
2. `_last_compress_aborted` 分支（summary 生成失败中止）

当会话当天已成功执行过 in-place 压缩（该标志残留 True），下一次压缩被中断时标志仍为 True。下游 consumer（gateway 的 `_compacted_in_place`、api_server 的 `_compressed`、`conversation_history_after_compression` 的 flush baseline）因此误判"本次尝试已提交压缩边界"，把未压缩的完整 transcript 当作已压缩集执行重写/归档路径——物理删除 pre-compaction 行（live + archived 均丢失），产生硬 ID gap。

## 修复方式

在 `explicit_interrupt` 分支与 `_last_compress_aborted` 分支返回前，将 `agent._last_compaction_in_place` 重置为 False，与其它所有 abort 路径保持一致。中断/中止的压缩尝试是 true no-op，绝不能向调用方宣告"已发生 in-place 压缩"。

## 验证

- [x] 新增 2 个回归测试：explicit_interrupt 与 summary-abort 后 `_last_compaction_in_place` 必须为 False（即使之前有成功 in-place 压缩的残留 True）
- [x] `tests/run_agent/test_compression_abort_state_reset.py` 3 passed
- [x] `tests/run_agent/test_in_place_compaction.py` `test_compression_interrupt_protection.py` `test_compression_concurrent_fork.py` 54 passed
- [x] `test_compression_persistence.py` `test_compression_boundary_hook.py` 20 passed
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #79391
