### PR TITLE
feat(mcp): associate OAuth tokens with requesting user and surface consent in chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5708,6 +5708,42 @@ class BasePlatformAdapter(ABC):
                         )
                     return
 
+            # MCP OAuth consent paste (#78169): while the agent is blocked
+            # waiting for an OAuth callback, a pasted redirect URL must reach
+            # the flow — not the pending-message queue (same deadlock class
+            # as /approve and clarify replies).
+            if not cmd and event.text:
+                try:
+                    from tools.mcp_gateway_oauth import try_deliver_oauth_paste
+
+                    if try_deliver_oauth_paste(session_key, event.text):
+                        logger.debug(
+                            "[%s] Consumed MCP OAuth paste for session %s",
+                            self.name, session_key,
+                        )
+                        try:
+                            _thread_meta = _thread_metadata_for_source(
+                                event.source, _reply_anchor_for_event(event)
+                            )
+                            await self._send_with_retry(
+                                chat_id=event.source.chat_id,
+                                content=(
+                                    "OAuth authorization received — "
+                                    "continuing MCP setup."
+                                ),
+                                reply_to=_reply_anchor_for_event(event),
+                                metadata=_mark_notify_metadata(_thread_meta),
+                            )
+                        except Exception as e:
+                            logger.debug(
+                                "[%s] OAuth paste ack failed: %s", self.name, e
+                            )
+                        return
+                except Exception as e:
+                    logger.debug(
+                        "[%s] MCP OAuth paste check failed: %s", self.name, e
+                    )
+
             if self._busy_session_handler is not None:
                 try:
                     if await self._busy_session_handler(event, session_key):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5068,6 +5068,32 @@ class TurnRunner:
                     )
                 return
 
+            if approval_data.get("kind") == "mcp_oauth_consent_result":
+                ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+                msg = (
+                    approval_data.get("description")
+                    or approval_data.get("command")
+                    or "MCP OAuth did not complete."
+                )
+                try:
+                    _oauth_fut = safe_schedule_threadsafe(
+                        ctx._status_adapter.send(
+                            ctx._status_chat_id,
+                            msg,
+                            metadata=ctx._status_thread_metadata,
+                        ),
+                        ctx._loop_for_step,
+                        logger=logger,
+                        log_message="mcp oauth consent result send scheduling error",
+                    )
+                    if _oauth_fut is not None:
+                        _oauth_fut.result(timeout=15)
+                except Exception as _e:
+                    logger.warning(
+                        "Failed to deliver MCP OAuth consent result: %s", _e
+                    )
+                return
+
             # Pause the typing indicator while the agent waits for
             # user approval.  Critical for Slack's Assistant API where
             # assistant_threads_setStatus disables the compose box — the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5036,6 +5036,38 @@ class TurnRunner:
                 UX.  Otherwise fall back to a plain text message with
                 ``/approve`` instructions.
                 """
+            # MCP OAuth consent URL (#78169): deliver authorize link to the
+            # originating chat — not an /approve prompt.
+            if approval_data.get("kind") == "mcp_oauth_consent":
+                ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+                server = approval_data.get("server_name") or "MCP"
+                url = approval_data.get("authorization_url") or ""
+                msg = (
+                    f"MCP OAuth required for `{server}`.\n\n"
+                    f"Open this URL to authorize:\n{url}\n\n"
+                    f"After authorizing, if your browser shows a connection "
+                    f"error, copy the full redirect URL from the address bar "
+                    f"and paste it back here as a reply."
+                )
+                try:
+                    _oauth_fut = safe_schedule_threadsafe(
+                        ctx._status_adapter.send(
+                            ctx._status_chat_id,
+                            msg,
+                            metadata=ctx._status_thread_metadata,
+                        ),
+                        ctx._loop_for_step,
+                        logger=logger,
+                        log_message="mcp oauth consent send scheduling error",
+                    )
+                    if _oauth_fut is not None:
+                        _oauth_fut.result(timeout=15)
+                except Exception as _e:
+                    logger.warning(
+                        "Failed to deliver MCP OAuth consent URL: %s", _e
+                    )
+                return
+
             # Pause the typing indicator while the agent waits for
             # user approval.  Critical for Slack's Assistant API where
             # assistant_threads_setStatus disables the compose box — the
@@ -8686,6 +8718,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # waiting thread, resume typing, AND return a localized confirmation
         # string.  The busy-handler path does not auto-send that return, so
         # we deliver it ourselves (mirroring the draining-case send above).
+        try:
+            from tools.mcp_gateway_oauth import try_deliver_oauth_paste
+
+            if try_deliver_oauth_paste(session_key, event.text or ""):
+                try:
+                    adapter = self.adapters.get(event.source.platform)
+                    if adapter is not None:
+                        await adapter.send(
+                            event.source.chat_id,
+                            "OAuth authorization received — continuing MCP setup.",
+                        )
+                except Exception:
+                    pass
+                return True
+        except Exception:
+            pass
+
         try:
             from tools.approval import has_blocking_approval
             if has_blocking_approval(session_key):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -506,6 +506,13 @@ DEFAULT_CONFIG = {
         # When disabled, the watcher still detects the change and prints
         # guidance to apply it deliberately via /reload-mcp.
         "auto_reload_on_config_change": True,
+        # OAuth identity boundary (#78174). shared = one token set per
+        # profile+server; per_user = key by gateway session user so User A
+        # cannot silently reuse User B's MCP OAuth. Companion consent UX:
+        # #78169.
+        "oauth": {
+            "identity_mode": "shared",
+        },
     },
 
     # Tool-output truncation thresholds. When terminal output or a

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -378,7 +378,7 @@ def _probe_single_server(
     return tools_found
 
 
-def _oauth_tokens_present(name: str) -> bool:
+def _oauth_tokens_present(name: str, *, user_key: str = "") -> bool:
     """Return True if an OAuth token file exists on disk for ``name``.
 
     Used after ``hermes mcp login`` to distinguish a genuine authentication
@@ -387,7 +387,7 @@ def _oauth_tokens_present(name: str) -> bool:
     """
     try:
         from tools.mcp_oauth import HermesTokenStorage
-        return HermesTokenStorage(name).has_cached_tokens()
+        return HermesTokenStorage(name, user_key=user_key or None).has_cached_tokens()
     except Exception as exc:  # pragma: no cover — defensive
         logger.debug("Could not check OAuth tokens for '%s': %s", name, exc)
         # Be permissive on unexpected errors: don't block a real success.
@@ -784,13 +784,18 @@ def cmd_mcp_test(args):
 
 # ─── hermes mcp login ────────────────────────────────────────────────────────
 
-def _reauth_oauth_server(name: str, server_config: dict) -> bool:
+def _reauth_oauth_server(
+    name: str, server_config: dict, *, user_key: str = "",
+) -> bool:
     """Force a fresh OAuth flow for one server. Returns True on success.
 
     Wipes cached OAuth state (disk + in-process MCPOAuthManager cache),
     re-probes to trigger the browser flow, and verifies a token actually
     landed before reporting success. Shared by ``hermes mcp login`` and
     ``hermes mcp reauth`` so both behave identically for a single server.
