### PR TITLE
feat(moa): support explicit per-slot connection info (base_url/api_key/api_mode)

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -346,16 +346,36 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     provider/model on any resolution error so a misconfigured slot still
     attempts the call rather than aborting the whole MoA turn.
 
-    The resolved runtime is cached per (provider, model) with a short TTL
+    A slot may also carry explicit ``base_url`` / ``api_key`` / ``api_mode``
+    keys (inline connection info). These are forwarded to
+    ``resolve_runtime_provider`` as ``explicit_base_url`` / ``explicit_api_key``
+    — the same escape hatch the CLI's runtime resolution already supports — so
+    two slots can reference the same model served by different endpoints (e.g.
+    a primary provider and a mirror) without registering each endpoint as a
+    separate named provider. An explicit slot ``api_mode`` wins over the
+    auto-detected one.
+
+    The resolved runtime is cached per (provider, model, and the slot's
+    explicit connection fields) with a short TTL
     (``_RUNTIME_CACHE_TTL_SECONDS``): the resolution does real I/O (catalog
     query + config read) that used to run serially per create() call before
     the parallel fan-out could start — the dominant source of MoA cold-start
     latency (#66793). The TTL bounds credential staleness (key rotation,
-    base_url edits) instead of caching for the process lifetime.
+    base_url edits) instead of caching for the process lifetime. The
+    connection fields MUST be part of the key: two slots sharing
+    provider+model but differing only in base_url would otherwise collide,
+    and every sibling slot would silently inherit the first slot's endpoint
+    and credentials.
     """
     provider = str(slot.get("provider") or "").strip()
     model = str(slot.get("model") or "").strip()
-    cache_key = (provider, model)
+    cache_key = (
+        provider,
+        model,
+        str(slot.get("base_url") or ""),
+        str(slot.get("api_key") or ""),
+        str(slot.get("api_mode") or ""),
+    )
     now = time.monotonic()
     with _runtime_cache_lock:
         entry = _runtime_cache.get(cache_key)
@@ -367,13 +387,24 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        rt = resolve_runtime_provider(requested=provider, target_model=model)
+        rt = resolve_runtime_provider(
+            requested=provider,
+            target_model=model,
+            explicit_base_url=slot.get("base_url"),
+            explicit_api_key=slot.get("api_key"),
+        )
         if rt.get("base_url"):
             out["base_url"] = rt["base_url"]
         if rt.get("api_key"):
             out["api_key"] = rt["api_key"]
         if rt.get("api_mode"):
             out["api_mode"] = rt["api_mode"]
+        # An explicit slot api_mode overrides the auto-detected one: the
+        # whole point of inline connection info is that the slot author
+        # knows the endpoint's API surface better than the catalog does.
+        slot_api_mode = str(slot.get("api_mode") or "").strip()
+        if slot_api_mode:
+            out["api_mode"] = slot_api_mode
         request_overrides = rt.get("request_overrides")
         if isinstance(request_overrides, dict):
             extra_body = request_overrides.get("extra_body")

--- a/tests/agent/test_moa_cold_start_cache_66793.py
+++ b/tests/agent/test_moa_cold_start_cache_66793.py
@@ -180,8 +180,9 @@ def test_slot_runtime_cache_expires_after_ttl(monkeypatch):
     assert moa._slot_runtime(slot)["api_key"] == "key-1"
     assert calls["n"] == 1
 
-    # Age the entry past the TTL and confirm re-resolution.
-    key = ("openai", "gpt-5")
+    # Age the entry past the TTL and confirm re-resolution. The cache key
+    # includes the slot's explicit connection fields (empty for this slot).
+    key = ("openai", "gpt-5", "", "", "")
     stamped_at, cached = moa._runtime_cache[key]
     moa._runtime_cache[key] = (
         stamped_at - moa._RUNTIME_CACHE_TTL_SECONDS - 1, cached

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -55,6 +55,81 @@ class TestSlotRuntimeApiMode:
         result = _slot_runtime({"provider": "copilot", "model": "gpt-5.5"})
         assert "api_mode" not in result
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_slot_explicit_connection_info_forwarded(self, mock_resolve):
+        """Slot base_url/api_key reach resolve_runtime_provider as explicit_*."""
+        mock_resolve.return_value = {
+            "base_url": "https://mirror.example/v1",
+            "api_key": "mirror-key",
+        }
+        import agent.moa_loop as moa
+        moa._runtime_cache.clear()
+
+        moa._slot_runtime({
+            "provider": "custom", "model": "some-model",
+            "base_url": "https://mirror.example/v1", "api_key": "mirror-key",
+        })
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["explicit_base_url"] == "https://mirror.example/v1"
+        assert kwargs["explicit_api_key"] == "mirror-key"
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_slot_api_mode_overrides_autodetected(self, mock_resolve):
+        """An explicit slot api_mode wins over the resolver's auto-detected one."""
+        mock_resolve.return_value = {
+            "base_url": "https://x.example/v1",
+            "api_key": "k",
+            "api_mode": "chat_completions",
+        }
+        import agent.moa_loop as moa
+        moa._runtime_cache.clear()
+
+        result = moa._slot_runtime({
+            "provider": "custom", "model": "m",
+            "base_url": "https://x.example/v1",
+            "api_mode": "anthropic_messages",
+        })
+        assert result["api_mode"] == "anthropic_messages"
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_slot_runtime_cache_keyed_by_connection_info(self, mock_resolve):
+        """Slots sharing provider+model but differing in base_url/api_key must
+        NOT share a cache entry — otherwise the first slot resolved poisons
+        the cache and every sibling silently inherits its endpoint and
+        credentials.
+        """
+
+        def _echo_explicit(**kwargs):
+            return {
+                "base_url": kwargs.get("explicit_base_url") or "http://catalog",
+                "api_key": kwargs.get("explicit_api_key") or "catalog-key",
+            }
+
+        mock_resolve.side_effect = _echo_explicit
+        import agent.moa_loop as moa
+        moa._runtime_cache.clear()
+
+        slot_a = {
+            "provider": "custom", "model": "shared-model",
+            "base_url": "https://a.example/v1", "api_key": "KEY-A",
+        }
+        slot_b = {
+            "provider": "custom", "model": "shared-model",
+            "base_url": "https://b.example/v1", "api_key": "KEY-B",
+        }
+        result_a = moa._slot_runtime(slot_a)
+        result_b = moa._slot_runtime(slot_b)
+        assert result_a["base_url"] == "https://a.example/v1"
+        assert result_b["base_url"] == "https://b.example/v1"
+        assert result_a["api_key"] == "KEY-A"
+        assert result_b["api_key"] == "KEY-B"
+
+        # The cache itself still works: an identical slot re-resolves from
+        # cache without another resolve_runtime_provider call.
+        calls_before = mock_resolve.call_count
+        again = moa._slot_runtime(dict(slot_a))
+        assert again["base_url"] == "https://a.example/v1"
+        assert mock_resolve.call_count == calls_before
 
 
 def test_run_reference_passes_slot_extra_body(monkeypatch):


