### PR TITLE
feat(teams): gate channel traffic on a channel allowlist and a mention

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1037,6 +1037,27 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#
+# Microsoft Teams settings (config.yaml top-level, or under platforms.teams):
+#
+# teams:
+#   enabled: true
+#   extra:
+#     client_id: "your-client-id"      # or TEAMS_CLIENT_ID env var
+#     client_secret: "your-secret"     # or TEAMS_CLIENT_SECRET env var
+#     tenant_id: "your-tenant-id"      # or TEAMS_TENANT_ID env var
+#   # allowed_channels restricts which team channels the bot answers in — a
+#   # channel's conversation ID, its channelData.channel.id, or its
+#   # channelData.team.id (which allows every channel in that team). Copy the
+#   # id exactly — matching is case-sensitive. Empty (default) means
+#   # unrestricted but still needs normal user authorization
+#   # (TEAMS_ALLOWED_USERS, TEAMS_ALLOW_ALL_USERS, pairing, or a global
+#   # grant); "*" instead of a list allows every channel and bypasses that
+#   # authorization entirely — not the same thing as leaving this empty.
+#   allowed_channels: []
+#   # require_mention applies to every channel message, listed or not
+#   # (default: true) — it is independent of allowed_channels.
+#   require_mention: true
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/contributors/emails/fernandrewm@gmail.com
+++ b/contributors/emails/fernandrewm@gmail.com
@@ -1,0 +1,1 @@
+Fernandrewm

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -18,6 +18,15 @@ Configuration in config.yaml:
           client_secret: "your-secret"      # or TEAMS_CLIENT_SECRET env var
           tenant_id: "your-tenant-id"       # or TEAMS_TENANT_ID env var
           port: 3978                        # or TEAMS_PORT env var
