### PR TITLE
fix(fallback): honor explicit API mode

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1665,11 +1665,27 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Determine api_mode from the explicit fallback entry first, then infer
+        # from provider / base URL / model.  Named custom providers may expose
+        # Anthropic Messages on an ordinary localhost URL (for example a
+        # Claude Code OAuth proxy), so URL inference alone is insufficient.
+        _fb_configured_api_mode = str(fb.get("api_mode") or "").strip().lower()
+        _fb_valid_api_modes = {
+            "chat_completions",
+            "anthropic_messages",
+            "codex_responses",
+            "bedrock_converse",
+        }
+        fb_api_mode = (
+            _fb_configured_api_mode
+            if _fb_configured_api_mode in _fb_valid_api_modes
+            else "chat_completions"
+        )
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        if _fb_configured_api_mode in _fb_valid_api_modes:
+            pass
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -211,6 +211,37 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
 
+    def test_explicit_api_mode_uses_anthropic_messages_for_local_proxy(self):
+        """A fallback entry must be able to declare its wire protocol.
+
+        Local Claude Code OAuth proxies expose /v1/messages on a plain
+        localhost URL, so hostname/path inference cannot identify the
+        Anthropic Messages API.  Ignoring this field makes Hermes rebuild an
+        OpenAI client and POST /chat/completions instead.
+        """
+        fbs = [
+            {
+                "provider": "claude-max-cliproxy",
+                "model": "claude-opus-5",
+                "api_mode": "anthropic_messages",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="http://127.0.0.1:8317"),
+                    "claude-opus-5",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert getattr(agent, "api_mode") == "anthropic_messages"
+            assert getattr(agent, "_anthropic_base_url") == "http://127.0.0.1:8317"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
## Summary

Honor an explicit `api_mode` on a `fallback_providers` entry before applying provider, URL, or model heuristics.

## Problem

`try_activate_fallback()` rebuilds fallback runtime state by inferring the wire protocol. That fails for named custom providers whose ordinary localhost URL does not identify the protocol. For example, an Anthropic Messages-compatible local proxy configured with `api_mode: anthropic_messages` was silently activated as `chat_completions`, so Hermes targeted the wrong endpoint and client type.

## Fix

- Normalize and validate the fallback entry's explicit `api_mode`.
- Treat a valid explicit mode as authoritative.
- Preserve all existing inference when the field is absent or invalid.
- Add a regression covering an Anthropic Messages-compatible localhost proxy and verify the native Anthropic client/base URL are selected.

## Verification

Applied cleanly to current upstream `main` (`ae6c2e57`).

```text
scripts/run_tests.sh tests/run_agent/ -q
1387 passed, 0 failed

ruff check agent/chat_completion_helpers.py tests/run_agent/test_provider_fallback.py
All checks passed!
```

The published fork branch also passes its focused test file: 24 passed.

## Full-suite baseline

The canonical full suite was also run on the current-main patch. It reported 57 failures across 19 unrelated files. Re-running exactly those 19 files on unpatched current `main` reproduced the same 57 failures; no failure touches the files changed here.

## Related work

There are overlapping open implementations, including #70141 and #76730. This PR submits the smaller fleet-carried patch with a focused end-to-end fallback activation regression; maintainers can choose the preferred implementation.
