### PR TITLE
fix(gateway): keep MarkdownV2 inline entities balanced across truncate_message chunks (#52093)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -240,6 +240,68 @@ def _custom_unit_to_cp(s: str, budget: int, len_fn) -> int:
     return lo
 
 
+# MarkdownV2 inline formatting delimiters, longest first so ``||`` is matched
+# before a bare ``|``.  These are the markers ``format_message`` emits: bold
+# ``*``, italic ``_``, strikethrough ``~`` and spoiler ``||``.  Code spans and
+# fenced blocks are handled separately (their contents are literal).
+_INLINE_MARKERS = ("||", "*", "_", "~")
+
+
+def _open_inline_entities(text: str, initial: "Optional[List[str]]" = None) -> "List[str]":
+    """Return the MarkdownV2 inline markers left unclosed at the end of *text*.
+
+    Walks *text* honouring backslash escapes (``\\*`` is a literal asterisk,
+    not a delimiter) and skipping fenced blocks and inline code spans, where
+    these characters carry no formatting meaning.
+
+    The result is ordered outermost-first, so closing it in reverse order and
+    reopening it in forward order round-trips the original nesting.  Used by
+    :meth:`BasePlatformAdapter.truncate_message` to keep every emitted chunk
+    independently parseable: an unpaired delimiter makes Telegram reject the
+    whole message with "can't parse entities" and fall back to plain text,
+    silently stripping all formatting.
+
+    Note: ``__underline__`` is seen as two ``_`` toggles and therefore nets to
+    balanced, which is correct for a whole span.  ``format_message`` never
+    emits underline, so a split inside one is not reachable in practice.
+    """
+    stack = list(initial or [])
+    i, n = 0, len(text)
+    in_fence = False
+    in_code = False
+    while i < n:
+        ch = text[i]
+        if ch == "\\":
+            i += 2                       # escaped delimiter: not formatting
+            continue
+        if text.startswith("```", i):
+            in_fence = not in_fence
+            in_code = False
+            i += 3
+            continue
+        if in_fence:
+            i += 1
+            continue
+        if ch == "`":
+            in_code = not in_code
+            i += 1
+            continue
+        if in_code:
+            i += 1
+            continue
+        for mark in _INLINE_MARKERS:
+            if text.startswith(mark, i):
+                if stack and stack[-1] == mark:
+                    stack.pop()
+                else:
+                    stack.append(mark)
+                i += len(mark)
+                break
+        else:
+            i += 1
+    return stack
+
+
 def is_network_accessible(host: str) -> bool:
     """Return True if *host* would expose the server beyond loopback.
 
@@ -6696,12 +6758,20 @@ class BasePlatformAdapter(ABC):
         len_fn: Optional["Callable[[str], int]"] = None,
     ) -> List[str]:
         """
-        Split a long message into chunks, preserving code block boundaries.
+        Split a long message into chunks, preserving formatting boundaries.
 
         When a split falls inside a triple-backtick code block, the fence is
         closed at the end of the current chunk and reopened (with the original
         language tag) at the start of the next chunk.  Multi-chunk responses
         receive indicators like ``(1/3)``.
+
+        MarkdownV2 inline entities (``*bold*``, ``_italic_``, ``~strike~``,
+        ``||spoiler||``) are carried the same way: any delimiter still open at
+        a boundary is closed on the current chunk and reopened on the next, so
+        every chunk is independently parseable.  A chunk containing an
+        unpaired delimiter is rejected by Telegram with "can't parse entities"
+        and falls back to plain text, which strips formatting from the entire
+        response.
 
         Args:
             content: The full message content
@@ -6720,21 +6790,41 @@ class BasePlatformAdapter(ABC):
 
         INDICATOR_RESERVE = 10   # room for " (XX/XX)"
         FENCE_CLOSE = "\n```"
+        # Room to close a nested run of inline delimiters at a boundary
+        # (``||`` + ``*`` + ``_`` + ``~`` is 5 units; 8 leaves margin).
+        INLINE_RESERVE = 8
 
         chunks: List[str] = []
         remaining = content
         # When the previous chunk ended mid-code-block, this holds the
         # language tag (possibly "") so we can reopen the fence.
         carry_lang: Optional[str] = None
+        # Inline MarkdownV2 delimiters left open by the previous chunk,
+        # outermost-first, so they can be reopened here.  Mutually exclusive
+        # with carry_lang: inside a fence these characters are literal.
+        carry_inline: List[str] = []
 
         while remaining:
+            # A delimiter we closed at the end of the previous chunk may be
+            # followed immediately by its original closer.  Reopening only to
+            # close again would emit an empty entity (e.g. ``**``), which
+            # Telegram rejects, so drop the redundant closer instead.
+            while carry_inline and remaining.startswith(carry_inline[-1]):
+                remaining = remaining[len(carry_inline.pop()):]
+            if not remaining:
+                break
+
             # If we're continuing a code block from the previous chunk,
             # prepend a new opening fence with the same language tag.
             prefix = f"```{carry_lang}\n" if carry_lang is not None else ""
+            # Reopen any inline entities the previous chunk had to close.
+            prefix += "".join(carry_inline)
 
             # How much body text we can fit after accounting for the prefix,
-            # a potential closing fence, and the chunk indicator.
-            headroom = max_length - INDICATOR_RESERVE - _len(prefix) - _len(FENCE_CLOSE)
+            # a potential closing fence, the inline closers we may need to
+            # append, and the chunk indicator.
+            headroom = (max_length - INDICATOR_RESERVE - _len(prefix)
+                        - _len(FENCE_CLOSE) - INLINE_RESERVE)
             if headroom < 1:
                 # Floor at 1 so a pathologically small max_length (0 or 1 —
                 # e.g. a relay capability descriptor whose max_message_length
@@ -6762,6 +6852,13 @@ class BasePlatformAdapter(ABC):
                                 _final_lang = _tag.split()[0] if _tag else ""
                     if _final_in_code:
                         final_chunk += FENCE_CLOSE
+                else:
+                    # Close anything still open so the last chunk is valid on
+                    # its own too.  Balanced input closes itself here; this
+                    # only fires when the source text was already unbalanced.
+                    _final_open = _open_inline_entities(final_chunk)
+                    if _final_open:
+                        final_chunk += "".join(reversed(_final_open))
                 chunks.append(final_chunk)
                 break
 
@@ -6846,8 +6943,19 @@ class BasePlatformAdapter(ABC):
                 # Close the orphaned fence so the chunk is valid on its own
                 full_chunk += FENCE_CLOSE
                 carry_lang = lang
+                carry_inline = []
             else:
                 carry_lang = None
+                # Close any inline entities left open at this boundary and
+                # remember them so the next chunk reopens them.  Without this
+                # the chunk carries an unpaired delimiter, Telegram rejects it
+                # with "can't parse entities", and the adapter falls back to
+                # plain text — silently stripping formatting from the whole
+                # response.  Closing and reopening (rather than rewinding the
+                # split) also handles an entity longer than a single chunk.
+                carry_inline = _open_inline_entities(full_chunk)
+                if carry_inline:
+                    full_chunk += "".join(reversed(carry_inline))
 
             chunks.append(full_chunk)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -227,6 +227,68 @@ def _prefix_within_utf16_limit(s: str, limit: int) -> str:
     return s[:_custom_unit_to_cp(s, limit, utf16_len)]
 
 
+# MarkdownV2 inline formatting delimiters, longest first so ``||`` is matched
+# before a bare ``|``.  These are the markers ``format_message`` emits: bold
+# ``*``, italic ``_``, strikethrough ``~`` and spoiler ``||``.  Code spans and
+# fenced blocks are handled separately (their contents are literal).
+_INLINE_MARKERS = ("||", "*", "_", "~")
+
+
+def _open_inline_entities(text: str, initial: "Optional[List[str]]" = None) -> "List[str]":
+    """Return the MarkdownV2 inline markers left unclosed at the end of *text*.
+
+    Walks *text* honouring backslash escapes (``\\*`` is a literal asterisk,
+    not a delimiter) and skipping fenced blocks and inline code spans, where
+    these characters carry no formatting meaning.
+
+    The result is ordered outermost-first, so closing it in reverse order and
+    reopening it in forward order round-trips the original nesting.  Used by
+    :meth:`BasePlatformAdapter.truncate_message` to keep every emitted chunk
+    independently parseable: an unpaired delimiter makes Telegram reject the
+    whole message with "can't parse entities" and fall back to plain text,
+    silently stripping all formatting.
+
+    Note: ``__underline__`` is seen as two ``_`` toggles and therefore nets to
+    balanced, which is correct for a whole span.  ``format_message`` never
+    emits underline, so a split inside one is not reachable in practice.
+    """
+    stack = list(initial or [])
+    i, n = 0, len(text)
+    in_fence = False
+    in_code = False
+    while i < n:
+        ch = text[i]
+        if ch == "\\":
+            i += 2                       # escaped delimiter: not formatting
+            continue
+        if text.startswith("```", i):
+            in_fence = not in_fence
+            in_code = False
+            i += 3
+            continue
+        if in_fence:
+            i += 1
+            continue
+        if ch == "`":
+            in_code = not in_code
+            i += 1
+            continue
+        if in_code:
+            i += 1
+            continue
+        for mark in _INLINE_MARKERS:
+            if text.startswith(mark, i):
+                if stack and stack[-1] == mark:
+                    stack.pop()
+                else:
+                    stack.append(mark)
+                i += len(mark)
+                break
+        else:
+            i += 1
+    return stack
+
+
 def is_network_accessible(host: str) -> bool:
     """True if *host* would expose the server beyond loopback (incl. IPv4-mapped
     ::ffff:127.0.0.1); hostnames are resolved and DNS failure fails closed (True)."""
@@ -4205,27 +4267,44 @@ class BasePlatformAdapter(ABC):
     def truncate_message(content: str, max_length: int = 4096,
                          len_fn: Optional["Callable[[str], int]"] = None) -> List[str]:
         """Split a long message into chunks preserving code blocks: a split inside a fence closes it
-        at the chunk end and reopens it (same language tag) in the next; multi-chunk output gets
-        ``(1/3)`` indicators. ``len_fn`` overrides ``len`` (``utf16_len`` for Telegram)."""
+        at the chunk end and reopens it (same language tag) in the next. MarkdownV2 inline
+        entities are also closed and reopened so each chunk stays independently parseable.
+        Multi-chunk output gets ``(1/3)`` indicators. ``len_fn`` overrides ``len`` (``utf16_len`` for Telegram)."""
         _len = len_fn or len
         if _len(content) <= max_length:
             return [content]
         INDICATOR_RESERVE = 10   # room for " (XX/XX)"
         FENCE_CLOSE = "\n```"
+        INLINE_RESERVE = 8  # room for nested inline closers
         chunks: List[str] = []
         remaining = content
         carry_lang: Optional[str] = None  # language tag ("" ok) when previous chunk ended mid-fence
+        carry_inline: List[str] = []
         while remaining:
+            # Do not reopen an entity only to close it immediately: Telegram
+            # rejects empty entities left by a boundary before the original closer.
+            while carry_inline and remaining.startswith(carry_inline[-1]):
+                remaining = remaining[len(carry_inline.pop()):]
+            if not remaining:
+                break
             prefix = f"```{carry_lang}\n" if carry_lang is not None else ""
-            # Body budget after prefix/fence/indicator; floored so a tiny max_length can't stall.
-            headroom = max_length - INDICATOR_RESERVE - _len(prefix) - _len(FENCE_CLOSE)
+            prefix += "".join(carry_inline)
+            # Body budget after prefix/fence/inline closers/indicator; floored so a tiny max_length can't stall.
+            headroom = (max_length - INDICATOR_RESERVE - _len(prefix)
+                        - _len(FENCE_CLOSE) - INLINE_RESERVE)
             if headroom < 1:
                 headroom = max(1, max_length // 2)
             # Remainder fits in one final chunk; close a reopened fence if still open.
             if _len(prefix) + _len(remaining) <= max_length - INDICATOR_RESERVE:
                 final_chunk = prefix + remaining
-                if carry_lang is not None and fence_state_after(remaining, True, carry_lang)[0]:
-                    final_chunk += FENCE_CLOSE
+                if carry_lang is not None:
+                    if fence_state_after(remaining, True, carry_lang)[0]:
+                        final_chunk += FENCE_CLOSE
+                else:
+                    # Balanced input closes itself; also close unbalanced source text.
+                    final_open = _open_inline_entities(final_chunk)
+                    if final_open:
+                        final_chunk += "".join(reversed(final_open))
                 chunks.append(final_chunk)
                 break
             # Natural split (newline, then space); a custom _len budget maps to a codepoint offset.
@@ -4258,8 +4337,15 @@ class BasePlatformAdapter(ABC):
             # Walk only chunk_body (not the prepended prefix) for the fence state.
             in_code, lang = fence_state_after(chunk_body, carry_lang is not None, carry_lang or "")
             carry_lang = lang if in_code else None
-            # Close the orphaned fence so the chunk stands alone.
-            chunks.append(full_chunk + FENCE_CLOSE if in_code else full_chunk)
+            if in_code:
+                full_chunk += FENCE_CLOSE
+                carry_inline = []
+            else:
+                # Closing and reopening also handles entities longer than one chunk.
+                carry_inline = _open_inline_entities(full_chunk)
+                if carry_inline:
+                    full_chunk += "".join(reversed(carry_inline))
+            chunks.append(full_chunk)
         if len(chunks) > 1:
             chunks = [f"{chunk} ({i + 1}/{len(chunks)})" for i, chunk in enumerate(chunks)]
         return chunks

--- a/tests/gateway/test_telegram_inline_entity_split.py
+++ b/tests/gateway/test_telegram_inline_entity_split.py
@@ -1,0 +1,267 @@
+"""Tests for MarkdownV2 inline-entity balance across truncate_message chunks.
+
+The problem (issue #52093): ``truncate_message`` guards triple-backtick fences
+and inline code spans when picking a split point, but nothing else.  When a
+boundary lands inside ``*bold*``, ``_italic_``, ``~strike~`` or ``||spoiler||``,
+each chunk carries an unpaired delimiter, Telegram rejects the message with
+"can't parse entities", and the adapter falls back to plain text — silently
+stripping formatting from the whole response.
+
+Trigger conditions (both required, which is why this is rarely seen):
+
+  1. No newline in the second half of the region, so the splitter falls back
+     from ``region.rfind("\\n")`` to ``region.rfind(" ")``.  Every inline
+     entity ``format_message`` emits is newline-free by construction (bold /
+     strike / spoiler use ``.``, italic uses ``[^*\\n]+``), so a newline
+     boundary is ALWAYS entity-safe.
+  2. The chosen space falls *inside* an entity, i.e. the span contains
+     internal spaces.  A span without them is skipped over harmlessly.
+
+These tests drive the real production pipeline — ``TelegramAdapter.format_message``
+followed by ``truncate_message(..., len_fn=utf16_len)`` — because the markers
+that reach the splitter are the *converted* ones (``**bold**`` becomes
+``*bold*``, ``*italic*`` becomes ``_italic_``, ``~~strike~~`` becomes
+``~strike~``), not the markdown the model wrote.
+"""
+
+import re
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, utf16_len
+
+# The behavioural tests below deliberately do NOT depend on this helper, so
+# they express the delivery contract and fail (rather than error) against an
+# unguarded splitter.  Only the scanner unit tests need it.
+try:
+    from gateway.platforms.base import _open_inline_entities
+except ImportError:  # pragma: no cover - pre-guard tree
+    _open_inline_entities = None
+
+
+def _ensure_telegram_mock():
+    """Mock the telegram package if it's not installed."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+MAX = 4096
+
+# (markdown the model writes, delimiter format_message emits, label)
+MARKERS = [
+    ("**", "*", "bold"),
+    ("*", "_", "italic"),
+    ("~~", "~", "strike"),
+    ("||", "||", "spoiler"),
+]
+
+
+@pytest.fixture()
+def fmt():
+    """The real Telegram markdown -> MarkdownV2 converter."""
+    return TelegramAdapter(PlatformConfig(enabled=True, token="test-token")).format_message
+
+
+# ── oracle ────────────────────────────────────────────────────────────────
+# Deliberately implemented differently from _open_inline_entities (regex
+# stripping + parity counting, rather than a stateful scan) so these tests do
+# not merely assert the implementation against itself.
+
+def _unclosed(text: str) -> list:
+    s = re.sub(r"\\.", "", text, flags=re.S)      # escaped chars are literals
+    s = re.sub(r"```.*?```", "", s, flags=re.S)   # fenced blocks
+    s = re.sub(r"`[^`]*`", "", s)                 # inline code spans
+    bad = []
+    if s.count("||") % 2:
+        bad.append("||")
+    s = s.replace("||", "")
+    for m in ("*", "_", "~"):
+        if s.count(m) % 2:
+            bad.append(m)
+    return bad
+
+
+def _forced_boundary(md_marker: str) -> str:
+    """Source whose formatted form puts a space-containing span across 4096."""
+    return ("x" * 3900 + md_marker + ("word inside span " * 60) + md_marker
+            + " tail" + " z" * 1500)
+
+
+def _split(fmt, raw, max_length=MAX):
+    return BasePlatformAdapter.truncate_message(fmt(raw), max_length, len_fn=utf16_len)
+
+
+def _content(chunks) -> str:
+    """Whitespace- and delimiter-free view, for content-preservation checks."""
+    joined = "".join(re.sub(r" \(\d+/\d+\)$", "", c) for c in chunks)
+    joined = re.sub(r"\\(.)", r"\1", joined)
+    for tok in ("```", "||", "*", "_", "~", "`"):
+        joined = joined.replace(tok, "")
+    return re.sub(r"\s+", "", joined)
+
+
+# ── the scanner ───────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(_open_inline_entities is None,
+                    reason="inline-entity scanner not present in this tree")
+class TestOpenInlineEntities:
+    def test_balanced_span_reports_nothing(self):
+        assert _open_inline_entities("a *bold* b") == []
+
+    @pytest.mark.parametrize("delim", ["*", "_", "~", "||"])
+    def test_unclosed_delimiter_reported(self, delim):
+        assert _open_inline_entities("text %sopen" % delim) == [delim]
+
+    def test_escaped_delimiter_is_literal(self):
+        assert _open_inline_entities(r"a \* literal star") == []
+
+    def test_delimiters_inside_inline_code_ignored(self):
+        assert _open_inline_entities("before `a * b` after") == []
+
+    def test_delimiters_inside_fence_ignored(self):
+        assert _open_inline_entities("```\na * b _ c\n```") == []
+
+    def test_nesting_is_outermost_first(self):
+        assert _open_inline_entities("||spoiler *bold") == ["||", "*"]
+
+    def test_spoiler_matched_before_single_pipe(self):
+        assert _open_inline_entities("||x||") == []
+
+    def test_initial_state_is_carried(self):
+        assert _open_inline_entities("still bold", initial=["*"]) == ["*"]
+
+
+# ── the regression: real pipeline, every marker type ──────────────────────
+
+class TestFormatThenTruncate:
+    @pytest.mark.parametrize("md,delim,label", MARKERS, ids=[m[2] for m in MARKERS])
+    def test_span_across_boundary_stays_balanced(self, fmt, md, delim, label):
+        chunks = _split(fmt, _forced_boundary(md))
+        assert len(chunks) > 1, "expected a multi-chunk split for this fixture"
+        for i, chunk in enumerate(chunks, 1):
+            assert _unclosed(chunk) == [], (
+                "chunk %d/%d has unpaired %s delimiter(s) %s; Telegram would "
+                "reject it and strip formatting"
+                % (i, len(chunks), label, _unclosed(chunk))
+            )
+
+    @pytest.mark.parametrize("md,delim,label", MARKERS, ids=[m[2] for m in MARKERS])
+    def test_chunks_respect_the_cap(self, fmt, md, delim, label):
+        for chunk in _split(fmt, _forced_boundary(md)):
+            assert utf16_len(chunk) <= MAX
+
+    @pytest.mark.parametrize("md,delim,label", MARKERS, ids=[m[2] for m in MARKERS])
+    def test_no_content_lost_or_duplicated(self, fmt, md, delim, label):
+        raw = _forced_boundary(md)
+        assert _content(_split(fmt, raw)) == _content([fmt(raw)])
+
+
+# ── the defect that sank the previous attempt (#52096) ────────────────────
+
+class TestOverlongEntity:
+    """An entity longer than one whole chunk.
+
+    Rewinding the split point cannot fix this: after moving the boundary
+    before the opener, the next chunk starts *at* the opener with no preceding
+    whitespace, so a later boundary splits it anyway.  Closing and reopening
+    has no such limit.
+    """
+
+    def test_entity_spanning_several_chunks(self, fmt):
+        raw = "y" * 200 + "**" + ("long bold body " * 900) + "**" + " end"
+        chunks = _split(fmt, raw)
+        assert len(chunks) >= 3, "fixture should span at least three chunks"
+        for i, chunk in enumerate(chunks, 1):
+            assert _unclosed(chunk) == [], "chunk %d/%d unbalanced" % (i, len(chunks))
+
+    def test_overlong_entity_terminates(self, fmt):
+        # A span with no spaces at all: the space fallback cannot help, so the
+        # splitter hard-cuts.  Must still terminate and stay balanced.
+        raw = "**" + ("b" * 9000) + "**"
+        chunks = _split(fmt, raw)
+        assert chunks
+        for chunk in chunks:
+            assert _unclosed(chunk) == []
+
+
+# ── the streaming overflow branch ────────────────────────────────────────
+
+class TestStreamingOverflowPreview:
+    """The mid-stream preview delegates to the same splitter, so it inherits
+    the guard rather than needing its own.
+
+    ``_truncate_stream_overflow_preview`` returns ``truncate_message(...)[0]``
+    (it deliberately takes only the head chunk, because splitting a preview
+    would move the active message id and re-trigger the overflow cycle,
+    #48648).  Before this change that head chunk could carry an unpaired
+    delimiter exactly like any other chunk.
+    """
+
+    def test_preview_head_chunk_is_balanced(self, fmt):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+        preview = adapter._truncate_stream_overflow_preview(fmt(_forced_boundary("**")))
+        assert utf16_len(preview) <= MAX
+        assert _unclosed(preview) == [], (
+            "streaming preview carries an unpaired delimiter %s" % _unclosed(preview))
+
+    def test_consumer_split_delegates_to_the_adapter(self):
+        """Guard the delegation itself: if the consumer stopped calling the
+        adapter's truncate_message, the fix would silently stop covering the
+        streaming path."""
+        import inspect
+        from gateway.stream_consumer import GatewayStreamConsumer
+        src = inspect.getsource(GatewayStreamConsumer)
+        assert 'getattr(self.adapter, "truncate_message", None)' in src
+
+
+# ── nothing already working may regress ──────────────────────────────────
+
+class TestNoRegression:
+    def test_newline_rich_text_unaffected(self, fmt):
+        raw = "\n".join("Line %03d with **bold phrase** trailing." % i for i in range(200))
+        for chunk in _split(fmt, raw):
+            assert _unclosed(chunk) == []
+
+    def test_short_message_passes_through_untouched(self, fmt):
+        formatted = fmt("a **short** message")
+        assert BasePlatformAdapter.truncate_message(
+            formatted, MAX, len_fn=utf16_len) == [formatted]
+
+    def test_fenced_block_still_closed_and_reopened(self, fmt):
+        raw = "intro\n```python\n" + ("print('x' * 3)\n" * 400) + "```\nouttro"
+        chunks = _split(fmt, raw)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert chunk.count("```") % 2 == 0, "fence parity broken"
+
+    def test_inline_code_across_boundary(self, fmt):
+        raw = "z" * 3900 + " `inline code span here` " + "q" * 2000
+        for chunk in _split(fmt, raw):
+            assert _unclosed(chunk) == []
+
+    def test_surrogate_pairs_counted_in_utf16(self, fmt):
+        raw = ("\U0001F600" * 1500) + "**bold after emoji**" + ("\U0001F389" * 1500)
+        for chunk in _split(fmt, raw):
+            assert utf16_len(chunk) <= MAX
+            assert _unclosed(chunk) == []
+
+    @pytest.mark.parametrize("max_length", [0, 1, 2, 12])
+    def test_degenerate_max_length_does_not_hang(self, fmt, max_length):
+        chunks = _split(fmt, "**bold text** and more " * 20, max_length=max_length)
+        assert chunks, "must always make progress"

--- a/tests/gateway/test_telegram_inline_entity_split.py
+++ b/tests/gateway/test_telegram_inline_entity_split.py
@@ -1,0 +1,275 @@
+"""Tests for MarkdownV2 inline-entity balance across truncate_message chunks.
+
+The problem (issue #52093): ``truncate_message`` guards triple-backtick fences
+and inline code spans when picking a split point, but nothing else.  When a
+boundary lands inside ``*bold*``, ``_italic_``, ``~strike~`` or ``||spoiler||``,
+each chunk carries an unpaired delimiter, Telegram rejects the message with
+"can't parse entities", and the adapter falls back to plain text - silently
+stripping formatting from the whole response.
+
+Trigger conditions (both required, which is why this is rarely seen):
+
+  1. No newline in the second half of the region, so the splitter falls back
+     from ``region.rfind("\\n")`` to ``region.rfind(" ")``.  Every inline
+     entity ``format_message`` emits is newline-free by construction (bold /
+     strike / spoiler use ``.``, italic uses ``[^*\\n]+``), so a newline
+     boundary is ALWAYS entity-safe.
+  2. The chosen space falls *inside* an entity, i.e. the span contains
+     internal spaces.  A span without them is skipped over harmlessly.
+
+These tests drive the real production pipeline - ``TelegramAdapter.format_message``
+followed by ``truncate_message(..., len_fn=utf16_len)`` - because the markers
+that reach the splitter are the *converted* ones (``**bold**`` becomes
+``*bold*``, ``*italic*`` becomes ``_italic_``, ``~~strike~~`` becomes
+``~strike~``), not the markdown the model wrote.
+"""
+
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, utf16_len
+
+# The behavioural tests below deliberately do NOT depend on this helper, so
+# they express the delivery contract and fail (rather than error) against an
+# unguarded splitter.  Only the scanner unit tests need it.
+try:
+    from gateway.platforms.base import _open_inline_entities
+except ImportError:  # pragma: no cover - pre-guard tree
+    _open_inline_entities = None
+
+
+def _ensure_telegram_mock():
+    """Mock the telegram package if it's not installed."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+MAX = 4096
+
+# (markdown the model writes, delimiter format_message emits, label)
+MARKERS = [
+    ("**", "*", "bold"),
+    ("*", "_", "italic"),
+    ("~~", "~", "strike"),
+    ("||", "||", "spoiler"),
+]
+
+
+@pytest.fixture()
+def fmt():
+    """The real Telegram markdown -> MarkdownV2 converter."""
+    return TelegramAdapter(PlatformConfig(enabled=True, token="test-token")).format_message
+
+
+# ── oracle ────────────────────────────────────────────────────────────────
+# Deliberately implemented differently from _open_inline_entities (regex
+# stripping + parity counting, rather than a stateful scan) so these tests do
+# not merely assert the implementation against itself.
+
+def _unclosed(text: str) -> list:
+    s = re.sub(r"\\.", "", text, flags=re.S)      # escaped chars are literals
+    s = re.sub(r"```.*?```", "", s, flags=re.S)   # fenced blocks
+    s = re.sub(r"`[^`]*`", "", s)                 # inline code spans
+    bad = []
+    if s.count("||") % 2:
+        bad.append("||")
+    s = s.replace("||", "")
+    for m in ("*", "_", "~"):
+        if s.count(m) % 2:
+            bad.append(m)
+    return bad
+
+
+def _forced_boundary(md_marker: str) -> str:
+    """Source whose formatted form puts a space-containing span across 4096."""
+    return ("x" * 3900 + md_marker + ("word inside span " * 60) + md_marker
+            + " tail" + " z" * 1500)
+
+
+def _split(fmt, raw, max_length=MAX):
+    return BasePlatformAdapter.truncate_message(fmt(raw), max_length, len_fn=utf16_len)
+
+
+def _content(chunks) -> str:
+    """Whitespace- and delimiter-free view, for content-preservation checks."""
+    joined = "".join(re.sub(r" \(\d+/\d+\)$", "", c) for c in chunks)
+    joined = re.sub(r"\\(.)", r"\1", joined)
+    for tok in ("```", "||", "*", "_", "~", "`"):
+        joined = joined.replace(tok, "")
+    return re.sub(r"\s+", "", joined)
+
+
+# ── the scanner ───────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(_open_inline_entities is None,
+                    reason="inline-entity scanner not present in this tree")
+class TestOpenInlineEntities:
+    def test_balanced_span_reports_nothing(self):
+        assert _open_inline_entities("a *bold* b") == []
+
+    @pytest.mark.parametrize("delim", ["*", "_", "~", "||"])
+    def test_unclosed_delimiter_reported(self, delim):
+        assert _open_inline_entities("text %sopen" % delim) == [delim]
+
+    def test_escaped_delimiter_is_literal(self):
+        assert _open_inline_entities(r"a \* literal star") == []
+
+    def test_delimiters_inside_inline_code_ignored(self):
+        assert _open_inline_entities("before `a * b` after") == []
+
+    def test_delimiters_inside_fence_ignored(self):
+        assert _open_inline_entities("```\na * b _ c\n```") == []
+
+    def test_nesting_is_outermost_first(self):
+        assert _open_inline_entities("||spoiler *bold") == ["||", "*"]
+
+    def test_spoiler_matched_before_single_pipe(self):
+        assert _open_inline_entities("||x||") == []
+
+    def test_initial_state_is_carried(self):
+        assert _open_inline_entities("still bold", initial=["*"]) == ["*"]
+
+
+# ── the regression: real pipeline, every marker type ──────────────────────
+
+class TestFormatThenTruncate:
+    @pytest.mark.parametrize("md,delim,label", MARKERS, ids=[m[2] for m in MARKERS])
+    def test_span_across_boundary_stays_balanced(self, fmt, md, delim, label):
+        chunks = _split(fmt, _forced_boundary(md))
+        assert len(chunks) > 1, "expected a multi-chunk split for this fixture"
+        for i, chunk in enumerate(chunks, 1):
+            assert _unclosed(chunk) == [], (
+                "chunk %d/%d has unpaired %s delimiter(s) %s; Telegram would "
+                "reject it and strip formatting"
+                % (i, len(chunks), label, _unclosed(chunk))
+            )
+
+    @pytest.mark.parametrize("md,delim,label", MARKERS, ids=[m[2] for m in MARKERS])
+    def test_chunks_respect_the_cap(self, fmt, md, delim, label):
+        for chunk in _split(fmt, _forced_boundary(md)):
+            assert utf16_len(chunk) <= MAX
+
+    @pytest.mark.parametrize("md,delim,label", MARKERS, ids=[m[2] for m in MARKERS])
+    def test_no_content_lost_or_duplicated(self, fmt, md, delim, label):
+        raw = _forced_boundary(md)
+        assert _content(_split(fmt, raw)) == _content([fmt(raw)])
+
+
+# ── the defect that sank the previous attempt (#52096) ────────────────────
+
+class TestOverlongEntity:
+    """An entity longer than one whole chunk.
+
+    Rewinding the split point cannot fix this: after moving the boundary
+    before the opener, the next chunk starts *at* the opener with no preceding
+    whitespace, so a later boundary splits it anyway.  Closing and reopening
+    has no such limit.
+    """
+
+    def test_entity_spanning_several_chunks(self, fmt):
+        raw = "y" * 200 + "**" + ("long bold body " * 900) + "**" + " end"
+        chunks = _split(fmt, raw)
+        assert len(chunks) >= 3, "fixture should span at least three chunks"
+        for i, chunk in enumerate(chunks, 1):
+            assert _unclosed(chunk) == [], "chunk %d/%d unbalanced" % (i, len(chunks))
+
+    def test_overlong_entity_terminates(self, fmt):
+        # A span with no spaces at all: the space fallback cannot help, so the
+        # splitter hard-cuts.  Must still terminate and stay balanced.
+        raw = "**" + ("b" * 9000) + "**"
+        chunks = _split(fmt, raw)
+        assert chunks
+        for chunk in chunks:
+            assert _unclosed(chunk) == []
+
+
+# ── the streaming overflow branch ────────────────────────────────────────
+
+class TestStreamingOverflowPreview:
+    """The mid-stream preview delegates to the same splitter, so it inherits
+    the guard rather than needing its own.
+
+    ``_truncate_stream_overflow_preview`` returns ``truncate_message(...)[0]``
+    (it deliberately takes only the head chunk, because splitting a preview
+    would move the active message id and re-trigger the overflow cycle,
+    #48648).  Before this change that head chunk could carry an unpaired
+    delimiter exactly like any other chunk.
+    """
+
+    def test_preview_head_chunk_is_balanced(self, fmt):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+        preview = adapter._truncate_stream_overflow_preview(fmt(_forced_boundary("**")))
+        assert utf16_len(preview) <= MAX
+        assert _unclosed(preview) == [], (
+            "streaming preview carries an unpaired delimiter %s" % _unclosed(preview))
+
+    def test_consumer_split_delegates_to_the_adapter(self):
+        """Guard the delegation itself: if the consumer stopped calling the
+        adapter's truncate_message, the fix would silently stop covering the
+        streaming path."""
+        from gateway.stream_consumer import GatewayStreamConsumer
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+        consumer = GatewayStreamConsumer.__new__(GatewayStreamConsumer)
+        consumer.adapter = adapter
+        formatted = adapter.format_message(_forced_boundary("**"))
+        with patch.object(
+            adapter, "truncate_message", wraps=adapter.truncate_message,
+        ) as truncate:
+            chunks = consumer._truncate_for_stream(formatted, MAX, utf16_len)
+        truncate.assert_called_once_with(formatted, MAX, len_fn=utf16_len)
+        assert all(_unclosed(chunk) == [] for chunk in chunks)
+
+
+
+# ── nothing already working may regress ──────────────────────────────────
+
+class TestNoRegression:
+    def test_newline_rich_text_unaffected(self, fmt):
+        raw = "\n".join("Line %03d with **bold phrase** trailing." % i for i in range(200))
+        for chunk in _split(fmt, raw):
+            assert _unclosed(chunk) == []
+
+    def test_short_message_passes_through_untouched(self, fmt):
+        formatted = fmt("a **short** message")
+        assert BasePlatformAdapter.truncate_message(
+            formatted, MAX, len_fn=utf16_len) == [formatted]
+
+    def test_fenced_block_still_closed_and_reopened(self, fmt):
+        raw = "intro\n```python\n" + ("print('x' * 3)\n" * 400) + "```\nouttro"
+        chunks = _split(fmt, raw)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert chunk.count("```") % 2 == 0, "fence parity broken"
+
+    def test_inline_code_across_boundary(self, fmt):
+        raw = "z" * 3900 + " `inline code span here` " + "q" * 2000
+        for chunk in _split(fmt, raw):
+            assert _unclosed(chunk) == []
+
+    def test_surrogate_pairs_counted_in_utf16(self, fmt):
+        raw = ("\U0001F600" * 1500) + "**bold after emoji**" + ("\U0001F389" * 1500)
+        for chunk in _split(fmt, raw):
+            assert utf16_len(chunk) <= MAX
+            assert _unclosed(chunk) == []
+
+    @pytest.mark.parametrize("max_length", [0, 1, 2, 12])
+    def test_degenerate_max_length_does_not_hang(self, fmt, max_length):
+        chunks = _split(fmt, "**bold text** and more " * 20, max_length=max_length)
+        assert chunks, "must always make progress"


### PR DESCRIPTION
## What does this PR do?

`truncate_message()` guards triple-backtick fences and inline code spans when choosing a split point, but nothing else. When a chunk boundary lands inside `*bold*`, `_italic_`, `~strike~` or `||spoiler||`, both chunks carry an unpaired delimiter, Telegram rejects them with "can't parse entities", and the adapter falls back to plain text — stripping formatting from the entire response.

The fix carries inline entity state across chunks exactly the way the language tag is already carried for fences: close whatever is still open at the boundary, reopen it at the start of the next chunk.

**Why close/reopen rather than rewinding the split point.** @teknium1's review of #52096 noted that a rewind "cannot handle an entity longer than one chunk: after moving the split before its opener, the next `remaining` begins at that opener, so there is no preceding whitespace to select and a later chunk can still split the entity." Close/reopen has no such limit — an entity spanning four chunks is simply closed and reopened three times, and each chunk is independently parseable. This is also the mechanism the function already uses for fences, so it adds no new concept.

**Why this is rarely reported.** The trigger is narrower than the issue suggests, and worth recording. The splitter takes `region.rfind("\n")` and only falls back to `region.rfind(" ")` when that newline sits in the first half. Every inline entity `format_message` emits is **newline-free by construction** (bold, strike and spoiler use `.`, which excludes newlines; italic is explicitly `[^*\n]+`). So a newline boundary is *always* entity-safe, and normal newline-rich prose can never hit this. It takes **both** a region with no newline in its second half **and** a span containing internal spaces for the chosen space to land inside an entity. A span without internal spaces does not reproduce it — the fallback lands harmlessly before the opener.

Credit to @liuhao1024 in #52096 for isolating the failure; this takes the different approach the review asked for.

## Related Issue

Fixes #52093

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`:
  - New module-level `_INLINE_MARKERS` and `_open_inline_entities()`. The scanner walks text honouring backslash escapes (`\*` is a literal asterisk) and skipping fenced blocks and code spans, where these characters carry no formatting meaning. Returns the open stack outermost-first so closing in reverse and reopening forward round-trips the nesting.
  - `truncate_message()` gains `carry_inline` alongside `carry_lang`, mutually exclusive because inline markers are literal inside a fence. Open delimiters are closed on the current chunk and reopened via the next chunk's prefix.
  - A redundant closer sitting at the head of the next chunk is consumed, so reopening-only-to-close-again never emits an empty entity like `**`.
  - `INLINE_RESERVE = 8` of headroom for the closers, mirroring the existing unconditional `FENCE_CLOSE` and `INDICATOR_RESERVE` reserves. This shifts boundaries by up to 8 units; content is unaffected.
  - The final-chunk branch also closes anything still open, so a source that was already unbalanced can't emit an unparseable tail.
- `tests/gateway/test_telegram_inline_entity_split.py`: new, 36 tests.

## Addressing the review feedback on #52096

All three points from @teknium1's review:

1. **"The added rewind cannot handle an entity longer than one chunk."** Solved by design rather than patched around — see above. Covered by `TestOverlongEntity`, including a 9,000-character span with no spaces at all, where the space fallback cannot help and the splitter must hard-cut. Every chunk still comes out balanced and the loop still terminates.

2. **"The proposed tests bypass the production formatter."** These tests call the real `TelegramAdapter.format_message` and then the real `truncate_message(..., len_fn=utf16_len)`. That matters exactly as you said: the delimiters reaching the splitter are the converted ones (`**bold**` → `*bold*`, `*italic*` → `_italic_`, `~~strike~~` → `~strike~`), not the markdown the model wrote. Every marker type is parametrised over a forced boundary. The balance oracle in the test file is deliberately implemented differently from `_open_inline_entities` (regex stripping plus parity counting, not a stateful scan) so the tests don't assert the implementation against itself.

3. **"Active-preview overflow also bypasses `truncate_message`."** Assessed, and it turns out to inherit the fix rather than need its own. `_truncate_stream_overflow_preview()` returns `self.truncate_message(content, MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]` — it takes only the head chunk deliberately, because splitting a preview would move the active message id and re-trigger the overflow cycle (#48648). That head chunk previously could carry an unpaired delimiter like any other; now it can't. `GatewayStreamConsumer` likewise delegates to `getattr(self.adapter, "truncate_message", None)`, falling back to `_split_text_chunks` only for non-base adapters and test doubles. `TestStreamingOverflowPreview` covers both: one test asserts the preview head chunk is balanced, and one guards the delegation itself so the streaming path can't silently stop being covered.

## How to Test

```bash
# 1. The new tests pass with the fix
pytest tests/gateway/test_telegram_inline_entity_split.py -q
# 36 passed

# 2. They genuinely catch the bug — revert just the source change and rerun
git stash push -- gateway/platforms/base.py
pytest tests/gateway/test_telegram_inline_entity_split.py -q
# 8 failed, 17 passed, 11 skipped
#   - test_span_across_boundary_stays_balanced[bold|italic|strike|spoiler]
#   - TestOverlongEntity::test_entity_spanning_several_chunks
#   - TestOverlongEntity::test_overlong_entity_terminates
#   - TestStreamingOverflowPreview::test_preview_head_chunk_is_balanced
#   - TestNoRegression::test_surrogate_pairs_counted_in_utf16
git stash pop

# 3. No regressions across the gateway suite
pytest tests/gateway -q --continue-on-collection-errors
```

Gateway suite, same machine, before and after:

| | result |
|---|---|
| baseline (unpatched, new file excluded) | 26 failed, **4783 passed**, 39 skipped, 1 xfailed |
| with this PR | 26 failed, **4817 passed**, 39 skipped, 1 xfailed |

The +34 are this PR's tests. Diffing the two `FAILED` lists gives an empty set in the regression direction: the same 26 pre-existing failures occur both ways (`test_whatsapp_bridge_pidfile.py` and friends, environment-dependent and unrelated to this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #52096 is the prior attempt on the same issue and is addressed above. #48237 (fence parity) and #11287 (MessageEntity-based sending) touch the same code path but are complementary; if #11287 lands, MarkdownV2 chunking stops mattering and this guard becomes redundant.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **scoped, see note.** I ran `tests/gateway` in full (4,866 collected) plus the specific suites that exercise `truncate_message` (`test_code_fence_tracking`, `test_platform_base`, `test_telegram_reply_mode`, `test_feishu`, `test_mattermost`: 192 passed, 19 skipped). I did not run the entire `tests/` tree, so I'm leaving this unticked rather than claiming it.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.6), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the `truncate_message` docstring now documents the inline-entity carry alongside the existing fence carry; `_open_inline_entities` carries its own docstring including the `__underline__` note below. No user-facing docs affected.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, pure string handling with no platform-dependent behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Known limitation

`__underline__` is seen as two `_` toggles and therefore nets to balanced, which is correct for a whole span but means a split *inside* one is not protected. `format_message` never emits underline, so this isn't reachable today; it's noted in the helper's docstring so it doesn't become a silent gap if underline conversion is added later.