+
+Channel access control (optional; empty/unset means unrestricted, exactly as
+before these keys existed):
+        allowed_channels:                   # or TEAMS_ALLOWED_CHANNELS (CSV)
+          - "19:abc123@thread.tacv2"        # a channel's conversation id
+          - "19:def456@thread.tacv2"        # channelData.channel.id / .team.id also match
+        require_mention: true               # or TEAMS_REQUIRE_MENTION (default: true)
+    Only conversationType == "channel" is gated by allowed_channels — DMs stay
+    governed by TEAMS_ALLOWED_USERS and ad-hoc group chats are unaffected.
 """
 
 from __future__ import annotations
@@ -147,6 +156,111 @@ def _coerce_port(value: Any, *, default: int = _DEFAULT_PORT) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _scoped_gate_env(name: str, default: str = "") -> str:
+    """Read a TEAMS_*/GATEWAY_* authorization gate env var per-profile.
+
+    Under gateway.multiplex_profiles the process env is first-writer-wins
+    (the YAML→env bridge in ``_apply_yaml_config``), so a raw ``os.getenv``
+    can return ANOTHER profile's allowlist (issue #72348, mirrors the
+    identical Telegram/DingTalk helper). Reads the active profile's secret
+    scope when installed; falls back to ``os.getenv`` outside multiplex —
+    identical single-profile behavior.
+    """
+    try:
+        from gateway.authz_mixin import _platform_gate_env
+
+        return _platform_gate_env(name, default)
+    except Exception:
+        return (os.getenv(name) or default).strip()
+
+
+def _coerce_id_set(raw: Any) -> "set[str]":
+    """Parse a channel-id allowlist from a YAML list or a CSV string.
+
+    Compared exactly (only whitespace-trimmed) — deliberately NOT
+    case-folded. Teams/Bot Framework conversation, channel, and team ids are
+    opaque platform-issued strings (``19:<encoded-data>@thread.tacv2``) with
+    no documented case-insensitive contract; the encoded segment can be
+    base64-shaped, where case carries meaning. Folding case could collapse
+    two genuinely distinct ids and let a message from an unintended channel
+    match the allowlist, widening it rather than narrowing it — the wrong
+    direction to guess for a security boundary. An operator must copy the id
+    exactly, matching the precedent of Telegram's own ``allowed_chats``
+    (``plugins/platforms/telegram/adapter.py``), which also compares exactly.
+    """
+    if raw is None:
+        return set()
+    if isinstance(raw, list):
+        return {str(part).strip() for part in raw if str(part).strip()}
+    return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+
+def _base_conversation_id(conv_id: str) -> str:
+    """Strip the ``;messageid=<id>`` suffix Teams appends to channel replies.
+
+    A reply inside a channel thread carries the parent channel's
+    ``conversation.id`` plus a ``;messageid=<rootActivityId>`` suffix — same
+    channel, different string. Without stripping this, an allowlist of base
+    channel ids would silently stop matching on every threaded reply. Only
+    whitespace is trimmed beyond that — see ``_coerce_id_set`` for why case
+    is never folded.
+    """
+    return conv_id.split(";", 1)[0].strip()
+
+
+def _channel_data_ids(activity: Any) -> "set[str]":
+    """Pull ``channelData.channel.id`` / ``channelData.team.id`` off an activity.
+
+    Tolerates both an SDK object graph (attribute access) and a raw dict, the
+    same defensive dict-or-object pattern used for attachment content in
+    ``TeamsAdapter._on_message``. Lets an operator allowlist a channel by
+    channel id or by team id (allowing every channel in that team) in
+    addition to the raw conversation id.
+    """
+    channel_data = getattr(activity, "channel_data", None)
+    if channel_data is None and isinstance(activity, dict):
+        channel_data = activity.get("channelData")
+    if not isinstance(channel_data, dict):
+        channel_data = getattr(channel_data, "__dict__", None)
+    if not isinstance(channel_data, dict):
+        return set()
+
+    ids: set[str] = set()
+    for key in ("channel", "team"):
+        node = channel_data.get(key)
+        if not isinstance(node, dict):
+            node = getattr(node, "__dict__", None)
+        if not isinstance(node, dict):
+            continue
+        node_id = node.get("id")
+        if node_id:
+            ids.add(str(node_id).strip())
+    return ids
+
+
+def _apply_yaml_config(yaml_cfg: dict, teams_cfg: dict) -> "dict | None":
+    """Translate config.yaml ``teams:`` keys into ``PlatformConfig.extra``.
+
+    Implements the ``apply_yaml_config_fn`` contract
+    (``gateway/platform_registry.py``). Unlike the Telegram/DingTalk/Matrix
+    siblings, which bridge into a process-global ``os.environ`` var, this
+    returns the seeded dict directly: ``extra.update(seeded)``
+    (``gateway/config.py``) writes straight into *this profile's own*
+    ``PlatformConfig.extra``. Bridging through ``os.environ`` instead would
+    reproduce the exact multiplex bug ``_platform_gate_env`` documents
+    (#72348): under multiplexing, a secondary profile's secret scope is
+    authoritative and does NOT fall through to a process-global env write, so
+    a YAML-configured allowlist would silently vanish for that profile —
+    ``_teams_allowed_channels()`` would see an empty set and fail OPEN
+    (every channel admitted). Returning the dict sidesteps env entirely.
+    """
+    del yaml_cfg  # unused — no cross-platform lookups needed for this key
+    allowed_channels = teams_cfg.get("allowed_channels")
+    if allowed_channels is None:
+        return None
+    return {"allowed_channels": allowed_channels}
 
 
 class _StaticAccessTokenProvider:
@@ -767,6 +881,149 @@ class TeamsAdapter(BasePlatformAdapter):
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
 
+    # -- Channel access control -----------------------------------------------
+
+    def _teams_allowed_channels(self) -> "set[str]":
+        """Return the whitelist of Teams channel/team ids this bot answers in.
+
+        Empty means unrestricted — fully backward compatible with every
+        existing deployment (mirrors Telegram's ``allowed_chats``). When
+        non-empty, a channel message whose base conversation id,
+        ``channelData.channel.id``, and ``channelData.team.id`` all miss the
+        set is dropped before ``handle_message()`` ever sees it. DMs and
+        ad-hoc group chats are never filtered by this list — only
+        ``conversationType == "channel"`` is in scope
+        (``_should_process_message``).
+
+        ``config.extra`` (config.yaml) is checked before the env var
+        deliberately, not by oversight: this matches Telegram's own
+        ``_telegram_allowed_chats`` and this adapter's own pre-existing
+        ``client_id``/``client_secret``/``tenant_id`` handling. config.yaml
+        is the richer, version-controlled surface; the env var is the
+        fallback for a key not yet present in config.yaml, not a
+        higher-priority override once it is (see
+        ``TestTeamsConfigPrecedence`` in ``tests/gateway/test_teams.py``).
+        """
+        extra = self.config.extra or {}
+        raw = extra.get("allowed_channels")
+        if raw is None:
+            raw = _scoped_gate_env("TEAMS_ALLOWED_CHANNELS")
+        return _coerce_id_set(raw)
+
+    def _teams_require_mention(self) -> bool:
+        """Whether ANY channel message must carry an explicit @mention.
+
+        Applies to every channel — allowlisted or not (see
+        ``_should_process_message``). Defaults to True. For a standard
+        tenant this is a no-op — Teams only delivers mentioned channel
+        activities to a bot in the first place — but it closes the gap when
+        a tenant grants the bot broader ``ChannelMessage.Read.Group`` RSC
+        permission and starts delivering every channel message regardless of
+        mention.
+        """
+        extra = self.config.extra or {}
+        configured = extra.get("require_mention")
+        if configured is None:
+            env_val = _scoped_gate_env("TEAMS_REQUIRE_MENTION")
+            configured = env_val if env_val else None
+        if configured is None:
+            return True
+        return _parse_bool(configured, default=True)
+
+    def _activity_mentions_bot(self, activity: Any) -> bool:
+        """Whether *activity* explicitly @mentions the recipient bot.
+
+        Compares against ``activity.recipient.id`` — the addressee Teams
+        itself stamped on this specific activity — NOT ``self._app.id`` (the
+        OAuth client id used for the self-message filter above). The two can
+        differ: a channel can address the bot by a scoped recipient id
+        distinct from the Bot Framework app registration's client id, so
+        comparing against ``self._app.id`` can silently drop a genuinely
+        mentioned message. Mirrors the SDK's own
+        ``Activity.is_recipient_mentioned()``
+        (``microsoft_teams.api.activities.message.message``), reimplemented
+        here (rather than called directly) so a bare mock activity in tests
+        behaves predictably instead of auto-vivifying a truthy callable.
+        """
+        recipient = getattr(activity, "recipient", None)
+        recipient_id = getattr(recipient, "id", None)
+        if recipient_id is None and isinstance(recipient, dict):
+            recipient_id = recipient.get("id")
+        if not recipient_id:
+            return False
+        entities = getattr(activity, "entities", None)
+        if not isinstance(entities, (list, tuple)):
+            entities = []
+        for entity in entities:
+            entity_type = getattr(entity, "type", None)
+            if entity_type is None and isinstance(entity, dict):
+                entity_type = entity.get("type")
+            if entity_type != "mention":
+                continue
+            mentioned = getattr(entity, "mentioned", None)
+            if mentioned is None and isinstance(entity, dict):
+                mentioned = entity.get("mentioned")
+            mentioned_id = getattr(mentioned, "id", None)
+            if mentioned_id is None and isinstance(mentioned, dict):
+                mentioned_id = mentioned.get("id")
+            if mentioned_id and str(mentioned_id) == str(recipient_id):
+                return True
+        return False
+
+    def _should_process_message(self, activity: Any, chat_type: str) -> "tuple[bool, bool]":
+        """Decide whether to dispatch *activity*, and whether it was channel-authorized.
+
+        Returns ``(process, channel_authorized)``. Only ``chat_type ==
+        "channel"`` is gated here — DMs stay governed by ``TEAMS_ALLOWED_USERS``
+        and ad-hoc group chats are unchanged. ``channel_authorized`` becomes
+        ``SessionSource.role_authorized`` so the gateway's central
+        ``_is_user_authorized`` (``gateway/authz_mixin.py``) admits the sender
+        without requiring them to also appear in ``TEAMS_ALLOWED_USERS`` —
+        mirrors the precedent Discord sets after it verifies
+        ``DISCORD_ALLOWED_ROLES`` itself. Only a matched allowlist entry
+        grants it — never the mention check alone.
+
+        The mention check (``_teams_require_mention`` / ``_activity_mentions_bot``)
+        applies to every channel message, WITH or WITHOUT an
+        ``allowed_channels`` restriction — it is not a bonus that only
+        activates once an allowlist is configured. Teams itself normally
+        only delivers a mentioned channel activity to a bot in the first
+        place, so for a standard tenant this is a no-op; it exists to close
+        the gap for a tenant that grants the bot broader
+        ``ChannelMessage.Read.Group`` RSC permission and starts delivering
+        every channel message regardless of mention — a gap that exists
+        for every Teams channel, allowlisted or not.
+
+        An empty allowlist leaves the CHANNEL-SCOPING behavior byte-identical
+        to before this method existed (every channel is in scope, none
+        excluded) — only the mention requirement is new.
+        """
+        if chat_type != "channel":
+            return True, False
+
+        channel_authorized = False
+        allowed_channels = self._teams_allowed_channels()
+        if allowed_channels:
+            if "*" in allowed_channels:
+                channel_authorized = True
+            else:
+                conv = getattr(activity, "conversation", None)
+                conv_id = _base_conversation_id(str(getattr(conv, "id", "") or ""))
+                candidate_ids = {conv_id} | _channel_data_ids(activity)
+                if not (candidate_ids & allowed_channels):
+                    logger.info(
+                        "[teams] ignoring channel message: conversation not in "
+                        "TEAMS_ALLOWED_CHANNELS"
+                    )
+                    return False, False
+                channel_authorized = True
+
+        if self._teams_require_mention() and not self._activity_mentions_bot(activity):
+            logger.info("[teams] ignoring channel message: bot not @mentioned")
+            return False, False
+
+        return True, channel_authorized
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
         # then re-check the module globals it rebinds.
@@ -923,8 +1180,23 @@ class TeamsAdapter(BasePlatformAdapter):
             chat_type = "group"
         elif conv_type == "channel":
             chat_type = "channel"
+        elif _channel_data_ids(activity):
+            # conversationType is missing/unrecognized but channelData names a
+            # channel or team — treat as a channel rather than falling into
+            # the DM default below, so the channel allowlist below still
+            # applies instead of silently skipping it (hardening; a standard
+            # Bot Framework activity always sets conversationType).
+            chat_type = "channel"
         else:
             chat_type = "dm"
+
+        # Channel access control: gate on the configured channel allowlist and
+        # (when one is set) require an explicit @mention. No-op for DMs and
+        # group chats, and a no-op for channels too when no allowlist is
+        # configured — see _should_process_message for the exact matrix.
+        process, channel_authorized = self._should_process_message(activity, chat_type)
+        if not process:
+            return
 
         # Build source
         from_account = activity.from_
@@ -938,6 +1210,7 @@ class TeamsAdapter(BasePlatformAdapter):
             user_id=str(user_id),
             user_name=user_name,
             guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
+            role_authorized=channel_authorized,
         )
 
         # Handle attachments (images, documents, video, audio)
@@ -1488,6 +1761,10 @@ def register(ctx) -> None:
         # Auth env vars for _is_user_authorized() integration
         allowed_users_env="TEAMS_ALLOWED_USERS",
         allow_all_env="TEAMS_ALLOW_ALL_USERS",
+        # config.yaml `teams: allowed_channels: [...]` → PlatformConfig.extra.
+        # `require_mention` needs no hook here — the generic shared-key loop
+        # (gateway/config.py) already bridges it into extra for every platform.
+        apply_yaml_config_fn=_apply_yaml_config,
         # Teams supports up to ~28 KB per message
         max_message_length=28000,
         # Display

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1,6 +1,7 @@
 """Tests for the Microsoft Teams platform adapter plugin."""
 
 import json
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -484,6 +485,554 @@ class TestTeamsMessageHandling:
 
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "group"
+
+
+# ---------------------------------------------------------------------------
+# Tests: chat-type classification (channel + channelData hardening)
+# ---------------------------------------------------------------------------
+
+class TestTeamsChannelClassification:
+    def _make_activity(
+        self,
+        *,
+        conversation_type="",
+        conversation_id="19:abc@thread.tacv2",
+        channel_data=None,
+    ):
+        activity = MagicMock()
+        activity.text = "Hello"
+        activity.id = "activity-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = conversation_id
+        activity.conversation.conversation_type = conversation_type
+        activity.conversation.name = "Test Channel"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = []
+        activity.entities = []
+        if channel_data is not None:
+            activity.channel_data = channel_data
+        else:
+            del activity.channel_data  # MagicMock: make getattr(..., None) really return None
+        return activity
+
+    def _make_ctx(self, activity):
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    def _make_adapter(self):
+        # require_mention=False: this class tests conversationType ->
+        # chat_type classification only. Mention-gating is an independent
+        # axis (see TestTeamsRequireMention) and would otherwise drop these
+        # activities before chat_type is ever observable, since none of them
+        # carry a mention entity.
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            require_mention=False,
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    @pytest.mark.anyio
+    async def test_conversation_type_channel_maps_to_channel(self):
+        """conversationType == "channel" was previously untested end to end."""
+        adapter = self._make_adapter()
+        activity = self._make_activity(conversation_type="channel")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.chat_type == "channel"
+
+    @pytest.mark.anyio
+    async def test_missing_conversation_type_with_channel_data_is_channel(self):
+        """Hardening: a missing/unrecognized conversationType with channelData
+        naming a channel/team must not fall through to the DM default, or the
+        channel allowlist below would never see it."""
+        adapter = self._make_adapter()
+        activity = self._make_activity(
+            conversation_type="",
+            channel_data={"channel": {"id": "19:abc@thread.tacv2"}},
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.chat_type == "channel"
+
+    @pytest.mark.anyio
+    async def test_missing_conversation_type_without_channel_data_is_dm(self):
+        """Preserves the pre-existing fail-toward-DM default when there is no
+        channelData signal to classify by either."""
+        adapter = self._make_adapter()
+        activity = self._make_activity(conversation_type="", channel_data=None)
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.chat_type == "dm"
+
+
+# ---------------------------------------------------------------------------
+# Tests: channel allowlist (TEAMS_ALLOWED_CHANNELS / allowed_channels)
+# ---------------------------------------------------------------------------
+
+class TestTeamsChannelAllowlist:
+    def _make_activity(
+        self,
+        *,
+        conversation_id="19:abc@thread.tacv2",
+        channel_data=None,
+        mentions_bot=True,
+        bot_id="bot-id",
+    ):
+        activity = MagicMock()
+        activity.text = "<at>Hermes</at> hello"
+        activity.id = "activity-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = conversation_id
+        activity.conversation.conversation_type = "channel"
+        activity.conversation.name = "Test Channel"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = []
+        if channel_data is not None:
+            activity.channel_data = channel_data
+        else:
+            del activity.channel_data
+        activity.recipient = MagicMock()
+        activity.recipient.id = bot_id
+        mention_entity = MagicMock()
+        mention_entity.type = "mention"
+        mention_entity.mentioned = MagicMock()
+        mention_entity.mentioned.id = bot_id if mentions_bot else "someone-else"
+        activity.entities = [mention_entity]
+        return activity
+
+    def _make_ctx(self, activity):
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    def _make_adapter(self, **extra):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant", **extra,
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    @pytest.mark.anyio
+    async def test_empty_allowlist_is_unchanged_and_not_role_authorized(self):
+        """Empty allowed_channels leaves the CHANNEL-SCOPING behavior
+        byte-identical to before this feature existed -- no channel is
+        excluded, and role_authorized stays False (TEAMS_ALLOWED_USERS is
+        still what gates it). The mention requirement is a separate,
+        independent default (see TestTeamsRequireMention) -- this activity
+        is mentioned so it isolates the channel-scoping behavior alone."""
+        adapter = self._make_adapter()
+        activity = self._make_activity(mentions_bot=True)
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.role_authorized is False
+
+    @pytest.mark.anyio
+    async def test_channel_not_in_allowlist_is_dropped_silently(self):
+        adapter = self._make_adapter(allowed_channels=["19:other@thread.tacv2"])
+        activity = self._make_activity(conversation_id="19:abc@thread.tacv2")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_channel_in_allowlist_dispatches_role_authorized(self):
+        adapter = self._make_adapter(allowed_channels=["19:abc@thread.tacv2"])
+        activity = self._make_activity(conversation_id="19:abc@thread.tacv2")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.role_authorized is True
+
+    @pytest.mark.anyio
+    async def test_threaded_reply_still_matches_base_channel_id(self):
+        """A channel reply's conversation.id carries a ;messageid=<root>
+        suffix — the same channel, different string. Must still match."""
+        adapter = self._make_adapter(allowed_channels=["19:abc@thread.tacv2"])
+        activity = self._make_activity(
+            conversation_id="19:abc@thread.tacv2;messageid=1699999999999"
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_matches_by_channel_data_channel_id(self):
+        adapter = self._make_adapter(allowed_channels=["channel-xyz"])
+        activity = self._make_activity(
+            conversation_id="19:different@thread.tacv2",
+            channel_data={"channel": {"id": "channel-xyz"}},
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_matches_by_channel_data_team_id(self):
+        adapter = self._make_adapter(allowed_channels=["team-xyz"])
+        activity = self._make_activity(
+            conversation_id="19:different@thread.tacv2",
+            channel_data={"team": {"id": "team-xyz"}},
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_wildcard_allows_any_channel(self):
+        adapter = self._make_adapter(allowed_channels=["*"])
+        activity = self._make_activity(conversation_id="19:whatever@thread.tacv2")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.role_authorized is True
+
+    @pytest.mark.anyio
+    async def test_allowlist_match_is_case_sensitive(self):
+        """Deliberately case-sensitive: Teams ids are opaque platform strings
+        with no documented case-insensitive contract, and folding case could
+        collapse two genuinely distinct ids -- widening the allowlist rather
+        than narrowing it. A differently-cased id must NOT match."""
+        adapter = self._make_adapter(allowed_channels=["19:ABC@Thread.Tacv2"])
+        activity = self._make_activity(conversation_id="19:abc@thread.tacv2")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_allowlist_match_is_exact(self):
+        adapter = self._make_adapter(allowed_channels=["19:ABC@Thread.Tacv2"])
+        activity = self._make_activity(conversation_id="19:ABC@Thread.Tacv2")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_dm_is_unaffected_by_channel_allowlist(self):
+        adapter = self._make_adapter(allowed_channels=["19:only-this-channel@thread.tacv2"])
+        activity = self._make_activity(conversation_id="19:some-dm-conversation")
+        activity.conversation.conversation_type = "personal"
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.chat_type == "dm"
+        assert event.source.role_authorized is False
+
+    @pytest.mark.anyio
+    async def test_group_chat_is_unaffected_by_channel_allowlist(self):
+        adapter = self._make_adapter(allowed_channels=["19:only-this-channel@thread.tacv2"])
+        activity = self._make_activity(conversation_id="19:some-group-chat")
+        activity.conversation.conversation_type = "groupChat"
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.chat_type == "group"
+        assert event.source.role_authorized is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: mention gate (require_mention / TEAMS_REQUIRE_MENTION)
+# ---------------------------------------------------------------------------
+
+class TestTeamsRequireMention:
+    def _make_activity(self, *, mentioned_id=None, recipient_id="recipient-id"):
+        activity = MagicMock()
+        activity.text = "hello"
+        activity.id = "activity-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.tacv2"
+        activity.conversation.conversation_type = "channel"
+        activity.conversation.name = "Test Channel"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = []
+        del activity.channel_data
+        activity.recipient = MagicMock()
+        activity.recipient.id = recipient_id
+        if mentioned_id is not None:
+            mention_entity = MagicMock()
+            mention_entity.type = "mention"
+            mention_entity.mentioned = MagicMock()
+            mention_entity.mentioned.id = mentioned_id
+            activity.entities = [mention_entity]
+        else:
+            activity.entities = []
+        return activity
+
+    def _make_ctx(self, activity):
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    def _make_adapter(self, **extra):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            allowed_channels=["19:abc@thread.tacv2"], **extra,
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    @pytest.mark.anyio
+    async def test_mentioned_channel_message_dispatches(self):
+        adapter = self._make_adapter()
+        activity = self._make_activity(mentioned_id="recipient-id")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_mention_matches_activity_recipient_not_oauth_client_id(self):
+        """Regression: an earlier version compared the mention entity against
+        self._app.id (the OAuth client id used for the self-message filter),
+        not activity.recipient.id (the addressee Teams actually stamped on
+        this activity, per the SDK's own is_recipient_mentioned()). The two
+        can differ -- a genuinely mentioned message must not be dropped just
+        because those ids don't match."""
+        adapter = self._make_adapter()
+        adapter._app.id = "oauth-client-id"  # deliberately NOT the recipient id
+        activity = self._make_activity(
+            recipient_id="channel-scoped-recipient-id",
+            mentioned_id="channel-scoped-recipient-id",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_unmentioned_channel_message_is_dropped_by_default(self):
+        adapter = self._make_adapter()
+        activity = self._make_activity(mentioned_id=None)
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_require_mention_false_lets_unmentioned_message_through(self):
+        adapter = self._make_adapter(require_mention=False)
+        activity = self._make_activity(mentioned_id=None)
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_mention_of_a_different_user_does_not_count(self):
+        adapter = self._make_adapter()
+        activity = self._make_activity(mentioned_id="someone-else")
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_dm_never_requires_a_mention(self):
+        adapter = self._make_adapter()
+        activity = self._make_activity(mentioned_id=None)
+        activity.conversation.conversation_type = "personal"
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_require_mention_applies_even_without_an_allowlist(self):
+        """require_mention is independent of allowed_channels -- it is not a
+        bonus that only activates once a channel allowlist is configured.
+        An unmentioned channel message must be dropped by default even when
+        TEAMS_ALLOWED_CHANNELS/allowed_channels is unset entirely, closing
+        the RSC-delivered-unmentioned-message gap for every Teams channel,
+        not just allowlisted ones."""
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(mentioned_id=None)
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: config.yaml -> env bridging (apply_yaml_config_fn)
+# ---------------------------------------------------------------------------
+
+class TestTeamsYamlConfigBridge:
+    def test_seeds_allowed_channels_into_extra_from_list(self):
+        result = _teams_mod._apply_yaml_config(
+            {}, {"allowed_channels": ["19:abc@thread.tacv2", "19:def@thread.tacv2"]}
+        )
+        assert result == {"allowed_channels": ["19:abc@thread.tacv2", "19:def@thread.tacv2"]}
+
+    def test_seeds_allowed_channels_into_extra_from_csv_string(self):
+        result = _teams_mod._apply_yaml_config({}, {"allowed_channels": "19:abc@thread.tacv2"})
+        assert result == {"allowed_channels": "19:abc@thread.tacv2"}
+
+    def test_absent_key_is_a_no_op(self):
+        assert _teams_mod._apply_yaml_config({}, {}) is None
+
+    def test_does_not_touch_os_environ(self, monkeypatch):
+        """Regression: an earlier version bridged through a process-global env
+        var, which silently dropped a multiplexed secondary profile's
+        allowlist (_platform_gate_env treats its own scope as authoritative
+        and does not fall through to another profile's env write, #72348
+        mirror) -- letting every channel through unrestricted. Seeding
+        PlatformConfig.extra directly instead means this key must never touch
+        os.environ at all."""
+        monkeypatch.delenv("TEAMS_ALLOWED_CHANNELS", raising=False)
+        _teams_mod._apply_yaml_config({}, {"allowed_channels": ["19:abc@thread.tacv2"]})
+        assert "TEAMS_ALLOWED_CHANNELS" not in os.environ
+
+    def test_allowed_channels_survive_a_multiplexed_profile_scope(self, monkeypatch):
+        """Reproduces the exact failure class _platform_gate_env's docstring
+        warns about (#72348): under multiplexing, a secondary profile's own
+        secret scope is authoritative and does NOT fall through to a
+        process-global env write. Bridging allowed_channels through
+        os.environ (like the Telegram/DingTalk/Matrix siblings do) would
+        silently return an empty set there -- and an empty set means
+        UNRESTRICTED, not "deny all" (_teams_allowed_channels /
+        _should_process_message) -- admitting every channel. Seeding
+        PlatformConfig.extra directly must survive this scenario."""
+        from agent import secret_scope
+
+        seeded = _teams_mod._apply_yaml_config(
+            {}, {"allowed_channels": ["19:abc@thread.tacv2"]}
+        )
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant", **seeded,
+        ))
+
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})  # this profile's scope: no such key
+        try:
+            assert adapter._teams_allowed_channels() == {"19:abc@thread.tacv2"}
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_real_config_loader_wires_allowed_channels_through_to_the_adapter(
+        self, tmp_path, monkeypatch
+    ):
+        """Exercises the actual wiring end to end, not just _apply_yaml_config
+        in isolation: the module's real register() -> PlatformEntry(
+        apply_yaml_config_fn=_apply_yaml_config) -> gateway/config.py's real
+        load_gateway_config() dispatch loop -> PlatformConfig.extra ->
+        _teams_allowed_channels(), surviving a multiplexed secret scope at
+        the end. Registering through register() itself (not a hand-built
+        PlatformEntry) means this test would fail if register() ever forgot
+        the apply_yaml_config_fn kwarg -- a prior version of this test built
+        the PlatformEntry directly and would have missed exactly that.
+        Mirrors the harness tests/gateway/test_platform_registry.py already
+        uses for the generic apply_yaml_config_fn contract.
+        """
+        from agent import secret_scope
+        from gateway.config import Platform, load_gateway_config
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        class _RealCtx:
+            """Forwards register_platform(...) into the real platform_registry,
+            building the same PlatformEntry the production PluginContext
+            would -- but without needing a full PluginContext/manifest."""
+
+            def register_platform(
+                self, name, label, adapter_factory, check_fn,
+                validate_config=None, required_env=None, install_hint="",
+                **entry_kwargs,
+            ):
+                entry_kwargs.setdefault("plugin_name", "teams-platform")
+                platform_registry.register(PlatformEntry(
+                    name=name, label=label, adapter_factory=adapter_factory,
+                    check_fn=check_fn, validate_config=validate_config,
+                    required_env=required_env or [], install_hint=install_hint,
+                    source="plugin", **entry_kwargs,
+                ))
+
+        _teams_mod.register(_RealCtx())
+        try:
+            hermes_home = tmp_path / ".hermes"
+            hermes_home.mkdir()
+            (hermes_home / "config.yaml").write_text(
+                'teams:\n  allowed_channels:\n    - "19:abc@thread.tacv2"\n',
+                encoding="utf-8",
+            )
+            monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+            config = load_gateway_config()
+            platform_cfg = config.platforms[Platform("teams")]
+            assert platform_cfg.extra["allowed_channels"] == ["19:abc@thread.tacv2"]
+
+            adapter = TeamsAdapter(platform_cfg)
+            monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+            token = secret_scope.set_secret_scope({})  # this profile's scope: no such key
+            try:
+                assert adapter._teams_allowed_channels() == {"19:abc@thread.tacv2"}
+            finally:
+                secret_scope.reset_secret_scope(token)
+        finally:
+            platform_registry.unregister("teams")
+
+
+# ---------------------------------------------------------------------------
+# Tests: config.yaml vs env precedence (explicit contract, not an accident)
+# ---------------------------------------------------------------------------
+
+class TestTeamsConfigPrecedence:
+    """config.yaml (PlatformConfig.extra) wins over the env var when both
+    are set for the same key. This is a DELIBERATE, precedented choice, not
+    an oversight: it matches Telegram's own channel/chat allowlist
+    (``_telegram_allowed_chats`` — ``plugins/platforms/telegram/adapter.py``
+    checks ``extra.get("allowed_chats")`` before ``TELEGRAM_ALLOWED_CHATS``),
+    DingTalk's own ``require_mention`` (``_dingtalk_require_mention`` —
+    ``plugins/platforms/dingtalk/adapter.py`` checks extra before
+    ``DINGTALK_REQUIRE_MENTION``), and this same Teams adapter's own
+    pre-existing ``client_id``/``client_secret``/``tenant_id`` handling
+    (``extra.get(...) or os.getenv(...)``). config.yaml is the richer,
+    version-controlled surface; env vars are the fallback for operators who
+    haven't migrated a given key to config.yaml yet -- not a
+    higher-priority override once a key IS in config.yaml.
+    """
+
+    def test_allowed_channels_extra_wins_over_conflicting_env(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_CHANNELS", "19:from-env@thread.tacv2")
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            allowed_channels=["19:from-extra@thread.tacv2"],
+        ))
+        assert adapter._teams_allowed_channels() == {"19:from-extra@thread.tacv2"}
+
+    def test_require_mention_extra_wins_over_conflicting_env(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_REQUIRE_MENTION", "true")
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            require_mention=False,
+        ))
+        assert adapter._teams_require_mention() is False
 
 
 class TestTeamsAttachmentClassification:

