### PR TITLE
fix(chat_completions): refresh activity during non-streaming cron requests

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -57,6 +57,13 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+# direct_api_call refreshes the activity tracker this often while a
+# non-streaming request is in flight, so the cron inactivity watchdog
+# (HERMES_CRON_TIMEOUT) sees "slow but alive" rather than "hung". A fraction
+# of typical inactivity limits — frequent enough to feed the watchdog, rare
+# enough to be noise-free on fast responses. See direct_api_call docstring.
+_DIRECT_API_CALL_HEARTBEAT_INTERVAL_S = 30.0
+
 
 def _context_thread_target(callback):
     """Bind a no-argument thread target to the caller's ContextVars."""
@@ -565,11 +572,42 @@ def direct_api_call(agent, api_kwargs: dict):
     request runs in-flight normally, the per-request OpenAI client's own httpx
     timeout (provider ``request_timeout_seconds`` / ``HERMES_API_TIMEOUT``) bounds
     a genuinely hung provider — the same bound interactive calls already rely on.
+
+    A daemon heartbeat refreshes the activity tracker while the request is in
+    flight. Unlike the streaming paths (commit 2773b18b5), which call
+    ``_touch_activity()`` on every chunk/event, this path blocks on a single
+    ``create()`` with no intermediate events. Without the heartbeat, a provider
+    whose first byte is slow (connection alive, not a connection error) is
+    indistinguishable from a hung job, so the cron inactivity watchdog
+    (``HERMES_CRON_TIMEOUT``, default 600s) kills tasks that would have succeeded
+    once the httpx timeout elapsed. Symmetric gap left by 2773b18b5, which only
+    patched the four streaming paths.
     """
     _check_stale_giveup(agent)
     agent._touch_activity("waiting for non-streaming API response")
     request_client_holder = {"client": None}
     request_client_lock = threading.Lock()
+
+    # Heartbeat: see docstring. Daemon thread, stopped in finally so it never
+    # outlives the request (success, error, or interrupt). Event.wait returns
+    # True the instant the request finishes, so the thread exits promptly
+    # without sleeping off the tail of the interval.
+    _heartbeat_stop = threading.Event()
+    _heartbeat_started_at = time.time()
+
+    def _activity_heartbeat() -> None:
+        while not _heartbeat_stop.wait(_DIRECT_API_CALL_HEARTBEAT_INTERVAL_S):
+            agent._touch_activity(
+                "waiting for non-streaming API response "
+                f"({int(time.time() - _heartbeat_started_at)}s)"
+            )
+
+    _heartbeat_thread = threading.Thread(
+        target=_activity_heartbeat,
+        name="direct-api-call-heartbeat",
+        daemon=True,
+    )
+    _heartbeat_thread.start()
 
     def _abort_active_request(reason: str) -> None:
         """Abort the inline request from a watchdog/interrupt thread."""
@@ -614,6 +652,7 @@ def direct_api_call(agent, api_kwargs: dict):
         succeeded = True
         return response
     finally:
+        _heartbeat_stop.set()
         if getattr(agent, "_active_request_abort", None) is _abort_active_request:
             agent._active_request_abort = None
         with request_client_lock:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -676,6 +676,80 @@ class TestCodexStreamCallbacks:
         assert touch_calls.count("receiving stream response") == len(events)
 
 
+class TestDirectApiCallHeartbeat:
+    """direct_api_call must refresh the activity tracker while a non-streaming
+    request is in flight.
+
+    Symmetric gap left by commit 2773b18b5, which added per-event
+    ``_touch_activity()`` calls to the four streaming paths but not to the
+    inline non-streaming path. Without these touches, a provider whose first
+    byte is slow (connection alive, not an error) is indistinguishable from a
+    hung job, so the cron inactivity watchdog (``HERMES_CRON_TIMEOUT``, default
+    600s) kills tasks that would have succeeded once httpx's own timeout
+    elapsed.
+    """
+
+    def test_heartbeat_refreshes_activity_during_slow_response(self, monkeypatch):
+        import time as _time
+        from run_agent import AIAgent
+        from agent import chat_completion_helpers as helpers
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        touch_calls = []
+        agent._touch_activity = lambda desc: touch_calls.append(desc)
+
+        # Shrink the heartbeat interval so the test exercises several beats
+        # in tens of milliseconds rather than waiting 30s.
+        monkeypatch.setattr(helpers, "_DIRECT_API_CALL_HEARTBEAT_INTERVAL_S", 0.02)
+
+        # Stub the dispatch so it blocks long enough for multiple heartbeats
+        # to fire, then returns a minimal response.
+        def _slow_dispatch(agent, api_kwargs, *, make_client):
+            _time.sleep(0.10)
+            return SimpleNamespace(choices=[SimpleNamespace(finish_reason="stop")])
+
+        monkeypatch.setattr(
+            helpers, "_dispatch_nonstreaming_api_request", _slow_dispatch
+        )
+        monkeypatch.setattr(helpers, "_check_stale_giveup", lambda *a, **k: None)
+        monkeypatch.setattr(helpers, "_reset_stale_streak", lambda *a, **k: None)
+        agent._create_request_openai_client = lambda **kw: MagicMock()
+        agent._abort_request_openai_client = lambda *a, **kw: None
+        agent._close_request_openai_client = lambda *a, **kw: None
+
+        helpers.direct_api_call(agent, {"model": "test/model"})
+
+        # Initial touch fires before the request.
+        assert "waiting for non-streaming API response" in touch_calls
+
+        # Heartbeats (elapsed-suffixed) fired while the request blocked.
+        heartbeats = [
+            c for c in touch_calls
+            if c.startswith("waiting for non-streaming API response (")
+        ]
+        assert len(heartbeats) >= 2, (
+            f"expected >=2 heartbeat touches during the wait, got {heartbeats}"
+        )
+
+        # The heartbeat thread stops after the request returns — no further
+        # touches accumulate once _heartbeat_stop is set in finally.
+        before = len(touch_calls)
+        _time.sleep(0.10)
+        assert len(touch_calls) == before, (
+            "heartbeat thread kept touching activity after the request returned"
+        )
+
+
 class TestAnthropicStreamCallbacks:
     """Verify Anthropic streaming refreshes activity on every event."""
 


### PR DESCRIPTION
Fixes #79469.

## Problem

`direct_api_call()` — the inline non-streaming path taken by every cron turn and delegated child (`should_use_direct_api_call()` → `True`) — calls `_touch_activity()` only once, *before* the request. The subsequent `chat.completions.create()` blocks with no intermediate events, so the cron inactivity watchdog (`HERMES_CRON_TIMEOUT`, default 600s) sees zero activity and kills the job. When the provider's first byte is slow but the connection is alive (not a connection error), this is a false positive — the job would have succeeded once httpx's own `request_timeout_seconds` / `HERMES_API_TIMEOUT` elapsed.

Real-world repro in #79469 (DeepSeek, both `deepseek-v4-pro` and `deepseek-v4-flash` killed at exactly the 600s inactivity limit; same job returned in 3.0s once TTFB normalized).

This is the symmetric gap left by commit `2773b18b5` (#7794), which added per-event `_touch_activity()` to the four streaming paths but missed the inline non-streaming path.

## Fix

Add a daemon heartbeat thread inside `direct_api_call()`:

- Before the `try`: start a daemon thread calling `_touch_activity(f"waiting for non-streaming API response ({elapsed}s)")` every `_DIRECT_API_CALL_HEARTBEAT_INTERVAL_S` (30s).
- In `finally`: set the stop `Event`; `Event.wait(interval)` returns `True` the instant the request finishes, so the thread exits promptly and never outlives the request — success, error, and interrupt all share the same `finally`.

The interval is a fraction of typical inactivity limits (default 600s): frequent enough to feed the watchdog, rare enough to be noise-free on fast responses.

## What this does *not* change

- `should_use_direct_api_call()` is untouched — takes no position on #71268 (whether cron should use non-streaming at all). Complementary.
- The interrupt / abort / close lifecycle is untouched. The heartbeat thread only calls `_touch_activity`; it never touches the request client.
- httpx's own timeout remains the bound for genuinely hung providers.

## Tests

New `TestDirectApiCallHeartbeat::test_heartbeat_refreshes_activity_during_slow_response` — stubs `_dispatch_nonstreaming_api_request` to block 100ms with a shrunk 20ms heartbeat interval; asserts ≥2 elapsed-suffixed touches during the wait and that touching stops after the request returns.

All 37 tests in `tests/run_agent/test_streaming.py` pass (including the `2773b18b5` streaming-activity tests this mirrors).
