### PR TITLE
fix(buzz): extract Nostr e-tags as thread_id and track active-thread state

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -920,7 +920,7 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def _seed_channel(self, channel_id: str, chat_type: str) -> None:
         """Initialize a channel's high-water mark from its newest events."""
-        state = {"chat_type": chat_type, "last_ts": 0, "seen": OrderedDict()}
+        state = {"chat_type": chat_type, "last_ts": 0, "seen": OrderedDict(), "active_threads": set()}
         self._channel_state[channel_id] = state
         code, out, err = await self._run_cli(
             ["messages", "get", "--channel", channel_id, "--limit", str(_FETCH_LIMIT)]
@@ -967,7 +967,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 if seed:
                     await self._seed_channel(dm_id, chat_type="dm")
                 else:
-                    self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict()}
+                    self._channel_state[dm_id] = {"chat_type": "dm", "last_ts": 0, "seen": OrderedDict(), "active_threads": set()}
                 self._channel_names.setdefault(dm_id, "DM")
 
         code, out, _err = await self._run_cli(["channels", "list"])
@@ -984,7 +984,7 @@ class BuzzAdapter(BasePlatformAdapter):
             if seed:
                 await self._seed_channel(ch_id, chat_type="group")
             else:
-                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict(), "active_threads": set()}
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)
@@ -1030,10 +1030,28 @@ class BuzzAdapter(BasePlatformAdapter):
         self._maybe_latch_dm(channel_id, state, event)
 
         is_dm = state["chat_type"] == "dm"
+        # Track active-thread context for group channels. Nostr e-tags tell us
+        # when a message is a reply inside a thread the agent already
+        # participates in — non-mentioned replies in those threads should
+        # dispatch so the conversation can continue without @-mentions.
+        thread_id = self._extract_thread_id(event.get("tags"))
+        if thread_id and not is_dm and self.require_mention:
+            active_threads = state.setdefault("active_threads", set())
+            if thread_id in active_threads and not self._is_mentioned(content):
+                pass  # fall through to dispatch — this is an active-thread reply
+            elif self._is_mentioned(content):
+                active_threads.add(thread_id)
+                pass
+            else:
+                return
+        elif not thread_id and not is_dm and self.require_mention and self._is_mentioned(content):
+            # The agent was @-mentioned in a root message. Mark the message as
+            # an active thread root so replies inside it also dispatch.
+            state.setdefault("active_threads", set()).add(event_id)
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
         # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        elif not is_dm and self.require_mention and not self._is_mentioned(content):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1056,6 +1074,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=thread_id,
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1176,6 +1195,35 @@ class BuzzAdapter(BasePlatformAdapter):
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 
+    @staticmethod
+    def _extract_thread_id(tags: list) -> str | None:
+        """Extract the thread root from Nostr e-tags.
+
+        Nostr kind-9 chat events mark thread context with ``e`` tags:
+            ``["e", "<root-event-id>", "", "root"]``  — thread root
+            ``["e", "<parent-event-id>", "", "reply"]`` — direct parent
+
+        Returns the ``root`` event id first (which anchors the whole thread),
+        falling back to the ``reply`` parent.  When both are present they
+        always point to the same thread tree, so either one gives the gateway
+        enough context to reply in-thread.
+        """
+        if not isinstance(tags, list):
+            return None
+        root_id = None
+        reply_id = None
+        for tag in tags:
+            if not isinstance(tag, (list, tuple)) or len(tag) < 2:
+                continue
+            if tag[0] != "e":
+                continue
+            marker = tag[3] if len(tag) > 3 else ""
+            if marker == "root" and not root_id:
+                root_id = str(tag[1])
+            elif marker == "reply" and not reply_id:
+                reply_id = str(tag[1])
+        return root_id or reply_id
+
     async def _resolve_user_name(self, pubkey: str) -> str:
         """Resolve a pubkey to a display name (cached; falls back to npub prefix).
 
@@ -1219,6 +1267,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: str | None = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1230,6 +1279,7 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from collections import OrderedDict
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -538,3 +539,121 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+
+
+# ── Thread tagging ────────────────────────────────────────────────────────
+
+
+class TestThreadExtraction:
+
+    def test_root_e_tag_extracted(self):
+        """Root e-tag with marker 'root' is extracted as thread_id."""
+        tags = [
+            ["h", CHANNEL],
+            ["e", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", "", "root"],
+        ]
+        assert _buzz_mod.BuzzAdapter._extract_thread_id(tags) == \
+            "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+    def test_reply_e_tag_extracted_when_no_root(self):
+        """Reply e-tag is extracted as thread_id when no root marker exists."""
+        tags = [
+            ["h", CHANNEL],
+            ["e", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "", "reply"],
+        ]
+        assert _buzz_mod.BuzzAdapter._extract_thread_id(tags) == \
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+    def test_root_wins_over_reply(self):
+        """Root marker takes priority over reply marker."""
+        tags = [
+            ["e", "root_event_id_placeholder_root_event_id_placeholder_rootid", "", "root"],
+            ["e", "reply_event_id_placeholder_reply_event_id_placeholder_reply", "", "reply"],
+        ]
+        assert _buzz_mod.BuzzAdapter._extract_thread_id(tags) == \
+            "root_event_id_placeholder_root_event_id_placeholder_rootid"
+
+    def test_no_e_tag_returns_none(self):
+        """None returned when no e-tags present."""
+        tags = [["h", CHANNEL], ["p", OTHER_PUBKEY]]
+        assert _buzz_mod.BuzzAdapter._extract_thread_id(tags) is None
+
+    def test_non_list_tags_returns_none(self):
+        """None returned for non-list tags."""
+        assert _buzz_mod.BuzzAdapter._extract_thread_id(None) is None
+        assert _buzz_mod.BuzzAdapter._extract_thread_id("not-a-list") is None
+
+
+class TestThreadedReplyDispatch:
+
+    @pytest.fixture
+    def adapter(self):
+        a = _make_adapter()
+        a._dispatched = []
+
+        async def capture(**kwargs):
+            a._dispatched.append(kwargs)
+
+        a._dispatch_message = capture
+        a._message_handler = AsyncMock()
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"pubkey": OTHER_PUBKEY, "display_name": "testuser"}])
+        a._run_cli = cli
+        return a
+
+    @pytest.mark.asyncio
+    async def test_threaded_reply_dispatches_without_mention(self, adapter):
+        """Replies with a known root tag dispatch even without @mention."""
+        root_id = "root_event_id_placeholder_root_event_id_placeholder_rootid"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 0, "seen": {}, "active_threads": {root_id},
+        }
+        adapter._allowed_pubkeys = set()
+
+        event = _tagged_event("e1", CHANNEL, content="sounds good", reply_to=root_id)
+        state = adapter._channel_state[CHANNEL]
+        await adapter._handle_event(CHANNEL, state, event)
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_mention_in_unrelated_thread_still_dispatches(self, adapter):
+        """@mention in a thread we haven't seen triggers dispatch + tracking."""
+        root_id = "new_thread_root_new_thread_root_new_thread_root_ne"
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 0, "seen": {}, "active_threads": set(),
+        }
+        adapter._allowed_pubkeys = set()
+
+        event = _tagged_event("e1", CHANNEL, content="@Chip what about this?", reply_to=root_id)
+        state = adapter._channel_state[CHANNEL]
+        await adapter._handle_event(CHANNEL, state, event)
+        assert len(adapter._dispatched) == 1
+        assert root_id in adapter._channel_state[CHANNEL]["active_threads"]
+
+    @pytest.mark.asyncio
+    async def test_non_thread_reply_ignored_without_mention(self, adapter):
+        """Thread reply without a tracked root AND without @mention is still ignored."""
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 0, "seen": {}, "active_threads": set(),
+        }
+        adapter._allowed_pubkeys = set()
+        unknown_root = "unknown_root_id_unknown_root_id_unknown_root_id_unkn"
+
+        event = _tagged_event("e1", CHANNEL, content="just chatting", reply_to=unknown_root)
+        state = adapter._channel_state[CHANNEL]
+        await adapter._handle_event(CHANNEL, state, event)
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_root_message_mention_tracks_for_replies(self, adapter):
+        """An @mentioned non-threaded message creates an active-thread entry."""
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "group", "last_ts": 0, "seen": {}, "active_threads": set(),
+        }
+        adapter._allowed_pubkeys = set()
+
+        event = _event("e1", content="@Chip what do you think?")
+        state = adapter._channel_state[CHANNEL]
+        await adapter._handle_event(CHANNEL, state, event)
+        assert len(adapter._dispatched) == 1
+        assert "e1" in adapter._channel_state[CHANNEL]["active_threads"]


