### PR TITLE
fix(state): bound session database file descriptors

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1991,20 +1991,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self.read_only = read_only
 
         self._lock = threading.Lock()
-        # Read-path split (WAL only): recall/browse queries run on per-thread
-        # read-only connections so they never queue behind writer flushes on
-        # self._lock. See _read_ctx().
-        self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
-        # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
-        self._read_conns_lock = threading.Lock()
-        # Set when close() begins.  _get_read_conn checks this under the
-        # lock so a reader that finishes opening after the drain finds the
-        # shutdown in progress and closes its own connection immediately.
-        self._read_conns_closed = False
+        # Read-path split (WAL only): recall/browse queries run on one shared
+        # read-only connection so they never queue behind writer flushes on
+        # self._lock. Serialising readers on their own lock still isolates them
+        # from writes while bounding each SessionDB to one extra connection.
+        # A per-thread cache retained two file descriptors (state.db + WAL) for
+        # every gateway worker thread until shutdown and exhausted macOS's
+        # default 256-FD service limit.
+        self._read_conn: Optional[sqlite3.Connection] = None
+        self._read_conn_lock = threading.RLock()
+        self._read_conn_failed = False
+        self._read_conn_closed = False
         self._wal_active = False
         self._write_count = 0
         # One-shot guard for the runtime FTS rebuild recovery on the write
@@ -2235,7 +2232,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # ── Read-path split ──
 
     def _get_read_conn(self) -> Optional[sqlite3.Connection]:
-        """Per-thread read-only connection, or None when unavailable.
+        """Shared read-only connection, or None when unavailable.
 
         Only used under WAL: WAL readers see a consistent snapshot and never
         block on (or get blocked by) the writer, so recall/browse queries can
@@ -2245,62 +2242,62 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         Fresh read transactions begin per statement (autocommit), so each
         query observes everything committed so far — read-your-writes holds
-        for the flush-then-search patterns in a turn.
+        for the flush-then-search patterns in a turn. ``check_same_thread`` is
+        disabled because gateway executor threads share this handle; callers
+        use it through :meth:`_read_ctx`, which serialises access.
         """
         if not self._wal_active or self.read_only:
             return None
-        conn = getattr(self._read_local, "conn", None)
-        if conn is not None:
+        with self._read_conn_lock:
+            if self._read_conn is not None:
+                return self._read_conn
+            if self._read_conn_failed or self._read_conn_closed:
+                return None
+            try:
+                conn = _connect_tracked_db(
+                    f"file:{self.db_path}?mode=ro",
+                    tracking_path=self.db_path,
+                    uri=True,
+                    check_same_thread=False,
+                    timeout=5.0,
+                    isolation_level=None,
+                )
+                conn.row_factory = sqlite3.Row
+                apply_database_pragmas(conn, db_label="state.db")
+                # Load the CJK tokenizer extension on this connection so
+                # messages_fts_cjk queries work on the read path. The .so
+                # registers the tokenizer in the connection's in-memory
+                # registry, not the database file, so mode=ro is fine.
+                if self._fts_cjk_loaded:
+                    load_fts5_cjk_extension(conn)
+            except sqlite3.Error:
+                # The locked writer connection still serves reads. Remember
+                # the failure for this SessionDB instead of retrying per query.
+                self._read_conn_failed = True
+                logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
+                return None
+            self._read_conn = conn
             return conn
-        if getattr(self._read_local, "failed", False):
-            return None
-        try:
-            conn = _connect_tracked_db(
-                f"file:{self.db_path}?mode=ro",
-                tracking_path=self.db_path,
-                uri=True,
-                timeout=5.0,
-                isolation_level=None,
-            )
-            conn.row_factory = sqlite3.Row
-            apply_database_pragmas(conn, db_label="state.db")
-            # Load the CJK tokenizer extension on this connection so
-            # messages_fts_cjk queries work on the read path. The .so
-            # registers the tokenizer in the connection's in-memory
-            # registry, not the database file, so mode=ro is fine.
-            if self._fts_cjk_loaded:
-                load_fts5_cjk_extension(conn)
-            with self._read_conns_lock:
-                if self._read_conns_closed:
-                    # close() already drained — don't register; close
-                    # immediately so no tracked fd leaks.
-                    conn.close()
-                    self._read_local.failed = True
-                    return None
-                self._read_conns.add(conn)
-        except sqlite3.Error:
-            # Mark this thread failed so we don't retry the open on every
-            # query; the locked writer connection still serves reads.
-            self._read_local.failed = True
-            logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
-            return None
-        self._read_local.conn = conn
-        return conn
 
     @contextmanager
     def _read_ctx(self):
         """Yield a connection for read-only statements.
 
