### PR TITLE
fix(buzz): recover replies with unresolved mentions

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -46,7 +46,7 @@ import time
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -88,6 +88,10 @@ from gateway.config import Platform
 # returns housekeeping kinds (joins, canvas updates, …) — only kind 9 is
 # dispatched to the agent.
 _CHAT_KIND = 9
+_MENTION_RECOVERY_LIMIT = 5
+_REJECTED_MENTION_RE = re.compile(
+    r"mention ['\"](?P<token>@.+?)['\"] (?:does not match a current channel member|is ambiguous)"
+)
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
@@ -344,6 +348,46 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _neutralize_rejected_mention(content: str, error: str) -> Optional[str]:
+    """Render one rejected ``@Name`` as prose so the next CLI preflight can proceed."""
+    match = _REJECTED_MENTION_RE.search(error or "")
+    if not match:
+        return None
+    token = match.group("token")
+    if token not in content:
+        return None
+    core = token.rstrip(".,!?;:")
+    suffix = token[len(core):]
+    if not core:
+        return None
+    return content.replace(token, f"`{core}`{suffix}")
+
+
+async def _send_with_mention_recovery(
+    execute: Callable[[str, Optional[str]], Awaitable[Tuple[int, str, str]]],
+    content: str,
+    *,
+    reply_author: Optional[str] = None,
+) -> Tuple[int, str, str]:
+    """Retry only CLI-rejected presentation mentions; publishing never occurred."""
+    current = content
+    explicit_mention: Optional[str] = None
+    for attempt in range(_MENTION_RECOVERY_LIMIT + 1):
+        code, out, err = await execute(current, explicit_mention)
+        if code == 0:
+            return code, out, err
+        revised = _neutralize_rejected_mention(current, err)
+        if revised is None or attempt == _MENTION_RECOVERY_LIMIT:
+            return code, out, err
+        if reply_author and explicit_mention is None:
+            explicit_mention = reply_author
+            logger.warning("Buzz: retrying rejected presentation mention with reply recipient")
+            continue
+        logger.warning("Buzz: neutralizing unresolved presentation mention before retry")
+        current = revised
+    raise AssertionError("unreachable")
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -435,6 +479,10 @@ class BuzzAdapter(BasePlatformAdapter):
         # classification (see _may_reclassify_as_dm).
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
+        # Inbound message id -> author pubkey. Outbound replies use this to
+        # supply the CLI's explicit mention identity, which both notifies the
+        # requester and permits unrelated @words in generated prose.
+        self._reply_authors: OrderedDict[str, str] = OrderedDict()
         self._poll_count = 0
 
     @property
@@ -595,6 +643,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
         self._channel_state = {}
+        self._reply_authors.clear()
         self._poll_count = 0
 
     # ── Sending ───────────────────────────────────────────────────────────
