### PR TITLE
fix(gateway): filter iteration-budget-exhausted status from chat platforms (#79424)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -115,6 +115,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
+    # #79424 — iteration-budget-exhausted diagnostic must not leak to chat platforms
+    r"|iteration\s+budget\s+exhausted"
     r")",
     re.IGNORECASE | re.DOTALL,
 )


### PR DESCRIPTION
## Summary

Fixes #79424

When a turn exhausts its iteration budget, `agent/turn_finalizer.py` calls `_emit_status()` with a diagnostic message. This passes through `_prepare_gateway_status_message()` in `gateway/run.py` unfiltered, leaking internal diagnostics to gateway chat platforms (Slack, Discord, etc.).

## Root Cause

`_TELEGRAM_NOISY_STATUS_RE` (line 87 in `gateway/run.py`) has patterns for compression, fallback, rate-limit, and retry status messages — but no pattern for `"iteration budget exhausted"`. The diagnostic passes the regex check and gets posted as a real message in the user's chat.

## Fix

Added `iteration\s+budget\s+exhausted` to `_TELEGRAM_NOISY_STATUS_RE` so the message stays in logs only and never reaches end users.

## Testing

- Verified regex compiles correctly with `python3 -m py_compile gateway/run.py`
- The pattern matches the exact format emitted by `turn_finalizer.py`: `"⚠️ Iteration budget exhausted ({count}/{max}) — asking model to summarise"`