+
+    When ``user_key`` is set, tokens land under
+    ``mcp-tokens/by-user/<user_key>/`` (#78174).
     """
     url = server_config.get("url")
     if not url:
@@ -805,12 +810,15 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     # OAuth flow.
     try:
         from tools.mcp_oauth_manager import get_manager
-        get_manager().remove(name)
+        get_manager().remove(name, user_key=user_key or "")
     except Exception as exc:
         _warning(f"Could not clear existing OAuth state: {exc}")
 
     print()
-    _info(f"Starting OAuth flow for '{name}'...")
+    if user_key:
+        _info(f"Starting OAuth flow for '{name}' (user={user_key})...")
+    else:
+        _info(f"Starting OAuth flow for '{name}'...")
 
     # Probe triggers the OAuth flow (browser redirect + callback capture).
     # Honor the server's configured connect_timeout so a human has enough
@@ -832,7 +840,14 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         except (TypeError, ValueError):
             _login_connect_timeout = 0.0
         _login_connect_timeout = max(_login_connect_timeout, 315.0)
-        with force_interactive_oauth():
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            stack.enter_context(force_interactive_oauth())
+            if user_key:
+                from tools.mcp_oauth_identity import force_oauth_user_key
+
+                stack.enter_context(force_oauth_user_key(user_key))
             tools = _probe_single_server(
                 name, server_config, connect_timeout=_login_connect_timeout
             )
@@ -844,7 +859,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         # "Authenticated — N tools" in that case is a false success: every
         # real tool call later hangs until timeout because there's no token.
         # Verify a token actually landed on disk before claiming success.
-        if not _oauth_tokens_present(name):
+        if not _oauth_tokens_present(name, user_key=user_key):
             _warning(
                 "Server responded, but no OAuth token was obtained — "
                 "authentication did not complete."
@@ -906,7 +921,8 @@ def cmd_mcp_login(args):
             _info(f"Available servers: {', '.join(servers)}")
         return
 
-    _reauth_oauth_server(name, servers[name])
+    user_key = (getattr(args, "user", None) or "").strip()
+    _reauth_oauth_server(name, servers[name], user_key=user_key)
 
 
 def cmd_mcp_reauth(args):

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -641,12 +641,45 @@ def cmd_mcp_remove(args):
     # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
     # any provider instance cached in the current process (e.g. from an
     # earlier `hermes mcp test` in the same session) is evicted too.
+    # Default wipe covers shared + every by-user identity for this server.
     try:
         from tools.mcp_oauth_manager import get_manager
         get_manager().remove(name)
-        _success("Cleaned up OAuth tokens")
+        _success("Cleaned up OAuth tokens (all identities)")
     except Exception:
         pass
+
+
+# ─── hermes mcp logout ────────────────────────────────────────────────────────
+
+def cmd_mcp_logout(args):
+    """Revoke stored OAuth tokens for a server without removing config.
+
+    ``hermes mcp logout <server>`` clears shared tokens and every
+    ``mcp-tokens/by-user/*/`` identity for that server.
+    ``hermes mcp logout <server> --user KEY`` clears only that identity.
+    """
+    name = getattr(args, "name", "") or ""
+    user_key = (getattr(args, "user", None) or "").strip()
+    if not name:
+        _error("Server name required.")
+        return
+
+    existing = _get_mcp_servers()
+    if name not in existing:
+        # Still allow logout for orphaned token files after config was edited
+        _warning(f"Server '{name}' not in config — clearing token files anyway.")
+
+    try:
+        from tools.mcp_oauth_manager import get_manager
+        if user_key:
+            get_manager().remove(name, user_key=user_key)
+            _success(f"Logged out '{name}' for user '{user_key}'")
+        else:
+            get_manager().remove(name, all_identities=True)
+            _success(f"Logged out '{name}' (all identities)")
+    except Exception as exc:
+        _error(f"Logout failed: {exc}")
 
 
 # ─── hermes mcp list ──────────────────────────────────────────────────────────
@@ -807,10 +840,13 @@ def _reauth_oauth_server(
         return False
 
     # Wipe both disk and in-memory cache so the next probe forces a fresh
-    # OAuth flow.
+    # OAuth flow. Limit to the login identity (shared or --user) — do not
+    # wipe every by-user tree when re-authing the shared profile.
     try:
         from tools.mcp_oauth_manager import get_manager
-        get_manager().remove(name, user_key=user_key or "")
+        get_manager().remove(
+            name, user_key=user_key or "", all_identities=False,
+        )
     except Exception as exc:
         _warning(f"Could not clear existing OAuth state: {exc}")
 
@@ -1117,6 +1153,7 @@ def mcp_command(args):
         "add": cmd_mcp_add,
         "remove": cmd_mcp_remove,
         "rm": cmd_mcp_remove,
+        "logout": cmd_mcp_logout,
         "list": cmd_mcp_list,
         "ls": cmd_mcp_list,
         "test": cmd_mcp_test,
@@ -1143,6 +1180,7 @@ def mcp_command(args):
         _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
         _info("hermes mcp add <name> --preset <preset>       Add from a known preset")
         _info("hermes mcp remove <name>                      Remove a server")
+        _info("hermes mcp logout <name> [--user KEY]         Clear OAuth tokens")
         _info("hermes mcp list                               List configured servers")
         _info("hermes mcp test <name>                        Test connection")
         _info("hermes mcp configure <name>                   Toggle tools")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -90,6 +90,14 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         help="Force re-authentication for an OAuth-based MCP server",
     )
     mcp_login_p.add_argument("name", help="Server name to re-authenticate")
+    mcp_login_p.add_argument(
+        "--user",
+        default="",
+        help=(
+            "Store tokens under mcp-tokens/by-user/<key>/ for per-user OAuth "
+            "(mcp.oauth.identity_mode: per_user). Example: telegram:12345"
+        ),
+    )
 
     mcp_reauth_p = mcp_sub.add_parser(
         "reauth",

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -99,6 +99,20 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         ),
     )
 
+    mcp_logout_p = mcp_sub.add_parser(
+        "logout",
+        help="Clear stored OAuth tokens for an MCP server (keeps config)",
+    )
+    mcp_logout_p.add_argument("name", help="Server name to log out of")
+    mcp_logout_p.add_argument(
+        "--user",
+        default="",
+        help=(
+            "Clear only mcp-tokens/by-user/<key>/ for this server. "
+            "Omit to wipe shared + all by-user identities."
+        ),
+    )
+
     mcp_reauth_p = mcp_sub.add_parser(
         "reauth",
         help="Re-authenticate one OAuth MCP server, or all of them (--all)",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12164,9 +12164,12 @@ def _run_dashboard_mcp_oauth(flow, cfg: dict) -> None:
                 backup = storage.snapshot()
                 previous_entry = None
                 try:
+                    # Re-auth clears only the shared/dashboard identity —
+                    # never wipe every by-user token tree (#78174).
                     previous_entry = manager.remove(
                         flow.server_name,
                         hermes_home=flow.hermes_home,
+                        all_identities=False,
                     )
                     tools = _probe_single_server(
                         flow.server_name,

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -168,6 +168,94 @@ class TestMcpRemove:
         cmd_mcp_remove(_make_args(name="oauth-srv"))
         assert not token_file.exists()
 
+    def test_remove_wipes_all_by_user_tokens(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "oauth-srv": {"url": "https://example.com/mcp", "auth": "oauth"},
+        })
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path
+        )
+
+        from tools.mcp_oauth import HermesTokenStorage
+
+        shared = HermesTokenStorage("oauth-srv", hermes_home=tmp_path)
+        user_a = HermesTokenStorage(
+            "oauth-srv", hermes_home=tmp_path, user_key="telegram:111",
+        )
+        user_b = HermesTokenStorage(
+            "oauth-srv", hermes_home=tmp_path, user_key="telegram:222",
+        )
+        for storage in (shared, user_a, user_b):
+            storage._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+            storage._tokens_path().write_text("{}")
+
+        from hermes_cli.mcp_config import cmd_mcp_remove
+
+        cmd_mcp_remove(_make_args(name="oauth-srv"))
+        assert not shared._tokens_path().exists()
+        assert not user_a._tokens_path().exists()
+        assert not user_b._tokens_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: cmd_mcp_logout
+# ---------------------------------------------------------------------------
+
+class TestMcpLogout:
+    def test_logout_all_identities(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "oauth-srv": {"url": "https://example.com/mcp", "auth": "oauth"},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path
+        )
+        from tools.mcp_oauth import HermesTokenStorage
+
+        shared = HermesTokenStorage("oauth-srv", hermes_home=tmp_path)
+        user_a = HermesTokenStorage(
+            "oauth-srv", hermes_home=tmp_path, user_key="telegram:111",
+        )
+        user_b = HermesTokenStorage(
+            "oauth-srv", hermes_home=tmp_path, user_key="telegram:222",
+        )
+        for storage in (shared, user_a, user_b):
+            storage._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+            storage._tokens_path().write_text("{}")
+
+        from hermes_cli.mcp_config import cmd_mcp_logout
+
+        cmd_mcp_logout(_make_args(name="oauth-srv", user=""))
+        assert not shared._tokens_path().exists()
+        assert not user_a._tokens_path().exists()
+        assert not user_b._tokens_path().exists()
+        assert "all identities" in capsys.readouterr().out.lower()
+
+    def test_logout_one_user(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "oauth-srv": {"url": "https://example.com/mcp", "auth": "oauth"},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config.get_hermes_home", lambda: tmp_path
+        )
+        from tools.mcp_oauth import HermesTokenStorage
+
+        user_a = HermesTokenStorage(
+            "oauth-srv", hermes_home=tmp_path, user_key="telegram:111",
+        )
+        user_b = HermesTokenStorage(
+            "oauth-srv", hermes_home=tmp_path, user_key="telegram:222",
+        )
+        for storage in (user_a, user_b):
+            storage._tokens_path().parent.mkdir(parents=True, exist_ok=True)
+            storage._tokens_path().write_text("{}")
+
+        from hermes_cli.mcp_config import cmd_mcp_logout
+
+        cmd_mcp_logout(_make_args(name="oauth-srv", user="telegram:111"))
+        assert not user_a._tokens_path().exists()
+        assert user_b._tokens_path().exists()
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_add

--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -357,7 +357,7 @@ def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
     # Force handle_401 to claim recovery succeeded.
     mgr = get_manager()
 
-    async def _h401(name, token=None):
+    async def _h401(name, token=None, user_key=""):
         return True
 
     monkeypatch.setattr(mgr, "handle_401", _h401)

--- a/tests/tools/test_mcp_gateway_oauth.py
+++ b/tests/tools/test_mcp_gateway_oauth.py
@@ -117,3 +117,124 @@ def test_gateway_oauth_available_requires_notify(monkeypatch):
         assert mod.gateway_oauth_available() is True
     finally:
         approval.unregister_gateway_notify("telegram:42")
+
+
+def test_consent_failure_notify_timeout(gateway_notify):
+    from tools.mcp_gateway_oauth import (
+        GatewayOAuthFlow,
+        gateway_oauth_flow,
+        notify_gateway_consent_result,
+    )
+
+    flow, notify = _start_flow("telegram:1", gateway_notify=gateway_notify)
+    with gateway_oauth_flow(flow):
+        notify_gateway_consent_result(
+            session_key="telegram:1",
+            server_name="linear",
+            outcome="timeout",
+        )
+    kinds = [c.args[0]["kind"] for c in notify.call_args_list]
+    assert "mcp_oauth_consent_result" in kinds
+    result_payload = next(
+        c.args[0] for c in notify.call_args_list
+        if c.args[0]["kind"] == "mcp_oauth_consent_result"
+    )
+    assert "timed out" in result_payload["description"].lower()
+    assert "linear" in result_payload["description"]
+
+
+def test_consent_failure_notify_cancelled_and_state(gateway_notify):
+    from tools.mcp_gateway_oauth import (
+        classify_oauth_consent_failure,
+        notify_gateway_consent_result,
+    )
+
+    assert classify_oauth_consent_failure(TimeoutError("x")) == "timeout"
+    assert classify_oauth_consent_failure(RuntimeError("user_skipped")) == "cancelled"
+    assert classify_oauth_consent_failure(ValueError("state mismatch")) == "state_mismatch"
+
+    notify = MagicMock()
+    gateway_notify["telegram:9"] = notify
+    notify_gateway_consent_result(
+        session_key="telegram:9",
+        server_name="srv",
+        outcome="cancelled",
+    )
+    assert "cancelled" in notify.call_args[0][0]["description"].lower()
+
+
+def test_oauth_paste_wrong_session_rejected(gateway_notify):
+    """Paste on session B with A's state must not complete A's flow."""
+    from tools.mcp_gateway_oauth import gateway_oauth_flow, try_deliver_oauth_paste
+
+    flow_a, notify_a = _start_flow("telegram:111", gateway_notify=gateway_notify)
+    flow_b, _notify_b = _start_flow("telegram:222", gateway_notify=gateway_notify)
+    with gateway_oauth_flow(flow_a):
+        asyncio.run(
+            flow_a.publish_authorization_url(
+                "https://auth.example/authorize?state=stateA"
+            )
+        )
+        # Session B has its own flow with different state
+        with gateway_oauth_flow(flow_b):
+            asyncio.run(
+                flow_b.publish_authorization_url(
+                    "https://auth.example/authorize?state=stateB"
+                )
+            )
+            assert not try_deliver_oauth_paste(
+                "telegram:222",
+                "http://127.0.0.1:9/callback?code=tok&state=stateA",
+            )
+            assert not flow_a._callback_ready.is_set()
+            assert not flow_b._callback_ready.is_set()
+        # Completing on A still works
+        assert try_deliver_oauth_paste(
+            "telegram:111",
+            "http://127.0.0.1:9/callback?code=tok&state=stateA",
+        )
+        assert flow_a._callback == ("tok", "stateA")
+    # State-mismatch on B should have notified
+    assert any(
+        c.args[0].get("kind") == "mcp_oauth_consent_result"
+        and c.args[0].get("outcome") == "state_mismatch"
+        for c in gateway_notify["telegram:222"].call_args_list
+    )
+
+
+def test_start_gateway_reauth_publishes_url(monkeypatch, gateway_notify):
+    from tools import approval
+    from tools.mcp_gateway_oauth import (
+        GatewayOAuthFlow,
+        get_gateway_oauth_flow,
+        start_gateway_reauth_and_wait_for_url,
+    )
+
+    session_key = "telegram:42"
+    notify = MagicMock()
+    gateway_notify[session_key] = notify
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "get_current_session_key", lambda: session_key)
+    monkeypatch.setattr(
+        "tools.mcp_oauth_identity.current_oauth_user_key",
+        lambda require=False: "telegram:42",
+    )
+
+    def _reconnect():
+        flow = get_gateway_oauth_flow()
+        assert isinstance(flow, GatewayOAuthFlow)
+        asyncio.run(
+            flow.publish_authorization_url(
+                "https://auth.example/authorize?state=reauth1"
+            )
+        )
+        # Simulate user paste completing the wait inside reconnect.
+        flow.deliver_callback(code="c", state="reauth1")
+
+    url, user_key = start_gateway_reauth_and_wait_for_url(
+        "linear", reconnect_fn=_reconnect, wait_url_timeout=5.0,
+    )
+    assert url == "https://auth.example/authorize?state=reauth1"
+    assert user_key == "telegram:42"
+    assert notify.call_args_list
+    assert notify.call_args_list[0].args[0]["kind"] == "mcp_oauth_consent"

--- a/tests/tools/test_mcp_gateway_oauth.py
+++ b/tests/tools/test_mcp_gateway_oauth.py
@@ -1,0 +1,119 @@
+"""Tests for gateway-surfaced MCP OAuth consent URLs (#78169 / #78174)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def gateway_notify(monkeypatch):
+    from tools import approval
+
+    cbs = {}
+    monkeypatch.setattr(approval, "_gateway_notify_cbs", cbs)
+    return cbs
+
+
+def _start_flow(session_key: str, *, gateway_notify):
+    from tools.mcp_gateway_oauth import GatewayOAuthFlow
+
+    notify = MagicMock()
+    gateway_notify[session_key] = notify
+    flow = GatewayOAuthFlow(server_name="linear", session_key=session_key)
+    return flow, notify
+
+
+def test_parse_and_deliver_oauth_paste(gateway_notify):
+    from tools.mcp_gateway_oauth import gateway_oauth_flow, try_deliver_oauth_paste
+
+    flow, notify = _start_flow("telegram:1", gateway_notify=gateway_notify)
+    with gateway_oauth_flow(flow):
+        asyncio.run(
+            flow.publish_authorization_url(
+                "https://auth.example/authorize?state=abc123&code_challenge=x"
+            )
+        )
+        assert flow.authorization_url is not None
+        notify.assert_called_once()
+        assert notify.call_args[0][0]["kind"] == "mcp_oauth_consent"
+        assert try_deliver_oauth_paste(
+            "telegram:1",
+            "http://127.0.0.1:9/callback?code=tok&state=abc123",
+        )
+        assert flow._callback == ("tok", "abc123")
+
+
+def test_oauth_paste_rejects_wrong_state(gateway_notify):
+    from tools.mcp_gateway_oauth import gateway_oauth_flow, try_deliver_oauth_paste
+
+    flow, _notify = _start_flow("telegram:1", gateway_notify=gateway_notify)
+    with gateway_oauth_flow(flow):
+        asyncio.run(
+            flow.publish_authorization_url(
+                "https://auth.example/authorize?state=abc123"
+            )
+        )
+        assert not try_deliver_oauth_paste(
+            "telegram:1",
+            "http://127.0.0.1:9/callback?code=tok&state=WRONG",
+        )
+        assert not flow._callback_ready.is_set()
+
+
+def test_oauth_paste_ignores_unrelated_text(gateway_notify):
+    from tools.mcp_gateway_oauth import gateway_oauth_flow, try_deliver_oauth_paste
+
+    flow, _notify = _start_flow("telegram:1", gateway_notify=gateway_notify)
+    with gateway_oauth_flow(flow):
+        asyncio.run(
+            flow.publish_authorization_url(
+                "https://auth.example/authorize?state=abc123"
+            )
+        )
+        assert not try_deliver_oauth_paste("telegram:1", "hello there")
+
+
+def test_redirect_handler_publishes_to_gateway_flow(monkeypatch, gateway_notify):
+    from tools import mcp_oauth
+    from tools.mcp_gateway_oauth import GatewayOAuthFlow, gateway_oauth_flow
+
+    gateway_notify["slack:U1"] = MagicMock()
+    monkeypatch.setattr(mcp_oauth, "_raise_if_non_interactive", lambda *_a, **_k: None)
+
+    flow = GatewayOAuthFlow(server_name="srv", session_key="slack:U1")
+    handler = mcp_oauth._make_redirect_handler(1234)
+    with gateway_oauth_flow(flow):
+        asyncio.run(handler("https://auth.example/authorize?state=s"))
+
+    assert flow.authorization_url == "https://auth.example/authorize?state=s"
+    gateway_notify["slack:U1"].assert_called_once()
+
+
+def test_is_interactive_when_gateway_flow_bound(gateway_notify):
+    from tools.mcp_oauth import _is_interactive
+    from tools.mcp_gateway_oauth import GatewayOAuthFlow, gateway_oauth_flow
+
+    gateway_notify["discord:9"] = MagicMock()
+    flow = GatewayOAuthFlow(server_name="srv", session_key="discord:9")
+    with gateway_oauth_flow(flow):
+        assert _is_interactive() is True
+
+
+def test_gateway_oauth_available_requires_notify(monkeypatch):
+    from tools import mcp_gateway_oauth as mod
+    from tools import approval
+
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "get_current_session_key", lambda: "telegram:42")
+    with approval._lock:
+        approval._gateway_notify_cbs.clear()
+    assert mod.gateway_oauth_available() is False
+
+    approval.register_gateway_notify("telegram:42", MagicMock())
+    try:
+        assert mod.gateway_oauth_available() is True
+    finally:
+        approval.unregister_gateway_notify("telegram:42")

--- a/tests/tools/test_mcp_oauth_integration.py
+++ b/tests/tools/test_mcp_oauth_integration.py
@@ -134,10 +134,12 @@ async def test_handle_401_deduplicates_concurrent_callers(tmp_path, monkeypatch)
     call_count = 0
     real_invalidate = mgr.invalidate_if_disk_changed
 
-    async def counting(name):
+    async def counting(name, *, hermes_home=None, user_key=""):
         nonlocal call_count
         call_count += 1
-        return await real_invalidate(name)
+        return await real_invalidate(
+            name, hermes_home=hermes_home, user_key=user_key,
+        )
 
     monkeypatch.setattr(mgr, "invalidate_if_disk_changed", counting)
 

--- a/tests/tools/test_mcp_oauth_per_user_identity.py
+++ b/tests/tools/test_mcp_oauth_per_user_identity.py
@@ -123,3 +123,190 @@ def test_shared_mode_ignores_session_user(monkeypatch):
         lambda name, default="": {"HERMES_SESSION_USER_ID": "999", "HERMES_SESSION_PLATFORM": "telegram"}.get(name, default),
     )
     assert identity.current_oauth_user_key(require=True) == ""
+
+
+def test_strip_credential_selector_args():
+    from tools.mcp_oauth_identity import strip_credential_selector_args
+
+    cleaned = strip_credential_selector_args(
+        {
+            "query": "hello",
+            "user_key": "telegram:OTHER",
+            "user_id": "999",
+            "hermes_user": "evil",
+            "limit": 3,
+            "arguments": {
+                "topic": "x",
+                "user_key": "telegram:OTHER",
+                "oauth_user": "nope",
+            },
+        }
+    )
+    assert cleaned == {
+        "query": "hello",
+        "limit": 3,
+        "arguments": {"topic": "x"},
+    }
+
+
+def test_tool_args_cannot_select_oauth_user(monkeypatch, tmp_path):
+    """Even if the model passes user_key in args, storage/registry use session identity."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_oauth_identity import force_oauth_user_key
+    from tools.mcp_oauth_manager import reset_manager_for_tests
+
+    reset_manager_for_tests()
+    monkeypatch.setattr(
+        "tools.mcp_oauth_identity.get_oauth_identity_mode", lambda: "per_user"
+    )
+    monkeypatch.setattr(mcp_tool, "_server_config_is_oauth", lambda *a, **k: True)
+
+    captured = {}
+
+    server = MagicMock()
+    server.name = "srv"
+    session = MagicMock()
+
+    async def _call_tool(name, arguments=None, **kw):
+        from types import SimpleNamespace
+
+        captured["arguments"] = dict(arguments or {})
+        return SimpleNamespace(isError=False, content=[], structuredContent=None)
+
+    session.call_tool = _call_tool
+    server.session = session
+    server._rpc_lock = MagicMock()
+    server._rpc_lock.__aenter__ = AsyncMock(return_value=None)
+    server._rpc_lock.__aexit__ = AsyncMock(return_value=None)
+    server.mark_tool_call = MagicMock()
+
+    mcp_tool._servers["srv@@telegram:111"] = server
+    mcp_tool._server_error_counts.pop("srv", None)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = mcp_tool._make_tool_handler("srv", "tool1", 10.0)
+        with force_oauth_user_key("telegram:111"):
+            result = handler({"query": "x", "user_key": "telegram:OTHER"})
+        parsed = json.loads(result)
+        assert "error" not in parsed
+        assert "user_key" not in captured["arguments"]
+        assert captured["arguments"].get("query") == "x"
+        # Wrong-user registry key must not be used
+        assert "srv@@telegram:OTHER" not in mcp_tool._servers
+    finally:
+        mcp_tool._servers.pop("srv@@telegram:111", None)
+        mcp_tool._server_error_counts.pop("srv", None)
+
+
+def test_remove_all_oauth_tokens_for_server(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth import (
+        HermesTokenStorage,
+        remove_all_oauth_tokens_for_server,
+    )
+
+    shared = HermesTokenStorage("linear")
+    a = HermesTokenStorage("linear", user_key="telegram:111")
+    b = HermesTokenStorage("linear", user_key="telegram:222")
+    for storage, token in ((shared, "S"), (a, "A"), (b, "B")):
+        _write_token(storage._tokens_path(), token)
+
+    cleared = remove_all_oauth_tokens_for_server("linear")
+    assert "" in cleared
+    # Filenames sanitize ':' → '_'
+    assert "telegram_111" in cleared
+    assert "telegram_222" in cleared
+    assert not shared._tokens_path().exists()
+    assert not a._tokens_path().exists()
+    assert not b._tokens_path().exists()
+
+
+def test_manager_remove_all_identities_false_preserves_by_user(tmp_path, monkeypatch):
+    """Dashboard/login re-auth must not wipe every by-user token tree."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = True
+    monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    shared = HermesTokenStorage("linear")
+    user_a = HermesTokenStorage("linear", user_key="telegram:111")
+    _write_token(shared._tokens_path(), "SHARED")
+    _write_token(user_a._tokens_path(), "TOKEN_A")
+
+    mgr = MCPOAuthManager()
+    mgr.get_or_build_provider("linear", "https://example.com/mcp", None)
+    mgr.remove("linear", all_identities=False)
+
+    assert not shared._tokens_path().exists()
+    assert user_a._tokens_path().exists()
+    assert json.loads(user_a._tokens_path().read_text())["access_token"] == "TOKEN_A"
+
+
+def test_two_users_separate_registry_and_tokens(monkeypatch, tmp_path):
+    """Hermetic multi-user isolation: distinct files + registry keys."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "tools.mcp_oauth_identity.get_oauth_identity_mode", lambda: "per_user"
+    )
+    from tools import mcp_tool
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_identity import (
+        force_oauth_user_key,
+        oauth_connection_registry_key,
+    )
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    monkeypatch.setattr(mcp_tool, "_server_config_is_oauth", lambda *a, **k: True)
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = True
+    monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+    for key, token in (("telegram:111", "TOKEN_A"), ("telegram:222", "TOKEN_B")):
+        storage = HermesTokenStorage("linear", user_key=key)
+        _write_token(storage._tokens_path(), token)
+
+    mgr = MCPOAuthManager()
+    pa = mgr.get_or_build_provider(
+        "linear", "https://example.com/mcp", None, user_key="telegram:111",
+    )
+    pb = mgr.get_or_build_provider(
+        "linear", "https://example.com/mcp", None, user_key="telegram:222",
+    )
+    asyncio.run(pa._initialize())
+    asyncio.run(pb._initialize())
+    assert pa.context.current_tokens.access_token == "TOKEN_A"
+    assert pb.context.current_tokens.access_token == "TOKEN_B"
+    # User B must never see User A's token
+    assert pa.context.current_tokens.access_token != pb.context.current_tokens.access_token
+
+    key_a = oauth_connection_registry_key("linear", "telegram:111")
+    key_b = oauth_connection_registry_key("linear", "telegram:222")
+    assert key_a != key_b
+
+    srv_a = MagicMock()
+    srv_a.session = MagicMock()
+    srv_a.name = "linear"
+    srv_b = MagicMock()
+    srv_b.session = MagicMock()
+    srv_b.name = "linear"
+    mcp_tool._servers[key_a] = srv_a
+    mcp_tool._servers[key_b] = srv_b
+    try:
+        with force_oauth_user_key("telegram:111"):
+            got = mcp_tool._get_connected_server_for_call("linear")
+            assert got is srv_a
+        with force_oauth_user_key("telegram:222"):
+            got = mcp_tool._get_connected_server_for_call("linear")
+            assert got is srv_b
+    finally:
+        mcp_tool._servers.pop(key_a, None)
+        mcp_tool._servers.pop(key_b, None)

--- a/tests/tools/test_mcp_oauth_per_user_identity.py
+++ b/tests/tools/test_mcp_oauth_per_user_identity.py
@@ -1,0 +1,125 @@
+"""Tests for per-user MCP OAuth identity (#78174)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip(
+    "mcp.client.auth.oauth2",
+    reason="MCP SDK 1.26.0+ required for OAuth support",
+)
+
+
+def _write_token(path: Path, access_token: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": access_token,
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }
+        )
+    )
+
+
+def test_token_storage_isolates_users(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth import HermesTokenStorage
+
+    shared = HermesTokenStorage("linear")
+    user_a = HermesTokenStorage("linear", user_key="telegram:111")
+    user_b = HermesTokenStorage("linear", user_key="telegram:222")
+
+    assert "by-user" not in str(shared._tokens_path())
+    assert "by-user" in str(user_a._tokens_path())
+    assert "by-user" in str(user_b._tokens_path())
+    assert user_a._tokens_path() != user_b._tokens_path()
+    assert user_a._tokens_path() != shared._tokens_path()
+
+    _write_token(shared._tokens_path(), "SHARED")
+    _write_token(user_a._tokens_path(), "TOKEN_A")
+    _write_token(user_b._tokens_path(), "TOKEN_B")
+
+    assert shared.has_cached_tokens()
+    assert user_a.has_cached_tokens()
+    assert user_b.has_cached_tokens()
+    assert json.loads(user_a._tokens_path().read_text())["access_token"] == "TOKEN_A"
+    assert json.loads(user_b._tokens_path().read_text())["access_token"] == "TOKEN_B"
+    assert json.loads(shared._tokens_path().read_text())["access_token"] == "SHARED"
+
+
+def test_manager_isolates_providers_by_user_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = True
+    monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    for key, token in (("telegram:111", "TOKEN_A"), ("telegram:222", "TOKEN_B")):
+        storage = HermesTokenStorage("srv", user_key=key)
+        _write_token(storage._tokens_path(), token)
+
+    mgr = MCPOAuthManager()
+    provider_a = mgr.get_or_build_provider(
+        "srv", "https://example.com/mcp", None, user_key="telegram:111",
+    )
+    provider_b = mgr.get_or_build_provider(
+        "srv", "https://example.com/mcp", None, user_key="telegram:222",
+    )
+    assert provider_a is not None and provider_b is not None
+    assert provider_a is not provider_b
+
+    asyncio.run(provider_a._initialize())
+    asyncio.run(provider_b._initialize())
+    assert provider_a.context.current_tokens.access_token == "TOKEN_A"
+    assert provider_b.context.current_tokens.access_token == "TOKEN_B"
+
+
+def test_current_oauth_user_key_fail_closed(monkeypatch):
+    from tools import mcp_oauth_identity as identity
+
+    monkeypatch.setattr(identity, "get_oauth_identity_mode", lambda: "per_user")
+    # No force override, no session user.
+    monkeypatch.setattr(
+        identity,
+        "_FORCE_USER_KEY",
+        identity._FORCE_USER_KEY,  # keep real ContextVar
+    )
+    # Ensure no leftover force
+    token = identity._FORCE_USER_KEY.set(None)
+    try:
+        with pytest.raises(identity.MissingMcpOAuthIdentityError):
+            identity.current_oauth_user_key(require=True)
+        assert identity.current_oauth_user_key(require=False) == ""
+    finally:
+        identity._FORCE_USER_KEY.reset(token)
+
+    with identity.force_oauth_user_key("discord:99"):
+        assert identity.current_oauth_user_key(require=True) == "discord:99"
+
+
+def test_oauth_connection_registry_key():
+    from tools.mcp_oauth_identity import oauth_connection_registry_key
+
+    assert oauth_connection_registry_key("linear", "") == "linear"
+    assert oauth_connection_registry_key("linear", "telegram:1") == "linear@@telegram:1"
+
+
+def test_shared_mode_ignores_session_user(monkeypatch):
+    from tools import mcp_oauth_identity as identity
+
+    monkeypatch.setattr(identity, "get_oauth_identity_mode", lambda: "shared")
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env",
+        lambda name, default="": {"HERMES_SESSION_USER_ID": "999", "HERMES_SESSION_PLATFORM": "telegram"}.get(name, default),
+    )
+    assert identity.current_oauth_user_key(require=True) == ""

--- a/tests/tools/test_mcp_tool_401_handling.py
+++ b/tests/tools/test_mcp_tool_401_handling.py
@@ -104,3 +104,72 @@ def test_call_tool_handler_non_auth_error_still_generic(monkeypatch, tmp_path):
     finally:
         mcp_tool._servers.pop("srv", None)
         mcp_tool._server_error_counts.pop("srv", None)
+
+
+def test_needs_reauth_includes_authorization_url_when_gateway_publishes(
+    monkeypatch, tmp_path,
+):
+    """Unrecovered 401 in a gateway session returns authorization_url."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools import approval
+    from tools.mcp_oauth_manager import get_manager, reset_manager_for_tests
+    from mcp.client.auth import OAuthFlowError
+
+    reset_manager_for_tests()
+    mcp_tool._ensure_mcp_loop()
+
+    server = MagicMock()
+    server.name = "srv"
+    session = MagicMock()
+
+    async def _call_tool_raises(*a, **kw):
+        raise OAuthFlowError("token expired")
+
+    session.call_tool = _call_tool_raises
+    server.session = session
+    server._reconnect_event = MagicMock()
+    server._ready = MagicMock()
+    server._ready.is_set.return_value = True
+
+    mcp_tool._servers["srv"] = server
+    mcp_tool._server_error_counts.pop("srv", None)
+
+    mgr = get_manager()
+
+    async def _h401(name, token=None, user_key=""):
+        return False
+
+    monkeypatch.setattr(mgr, "handle_401", _h401)
+
+    notify = MagicMock()
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "get_current_session_key", lambda: "telegram:7")
+    approval.register_gateway_notify("telegram:7", notify)
+
+    def _fake_start(server_name, *, reconnect_fn, wait_url_timeout=45.0):
+        return "https://auth.example/authorize?state=xyz", "telegram:7"
+
+    monkeypatch.setattr(
+        "tools.mcp_gateway_oauth.start_gateway_reauth_and_wait_for_url",
+        _fake_start,
+    )
+    monkeypatch.setattr(
+        "tools.mcp_gateway_oauth.gateway_oauth_available", lambda: True,
+    )
+
+    try:
+        handler = mcp_tool._make_tool_handler("srv", "tool1", 10.0)
+        result = handler({"arg": "v"})
+        parsed = json.loads(result)
+        assert parsed.get("needs_reauth") is True
+        assert parsed.get("authorization_url") == (
+            "https://auth.example/authorize?state=xyz"
+        )
+        assert "chat" in parsed.get("error", "").lower()
+        assert parsed.get("user_key") == "telegram:7"
+    finally:
+        approval.unregister_gateway_notify("telegram:7")
+        mcp_tool._servers.pop("srv", None)
+        mcp_tool._server_error_counts.pop("srv", None)

--- a/tests/tools/test_mcp_tool_401_handling.py
+++ b/tests/tools/test_mcp_tool_401_handling.py
@@ -58,7 +58,7 @@ def test_call_tool_handler_returns_needs_reauth_on_unrecoverable_401(monkeypatch
     # Force handle_401 to return False (no recovery available)
     mgr = get_manager()
 
-    async def _h401(name, token=None):
+    async def _h401(name, token=None, user_key=""):
         return False
 
     monkeypatch.setattr(mgr, "handle_401", _h401)

--- a/tools/mcp_gateway_oauth.py
+++ b/tools/mcp_gateway_oauth.py
@@ -1,0 +1,243 @@
+"""Gateway-mediated MCP OAuth consent bridge (#78169 / #78174).
+
+When Hermes needs browser authorization for an OAuth MCP server during a
+gateway session (Telegram/Discord/Slack/…), the authorize URL is delivered
+to the originating chat instead of only the host terminal.
+
+The MCP SDK still owns PKCE, state, DCR, and token exchange. This module:
+
+- publishes the authorization URL into the active gateway session
+- waits for the OAuth callback (public ``redirect_uri``, loopback, or a
+  pasted ``?code=&state=`` reply from the same user/session)
+- keeps flows keyed by session so User A's paste cannot complete User B's flow
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import secrets
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Iterator
+from urllib.parse import parse_qs, urlparse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GatewayOAuthFlow:
+    """In-flight OAuth consent flow owned by one gateway session."""
+
+    server_name: str
+    session_key: str
+    user_key: str = ""
+    created_at: float = field(default_factory=time.time)
+    authorization_url: str | None = None
+    expected_state: str | None = field(default=None, init=False)
+    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback_error: str | None = field(default=None, init=False, repr=False)
+    _authorization_ready: threading.Event = field(
+        default_factory=threading.Event, init=False, repr=False
+    )
+    _callback_ready: threading.Event = field(
+        default_factory=threading.Event, init=False, repr=False
+    )
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    async def publish_authorization_url(self, url: str) -> None:
+        state = parse_qs(urlparse(url).query).get("state", [None])[0]
+        if not state:
+            raise ValueError("OAuth authorization URL did not include state")
+        with self._lock:
+            if self._callback_ready.is_set():
+                raise RuntimeError("OAuth flow already ended")
+            self.expected_state = state
+            self.authorization_url = url
+            self._authorization_ready.set()
+
+        # Deliver into the originating platform (never log the full URL —
+        # it can contain sensitive query material).
+        _deliver_consent_url_to_gateway(
+            session_key=self.session_key,
+            server_name=self.server_name,
+            authorization_url=url,
+        )
+
+    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+        ready = await __import__("asyncio").to_thread(
+            self._callback_ready.wait, timeout
+        )
+        if not ready:
+            raise TimeoutError(
+                f"Timed out waiting for MCP OAuth callback for '{self.server_name}'"
+            )
+        if self._callback_error:
+            raise RuntimeError(f"OAuth authorization failed: {self._callback_error}")
+        if self._callback is None:
+            raise RuntimeError("OAuth callback did not include an authorization code")
+        return self._callback
+
+    def deliver_callback(
+        self,
+        *,
+        code: str | None,
+        state: str | None,
+        error: str | None = None,
+    ) -> None:
+        with self._lock:
+            if self._callback_ready.is_set():
+                raise ValueError("OAuth callback already received")
+            if (
+                self.expected_state is None
+                or state is None
+                or not secrets.compare_digest(self.expected_state, state)
+            ):
+                raise ValueError("OAuth callback state mismatch")
+            if error:
+                self._callback_error = error
+            elif code:
+                self._callback = (code, state)
+            else:
+                self._callback_error = "OAuth callback did not include code or error"
+            self._callback_ready.set()
+
+
+_current_gateway_flow: contextvars.ContextVar[GatewayOAuthFlow | None] = (
+    contextvars.ContextVar("mcp_gateway_oauth_flow", default=None)
+)
+
+# session_key → active flow (for inbound paste / correlation)
+_active_flows_by_session: dict[str, GatewayOAuthFlow] = {}
+_active_flows_lock = threading.Lock()
+
+
+@contextmanager
+def gateway_oauth_flow(flow: GatewayOAuthFlow) -> Iterator[None]:
+    """Bind *flow* for the current context and register it by session."""
+    token = _current_gateway_flow.set(flow)
+    with _active_flows_lock:
+        _active_flows_by_session[flow.session_key] = flow
+    try:
+        yield
+    finally:
+        with _active_flows_lock:
+            current = _active_flows_by_session.get(flow.session_key)
+            if current is flow:
+                _active_flows_by_session.pop(flow.session_key, None)
+        _current_gateway_flow.reset(token)
+
+
+def get_gateway_oauth_flow() -> GatewayOAuthFlow | None:
+    return _current_gateway_flow.get()
+
+
+def get_active_gateway_oauth_flow(session_key: str) -> GatewayOAuthFlow | None:
+    with _active_flows_lock:
+        return _active_flows_by_session.get(session_key)
+
+
+def gateway_oauth_available() -> bool:
+    """True when a gateway notify callback exists for the current session."""
+    try:
+        from tools.approval import (
+            _gateway_notify_cbs,
+            _is_gateway_approval_context,
+            _lock,
+            get_current_session_key,
+        )
+    except Exception:
+        return False
+    if not _is_gateway_approval_context():
+        return False
+    try:
+        session_key = get_current_session_key()
+    except Exception:
+        return False
+    if not session_key:
+        return False
+    with _lock:
+        return session_key in _gateway_notify_cbs
+
+
+def try_deliver_oauth_paste(session_key: str, text: str) -> bool:
+    """If *text* is an OAuth redirect/paste for an active flow, complete it.
+
+    Returns True when the message was consumed as an OAuth callback (caller
+    should not queue it as a normal agent turn).
+    """
+    flow = get_active_gateway_oauth_flow(session_key)
+    if flow is None or not text:
+        return False
+
+    code, state, error = _parse_oauth_paste(text)
+    if not code and not error:
+        return False
+    try:
+        flow.deliver_callback(code=code, state=state, error=error)
+    except ValueError as exc:
+        logger.info(
+            "MCP OAuth paste for session %s rejected: %s", session_key, exc
+        )
+        return False
+    return True
+
+
+def _parse_oauth_paste(text: str) -> tuple[str | None, str | None, str | None]:
+    """Extract code/state/error from a pasted redirect URL or query string."""
+    raw = (text or "").strip()
+    if not raw:
+        return None, None, None
+    # Accept full URLs or bare query fragments.
+    if "://" in raw or raw.startswith("?"):
+        parsed = urlparse(raw if "://" in raw else f"http://localhost{raw}")
+        qs = parse_qs(parsed.query)
+    elif "code=" in raw or "error=" in raw:
+        qs = parse_qs(raw.lstrip("?"))
+    else:
+        return None, None, None
+    code = (qs.get("code") or [None])[0]
+    state = (qs.get("state") or [None])[0]
+    error = (qs.get("error") or [None])[0]
+    if code or error:
+        return code, state, error
+    return None, None, None
+
+
+def _deliver_consent_url_to_gateway(
+    *,
+    session_key: str,
+    server_name: str,
+    authorization_url: str,
+) -> None:
+    from tools.approval import _gateway_notify_cbs, _lock
+
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if notify_cb is None:
+        raise RuntimeError(
+            f"No gateway notify callback for session {session_key}; "
+            "cannot surface MCP OAuth consent URL"
+        )
+    try:
+        notify_cb(
+            {
+                "kind": "mcp_oauth_consent",
+                "server_name": server_name,
+                "authorization_url": authorization_url,
+                "command": authorization_url,
+                "description": (
+                    f"MCP OAuth authorization required for '{server_name}'"
+                ),
+                "pattern_key": "mcp_oauth_consent",
+                "pattern_keys": ["mcp_oauth_consent"],
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to deliver MCP OAuth consent URL for '%s': %s",
+            server_name, exc,
+        )
+        raise

--- a/tools/mcp_gateway_oauth.py
+++ b/tools/mcp_gateway_oauth.py
@@ -181,8 +181,124 @@ def try_deliver_oauth_paste(session_key: str, text: str) -> bool:
         logger.info(
             "MCP OAuth paste for session %s rejected: %s", session_key, exc
         )
+        notify_gateway_consent_result(
+            session_key=session_key,
+            server_name=flow.server_name,
+            outcome="state_mismatch",
+            detail=str(exc),
+        )
         return False
     return True
+
+
+# Consent failure / result copy delivered via the same notify path as the
+# authorize URL (kind: mcp_oauth_consent_result). Never include full URLs.
+_CONSENT_RESULT_MESSAGES = {
+    "timeout": (
+        "MCP OAuth timed out waiting for authorization for `{server}`. "
+        "Ask me to retry the MCP action when you are ready to authorize, "
+        "or paste the redirect URL sooner after approving in the browser."
+    ),
+    "cancelled": (
+        "MCP OAuth was cancelled for `{server}`. "
+        "Ask me to retry when you want to authorize again."
+    ),
+    "state_mismatch": (
+        "That paste did not match the pending MCP OAuth flow for `{server}` "
+        "(wrong or expired state). Open the authorize link from this chat "
+        "again, then paste the redirect URL from the same browser session."
+    ),
+    "failed": (
+        "MCP OAuth failed for `{server}`. "
+        "Ask me to retry the action, or have an operator run "
+        "`hermes mcp login {server}` on the host."
+    ),
+}
+
+
+def notify_gateway_consent_result(
+    *,
+    session_key: str,
+    server_name: str,
+    outcome: str,
+    detail: str = "",
+) -> None:
+    """Send an actionable in-chat message for a finished/failed consent flow."""
+    from tools.approval import _gateway_notify_cbs, _lock
+
+    template = _CONSENT_RESULT_MESSAGES.get(outcome) or _CONSENT_RESULT_MESSAGES["failed"]
+    message = template.format(server=server_name)
+    if detail and outcome == "failed":
+        # Keep detail short and URL-free for the chat surface.
+        cleaned = detail.replace("\n", " ").strip()
+        if "http://" in cleaned or "https://" in cleaned:
+            cleaned = cleaned.split("http", 1)[0].strip(" :")
+        if cleaned and len(cleaned) < 200:
+            message = f"{message} ({cleaned})"
+
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if notify_cb is None:
+        logger.debug(
+            "No gateway notify for MCP OAuth consent result (%s / %s)",
+            server_name, outcome,
+        )
+        return
+    try:
+        notify_cb(
+            {
+                "kind": "mcp_oauth_consent_result",
+                "server_name": server_name,
+                "outcome": outcome,
+                "command": message,
+                "description": message,
+                "pattern_key": "mcp_oauth_consent_result",
+                "pattern_keys": ["mcp_oauth_consent_result"],
+            }
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to deliver MCP OAuth consent result for '%s': %s",
+            server_name, exc,
+        )
+
+
+def classify_oauth_consent_failure(exc: BaseException) -> str:
+    """Map an OAuth/connect exception to a consent-result outcome key."""
+    text = str(exc).lower()
+    name = type(exc).__name__.lower()
+    if isinstance(exc, TimeoutError) or "timed out" in text or "timeout" in name:
+        return "timeout"
+    if "user_skipped" in text or ("skip" in text and "oauth" in text):
+        return "cancelled"
+    if "access_denied" in text or "cancelled" in text or "canceled" in text:
+        return "cancelled"
+    if "state mismatch" in text or ("state" in text and "mismatch" in text):
+        return "state_mismatch"
+    return "failed"
+
+
+def notify_consent_failure_for_active_flow(
+    *,
+    session_key: str | None = None,
+    exc: BaseException | None = None,
+    outcome: str | None = None,
+) -> None:
+    """Notify the chat about a failed consent when a gateway flow is active."""
+    flow = get_gateway_oauth_flow()
+    if flow is None and session_key:
+        flow = get_active_gateway_oauth_flow(session_key)
+    if flow is None:
+        return
+    resolved = outcome or (
+        classify_oauth_consent_failure(exc) if exc is not None else "failed"
+    )
+    notify_gateway_consent_result(
+        session_key=flow.session_key,
+        server_name=flow.server_name,
+        outcome=resolved,
+        detail=str(exc) if exc is not None else "",
+    )
 
 
 def _parse_oauth_paste(text: str) -> tuple[str | None, str | None, str | None]:
@@ -204,6 +320,80 @@ def _parse_oauth_paste(text: str) -> tuple[str | None, str | None, str | None]:
     if code or error:
         return code, state, error
     return None, None, None
+
+
+def start_gateway_reauth_and_wait_for_url(
+    server_name: str,
+    *,
+    reconnect_fn,
+    wait_url_timeout: float = 45.0,
+) -> tuple[str | None, str]:
+    """Begin gateway OAuth reauth; return ``(authorization_url, user_key)``.
+
+    ``reconnect_fn`` is a zero-arg callable that rebuilds the MCP session
+    (tokens already cleared by the caller). It runs in a background thread
+    under :class:`GatewayOAuthFlow` so the redirect handler can publish the
+    URL while this function waits for ``_authorization_ready``.
+
+    The flow stays registered until ``reconnect_fn`` finishes (callback,
+    timeout, or failure) so paste-back still works after this returns.
+    """
+    from tools.approval import get_current_session_key
+    from tools.mcp_oauth import force_interactive_oauth
+    from tools.mcp_oauth_identity import current_oauth_user_key
+
+    if not gateway_oauth_available():
+        return None, current_oauth_user_key(require=False)
+
+    session_key = get_current_session_key()
+    if not session_key:
+        return None, current_oauth_user_key(require=False)
+
+    user_key = current_oauth_user_key(require=False)
+    flow = GatewayOAuthFlow(
+        server_name=server_name,
+        session_key=session_key,
+        user_key=user_key,
+    )
+
+    done = threading.Event()
+    worker_exc: list[BaseException] = []
+
+    def _worker() -> None:
+        try:
+            with gateway_oauth_flow(flow), force_interactive_oauth():
+                try:
+                    reconnect_fn()
+                except BaseException as exc:  # noqa: BLE001 — surface to chat
+                    # Notify while the flow is still bound so session lookup works.
+                    notify_gateway_consent_result(
+                        session_key=session_key,
+                        server_name=server_name,
+                        outcome=classify_oauth_consent_failure(exc),
+                        detail=str(exc),
+                    )
+                    raise
+        except BaseException as exc:  # noqa: BLE001
+            worker_exc.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(
+        target=_worker,
+        name=f"mcp-oauth-reauth-{server_name}",
+        daemon=True,
+    )
+    thread.start()
+
+    # Wait until the authorize URL is published, or the worker ends early.
+    while not flow._authorization_ready.wait(timeout=0.25):
+        if done.is_set():
+            break
+        wait_url_timeout -= 0.25
+        if wait_url_timeout <= 0:
+            break
+
+    return flow.authorization_url, user_key
 
 
 def _deliver_consent_url_to_gateway(

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -302,6 +302,14 @@ def _is_interactive() -> bool:
     if _oauth_interactive_forced.get():
         return True
     try:
+        from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+        from tools.mcp_gateway_oauth import get_gateway_oauth_flow
+
+        if get_dashboard_oauth_flow() is not None or get_gateway_oauth_flow() is not None:
+            return True
+    except Exception:
+        pass
+    try:
         return sys.stdin.isatty()
     except (AttributeError, ValueError):
         return False
@@ -732,10 +740,16 @@ def _make_redirect_handler(port: int, redirect_uri: str | None = None):
         as a fallback for headless/SSH/gateway environments.
         """
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+        from tools.mcp_gateway_oauth import get_gateway_oauth_flow
 
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
             await dashboard_flow.publish_authorization_url(authorization_url)
+            return
+
+        gateway_flow = get_gateway_oauth_flow()
+        if gateway_flow is not None:
+            await gateway_flow.publish_authorization_url(authorization_url)
             return
 
         # Fail fast at the authorization boundary in non-interactive contexts
@@ -852,10 +866,15 @@ def _make_callback_waiter(port: int):
 
     async def _wait() -> tuple[str, str | None]:
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+        from tools.mcp_gateway_oauth import get_gateway_oauth_flow
 
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
             return await dashboard_flow.wait_for_callback()
+
+        gateway_flow = get_gateway_oauth_flow()
+        # When gateway_flow is set we still bind loopback (redirect_uri tunnels)
+        # and race it against chat paste via gateway_flow below.
 
         # Reject before binding the callback listener in non-interactive
         # contexts. Reaching here means the SDK entered the authorization-code
@@ -931,6 +950,21 @@ def _make_callback_waiter(port: int):
                 target=_paste_callback_reader, args=(result,), daemon=True
             )
             paste_thread.start()
+
+        # Gateway chat paste: messaging user pastes redirect URL → deliver_callback
+        # fills gateway_flow; mirror that into the shared result dict.
+        if gateway_flow is not None:
+            def _gateway_paste_watch() -> None:
+                if not gateway_flow._callback_ready.wait(timeout=300.0):
+                    return
+                if result["auth_code"] is not None or result["error"] is not None:
+                    return
+                if gateway_flow._callback_error:
+                    result["error"] = gateway_flow._callback_error
+                elif gateway_flow._callback is not None:
+                    result["auth_code"], result["state"] = gateway_flow._callback
+
+            threading.Thread(target=_gateway_paste_watch, daemon=True).start()
 
         timeout = 300.0
         poll_interval = 0.5

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1088,7 +1088,7 @@ def remove_oauth_tokens(
     hermes_home: str | Path | None = None,
     user_key: str | None = None,
 ) -> None:
-    """Delete stored OAuth tokens and client info for a server."""
+    """Delete stored OAuth tokens and client info for a server identity."""
     storage = HermesTokenStorage(
         server_name, hermes_home=hermes_home, user_key=user_key,
     )
@@ -1099,6 +1099,61 @@ def remove_oauth_tokens(
         )
     else:
         logger.info("OAuth tokens removed for '%s'", server_name)
+
+
+def remove_all_oauth_tokens_for_server(
+    server_name: str,
+    *,
+    hermes_home: str | Path | None = None,
+) -> list[str]:
+    """Delete shared + every by-user OAuth state file for ``server_name``.
+
+    Returns the list of identity keys cleared: empty string for the shared
+    path, plus each ``by-user/<key>/`` directory name that had matching files.
+    """
+    safe = _safe_filename(server_name)
+    cleared: list[str] = []
+
+    # Shared profile path
+    shared = HermesTokenStorage(server_name, hermes_home=hermes_home)
+    had_shared = any(
+        p.exists()
+        for p in (shared._tokens_path(), shared._client_info_path(), shared._meta_path())
+    )
+    shared.remove()
+    if had_shared:
+        cleared.append("")
+
+    # Per-user trees: mcp-tokens/by-user/<user_key>/<server>.*
+    by_user_root = _get_token_dir(hermes_home) / "by-user"
+    if by_user_root.is_dir():
+        for user_dir in sorted(by_user_root.iterdir()):
+            if not user_dir.is_dir():
+                continue
+            paths = [
+                user_dir / f"{safe}.json",
+                user_dir / f"{safe}.client.json",
+                user_dir / f"{safe}.meta.json",
+            ]
+            if not any(p.exists() for p in paths):
+                continue
+            for p in paths:
+                p.unlink(missing_ok=True)
+            cleared.append(user_dir.name)
+            # Drop empty user dirs
+            try:
+                next(user_dir.iterdir())
+            except StopIteration:
+                try:
+                    user_dir.rmdir()
+                except OSError:
+                    pass
+
+    logger.info(
+        "OAuth tokens removed for '%s' across %d identity path(s)",
+        server_name, len(cleared),
+    )
+    return cleared
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -429,25 +429,44 @@ def _write_json(path: Path, data: dict) -> None:
 class HermesTokenStorage:
     """Persist OAuth tokens and client registration to JSON files.
 
-    File layout::
+    File layout (shared / default)::
 
         HERMES_HOME/mcp-tokens/<server_name>.json         -- tokens
         HERMES_HOME/mcp-tokens/<server_name>.client.json   -- client info
         HERMES_HOME/mcp-tokens/<server_name>.meta.json     -- oauth server metadata
+
+    File layout when ``user_key`` is set (``mcp.oauth.identity_mode: per_user``)::
+
+        HERMES_HOME/mcp-tokens/by-user/<user_key>/<server_name>.json
+        HERMES_HOME/mcp-tokens/by-user/<user_key>/<server_name>.client.json
+        HERMES_HOME/mcp-tokens/by-user/<user_key>/<server_name>.meta.json
     """
 
-    def __init__(self, server_name: str, *, hermes_home: str | Path | None = None):
+    def __init__(
+        self,
+        server_name: str,
+        *,
+        hermes_home: str | Path | None = None,
+        user_key: str | None = None,
+    ):
         self._server_name = _safe_filename(server_name)
         self._hermes_home = Path(hermes_home) if hermes_home is not None else None
+        self._user_key = _safe_filename(user_key) if user_key else ""
+
+    def _storage_dir(self) -> Path:
+        base = _get_token_dir(self._hermes_home)
+        if self._user_key:
+            return base / "by-user" / self._user_key
+        return base
 
     def _tokens_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.json"
+        return self._storage_dir() / f"{self._server_name}.json"
 
     def _client_info_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.client.json"
+        return self._storage_dir() / f"{self._server_name}.client.json"
 
     def _meta_path(self) -> Path:
-        return _get_token_dir(self._hermes_home) / f"{self._server_name}.meta.json"
+        return self._storage_dir() / f"{self._server_name}.meta.json"
 
     # -- tokens ------------------------------------------------------------
 
@@ -1033,11 +1052,19 @@ def remove_oauth_tokens(
     server_name: str,
     *,
     hermes_home: str | Path | None = None,
+    user_key: str | None = None,
 ) -> None:
     """Delete stored OAuth tokens and client info for a server."""
-    storage = HermesTokenStorage(server_name, hermes_home=hermes_home)
+    storage = HermesTokenStorage(
+        server_name, hermes_home=hermes_home, user_key=user_key,
+    )
     storage.remove()
-    logger.info("OAuth tokens removed for '%s'", server_name)
+    if user_key:
+        logger.info(
+            "OAuth tokens removed for '%s' (user=%s)", server_name, user_key,
+        )
+    else:
+        logger.info("OAuth tokens removed for '%s'", server_name)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth_identity.py
+++ b/tools/mcp_oauth_identity.py
@@ -1,0 +1,141 @@
+"""MCP OAuth identity resolution for shared vs per-user authorization.
+
+Hermes historically stores one OAuth token set per (profile, MCP server).
+Multi-user gateways need a stronger boundary: the authorization used for an
+MCP call must belong to the human who initiated the request, not whoever
+first completed ``hermes mcp login``.
+
+Config (``mcp.oauth.identity_mode`` in config.yaml):
+
+- ``shared`` (default) — existing behaviour; tokens at
+  ``$HERMES_HOME/mcp-tokens/<server>.json``.
+- ``per_user`` — tokens at
+  ``$HERMES_HOME/mcp-tokens/by-user/<user_key>/<server>.json``.
+  The user key is derived from the gateway session
+  (``HERMES_SESSION_PLATFORM`` + ``HERMES_SESSION_USER_ID``). When no
+  authenticated user identity is available, MCP OAuth calls fail closed
+  instead of silently reusing another user's credentials.
+
+CLI operators can target a specific user key with
+``hermes mcp login <server> --user <key>`` (sets a force override for the
+duration of that login).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+# Explicit override for CLI ``--user`` / tests. Takes precedence over session.
+_FORCE_USER_KEY: ContextVar[Optional[str]] = ContextVar(
+    "mcp_oauth_force_user_key", default=None
+)
+
+_IDENTITY_MODE_SHARED = "shared"
+_IDENTITY_MODE_PER_USER = "per_user"
+_VALID_MODES = frozenset({_IDENTITY_MODE_SHARED, _IDENTITY_MODE_PER_USER})
+
+
+class MissingMcpOAuthIdentityError(RuntimeError):
+    """Raised when per-user OAuth mode requires a user identity and none is set."""
+
+
+def _safe_user_key(raw: str) -> str:
+    """Sanitize a user key for filesystem / registry use."""
+    cleaned = re.sub(r"[^\w\-.:@]", "_", (raw or "").strip()).strip("._")[:160]
+    return cleaned or "anonymous"
+
+
+def get_oauth_identity_mode() -> str:
+    """Return ``shared`` or ``per_user`` from config (default ``shared``)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        mcp = cfg.get("mcp") or {}
+        oauth = mcp.get("oauth") if isinstance(mcp, dict) else {}
+        if not isinstance(oauth, dict):
+            return _IDENTITY_MODE_SHARED
+        mode = str(oauth.get("identity_mode") or _IDENTITY_MODE_SHARED).strip().lower()
+        if mode in _VALID_MODES:
+            return mode
+        logger.warning(
+            "Unknown mcp.oauth.identity_mode %r — falling back to shared", mode
+        )
+    except Exception as exc:  # pragma: no cover — config load failure
+        logger.debug("mcp.oauth.identity_mode lookup failed: %s", exc)
+    return _IDENTITY_MODE_SHARED
+
+
+def is_per_user_oauth_identity() -> bool:
+    return get_oauth_identity_mode() == _IDENTITY_MODE_PER_USER
+
+
+@contextmanager
+def force_oauth_user_key(user_key: str) -> Iterator[None]:
+    """Force a specific OAuth user key for the current context (CLI/tests)."""
+    token = _FORCE_USER_KEY.set(_safe_user_key(user_key) if user_key else "")
+    try:
+        yield
+    finally:
+        _FORCE_USER_KEY.reset(token)
+
+
+def current_oauth_user_key(*, require: bool = False) -> str:
+    """Resolve the OAuth user key for the current request.
+
+    Returns ``\"\"`` in shared mode (or when an empty force override is set).
+    In ``per_user`` mode:
+
+    - Prefer ``force_oauth_user_key`` override.
+    - Else derive from gateway session platform + user_id.
+    - If neither is available and ``require`` is True, raise
+      :class:`MissingMcpOAuthIdentityError`.
+    - If ``require`` is False, return ``\"\"`` (caller decides fail-closed).
+    """
+    forced = _FORCE_USER_KEY.get()
+    if forced is not None:
+        # Explicit empty force means "shared path for this call" (tests).
+        return forced
+
+    if not is_per_user_oauth_identity():
+        return ""
+
+    platform = ""
+    user_id = ""
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip()
+        user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
+    except Exception as exc:  # pragma: no cover
+        logger.debug("session identity lookup failed: %s", exc)
+
+    if user_id:
+        raw = f"{platform}:{user_id}" if platform else user_id
+        return _safe_user_key(raw)
+
+    if require:
+        raise MissingMcpOAuthIdentityError(
+            "mcp.oauth.identity_mode is 'per_user' but no authenticated user "
+            "identity is available for this request. Hermes will not reuse "
+            "another user's MCP OAuth credentials. Bind a gateway session "
+            "user (or pass --user to hermes mcp login)."
+        )
+    return ""
+
+
+def oauth_connection_registry_key(server_name: str, user_key: str = "") -> str:
+    """Build the ``_servers`` dict key for an OAuth-aware connection.
+
+    Shared / empty user_key keeps the historical bare ``server_name`` key so
+    existing single-user deployments are unchanged.
+    """
+    if not user_key:
+        return server_name
+    return f"{server_name}@@{user_key}"

--- a/tools/mcp_oauth_identity.py
+++ b/tools/mcp_oauth_identity.py
@@ -139,3 +139,42 @@ def oauth_connection_registry_key(server_name: str, user_key: str = "") -> str:
     if not user_key:
         return server_name
     return f"{server_name}@@{user_key}"
+
+
+# Model-supplied tool args must never select which OAuth credentials to use.
+# Identity comes only from session ContextVars / force_oauth_user_key.
+_CREDENTIAL_SELECTOR_ARG_KEYS = frozenset(
+    {
+        "user_key",
+        "user_id",
+        "hermes_user",
+        "oauth_user",
+        "oauth_user_key",
+        "mcp_user",
+        "mcp_user_key",
+    }
+)
+
+
+def strip_credential_selector_args(args: dict | None) -> dict:
+    """Return a copy of *args* without credential-selector keys.
+
+    MCP tool/resource/prompt handlers must call this before using
+    arguments so a model cannot request ``user_key=telegram:OTHER``.
+    Nested ``arguments`` dicts (e.g. prompts/get) are scrubbed too.
+    """
+    if not args:
+        return {}
+    cleaned: dict = {}
+    for key, value in args.items():
+        if key in _CREDENTIAL_SELECTOR_ARG_KEYS:
+            continue
+        if key == "arguments" and isinstance(value, dict):
+            cleaned[key] = {
+                nested_key: nested_value
+                for nested_key, nested_value in value.items()
+                if nested_key not in _CREDENTIAL_SELECTOR_ARG_KEYS
+            }
+        else:
+            cleaned[key] = value
+    return cleaned

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -583,9 +583,11 @@ class MCPOAuthManager:
         storage = HermesTokenStorage(server_name, user_key=user_key or None)
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+        from tools.mcp_gateway_oauth import get_gateway_oauth_flow
 
         if (
             get_dashboard_oauth_flow() is None
+            and get_gateway_oauth_flow() is None
             and not _is_interactive()
             and not storage.has_cached_tokens()
         ):

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -625,12 +625,45 @@ class MCPOAuthManager:
         *,
         hermes_home: str | Path | None = None,
         user_key: str = "",
+        all_identities: bool | None = None,
     ) -> _ProviderEntry | None:
-        """Evict the provider from cache AND delete tokens from disk.
+        """Evict provider cache entries AND delete tokens from disk.
 
-        Called by ``hermes mcp remove <name>`` and (indirectly) by
-        ``hermes mcp login <name>`` during forced re-auth.
+        Called by ``hermes mcp remove <name>``, ``hermes mcp logout``, and
+        (indirectly) by ``hermes mcp login <name>`` during forced re-auth.
+
+        When ``user_key`` is non-empty, only that identity is cleared.
+        When ``user_key`` is empty, defaults to wiping **all** identities
+        (shared + every ``by-user/*/`` tree) unless ``all_identities=False``.
         """
+        wipe_all = bool(user_key == "" and all_identities is not False) or bool(
+            all_identities
+        )
+        if user_key:
+            wipe_all = False
+
+        entry: _ProviderEntry | None = None
+        if wipe_all:
+            home_key = self._key(server_name, hermes_home, user_key="")[0]
+            with self._entries_lock:
+                doomed = [
+                    k for k in self._entries
+                    if k[0] == home_key and k[1] == server_name
+                ]
+                for k in doomed:
+                    popped = self._entries.pop(k, None)
+                    if entry is None:
+                        entry = popped
+            from tools.mcp_oauth import remove_all_oauth_tokens_for_server
+            remove_all_oauth_tokens_for_server(
+                server_name, hermes_home=hermes_home,
+            )
+            logger.info(
+                "MCP OAuth '%s': evicted all identities from cache and disk",
+                server_name,
+            )
+            return entry
+
         with self._entries_lock:
             entry = self._entries.pop(
                 self._key(server_name, hermes_home, user_key=user_key), None,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -134,11 +134,13 @@ def _make_hermes_provider_class() -> Optional[type]:
             *args: Any,
             server_name: str = "",
             preregistered: bool = False,
+            user_key: str = "",
             **kwargs: Any,
         ):
             super().__init__(*args, **kwargs)
             self._hermes_server_name = server_name
             self._hermes_home = ""
+            self._hermes_user_key = user_key or ""
             # When the client_id comes from config.yaml (pre-registered), an
             # invalid_client rejection means the *config* is wrong — deleting
             # client.json would just be re-seeded from config and re-running
@@ -395,6 +397,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                 await get_manager().invalidate_if_disk_changed(
                     self._hermes_server_name,
                     hermes_home=self._hermes_home,
+                    user_key=getattr(self, "_hermes_user_key", "") or "",
                 )
             except Exception as exc:  # pragma: no cover — defensive
                 logger.debug(
@@ -466,16 +469,32 @@ class MCPOAuthManager:
         server_name: str,
         server_url: str,
         oauth_config: Optional[dict],
+        *,
+        user_key: str | None = None,
     ) -> Optional[Any]:
         """Return a cached OAuth provider for ``server_name`` or build one.
 