### PR DESCRIPTION
## Summary

The Buzz adapter discarded Nostr e-tag markers from incoming chat events, so `source.thread_id` was always `None`. This caused three compounding problems:

1. The gateway replied in the channel root instead of the existing thread — each reply created a new nested thread.
2. Non-mentioned replies in existing threads were filtered out because the adapter had no way to know they belonged to an active conversation.
3. Each @mention created yet another thread level, making conversations impossible to follow.

## Root Cause

`_handle_event` never read the Nostr `e` tags that carry thread markers (`["e", "<id>", "", "root"]` / `["e", "<id>", "", "reply"]`). Without a `thread_id`, the gateway routed replies to the channel root and the mention gate blocked follow-ups.

## Fix

- **`_extract_thread_id()`** — reads root/reply markers from Nostr event tags using the same tag-walking pattern already used by `_is_direct_message_event` for `p` tags.
- **Active-thread tracking** — a per-channel `active_threads` set stored in `_channel_state` so non-mentioned replies in known threads dispatch. A root message that @-mentions the agent creates an active-thread entry so replies inside it also route.
- **`thread_id` plumbing** — passed through `_handle_event` → `_dispatch_message` → `build_source` so the gateway can attach `--reply-to` on the Buzz CLI send path.

## Changes

| File | Change |
|---|---|
| `plugins/platforms/buzz/adapter.py` | +54/-4: active_threads tracking, thread_id extraction, dispatch plumbing |
| `tests/gateway/test_buzz_adapter.py` | +119: 9 new tests (5 thread extraction + 4 threaded dispatch) |

## Tests

```
pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -v  # 36 passed
pytest tests/gateway/ -v -k buzz                                                    # 41 passed
```

- **23 → 32 tests** in `test_buzz_adapter.py` (9 new: 5 thread extraction + 4 dispatch behaviour)
- All existing Buzz tests pass unchanged (mention gating, DM classification, send, lifecycle)

Fixes #78449