@@ -609,10 +658,21 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        source_message_id = reply_to or (metadata or {}).get("thread_id")
+        reply_target = source_message_id
+        reply_author = (
+            self._reply_authors.get(str(source_message_id)) if source_message_id else None
+        )
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
+        code, out, err = await _send_with_mention_recovery(
+            lambda revised, mention: self._run_cli(
+                args + (["--mention", mention] if mention else []),
+                input_text=revised,
+            ),
+            content,
+            reply_author=reply_author,
+        )
         if code != 0:
             return SendResult(
                 success=False,
@@ -681,9 +741,20 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
+            source_message_id = reply_to or (metadata or {}).get("thread_id")
+            reply_author = (
+                self._reply_authors.get(str(source_message_id)) if source_message_id else None
+            )
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
+            code, out, err = await _send_with_mention_recovery(
+                lambda revised, mention: self._run_cli(
+                    args + (["--mention", mention] if mention else []),
+                    input_text=revised,
+                ),
+                caption or "",
+                reply_author=reply_author,
+            )
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
             try:
@@ -1042,6 +1113,11 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
             return
 
+        self._reply_authors[event_id] = pubkey
+        self._reply_authors.move_to_end(event_id)
+        while len(self._reply_authors) > _SEEN_CAP:
+            self._reply_authors.popitem(last=False)
+
         # Strip a leading @mention so slash commands (@Chip /whoami ->
         # /whoami) and clean prompts are recognized. DM messages often still
         # open with "@Chip" even though no mention is required there, so the
@@ -1391,8 +1467,15 @@ async def _standalone_send(
     for path in media_files or []:
         args += ["--file", str(path)]
     try:
-        code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+        code, out, err = await _send_with_mention_recovery(
+            lambda revised, _mention: _exec_buzz(
+                cli_path,
+                args,
+                relay_url=relay,
+                private_key=private_key,
+                input_text=revised,
+            ),
+            message,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -104,6 +104,19 @@ class _ScriptedCli:
 # ── bech32 / identity helpers ─────────────────────────────────────────────
 
 
+def _rejected_mention_error(token="@mentioned."):
+    return json.dumps(
+        {
+            "error": "user_error",
+            "message": (
+                f"mention '{token}' does not match a current channel member; "
+                "retry with --mention <pubkey>"
+            ),
+            "retryable": False,
+        }
+    )
+
+
 class TestBech32Helpers:
 
     def test_hex_to_npub_known_pair(self):
@@ -407,6 +420,82 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_reply_supplies_triggering_author_as_explicit_mention(self):
+        adapter = _make_adapter()
+        state = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        adapter._channel_state[CHANNEL] = state
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=_rejected_mention_error(),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
+        adapter._run_cli = cli
+
+        await adapter._handle_event(
+            CHANNEL,
+            state,
+            _event("trigger", content="@Chip explain what happens when you are @mentioned"),
+        )
+        result = await adapter.send(
+            CHANNEL,
+            "You are notified when you are @mentioned.",
+            reply_to="trigger",
+        )
+
+        assert result.success is True
+        send_calls = [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert "--mention" not in send_calls[0][0]
+        assert send_calls[1][0][send_calls[1][0].index("--mention") + 1] == OTHER_PUBKEY
+        assert [stdin for _args, stdin in send_calls] == [
+            "You are notified when you are @mentioned.",
+            "You are notified when you are @mentioned.",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_neutralizes_only_rejected_presentation_mention(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=_rejected_mention_error(),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt125", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "You are @mentioned. Ask @Chip for help.")
+
+        assert result.success is True
+        send_calls = [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert len(send_calls) == 2
+        assert send_calls[0][1] == "You are @mentioned. Ask @Chip for help."
+        assert send_calls[1][1] == "You are `@mentioned`. Ask @Chip for help."
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_retry_unrelated_cli_error(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=json.dumps({"error": "relay_error", "message": "relay unavailable"}),
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "You are @mentioned.")
+
+        assert result.success is False
+        assert len([call for call in cli.calls if call[0][:2] == ["messages", "send"]]) == 1
+
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -420,6 +509,41 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_image_reply_supplies_triggering_author(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        state = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        adapter._channel_state[CHANNEL] = state
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=_rejected_mention_error(),
+        )
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt126", "message": ""})
+        adapter._run_cli = cli
+        await adapter._handle_event(CHANNEL, state, _event("image-trigger", content="@Chip show it"))
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="Diagram of being @mentioned.",
+            reply_to="image-trigger",
+        )
+
+        assert result.success is True
+        send_calls = [call for call in cli.calls if call[0][:2] == ["messages", "send"]]
+        assert "--mention" not in send_calls[0][0]
+        assert send_calls[1][0][send_calls[1][0].index("--mention") + 1] == OTHER_PUBKEY
+        assert [stdin for _args, stdin in send_calls] == [
+            "Diagram of being @mentioned.",
+            "Diagram of being @mentioned.",
+        ]
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -537,4 +661,39 @@ class TestStandaloneSend:
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_recovers_rejected_presentation_mention(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
 
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            calls.append((list(args), input_text))
+            if len(calls) == 1:
+                return (
+                    1,
+                    "",
+                    _rejected_mention_error(),
+                )
+            return 0, json.dumps({"accepted": True, "event_id": "evt-cron"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "Cron explains when you are @mentioned.",
+        )
+
+        assert result == {"success": True, "message_id": "evt-cron"}
+        assert [text for _args, text in calls] == [
+            "Cron explains when you are @mentioned.",
+            "Cron explains when you are `@mentioned`.",
+        ]


### PR DESCRIPTION
## What does this PR do?

Prevents the Buzz platform from silently losing a generated reply when its prose contains an `@token` that is not a current channel member.

The Buzz CLI intentionally rejects unresolved presentation mentions unless the caller supplies an explicit mention identity. The adapter previously retried the same rejected text through the gateway's generic plain-text fallback, so the user received no reply.

This change keeps the CLI's strict preflight as the first attempt. If that preflight rejects an unresolved or ambiguous presentation mention:

- replies retry with the authenticated triggering user's pubkey as `--mention`, preserving the generated text and notifying the requester
- sends without a known recipient neutralize only the rejected token as inline code and retry
- cron delivery and local-image captions use the same bounded recovery path
- unrelated CLI failures do not retry

Inbound message IDs are mapped only after the existing mention and allow-list gates, and the bounded map is cleared on disconnect.

## Related Issue

Fixes #78797

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add bounded, error-specific mention recovery to `plugins/platforms/buzz/adapter.py`
- Preserve reply text by retrying with the triggering user's authenticated pubkey
- Add the same recovery to local-image captions and standalone Buzz cron delivery
- Add behavior tests for reply preservation, token neutralization, image captions, cron delivery, and unrelated-error handling

## How to Test

1. Configure the Buzz platform and prompt Hermes to produce a reply containing ordinary prose such as `when you are @mentioned`.
2. Confirm the reply arrives with the original text and a `p` tag for the triggering user.
3. Run `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64 and a dedicated Linux Fly Machine

The canonical full-suite runner completed all discovered files. It reported 70 failures in 29 unrelated files under this local optional-dependency and macOS environment. Re-running those exact 29 files on untouched `origin/main` reproduced the baseline failures. The changed Buzz test file passes 28/28.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public configuration or usage changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — no platform-specific code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Validation

- `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py -q`: 28 passed
- Ruff on both changed files: passed
- Ty on both changed files: no new diagnostics compared with `origin/main`
- `git diff --check`: passed
- Live Fly-to-Buzz test: one reply arrived, its raw `@mentioned` prose was preserved, and the requester was p-tagged. The message made it through the wire.