-        Idempotent: repeat calls with the same name return the same instance.
-        If ``server_url`` changes for a given name, the cached entry is
-        discarded and a fresh provider is built.
+        Idempotent: repeat calls with the same name (and user_key) return the
+        same instance. If ``server_url`` changes for a given name, the cached
+        entry is discarded and a fresh provider is built.
+
+        ``user_key`` scopes the provider + on-disk tokens when
+        ``mcp.oauth.identity_mode`` is ``per_user``. Empty/None keeps the
+        historical shared profile path.
 
         Returns None if the MCP SDK's OAuth support is unavailable.
         """
-        key = self._key(server_name)
+        if user_key is None:
+            try:
+                from tools.mcp_oauth_identity import current_oauth_user_key
+
+                resolved_user = current_oauth_user_key(require=False)
+            except Exception:
+                resolved_user = ""
+        else:
+            resolved_user = user_key
+
+        key = self._key(server_name, user_key=resolved_user)
         with self._entries_lock:
             entry = self._entries.get(key)
             if entry is not None and entry.server_url != server_url:
@@ -493,9 +512,12 @@ class MCPOAuthManager:
                 self._entries[key] = entry
 
             if entry.provider is None:
-                entry.provider = self._build_provider(server_name, entry)
+                entry.provider = self._build_provider(
+                    server_name, entry, user_key=resolved_user,
+                )
                 if entry.provider is not None:
                     entry.provider._hermes_home = key[0]
+                    entry.provider._hermes_user_key = resolved_user
 
             return entry.provider
 
@@ -503,16 +525,24 @@ class MCPOAuthManager:
     def _key(
         server_name: str,
         hermes_home: str | Path | None = None,
-    ) -> tuple[str, str]:
+        *,
+        user_key: str = "",
+    ) -> tuple[str, str, str]:
         from hermes_constants import get_hermes_home
 
         home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
-        return (str(home.expanduser().resolve(strict=False)), server_name)
+        return (
+            str(home.expanduser().resolve(strict=False)),
+            server_name,
+            user_key or "",
+        )
 
     def _build_provider(
         self,
         server_name: str,
         entry: _ProviderEntry,
+        *,
+        user_key: str = "",
     ) -> Optional[Any]:
         """Build the underlying OAuth provider.
 