--- a/tests/gateway/test_teams_channel_allowlist_e2e.py
+++ b/tests/gateway/test_teams_channel_allowlist_e2e.py
@@ -1,0 +1,294 @@
+"""End-to-end proof that the Teams channel allowlist holds at the real
+gateway authorization boundary, not only inside the adapter's own unit tests.
+
+This is a security boundary (AGENTS.md: "resolution chains, config
+propagation, security boundaries ... real E2E against a temp HERMES_HOME --
+green unit mocks are not evidence"). ``tests/gateway/test_teams.py`` proves
+``TeamsAdapter._on_message`` builds the right ``SessionSource`` (stubbing
+``handle_message``); it never proves the gateway's real authorization gate
+actually honors what the adapter stamped. Here nothing about the
+authorization *decision* is mocked: a real ``TeamsAdapter._on_message`` builds
+a real ``SessionSource``, which is then run through the real
+``GatewayAuthorizationMixin._is_user_authorized``
+(``gateway/authz_mixin.py``) via a minimal ``GatewayRunner`` built with
+``object.__new__`` -- the same construction
+``tests/gateway/test_config_driven_access_policy.py`` uses for the
+WeCom/WhatsApp own-policy gate -- backed by a real ``PairingStore`` against
+the hermetic per-test ``HERMES_HOME`` every test already gets
+(``tests/conftest.py::_hermetic_environment``, autouse).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.pairing import PairingStore
+from gateway.session import SessionSource
+from tests.gateway.test_teams import TeamsAdapter, _make_config
+from tests.gateway.test_teams import register as _real_teams_register
+
+
+def _make_runner(adapter) -> "object":
+    """Bare GatewayRunner exposing only what _is_user_authorized touches.
+
+    Mirrors ``tests/gateway/test_config_driven_access_policy.py::_make_runner``.
+    ``pairing_store`` is a REAL store (not a mock) so "no pairing entry exists"
+    is proven by an empty on-disk store, not by a mock return value.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.adapters = {Platform("teams"): adapter}
+    runner.pairing_store = PairingStore()
+    return runner
+
+
+class _Ctx:
+    """Minimal ActivityContext stand-in: only ``.activity`` and
+    ``.conversation_ref`` are read by ``TeamsAdapter._on_message``."""
+
+    def __init__(self, activity):
+        self.activity = activity
+        self.conversation_ref = MagicMock()
+
+
+def _make_activity(
+    *,
+    conversation_id: str,
+    conversation_type: str,
+    mentioned: bool = True,
+    bot_id: str = "bot-id",
+    user_aad: str = "aad-e2e-user",
+):
+    activity = MagicMock()
+    activity.text = "<at>Hermes</at> hello" if mentioned else "hello"
+    activity.id = "activity-e2e-1"
+    activity.from_ = MagicMock()
+    activity.from_.id = "29:e2e-user"
+    activity.from_.aad_object_id = user_aad
+    activity.from_.name = "E2E User"
+    activity.conversation = MagicMock()
+    activity.conversation.id = conversation_id
+    activity.conversation.conversation_type = conversation_type
+    activity.conversation.name = "E2E Chat"
+    activity.conversation.tenant_id = "tenant-e2e"
+    activity.attachments = []
+    del activity.channel_data
+    activity.recipient = MagicMock()
+    activity.recipient.id = bot_id
+    mention_entity = MagicMock()
+    mention_entity.type = "mention"
+    mention_entity.mentioned = MagicMock()
+    mention_entity.mentioned.id = bot_id if mentioned else "someone-else"
+    activity.entities = [mention_entity]
+    return activity
+
+
+async def _dispatch(adapter: TeamsAdapter, activity) -> "SessionSource | None":
+    """Run the real _on_message and capture the SessionSource it builds.
+
+    Returns None when the message was dropped before ``handle_message`` --
+    i.e. never produced a session source at all.
+    """
+    captured: dict = {}
+
+    async def _capture(event):
+        captured["source"] = event.source
+
+    adapter.handle_message = _capture
+    await adapter._on_message(_Ctx(activity))
+    return captured.get("source")
+
+
+def _clear_teams_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "TEAMS_ALLOWED_USERS",
+        "TEAMS_ALLOW_ALL_USERS",
+        "TEAMS_ALLOWED_CHANNELS",
+        "TEAMS_REQUIRE_MENTION",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestTeamsChannelAllowlistE2E:
+    @pytest.fixture(autouse=True)
+    def _teams_platform_registered(self):
+        """Register the real Teams ``PlatformEntry`` in the global
+        ``platform_registry`` for the duration of one test, then remove it.
+
+        ``_is_user_authorized`` learns a plugin platform's
+        ``allowed_users_env`` / ``allow_all_env`` names from this registry
+        (``gateway/authz_mixin.py``), not from a hardcoded map. Driving the
+        real ``register()`` this module already loaded through a minimal
+        ctx -- rather than a ``MagicMock()`` (the unit-test shortcut
+        ``tests/gateway/test_teams.py`` uses) -- proves this suite exercises
+        the actual entry the gateway consults, not a stand-in for it.
+        """
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        class _RealCtx:
+            def register_platform(
+                self, name, label, adapter_factory, check_fn,
+                validate_config=None, required_env=None, install_hint="",
+                **entry_kwargs,
+            ):
+                entry_kwargs.setdefault("plugin_name", "teams-platform")
+                platform_registry.register(PlatformEntry(
+                    name=name, label=label, adapter_factory=adapter_factory,
+                    check_fn=check_fn, validate_config=validate_config,
+                    required_env=required_env or [], install_hint=install_hint,
+                    source="plugin", **entry_kwargs,
+                ))
+
+        _real_teams_register(_RealCtx())
+        try:
+            yield
+        finally:
+            platform_registry.unregister("teams")
+
+    @pytest.mark.anyio
+    async def test_allowed_channel_sender_authorized_without_teams_allowed_users(
+        self, monkeypatch
+    ):
+        """The core requirement: a sender absent from TEAMS_ALLOWED_USERS is
+        still authorized end to end when they post, mentioning the bot, in a
+        channel on the allowlist."""
+        _clear_teams_auth_env(monkeypatch)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            allowed_channels=["19:allowed@thread.tacv2"],
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+
+        activity = _make_activity(
+            conversation_id="19:allowed@thread.tacv2", conversation_type="channel",
+        )
+        source = await _dispatch(adapter, activity)
+        assert source is not None, "message from an allowed, mentioned channel must dispatch"
+        assert source.role_authorized is True
+
+        runner = _make_runner(adapter)
+        assert runner._is_user_authorized(source) is True
+
+    @pytest.mark.anyio
+    async def test_non_listed_channel_never_reaches_the_runner(self, monkeypatch):
+        """A message from a channel absent from the allowlist never produces a
+        SessionSource -- there is nothing left for the runner to authorize."""
+        _clear_teams_auth_env(monkeypatch)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            allowed_channels=["19:allowed@thread.tacv2"],
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+
+        activity = _make_activity(
+            conversation_id="19:not-allowed@thread.tacv2", conversation_type="channel",
+        )
+        source = await _dispatch(adapter, activity)
+        assert source is None
+
+    @pytest.mark.anyio
+    async def test_allowed_channel_but_unmentioned_never_reaches_the_runner(
+        self, monkeypatch
+    ):
+        """A listed channel still requires the mention -- the allowlist alone
+        is not a bypass for require_mention."""
+        _clear_teams_auth_env(monkeypatch)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            allowed_channels=["19:allowed@thread.tacv2"],
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+
+        activity = _make_activity(
+            conversation_id="19:allowed@thread.tacv2",
+            conversation_type="channel",
+            mentioned=False,
+        )
+        source = await _dispatch(adapter, activity)
+        assert source is None
+
+    @pytest.mark.anyio
+    async def test_same_sender_still_denied_over_dm(self, monkeypatch):
+        """The channel allowlist authorizes the CHANNEL, not the person: the
+        exact same AAD-object-id sender DMing the bot must still be denied,
+        because they are not in TEAMS_ALLOWED_USERS and no pairing entry
+        exists in the (real, empty) PairingStore."""
+        _clear_teams_auth_env(monkeypatch)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            allowed_channels=["19:allowed@thread.tacv2"],
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+
+        dm_activity = _make_activity(
+            conversation_id="19:dm-conversation", conversation_type="personal",
+        )
+        source = await _dispatch(adapter, dm_activity)
+        assert source is not None
+        assert source.chat_type == "dm"
+        assert source.role_authorized is False
+
+        runner = _make_runner(adapter)
+        assert runner._is_user_authorized(source) is False
+
+    @pytest.mark.anyio
+    async def test_empty_allowlist_falls_back_to_teams_allowed_users(self, monkeypatch):
+        """Backward compatibility, proven end to end: with no channel
+        allowlist configured, a channel message still reaches the runner
+        (role_authorized False), and the pre-existing TEAMS_ALLOWED_USERS
+        allowlist is what decides it -- exactly as before this feature."""
+        _clear_teams_auth_env(monkeypatch)
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "aad-e2e-user")
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+
+        activity = _make_activity(
+            conversation_id="19:any-channel@thread.tacv2", conversation_type="channel",
+        )
+        source = await _dispatch(adapter, activity)
+        assert source is not None
+        assert source.role_authorized is False
+
+        runner = _make_runner(adapter)
+        assert runner._is_user_authorized(source) is True
+
+    @pytest.mark.anyio
+    async def test_unmentioned_channel_message_never_reaches_the_runner_even_without_an_allowlist(
+        self, monkeypatch
+    ):
+        """require_mention is independent of the channel allowlist: an
+        unmentioned channel message must never produce a SessionSource at
+        all, even with no TEAMS_ALLOWED_CHANNELS configured -- closing the
+        RSC-delivered-unmentioned-message gap for every Teams channel."""
+        _clear_teams_auth_env(monkeypatch)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+
+        activity = _make_activity(
+            conversation_id="19:any-channel@thread.tacv2",
+            conversation_type="channel",
+            mentioned=False,
+        )
+        source = await _dispatch(adapter, activity)
+        assert source is None

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -718,8 +718,10 @@ The Microsoft Teams platform adapter (Bot Framework / Azure AD), distinct from t
 | `TEAMS_TENANT_ID` | Azure AD tenant ID hosting the bot application. |
 | `TEAMS_HOST` | Webhook bind host (default: unset → dual-stack, all interfaces IPv4+IPv6). |
 | `TEAMS_PORT` | Webhook listen port (Bot Framework default: `3978`). |
