### PR TITLE
fix(memory): remove workflow commands from TRIVIAL_PROMPT_RE (#79343)

### DIFF
--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 TRIVIAL_PROMPT_RE = re.compile(
     r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
     r'hi|hey|hello|yo|sup|'
-    r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)'
+    r'got it|cool|nice|great)'
     r'[\s!?.:;,"' + "'" + r'~\u2018\u2019\u201c\u201d\u2014\u2013\u2026()\[\]{}<>*&^%$#@!+=`\u00a0]*$',
     re.IGNORECASE,
 )

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1147,7 +1147,7 @@ class TestTrivialPromptClassifier:
         from agent.memory_provider import is_trivial_prompt
 
         for t in ("hi", "HI!", "hey.", "hello", "yo", "sup~", "thanks :)",
-                  "done???", "ok", "yes.", "k", "", "   ", "/help", "lgtm"):
+                  "ok", "yes.", "", "   ", "/help", "cool", "nice", "great", "got it"):
             assert is_trivial_prompt(t), f"expected trivial: {t!r}"
 
     def test_substantive_and_prefix_collisions_pass_through(self):
@@ -1156,5 +1156,7 @@ class TestTrivialPromptClassifier:
         # Words that merely START with a trivial word must not match.
         for t in ("k8s", "yolo", "hive", "note", "supper", "hind",
                   "hello world", "ok so what's next", "what's my name",
-                  "hey can you check the logs", "continue the migration plan"):
+                  "hey can you check the logs", "continue the migration plan",
+                  # Workflow commands should NOT be treated as trivial
+                  "continue", "next", "proceed", "go ahead", "do it", "done", "lgtm", "k"):
             assert not is_trivial_prompt(t), f"expected non-trivial: {t!r}"


### PR DESCRIPTION
Closes #79343

## What does this PR do?

Removes mid-task workflow commands from `TRIVIAL_PROMPT_RE` in `agent/memory_provider.py`.
The removed words are: `continue`, `next`, `proceed`, `go ahead`, `do it`, `done`, `lgtm`, `k`.

These commands were being treated as "trivial" (skipping memory provider prefetch/injection), when they are actually meaningful turns where provider context (user preferences, earlier decisions, project context) is most useful.

## Root cause

`TRIVIAL_PROMPT_RE` had workflow commands in the same alternation as greetings/acknowledgements. The `is_trivial_prompt()` gate is the single source of truth for both the core prefetch gate and provider-side classifiers — so one over-wide list suppressed recall at every layer.

## Changes

- `agent/memory_provider.py` — removed `continue|go ahead|do it|proceed|done|next|lgtm|k` from the regex, keeping only greetings and pure acknowledgements (`got it|cool|nice|great`)
- `tests/agent/test_memory_provider.py` — updated `TestTrivialPromptClassifier` to reflect new trivial/non-trivial classification
