### PR TITLE
fix(pricing): treat OpenAI-compatible /models pricing as per-million (#79400)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1134,6 +1134,7 @@ def _pricing_entry_from_metadata(
     *,
     source_url: str,
     pricing_version: str,
+    per_million: bool = False,
 ) -> Optional[PricingEntry]:
     if model_id not in metadata:
         return None
@@ -1157,6 +1158,8 @@ def _pricing_entry_from_metadata(
     def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
         if value is None:
             return None
+        if per_million:
+            return value
         return value * _ONE_MILLION
 
     return PricingEntry(
@@ -1196,6 +1199,7 @@ def get_pricing_entry(
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",
+            per_million=True,
         )
         if entry:
             return entry


### PR DESCRIPTION
## Summary

Fixes #79400

OpenAI-compatible `/models` endpoints report pricing as **dollars per million tokens** (e.g. `{"pricing": {"prompt": 3.2664}}` = $3.27/M input). The parser assumed all sources report **per-token** decimals (OpenRouter's format) and scaled by 1e6, producing prices 1,000,000x too high.

## Root Cause

`_pricing_entry_from_metadata()` in `agent/usage_pricing.py` always multiplies pricing values by `_ONE_MILLION` via `_per_token_to_per_million()`. This is correct for OpenRouter (per-token format) but wrong for OpenAI-compatible endpoints (already per-million).

The function is called from two paths:
1. `_openrouter_pricing_entry()` — per-token format → needs ×1e6 ✓
2. `get_pricing_entry()` for OpenAI-compatible endpoints — per-million format → should NOT ×1e6

## Fix

Add `per_million: bool = False` parameter to `_pricing_entry_from_metadata()`. When `True`, skip the 1e6 multiplication. Pass `per_million=True` for OpenAI-compatible endpoint calls.

## Impact

- OpenAI-compatible models with per-million pricing: corrected from 1e6x inflated to accurate values
- OpenRouter models: unchanged (still multiplied by 1e6 as before)
- Official docs pricing lookup: unchanged (uses separate `_OFFICIAL_DOCS_PRICING` table)