### PR TITLE
feat: make GitHub workflow activation and authentication provider-neutral

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -14,6 +14,7 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 
 from __future__ import annotations
 
+import os
 import sys
 
 from rich.markup import escape as _escape
@@ -345,6 +346,30 @@ class CLIAgentSetupMixin:
         _prepare_deferred_agent_startup()
         self._install_tool_callbacks()
         self._ensure_tirith_security()
+
+        # Activate the canonical GitHub workflow before the first agent/tool
+        # snapshot when the CLI is opened inside a GitHub repository. This
+        # changes the prompt only during initial construction; later turns see
+        # the same cached system prompt.
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.github_workflow import repository_context, resolve_github_capability
+            from agent.skill_commands import build_preloaded_skills_prompt
+            repo = repository_context(os.getenv("TERMINAL_CWD", os.getcwd()))
+            capability = resolve_github_capability(load_config(), perform_preflight=False)
+            if capability.workflow_enabled and repo.owner and repo.name:
+                github_prompt, loaded, _missing = build_preloaded_skills_prompt(
+                    ["github-auth"], task_id=self.session_id
+                )
+                if github_prompt and "github-auth" not in getattr(self, "preloaded_skills", []):
+                    self.system_prompt = "\n\n".join(
+                        part for part in (self.system_prompt, github_prompt) if part
+                    ).strip()
+                    self.preloaded_skills = [*getattr(self, "preloaded_skills", []), *loaded]
+        except Exception:
+            # GitHub bootstrap is advisory; a malformed remote or skill must
+            # never prevent the normal CLI agent from starting.
+            pass
 
         if not self._ensure_runtime_credentials():
             return False

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,6 +7,13 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
+    "github": {
+        "workflow": {
+            "enabled": True,
+            "api_timeout_seconds": 10,
+            "preflight_cache_seconds": 900,
+        },
+    },
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2598,7 +2598,28 @@ def run_doctor(args):
     elif _gh_authenticated():
         check_ok("GitHub authenticated via gh CLI", "(full API access — no GITHUB_TOKEN needed)")
     else:
-        check_warn("No GITHUB_TOKEN", f"(60 req/hr rate limit — set in {_DHH}/.env for better rates)")
+        check_warn(
+            "No GitHub credential",
+            "(public reads remain available — configure GITHUB_TOKEN in a supported Hermes secret source for authenticated access)",
+        )
+
+    # The CLI workflow capability is provider-neutral and reads the active
+    # profile's secret scope. Keep this diagnostic separate from the existing
+    # gh probe so newer/older gh compatibility fixes remain independently
+    # reviewable.
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.github_workflow import resolve_github_capability
+        capability = resolve_github_capability(load_config_readonly(), perform_preflight=False)
+        if capability.workflow_enabled:
+            if capability.credential_available:
+                check_ok("GitHub workflow available", "(Hermes secret scope configured)")
+            else:
+                check_warn("GitHub workflow credential unavailable", f"({capability.remediation})")
+        else:
+            check_ok("GitHub workflow disabled", "(github.workflow.enabled=false)")
+    except Exception as exc:
+        check_warn("GitHub workflow diagnostic unavailable", f"({exc})")
 
     _section("Memory Provider")
     _active_memory_provider = ""

