### PR TITLE
chore: ignore .codegraph local index (CodeGraph MCP artifact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ native/fts5_cjk/*.so
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).
 .lazy-refresh-incomplete
+
+# CodeGraph local index (codegraph init artifact)
+.codegraph/


### PR DESCRIPTION
## What

Adds `.codegraph/` to `.gitignore`.

## Why

[CodeGraph](https://github.com/colbymchenry/codegraph) (64.7k★) officially supports Hermes Agent — `codegraph install` auto-configures the Hermes MCP server, and `codegraph init` builds a per-project SQLite knowledge graph at `.codegraph/`. Without an ignore rule, the local index shows up as untracked noise in every working tree and risks accidental commits of generated data.

Trivial, self-contained hygiene fix.