@@ -529,7 +559,6 @@ class MCPOAuthManager:
             )
             return None
 
-        # Local imports avoid circular deps at module import time.
         from tools.mcp_oauth import (
             HermesTokenStorage,
             OAuthNonInteractiveError,
@@ -551,7 +580,7 @@ class MCPOAuthManager:
         apply_oauth_provider_defaults(
             cfg, server_name=server_name, server_url=entry.server_url
         )
-        storage = HermesTokenStorage(server_name)
+        storage = HermesTokenStorage(server_name, user_key=user_key or None)
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
@@ -579,6 +608,7 @@ class MCPOAuthManager:
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
             preregistered=bool(cfg.get("client_id")),
+            user_key=user_key or "",
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
@@ -592,6 +622,7 @@ class MCPOAuthManager:
         server_name: str,
         *,
         hermes_home: str | Path | None = None,
+        user_key: str = "",
     ) -> _ProviderEntry | None:
         """Evict the provider from cache AND delete tokens from disk.
 
@@ -599,10 +630,14 @@ class MCPOAuthManager:
         ``hermes mcp login <name>`` during forced re-auth.
         """
         with self._entries_lock:
-            entry = self._entries.pop(self._key(server_name, hermes_home), None)
+            entry = self._entries.pop(
+                self._key(server_name, hermes_home, user_key=user_key), None,
+            )
 
         from tools.mcp_oauth import remove_oauth_tokens
