### PR TITLE
fix(test): read add_contributor.py with explicit UTF-8 encoding

### DIFF
--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -100,7 +100,12 @@ def test_cli_entrypoint_end_to_end(tmp_path):
     scripts = tmp_path / "scripts"
     scripts.mkdir()
     for name in ("add_contributor.py",):
-        (scripts / name).write_text((SCRIPTS_DIR / name).read_text())
+        # Explicit encoding: add_contributor.py contains UTF-8 multi-byte
+        # characters (an em dash), so the locale-default read_text() raises
+        # UnicodeDecodeError on non-UTF-8 Windows locales (e.g. cp950).
+        (scripts / name).write_text(
+            (SCRIPTS_DIR / name).read_text(encoding="utf-8"), encoding="utf-8"
+        )
     # Minimal stub release.py so the legacy lookup import works
     (scripts / "release.py").write_text("LEGACY_AUTHOR_MAP = {}\n")
     proc = subprocess.run(
@@ -109,5 +114,5 @@ def test_cli_entrypoint_end_to_end(tmp_path):
         cwd=tmp_path, capture_output=True, text=True,
     )
     assert proc.returncode == 0, proc.stderr
-    out = (tmp_path / "contributors" / "emails" / "cli@example.com").read_text()
+    out = (tmp_path / "contributors" / "emails" / "cli@example.com").read_text(encoding="utf-8")
     assert out.splitlines()[0] == "cliperson"


### PR DESCRIPTION
## What

`test_cli_entrypoint_end_to_end` copies `add_contributor.py` with `read_text()` / `write_text()` and no encoding argument, so both fall back to the system locale.

## Why

`add_contributor.py` contains UTF-8 multi-byte characters (an em dash), so the read raises `UnicodeDecodeError` on any non-UTF-8 Windows locale — reproduced on cp950 (Traditional Chinese Windows), where this test fails on every run. The trailing mapping-file read gets the same treatment for symmetry.

Same footgun class as the `subprocess text=True` sweep in #60741, just on the pathlib `read_text`/`write_text` side.

## Verification

`pytest tests/scripts/test_contributor_map.py` — 7/7 pass on a cp950-locale Windows host (previously 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)