### PR DESCRIPTION
## What

A MoA reference slot can now carry inline `base_url` / `api_key` / `api_mode` fields. `_slot_runtime()` forwards them to `resolve_runtime_provider()` as `explicit_base_url` / `explicit_api_key` — the same escape hatch the CLI's runtime resolution already supports — and an explicit slot `api_mode` overrides the auto-detected one.

## Why

This lets two slots reference the **same model served by different endpoints** (a primary provider and a mirror, or several regional gateways) without registering each endpoint as a separate named provider:

```yaml
moa:
  presets:
    my-preset:
      reference_models:
        - provider: custom
          model: some-model
          base_url: https://primary.example/v1
          api_key: ${PRIMARY_KEY}
        - provider: custom
          model: some-model
          base_url: https://mirror.example/v1
          api_key: ${MIRROR_KEY}
          api_mode: chat_completions
```

## The cache-key part matters

The #66793 runtime cache keys by `(provider, model)`. With inline connection info, two slots sharing provider+model but differing only in `base_url` collide: the first slot resolved poisons the cache and **every sibling slot silently inherits its endpoint and credentials** — no error, just every "diverse" reference quietly calling the same backend. The key now includes the slot's connection fields; the new cache-collision regression test locks this in. (We ran exactly this configuration on a fork and the collision was silent for two days.)

## Tests

- `test_slot_explicit_connection_info_forwarded` — slot fields reach the resolver as `explicit_*`
- `test_slot_api_mode_overrides_autodetected`
- `test_slot_runtime_cache_keyed_by_connection_info` — the collision regression
- TTL test's hardcoded cache-key shape updated

`pytest tests/agent/test_moa_slot_api_mode.py tests/agent/test_moa_cold_start_cache_66793.py` — 15/15 pass. Slots without connection fields resolve exactly as before (empty strings in the key, same resolver call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)