### PR TITLE
fix: persist TUI session undo rewinds

### DIFF
--- a/tests/tui_gateway/test_undo_command.py
+++ b/tests/tui_gateway/test_undo_command.py
@@ -108,3 +108,45 @@ def test_undo_returns_prefill_with_target_text(server, session_with_history):
     assert "Undid" in result["notice"]
 
 
+def test_session_undo_persists_rewind_for_resume(server, db, session_with_history):
+    sid, session_key, s, _agent = session_with_history
+
+    resp = _call(server, "session.undo", session_id=sid)
+
+    assert resp["result"]["removed"] == 2
+    assert [m["content"] for m in s["history"]] == [
+        "question 1",
+        "answer 1",
+        "question 2",
+        "answer 2",
+    ]
+
+    # Restart/resume reloads from SessionDB's active rows.  The toolbar/RPC
+    # undo must therefore soft-delete durable rows, not just mutate memory.
+    resumed = db.get_messages_as_conversation(session_key)
+    assert [m["content"] for m in resumed] == [
+        "question 1",
+        "answer 1",
+        "question 2",
+        "answer 2",
+    ]
+
+
+def test_session_undo_falls_back_for_transient_history(server):
+    sid = "sid-transient-undo"
+    server._sessions[sid] = {
+        "session_key": "",
+        "history": [
+            {"role": "user", "content": "draft"},
+            {"role": "assistant", "content": "reply"},
+        ],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "agent": None,
+    }
+
+    resp = _call(server, "session.undo", session_id=sid)
+
+    assert resp["result"]["removed"] == 2
+    assert server._sessions[sid]["history"] == []

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2392,6 +2392,59 @@ def _(rid, params: dict) -> dict:
         return _err(
             rid, 4009, "session busy — /interrupt the current turn before /undo"
         )
+
+    # Prefer the durable SessionDB rewind path whenever this is a persisted
+    # session.  The Ink/TUI toolbar undo RPC used to only mutate the in-memory
+    # session["history"] list; that made the current view look rewound, but a
+    # restart + resume reloaded the soft-undone turn from state.db.  Mirror the
+    # slash-command /undo semantics here: find the most recent real user turn,
+    # soft-delete that row and everything after it, then refresh active history.
+    session_key = str(session.get("session_key") or "").strip()
+    db = _get_db() if session_key else None
+    if db is not None:
+        try:
+            recents = db.list_recent_user_messages(session_key, limit=10)
+            if not recents:
+                return _ok(rid, {"removed": 0})
+            result = db.rewind_to_message(session_key, recents[0]["id"])
+            active = db.get_messages_as_conversation(
+                session_key, repair_alternation=True
+            )
+            removed = int(result.get("rewound_count") or 0)
+        except Exception as exc:
+            return _err(rid, 5008, f"undo: {exc}")
+
+        with session["history_lock"]:
+            session["history"] = list(active)
+            session["history_version"] = int(session.get("history_version", 0)) + 1
+
+        agent = session.get("agent")
+        if agent is not None:
+            mm = getattr(agent, "_memory_manager", None)
+            if mm is not None:
+                try:
+                    mm.on_session_switch(
+                        session_key,
+                        parent_session_id="",
+                        reset=False,
+                        rewound=True,
+                    )
+                except Exception:
+                    pass
+            if hasattr(agent, "_invalidate_system_prompt"):
+                try:
+                    agent._invalidate_system_prompt()
+                except Exception:
+                    pass
+            if hasattr(agent, "_last_flushed_db_idx"):
+                try:
+                    agent._last_flushed_db_idx = len(active)
+                except Exception:
+                    pass
+
+        return _ok(rid, {"removed": removed})
+
+    # Fallback for purely transient sessions that have not written a DB row yet.
     removed = 0
     with session["history_lock"]:
         history = session.get("history", [])


### PR DESCRIPTION
## Summary

- make the TUI `session.undo` RPC persist rewinds through `SessionDB.rewind_to_message`
- reload the active-only transcript after undo so live context and durable resume state match
- preserve the previous in-memory fallback for transient sessions without a persisted DB row

## Why

The TUI undo path could report that messages were undone while only trimming the in-memory session history. After exiting and resuming the session, the supposedly undone turn reappeared because the rows were still active in `state.db`.

## Tests

- `HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/tui_gateway/test_undo_command.py`
- `git diff --check`
