### PR TITLE
docs: fix TUI workspace commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,16 +464,18 @@ Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. Se
 
 ### Dev Commands
 
+Run these from the repository root. The script names are defined in
+`ui-tui/package.json` and selected through npm's workspace flag:
+
 ```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
+npm install                            # first time; installs workspace dependencies
+npm run --workspace ui-tui dev         # watch mode (rebuilds hermes-ink + tsx --watch)
+npm start --workspace ui-tui           # production
+npm run --workspace ui-tui build       # full build (hermes-ink + tsc)
+npm run --workspace ui-tui typecheck   # typecheck only (tsc --noEmit)
+npm run --workspace ui-tui lint        # eslint
+npm run --workspace ui-tui fmt         # prettier
+npm test --workspace ui-tui            # vitest
 ```
 
 ### TUI in the Dashboard (`hermes dashboard` → `/chat`)


### PR DESCRIPTION
## Summary

- Run TUI package commands from the repository root through npm's `ui-tui` workspace selector.
- Make `ui-tui/package.json` explicit as the source of the documented script names.

## Verification

- Manifest/document assertion confirmed `dev`, `start`, `build`, `typecheck`, `lint`, `fmt`, and `test` all exist and are documented with workspace-scoped invocations.
- `npm run --workspace ui-tui build`
- `npm run --workspace ui-tui typecheck`
- `npm run --workspace ui-tui lint` (0 errors; 1 pre-existing warning)
- `npm test --workspace ui-tui -- --exclude src/lib/editor.test.ts --exclude src/__tests__/terminalParity.test.ts --exclude src/__tests__/terminalSetup.test.ts` (1,492 passed; 8 skipped)
- `git diff --check origin/main...HEAD`

The full `npm run --workspace ui-tui check` was also attempted. Its test phase reported eight Windows-only failures in the three excluded suites; those files are unrelated to this documentation-only diff. The remaining suite passed, and Linux CI remains authoritative for the full test run.

## Base

- Final base: `origin/main` at `acb590fc4aa1ae6336e799b498f364ccb964e26e`
- Base distance before push: 0 commits behind

## Scope

Documentation only: `AGENTS.md`.
