### PR TITLE
fix(cron): don't mislabel no_agent failures as provider failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -98,6 +98,23 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # Script-only jobs never call an LLM provider, so do not mislabel an
+    # upstream script/API failure as a provider or fallback-chain failure.
+    if job.get("no_agent"):
+        if "429" in text or "rate limit" in lower or "usage limit" in lower:
+            reason = "upstream service rate limit"
+        elif "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+            reason = "upstream service timeout"
+        elif re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
+            reason = "upstream service authentication error"
+        else:
+            reason = None
+        if reason:
+            return (
+                f"⚠️ Cron '{job_name}' script failed: {reason}. "
+                "Full details saved in cron output."
+            )
+
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
         reason = "rate limit"

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -329,3 +329,28 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+def test_no_agent_timeout_is_not_mislabeled_as_provider_failure(hermes_env):
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    message = _summarize_cron_failure_for_delivery(
+        {"name": "watchdog", "no_agent": True},
+        "Client.Timeout exceeded while awaiting headers",
+    )
+
+    assert "script failed: upstream service timeout" in message
+    assert "provider" not in message
+    assert "Fallback chain" not in message
+
+
+def test_agent_timeout_keeps_provider_failure_summary(hermes_env):
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    message = _summarize_cron_failure_for_delivery(
+        {"name": "agent job", "no_agent": False},
+        "ReadTimeout while calling model",
+    )
+
+    assert "provider timeout" in message
+    assert "Fallback chain" in message


### PR DESCRIPTION
## Summary

Report `no_agent` script failures as script/upstream-service failures instead of LLM provider or fallback-chain failures.

## Problem

`no_agent` jobs never invoke an LLM, but `_summarize_cron_failure_for_delivery()` currently applies provider-oriented substring classification to every failed job. A timeout, 429, or authentication error emitted by a script is therefore reported as an LLM provider failure, including the false claim that the fallback chain was exhausted.

## Fix

For script-only jobs, preserve the compact failure categories while naming the actual subsystem:

- rate limits become `script failed: upstream service rate limit`
- timeouts become `script failed: upstream service timeout`
- authentication failures become `script failed: upstream service authentication error`

Agent-mode jobs retain the existing provider/fallback wording. Full details remain in cron output rather than being dumped into chat delivery.

## Verification

Applied cleanly to current upstream `main` (`ae6c2e57`).

```text
scripts/run_tests.sh tests/cron/ -q
394 passed, 0 failed

ruff check cron/scheduler.py tests/cron/test_cron_no_agent.py
All checks passed!
```

The published fork branch also passes its focused test file: 20 passed.

## Related work

#70977, #60593, and #77648 address the same root misattribution by routing script-only failures through generic wording. This PR is the fleet-carried variant that keeps concise timeout/rate-limit/authentication categories while removing the impossible LLM provider and fallback-chain attribution.
