### PR TITLE
fix(status): redact home-channel identifiers

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -41,6 +41,11 @@ def redact_key(key: str) -> str:
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
+def _redacted_home_channel(value: str) -> str:
+    """Mask message delivery targets in shareable status output."""
+    return "[redacted]" if value else ""
+
+
 def _format_iso_timestamp(value) -> str:
     """Format ISO timestamps for status output, converting to local timezone."""
     if not value or not isinstance(value, str):
@@ -466,7 +471,7 @@ def show_status(args):
         
         status = "configured" if has_token else "not configured"
         if home_channel:
-            status += f" (home: {home_channel})"
+            status += f" (home: {_redacted_home_channel(home_channel)})"
         
         print(f"  {name:<12}  {check_mark(has_token)} {status}")
 

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -158,6 +158,25 @@ def _base_xai_mocks(monkeypatch, tmp_path):
     return status_mod
 
 
+def test_show_status_redacts_home_channel_identifiers(monkeypatch, capsys, tmp_path):
+    """Shareable status output must not expose message delivery targets."""
+    status_mod = _base_xai_mocks(monkeypatch, tmp_path)
+    telegram_chat_id = "-1001234567890"
+    email_address = "operator@example.test"
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", telegram_chat_id)
+    monkeypatch.setenv("EMAIL_ADDRESS", email_address)
+    monkeypatch.setenv("EMAIL_HOME_ADDRESS", email_address)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert telegram_chat_id not in output
+    assert email_address not in output
+    assert output.count("home: [redacted]") >= 2
+
+
 class TestShowStatusXaiOAuth:
     """xAI OAuth row in hermes status."""
 


### PR DESCRIPTION
### Summary

- mask configured messaging home-channel destinations in `hermes status`;
- keep configuration visibility with a `(home: [redacted])` marker;
- add a regression covering both a numeric chat ID and an email delivery address.

### Problem

`hermes status` currently prints raw values such as `TELEGRAM_HOME_CHANNEL` and `EMAIL_HOME_ADDRESS`. These identifiers are operational PII and can be copied unintentionally when status output is shared in chats, tickets, or support bundles.

### Scope

This only changes the built-in messaging-platform rows in `hermes status`. It does not change credentials, provider status, gateway lifecycle state, platform configuration, or message delivery.

### Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_status.py -q` — 11 passed
- neighboring CLI status/redaction suites — 92 passed
- touched-file Ruff and Ty
- repository-wide differential lint — 0 new Ruff/Ty diagnostics
- real CLI smoke with a temporary Hermes home
- Windows-footgun scan and `git diff --check`
