### PR TITLE
fix(desktop): do not inherit project cwd across profile switches

### DIFF
--- a/apps/desktop/src/store/profile-identity.ts
+++ b/apps/desktop/src/store/profile-identity.ts
@@ -1,0 +1,21 @@
+/**
+ * Lightweight profile identity atoms — no gateway/projects imports.
+ *
+ * Session/project modules can read the active / new-chat profile without
+ * pulling in the full profile switcher (which depends on projects cleanup).
+ */
+import { atom } from 'nanostores'
+
+// Canonical key for a profile: trimmed, empty → "default".
+export function normalizeProfileKey(name: string | null | undefined): string {
+  const value = (name ?? '').trim()
+
+  return value || 'default'
+}
+
+// The profile the live gateway WebSocket is currently connected to.
+export const $activeGatewayProfile = atom<string>('default')
+
+// Profile for the NEXT new chat (chosen via the new-chat picker). null = use
+// the live gateway profile.
+export const $newChatProfile = atom<string | null>(null)

--- a/apps/desktop/src/store/profile-projects-boundary.ts
+++ b/apps/desktop/src/store/profile-projects-boundary.ts
@@ -1,21 +1,8 @@
 /**
  * Boundary helpers between profile switching and the projects cache.
  *
- * Kept in its own module so `profile.ts` can clear project state without a
- * circular import through `projects.ts` (which already imports profile).
+ * Imports only gateway-free project state so unit tests that mock part of
+ * `@/store/gateway` can load `profile.ts` without needing a full gateway mock.
  */
 
-import {
-  $activeProjectId,
-  $projects,
-  $projectTree,
-  exitProjectScope
-} from '@/store/projects'
-
-/** Drop the previous profile's projects.db snapshot on profile switch (#79406). */
-export function clearProjectsCacheForProfileSwitch(): void {
-  $projects.set([])
-  $projectTree.set([])
-  $activeProjectId.set(null)
-  exitProjectScope()
-}
+export { clearProjectsCacheForProfileSwitch } from '@/store/projects-cache-state'

--- a/apps/desktop/src/store/profile-projects-boundary.ts
+++ b/apps/desktop/src/store/profile-projects-boundary.ts
@@ -1,0 +1,21 @@
+/**
+ * Boundary helpers between profile switching and the projects cache.
+ *
+ * Kept in its own module so `profile.ts` can clear project state without a
+ * circular import through `projects.ts` (which already imports profile).
+ */
+
+import {
+  $activeProjectId,
+  $projects,
+  $projectTree,
+  exitProjectScope
+} from '@/store/projects'
+
+/** Drop the previous profile's projects.db snapshot on profile switch (#79406). */
+export function clearProjectsCacheForProfileSwitch(): void {
+  $projects.set([])
+  $projectTree.set([])
+  $activeProjectId.set(null)
+  exitProjectScope()
+}

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -12,6 +12,9 @@ const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
 vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/profile-projects-boundary', () => ({
+  clearProjectsCacheForProfileSwitch: vi.fn()
+}))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,17 +12,18 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { $gateway, ensureGatewayForProfile, openGatewayForProfile } from '@/store/gateway'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  normalizeProfileKey
+} from '@/store/profile-identity'
+import { clearProjectsCacheForProfileSwitch } from '@/store/profile-projects-boundary'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
 
-// Canonical key for a profile: trimmed, empty → "default". Used everywhere we
-// compare a session's owning profile against the live gateway's profile.
-export function normalizeProfileKey(name: string | null | undefined): string {
-  const value = (name ?? '').trim()
-
-  return value || 'default'
-}
+// Re-export identity helpers so existing `@/store/profile` imports keep working.
+export { $activeGatewayProfile, $newChatProfile, normalizeProfileKey }
 
 // The profile the running local backend is actually scoped to (mirrors
 // /api/profiles/active `current`). "default" is the root ~/.hermes. This is the