--- a/hermes_cli/github_workflow.py
+++ b/hermes_cli/github_workflow.py
@@ -1,0 +1,200 @@
+"""Provider-neutral GitHub workflow bootstrap for the CLI.
+
+This module deliberately consumes the already-provisioned Hermes secret scope.
+It does not know which secret provider supplied ``GITHUB_TOKEN`` and does not
+implement provider precedence.  GitHub MCP is not required.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional
+
+from agent.secret_scope import get_secret
+from agent.secret_sources.base import ErrorKind
+from hermes_cli._subprocess_compat import noninteractive_git_env
+
+GITHUB_CREDENTIAL_PURPOSE = "github-workflow"
+_DEFAULT_TIMEOUT = 10.0
+_DEFAULT_CACHE_SECONDS = 900.0
+_CACHE: dict[str, tuple[float, "AuthState", Optional[str], Optional[str]]] = {}
+
+
+class AuthState(str, Enum):
+    DISABLED = "disabled"
+    UNAVAILABLE = "unavailable"
+    VERIFIED = "verified"
+    INVALID = "invalid"
+    PERMISSION_DENIED = "permission_denied"
+    RATE_LIMITED = "rate_limited"
+    NETWORK_ERROR = "network_error"
+
+
+@dataclass(frozen=True)
+class GitHubRepository:
+    root: Optional[str] = None
+    remote: Optional[str] = None
+    owner: Optional[str] = None
+    name: Optional[str] = None
+    branch: Optional[str] = None
+    sha: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class GitHubCapability:
+    workflow_enabled: bool
+    credential_available: bool
+    auth_state: AuthState
+    repository: GitHubRepository = field(default_factory=GitHubRepository)
+    identity: Optional[str] = None
+    public_read_available: bool = True
+    remediation: str = ""
+    error_kind: Optional[ErrorKind] = None
+    _credential: Optional[str] = field(default=None, repr=False, compare=False)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "workflow_enabled": self.workflow_enabled,
+            "credential_available": self.credential_available,
+            "auth_state": self.auth_state.value,
+            "repository": {
+                "root": self.repository.root,
+                "remote": self.repository.remote,
+                "owner": self.repository.owner,
+                "name": self.repository.name,
+                "branch": self.repository.branch,
+                "sha": self.repository.sha,
+            },
+            "identity": self.identity,
+            "public_read_available": self.public_read_available,
+            "remediation": self.remediation,
+        }
+
+    def __str__(self) -> str:
+        return str(self.to_public_dict())
+
+
+def _workflow_config(config: Optional[Mapping[str, Any]]) -> dict[str, Any]:
+    cfg = (config or {}).get("github", {})
+    workflow = cfg.get("workflow", {}) if isinstance(cfg, Mapping) else {}
+    return dict(workflow) if isinstance(workflow, Mapping) else {}
+
+
+def _git_stdout(cwd: str, args: list[str], timeout: float = _DEFAULT_TIMEOUT) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", stdin=subprocess.DEVNULL,
+            env=noninteractive_git_env(), timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def parse_github_remote(remote: str) -> Optional[tuple[str, str]]:
+    value = (remote or "").strip()
+    match = re.match(r"^(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+?)(?:\.git)?/?$", value, re.I)
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def repository_context(cwd: str) -> GitHubRepository:
+    root = _git_stdout(cwd, ["rev-parse", "--show-toplevel"]).strip() or None
+    base = root or cwd
+    remote = _git_stdout(base, ["config", "--get", "remote.origin.url"]).strip() or None
+    parsed = parse_github_remote(remote or "")
+    branch = _git_stdout(base, ["branch", "--show-current"]).strip() or None
+    sha = _git_stdout(base, ["rev-parse", "HEAD"]).strip() or None
+    owner, name = parsed if parsed else (None, None)
+    return GitHubRepository(root=root, remote=remote, owner=owner, name=name, branch=branch, sha=sha)
+
+
+def classify_github_response(status: int, headers: Mapping[str, str]) -> AuthState:
+    if status == 200:
+        return AuthState.VERIFIED
+    if status == 401:
+        return AuthState.INVALID
+    if status == 403:
+        lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+        if lowered.get("x-ratelimit-remaining") == "0" or "retry-after" in lowered:
+            return AuthState.RATE_LIMITED
+        return AuthState.PERMISSION_DENIED
+    return AuthState.NETWORK_ERROR if status >= 500 else AuthState.PERMISSION_DENIED
+
+
+def clear_preflight_cache() -> None:
+    _CACHE.clear()
+
+
+def _fingerprint(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _preflight(token: str, timeout: float, cache_seconds: float) -> tuple[AuthState, Optional[str], Optional[str]]:
+    key = _fingerprint(token)
+    now = time.monotonic()
+    cached = _CACHE.get(key)
+    if cached and now - cached[0] < cache_seconds:
+        return cached[1:]
+    try:
+        request = urllib.request.Request(
+            "https://api.github.com/user",
+            headers={"Authorization": "Bearer " + token, "Accept": "application/vnd.github+json"},
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            identity = None
+            try:
+                import json
+                identity = json.loads(response.read().decode()).get("login")
+            except Exception:
+                pass
+            state = classify_github_response(response.status, dict(response.headers.items()))
+            result = (state, identity, None)
+    except urllib.error.HTTPError as error:
+        state = classify_github_response(error.code, dict(error.headers.items()))
+        result = (state, None, "GitHub rejected the credential; check the configured GitHub secret.")
+    except (OSError, urllib.error.URLError, TimeoutError):
+        result = (AuthState.NETWORK_ERROR, None, "GitHub could not be reached; check connectivity and retry.")
+    _CACHE[key] = (now, *result)
+    return result
+
+
+def resolve_github_capability(config: Optional[Mapping[str, Any]] = None, *, operation: str = "public-read", perform_preflight: bool = True) -> GitHubCapability:
+    workflow = _workflow_config(config)
+    enabled = bool(workflow.get("enabled", True))
+    if not enabled:
+        return GitHubCapability(False, False, AuthState.DISABLED, remediation="Enable github.workflow.enabled to activate GitHub workflow support.")
+    token = get_secret("GITHUB_TOKEN", None)
+    if not token:
+        return GitHubCapability(True, False, AuthState.UNAVAILABLE, public_read_available=True, error_kind=ErrorKind.NOT_CONFIGURED, remediation="Add GITHUB_TOKEN to a configured Hermes secret source, then run `hermes secrets status`.")
+    if not perform_preflight and operation == "public-read":
+        return GitHubCapability(True, True, AuthState.UNAVAILABLE, public_read_available=True, remediation="Public-read operation does not require GitHub authentication.", _credential=token)
+    timeout = float(workflow.get("api_timeout_seconds", _DEFAULT_TIMEOUT))
+    cache_seconds = float(workflow.get("preflight_cache_seconds", _DEFAULT_CACHE_SECONDS))
+    state, identity, detail = _preflight(token, timeout, cache_seconds)
+    remediation = detail or ("GitHub authentication verified." if state is AuthState.VERIFIED else "Check the configured GitHub credential and retry.")
+    kind = None if state is AuthState.VERIFIED else (ErrorKind.AUTH_FAILED if state is AuthState.INVALID else ErrorKind.NETWORK if state is AuthState.NETWORK_ERROR else None)
+    return GitHubCapability(True, True, state, identity=identity, public_read_available=True, remediation=remediation, error_kind=kind, _credential=token)
+
+
+def activation_relevant(prompt: str, repository: Optional[GitHubRepository] = None) -> bool:
+    if repository and repository.owner and repository.name:
+        return True
+    return bool(re.search(r"\b(github|repository|repo|pull request|\bpr\b|issue|branch|fork|upstream|actions|commit|push)\b", prompt or "", re.I))
+
+
+def workflow_git_env(base: Optional[Mapping[str, str]] = None) -> dict[str, str]:
+    """Return isolated noninteractive Git env for future ephemeral auth use."""
+    env = noninteractive_git_env(base)
+    env.pop("GIT_ASKPASS", None)
+    env.pop("SSH_ASKPASS", None)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    return env

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -1,247 +1,80 @@
 ---
 name: github-auth
-description: "GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login."
-version: 1.1.0
+description: "Use Hermes-managed GitHub authentication for repository, issue, and PR workflows."
+version: 2.0.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [GitHub, Authentication, Git, gh-cli, SSH, Setup]
+    tags: [GitHub, Authentication, Git, Skills, Security]
     related_skills: [github-pr-workflow, github-code-review, github-issues, github-repo-management]
 ---
 
-# GitHub Authentication Setup
+# Hermes GitHub Workflow Authentication
 
-This skill sets up authentication so the agent can work with GitHub repositories, PRs, issues, and CI. It covers two paths:
+Use Hermes' canonical GitHub workflow before performing GitHub operations. The workflow is provider-neutral: it reads the logical `GITHUB_TOKEN` through Hermes' active secret scope. It does not call Bitwarden, 1Password, or another provider directly, and it does not implement credential precedence.
 
-- **`git` (always available)** — uses HTTPS personal access tokens or SSH keys
-- **`gh` CLI (if installed)** — richer GitHub API access with a simpler auth flow
+## Canonical sequence
 
-## Detection Flow
+1. Detect whether the current directory or request is GitHub-related.
+2. Resolve repository context from the local Git remote when present.
+3. Resolve `GITHUB_TOKEN` through Hermes' secret scope.
+4. For authenticated operations, verify identity with GitHub's `GET /user` preflight.
+5. Check repository authorization for the requested operation.
+6. Use the shared safe GitHub API/Git transport path.
+7. Verify the operation independently.
 
-When a user asks you to work with GitHub, run this check first:
+Never ask the user to paste a PAT before Hermes' configured secret scope has been checked.
 
-```bash
-# Check what's available
-git --version
-gh --version 2>/dev/null || echo "gh not installed"
+## Credential rules
 
-# Check if already authenticated
-gh auth status 2>/dev/null || echo "gh not authenticated"
-git config --global credential.helper 2>/dev/null || echo "no git credential helper"
-```
+- Do not call a provider-specific CLI or API from this skill.
+- Do not implement provider precedence here.
+- Do not use `git config --global credential.helper store`.
+- Do not put tokens in remotes, `.git/config`, command arguments, shell history, or persistent files.
+- Do not use `gh auth login` as a prerequisite.
+- `gh` authentication detection may be reported by `hermes doctor`, but this workflow's canonical credential path is Hermes secret scope.
+- Public repository reads may proceed without a credential when the requested GitHub operation permits unauthenticated access.
 
-**Decision tree:**
-1. If `gh auth status` shows authenticated → you're good, use `gh` for everything
-2. If `gh` is installed but not authenticated → use "gh auth" method below
-3. If `gh` is not installed → use "git-only" method below (no sudo needed)
+## Failure handling
 
----
+Report one classified failure and its remedy. Do not cycle through unrelated `gh`, SSH, Git credential-store, and token-prompt paths.
 
-## Method 1: Git-Only Authentication (No gh, No sudo)
+- No credential: tell the user to configure `GITHUB_TOKEN` in a supported Hermes secret source and run `hermes secrets status`.
+- Invalid/expired credential: tell the user to repair or rotate the configured GitHub credential.
+- Rate limited: distinguish quota exhaustion from invalid credentials and report the retry window when available.
+- Permission denied: identify the repository operation that lacks authorization.
+- Network failure: report connectivity rather than blaming credentials.
 
-This works on any machine with `git` installed. No root access needed.
+## Git transport safety
 
-### Option A: HTTPS with Personal Access Token (Recommended)
+Use the shared workflow transport. It must run Git non-interactively, clear ambient credential helpers for the invocation, disable system Git configuration, and deliver credentials ephemerally. Verify that credentials do not enter the remote URL, `.git/config`, argv, environment, or persistent helper stores.
 
-This is the most portable method — works everywhere, no SSH config needed.
+## Scope
 
-**Step 1: Create a personal access token**
+This skill provides the authentication/bootstrap contract. Domain skills own their operations:
 
-Tell the user to go to: **https://github.com/settings/tokens**
+- `github-repo-management` — repository and remote management;
+- `github-issues` — issue operations;
+- `github-pr-workflow` — branches, PRs, checks, and merges;
+- `github-code-review` — review workflow;
+- `codebase-inspection` — repository inspection.
 
-- Click "Generate new token (classic)"
-- Give it a name like "hermes-agent"
-- Select scopes:
-  - `repo` (full repository access — read, write, push, PRs)
-  - `workflow` (trigger and manage GitHub Actions)
-  - `read:org` (if working with organization repos)
-- Set expiration (90 days is a good default)
-- Copy the token — it won't be shown again
+All writes remain subject to the normal Hermes approval and explicit-user-intent rules.
 
-**Step 2: Configure git to store the token**
+## Diagnostics
 
-```bash
-# Set up the credential helper to cache credentials
-# "store" saves to ~/.git-credentials in plaintext (simple, persistent)
-git config --global credential.helper store
+Use the GitHub section of `hermes doctor`. PR1 does not add a separate `hermes github doctor` command. Diagnostic output must never include raw credentials or provider-specific secret identifiers.
 
-# Now do a test operation that triggers auth — git will prompt for credentials
-# Username: <their-github-username>
-# Password: <paste the personal access token, NOT their GitHub password>
-git ls-remote https://github.com/<their-username>/<any-repo>.git
-```
+## Legacy instructions removed
 
-After entering credentials once, they're saved and reused for all future operations.
+The following are intentionally not supported by this skill:
 
-**Alternative: cache helper (credentials expire from memory)**
+- persistent Git credential-store setup;
+- token-bearing remote URLs;
+- PATs pasted into chat;
+- provider-specific secret retrieval instructions;
+- `gh auth login` as the default workflow.
 
-```bash
-# Cache in memory for 8 hours (28800 seconds) instead of saving to disk
-git config --global credential.helper 'cache --timeout=28800'
-```
-
-**Alternative: set the token directly in the remote URL (per-repo)**
-
-```bash
-# Embed token in the remote URL (avoids credential prompts entirely)
-git remote set-url origin https://<username>:<token>@github.com/<owner>/<repo>.git
-```
-
-**Step 3: Configure git identity**
-
-```bash
-# Required for commits — set name and email
-git config --global user.name "Their Name"
-git config --global user.email "their-email@example.com"
-```
-
-**Step 4: Verify**
-
-```bash
-# Test push access (this should work without any prompts now)
-git ls-remote https://github.com/<their-username>/<any-repo>.git
-
-# Verify identity
-git config --global user.name
-git config --global user.email
-```
-
-### Option B: SSH Key Authentication
-
-Good for users who prefer SSH or already have keys set up.
-
-**Step 1: Check for existing SSH keys**
-
-```bash
-ls -la ~/.ssh/id_*.pub 2>/dev/null || echo "No SSH keys found"
-```
-
-**Step 2: Generate a key if needed**
-
-```bash
-# Generate an ed25519 key (modern, secure, fast)
-ssh-keygen -t ed25519 -C "their-email@example.com" -f ~/.ssh/id_ed25519 -N ""
-
-# Display the public key for them to add to GitHub
-cat ~/.ssh/id_ed25519.pub
-```
-
-Tell the user to add the public key at: **https://github.com/settings/keys**
-- Click "New SSH key"
-- Paste the public key content
-- Give it a title like "hermes-agent-<machine-name>"
-
-**Step 3: Test the connection**
-
-```bash
-ssh -T git@github.com
-# Expected: "Hi <username>! You've successfully authenticated..."
-```
-
-**Step 4: Configure git to use SSH for GitHub**
-
-```bash
-# Rewrite HTTPS GitHub URLs to SSH automatically
-git config --global url."git@github.com:".insteadOf "https://github.com/"
-```
-
-**Step 5: Configure git identity**
-
-```bash
-git config --global user.name "Their Name"
-git config --global user.email "their-email@example.com"
-```
-
----
-
-## Method 2: gh CLI Authentication
-
-If `gh` is installed, it handles both API access and git credentials in one step.
-
-### Interactive Browser Login (Desktop)
-
-```bash
-gh auth login
-# Select: GitHub.com
-# Select: HTTPS
-# Authenticate via browser
-```
-
-### Token-Based Login (Headless / SSH Servers)
-
-```bash
-echo "<THEIR_TOKEN>" | gh auth login --with-token
-
-# Set up git credentials through gh
-gh auth setup-git
-```
-
-### Verify
-
-```bash
-gh auth status
-```
-
----
-
-## Using the GitHub API Without gh
-
-When `gh` is not available, you can still access the full GitHub API using `curl` with a personal access token. This is how the other GitHub skills implement their fallbacks.
-
-### Setting the Token for API Calls
-
-```bash
-# Option 1: Export as env var (preferred — keeps it out of commands)
-export GITHUB_TOKEN="<token>"
-
-# Then use in curl calls:
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/user
-```
-
-### Extracting the Token from Git Credentials
-
-If git credentials are already configured (via credential.helper store), the token can be extracted:
-
-```bash
-# Read from git credential store
-uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py"
-```
-
-### Helper: Detect Auth Method
-
-Use this pattern at the start of any GitHub workflow:
-
-```bash
-# Try gh first, fall back to git + curl
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  echo "AUTH_METHOD=gh"
-elif [ -n "$GITHUB_TOKEN" ]; then
-  echo "AUTH_METHOD=curl"
-elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-  export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-  echo "AUTH_METHOD=curl"
-elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-  export GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-  echo "AUTH_METHOD=curl"
-else
-  echo "AUTH_METHOD=none"
-  echo "Need to set up authentication first"
-fi
-```
-
----
-
-## Troubleshooting
-
-| Problem | Solution |
-|---------|----------|
-| `git push` asks for password | GitHub disabled password auth. Use a personal access token as the password, or switch to SSH |
-| `remote: Permission to X denied` | Token may lack `repo` scope — regenerate with correct scopes |
-| `fatal: Authentication failed` | Cached credentials may be stale — run `git credential reject` then re-authenticate |
-| `ssh: connect to host github.com port 22: Connection refused` | Try SSH over HTTPS port: add `Host github.com` with `Port 443` and `Hostname ssh.github.com` to `~/.ssh/config` |
-| Credentials not persisting | Check `git config --global credential.helper` — must be `store` or `cache` |
-| Multiple GitHub accounts | Use SSH with different keys per host alias in `~/.ssh/config`, or per-repo credential URLs |
-| `gh: command not found` + no sudo | Use git-only Method 1 above — no installation needed |
+Use Hermes' configured secret source and the canonical workflow instead.

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -22,25 +22,15 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 
 ### Setup (for PR interactions)
 
-```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
+Use the canonical Hermes GitHub workflow from `github-auth`. It resolves the
+logical `GITHUB_TOKEN` through Hermes' active secret scope, discovers the
+repository context, and verifies authenticated access when PR interaction
+requires it. Do not probe `gh`, read `.git-credentials`, or extract tokens from
+`.env` manually. Local-only reviews do not require GitHub authentication.
 
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
-```
+The workflow supplies the verified repository context; do not guess `OWNER` or
+`REPO` or build a second authentication path.
+
 
 ---
 

--- a/skills/github/github-issues/SKILL.md
+++ b/skills/github/github-issues/SKILL.md
@@ -22,25 +22,15 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 
 ### Setup
 
-```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
+Use the canonical Hermes GitHub workflow from `github-auth`. It resolves the
+logical `GITHUB_TOKEN` through Hermes' active secret scope, discovers the
+repository context, and verifies authenticated access when the requested issue
+operation requires it. Do not probe `gh`, read `.git-credentials`, or extract
+tokens from `.env` manually. Public issue reads may proceed without a
+credential when GitHub permits them.
 
-REMOTE_URL=$(git remote get-url origin)
-OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
-REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
-```
+The workflow supplies `OWNER` and `REPO` from the verified repository context;
+do not guess them or build a second authentication path.
 
 ---
 

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -22,23 +22,11 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 
 ### Quick Auth Detection
 
-```bash
-# Determine which method to use throughout this workflow
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  # Ensure we have a token for API calls
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
-echo "Using: $AUTH"
-```
+Use the canonical Hermes GitHub workflow from `github-auth`. It resolves the
+logical `GITHUB_TOKEN` through Hermes' active secret scope and verifies the
+identity before authenticated API or Git operations. Do not probe `gh`, read
+`.git-credentials`, or extract tokens from `.env` manually. Public reads may
+proceed without a credential when GitHub permits them.
 
 ### Extracting Owner/Repo from the Git Remote
 

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -21,27 +21,14 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 
 ### Setup
 
-```bash
-if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-  AUTH="gh"
-else
-  AUTH="git"
-  if [ -z "$GITHUB_TOKEN" ]; then
-    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
-      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
-    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
-    fi
-  fi
-fi
+Use the canonical Hermes GitHub workflow from `github-auth` first. Do not
+recreate authentication by probing `gh`, reading `.git-credentials`, or
+extracting tokens from `.env` manually. The workflow resolves the logical
+`GITHUB_TOKEN` through Hermes' active secret scope and reports the verified
+identity or an actionable remediation.
 
-# Get your GitHub username (needed for several operations)
-if [ "$AUTH" = "gh" ]; then
-  GH_USER=$(gh api user --jq '.login')
-else
-  GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | python3 -c "import sys,json; print(json.load(sys.stdin)['login'])")
-fi
-```
+The canonical workflow supplies the authenticated identity to the agent. Do not
+extract it through a second shell authentication path.
 
 If you're inside a repo already:
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -926,8 +926,8 @@ class TestGitHubTokenCheck:
             run_doctor(Namespace(fix=False))
         out = buf.getvalue()
 
-        assert "No GITHUB_TOKEN" in out
-        assert "60 req/hr" in out
+        assert "No GitHub credential" in out
+        assert "public reads remain available" in out
 
 
     def test_gh_authenticated_without_env_token_shows_ok(self, monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_github_workflow.py
+++ b/tests/hermes_cli/test_github_workflow.py
@@ -1,0 +1,175 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.github_workflow import (
+    AuthState,
+    GitHubCapability,
+    GitHubRepository,
+    classify_github_response,
+    parse_github_remote,
+    repository_context,
+    resolve_github_capability,
+)
+
+
+def test_parse_https_github_remote():
+    assert parse_github_remote("https://github.com/NousResearch/hermes-agent.git") == ("NousResearch", "hermes-agent")
+
+
+def test_parse_ssh_github_remote():
+    assert parse_github_remote("git@github.com:NousResearch/hermes-agent.git") == ("NousResearch", "hermes-agent")
+
+
+def test_non_github_remote_is_not_guessed():
+    assert parse_github_remote("https://gitlab.com/example/project.git") is None
+
+
+def test_classify_rate_limited_403_separately():
+    assert classify_github_response(403, {"X-RateLimit-Remaining": "0"}) is AuthState.RATE_LIMITED
+    assert classify_github_response(403, {}) is AuthState.PERMISSION_DENIED
+
+
+def test_classify_identity_responses():
+    assert classify_github_response(200, {}) is AuthState.VERIFIED
+    assert classify_github_response(401, {}) is AuthState.INVALID
+
+
+def test_capability_without_token_keeps_public_read_available(monkeypatch):
+    monkeypatch.setattr("hermes_cli.github_workflow.get_secret", lambda name, default=None: default)
+    capability = resolve_github_capability(config={"github": {"workflow": {"enabled": True}}})
+    assert capability.public_read_available is True
+    assert capability.credential_available is False
+    assert capability.auth_state is AuthState.UNAVAILABLE
+    assert capability.remediation
+
+
+def test_capability_does_not_expose_token(monkeypatch):
+    token = "ghp_test_secret_value_1234567890"
+    monkeypatch.setattr("hermes_cli.github_workflow.get_secret", lambda name, default=None: token)
+    capability = resolve_github_capability(
+        config={"github": {"workflow": {"enabled": True}}}, perform_preflight=False
+    )
+    assert token not in repr(capability)
+    assert token not in str(capability)
+
+
+def test_repository_context_reads_remote_and_branch(tmp_path, monkeypatch):
+    calls = {
+        ("rev-parse", "--show-toplevel"): str(tmp_path),
+        ("config", "--get", "remote.origin.url"): "git@github.com:owner/repo.git\n",
+        ("branch", "--show-current"): "feature/test\n",
+        ("rev-parse", "HEAD"): "abc123\n",
+    }
+    monkeypatch.setattr("hermes_cli.github_workflow._git_stdout", lambda cwd, args: calls.get(tuple(args), ""))
+    context = repository_context(str(tmp_path))
+    assert context.owner == "owner"
+    assert context.name == "repo"
+    assert context.branch == "feature/test"
+    assert context.sha == "abc123"
+
+
+def test_disabled_workflow_returns_disabled_capability(monkeypatch):
+    called = False
+
+    def fail_get_secret(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("secret lookup must not run when disabled")
+
+    monkeypatch.setattr("hermes_cli.github_workflow.get_secret", fail_get_secret)
+    capability = resolve_github_capability(config={"github": {"workflow": {"enabled": False}}})
+    assert capability.workflow_enabled is False
+    assert capability.auth_state is AuthState.DISABLED
+    assert called is False
+
+
+def test_capability_status_is_json_safe(monkeypatch):
+    monkeypatch.setattr("hermes_cli.github_workflow.get_secret", lambda name, default=None: "secret")
+    capability = resolve_github_capability(
+        config={"github": {"workflow": {"enabled": True}}}, perform_preflight=False
+    )
+    payload = capability.to_public_dict()
+    serialized = json.dumps(payload)
+    assert '"_credential"' not in serialized
+    assert "ghp_" not in serialized
+    assert payload["public_read_available"] is True
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    from hermes_cli import github_workflow
+    github_workflow.clear_preflight_cache()
+    yield
+    github_workflow.clear_preflight_cache()
+
+
+def test_capability_type_is_provider_neutral():
+    assert GitHubCapability.__module__ == "hermes_cli.github_workflow"
+    assert GitHubRepository.__module__ == "hermes_cli.github_workflow"
+
+
+def test_credential_scope_is_explicit():
+    from hermes_cli.github_workflow import GITHUB_CREDENTIAL_PURPOSE
+    assert GITHUB_CREDENTIAL_PURPOSE == "github-workflow"
+
+
+def test_config_defaults_are_present():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    assert DEFAULT_CONFIG["github"]["workflow"]["enabled"] is True
+    assert DEFAULT_CONFIG["github"]["workflow"]["api_timeout_seconds"] == 10
+    assert DEFAULT_CONFIG["github"]["workflow"]["preflight_cache_seconds"] == 900
+
+
+def test_capability_has_no_provider_specific_code():
+    source = Path("hermes_cli/github_workflow.py").read_text()
+    assert "bitwarden" not in source.lower()
+    assert "onepassword" not in source.lower()
+    assert ".fetch(" not in source
+    assert "ErrorKind" in source
+
+
+def test_auth_state_is_serializable():
+    assert json.dumps({"state": AuthState.VERIFIED.value})
+
+
+def test_public_read_can_skip_preflight(monkeypatch):
+    calls = []
+    monkeypatch.setattr("hermes_cli.github_workflow.get_secret", lambda name, default=None: "secret")
+    monkeypatch.setattr("hermes_cli.github_workflow._preflight", lambda *args: calls.append(args))
+    capability = resolve_github_capability(
+        config={"github": {"workflow": {"enabled": True}}},
+        operation="public-read",
+        perform_preflight=False,
+    )
+    assert calls == []
+    assert capability.public_read_available is True
+
+
+def test_activation_relevant_for_github_repository():
+    from hermes_cli.github_workflow import activation_relevant
+    assert activation_relevant("anything", GitHubRepository(owner="owner", name="repo"))
+
+
+def test_activation_not_relevant_for_unrelated_prompt():
+    from hermes_cli.github_workflow import activation_relevant
+    assert not activation_relevant("Explain Python decorators", GitHubRepository())
+
+
+def test_workflow_git_env_disables_system_helpers():
+    from hermes_cli.github_workflow import workflow_git_env
+    env = workflow_git_env({"GIT_ASKPASS": "old", "GIT_TERMINAL_PROMPT": "1"})
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert "GIT_ASKPASS" not in env
+
+
+def test_error_kind_is_reused():
+    from hermes_cli.github_workflow import ErrorKind
+    assert ErrorKind.NOT_CONFIGURED.value == "not_configured"
+
+
+def test_capability_status_has_remediation_for_disabled():
+    capability = resolve_github_capability(config={"github": {"workflow": {"enabled": False}}})
+    assert capability.remediation


### PR DESCRIPTION
## Summary
- add a provider-neutral GitHub workflow capability shim over Hermes secret scope
- activate the GitHub workflow when the CLI starts in a GitHub repository
- extend `hermes doctor` with actionable provider-neutral GitHub workflow status
- consolidate GitHub skills onto Hermes-managed authentication guidance
- remove duplicate provider-specific authentication recipes

## Scope
- CLI-focused; no GitHub MCP and no new core model tool
- no provider-specific credential implementation or precedence logic
- no authenticated `gh`/SSH fallback in this PR

## Testing
- `./scripts/run_tests.sh tests/hermes_cli/test_github_workflow.py tests/hermes_cli/test_doctor.py tests/skills/test_github_credential_token.py tests/cli/test_cli_preloaded_skills.py -v`
- `./scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_set_config_value.py tests/skills/test_github_credential_token.py tests/cli/test_cli_preloaded_skills.py -v`
- 93 focused tests passed; 179 related regression tests passed
- `git diff --check` and Python compile checks passed

## Overall goal
This change makes GitHub access a predictable part of Hermes rather than a collection of model-selected authentication workarounds. When the CLI is operating in a GitHub repository, Hermes can recognize the context, use its existing provider-neutral secret plumbing, activate the relevant GitHub workflow, and report a clear authenticated or actionable unauthenticated state. The design removes the need for GitHub MCP and avoids tying the workflow to any specific secret manager, while preserving public repository access and existing approval boundaries for writes.
