### PR TITLE
fix(compression): use pre-watchdog timestamp for idle-compaction gap (#79357)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -662,7 +662,10 @@ def build_turn_context(
     # expensive) token estimate, mirroring ``_should_run_preflight_estimate``.
     _idle_after = getattr(agent, "compression_idle_compact_after_seconds", 0)
     if agent.compression_enabled and _idle_after > 0 and messages:
-        _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
+        # Use _prev_activity_ts (saved before the watchdog reset) to measure
+        # the real idle gap since the previous turn finished (#79357).
+        _idle_ref = getattr(agent, "_prev_activity_ts", None) or getattr(agent, "_last_activity_ts", time.time())
+        _idle_gap = time.time() - _idle_ref
         if _idle_gap >= _idle_after:
             _compressor = agent.context_compressor
             _idle_tokens = estimate_request_tokens_rough(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23204,6 +23204,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if interrupt_depth == 0:
             from agent.session_activity import ActivityProvenance
 
+            # Save previous ts for idle-compaction gap calculation (#79357)
+            # before the watchdog reset overwrites it.
+            agent._prev_activity_ts = getattr(agent, "_last_activity_ts", None)
             agent._last_activity_ts = time.time()
             agent._last_activity_desc = "starting new turn (cached)"
             agent._last_activity_provenance = ActivityProvenance.UNKNOWN


### PR DESCRIPTION
## Summary

Fixes #79357

`compression.idle_compact_after_seconds` can never fire in gateway mode. The gateway's inactivity watchdog resets `_last_activity_ts` at the start of every depth-0 turn, and the idle-compaction check reads that same timestamp a moment later — so the measured idle gap is always ~0.

## Root Cause

Two features share one timestamp:

1. **Inactivity watchdog** (`gateway/run.py:23207`): `_init_cached_agent_for_turn()` resets `agent._last_activity_ts = time.time()` at the start of every fresh external turn
2. **Idle compaction** (`agent/turn_context.py:665`): reads `_last_activity_ts` to measure the gap since the previous turn finished

The watchdog runs BEFORE the turn body (including the idle check), so the gap is always near-zero.

## Fix

Save the previous `_last_activity_ts` to `_prev_activity_ts` before the watchdog reset, and use that saved value in the idle-compaction gap calculation. Falls back to `_last_activity_ts` when `_prev_activity_ts` is not set (CLI/TUI sessions that don't go through the gateway path).

## Files Changed

- `gateway/run.py`: Save `_prev_activity_ts` before watchdog reset in `_init_cached_agent_for_turn()`
- `agent/turn_context.py`: Use `_prev_activity_ts` for idle gap calculation

## Testing

- Verified syntax with `python3 -m py_compile` on both files
- CLI/TUI sessions unaffected (no gateway watchdog → `_prev_activity_ts` is None → falls back to `_last_activity_ts`)