### PR TITLE
fix(kanban): make recursive decomposition atomic

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,14 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+# A frozen-plan binding is carried in task bodies by the admitted decomposition
+# bridge. Keep the parser deliberately line-oriented: accepting an arbitrary
+# 64-character substring would let a body carry two competing roots without
+# making the conflict visible to the transaction that records the receipt.
+FROZEN_PLAN_DIGEST_RE = re.compile(
+    r"(?m)^\s*(?:Frozen artifact|Frozen plan digest|Root frozen-plan digest):\s*"
+    r"([0-9a-f]{64})\s*$"
+)
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -2761,6 +2769,23 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     from hermes_cli.profiles import normalize_profile_name
 
     return normalize_profile_name(assignee)
+
+
+def _frozen_plan_digest_from_body(body: Optional[str]) -> Optional[str]:
+    """Return the one frozen-plan digest carried by ``body``.
+
+    ``None`` is the legacy/flat shape. A recursive decomposition opts into
+    strict binding by passing ``root_frozen_plan_digest``; in that mode a body
+    with multiple bindings is rejected rather than choosing one by accident.
+    """
+    if not isinstance(body, str):
+        return None
+    matches = FROZEN_PLAN_DIGEST_RE.findall(body)
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError("frozen-plan digest mismatch: body has multiple bindings")
+    return matches[0]
 
 
 def create_task(
@@ -5717,6 +5742,7 @@ def decompose_triage_task(
     children: list[dict],
     author: Optional[str] = None,
     auto_promote: bool = True,
+    root_frozen_plan_digest: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fan a triage task out into child tasks and promote the root to ``todo``.
 
@@ -5732,6 +5758,8 @@ def decompose_triage_task(
             "body": "...",                     # optional
             "assignee": "profile-name",        # optional, None -> default fallback
             "parents": [0, 2],                 # indices into this same children list
+            "depth": 2,                         # recursive descendants are triage
+            "plan_item_index": 0,               # inherited frozen-plan partition
         }
 
     Returns the list of created child task ids (in input order) on
@@ -5742,12 +5770,35 @@ def decompose_triage_task(
 
     Validation of titles/assignees happens inside the same write_txn as
     the inserts so a malformed entry aborts the whole decomposition
-    cleanly (no orphan children).
+    cleanly (no orphan children). When ``root_frozen_plan_digest`` is supplied,
+    every child body is bound to that digest and the binding is included in the
+    creation/decomposition receipts.
     """
     if not children:
         return None
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
+
+    child_digest_values = {
+        str(child.get("root_frozen_plan_digest"))
+        for child in children
+        if isinstance(child, dict)
+        and child.get("root_frozen_plan_digest") is not None
+    }
+    if len(child_digest_values) > 1:
+        raise ValueError("frozen-plan digest mismatch across children")
+    recursive_requested = bool(child_digest_values) or any(
+        isinstance(child, dict)
+        and (
+            child.get("recursive") is True
+            or (
+                isinstance(child.get("depth"), int)
+                and not isinstance(child.get("depth"), bool)
+                and child["depth"] > 1
+            )
+        )
+        for child in children
+    )
 
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
@@ -5798,11 +5849,16 @@ def decompose_triage_task(
     # add_comment) from inside this block — see architecture.md
     # write_txn pitfalls. Instead we inline the INSERTs and
     # _append_event calls.
+    if root_frozen_plan_digest is not None:
+        if re.fullmatch(r"[0-9a-f]{64}", root_frozen_plan_digest) is None:
+            raise ValueError("root frozen-plan digest is malformed")
+
     now = int(time.time())
     child_ids: list[str] = []
+    recursive_inserted = False
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, body, tenant, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -5811,6 +5867,17 @@ def decompose_triage_task(
         if root_row["status"] != "triage":
             return None
         tenant = root_row["tenant"]
+        bound_digest = root_frozen_plan_digest
+        if bound_digest is None and recursive_requested:
+            bound_digest = _frozen_plan_digest_from_body(root_row["body"])
+            if bound_digest is None:
+                raise ValueError("root frozen-plan digest is missing")
+        if bound_digest is not None:
+            if re.fullmatch(r"[0-9a-f]{64}", bound_digest) is None:
+                raise ValueError("root frozen-plan digest is malformed")
+            root_body_digest = _frozen_plan_digest_from_body(root_row["body"])
+            if root_body_digest != bound_digest:
+                raise ValueError("root frozen-plan digest mismatch")
         # Children inherit the root's workspace by default so a fan-out
         # of a code-gen task lands in the parent's project dir/worktree
         # rather than throwaway scratch tmp dirs. A child dict can still
@@ -5818,10 +5885,10 @@ def decompose_triage_task(
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
 
-        # Create children. Status is 'todo' regardless of parents — we
-        # link them under the root AFTER creation so the dispatcher
-        # sees a coherent state, and recompute_ready() at the end
-        # promotes parent-free children to 'ready'.
+        # Create children. Flat children keep their historical 'todo' status
+        # until the post-commit recompute promotes parent-free work to 'ready'.
+        # A depth-two recursive child is deliberately 'triage' so it cannot be
+        # claimed while the next fresh envelope is being prepared.
         for idx, child in enumerate(children):
             new_id = _new_task_id()
             title = child["title"].strip()
@@ -5843,17 +5910,54 @@ def decompose_triage_task(
             plan_item_index = child.get("plan_item_index")
             recursion_enabled = child.get("recursion_enabled")
             recursion_trigger_chars = child.get("recursion_trigger_chars")
+            recursive_child = (
+                isinstance(depth, int)
+                and not isinstance(depth, bool)
+                and depth > 1
+            )
+            recursive_child = recursive_child or child.get("recursive") is True
+            recursive_inserted = recursive_inserted or recursive_child
+            child_body = body if isinstance(body, str) else None
+            if bound_digest is not None:
+                child_body_digest = _frozen_plan_digest_from_body(child_body)
+                if (
+                    child_body_digest is not None
+                    and child_body_digest != bound_digest
+                ):
+                    raise ValueError("frozen-plan digest mismatch")
+                if child_body_digest is None:
+                    binding = f"Frozen artifact: {bound_digest}"
+                    child_body = (
+                        f"{child_body}\n{binding}"
+                        if child_body
+                        else binding
+                    )
+                if (
+                    recursive_child
+                    and bound_digest is not None
+                    and child_body is not None
+                    and "Recursive decomposition metadata:" not in child_body
+                ):
+                    child_body = (
+                        f"{child_body.rstrip()}\n"
+                        "Recursive decomposition metadata: "
+                        f"depth={depth if depth is not None else 'none'}; "
+                        f"plan_item_index={plan_item_index if plan_item_index is not None else 'none'}; "
+                        f"root_frozen_plan_digest={bound_digest}"
+                    )
+            child_status = "triage" if recursive_child else "todo"
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
                 " workspace_path, tenant, created_at, created_by, depth, "
                 " plan_item_index, recursion_enabled, recursion_trigger_chars) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ",
                 (
                     new_id,
                     title,
-                    body if isinstance(body, str) else None,
+                    child_body,
                     assignee,
+                    child_status,
                     child_ws_kind,
                     child_ws_path,
                     tenant,
@@ -5871,7 +5975,24 @@ def decompose_triage_task(
             )
             _append_event(
                 conn, new_id, "created",
-                {"by": author or "decomposer", "from_decompose_of": task_id},
+                {
+                    "by": author or "decomposer",
+                    "from_decompose_of": task_id,
+                    **(
+                        {
+                            "depth": (
+                                int(depth) if depth is not None else None
+                            ),
+                            "plan_item_index": (
+                                int(plan_item_index)
+                                if plan_item_index is not None else None
+                            ),
+                            "root_frozen_plan_digest": bound_digest,
+                        }
+                        if bound_digest is not None
+                        else {}
+                    ),
+                },
             )
             child_ids.append(new_id)
 
@@ -5887,7 +6008,15 @@ def decompose_triage_task(
                 )
                 _append_event(
                     conn, child_id, "linked",
-                    {"parent": parent_id, "child": child_id},
+                    {
+                        "parent": parent_id,
+                        "child": child_id,
+                        **(
+                            {"root_frozen_plan_digest": bound_digest}
+                            if bound_digest is not None
+                            else {}
+                        ),
+                    },
                 )
 
         # Link the ROOT task as a child of every leaf child — i.e. the
@@ -5927,20 +6056,25 @@ def decompose_triage_task(
                     now,
                 ),
             )
-        _append_event(
-            conn, task_id, "decomposed",
-            {
-                "child_ids": child_ids,
-                "root_assignee": root_assignee,
-            },
-        )
+        decomposed_payload = {
+            "child_ids": child_ids,
+            "root_assignee": root_assignee,
+        }
+        if bound_digest is not None:
+            decomposed_payload["root_frozen_plan_digest"] = bound_digest
+        _append_event(conn, task_id, "decomposed", decomposed_payload)
 
     # Outside the write_txn: promote parent-free children to 'ready'
     # so the dispatcher picks them up on its next tick. Same pattern
     # specify_triage_task uses.  When auto_promote is False children
     # stay in 'todo' until the user manually promotes them — useful
     # for manual-review-first workflows.
-    if auto_promote:
+    # Recursive children deliberately remain in triage. The old flat path
+    # promotes parent-free todo children after commit, but doing that for a
+    # recursive node creates a claimable interval before its next decomposition
+    # call can bind the child to the same frozen root. Flat mode retains the
+    # historical post-commit recompute byte-for-byte.
+    if auto_promote and not recursive_inserted:
         recompute_ready(conn)
     return child_ids
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -915,6 +915,12 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Recursive decomposition metadata is nullable on disk so legacy rows are
+    # never backfilled. A missing or NULL depth is the root-compatible depth 1.
+    depth: int = 1
+    plan_item_index: Optional[int] = None
+    recursion_enabled: Optional[bool] = None
+    recursion_trigger_chars: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1004,28 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            depth=(
+                int(row["depth"])
+                if "depth" in keys and row["depth"] is not None
+                else 1
+            ),
+            plan_item_index=(
+                int(row["plan_item_index"])
+                if "plan_item_index" in keys and row["plan_item_index"] is not None
+                else None
+            ),
+            recursion_enabled=(
+                bool(row["recursion_enabled"])
+                if "recursion_enabled" in keys
+                and row["recursion_enabled"] is not None
+                else None
+            ),
+            recursion_trigger_chars=(
+                int(row["recursion_trigger_chars"])
+                if "recursion_trigger_chars" in keys
+                and row["recursion_trigger_chars"] is not None
+                else None
             ),
         )
 
@@ -1176,7 +1204,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Recursive decomposition metadata. These columns intentionally remain
+    -- nullable so opening a legacy board never rewrites old rows.
+    depth                INTEGER,
+    plan_item_index      INTEGER,
+    recursion_enabled    INTEGER,
+    recursion_trigger_chars INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2202,6 +2236,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
+    # Recursive decomposition metadata is additive and nullable. Do not
+    # backfill depth: Task.from_row supplies the legacy-compatible value 1
+    # while the database preserves NULL for historical rows.
+    for name, definition in (
+        ("depth", "depth INTEGER"),
+        ("plan_item_index", "plan_item_index INTEGER"),
+        ("recursion_enabled", "recursion_enabled INTEGER"),
+        ("recursion_trigger_chars", "recursion_trigger_chars INTEGER"),
+    ):
+        if name not in cols:
+            _add_column_if_missing(conn, "tasks", name, definition)
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
     # legacy-column migration. Creating it here too would be redundant.
@@ -2742,6 +2787,10 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    depth: Optional[int] = None,
+    plan_item_index: Optional[int] = None,
+    recursion_enabled: Optional[bool] = None,
+    recursion_trigger_chars: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2970,8 +3019,10 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        depth, plan_item_index, recursion_enabled,
+                        recursion_trigger_chars
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2994,6 +3045,14 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        int(depth) if depth is not None else None,
+                        int(plan_item_index) if plan_item_index is not None else None,
+                        int(bool(recursion_enabled))
+                        if recursion_enabled is not None else None,
+                        (
+                            int(recursion_trigger_chars)
+                            if recursion_trigger_chars is not None else None
+                        ),
                     ),
                 )
                 for pid in parents:
@@ -5780,11 +5839,16 @@ def decompose_triage_task(
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            depth = child.get("depth")
+            plan_item_index = child.get("plan_item_index")
+            recursion_enabled = child.get("recursion_enabled")
+            recursion_trigger_chars = child.get("recursion_trigger_chars")
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, depth, "
+                " plan_item_index, recursion_enabled, recursion_trigger_chars) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -5795,6 +5859,14 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    int(depth) if depth is not None else None,
+                    int(plan_item_index) if plan_item_index is not None else None,
+                    int(bool(recursion_enabled))
+                    if recursion_enabled is not None else None,
+                    (
+                        int(recursion_trigger_chars)
+                        if recursion_trigger_chars is not None else None
+                    ),
                 ),
             )
             _append_event(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -49,6 +49,16 @@ from hermes_cli import profiles as profiles_mod
 logger = logging.getLogger(__name__)
 
 
+# The native decomposition call is intentionally a fresh envelope at every
+# level. A recursive child must not inherit the remaining excerpt budget of its
+# parent plan; the whole child body is the next call's input, capped once at the
+# same external 4k boundary.
+NATIVE_DECOMPOSER_ENVELOPE_CHARS = 4000
+_RECURSION_POLICY_RE = re.compile(r"(?m)^\s*R=(0|1);T=(\d+);")
+_CHILD_MARKER_RE = re.compile(r"(?m)^LINGUAL_ADMITTED_CHILD_V1 (\{[^\n]+\})$")
+_RECURSIVE_BODY_MARKER = "Recursive decomposition metadata:"
+
+
 _SYSTEM_PROMPT = """You are the Kanban decomposer for the Hermes Agent board.
 
 A user dropped a rough idea into the Triage column. Your job is to break it
@@ -268,6 +278,158 @@ def _normalize_assignee_choice(
     return chosen
 
 
+def _frozen_plan_digest(body: Optional[str]) -> Optional[str]:
+    """Extract the single admitted frozen-plan binding from a task body."""
+    if not isinstance(body, str):
+        return None
+    matches = kb.FROZEN_PLAN_DIGEST_RE.findall(body)
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError("frozen-plan digest mismatch: body has multiple bindings")
+    return matches[0]
+
+
+def _recursive_policy(task: kb.Task) -> tuple[bool, int]:
+    """Read the persisted recursion decision, with a legacy body fallback."""
+    if task.recursion_enabled is not None:
+        enabled = bool(task.recursion_enabled)
+        threshold = task.recursion_trigger_chars
+        return enabled, int(threshold) if threshold is not None else 400
+    match = _RECURSION_POLICY_RE.search(task.body or "")
+    if match is None:
+        return False, 400
+    return match.group(1) == "1", int(match.group(2))
+
+
+def _marker_metadata(body: str) -> dict:
+    """Read optional recursive fields from the admitted-child body marker."""
+    matches = list(_CHILD_MARKER_RE.finditer(body))
+    if not matches:
+        return {}
+    if len(matches) != 1:
+        raise ValueError("recursive child body has multiple admitted-child markers")
+    try:
+        marker = json.loads(matches[0].group(1))
+    except json.JSONDecodeError as exc:
+        raise ValueError("recursive child body marker is malformed") from exc
+    if not isinstance(marker, dict):
+        raise ValueError("recursive child body marker is malformed")
+    return marker
+
+
+def _thread_recursive_body(
+    body: str,
+    *,
+    root_digest: str,
+    depth: int,
+    plan_item_index: Optional[int],
+    recursion_trigger_chars: int,
+) -> str:
+    """Carry the root binding and per-level metadata into a child body."""
+    existing_digest = _frozen_plan_digest(body)
+    if existing_digest is not None and existing_digest != root_digest:
+        raise ValueError("frozen-plan digest mismatch")
+    if existing_digest is None:
+        body = (
+            f"{body.rstrip()}\nFrozen artifact: {root_digest}"
+            if body.strip()
+            else f"Frozen artifact: {root_digest}"
+        )
+    marker_matches = list(_CHILD_MARKER_RE.finditer(body))
+    if marker_matches:
+        marker = _marker_metadata(body)
+        marker.setdefault("depth", depth)
+        if plan_item_index is not None:
+            marker.setdefault("plan_item_index", plan_item_index)
+        replacement = (
+            "LINGUAL_ADMITTED_CHILD_V1 "
+            + json.dumps(marker, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        )
+        match = marker_matches[0]
+        body = body[: match.start()] + replacement + body[match.end() :]
+    metadata_line = (
+        f"{_RECURSIVE_BODY_MARKER} depth={depth}; "
+        f"plan_item_index={plan_item_index if plan_item_index is not None else 'none'}; "
+        f"root_frozen_plan_digest={root_digest}; "
+        f"envelope_chars={NATIVE_DECOMPOSER_ENVELOPE_CHARS}; "
+        f"trigger_chars={recursion_trigger_chars}"
+    )
+    if _RECURSIVE_BODY_MARKER not in body:
+        body = f"{body.rstrip()}\n{metadata_line}"
+    return body
+
+
+def _recursive_child_metadata(
+    task: kb.Task,
+    entry: dict,
+    body: str,
+    *,
+    root_digest: str,
+    recursion_trigger_chars: int,
+) -> tuple[str, int, Optional[int]]:
+    """Bind recursive child metadata to its parent and frozen root.
+
+    The bridge may carry metadata both in the JSON envelope and in the
+    ``LINGUAL_ADMITTED_CHILD_V1`` body marker. Treat disagreement as a hard
+    failure: otherwise the DB columns and the receipt body describe different
+    trees.
+    """
+    marker = _marker_metadata(body)
+    marker_digest = marker.get("root_frozen_plan_digest")
+    if marker_digest is not None and marker_digest != root_digest:
+        raise ValueError("frozen-plan digest mismatch")
+    declared_digest = entry.get("root_frozen_plan_digest")
+    if declared_digest is not None and declared_digest != root_digest:
+        raise ValueError("frozen-plan digest mismatch")
+
+    def metadata_int(name: str, *, non_negative: bool = False) -> Optional[int]:
+        value = entry.get(name)
+        marker_value = marker.get(name)
+        if value is None:
+            value = marker_value
+        elif marker_value is not None and marker_value != value:
+            raise ValueError(f"recursive child {name} mismatch")
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"recursive child {name} must be an integer")
+        if (non_negative and value < 0) or (not non_negative and value < 1):
+            qualifier = "non-negative" if non_negative else "positive"
+            raise ValueError(f"recursive child {name} must be {qualifier}")
+        return value
+
+    depth = metadata_int("depth")
+    is_recursive_call = task.plan_item_index is not None
+    if depth is None:
+        depth = task.depth + 1 if is_recursive_call else 1
+    expected_depth = task.depth + 1 if is_recursive_call else None
+    if expected_depth is not None and depth != expected_depth:
+        raise ValueError(
+            f"recursive child depth mismatch: expected {expected_depth}, got {depth}"
+        )
+    if depth > 2:
+        raise ValueError("recursive child depth exceeds 2")
+
+    plan_item_index = metadata_int("plan_item_index", non_negative=True)
+    if is_recursive_call:
+        if plan_item_index is None:
+            plan_item_index = task.plan_item_index
+        if plan_item_index != task.plan_item_index:
+            raise ValueError("recursive child plan_item_index mismatch")
+
+    if plan_item_index is None:
+        raise ValueError("recursive child plan_item_index is required")
+    body = _thread_recursive_body(
+        body,
+        root_digest=root_digest,
+        depth=depth,
+        plan_item_index=plan_item_index,
+        recursion_trigger_chars=recursion_trigger_chars,
+    )
+    return body, depth, plan_item_index
+
+
 def decompose_task(
     task_id: str,
     *,
@@ -295,6 +457,19 @@ def decompose_task(
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    recursive_enabled, recursion_trigger_chars = _recursive_policy(task)
+    root_digest: Optional[str] = None
+    if recursive_enabled:
+        try:
+            root_digest = _frozen_plan_digest(task.body)
+        except ValueError as exc:
+            return DecomposeOutcome(task_id, False, str(exc))
+        if root_digest is None:
+            return DecomposeOutcome(
+                task_id,
+                False,
+                "recursive decomposition requires a root frozen-plan digest",
+            )
     roster, valid_names = _build_roster()
 
     try:
@@ -306,7 +481,10 @@ def decompose_task(
     user_msg = _USER_TEMPLATE.format(
         task_id=task.id,
         title=_truncate(task.title or "", 400),
-        body=_truncate(task.body or "(no body)", 4000),
+        body=_truncate(
+            task.body or "(no body)",
+            NATIVE_DECOMPOSER_ENVELOPE_CHARS,
+        ),
         roster=_format_roster(roster),
         default_assignee=default_assignee,
     )
@@ -316,14 +494,26 @@ def decompose_task(
         # (provider/model/base_url, extra_body, reasoning_effort, retries)
         # all apply — the previous direct client.chat.completions.create()
         # path dropped auxiliary.<task>.extra_body entirely (#35566).
+        system_prompt = _SYSTEM_PROMPT
+        if recursive_enabled:
+            system_prompt += (
+                "\nRecursive mode is enabled for this admitted root. Every child "
+                "must carry integer `depth` and `plan_item_index` fields. A "
+                "depth-1 partition owns its plan item; recursive descendants "
+                "inherit that same plan_item_index. Copy exactly one `Frozen "
+                "artifact: <root digest>` line into every child body and never "
+                "change the root digest. The root receives a fresh 4,000-character "
+                "decomposition envelope at every recursive call; do not split "
+                "this child body using the parent's remaining allocation.\n"
+            )
         resp = call_llm(
             task="kanban_decomposer",
             messages=[
-                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
-            max_tokens=4000,
+            max_tokens=NATIVE_DECOMPOSER_ENVELOPE_CHARS,
             timeout=timeout or 180,
         )
     except Exception as exc:
@@ -350,6 +540,17 @@ def decompose_task(
         new_body = parsed.get("body")
         title_val = new_title.strip() if isinstance(new_title, str) and new_title.strip() else None
         body_val = new_body if isinstance(new_body, str) and new_body.strip() else None
+        if recursive_enabled and body_val is not None:
+            try:
+                body_val = _thread_recursive_body(
+                    body_val,
+                    root_digest=root_digest or "",
+                    depth=task.depth,
+                    plan_item_index=task.plan_item_index,
+                    recursion_trigger_chars=recursion_trigger_chars,
+                )
+            except ValueError as exc:
+                return DecomposeOutcome(task_id, False, str(exc))
         assignee_val = None
         if not task.assignee:
             assignee_val = _normalize_assignee_choice(
@@ -401,6 +602,19 @@ def decompose_task(
         body = entry.get("body")
         if not isinstance(body, str):
             body = ""
+        depth: Optional[int] = None
+        plan_item_index: Optional[int] = None
+        if recursive_enabled:
+            try:
+                body, depth, plan_item_index = _recursive_child_metadata(
+                    task,
+                    entry,
+                    body,
+                    root_digest=root_digest or "",
+                    recursion_trigger_chars=recursion_trigger_chars,
+                )
+            except ValueError as exc:
+                return DecomposeOutcome(task_id, False, str(exc))
         assignee = entry.get("assignee")
         chosen = _normalize_assignee_choice(
             assignee,
@@ -427,6 +641,16 @@ def decompose_task(
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
+            **(
+                {
+                    "depth": depth,
+                    "plan_item_index": plan_item_index,
+                    "recursion_enabled": recursive_enabled,
+                    "recursion_trigger_chars": recursion_trigger_chars,
+                }
+                if recursive_enabled
+                else {}
+            ),
         })
 
     try:
@@ -438,6 +662,7 @@ def decompose_task(
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
+                root_frozen_plan_digest=root_digest if recursive_enabled else None,
             )
     except ValueError as exc:
         return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4959,3 +4959,73 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_recursive_metadata_is_nullable_and_depth_defaults_without_backfill(tmp_path):
+    db_path = tmp_path / "legacy-kanban.db"
+    legacy = sqlite3.connect(db_path)
+    legacy.execute(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER
+        )
+        """
+    )
+    legacy.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old row', 'ready', 1)"
+    )
+    legacy.commit()
+    legacy.close()
+
+    with kb.connect(db_path) as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        row = conn.execute(
+            "SELECT depth, plan_item_index, recursion_enabled, "
+            "recursion_trigger_chars FROM tasks WHERE id = 'legacy'"
+        ).fetchone()
+        task = kb.get_task(conn, "legacy")
+
+    assert {
+        "depth",
+        "plan_item_index",
+        "recursion_enabled",
+        "recursion_trigger_chars",
+    } <= columns
+    assert tuple(row) == (None, None, None, None)
+    assert task is not None
+    assert task.depth == 1
+
+
+def test_recursive_metadata_is_written_for_new_tasks(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="recursive child",
+            depth=2,
+            plan_item_index=3,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.depth == 2
+    assert task.plan_item_index == 3
+    assert task.recursion_enabled is True
+    assert task.recursion_trigger_chars == 400

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -349,3 +349,135 @@ def test_decompose_no_aux_client_configured(kanban_home):
     assert outcome.ok is False
     # call_llm's no-provider RuntimeError surfaces via the LLM-error branch.
     assert "LLM error" in outcome.reason
+
+
+def test_recursive_child_metadata_and_root_digest_are_threaded(kanban_home):
+    digest = "e" * 64
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive root",
+            body=f"Frozen artifact: {digest}\nR=1;T=400;",
+            triage=True,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "recursive metadata",
+        "tasks": [
+            {
+                "title": "partition",
+                "body": "Implement the partition.",
+                "assignee": "engineer",
+                "parents": [],
+                "depth": 2,
+                "plan_item_index": 3,
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids
+    with kb.connect() as conn:
+        child = kb.get_task(conn, outcome.child_ids[0])
+        events = kb.list_events(conn, outcome.child_ids[0])
+    assert child is not None
+    assert child.status == "triage"
+    assert child.depth == 2
+    assert child.plan_item_index == 3
+    assert f"Frozen artifact: {digest}" in child.body
+    created = next(event for event in events if event.kind == "created")
+    assert created.payload["root_frozen_plan_digest"] == digest
+
+
+def test_recursive_child_rejects_a_different_root_digest(kanban_home):
+    digest = "f" * 64
+    wrong_digest = "0" * 64
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive root",
+            body=f"Frozen artifact: {digest}\nR=1;T=400;",
+            triage=True,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "bad binding",
+        "tasks": [
+            {
+                "title": "wrong partition",
+                "body": f"Frozen artifact: {wrong_digest}\nDo not accept.",
+                "assignee": "engineer",
+                "parents": [],
+                "depth": 2,
+                "plan_item_index": 0,
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "digest mismatch" in outcome.reason
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_recursive_call_uses_a_fresh_4k_envelope(kanban_home):
+    digest = "1" * 64
+    long_body = f"Frozen artifact: {digest}\n" + ("parent allocation exhausted " * 400)
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive child",
+            body=long_body,
+            triage=True,
+            depth=1,
+            plan_item_index=0,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "fresh envelope",
+        "title": "freshly specified",
+        "body": "The recursive call gets its own budget.",
+    })
+    patches = _patch_list_profiles(["orchestrator", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload) as call_llm, _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    call = call_llm.call_args
+    assert call.kwargs["max_tokens"] == 4000
+    user_message = call.kwargs["messages"][1]["content"]
+    assert "parent allocation exhausted" in user_message
+    assert user_message.count("parent allocation exhausted") < 400

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -4,6 +4,7 @@ from the triage column. LLM-free by design.
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -228,3 +229,183 @@ def test_decompose_per_child_workspace_override(kanban_home):
         inh = kb.get_task(conn, child_ids[1])
     assert over.workspace_path == "/other/repo"
     assert inh.workspace_path == proj
+
+
+def test_recursive_children_are_triage_and_receipt_bound_to_root_digest(kanban_home):
+    digest = "a" * 64
+    root_body = f"Frozen artifact: {digest}\nR=1;T=400;"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive root",
+            body=root_body,
+            triage=True,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            root_frozen_plan_digest=digest,
+            children=[
+                {
+                    "title": "recursive child",
+                    "body": f"Frozen artifact: {digest}\nchild body",
+                    "assignee": "engineer",
+                    "depth": 2,
+                    "plan_item_index": 0,
+                },
+            ],
+            author="decomposer",
+        )
+        assert child_ids
+        child = kb.get_task(conn, child_ids[0])
+        assert child is not None
+        assert child.status == "triage"
+        assert kb.claim_task(conn, child.id) is None
+        created = [event for event in kb.list_events(conn, child.id) if event.kind == "created"]
+        decomposed = [event for event in kb.list_events(conn, tid) if event.kind == "decomposed"]
+
+    assert created[-1].payload == {
+        "by": "decomposer",
+        "from_decompose_of": tid,
+        "depth": 2,
+        "plan_item_index": 0,
+        "root_frozen_plan_digest": digest,
+    }
+    assert decomposed[-1].payload["root_frozen_plan_digest"] == digest
+
+
+def test_recursive_digest_mismatch_rolls_back_all_inserts(kanban_home):
+    root_digest = "b" * 64
+    wrong_digest = "c" * 64
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive root",
+            body=f"Frozen artifact: {root_digest}\nR=1;T=400;",
+            triage=True,
+            recursion_enabled=True,
+            recursion_trigger_chars=400,
+        )
+        with pytest.raises(ValueError, match="digest mismatch"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orchestrator",
+                root_frozen_plan_digest=root_digest,
+                children=[
+                    {
+                        "title": "wrong binding",
+                        "body": f"Frozen artifact: {wrong_digest}",
+                        "depth": 2,
+                        "plan_item_index": 0,
+                    },
+                ],
+                author="decomposer",
+            )
+        assert kb.get_task(conn, tid).status == "triage"
+        assert conn.execute("SELECT COUNT(*) FROM tasks WHERE id != ?", (tid,)).fetchone()[0] == 0
+
+
+def test_recursive_decomposition_skips_post_commit_ready_update(kanban_home, monkeypatch):
+    digest = "d" * 64
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive root",
+            body=f"Frozen artifact: {digest}\nR=1;T=400;",
+            triage=True,
+        )
+
+        def fail_recompute(_conn):
+            raise AssertionError("recursive decomposition must not recompute ready after commit")
+
+        monkeypatch.setattr(kb, "recompute_ready", fail_recompute)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            root_frozen_plan_digest=digest,
+            children=[
+                {
+                    "title": "recursive child",
+                    "body": f"Frozen artifact: {digest}",
+                    "depth": 2,
+                    "plan_item_index": 0,
+                },
+            ],
+            author="decomposer",
+        )
+        assert child_ids
+
+
+def test_recursive_child_is_not_claimable_until_commit_and_stays_triage(
+    kanban_home,
+    monkeypatch,
+):
+    digest = "1" * 64
+    known_child_id = "t_recursive_race"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="recursive root",
+            body=f"Frozen artifact: {digest}\nR=1;T=400;",
+            triage=True,
+        )
+
+    commit_entered = threading.Event()
+    release_commit = threading.Event()
+    original_boundary = kb._execute_boundary_with_retry
+
+    def hold_recursive_commit(conn, sql):
+        if sql == "COMMIT" and threading.current_thread().name == "decomposer":
+            commit_entered.set()
+            assert release_commit.wait(timeout=5)
+        return original_boundary(conn, sql)
+
+    monkeypatch.setattr(kb, "_new_task_id", lambda: known_child_id)
+    monkeypatch.setattr(kb, "_execute_boundary_with_retry", hold_recursive_commit)
+    result: dict[str, object] = {}
+
+    def decompose():
+        with kb.connect() as conn:
+            result["ids"] = kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orchestrator",
+                root_frozen_plan_digest=digest,
+                children=[
+                    {
+                        "title": "recursive child",
+                        "body": f"Frozen artifact: {digest}",
+                        "depth": 2,
+                        "plan_item_index": 0,
+                    },
+                ],
+                author="decomposer",
+            )
+
+    worker = threading.Thread(target=decompose, name="decomposer")
+    worker.start()
+    assert commit_entered.wait(timeout=5)
+
+    claim_result: dict[str, object] = {}
+
+    def claim():
+        with kb.connect() as conn:
+            claim_result["task"] = kb.claim_task(conn, known_child_id)
+
+    claimer = threading.Thread(target=claim, name="claimer")
+    claimer.start()
+    # The claimer is blocked behind the uncommitted write, never observing a
+    # partially inserted ready child. Releasing the commit lets it read the
+    # final triage status and complete its CAS attempt.
+    release_commit.set()
+    worker.join(timeout=5)
+    claimer.join(timeout=5)
+    assert not worker.is_alive()
+    assert not claimer.is_alive()
+    assert result["ids"] == [known_child_id]
+    assert claim_result["task"] is None


### PR DESCRIPTION
## Summary

- Insert recursive descendants as `triage` rows in the same transaction that flips the decomposed parent from `triage` to `todo`.
- Bind child bodies and decomposition receipts to the root frozen-plan digest while carrying depth and `plan_item_index` metadata, preserving workspace inheritance.
- Keep the flat-mode path unchanged and give each recursive call an independent 4,000-character envelope.

Closes #1656

Stacked on Hermes metadata PR #79402 (`fix/issue-1656-recursion-metadata`).

Acknowledgements: [[lingual-release-process]], [[agent-issue-pr-protocol]].

## Verification evidence

- `python3 -m pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py` — 259 passed.
- `python3 -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban_decompose.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py` — passed.
- `git diff --cached --check` — passed.
- The required `python3 -m pytest -x -q` gate was attempted twice; each run stopped after 2,535 passed at the unchanged `tests/agent/test_copilot_acp_client.py::test_run_prompt_preserves_real_home_when_profile_home_available` HOME assertion. The same failure reproduces on the parent metadata worktree, outside this diff.

## Rollback plan

Revert commit `56aa9581cf81ba8db3020dd1c21879dc948bf2d8` to remove the atomic recursive insertion and receipt binding changes. Keep recursion disabled/default-off while this stacked change is reviewed; the additive metadata columns from #79402 remain harmless if retained.
