### PR TITLE
fix(tui_gateway): route model switches across the compute-host boundary

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16184,3 +16184,58 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         assert cleanup_order == ["trim", "reset_home"]
     finally:
         server._sessions.pop("sid_trim", None)
+
+# ---------------------------------------------------------------------------
+# Model switches on compute-host (turn-isolation) sessions must cross the
+# process boundary — regression tests for the queued-pick handoff.
+# ---------------------------------------------------------------------------
+
+
+def test_config_set_model_defers_on_compute_host_session(monkeypatch):
+    """Idle isolated session: config.set model must stash, not direct-apply."""
+    session = _session(agent=None, running=False)
+    session["_compute_host_active"] = True
+    server._sessions["sid"] = session
+    build_calls = []
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: build_calls.append(a))
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "config.set",
+             "params": {"session_id": "sid", "key": "model", "value": "gpt-5.5"}}
+        )
+        assert resp["result"].get("deferred") is True
+        assert session["pending_model_switch"]["raw"] == "gpt-5.5"
+        # The broken path built a second agent inside the server process.
+        assert build_calls == []
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_compute_host_turn_frame_carries_pending_switch():
+    session = _session(agent=None, running=False)
+    session["pending_model_switch"] = {"raw": "gpt-5.5", "display_model": "gpt-5.5"}
+    frame = server._compute_host_turn_frame("r1", "sid", session, "hello")
+    assert frame["pending_model_switch"]["raw"] == "gpt-5.5"
+    # Copied, not popped — the fail-open in-process path may still need it.
+    assert session["pending_model_switch"]["raw"] == "gpt-5.5"
+
+
+def test_compute_host_turn_done_clears_pending_switch_on_success():
+    session = _session(agent=None, running=True)
+    session["pending_model_switch"] = {"raw": "gpt-5.5"}
+    server._sessions["sid"] = session
+    try:
+        server._on_compute_host_turn_done(
+            "r1", "sid", session, {"type": "turn.end", "session_info_emitted": True}
+        )
+        assert "pending_model_switch" not in session
+        # An errored turn must KEEP the stash for the fail-open path.
+        session["pending_model_switch"] = {"raw": "gpt-5.5"}
+        session["running"] = True
+        server._on_compute_host_turn_done(
+            "r1", "sid", session, {"type": "turn.error", "message": "boom",
+                                    "session_info_emitted": True}
+        )
+        assert session["pending_model_switch"]["raw"] == "gpt-5.5"
+    finally:
+        server._sessions.pop("sid", None)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -535,6 +535,11 @@ class ComputeHost:
                 session["profile_home"] = str(frame.get("profile_home"))
             if isinstance(frame.get("attached_images"), list):
                 session["attached_images"] = list(frame.get("attached_images") or [])
+            # Adopt a model switch queued on the server side while this
+            # session was busy. _run_prompt_submit's turn thread applies it via
+            # _apply_pending_model_switch — HERE the live agent exists.
+            if frame.get("pending_model_switch"):
+                session["pending_model_switch"] = dict(frame["pending_model_switch"])
             return session
 
         history = frame.get("history") if isinstance(frame.get("history"), list) else []
@@ -622,6 +627,10 @@ class ComputeHost:
             session["attached_images"] = list(frame.get("attached_images") or [])
         if frame.get("model_override") is not None:
             session["model_override"] = frame.get("model_override")
+        # See the existing-session branch above — queued model switch
+        # crosses the process boundary and applies at this child's turn start.
+        if frame.get("pending_model_switch"):
+            session["pending_model_switch"] = dict(frame["pending_model_switch"])
         return session
 
     def _handle_reload_mcp(self, frame: dict[str, Any]) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1655,6 +1655,14 @@ def _compute_host_turn_frame(
         "cwd": _session_cwd(session),
         "profile_home": session.get("profile_home") or "",
         "model_override": session.get("model_override"),
+        # A model switch queued while the session was busy
+        # (config.set model -> pending_model_switch) must cross the process
+        # boundary — the live agent is in the compute host, and the server-side
+        # _apply_pending_model_switch would pop-and-drop it against agent=None.
+        # COPIED (not popped): the stash is cleared only after a successful
+        # isolated turn (_on_compute_host_turn_done), so the fail-open
+        # in-process path can still apply it if the host dispatch fails.
+        "pending_model_switch": session.get("pending_model_switch"),
         "reasoning_config_override": session.get("create_reasoning_override"),
         "service_tier_override": session.get("create_service_tier_override"),
         "source": _session_source(session),
@@ -1717,6 +1725,12 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
         session["running"] = False
         session["last_active"] = time.time()
         _clear_inflight_turn(session)
+        # The isolated turn carried the queued model switch to the
+        # compute host, whose turn thread applied it. Clear the server-side
+        # stash so it isn't re-forwarded (kept on error so the fail-open
+        # in-process path can still apply it).
+        if not is_error:
+            session.pop("pending_model_switch", None)
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
         _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
@@ -10490,7 +10504,15 @@ def _(rid, params: dict) -> dict:
                 # (_apply_pending_model_switch), where nothing is in flight.
                 # The user gets to pick, keep typing, and send the next turn on
                 # the new model without waiting for the swap or interrupting.
-                if session.get("running"):
+                #
+                # Compute-host sessions ALWAYS defer, busy or idle. Their
+                # live agent is in the child process — the direct path below
+                # would build a SECOND agent in the server, switch that copy,
+                # and leave the child (which handles every turn) on the old
+                # model: checkmark shows the pick, requests keep the old model.
+                # The stash crosses the boundary in the turn frame and the
+                # child's turn thread applies it (_apply_pending_model_switch).
+                if session.get("running") or session.get("_compute_host_active"):
                     parsed = parse_model_switch_args(value)
                     try:
                         pending_model = parsed.model_input


### PR DESCRIPTION
## What does this PR do?

Fixes model switching on sessions running under `dashboard.turn_isolation`. Today a model pick on an isolated session looks successful (picker updates, `config.set` returns ok) but every subsequent request keeps the old model — the live agent runs in the compute-host child, and the switch machinery only operates on the serving process. Found while canarying turn isolation on a real deployment; full analysis in the linked issue.

The fix keeps the existing pending-switch design and extends it across the process boundary:

- Compute-host sessions **always defer** (busy or idle) instead of the idle path building and switching a second, unused agent inside the serving process.
- `_compute_host_turn_frame` carries `pending_model_switch` to the child — **copied, not popped**, so the fail-open in-process path still has it if host dispatch fails.
- The child adopts the stash in `_ensure_server_session` (both branches); its turn thread then applies it through the existing `_apply_pending_model_switch`, where the real agent is present.
- The server clears the stash only after a **successful** isolated turn (kept on `turn.error` for the fail-open path).

## Related Issue

Fixes #79509

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — defer on `_compute_host_active` in `config.set model`; include `pending_model_switch` in the compute-host turn frame; clear the stash in `_on_compute_host_turn_done` on success only.
- `tui_gateway/compute_host.py` — adopt the forwarded pending switch in `_ensure_server_session` (existing-session and new-session branches).
- `tests/test_tui_gateway_server.py` — three regression tests: idle defer (asserts no server-side agent build), frame handoff (copied-not-popped), clear-on-success / keep-on-error.

## Testing

- `tests/test_tui_gateway_server.py` — 520 passed on this branch (`python -m pytest`, macOS arm64, Python 3.13).
- Verified live on a remote-mode deployment: with isolation on, an idle-session picker switch previously left requests on the old model; after this change the next turn runs on the picked model and the stash clears.