-        remove_oauth_tokens(server_name, hermes_home=hermes_home)
+        remove_oauth_tokens(
+            server_name, hermes_home=hermes_home, user_key=user_key or None,
+        )
         logger.info(
             "MCP OAuth '%s': evicted from cache and removed from disk",
             server_name,
@@ -615,47 +650,54 @@ class MCPOAuthManager:
         entry: _ProviderEntry | None,
         *,
         hermes_home: str | Path | None = None,
+        user_key: str = "",
     ) -> None:
         """Restore a provider entry removed for a failed reauthorization."""
         if entry is None:
             return
         with self._entries_lock:
-            self._entries.setdefault(self._key(server_name, hermes_home), entry)
+            self._entries.setdefault(
+                self._key(server_name, hermes_home, user_key=user_key), entry,
+            )
 
     def evict(
         self,
         server_name: str,
         *,
         hermes_home: str | Path | None = None,
+        user_key: str = "",
     ) -> None:
         """Drop only the in-process provider, preserving persisted OAuth state."""
         with self._entries_lock:
-            self._entries.pop(self._key(server_name, hermes_home), None)
-
-    # -- Disk watch ----------------------------------------------------------
+            self._entries.pop(
+                self._key(server_name, hermes_home, user_key=user_key), None,
+            )
 
     async def invalidate_if_disk_changed(
         self,
         server_name: str,
         *,
         hermes_home: str | Path | None = None,
+        user_key: str = "",
     ) -> bool:
         """If the tokens file on disk has a newer mtime than last-seen, force
         the MCP SDK provider to reload its in-memory state.
 
-        Returns True if the cache was invalidated (mtime differed). This is
-        the core fix for the external-refresh workflow: a cron job writes
-        fresh tokens to disk, and on the next tool call the running MCP
-        session picks them up without a restart.
+        Returns True if the cache was invalidated (mtime differed).
         """
