### PR TITLE
fix(memory): log init failures and surface memory-full to user (#79472)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1688,7 +1688,7 @@ def init_agent(
                 )
                 agent._memory_store.load_from_disk()
         except Exception:
-            pass  # Memory is optional -- don't break agent init
+            logger.warning("Memory store init failed — agent running without memory", exc_info=True)
     
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1620,6 +1620,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_call_id=getattr(tool_call, "id", None),
                         ),
                     )
+                # Surface memory-full / consolidation failure to the user.
+                # The tool result is only seen by the model; without this the
+                # user has no idea writes are being silently dropped.
+                try:
+                    parsed = json.loads(result) if isinstance(result, str) else result
+                    if isinstance(parsed, dict) and not parsed.get("success") and parsed.get("done"):
+                        usage = parsed.get("usage", "unknown")
+                        agent._emit_warning(
+                            f"Memory write rejected ({usage}). Consolidate entries or raise memory.memory_char_limit."
+                        )
+                except Exception:
+                    pass
                 return result
             function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                 agent,


### PR DESCRIPTION
Closes #79472

## What does this PR do?

Two memory-user-visible fixes from issue #79472:

### Patch 1: Log memory init failures

In `agent/agent_init.py`, the bare `except Exception: pass` around memory store initialization silently swallowed all errors. Now logs a warning with exception details so operators can diagnose why memory is unavailable.

### Patch 2: Surface memory-full to user

In `agent/tool_executor.py`, when the memory tool returns a failure result (memory full, char limit reached), emit a warning via `_emit_warning()` so the user sees "⚠️ Memory write rejected (98% — N/M chars). Consolidate entries or raise memory.memory_char_limit." instead of silent drop.

Previously, the user would see no indication that their memory writes were being silently dropped after the model tried and failed 3 times.
