### PR TITLE
fix(model_metadata): handle per_1m_tokens/per_1k_tokens unit in pricing extraction (#79174)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1138,6 +1138,18 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
                     pricing[target] = normalized[alias]
                     break
         if pricing:
+            # Apply unit conversion: generic paths return per-token values,
+            # but the pricing payload may ship per-1m or per-1k. Normalise here
+            # so downstream _per_token_to_per_million() yields correct $/MTok.
+            unit = normalized.get("unit", "per_token")
+            if unit == "per_1m_tokens":
+                for key in ("prompt", "completion", "cache_read", "cache_write", "request"):
+                    if key in pricing:
+                        pricing[key] = str(float(pricing[key]) / 1_000_000)
+            elif unit == "per_1k_tokens":
+                for key in ("prompt", "completion", "cache_read", "cache_write", "request"):
+                    if key in pricing:
+                        pricing[key] = str(float(pricing[key]) / 1_000)
             return pricing
     return {}
 


### PR DESCRIPTION
Closes #79174

## What does this PR do?

Fixes false expensive-model warnings triggered by OpenAI-compatible providers that return pricing with `unit: "per_1m_tokens"` in the pricing dict.

## Root cause

`agent/model_metadata.py::_extract_pricing()` ignored the `unit` field in the generic pricing extraction path. When a provider returns `{"unit": "per_1m_tokens", "prompt": 1, "completion": 2}`, these values were returned as-is. Downstream, `_per_token_to_per_million()` multiplies by 1,000,000, yielding $1,000,000/M and $2,000,000/M — causing a false "expensive model" warning.

## Fix

After extracting pricing values in `_extract_pricing()`, read the `unit` field from the same dict and apply the appropriate divisor before returning:
- `unit == "per_1m_tokens"`: divide by 1,000,000 (already per-million, normalize to per-token)
- `unit == "per_1k_tokens"`: divide by 1,000 (per-1k, normalize to per-token)
- `unit == "per_token"` / missing: keep as-is (default per-token)

This ensures the downstream ×1,000,000 round-trip yields the correct per-million carrier, and no false warning fires.