-        WAL: a per-thread read-only connection with NO lock — recall queries
+        WAL: a shared read-only connection under its own lock — recall queries
         never convoy behind writer flushes (the gateway shares one SessionDB
-        across every agent, so this lock was a global choke point).
+        across every agent, so the writer lock was a global choke point).
         Non-WAL or read-conn failure: the shared writer connection under
         self._lock, byte-for-byte the legacy behavior.
         """
-        conn = self._get_read_conn()
-        if conn is not None:
-            yield conn
-            return
+        if self._wal_active and not self.read_only:
+            # sqlite3 permits cross-thread use with check_same_thread=False but
+            # not concurrent operations on one handle. This lock is independent
+            # of the writer lock, preserving the read/write split.
+            with self._read_conn_lock:
+                conn = self._get_read_conn()
+                if conn is not None:
+                    yield conn
+                    return
         with self._lock:
             yield self._conn
 
@@ -2811,23 +2808,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # (instance, function), so this removes exactly our registration;
         # no-op when the writer never started.
         atexit.unregister(self._drain_token_queue_at_exit)
-        # Close all read-only connections across all threads.  Per-thread
-        # connections live in threading.local() and would otherwise be GC'd
-        # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
-        # flag under the lock prevents a reader from registering a new
-        # connection after the drain.
-        with self._read_conns_lock:
-            self._read_conns_closed = True
-            read_conns = list(self._read_conns)
-            self._read_conns.clear()
-        for conn in read_conns:
-            try:
-                conn.close()
-            except Exception:
-                pass
-        self._read_local.conn = None
+        # Wait for any active reader, prevent a new one from opening, then close
+        # the shared handle while its lifecycle lock is still held.
+        with self._read_conn_lock:
+            self._read_conn_closed = True
+            if self._read_conn is not None:
+                try:
+                    self._read_conn.close()
+                except Exception:
+                    pass
+                self._read_conn = None
         with self._lock:
             if self._conn:
                 if not self.read_only:

--- a/tests/test_message_reactions.py
+++ b/tests/test_message_reactions.py
@@ -173,3 +173,61 @@ def test_row_id_is_opt_in_and_never_reaches_the_provider(session, db):
     for message in db.get_messages_as_conversation(key, include_row_ids=True):
         assert "_row_id" in message
         assert all(not k.startswith("_") or k == "_row_id" for k in message)
+
+
+def test_reaction_tool_closes_session_db_it_opens(monkeypatch):
+    """A standalone reaction call deterministically releases its DB handles."""
+    from tools import react_to_message_tool as reaction_tool
+
+    class FakeDB:
+        close_calls = 0
+
+        def get_message_role(self, session_key, row_id):
+            return "user"
+
+        def set_message_reaction(self, session_key, row_id, emoji, author):
+            return [{"author": author, "emoji": emoji}]
+
+        def close(self):
+            self.close_calls += 1
+
+    fake = FakeDB()
+    monkeypatch.setattr(reaction_tool, "get_session_env", lambda key, default="": "react-test")
+    monkeypatch.setattr(reaction_tool, "_open_session_db", lambda: fake)
+    monkeypatch.setattr(reaction_tool.desktop_ui, "emit", lambda *args, **kwargs: None)
+
+    result = reaction_tool.react_to_message_tool("👍", message_row_id=1)
+
+    assert '"success": true' in result
+    assert fake.close_calls == 1
+
+
+def test_reaction_tool_reuses_caller_db_without_closing(monkeypatch):
+    """Agent calls reuse the turn's SessionDB instead of opening another one."""
+    from tools import react_to_message_tool as reaction_tool
+
+    class FakeDB:
+        close_calls = 0
+
+        def get_message_role(self, session_key, row_id):
+            return "user"
+
+        def set_message_reaction(self, session_key, row_id, emoji, author):
+            return [{"author": author, "emoji": emoji}]
+
+        def close(self):
+            self.close_calls += 1
+
+    fake = FakeDB()
+    monkeypatch.setattr(reaction_tool, "get_session_env", lambda key, default="": "react-test")
+    monkeypatch.setattr(
+        reaction_tool,
+        "_open_session_db",
+        lambda: pytest.fail("caller-provided DB should be reused"),
+    )
+    monkeypatch.setattr(reaction_tool.desktop_ui, "emit", lambda *args, **kwargs: None)
+
+    result = reaction_tool.react_to_message_tool("❤️", message_row_id=1, db=fake)
+
+    assert '"success": true' in result
+    assert fake.close_calls == 0

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -1,11 +1,12 @@
-"""Tests for the SessionDB read-path split (per-thread read-only connections).
+"""Tests for the SessionDB read-path split (shared read-only connection).
 
 The gateway shares ONE SessionDB across every agent, so recall/browse reads
 used to queue behind writer flushes on self._lock — a measured production
 convoy (a 0.2s FTS query stretched to 112s while 6-8 concurrent turns
 flushed tool results). These tests pin the new contract: reads run on a
