### PR TITLE
lifecycle guard: don't treat a referenced directory as an unsafe script

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -262,6 +262,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     try:
         metadata = os.fstat(descriptor)
+        if stat.S_ISDIR(metadata.st_mode):
+            # A directory cannot be an executable script. Treating it as
+            # unsafe false-positives any command whose scanned text contains
+            # a bare "/" token (e.g. Python sources with rstrip("/")),
+            # blocking benign CLIs from inside the gateway.
+            return None, False
         if not stat.S_ISREG(metadata.st_mode):
             return None, True
         # Read a bounded chunk first — even for oversized files, the first


### PR DESCRIPTION
## Problem

The gateway lifecycle guard's referenced-script scan (`cron/lifecycle_guard.py`) fails closed on any non-regular file. When it scans a referenced script's contents, a bare `/` token — present in almost any Python CLI (e.g. `rstrip("/")`) — resolves to the root directory. The directory opens fine but fails `S_ISREG`, so the guard blocks the entire command with the gateway-lifecycle message:

```
Blocked: command or referenced script cannot restart or stop the gateway from inside the gateway process.
```

In practice this silently breaks benign CLIs invoked from inside a gateway. In our deployment, every in-gateway invocation of a local idea-capture CLI failed with exit 1 and empty output for hours (the `execute_code` wrapper discards the `error` field, so agents saw only a silent failure). Any user CLI containing a bare `/` string hits the same wall.

## Fix

A directory cannot be an executable script — skip it instead of flagging it. Real lifecycle commands and nested restart scripts still block.

## Testing

- `tests/hermes_cli/test_gateway_restart_loop.py` — 82 passed
- Reproduced the false positive against a real-world CLI before the fix; verified it executes after the fix while `hermes gateway restart`-shaped payloads remain blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQvuLugn4ejwA7z8Szci55