-| `TEAMS_ALLOWED_USERS` | Comma-separated Teams user IDs / UPNs allowed to talk to the bot. |
+| `TEAMS_ALLOWED_USERS` | Comma-separated Teams AAD object IDs allowed to talk to the bot. UPNs are not matched — the adapter identifies senders by `aad_object_id`, never by UPN/email. |
 | `TEAMS_ALLOW_ALL_USERS` | Allow any Teams user to trigger the bot (dev only). |
+| `TEAMS_ALLOWED_CHANNELS` | Comma-separated channel/team IDs the bot may respond in (empty: unrestricted, but still gated by normal user authorization). `*` allows every channel and bypasses normal Hermes user authorization entirely — not the same as leaving this unset. Equivalent to `teams.allowed_channels` in `config.yaml`. |
+| `TEAMS_REQUIRE_MENTION` | Require an explicit @mention in channel messages (default: `true`). Equivalent to `teams.require_mention` in `config.yaml`. |
 | `TEAMS_HOME_CHANNEL` | Default chat/channel ID for cron / notification delivery. |
 | `TEAMS_HOME_CHANNEL_NAME` | Display name for the Teams home channel. |
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -16,11 +16,50 @@ Need meeting summaries from Microsoft Graph events rather than normal bot conver
 
 | Context | Behavior |
 |---------|----------|