-        from tools.mcp_oauth import _get_token_dir, _safe_filename
+        from tools.mcp_oauth import HermesTokenStorage
 
-        entry = self._entries.get(self._key(server_name, hermes_home))
+        entry = self._entries.get(
+            self._key(server_name, hermes_home, user_key=user_key)
+        )
         if entry is None or entry.provider is None:
             return False
 
         async with entry.lock:
-            tokens_path = _get_token_dir(hermes_home) / f"{_safe_filename(server_name)}.json"
+            storage = HermesTokenStorage(
+                server_name, hermes_home=hermes_home, user_key=user_key or None,
+            )
+            tokens_path = storage._tokens_path()
             try:
                 mtime_ns = tokens_path.stat().st_mtime_ns
             except (FileNotFoundError, OSError):
@@ -664,9 +706,6 @@ class MCPOAuthManager:
             if mtime_ns != entry.last_mtime_ns:
                 old = entry.last_mtime_ns
                 entry.last_mtime_ns = mtime_ns
-                # Force the SDK's OAuthClientProvider to reload from storage
-                # on its next auth flow. `_initialized` is private API but
-                # stable across the MCP SDK versions we pin (>=1.26.0).
                 if hasattr(entry.provider, "_initialized"):
                     entry.provider._initialized = False  # noqa: SLF001
                 logger.info(
@@ -677,27 +716,15 @@ class MCPOAuthManager:
                 return True
             return False
 
-    # -- 401 handler (dedup'd) -----------------------------------------------
-
     async def handle_401(
         self,
         server_name: str,
         failed_access_token: Optional[str] = None,
+        *,
+        user_key: str = "",
     ) -> bool:
-        """Handle a 401 from a tool call, deduplicated across concurrent callers.
-
-        Returns:
-            True  if a (possibly new) access token is now available — caller
-                  should trigger a reconnect and retry the operation.
-            False if no recovery path exists — caller should surface a
-                  ``needs_reauth`` error to the model so it stops hallucinating
-                  manual refresh attempts.
-
-        Thundering-herd protection: if N concurrent tool calls hit 401 with
-        the same ``failed_access_token``, only one recovery attempt fires.
-        Others await the same future.
-        """
-        entry = self._entries.get(self._key(server_name))
+        """Handle a 401 from a tool call, deduplicated across concurrent callers."""
+        entry = self._entries.get(self._key(server_name, user_key=user_key))
         if entry is None or entry.provider is None:
             return False
 
@@ -712,18 +739,14 @@ class MCPOAuthManager:
 
                 async def _do_handle() -> None:
                     try:
-                        # Step 1: Did disk change? Picks up external refresh.
                         disk_changed = await self.invalidate_if_disk_changed(
-                            server_name
+                            server_name, user_key=user_key,
                         )
                         if disk_changed:
                             if not pending.done():
                                 pending.set_result(True)
                             return
 
-                        # Step 2: No disk change — if the SDK can refresh
-                        # in-place, let the caller retry. The SDK's httpx.Auth
-                        # flow will issue the refresh on the next request.
                         provider = entry.provider
                         ctx = getattr(provider, "context", None)
                         can_refresh = False
@@ -736,7 +759,7 @@ class MCPOAuthManager:
                                     can_refresh = False
                         if not pending.done():
                             pending.set_result(can_refresh)
-                    except Exception as exc:  # pragma: no cover — defensive
+                    except Exception as exc:  # pragma: no cover
                         logger.warning(
                             "MCP OAuth '%s': 401 handler failed: %s",
                             server_name, exc,
@@ -752,12 +775,13 @@ class MCPOAuthManager:
 
         try:
             return await pending
-        except Exception as exc:  # pragma: no cover — defensive
+        except Exception as exc:  # pragma: no cover
             logger.warning(
                 "MCP OAuth '%s': awaiting 401 handler failed: %s",
                 server_name, exc,
             )
             return False
+
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3679,8 +3679,7 @@ def _signal_reconnect(server: Any) -> bool:
 
 def reconnect_mcp_server(server_name: str) -> bool:
     """Ask a currently-live MCP server to rebuild after external re-auth."""
-    with _lock:
-        server = _servers.get(server_name)
+    server = _lookup_live_server(server_name)
     if server is None:
         return False
     return _signal_reconnect(server)
@@ -3899,8 +3898,7 @@ def _handle_auth_error_and_retry(
         recovered = False
 
     if recovered:
-        with _lock:
-            srv = _servers.get(server_name)
+        srv = _lookup_live_server(server_name)
         reconnected = False
         if srv is not None and hasattr(srv, "_reconnect_event"):
             reconnected = _signal_reconnect_and_wait(
@@ -4084,8 +4082,7 @@ def _handle_session_expired_and_retry(
     if not _is_session_expired_error(exc):
         return None
 
-    with _lock:
-        srv = _servers.get(server_name)
+    srv = _lookup_live_server(server_name)
     if srv is None or not hasattr(srv, "_reconnect_event"):
         return None
 
@@ -4781,6 +4778,32 @@ def _request_lazy_reconnect(server_name: str, server: MCPServerTask) -> bool:
 
 
 
+
+def _lookup_live_server(server_name: str) -> Optional["MCPServerTask"]:
+    """Find a live MCPServerTask by logical name (shared or per-user key).
+
+    Prefers the current OAuth registry key, then any connected entry whose
+    ``.name`` matches. Used by reconnect / check paths that only know the
+    logical server name.
+    """
+    try:
+        registry_key = _resolve_oauth_registry_key(server_name, require_identity=False)
+    except Exception:
+        registry_key = server_name
+    with _lock:
+        server = _servers.get(registry_key)
+        if server is not None:
+            return server
+        if registry_key != server_name:
+            server = _servers.get(server_name)
+            if server is not None:
+                return server
+        for key, srv in _servers.items():
+            if srv is not None and srv.name == server_name:
+                return srv
+    return None
+
+
 def _server_registry_key_for_task(server: "MCPServerTask") -> str:
     """Registry key for an already-constructed MCPServerTask."""
     from tools.mcp_oauth_identity import oauth_connection_registry_key
@@ -5450,12 +5473,12 @@ def _make_check_fn(server_name: str):
     """Return a check function that verifies the MCP connection is alive."""
 
     def _check() -> bool:
+        server = _lookup_live_server(server_name)
+        if server is not None and (
+            server.session is not None or server._is_recycled_stdio()
+        ):
+            return True
         with _lock:
-            server = _servers.get(server_name)
-            if server is not None and (
-                server.session is not None or server._is_recycled_stdio()
-            ):
-                return True
             # Lazy (schema-cache registered) servers are available: the
             # first real call spawns/connects them (#56832).
             return server_name in _lazy_server_configs

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3936,16 +3936,103 @@ def _handle_auth_error_and_retry(
 
     # No recovery available, or retry also failed: surface a structured
     # needs_reauth error. Bumps the circuit breaker so the model stops
-    # retrying the tool.
+    # retrying the tool. In a gateway session, kick off in-chat OAuth so
+    # the user gets an authorize URL (#78169 / #78174).
     _bump_server_error(server_name)
-    return tool_error(
-        f"MCP server '{server_name}' requires re-authentication. "
-        f"Run `hermes mcp login {server_name}` (or delete the tokens "
-        f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
-        f"this tool — ask the user to re-authenticate.",
-        needs_reauth=True,
-        server=server_name,
-    )
+
+    authorization_url = None
+    user_key = ""
+    try:
+        from tools.mcp_oauth_identity import (
+            current_oauth_user_key,
+            is_per_user_oauth_identity,
+        )
+
+        user_key = current_oauth_user_key(require=False)
+    except Exception:
+        user_key = ""
+
+    try:
+        from tools.mcp_gateway_oauth import (
+            gateway_oauth_available,
+            start_gateway_reauth_and_wait_for_url,
+        )
+        from tools.mcp_oauth_manager import get_manager as _get_oauth_mgr
+
+        if gateway_oauth_available():
+            # Clear this identity's tokens so reconnect forces interactive OAuth.
+            _get_oauth_mgr().remove(
+                server_name, user_key=user_key or "", all_identities=False,
+            )
+
+            def _reconnect() -> None:
+                srv = _lookup_live_server(server_name)
+                if srv is not None and hasattr(srv, "_reconnect_event"):
+                    _signal_reconnect_and_wait(
+                        server_name,
+                        srv,
+                        op_description=f"{op_description} gateway OAuth reauth",
+                        timeout=320,
+                    )
+                else:
+                    # Lazy / parked: try on-demand connect under the flow.
+                    _ensure_lazy_server_connected(server_name)
+
+            authorization_url, user_key = start_gateway_reauth_and_wait_for_url(
+                server_name, reconnect_fn=_reconnect,
+            )
+    except Exception as reauth_exc:
+        logger.warning(
+            "MCP OAuth '%s': gateway reauth attempt failed: %s",
+            server_name, reauth_exc,
+        )
+
+    if authorization_url:
+        message = (
+            f"MCP server '{server_name}' requires re-authentication. "
+            f"An authorize link was sent in this chat — open it to "
+            f"continue, then paste the redirect URL back if needed. "
+            f"Do NOT invent alternate login steps. authorization_url is "
+            f"included in this error for restating to the user."
+        )
+    else:
+        try:
+            from tools.mcp_oauth_identity import is_per_user_oauth_identity
+
+            per_user = is_per_user_oauth_identity()
+        except Exception:
+            per_user = False
+        if user_key:
+            message = (
+                f"MCP server '{server_name}' requires re-authentication. "
+                f"Run `hermes mcp login {server_name} --user {user_key}` "
+                f"(or delete tokens under ~/.hermes/mcp-tokens/ and restart). "
+                f"Do NOT retry this tool — ask the user to re-authenticate."
+            )
+        elif per_user:
+            message = (
+                f"MCP server '{server_name}' requires re-authentication. "
+                f"Run `hermes mcp login {server_name} --user <platform:user_id>` "
+                f"(mcp.oauth.identity_mode is per_user). Do NOT retry this "
+                f"tool — ask the user to re-authenticate."
+            )
+        else:
+            message = (
+                f"MCP server '{server_name}' requires re-authentication. "
+                f"Run `hermes mcp login {server_name}` (or delete the tokens "
+                f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
+                f"this tool — ask the user to re-authenticate."
+            )
+
+    extra = {
+        "needs_reauth": True,
+        "server": server_name,
+    }
+    if authorization_url:
+        extra["authorization_url"] = authorization_url
+    if user_key:
+        extra["user_key"] = user_key
+    return tool_error(message, **extra)
 
 
 # Substrings (lower-cased match) that indicate the MCP server rejected
@@ -4941,6 +5028,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
 
     from contextlib import ExitStack
 
+    owned_gateway_flow = False
     try:
         with ExitStack() as stack:
             # Headless messaging: surface the authorize URL in-chat (#78169).
@@ -4949,12 +5037,14 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
                     GatewayOAuthFlow,
                     gateway_oauth_available,
                     gateway_oauth_flow,
+                    get_gateway_oauth_flow,
                 )
                 from tools.mcp_oauth import force_interactive_oauth
                 from tools.approval import get_current_session_key
                 from tools.mcp_oauth_identity import current_oauth_user_key
 
-                if (
+                # Reuse an outer reauth flow when present (nested connect).
+                if get_gateway_oauth_flow() is None and (
                     gateway_oauth_available()
                     and _server_config_is_oauth(server_name, config)
                 ):
@@ -4967,12 +5057,27 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
                         )
                         stack.enter_context(gateway_oauth_flow(flow))
                         stack.enter_context(force_interactive_oauth())
+                        owned_gateway_flow = True
+                elif get_gateway_oauth_flow() is not None:
+                    stack.enter_context(force_interactive_oauth())
             except Exception as exc:
                 logger.debug(
                     "MCP gateway OAuth context not entered for '%s': %s",
                     server_name, exc,
                 )
-            _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
+            try:
+                _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
+            except BaseException as connect_exc:
+                if owned_gateway_flow:
+                    try:
+                        from tools.mcp_gateway_oauth import (
+                            notify_consent_failure_for_active_flow,
+                        )
+
+                        notify_consent_failure_for_active_flow(exc=connect_exc)
+                    except Exception:
+                        pass
+                raise
     except BaseException as exc:
         message = _format_connect_error(exc)
         with _lock:
@@ -5070,6 +5175,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """
 
     def _handler(args: dict, **kwargs) -> str:
+        # Identity is session/ContextVar only — never let tool args pick
+        # which OAuth credentials to use (#78174).
+        from tools.mcp_oauth_identity import strip_credential_selector_args
+
+        args = strip_credential_selector_args(args)
+
         # Circuit breaker: if this server has failed too many times
         # consecutively, short-circuit with a clear message so the model
         # stops retrying and uses alternative approaches (#10447).
@@ -5284,6 +5395,9 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists resources from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
+        from tools.mcp_oauth_identity import strip_credential_selector_args
+
+        args = strip_credential_selector_args(args)
         server = _get_connected_server_for_call(server_name)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
@@ -5340,6 +5454,9 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that reads a resource by URI from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
+        from tools.mcp_oauth_identity import strip_credential_selector_args
+
+        args = strip_credential_selector_args(args)
         server = _get_connected_server_for_call(server_name)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
@@ -5401,6 +5518,9 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists prompts from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
+        from tools.mcp_oauth_identity import strip_credential_selector_args
+
+        args = strip_credential_selector_args(args)
         server = _get_connected_server_for_call(server_name)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")
@@ -5462,6 +5582,9 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that gets a prompt by name from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
+        from tools.mcp_oauth_identity import strip_credential_selector_args
+
+        args = strip_credential_selector_args(args)
         server = _get_connected_server_for_call(server_name)
         if not server or not server.session:
             return tool_error(f"MCP server '{server_name}' is not connected")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4456,6 +4456,27 @@ def _wrap_with_dashboard_oauth_flow(coro):
     return _scoped()
 
 
+def _wrap_with_gateway_oauth_flow(coro):
+    """Propagate a gateway OAuth consent flow onto the dedicated MCP loop task."""
+    try:
+        from tools.mcp_gateway_oauth import (
+            gateway_oauth_flow,
+            get_gateway_oauth_flow,
+        )
+
+        flow = get_gateway_oauth_flow()
+    except Exception:
+        return coro
+    if flow is None:
+        return coro
+
+    async def _scoped():
+        with gateway_oauth_flow(flow):
+            return await coro
+
+    return _scoped()
+
+
 def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
     """Schedule a coroutine on the MCP event loop and block until done.
 
@@ -4491,6 +4512,7 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
     # scopes don't interfere). No-op when no override is active.
     coro = _wrap_with_home_override(coro)
     coro = _wrap_with_dashboard_oauth_flow(coro)
+    coro = _wrap_with_gateway_oauth_flow(coro)
 
     future = safe_schedule_threadsafe(
         coro, loop,
@@ -4917,8 +4939,40 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     async def _connect():
         return await _discover_and_register_server(server_name, config)
 
+    from contextlib import ExitStack
+
     try:
-        _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
+        with ExitStack() as stack:
+            # Headless messaging: surface the authorize URL in-chat (#78169).
+            try:
+                from tools.mcp_gateway_oauth import (
+                    GatewayOAuthFlow,
+                    gateway_oauth_available,
+                    gateway_oauth_flow,
+                )
+                from tools.mcp_oauth import force_interactive_oauth
+                from tools.approval import get_current_session_key
+                from tools.mcp_oauth_identity import current_oauth_user_key
+
+                if (
+                    gateway_oauth_available()
+                    and _server_config_is_oauth(server_name, config)
+                ):
+                    session_key = get_current_session_key()
+                    if session_key:
+                        flow = GatewayOAuthFlow(
+                            server_name=server_name,
+                            session_key=session_key,
+                            user_key=current_oauth_user_key(require=False),
+                        )
+                        stack.enter_context(gateway_oauth_flow(flow))
+                        stack.enter_context(force_interactive_oauth())
+            except Exception as exc:
+                logger.debug(
+                    "MCP gateway OAuth context not entered for '%s': %s",
+                    server_name, exc,
+                )
+            _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
     except BaseException as exc:
         message = _format_connect_error(exc)
         with _lock:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1836,6 +1836,7 @@ class MCPServerTask:
         "_registered_tool_names", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
         "_pending_call_context",
+        "_oauth_user_key",
         "_lifecycle_started_at", "_last_tool_call_at",
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
@@ -1894,6 +1895,7 @@ class MCPServerTask:
         # gateway-platform attribution and routes the approval prompt
         # to the right surface (Telegram, Slack, etc.).
         self._pending_call_context: Optional[contextvars.Context] = None
+        self._oauth_user_key: str = ""
         now = time.monotonic()
         self._lifecycle_started_at: float = now
         self._last_tool_call_at: float = now
@@ -2782,6 +2784,7 @@ class MCPServerTask:
                 from tools.mcp_oauth_manager import get_manager
                 _oauth_auth = get_manager().get_or_build_provider(
                     self.name, url, config.get("oauth"),
+                    user_key=getattr(self, "_oauth_user_key", "") or "",
                 )
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
@@ -3037,7 +3040,7 @@ class MCPServerTask:
             return
         if not self._ready.is_set():
             with _lock:
-                if _servers.get(self.name) is not self:
+                if _servers.get(_server_registry_key_for_task(self)) is not self:
                     return
         self._registered_tool_names = _register_server_tools(
             self.name, self, self._config
@@ -3046,7 +3049,7 @@ class MCPServerTask:
         # recovered: drop its stale connect error so status surfaces stop
         # reporting it as failed.
         with _lock:
-            if _servers.get(self.name) is self:
+            if _servers.get(_server_registry_key_for_task(self)) is self:
                 _server_connect_errors.pop(self.name, None)
 
     async def run(self, config: dict):
@@ -3877,7 +3880,14 @@ def _handle_auth_error_and_retry(
     manager = get_manager()
 
     async def _recover():
-        return await manager.handle_401(server_name, None)
+        user_key = ""
+        try:
+            from tools.mcp_oauth_identity import current_oauth_user_key
+
+            user_key = current_oauth_user_key(require=False)
+        except Exception:
+            user_key = ""
+        return await manager.handle_401(server_name, None, user_key=user_key)
 
     try:
         recovered = _run_on_mcp_loop(_recover, timeout=10)
@@ -4692,6 +4702,12 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         Exception: on connection or initialization failure.
     """
     server = MCPServerTask(name)
+    try:
+        from tools.mcp_oauth_identity import current_oauth_user_key
+
+        server._oauth_user_key = current_oauth_user_key(require=False)
+    except Exception:
+        server._oauth_user_key = ""
     claim = _connect_server_claim.get()
     claim_token = None
     if claim is not None:
@@ -4764,14 +4780,73 @@ def _request_lazy_reconnect(server_name: str, server: MCPServerTask) -> bool:
         return False
 
 
+
+def _server_registry_key_for_task(server: "MCPServerTask") -> str:
+    """Registry key for an already-constructed MCPServerTask."""
+    from tools.mcp_oauth_identity import oauth_connection_registry_key
+
+    return oauth_connection_registry_key(
+        server.name, getattr(server, "_oauth_user_key", "") or "",
+    )
+
+
+def _server_config_is_oauth(server_name: str, config: Optional[dict] = None) -> bool:
+    """True when the named MCP server is configured for OAuth auth."""
+    cfg = config
+    if cfg is None:
+        cfg = _lazy_server_configs.get(server_name)
+    if cfg is None:
+        try:
+            cfg = (_load_mcp_config() or {}).get(server_name)
+        except Exception:
+            cfg = None
+    if not isinstance(cfg, dict):
+        with _lock:
+            for _key, srv in _servers.items():
+                if srv is not None and srv.name == server_name:
+                    return (getattr(srv, "_auth_type", "") or "") == "oauth"
+        return False
+    return (cfg.get("auth") or "").lower().strip() == "oauth"
+
+
+def _resolve_oauth_registry_key(server_name: str, *, require_identity: bool = False) -> str:
+    """Return the ``_servers`` registry key for ``server_name``.
+
+    In shared mode this is ``server_name``. In per-user OAuth mode for OAuth
+    servers it becomes ``server@@user_key`` (#78174).
+    """
+    from tools.mcp_oauth_identity import (
+        current_oauth_user_key,
+        is_per_user_oauth_identity,
+        oauth_connection_registry_key,
+    )
+
+    if not is_per_user_oauth_identity() or not _server_config_is_oauth(server_name):
+        return server_name
+    user_key = current_oauth_user_key(require=require_identity)
+    return oauth_connection_registry_key(server_name, user_key)
+
+
 def _resolve_server_lazy(name: str, config: dict) -> bool:
     """True when this server defers spawn/connect until first tool use.
 
     Gated per-server by ``mcp_servers.<name>.lazy`` in config (default OFF),
     following the same per-server key pattern as ``idle_timeout_seconds``.
     Design from #56832 (Vansh5632).
+
+    Also forced ON for OAuth servers when ``mcp.oauth.identity_mode`` is
+    ``per_user`` (#78174).
     """
-    return _parse_boolish(config.get("lazy", False), default=False)
+    if _parse_boolish(config.get("lazy", False), default=False):
+        return True
+    try:
+        from tools.mcp_oauth_identity import is_per_user_oauth_identity
+
+        if is_per_user_oauth_identity() and _server_config_is_oauth(name, config):
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def _ensure_lazy_server_connected(server_name: str) -> bool:
@@ -4783,8 +4858,19 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
     cooldown bookkeeping stays in one place. Returns True when a live
     session is available afterwards.
     """
+    try:
+        registry_key = _resolve_oauth_registry_key(server_name, require_identity=True)
+    except Exception as exc:
+        logger.warning(
+            "MCP server '%s': refusing lazy connect without user identity: %s",
+            server_name, exc,
+        )
+        with _lock:
+            _server_connect_errors[server_name] = str(exc)
+        return False
+
     with _lock:
-        server = _servers.get(server_name)
+        server = _servers.get(registry_key)
         if server is not None and server.session is not None:
             return True
         config = _lazy_server_configs.get(server_name)
@@ -4792,12 +4878,16 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
             return False
         if _connect_cooldown_active(server_name):
             return False
-        if server_name in _server_connecting:
+        if registry_key in _server_connecting or server_name in _server_connecting:
             return False
+        _server_connecting.add(registry_key)
         _server_connecting.add(server_name)
         _server_connect_errors.pop(server_name, None)
 
-    logger.info("MCP server '%s': lazy start on first use", server_name)
+    logger.info(
+        "MCP server '%s': lazy start on first use (key=%s)",
+        server_name, registry_key,
+    )
     _ensure_mcp_loop()
     connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
 
@@ -4810,6 +4900,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         message = _format_connect_error(exc)
         with _lock:
             _server_connecting.discard(server_name)
+            _server_connecting.discard(registry_key)
             _server_connect_errors[server_name] = message
             _record_connect_failure(server_name)
         logger.warning(
@@ -4819,11 +4910,16 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
 
     with _lock:
         _server_connecting.discard(server_name)
+        _server_connecting.discard(registry_key)
         _clear_connect_failure(server_name)
-        _lazy_server_configs.pop(server_name, None)
-        stale_fingerprint = _lazy_server_fingerprints.pop(server_name, None)
-        cached_names = _lazy_server_tool_names.pop(server_name, None) or []
-        server = _servers.get(server_name)
+        if registry_key == server_name:
+            _lazy_server_configs.pop(server_name, None)
+            stale_fingerprint = _lazy_server_fingerprints.pop(server_name, None)
+            cached_names = _lazy_server_tool_names.pop(server_name, None) or []
+        else:
+            stale_fingerprint = _lazy_server_fingerprints.get(server_name)
+            cached_names = list(_lazy_server_tool_names.get(server_name) or [])
+        server = _servers.get(registry_key)
         live_names = set(
             getattr(server, "_registered_tool_names", []) or []
         )
@@ -4852,19 +4948,33 @@ def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
     Also the single first-use connect point for lazy (schema-cache
     registered) servers, so raw tool calls AND the resource/prompt utility
     handlers all trigger the deferred spawn (#56832).
+
+    Under ``mcp.oauth.identity_mode: per_user``, OAuth servers are looked up
+    by ``server@@user_key`` so concurrent users never share a bearer (#78174).
     """
+    try:
+        registry_key = _resolve_oauth_registry_key(server_name, require_identity=True)
+    except Exception as exc:
+        logger.warning(
+            "MCP server '%s': no user identity for OAuth call: %s",
+            server_name, exc,
+        )
+        with _lock:
+            _server_connect_errors[server_name] = str(exc)
+        return None
+
     with _lock:
-        server = _servers.get(server_name)
+        server = _servers.get(registry_key)
         is_lazy = server_name in _lazy_server_configs
     if is_lazy and (server is None or server.session is None):
         _ensure_lazy_server_connected(server_name)
         with _lock:
-            server = _servers.get(server_name)
+            server = _servers.get(registry_key)
         return server
     if server is not None and server.session is None and server._is_recycled_stdio():
         _request_lazy_reconnect(server_name, server)
         with _lock:
-            server = _servers.get(server_name)
+            server = _servers.get(registry_key)
     return server
 
 
@@ -4909,6 +5019,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         server = _get_connected_server_for_call(server_name)
         if not server:
+            identity_err = _server_connect_errors.get(server_name, "")
+            if "identity_mode is 'per_user'" in identity_err or "no authenticated user" in identity_err.lower():
+                return tool_error(identity_err)
             _bump_server_error(server_name)
             return tool_error(f"MCP server '{server_name}' is not connected")
 
@@ -6189,18 +6302,38 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         ):
             # Recoverable park: the run task deliberately stays alive to
             # self-probe, so adopt it into the registry for shutdown/revival.
+            park_key = name
+            try:
+                from tools.mcp_oauth_identity import oauth_connection_registry_key
+
+                park_key = oauth_connection_registry_key(
+                    name, getattr(server, "_oauth_user_key", "") or "",
+                )
+            except Exception:
+                park_key = name
             with _lock:
-                _servers[name] = server
+                _servers[park_key] = server
         elif server is not None:
             await server.shutdown()
         raise
     finally:
         _connect_server_claim.reset(claim_token)
 
+    registry_key = name
+    try:
+        from tools.mcp_oauth_identity import oauth_connection_registry_key
+
+        registry_key = oauth_connection_registry_key(
+            name, getattr(server, "_oauth_user_key", "") or "",
+        )
+    except Exception:
+        registry_key = name
+
     with _lock:
         _server_connecting.discard(name)
+        _server_connecting.discard(registry_key)
         _server_connect_errors.pop(name, None)
-        _servers[name] = server
+        _servers[registry_key] = server
 
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -235,6 +235,28 @@ mcp_servers:
 
 On first connect, Hermes prints an authorize URL, opens your browser when possible, and waits for the OAuth callback on a local loopback port. Tokens are cached at `~/.hermes/mcp-tokens/<server>.json` with 0o600 perms; subsequent runs reuse them silently until refresh fails.
 
+#### Per-user OAuth identity (shared gateways)
+
+By default Hermes uses **shared** MCP OAuth: one token set per Hermes profile and MCP server. That is correct for single-operator CLI use, but on a multi-user gateway it means whoever completed `hermes mcp login` first authorizes every later caller.
+
+Set the identity boundary explicitly:
+
+```yaml
+mcp:
+  oauth:
+    identity_mode: per_user   # default: shared
+```
+
+In `per_user` mode:
+
+- Tokens are stored at `~/.hermes/mcp-tokens/by-user/<platform:user_id>/<server>.json`
+- The gateway session user (`HERMES_SESSION_USER_ID` + platform) selects which authorization is used
+- Missing identity fails closed — Hermes will not silently reuse another user's credentials
+- Operators can seed a user's tokens with `hermes mcp login <server> --user telegram:12345`
+
+Headless consent URL delivery in the originating messaging platform is tracked separately in [#78169](https://github.com/NousResearch/hermes-agent/issues/78169).
+
+
 **Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Two ways to complete the flow:
 
 - **Paste-back (no setup):** on an interactive terminal Hermes prints "Or paste the redirect URL here…" alongside the authorize URL. Open the URL in your browser, approve, copy the full URL the browser ends up on (the redirect will show a connection error — that's expected), paste it at the prompt. Bare `?code=…&state=…` query strings work too.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -249,14 +249,17 @@ mcp:
 
 In `per_user` mode:
 
-- Tokens are stored at `~/.hermes/mcp-tokens/by-user/<platform:user_id>/<server>.json`
-- The gateway session user (`HERMES_SESSION_USER_ID` + platform) selects which authorization is used
+- Tokens are stored at `~/.hermes/mcp-tokens/by-user/<sanitized-key>/<server>.json`. The logical key is `platform:user_id` (e.g. `telegram:12345`); on disk `:` and other unsafe characters are normalized (e.g. `telegram_12345`).
+- The gateway session user (`HERMES_SESSION_USER_ID` + platform) selects which authorization is used — never a tool argument
 - Missing identity fails closed — Hermes will not silently reuse another user's credentials
 - Operators can seed a user's tokens with `hermes mcp login <server> --user telegram:12345`
-- When a messaging user hits an OAuth MCP without tokens, Hermes sends the authorize URL **into that chat** (not only the host terminal). After authorizing, if the browser lands on a connection error, paste the full redirect URL back as a reply to complete the flow. Prefer configuring `oauth.redirect_uri` to a public HTTPS callback that reaches the Hermes host when possible.
+- When a messaging user hits an OAuth MCP without tokens (or tokens are rejected), Hermes sends the authorize URL **into that chat** (not only the host terminal). After authorizing, if the browser lands on a connection error, paste the full redirect URL back as a reply to complete the flow.
+- **Recommended for messaging users:** set `oauth.redirect_uri` to a public HTTPS callback that reaches the Hermes host so the browser redirect completes without paste-back.
+- **Fallback:** paste the redirect URL in the same chat. Pastes are correlated to the pending flow for that session — another user's paste cannot complete yours.
+- Consent delivery uses the gateway notify path (same mechanism as approvals). Messaging gateway sessions and TUI/`tui_gateway` sessions that register notify get the authorize URL in-chat. There is no separate Electron OAuth modal; a desktop path that never registers notify will not surface the URL in the app UI.
+- `hermes mcp logout <server>` clears the shared token file **and** every `by-user/*/ <server>.*` identity. Pass `--user <key>` to revoke only one identity. `hermes mcp remove <server>` performs the same wipe-all token cleanup when deleting the server from config. Dashboard/`hermes mcp login` re-auth clears only the identity being re-authorized, not every by-user tree.
 
-
-**Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Two ways to complete the flow:
+**Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Ways to complete the flow:
 
 - **Paste-back (no setup):** on an interactive terminal Hermes prints "Or paste the redirect URL here…" alongside the authorize URL. Open the URL in your browser, approve, copy the full URL the browser ends up on (the redirect will show a connection error — that's expected), paste it at the prompt. Bare `?code=…&state=…` query strings work too.
 - **SSH port forward:** `ssh -N -L <port>:127.0.0.1:<port> user@host` in a separate terminal, then let the redirect flow normally.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -253,8 +253,7 @@ In `per_user` mode:
 - The gateway session user (`HERMES_SESSION_USER_ID` + platform) selects which authorization is used
 - Missing identity fails closed — Hermes will not silently reuse another user's credentials
 - Operators can seed a user's tokens with `hermes mcp login <server> --user telegram:12345`
-
-Headless consent URL delivery in the originating messaging platform is tracked separately in [#78169](https://github.com/NousResearch/hermes-agent/issues/78169).
+- When a messaging user hits an OAuth MCP without tokens, Hermes sends the authorize URL **into that chat** (not only the host terminal). After authorizing, if the browser lands on a connection error, paste the full redirect URL back as a reply to complete the flow. Prefer configuring `oauth.redirect_uri` to a public HTTPS callback that reaches the Hermes host when possible.
 
 
 **Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Two ways to complete the flow:


### PR DESCRIPTION
## What does this PR do?

Hermes historically stored one MCP OAuth token set per profile/server, so on a shared gateway User B could silently reuse User A's authorization. This PR adds an opt-in `mcp.oauth.identity_mode: per_user` boundary that scopes tokens and connections to the authenticated session user, fails closed when identity is missing, and surfaces headless OAuth consent URLs in the originating chat (with paste-back) instead of only the host terminal.

Default remains `shared` for single-operator CLI/profile compatibility.

## Related Issue

Fixes #78174
Fixes #78169

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/mcp_oauth_identity.py` — `shared` / `per_user` mode, session-derived user key, fail-closed missing identity, credential-selector arg stripping
- `tools/mcp_oauth.py` / `tools/mcp_oauth_manager.py` — per-user token paths (`mcp-tokens/by-user/<sanitized-key>/`), provider cache keyed by user, wipe-all vs single-identity remove
- `tools/mcp_gateway_oauth.py` — gateway consent flow, chat URL delivery, paste correlation, consent failure notify (`mcp_oauth_consent_result`)
- `tools/mcp_tool.py` — per-user registry keys, lazy connect + gateway reauth, `needs_reauth` includes `authorization_url` when published
- `gateway/run.py` / `gateway/platforms/base.py` — deliver consent / consent-result messages; OAuth paste bypass of active-session queue
- `hermes_cli/mcp_config.py` / `subcommands/mcp.py` — `hermes mcp login --user`, `hermes mcp logout [--user]`
- `hermes_cli/web_server.py` / login path — dashboard/CLI re-auth uses `all_identities=False` so by-user trees are not wiped
- `hermes_cli/config_defaults.py` — `mcp.oauth.identity_mode: shared`
- `website/docs/user-guide/features/mcp.md` — per-user mode, redirect_uri recommendation, logout/remove, notify-path desktop note
- Tests: `tests/tools/test_mcp_oauth_per_user_identity.py`, `test_mcp_gateway_oauth.py`, `test_mcp_tool_401_handling.py`, `tests/hermes_cli/test_mcp_config.py`

## How to Test

1. Enable per-user mode in `config.yaml`:
   ```yaml
   mcp:
     oauth:
       identity_mode: per_user
   ```
2. From the worktree, run:
   ```bash
   export HERMES_PYTHON=/path/to/venv/bin/python   # if needed
   scripts/run_tests.sh \
     tests/tools/test_mcp_oauth_per_user_identity.py \
     tests/tools/test_mcp_gateway_oauth.py \
     tests/tools/test_mcp_oauth_manager.py \
     tests/tools/test_mcp_tool_401_handling.py \
     tests/hermes_cli/test_mcp_config.py \
     -q
   ```
3. Manual / gateway (optional): two messaging users hit the same OAuth MCP — confirm separate `mcp-tokens/by-user/` files, consent URL lands in the originating chat, and pasting User A's redirect on User B's session is rejected.
4. CLI: `hermes mcp logout <server>` clears shared + all by-user tokens; `--user <key>` clears one identity. Dashboard/`hermes mcp login` must not wipe other users' tokens.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the MCP OAuth-focused files above and they pass (full suite not re-run in this session)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/mcp.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (key lives in `config.yaml` / `config_defaults.py`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (token paths use `pathlib` / Hermes home)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (identity is session ContextVar, not tool schema)

## Screenshots / Logs

N/A — hermetic unit/integration coverage; no live Telegram/Discord E2E in CI for this PR.