### PR TITLE
fix(tui): make terminal path tests platform-independent

### DIFF
--- a/ui-tui/src/__tests__/terminalParity.test.ts
+++ b/ui-tui/src/__tests__/terminalParity.test.ts
@@ -19,7 +19,8 @@ describe('terminalParityHints', () => {
 
     const hints = await terminalParityHints({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv, {
       fileOps: { readFile },
-      homeDir: '/tmp/fake-home'
+      homeDir: '/tmp/fake-home',
+      platform: 'linux'
     })
 
     expect(hints.some(h => h.key === 'ide-setup')).toBe(true)
@@ -69,7 +70,8 @@ describe('terminalParityHints', () => {
 
     const hints = await terminalParityHints({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv, {
       fileOps: { readFile },
-      homeDir: '/tmp/fake-home'
+      homeDir: '/tmp/fake-home',
+      platform: 'linux'
     })
 
     expect(hints.some(h => h.key === 'ide-setup')).toBe(false)

--- a/ui-tui/src/__tests__/terminalParity.test.ts
+++ b/ui-tui/src/__tests__/terminalParity.test.ts
@@ -19,7 +19,8 @@ describe('terminalParityHints', () => {
 
     const hints = await terminalParityHints({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv, {
       fileOps: { readFile },
-      homeDir: '/tmp/fake-home'
+      homeDir: '/tmp/fake-home',
+      platform: 'linux'
     })
 
     expect(hints.some(h => h.key === 'ide-setup')).toBe(true)
@@ -69,7 +70,8 @@ describe('terminalParityHints', () => {
 
     const hints = await terminalParityHints({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv, {
       fileOps: { readFile },
-      homeDir: '/tmp/fake-home'
+      homeDir: '/tmp/fake-home',
+      platform: 'linux'
     })
 
     expect(hints.some(h => h.key === 'ide-setup')).toBe(false)
@@ -119,7 +121,8 @@ describe('terminalParityHints', () => {
 
     const hints = await terminalParityHints({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv, {
       fileOps: { readFile },
-      homeDir: '/tmp/fake-home'
+      homeDir: '/tmp/fake-home',
+      platform: 'linux'
     })
 
     // Legacy bindings don't match current CSI u targets, so setup is still needed

--- a/ui-tui/src/__tests__/terminalSetup.test.ts
+++ b/ui-tui/src/__tests__/terminalSetup.test.ts
@@ -44,7 +44,7 @@ describe('terminalSetup helpers', () => {
         { APPDATA: 'C:/Users/me/AppData/Roaming' } as NodeJS.ProcessEnv,
         '/home/me'
       )
-    ).toBe('C:/Users/me/AppData/Roaming/Code/User')
+    ).toBe('C:\\Users\\me\\AppData\\Roaming\\Code\\User')
   })
 
   it('strips line comments from keybindings JSON', () => {
@@ -75,6 +75,26 @@ describe('terminalSetup helpers', () => {
 })
 
 describe('configureTerminalKeybindings', () => {
+  it('uses target-native separators for Windows keybindings paths', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined)
+    const readFile = vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+
+    const result = await configureTerminalKeybindings('vscode', {
+      env: { APPDATA: 'C:/Users/me/AppData/Roaming' } as NodeJS.ProcessEnv,
+      fileOps: { mkdir, readFile, writeFile },
+      platform: 'win32'
+    })
+
+    const configDir = 'C:\\Users\\me\\AppData\\Roaming\\Code\\User'
+    const keybindingsFile = `${configDir}\\keybindings.json`
+
+    expect(result.success).toBe(true)
+    expect(mkdir).toHaveBeenCalledWith(configDir, { recursive: true })
+    expect(readFile).toHaveBeenCalledWith(keybindingsFile, 'utf8')
+    expect(writeFile).toHaveBeenCalledWith(keybindingsFile, expect.any(String), 'utf8')
+  })
+
   it('writes missing bindings into a VS Code style keybindings file', async () => {
     const mkdir = vi.fn().mockResolvedValue(undefined)
     const readFile = vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
@@ -340,7 +360,8 @@ describe('configureTerminalKeybindings', () => {
     await expect(
       shouldPromptForTerminalSetup({
         env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
-        fileOps: { readFile: readMissing }
+        fileOps: { readFile: readMissing },
+        platform: 'linux'
       })
     ).resolves.toBe(true)
 
@@ -388,7 +409,8 @@ describe('configureTerminalKeybindings', () => {
     await expect(
       shouldPromptForTerminalSetup({
         env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
-        fileOps: { readFile: readComplete }
+        fileOps: { readFile: readComplete },
+        platform: 'linux'
       })
     ).resolves.toBe(false)
   })
@@ -448,7 +470,8 @@ describe('configureTerminalKeybindings', () => {
     await expect(
       shouldPromptForTerminalSetup({
         env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
-        fileOps: { readFile: readLegacy }
+        fileOps: { readFile: readLegacy },
+        platform: 'linux'
       })
     ).resolves.toBe(true)
   })

--- a/ui-tui/src/__tests__/terminalSetup.test.ts
+++ b/ui-tui/src/__tests__/terminalSetup.test.ts
@@ -44,7 +44,7 @@ describe('terminalSetup helpers', () => {
         { APPDATA: 'C:/Users/me/AppData/Roaming' } as NodeJS.ProcessEnv,
         '/home/me'
       )
-    ).toBe('C:/Users/me/AppData/Roaming/Code/User')
+    ).toBe('C:\\Users\\me\\AppData\\Roaming\\Code\\User')
   })
 
   it('strips line comments from keybindings JSON', () => {
@@ -75,6 +75,26 @@ describe('terminalSetup helpers', () => {
 })
 
 describe('configureTerminalKeybindings', () => {
+  it('uses target-native separators for Windows keybindings paths', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined)
+    const readFile = vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+
+    const result = await configureTerminalKeybindings('vscode', {
+      env: { APPDATA: 'C:/Users/me/AppData/Roaming' } as NodeJS.ProcessEnv,
+      fileOps: { mkdir, readFile, writeFile },
+      platform: 'win32'
+    })
+
+    const configDir = 'C:\\Users\\me\\AppData\\Roaming\\Code\\User'
+    const keybindingsFile = `${configDir}\\keybindings.json`
+
+    expect(result.success).toBe(true)
+    expect(mkdir).toHaveBeenCalledWith(configDir, { recursive: true })
+    expect(readFile).toHaveBeenCalledWith(keybindingsFile, 'utf8')
+    expect(writeFile).toHaveBeenCalledWith(keybindingsFile, expect.any(String), 'utf8')
+  })
+
   it('writes missing bindings into a VS Code style keybindings file', async () => {
     const mkdir = vi.fn().mockResolvedValue(undefined)
     const readFile = vi.fn().mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
@@ -336,7 +356,8 @@ describe('configureTerminalKeybindings', () => {
     await expect(
       shouldPromptForTerminalSetup({
         env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
-        fileOps: { readFile: readMissing }
+        fileOps: { readFile: readMissing },
+        platform: 'linux'
       })
     ).resolves.toBe(true)
 
@@ -384,7 +405,8 @@ describe('configureTerminalKeybindings', () => {
     await expect(
       shouldPromptForTerminalSetup({
         env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
-        fileOps: { readFile: readComplete }
+        fileOps: { readFile: readComplete },
+        platform: 'linux'
       })
     ).resolves.toBe(false)
   })

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -23,22 +23,22 @@ describe('resolveEditor', () => {
   })
 
   it('honors $VISUAL above all else', () => {
-    expect(resolveEditor({ EDITOR: 'vim', PATH: dir, VISUAL: 'helix' })).toEqual(['helix'])
+    expect(resolveEditor({ EDITOR: 'vim', PATH: dir, VISUAL: 'helix' }, 'linux')).toEqual(['helix'])
   })
 
   it('falls back to $EDITOR when $VISUAL is unset', () => {
-    expect(resolveEditor({ EDITOR: 'nvim', PATH: dir })).toEqual(['nvim'])
+    expect(resolveEditor({ EDITOR: 'nvim', PATH: dir }, 'linux')).toEqual(['nvim'])
   })
 
   it('shell-tokenizes editors with arguments', () => {
-    expect(resolveEditor({ EDITOR: 'code --wait', PATH: dir })).toEqual(['code', '--wait'])
-    expect(resolveEditor({ PATH: dir, VISUAL: 'emacsclient -t' })).toEqual(['emacsclient', '-t'])
+    expect(resolveEditor({ EDITOR: 'code --wait', PATH: dir }, 'linux')).toEqual(['code', '--wait'])
+    expect(resolveEditor({ PATH: dir, VISUAL: 'emacsclient -t' }, 'linux')).toEqual(['emacsclient', '-t'])
   })
 
   it('ignores whitespace-only env vars', () => {
     const expected = exe(dir, 'editor')
 
-    expect(resolveEditor({ EDITOR: '   ', PATH: dir, VISUAL: '' })).toEqual([expected])
+    expect(resolveEditor({ EDITOR: '   ', PATH: dir, VISUAL: '' }, 'linux')).toEqual([expected])
   })
 
   it('prefers `editor` over nano over vi on $PATH', () => {
@@ -46,18 +46,18 @@ describe('resolveEditor', () => {
     exe(dir, 'vi')
     const expected = exe(dir, 'editor')
 
-    expect(resolveEditor({ PATH: dir })).toEqual([expected])
+    expect(resolveEditor({ PATH: dir }, 'linux')).toEqual([expected])
   })
 
   it('falls back to nano before vi when both exist', () => {
     exe(dir, 'vi')
     const expected = exe(dir, 'nano')
 
-    expect(resolveEditor({ PATH: dir })).toEqual([expected])
+    expect(resolveEditor({ PATH: dir }, 'linux')).toEqual([expected])
   })
 
   it('returns ["vi"] when $PATH is empty', () => {
-    expect(resolveEditor({ PATH: '' })).toEqual(['vi'])
+    expect(resolveEditor({ PATH: '' }, 'linux')).toEqual(['vi'])
   })
 
   it('walks multi-entry $PATH', () => {
@@ -65,7 +65,7 @@ describe('resolveEditor', () => {
     const b = mkdtempSync(join(tmpdir(), 'editor-b-'))
     const expected = exe(b, 'editor')
 
-    expect(resolveEditor({ PATH: [a, b].join(delimiter) })).toEqual([expected])
+    expect(resolveEditor({ PATH: [a, b].join(delimiter) }, 'linux')).toEqual([expected])
   })
 
   it('uses notepad.exe on Windows when no env override', () => {

--- a/ui-tui/src/lib/terminalParity.ts
+++ b/ui-tui/src/lib/terminalParity.ts
@@ -31,14 +31,19 @@ export function detectMacTerminalContext(env: NodeJS.ProcessEnv = process.env): 
 
 export async function terminalParityHints(
   env: NodeJS.ProcessEnv = process.env,
-  options?: { fileOps?: Partial<FileOps>; homeDir?: string }
+  options?: { fileOps?: Partial<FileOps>; homeDir?: string; platform?: NodeJS.Platform }
 ): Promise<MacTerminalHint[]> {
   const ctx = detectMacTerminalContext(env)
   const hints: MacTerminalHint[] = []
 
   if (
     ctx.vscodeLike &&
-    (await shouldPromptForTerminalSetup({ env, fileOps: options?.fileOps, homeDir: options?.homeDir }))
+    (await shouldPromptForTerminalSetup({
+      env,
+      fileOps: options?.fileOps,
+      homeDir: options?.homeDir,
+      platform: options?.platform
+    }))
   ) {
     hints.push({
       key: 'ide-setup',

--- a/ui-tui/src/lib/terminalSetup.ts
+++ b/ui-tui/src/lib/terminalSetup.ts
@@ -1,6 +1,6 @@
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { posix, win32 } from 'node:path'
 
 export type SupportedTerminal = 'cursor' | 'vscode' | 'windsurf'
 
@@ -215,14 +215,14 @@ export function getVSCodeStyleConfigDir(
   homeDir: string = homedir()
 ): null | string {
   if (platform === 'darwin') {
-    return join(homeDir, 'Library', 'Application Support', appName, 'User')
+    return posix.join(homeDir, 'Library', 'Application Support', appName, 'User')
   }
 
   if (platform === 'win32') {
-    return env['APPDATA'] ? join(env['APPDATA'], appName, 'User') : null
+    return env['APPDATA'] ? win32.join(env['APPDATA'], appName, 'User') : null
   }
 
-  return join(homeDir, '.config', appName, 'User')
+  return posix.join(homeDir, '.config', appName, 'User')
 }
 
 function isKeybinding(value: unknown): value is Keybinding {
@@ -353,7 +353,8 @@ export async function configureTerminalKeybindings(
     }
   }
 
-  const keybindingsFile = join(configDir, 'keybindings.json')
+  const pathApi = platform === 'win32' ? win32 : posix
+  const keybindingsFile = pathApi.join(configDir, 'keybindings.json')
 
   try {
     await ops.mkdir(configDir, { recursive: true })
@@ -489,7 +490,8 @@ export async function shouldPromptForTerminalSetup(options?: {
   }
 
   try {
-    const content = await ops.readFile(join(configDir, 'keybindings.json'), 'utf8')
+    const pathApi = platform === 'win32' ? win32 : posix
+    const content = await ops.readFile(pathApi.join(configDir, 'keybindings.json'), 'utf8')
     const parsed: unknown = JSON.parse(stripJsonComments(content))
 
     if (!Array.isArray(parsed)) {

--- a/ui-tui/src/lib/terminalSetup.ts
+++ b/ui-tui/src/lib/terminalSetup.ts
@@ -1,6 +1,6 @@
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { posix, win32 } from 'node:path'
 
 export type SupportedTerminal = 'cursor' | 'vscode' | 'windsurf'
 
@@ -165,14 +165,14 @@ export function getVSCodeStyleConfigDir(
   homeDir: string = homedir()
 ): null | string {
   if (platform === 'darwin') {
-    return join(homeDir, 'Library', 'Application Support', appName, 'User')
+    return posix.join(homeDir, 'Library', 'Application Support', appName, 'User')
   }
 
   if (platform === 'win32') {
-    return env['APPDATA'] ? join(env['APPDATA'], appName, 'User') : null
+    return env['APPDATA'] ? win32.join(env['APPDATA'], appName, 'User') : null
   }
 
-  return join(homeDir, '.config', appName, 'User')
+  return posix.join(homeDir, '.config', appName, 'User')
 }
 
 function isKeybinding(value: unknown): value is Keybinding {
@@ -303,7 +303,8 @@ export async function configureTerminalKeybindings(
     }
   }
 
-  const keybindingsFile = join(configDir, 'keybindings.json')
+  const pathApi = platform === 'win32' ? win32 : posix
+  const keybindingsFile = pathApi.join(configDir, 'keybindings.json')
 
   try {
     await ops.mkdir(configDir, { recursive: true })
@@ -428,7 +429,8 @@ export async function shouldPromptForTerminalSetup(options?: {
   }
 
   try {
-    const content = await ops.readFile(join(configDir, 'keybindings.json'), 'utf8')
+    const pathApi = platform === 'win32' ? win32 : posix
+    const content = await ops.readFile(pathApi.join(configDir, 'keybindings.json'), 'utf8')
     const parsed: unknown = JSON.parse(stripJsonComments(content))
 
     if (!Array.isArray(parsed)) {


### PR DESCRIPTION
## What does this PR do?

Fixes 8 `ui-tui` test failures observed on Windows by making the intended target platform explicit throughout terminal path and editor tests.

`getVSCodeStyleConfigDir()` already accepts a target `platform`, but previously used the host-specific `node:path.join()`.
This PR selects `path.win32` or `path.posix` from the target platform and uses the same path API when appending `keybindings.json`.
A Windows target therefore produces `C:\...` paths even when the test runs on Linux, while Linux and macOS targets consistently produce POSIX paths.

The PR also pins `'linux'` in tests that intentionally exercise POSIX editor and terminal behavior. `terminalParityHints()` now accepts an optional platform override and passes it through to `shouldPromptForTerminalSetup()` so that this call path can be tested without depending on the runner OS.

This is primarily a cross-platform correctness and test portability fix.
It does not claim a terminal setup failure in normal Windows runtime usage.

## Related Issue

Fixes [#79495](https://github.com/NousResearch/hermes-agent/issues/79495)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Use `node:path.posix` for Linux/macOS targets and `node:path.win32` for Windows targets in `ui-tui/src/lib/terminalSetup.ts`.
- Use the selected target path API when reading, writing, and backing up `keybindings.json`.
- Add a Windows regression test covering both the config directory and complete keybindings file path.
- Pin `'linux'` in all POSIX-oriented `resolveEditor()` tests and terminal setup prompt tests.
- Thread an optional platform override through `terminalParityHints()` and pin it in both IDE setup hint tests.

## How to Test

1. From the repository root, run `npm ci`.
2. Run `npm test --prefix ui-tui` on Windows and on a POSIX host if available.
3. Run `npm run typecheck --prefix ui-tui` and `npm run lint --prefix ui-tui`.

Expected result: all commands pass.
Before this fix, the Windows test run had 8 failures: 5 editor fallback tests, 2 terminal setup tests, and 1 terminal parity test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A**: this change touches only `ui-tui/` (TypeScript/vitest); the Python `tests/` suite does not cover it. TUI JS validation is `npm test`/vitest.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the final patch on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Not applicable.

## Related PRs

[#79535](https://github.com/NousResearch/hermes-agent/pull/79535) fixes the sibling `tests/tui_gateway/` Python path tests (also Windows-flaky, e.g. POSIX-only `signal.SIGPIPE`). This PR covers the `ui-tui/` vitest side. They are complementary and do not overlap.