-| **Personal chat (DM)** | Bot responds to every message. No @mention needed. |
-| **Group chat** | Bot only responds when @mentioned. |
-| **Channel** | Bot only responds when @mentioned. |
+| **Personal chat (DM)** | Bot responds to every message from an authorized user (`TEAMS_ALLOWED_USERS`, `TEAMS_ALLOW_ALL_USERS`, an approved pairing, or a global `GATEWAY_ALLOWED_USERS`/`GATEWAY_ALLOW_ALL_USERS` grant). No @mention needed. |
+| **Group chat** | Teams itself only delivers a group message to the bot once it's @mentioned — Hermes doesn't additionally enforce this. |
+| **Channel** | Bot only responds when @mentioned (Hermes enforces this directly — see below), and, if `allowed_channels` is configured, only in a listed channel. |
 
 Teams delivers @mentions as regular messages with `<at>BotName</at>` tags, which Hermes strips automatically before processing.
+
+### Restricting which channels the bot answers in
+
+By default the bot answers in any team channel it has been added to, as long as it's @mentioned and the sender passes normal user authorization (see the matrix below) — this is unchanged from before. Set `allowed_channels` in `~/.hermes/config.yaml` to restrict it to specific channels.
+
+```yaml
+platforms:
+  teams:
+    enabled: true
+    extra:
+      client_id: "your-client-id"
+      client_secret: "your-secret"
+      tenant_id: "your-tenant-id"
+    # A channel's conversation ID, its channelData.channel.id, or its
+    # channelData.team.id (which allows every channel in that team). Copy
+    # the id exactly — matching is case-sensitive, not case-folded.
+    # "*" instead of a list of ids allows every channel and bypasses normal
+    # Hermes user authorization entirely -- see the matrix below; it is not
+    # the same as leaving allowed_channels empty/unset, which still requires
+    # some applicable authorization grant (TEAMS_ALLOWED_USERS,
+    # TEAMS_ALLOW_ALL_USERS, an approved pairing, or a global grant).
+    allowed_channels:
+      - "19:abc123@thread.tacv2"
+      - "19:def456@thread.tacv2"
+```
+
+The exact authorization matrix for a channel message:
+
+| `allowed_channels` | Channel matches | Channel does NOT match |
+|---|---|---|
+| Empty / unset (default) | Sender still needs normal Hermes user authorization (`TEAMS_ALLOWED_USERS`, `TEAMS_ALLOW_ALL_USERS`, an approved pairing, or a global grant) — same as before this setting existed | n/a — no channel is excluded |
+| Specific channel/team ids | Anyone may interact by @mentioning the bot — being in the channel is the access signal, no further user authorization is consulted | Dropped silently before the message ever reaches the agent or any user authorization check |
+| `"*"` (every channel) | Anyone may interact by @mentioning the bot in ANY channel — bypasses normal Hermes user authorization entirely | n/a — every channel matches |
+
+So once a channel is listed (or `allowed_channels` is `"*"`), you don't need to also add every teammate in that channel to `TEAMS_ALLOWED_USERS`. Channel authorization only ever widens access to channels — it never affects DMs, which are still governed by the normal Hermes user-authorization chain regardless. When `allowed_channels` names specific ids, a channel that isn't one of them is dropped outright — no user-authorization check is ever consulted for it, so adding a sender to `TEAMS_ALLOWED_USERS` cannot grant access from an unlisted channel.
+
+Independently of `allowed_channels`, every channel message needs an explicit @mention by default (`require_mention`, default `true`) — this applies whether or not a channel is listed, and is what makes the **Channel** row above true even without `allowed_channels` configured. Set `require_mention: false` to disable it. This has no effect on group chats — see the table above.
+
+Channel authorization covers ordinary messages only. Clicking an [Adaptive Card approval button](#interactive-approval-cards) is a separate check that requires `TEAMS_ALLOWED_USERS` or `TEAMS_ALLOW_ALL_USERS` regardless of `allowed_channels` — someone who can message the bot in a listed channel but is neither in `TEAMS_ALLOWED_USERS` nor covered by `TEAMS_ALLOW_ALL_USERS` can ask the agent to do something, but can't click Allow/Deny on the resulting approval card.
 
 ---
 
@@ -149,7 +188,7 @@ Open the printed link in your browser — it opens directly in the Teams client.
 
 ### config.yaml
 
-Alternatively, configure via `~/.hermes/config.yaml`:
+Alternatively, configure credentials via `~/.hermes/config.yaml`:
 
 ```yaml
 platforms:
@@ -160,6 +199,16 @@ platforms:
       client_secret: "your-secret"
       tenant_id: "your-tenant-id"
       port: 3978
+```
+
+`config.yaml` is the documented, primary way to set the channel allowlist and mention requirement — see [Restricting which channels the bot answers in](#restricting-which-channels-the-bot-answers-in). `TEAMS_ALLOWED_CHANNELS` (comma-separated) and `TEAMS_REQUIRE_MENTION` also work as an internal fallback, but `config.yaml` wins whenever both are set for the same key:
+
+```yaml
+platforms:
+  teams:
+    allowed_channels:
+      - "19:abc123@thread.tacv2"   # empty/unset: unrestricted (default)
+    require_mention: true          # default: true
 ```
 
 ---
@@ -176,6 +225,8 @@ When the agent needs to run a potentially dangerous command, it sends an Adaptiv
 - **Deny** — reject the command
 
 Clicking a button resolves the approval inline and replaces the card with the decision.
+
+Clicking a button requires `TEAMS_ALLOWED_USERS` or `TEAMS_ALLOW_ALL_USERS` — a channel allowlist does not grant this. See [the note above](#restricting-which-channels-the-bot-answers-in) if you're using `allowed_channels`. (This check reads those two env vars directly rather than through the profile-scoped resolution the rest of Hermes uses, so it is not multiplex-profile-aware — a pre-existing adapter limitation, not something introduced by `allowed_channels`.)
 
 ### Meeting Summary Delivery (Teams Meeting Pipeline)
 
@@ -248,13 +299,14 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 ## Security
 
 :::warning
-**Always set `TEAMS_ALLOWED_USERS`** with the AAD object IDs of authorized users. Without this, anyone who can find or install your bot can interact with it.
+**Set `TEAMS_ALLOWED_USERS`** with the AAD object IDs of authorized users, for a fixed, known list of who can DM the bot, rather than relying on `TEAMS_ALLOW_ALL_USERS`.
 
 Treat `TEAMS_CLIENT_SECRET` like a password — rotate it periodically via the Azure portal or Teams CLI.
 :::
 
 - Store credentials in `~/.hermes/.env` with permissions `600` (`chmod 600 ~/.hermes/.env`)
-- The bot only accepts messages from users in `TEAMS_ALLOWED_USERS`; unauthorized messages are silently dropped
+- DMs are governed by the normal Hermes user-authorization chain (`TEAMS_ALLOWED_USERS`, `TEAMS_ALLOW_ALL_USERS`, an approved pairing, or a global `GATEWAY_ALLOWED_USERS`/`GATEWAY_ALLOW_ALL_USERS` grant). An unrecognized sender is offered a pairing code by default rather than being silently ignored, even with `TEAMS_ALLOWED_USERS` set — Teams isn't wired into the automatic switch-to-silent-drop some other platforms get from having an allowlist configured. Set `platforms.teams.unauthorized_dm_behavior: ignore` in config.yaml if you want unapproved DMs dropped with no reply at all.
+- When `allowed_channels` names specific channel/team ids, a channel message from any other channel is dropped before the agent ever sees it, regardless of who sent it — but `allowed_channels: ["*"]` authorizes every channel sender outright, bypassing user authorization entirely (see the matrix above)
 - Your public endpoint (`/api/messages`) is authenticated by the Teams Bot Framework — requests without valid JWTs are rejected
 
 ## Related Docs


### PR DESCRIPTION
> **Status update:** The mention-gate portion landed in #114835 and this PR was closed by the maintainer. The remaining changes are now in two independent follow-ups: #115296 (YAML-only channel allowlist) and #115297 (targeted activities and the SDK mention helper). The original proposal below is retained for history; the follow-up PR descriptions document the current behavior and validation.

---

## What does this PR do?

The Teams adapter today has no channel-level access control and no enforced mention requirement in code. `TEAMS_ALLOWED_USERS` is the only gate, and it applies uniformly to DMs, group chats, and channels — there's no way to say "answer in these channels" without also enumerating every person who should be able to talk to the bot there, and `TeamsAdapter._on_message` dispatches every message it receives with no channel-scoped check of its own.

This adds two independent, opt-in settings:

- **`allowed_channels`** (config.yaml) / `TEAMS_ALLOWED_CHANNELS` (env fallback) — restricts which team channels the bot answers in, matched by conversation ID, `channelData.channel.id`, or `channelData.team.id` (so a whole team can be allowed at once). A message from a listed channel is authorized without also needing `TEAMS_ALLOWED_USERS`; a message from an unlisted channel is dropped before it reaches the agent. Empty/unset (the default) leaves channel behavior exactly as it is today.
- **`require_mention`** (config.yaml) / `TEAMS_REQUIRE_MENTION` (env fallback), default `true` — every channel message, listed or not, must carry an explicit @mention of the bot. Teams itself normally only delivers mentioned channel activities to a bot in the first place, so this is a no-op for a standard tenant; it closes the gap for a tenant that grants the bot broader `ChannelMessage.Read.Group` RSC permission and starts delivering every channel message regardless of mention.

DMs are untouched — still governed by `TEAMS_ALLOWED_USERS` as before.

## Related Issue

N/A — no existing issue for this; happy to open one first if preferred.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/teams/adapter.py` — `_teams_allowed_channels()`, `_teams_require_mention()`, `_activity_mentions_bot()`, `_should_process_message()`; `_coerce_id_set()`, `_base_conversation_id()`, `_channel_data_ids()`, `_apply_yaml_config()` module-level helpers; wired into `_on_message()` (channel classification hardening + the gate itself, stamping `SessionSource.role_authorized`) and `register()` (`apply_yaml_config_fn`).
- `tests/gateway/test_teams.py` — new test classes covering channel classification, the allowlist matrix (empty/specific/wildcard), the mention gate, config precedence, and the config.yaml → `PlatformConfig.extra` bridge (including a real `register()` → `load_gateway_config()` integration test and a multiplexed-profile-scope regression test).
- `tests/gateway/test_teams_channel_allowlist_e2e.py` (new) — drives a real `TeamsAdapter` through the real `GatewayAuthorizationMixin._is_user_authorized`, with a real `PairingStore`, proving the boundary holds end to end rather than only inside adapter-local unit tests.
- `website/docs/user-guide/messaging/teams.md` — documents the exact authorization matrix (empty/specific-ids/wildcard × listed/unlisted), the mention requirement, and two adjacent pre-existing behaviors worth knowing about once this exists (see below).
- `website/docs/reference/environment-variables.md`, `cli-config.yaml.example` — new keys documented, config.yaml-first per this project's convention that behavioral settings belong in config.yaml with the env var as a fallback, not the primary documented surface.

Two **pre-existing** things, unrelated to this change, are called out in the docs as known limitations rather than fixed here (out of scope for this PR):
- An unrecognized Teams DM sender gets a pairing code by default rather than silence, even with `TEAMS_ALLOWED_USERS` configured — Teams is absent from the hardcoded per-platform map `gateway/authz_mixin.py`'s `_get_unauthorized_dm_behavior()` uses to auto-switch some other platforms to silent-drop once their allowlist env var is set.
- Adaptive Card approval-button clicks (`_on_card_action`) read `TEAMS_ALLOWED_USERS`/`TEAMS_ALLOW_ALL_USERS` directly via `os.getenv` rather than through the profile-scoped resolution the rest of the gateway uses, so it isn't multiplex-profile-aware.

## How to Test

1. Unit + E2E: `scripts/run_tests.sh tests/gateway/test_teams.py tests/gateway/test_teams_channel_allowlist_e2e.py` (57 tests).
2. Config wiring, no mocks: with a real `~/.hermes/config.yaml` containing `platforms.teams.allowed_channels`/`require_mention`, `gateway.config.load_gateway_config()` correctly seeds `PlatformConfig.extra` — verified directly against the real bundled-plugin discovery path (not a test-registered one).
3. Live: register a bot in a Teams tenant, set `allowed_channels` to one channel, message from an allowed channel as a user absent from `TEAMS_ALLOWED_USERS` (expect a reply once mentioned), message from a non-listed channel (expect silence), DM as that same user (expect the existing unauthorized-DM path) — I do not have a Teams/Azure tenant to run this against myself; steps 1–2 are what I actually ran.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the project's test wrapper (`scripts/run_tests.sh`, which is what CI invokes — plain `pytest` skips the hermetic env/isolation it sets up) and all tests pass, including the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, follows the existing platform-adapter conventions (mirrors Telegram's `allowed_chats` / DingTalk's `require_mention`), no new architecture
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, no new process/signal/file-I/O code
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A, not a tool

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_teams.py tests/gateway/test_teams_channel_allowlist_e2e.py
=== Summary: 2 files, 57 tests passed, 0 failed (100% complete) ===
```