@@ -145,14 +146,6 @@ export async function switchProfile(name: string): Promise<void> {
 // differs from the gateway's current profile, we lazily reconnect the single
 // gateway to that profile's backend (spawned on demand by the Electron pool).
 // A single-profile user never triggers a swap, so their path is unchanged.
-
-// The profile the live gateway WebSocket is currently connected to. Initialized
-// to the primary (window) backend's profile on boot.
-export const $activeGatewayProfile = atom<string>('default')
-
-// Profile for the NEXT new chat (chosen via the new-chat picker). null = primary
-// / default, so single-profile users are unaffected.
-export const $newChatProfile = atom<string | null>(null)
 
 // Bumped whenever the open session should be dropped for a fresh new-session
 // draft: a profile switch/create (below), or deleting the project that owns the
@@ -342,6 +335,10 @@ export function selectProfile(name: string): void {
   $newChatProfile.set(target)
 
   if (switching) {
+    // Drop the previous profile's project scope/tree before the fresh draft
+    // resolves cwd — otherwise resolveNewSessionCwd can still see the old
+    // projects.db snapshot and attach the wrong AGENTS.md (#79406).
+    clearProjectsCacheForProfileSwitch()
     requestFreshSession()
   }
 
@@ -356,7 +353,13 @@ export function selectProfile(name: string): void {
 // message lands in the right place.
 export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
+  const switching = target !== normalizeProfileKey($activeGatewayProfile.get())
   $newChatProfile.set(target)
+
+  if (switching) {
+    clearProjectsCacheForProfileSwitch()
+  }
+
   requestFreshSession()
   void ensureGatewayProfile(target)
 }

--- a/apps/desktop/src/store/projects-cache-state.ts
+++ b/apps/desktop/src/store/projects-cache-state.ts
@@ -1,0 +1,37 @@
+/**
+ * Project list/tree/scope atoms with no gateway dependency.
+ *
+ * Profile-switch cleanup and unit tests that mock only part of `@/store/gateway`
+ * can touch this module without loading the projects RPC client (#79406).
+ */
+import { atom } from 'nanostores'
+
+import { type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
+import { persistentAtom } from '@/lib/persisted'
+import type { ProjectInfo } from '@/types/hermes'
+
+export const $projects = atom<ProjectInfo[]>([])
+export const $activeProjectId = atom<null | string>(null)
+export const $projectTree = atom<SidebarProjectTree[]>([])
+export const $projectTreeLoading = atom(false)
+
+export const ALL_PROJECTS = '__all_projects__'
+
+const PROJECT_SCOPE_KEY = 'hermes.desktop.projectScope'
+
+export const $projectScope = persistentAtom<string>(PROJECT_SCOPE_KEY, ALL_PROJECTS, {
+  decode: raw => raw || ALL_PROJECTS,
+  encode: value => value || ALL_PROJECTS
+})
+
+export function exitProjectScope(): void {
+  $projectScope.set(ALL_PROJECTS)
+}
+
+/** Drop the previous profile's projects.db snapshot on profile switch (#79406). */
+export function clearProjectsCacheForProfileSwitch(): void {
+  $projects.set([])
+  $projectTree.set([])
+  $activeProjectId.set(null)
+  exitProjectScope()
+}

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -3,12 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped } from '@/store/layout'
-import { $activeGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
 import {
   $activeProjectId,
   $projectScope,
+  $projects,
   $projectsRpcAvailable,
   $projectTree,
   $removedSessionIds,
@@ -119,6 +120,9 @@ describe('resolveNewSessionCwd', () => {
     $currentCwd.set('')
     $selectedStoredSessionId.set(null)
     $sessions.set([])
+    $activeProjectId.set(null)
+    $projectTree.set([])
+    $projects.set([])
     // Reset focused-session projections by clearing the inputs they read.
     // $focusedStoredSessionId falls back to $selectedStoredSessionId.
     // $focusedSessionState needs a runtime — leave it empty via no session states.
@@ -130,6 +134,9 @@ describe('resolveNewSessionCwd', () => {
     $currentCwd.set('')
     $selectedStoredSessionId.set(null)
     $sessions.set([])
+    $activeProjectId.set(null)
+    $projectTree.set([])
+    $projects.set([])
   })
 
   it('starts a chat detached inside Home, ignoring the configured default dir', () => {
@@ -191,6 +198,63 @@ describe('resolveNewSessionCwd', () => {
 
     // Focused session has no workspace → fall through to configured default,
     // not the stale $currentCwd from an earlier chat.
+    expect(resolveNewSessionCwd()).toBe('/home/user/configured')
+  })
+
+  it('does not inherit a focused session cwd from another profile (#79406)', () => {
+    // Profile A session still selected/listed while new chats target profile B
+    // (selectProfile sets $newChatProfile before gateway/projects refresh).
+    $activeGatewayProfile.set('profile-a')
+    $newChatProfile.set('profile-b')
+    $selectedStoredSessionId.set('sess-a')
+    $sessions.set([
+      {
+        archived: false,
+        cwd: '/workspace/domain/subproject',
+        ended_at: null,
+        id: 'sess-a',
+        input_tokens: 0,
+        is_active: true,
+        last_active: 0,
+        message_count: 1,
+        model: null,
+        output_tokens: 0,
+        profile: 'profile-a',
+        started_at: 0,
+        title: 'A work'
+      } as never
+    ])
+    $currentCwd.set('/workspace/domain/subproject')
+
+    expect(resolveNewSessionCwd()).toBe('/home/user/configured')
+
+    $newChatProfile.set(null)
+    $activeGatewayProfile.set('default')
+  })
+
+  it('uses this profile active project primary_path before configured default (#79406)', () => {
+    $activeProjectId.set('p_b')
+    $projectTree.set([
+      {
+        color: null,
+        icon: null,
+        id: 'p_b',
+        isAuto: false,
+        label: 'Project B',
+        path: '/workspace',
+        previewSessions: [],
+        repos: [],
+        sessionCount: 0
+      }
+    ])
+
+    expect(resolveNewSessionCwd()).toBe('/workspace')
+  })
+
+  it('ignores a project scope id that is not on the current tree (stale after profile switch)', () => {
+    enterProject('p_from_profile_a')
+    $projectTree.set([]) // new profile tree not loaded yet / cleared
+
     expect(resolveNewSessionCwd()).toBe('/home/user/configured')
   })
 })

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -8,8 +8,8 @@ import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaul
 
 import {
   $activeProjectId,
-  $projectScope,
   $projects,
+  $projectScope,
   $projectsRpcAvailable,
   $projectTree,
   $removedSessionIds,

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -11,7 +11,6 @@ import { translateNow } from '@/i18n'
 import { desktopDefaultCwd, isDesktopFsRemoteMode, selectDesktopPaths, writeDesktopFileText } from '@/lib/desktop-fs'
 import { desktopGit } from '@/lib/desktop-git'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
-import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
@@ -21,6 +20,15 @@ import {
   $newChatProfile,
   normalizeProfileKey
 } from '@/store/profile-identity'
+import {
+  $activeProjectId,
+  $projects,
+  $projectScope,
+  $projectTree,
+  $projectTreeLoading,
+  ALL_PROJECTS,
+  exitProjectScope
+} from '@/store/projects-cache-state'
 import {
   $currentCwd,
   $selectedStoredSessionId,
@@ -33,20 +41,21 @@ import {
 import { $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
+// Re-export cache atoms so existing `@/store/projects` imports keep working.
+export {
+  $activeProjectId,
+  $projects,
+  $projectScope,
+  $projectTree,
+  $projectTreeLoading,
+  ALL_PROJECTS,
+  exitProjectScope
+}
+
 // First-class, per-profile Projects (named, multi-folder workspaces). State is
 // served by the live gateway's `projects.*` JSON-RPC methods, which wrap the
 // per-profile projects.db store. The sidebar groups sessions by project folder
 // membership; these atoms are the renderer's cached view.
-
-export const $projects = atom<ProjectInfo[]>([])
-export const $activeProjectId = atom<null | string>(null)
-
-// The authoritative project -> repo -> lane tree (overview), served by
-// `projects.tree`. Lanes carry counts + structure; per-project session rows are
-// fetched lazily on drill-in via `fetchProjectSessions`. This is the single
-// source of project membership — the desktop no longer derives it.
-export const $projectTree = atom<SidebarProjectTree[]>([])
-export const $projectTreeLoading = atom(false)
 
 // False when the connected backend predates the projects.* JSON-RPC surface
 // (same semver label, older install). Null until the first probe.
@@ -141,22 +150,6 @@ export const endSessionMutation = (ids: Array<null | string | undefined>): void 
 // True while the disk scan is in flight (drives the "finding repos" hint).
 export const $reposScanning = atom(false)
 
-// ── Project scope (the "you're inside a project" view, mirroring profile scope)─
-// The sidebar's grouped view is a project switcher: ALL_PROJECTS shows the
-// project overview (a list you drill into), and a concrete id means you've
-// "entered" that project so only its worktrees/branches/sessions show. This is
-// pure view state (localStorage), distinct from the durable active-project
-// pointer in projects.db — though entering a project also makes it active so new
-// chats land there, exactly as selecting a profile does.
-export const ALL_PROJECTS = '__all_projects__'
-
-const PROJECT_SCOPE_KEY = 'hermes.desktop.projectScope'
-
-export const $projectScope = persistentAtom<string>(PROJECT_SCOPE_KEY, ALL_PROJECTS, {
-  decode: raw => raw || ALL_PROJECTS,
-  encode: value => value || ALL_PROJECTS
-})
-
 // Enter a project: scope the sidebar to it and make it the active project
 // (best-effort — the durable pointer is nice-to-have, the view scope is the
 // point). Never opens a session.
@@ -169,10 +162,6 @@ export function enterProject(id: string): void {
   if (id.startsWith('p_')) {
     void setActiveProject(id).catch(() => undefined)
   }
-}
-
-export function exitProjectScope(): void {
-  $projectScope.set(ALL_PROJECTS)
 }
 
 // A project's working root: its primary folder, else the first repo that has

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -15,12 +15,12 @@ import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
+import { requestFreshSession } from '@/store/profile'
 import {
   $activeGatewayProfile,
   $newChatProfile,
   normalizeProfileKey
 } from '@/store/profile-identity'
-import { requestFreshSession } from '@/store/profile'
 import {
   $currentCwd,
   $selectedStoredSessionId,

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -15,7 +15,12 @@ import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
 import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
-import { $activeGatewayProfile, requestFreshSession } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  normalizeProfileKey
+} from '@/store/profile-identity'
+import { requestFreshSession } from '@/store/profile'
 import {
   $currentCwd,
   $selectedStoredSessionId,
@@ -200,13 +205,43 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
   }
 }
 
+/** Profile that owns the next new chat (switcher may set $newChatProfile first). */
+function targetProfileForNewSession(): string {
+  return normalizeProfileKey($newChatProfile.get() || $activeGatewayProfile.get() || 'default')
+}
+
+function sessionProfileKey(session: { profile?: null | string } | undefined): string {
+  return normalizeProfileKey((session?.profile ?? '').trim() || 'default')
+}
+
+/** Primary path of this profile's durable active project (projects.db). */
+export function activeProjectPrimaryPath(): string {
+  const id = $activeProjectId.get()
+
+  if (!id) {
+    return ''
+  }
+
+  const fromTree = projectRootCwd($projectTree.get().find(node => node.id === id))
+
+  if (fromTree) {
+    return fromTree
+  }
+
+  const project = $projects.get().find(p => p.id === id)
+
+  return (project?.primary_path ?? project?.folders?.[0]?.path ?? '').trim()
+}
+
 // The cwd a NEW chat should start in.
 //
 // Priority (first hit wins):
 //   1. Explicit sidebar project scope (drilled into a project / Home bucket)
-//   2. The FOCUSED session's workspace — so ⌘N / ⌘T from a chat that's already
-//      in a project/worktree stay there without requiring a sidebar drill-in
-//   3. Configured default project dir / remote remembered cwd (detached otherwise)
+//      — only when that id still exists on the CURRENT profile's tree
+//   2. The FOCUSED session's workspace — only when that session belongs to
+//      the target profile (never cross-profile; #79406)
+//   3. This profile's durable active project primary_path (projects.db)
+//   4. Configured default project dir / remote remembered cwd (detached otherwise)
 //
 // The "active project" is just an atom ($projectScope) — so when you're inside
 // a project, a new session (cmd-n, the trunk "+") starts at that project's root
@@ -223,6 +258,8 @@ export function resolveNewSessionCwd(): string {
   }
 
   if (scope !== ALL_PROJECTS) {
+    // Stale scope ids from another profile must not win after a switch —
+    // the previous tree can still be in memory until projects.tree returns.
     const cwd = projectRootCwd($projectTree.get().find(node => node.id === scope))
 
     if (cwd) {
@@ -230,13 +267,23 @@ export function resolveNewSessionCwd(): string {
     }
   }
 
-  // Inherit the focused chat's workspace. ⌘N/⌘T from a session that already
-  // has a project/pwd should stay there — drilling into the sidebar project
-  // is the uncommon path, not the requirement.
+  // Inherit the focused chat's workspace only when it belongs to the profile
+  // that will own the new session. Cross-profile inheritance is what loads the
+  // wrong AGENTS.md after a profile switch (#79406).
   const focusedCwd = focusedSessionWorkspaceCwd()
 
   if (focusedCwd) {
     return focusedCwd
+  }
+
+  // Prefer this profile's projects.db active project before the configured
+  // default — the durable pin survives the switch once the new gateway's
+  // projects.tree lands (and clearProjectsCacheForProfileSwitch avoids the
+  // previous profile's active_id leaking in the meantime).
+  const activePath = activeProjectPrimaryPath()
+
+  if (activePath) {
+    return activePath
   }
 
   return workspaceCwdForNewSession()
@@ -246,6 +293,8 @@ export function resolveNewSessionCwd(): string {
 function focusedSessionWorkspaceCwd(): string {
   const focusedStoredId = $focusedStoredSessionId.get()
   const state = $focusedSessionState.get()
+  const targetProfile = targetProfileForNewSession()
+  const sessions = $sessions.get()
 
   // Prefer the live runtime slice when it belongs to the focused chat
   // (agent can relocate mid-turn). Cold tabs / mid-switch lag fall through
@@ -258,28 +307,55 @@ function focusedSessionWorkspaceCwd(): string {
     (!focusedStoredId ||
       !stateStoredId ||
       stateStoredId === focusedStoredId ||
-      idsShareLineage(focusedStoredId, stateStoredId, $sessions.get()))
+      idsShareLineage(focusedStoredId, stateStoredId, sessions))
   ) {
-    return stateCwd
+    // Gate by profile: a still-focused row from the previous profile must not
+    // seed the next chat after selectProfile (#79406).
+    const owner =
+      sessions.find(s => sessionMatchesStoredId(s, focusedStoredId || stateStoredId || '')) ??
+      sessions.find(s => sessionMatchesStoredId(s, stateStoredId || focusedStoredId || ''))
+
+    if (!owner || sessionProfileKey(owner) === targetProfile) {
+      // No row yet (draft) — only accept state cwd when we are not mid
+      // profile-switch to a different profile than the live gateway.
+      if (!owner) {
+        const liveProfile = normalizeProfileKey($activeGatewayProfile.get() || 'default')
+
+        if (liveProfile === targetProfile) {
+          return stateCwd
+        }
+      } else {
+        return stateCwd
+      }
+    }
   }
 
   if (focusedStoredId) {
-    const row = $sessions.get().find(s => sessionMatchesStoredId(s, focusedStoredId))
+    const row = sessions.find(s => sessionMatchesStoredId(s, focusedStoredId))
     const rowCwd = row?.cwd?.trim() || ''
 
-    if (rowCwd) {
+    if (rowCwd && sessionProfileKey(row) === targetProfile) {
       return rowCwd
     }
 
-    // Focused a real session with no workspace → stay detached. Do NOT fall
-    // through to `$currentCwd` (it may still hold a remembered path from an
-    // earlier chat and would re-attach a project the user left).
+    // Focused a real session with no workspace, or a foreign-profile session
+    // still in the list mid-switch → do not fall through to `$currentCwd`
+    // (it may still hold a remembered path from the previous profile).
+    if (row) {
+      return ''
+    }
+
     return ''
   }
 
   // No focused stored session: primary draft. The composer atom is the draft's
-  // workspace target (set by startFreshSession / startSessionInWorkspace).
-  return $currentCwd.get().trim()
+  // workspace target (set by startFreshSession / startSessionInWorkspace) —
+  // only trust it for the target profile.
+  if (normalizeProfileKey($activeGatewayProfile.get() || 'default') === targetProfile) {
+    return $currentCwd.get().trim()
+  }
+
+  return ''
 }
 
 const underPath = (parent: string, child: string): boolean =>


### PR DESCRIPTION
## Summary

Fixes #79406: after switching profiles, a new session could inherit the previous profile's workspace cwd (or a stale project-scope / projects.db snapshot), so the wrong `AGENTS.md` was injected as Project Context.

### Fix

1. **Profile-gated session inheritance** — `resolveNewSessionCwd` only inherits the focused session's cwd when that session belongs to the target profile (`$newChatProfile` / `$activeGatewayProfile`).
2. **Active project path** — prefer this profile's durable `active_id` → `primary_path` before the configured default.
3. **Clear on switch** — `selectProfile` / `newSessionInProfile` drop the previous profile's projects tree, active pointer, and sidebar project scope before the fresh draft resolves cwd.
4. **Import hygiene** — lightweight `profile-identity` + `profile-projects-boundary` modules avoid circular imports between profile and projects stores.

## Test plan

- [x] `apps/desktop` vitest: `projects.test.ts` + `profile.test.ts` (41 passed)
  - cross-profile focused session does not seed cwd
  - active project primary_path preferred
  - stale project scope id ignored when not on current tree
- [ ] Manual: Profile A project → switch to Profile B → new chat loads B's AGENTS.md
- [ ] CI green on this PR