### PR TITLE
fix(memory): warn when startup files are unreadable

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+import logging
 import pytest
 from pathlib import Path
 
@@ -267,6 +268,88 @@ class TestMemoryStorePersistence:
         store = MemoryStore()
         store.load_from_disk()
         assert len(store.memory_entries) == 2
+
+
+class TestMemoryStoreLoadDiagnostics:
+    @staticmethod
+    def _memory_warnings(caplog):
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "tools.memory_tool"
+            and record.levelno == logging.WARNING
+        ]
+
+    def test_invalid_utf8_memory_warns_without_hiding_valid_user_profile(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        memory_path = tmp_path / "MEMORY.md"
+        original = b"valid prefix\n\xff\xfe\x80 private memory"
+        memory_path.write_bytes(original)
+        (tmp_path / "USER.md").write_text(
+            "User prefers Chinese.", encoding="utf-8"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore()
+            store.load_from_disk()
+
+        assert store.memory_entries == []
+        assert store.format_for_system_prompt("memory") is None
+        assert store.user_entries == ["User prefers Chinese."]
+        assert "User prefers Chinese." in store.format_for_system_prompt("user")
+        assert memory_path.read_bytes() == original
+        assert self._memory_warnings(caplog) == [
+            "Could not read MEMORY.md; omitting it from this session's memory "
+            "snapshot. The file was left unchanged. Check its permissions and "
+            "UTF-8 encoding."
+        ]
+
+    def test_permission_error_user_warns_without_hiding_valid_memory(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        (tmp_path / "MEMORY.md").write_text(
+            "Project uses Python 3.12.", encoding="utf-8"
+        )
+        user_path = tmp_path / "USER.md"
+        original = b"User prefers concise replies."
+        user_path.write_bytes(original)
+        real_read_text = Path.read_text
+
+        def deny_user(self, *args, **kwargs):
+            if self == user_path:
+                raise PermissionError("access denied")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", deny_user)
+
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore()
+            store.load_from_disk()
+
+        assert store.memory_entries == ["Project uses Python 3.12."]
+        assert "Project uses Python 3.12." in store.format_for_system_prompt("memory")
+        assert store.user_entries == []
+        assert store.format_for_system_prompt("user") is None
+        assert user_path.read_bytes() == original
+        assert self._memory_warnings(caplog) == [
+            "Could not read USER.md; omitting it from this session's memory "
+            "snapshot. The file was left unchanged. Check its permissions and "
+            "UTF-8 encoding."
+        ]
+
+    def test_missing_files_do_not_warn(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore()
+            store.load_from_disk()
+
+        assert store.memory_entries == []
+        assert store.user_entries == []
+        assert self._memory_warnings(caplog) == []
 
 
 class TestMemoryStoreSnapshot:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -220,8 +220,22 @@ class MemoryStore:
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
 
-        self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
-        self.user_entries = self._read_file(mem_dir / "USER.md")
+        memory_path = mem_dir / "MEMORY.md"
+        user_path = mem_dir / "USER.md"
+        self.memory_entries, memory_read_ok = self._read_entries_checked(memory_path)
+        self.user_entries, user_read_ok = self._read_entries_checked(user_path)
+
+        for path, read_ok in (
+            (memory_path, memory_read_ok),
+            (user_path, user_read_ok),
+        ):
+            if not read_ok:
+                logger.warning(
+                    "Could not read %s; omitting it from this session's memory "
+                    "snapshot. The file was left unchanged. Check its permissions "
+                    "and UTF-8 encoding.",
+                    path.name,
+                )
 
         # Deduplicate entries (preserves order, keeps first occurrence)
         self.memory_entries = list(dict.fromkeys(self.memory_entries))


### PR DESCRIPTION
## What does this PR do?

An existing but unreadable `MEMORY.md` or `USER.md` currently degrades to an empty startup snapshot with no diagnostic. `_read_raw_checked()` records the failure, but `load_from_disk()` previously discarded that status.

This PR keeps the existing fail-open and data-preservation behavior while logging one filename-only warning for each unreadable startup file. The failing file is omitted only from the current in-memory snapshot, its bytes are left unchanged, a healthy companion file still loads, and missing files remain silent.

Generic agent-initialization exception logging cannot observe this path because no exception escapes the checked reader.

## Related Issue

Related to #79472.  
Follow-up to #71004.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Load `MEMORY.md` and `USER.md` through the checked reader so startup retains each file's read status.
- Warn once per existing unreadable file without exposing its full path or contents.
- Add regression coverage for invalid UTF-8, `PermissionError`, healthy companion loading, frozen snapshots, unchanged disk bytes, and silent missing files.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_memory_tool.py -q
```

Result: `37 passed, 0 failed` on Windows 11 with Python 3.12.7.

## Checklist

### Code

- [x] I have read the contributing guide.
- [x] The commit follows the project's conventional commit style.
- [x] I searched open and closed PRs for overlapping work.
- [x] The change is limited to the relevant implementation and tests.
- [x] I added regression tests and ran the complete targeted test file.
- [ ] I ran the entire repository test suite.

### Documentation & Housekeeping

- [x] Documentation changes are not needed for this internal diagnostic.
- [x] No configuration or environment-template changes are required.
- [x] Cross-platform behavior was considered; no platform-specific logic was added.
- [x] No tool schema changed.

## Screenshots / Logs

Not applicable; this change adds a startup log diagnostic and regression tests.