-per-thread read-only connection under WAL, never touch self._lock, and fall
-back to the legacy locked path when WAL or the read connection is missing.
+shared read-only connection under WAL, never touch self._lock, and fall back
+to the legacy locked path when WAL or the read connection is missing. Sharing
+the connection bounds file descriptors even when gateway worker threads churn.
 """
 
 import threading
@@ -25,18 +26,25 @@ def db(tmp_path):
     d.close()
 
 
-@pytest.mark.requires_wal
-def test_read_conn_is_per_thread(db):
-    conns = {}
+def test_short_lived_reader_threads_reuse_one_connection(db):
+    # Exercise the WAL-only split even on CI runtimes where Hermes' SQLite
+    # compatibility guard selects DELETE mode.
+    db._wal_active = True
+    conns = []
 
-    def grab(key):
-        conns[key] = db._get_read_conn()
+    def grab():
+        conns.append(db._get_read_conn())
 
-    t1 = threading.Thread(target=grab, args=(1,))
-    t2 = threading.Thread(target=grab, args=(2,))
-    t1.start(); t2.start(); t1.join(); t2.join()
-    assert conns[1] is not None and conns[2] is not None
-    assert conns[1] is not conns[2]
+    # The gateway's executor creates and retires worker threads over its
+    # lifetime. A per-thread connection retained by SessionDB leaked two file
+    # descriptors (state.db + WAL) for every thread until process shutdown.
+    for _ in range(64):
+        thread = threading.Thread(target=grab)
+        thread.start()
+        thread.join()
+
+    assert all(conn is not None for conn in conns)
+    assert len({id(conn) for conn in conns}) == 1
 
 
 def test_read_conn_reused_within_thread(db):
@@ -105,7 +113,7 @@ def test_read_conn_open_failure_marks_thread(db, monkeypatch, tmp_path):
         monkeypatch.setattr("hermes_state.sqlite3.connect", failing_connect)
         assert fresh.get_session("x")["id"] == "x"
         assert fresh.get_session("x")["id"] == "x"
-        assert calls["n"] == 1, "open failure should be remembered per thread"
+        assert calls["n"] == 1, "open failure should be remembered by SessionDB"
     finally:
         fresh.close()
 

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -31,7 +31,9 @@ def _open_session_db():
         return None
 
 
-def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -> str:
+def react_to_message_tool(
+    emoji: str, message_row_id=None, messages_back=None, db=None
+) -> str:
     """Attach (or with an empty ``emoji`` retract) the agent's reaction."""
     emoji = (emoji or "").strip()
     session_key = get_session_env("HERMES_SESSION_KEY", "") or get_session_env(
@@ -41,52 +43,64 @@ def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -
     if not session_key:
         return tool_error("No active session — reactions need a persisted conversation.")
 
-    db = _open_session_db()
+    owns_db = db is None
+    if owns_db:
+        db = _open_session_db()
     if db is None:
         return tool_error("Session storage is unavailable.")
 
-    row_id = message_row_id
-    target_role = "user"
-    if row_id is None:
-        # Default target: the latest user message. `messages_back` steps to
-        # earlier user turns (1 = the one before, etc.) for retroactive
-        # reactions — quoting text would be ambiguous, ids aren't visible to
-        # the model, but "two messages ago" is how a person thinks about it.
-        back = max(0, int(messages_back or 0))
-        row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+    try:
+        row_id = message_row_id
+        target_role = "user"
         if row_id is None:
-            return tool_error(
-                f"No user message found {back} back." if back else "No user message to react to yet."
+            # Default target: the latest user message. `messages_back` steps to
+            # earlier user turns (1 = the one before, etc.) for retroactive
+            # reactions — quoting text would be ambiguous, ids aren't visible to
+            # the model, but "two messages ago" is how a person thinks about it.
+            back = max(0, int(messages_back or 0))
+            row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+            if row_id is None:
+                return tool_error(
+                    f"No user message found {back} back."
+                    if back
+                    else "No user message to react to yet."
+                )
+        else:
+            row = db.get_message_role(session_key, int(row_id))
+            target_role = row or "user"
+
+        try:
+            reactions = db.set_message_reaction(
+                session_key, int(row_id), emoji or None, author="agent"
             )
-    else:
-        row = db.get_message_role(session_key, int(row_id))
-        target_role = row or "user"
+        except Exception as exc:
+            return tool_error(f"Failed to set the reaction: {exc}")
 
-    try:
-        reactions = db.set_message_reaction(
-            session_key, int(row_id), emoji or None, author="agent"
+        if reactions is None:
+            return tool_error(f"Message {row_id} is not part of this conversation.")
+
+        # Paint it live. A missing bridge (non-desktop surface) is not an error —
+        # the reaction is persisted either way and shows on the next load.
+        # `role` lets the renderer match a live message that doesn't know its
+        # durable row id yet (it only learns rowId on resume).
+        try:
+            desktop_ui.emit(
+                "message.reaction",
+                {"row_id": int(row_id), "reactions": reactions, "role": target_role},
+            )
+        except Exception:
+            pass
+
+        return json.dumps(
+            {"success": True, "row_id": int(row_id), "reactions": reactions},
+            ensure_ascii=False,
         )
-    except Exception as exc:
-        return tool_error(f"Failed to set the reaction: {exc}")
-
-    if reactions is None:
-        return tool_error(f"Message {row_id} is not part of this conversation.")
-
-    # Paint it live. A missing bridge (non-desktop surface) is not an error —
-    # the reaction is persisted either way and shows on the next load.
-    # `role` lets the renderer match a live message that doesn't know its
-    # durable row id yet (it only learns rowId on resume).
-    try:
-        desktop_ui.emit(
-            "message.reaction",
-            {"row_id": int(row_id), "reactions": reactions, "role": target_role},
-        )
-    except Exception:
-        pass
-
-    return json.dumps(
-        {"success": True, "row_id": int(row_id), "reactions": reactions}, ensure_ascii=False
-    )
+    finally:
+        if owns_db:
+            try:
+                db.close()
+            except Exception:
+                pass
 
 
 def check_react_requirements() -> bool:
@@ -161,6 +175,7 @@ registry.register(
         emoji=args.get("emoji", ""),
         message_row_id=args.get("message_row_id"),
         messages_back=args.get("messages_back"),
+        db=kw.get("db"),
     ),
     check_fn=check_react_requirements,
     emoji="💛",


### PR DESCRIPTION
## Summary

- bound each `SessionDB` to one synchronized read-only WAL connection instead of retaining one connection per transient reader thread
- close reaction-tool-owned `SessionDB` instances on every return path
- reuse the caller-owned execution database for registered reaction calls
- add regressions for short-lived reader-thread churn and reaction database ownership

## Root cause

A long-running macOS gateway reached its 256-descriptor soft limit with 88 `state.db` and 86 `state.db-wal` handles. The transient gateway reader threads were retained through per-thread SQLite connections, and standalone reaction calls created `SessionDB` instances without deterministic closure. Descriptor exhaustion then surfaced as provider connection failures (`OSError: [Errno 24] Too many open files` followed by `openai.APIConnectionError`).

## Verification

- `uv run --extra dev pytest -q tests/test_session_db_read_path_split.py tests/test_message_reactions.py` — 19 passed, 4 skipped
- `uv run --extra dev ruff check hermes_state.py tools/react_to_message_tool.py tests/test_session_db_read_path_split.py tests/test_message_reactions.py` — passed
- pre-rebase relevant suite — 189 passed, 9 skipped
- live patched gateway descriptors remained bounded around 23–39 total FDs and 0–12 database handles during observation, versus 255 total before repair
- real provider smoke test returned the expected response after restart

## Notes

The shared read connection has `check_same_thread=False` and is serialized under an independent `RLock`, preserving read/write separation while bounding descriptors. Caller-owned reaction databases are never closed by the tool.
