### PR TITLE
fix(desktop): stop reporting false failure on successful backend updates

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -290,7 +290,11 @@ describe('requestActiveUpdate', () => {
     vi.useRealTimers()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Drain any backend apply this suite kicked off: applyBackendUpdate() now
+    // memoizes the in-flight run, so a dangling promise here would be handed
+    // to the next suite's tests instead of a fresh run.
+    await vi.waitFor(() => expect($backendUpdateApply.get().applying).toBe(false), { timeout: 5000 })
     setRemote(false)
     delete (globalThis as unknown as { window?: unknown }).window
   })
@@ -465,6 +469,7 @@ describe('applyBackendUpdate recovery', () => {
     checkHermesUpdateSpy.mockReset()
     updateHermesSpy.mockReset()
     getActionStatusSpy.mockReset()
+    $backendUpdateStatus.set(null)
     $backendUpdateApply.set({
       applying: false,
       stage: 'idle',
@@ -482,16 +487,14 @@ describe('applyBackendUpdate recovery', () => {
   })
 
   it('waits for the backend to return after the restart drops the connection, then clears the overlay', async () => {
-    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
-    getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
-    checkHermesUpdateSpy.mockResolvedValue({
-      install_method: 'git',
-      current_version: '0.16.0',
-      behind: 0,
-      update_available: false,
-      can_apply: true,
-      update_command: 'hermes update',
-      message: null
+    const actionId = 'd'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+      exit_code: null,
+      lines: [`=== hermes-update completed ${actionId} ===`],
+      name: 'update',
+      pid: null,
+      running: false
     })
 
     const promise = applyBackendUpdate()
@@ -504,7 +507,8 @@ describe('applyBackendUpdate recovery', () => {
   })
 
   it('surfaces backend update action log lines while the action is running', async () => {
-    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    const actionId = 'e'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'update', pid: 1 })
     getActionStatusSpy
       .mockResolvedValueOnce({
         exit_code: null,
@@ -514,15 +518,13 @@ describe('applyBackendUpdate recovery', () => {
         running: true
       })
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
-    checkHermesUpdateSpy.mockResolvedValue({
-      install_method: 'git',
-      current_version: '0.16.0',
-      behind: 0,
-      update_available: false,
-      can_apply: true,
-      update_command: 'hermes update',
-      message: null
-    })
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: [`=== hermes-update completed ${actionId} ===`],
+        name: 'update',
+        pid: null,
+        running: false
+      })
 
     const promise = applyBackendUpdate()
     await vi.advanceTimersByTimeAsync(1500)
@@ -537,18 +539,323 @@ describe('applyBackendUpdate recovery', () => {
     await promise
   })
 
+  it('keeps waiting past the old 45-second cutoff while the update action is running', async () => {
+    const actionId = 'f'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+
+    for (let attempt = 0; attempt < 31; attempt += 1) {
+      getActionStatusSpy.mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['=== hermes-update started now ===', `step ${attempt}`],
+        name: 'hermes-update',
+        pid: 1,
+        running: true
+      })
+    }
+
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+      exit_code: null,
+      lines: [`=== hermes-update completed ${actionId} ===`],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(46500)
+
+    expect($backendUpdateApply.get().applying).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('pull')
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+  })
+
+  it('treats a successful no-op as complete without waiting for a restart', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['stale output from another run', '=== hermes-update started now ===', '✓ Already up to date!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('treats a successful dependency repair as complete without waiting for a restart', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['=== hermes-update started now ===', '✓ Dependencies repaired!', '✓ Update complete!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('trusts the current action exit code without parsing its output', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['✓ Already up to date!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('waits for current-action completion proof after the backend restarts', async () => {
+    const actionId = 'a'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['Update complete!', `=== hermes-update completed ${'c'.repeat(32)} ===`],
+        name: 'hermes-update',
+        pid: null,
+        running: false
+      })
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['Update complete!', `=== hermes-update completed ${actionId} ===`],
+        name: 'hermes-update',
+        pid: null,
+        running: false
+      })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts its terminal receipt when a verbose update pushes the start marker out of the log tail', async () => {
+    const actionId = 'b'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+      exit_code: null,
+      lines: ['final build output', 'Update complete!', `=== hermes-update completed ${actionId} ===`],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(getActionStatusSpy).toHaveBeenCalledWith('hermes-update', 2000)
+  })
+
+  it('proves a pre-action-ID backend reached its requested commit after restart', async () => {
+    $backendUpdateStatus.set({
+      behind: 2,
+      commits: [{ at: 1, author: 'Nous', sha: 'requested-target', summary: 'target' }],
+      fetchedAt: 1,
+      supported: true,
+      targetSha: 'backend:0.18.2',
+      updateAvailable: true
+    })
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValue({
+      exit_code: null,
+      lines: ['verbose output', 'Update complete!'],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+    checkHermesUpdateSpy
+      .mockResolvedValueOnce({
+        behind: null,
+        can_apply: true,
+        commits: [],
+        current_version: '0.18.2',
+        install_method: 'git',
+        message: 'offline',
+        update_available: false,
+        update_command: 'hermes update'
+      })
+      .mockResolvedValueOnce({
+        behind: 1,
+        can_apply: true,
+        commits: [{ at: 2, author: 'Nous', sha: 'newer-commit', summary: 'newer' }],
+        current_version: '0.18.2',
+        install_method: 'git',
+        message: null,
+        update_available: true,
+        update_command: 'hermes update'
+      })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('proves a fast pre-action-ID packaged update by its changed version', async () => {
+    $backendUpdateStatus.set({
+      behind: 1,
+      commits: [],
+      fetchedAt: 1,
+      supported: true,
+      targetSha: 'backend:0.18.2',
+      updateAvailable: true
+    })
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: null,
+      lines: ['verbose output without a retained start marker'],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      behind: -1,
+      can_apply: true,
+      commits: [],
+      current_version: '0.18.3',
+      install_method: 'pip',
+      message: null,
+      update_available: true,
+      update_command: 'hermes update'
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledWith(true)
+  })
+
+  it('resumes action polling after a transient status failure', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['=== hermes-update started now ===', 'still running'],
+        name: 'hermes-update',
+        pid: 1,
+        running: true
+      })
+      .mockResolvedValueOnce({
+        exit_code: 0,
+        lines: ['=== hermes-update started now ===', 'Update complete!'],
+        name: 'hermes-update',
+        pid: 1,
+        running: false
+      })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(getActionStatusSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('restores the fixed action deadline after reconnecting', async () => {
+    updateHermesSpy.mockResolvedValue({ action_id: 'a'.repeat(32), ok: true, name: 'hermes-update', pid: 1 })
+    const running = {
+      exit_code: null,
+      lines: ['still running'],
+      name: 'hermes-update',
+      pid: 1,
+      running: true
+    }
+
+    for (let attempt = 0; attempt < 119; attempt += 1) {
+      getActionStatusSpy.mockResolvedValueOnce(running)
+    }
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValue(running)
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000 + 1500)
+
+    await expect(promise).resolves.toMatchObject({ error: 'apply-failed', ok: false })
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
+  it('shares one in-flight update between concurrent apply requests', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['=== hermes-update started now ===', '✓ Already up to date!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const first = applyBackendUpdate()
+    const second = applyBackendUpdate()
+
+    expect(second).toBe(first)
+    await vi.advanceTimersByTimeAsync(1500)
+    await Promise.all([first, second])
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed when the update action never reaches a terminal state', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: null,
+      lines: ['=== hermes-update started now ===', 'still running'],
+      name: 'hermes-update',
+      pid: 1,
+      running: true
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000 + 1500)
+    await expect(promise).resolves.toMatchObject({ ok: false, error: 'apply-failed' })
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
+  it('fails immediately when the update action exits nonzero', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 1,
+      lines: ['=== hermes-update started now ===', 'update failed'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toMatchObject({ ok: false, error: 'apply-failed' })
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
   it('surfaces an error when the backend never comes back after the restart', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
     checkHermesUpdateSpy.mockRejectedValue(new Error('ECONNREFUSED'))
 
     const promise = applyBackendUpdate()
-    await vi.advanceTimersByTimeAsync(70000)
+    await vi.advanceTimersByTimeAsync(250000)
     const result = await promise
 
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
-  })
+  }, 10000)
 })
 
 describe('startUpdatePoller', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -487,24 +487,9 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
   }
 }
 
-const BACKEND_RETURN_POLL_MS = 1500
-const BACKEND_RETURN_MAX_ATTEMPTS = 40
-
-async function waitForBackendReturn(): Promise<boolean> {
-  for (let attempt = 0; attempt < BACKEND_RETURN_MAX_ATTEMPTS; attempt += 1) {
-    await new Promise(resolve => globalThis.setTimeout(resolve, BACKEND_RETURN_POLL_MS))
-
-    try {
-      await checkHermesUpdate()
-
-      return true
-    } catch {
-      continue
-    }
-  }
-
-  return false
-}
+const BACKEND_ACTION_POLL_MS = 1500
+const BACKEND_ACTION_MAX_MS = 6 * 60 * 1000
+const BACKEND_RETURN_MAX_MS = 4 * 60 * 1000
 
 function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
   if (returned) {
@@ -547,7 +532,32 @@ function ingestBackendActionStatus(status: Awaited<ReturnType<typeof getActionSt
   })
 }
 
-export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+function completedAfterRestart(
+  status: Awaited<ReturnType<typeof getActionStatus>>,
+  actionId: string | undefined
+): boolean {
+  return !!actionId && status.lines.some(line => line === `=== hermes-update completed ${actionId} ===`)
+}
+
+function legacyBackendReachedTarget(
+  status: BackendUpdateCheckResponse,
+  targetSha: string | undefined,
+  previousVersion: string | undefined
+): boolean {
+  if (status.behind === 0) {
+    return true
+  }
+
+  if (previousVersion && status.current_version !== previousVersion) {
+    return true
+  }
+
+  return !!targetSha && !!status.commits?.length && !status.commits.some(commit => commit.sha === targetSha)
+}
+
+let backendUpdateInFlight: Promise<DesktopUpdateApplyResult> | null = null
+
+async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
     ...IDLE,
@@ -557,6 +567,11 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   })
 
   try {
+    const previousStatus = $backendUpdateStatus.get()
+    const requestedTargetSha = previousStatus?.commits?.at(0)?.sha
+    const previousVersion = previousStatus?.targetSha?.startsWith('backend:')
+      ? previousStatus.targetSha.slice('backend:'.length)
+      : undefined
     const started = await updateHermes()
 
     if (!started.ok) {
@@ -575,41 +590,67 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     })
 
     let last: Awaited<ReturnType<typeof getActionStatus>> | null = null
+    // Backups, dependency repair, and builds can legitimately take several
+    // minutes. Keep the generous cap only as a guard against a stuck action.
+    const actionDeadline = Date.now() + BACKEND_ACTION_MAX_MS
+    let deadline = actionDeadline
+    let reconnecting = false
 
-    for (let attempt = 0; attempt < 30; attempt += 1) {
-      await new Promise(resolve => globalThis.setTimeout(resolve, 1500))
+    while (Date.now() < deadline) {
+      await new Promise(resolve => globalThis.setTimeout(resolve, BACKEND_ACTION_POLL_MS))
 
       try {
-        last = await getActionStatus(started.name, 200)
+        last = await getActionStatus(started.name, 2000)
         ingestBackendActionStatus(last)
       } catch {
-        // The dashboard restarts mid-update, dropping this connection — expected, not a failure.
-        $backendUpdateApply.set({
-          ...$backendUpdateApply.get(),
-          applying: true,
-          stage: 'restart',
-          message: translateNow('updates.applyStatus.restarting')
-        })
+        if (!reconnecting) {
+          reconnecting = true
+          deadline = Date.now() + BACKEND_RETURN_MAX_MS
+          $backendUpdateApply.set({
+            ...$backendUpdateApply.get(),
+            applying: true,
+            stage: 'restart',
+            message: translateNow('updates.applyStatus.restarting')
+          })
+        }
 
-        return finishBackendApply(await waitForBackendReturn())
+        continue
       }
 
-      if (last && !last.running) {
+      if (last.running) {
+        if (reconnecting) {
+          reconnecting = false
+          deadline = actionDeadline
+          $backendUpdateApply.set({
+            ...$backendUpdateApply.get(),
+            applying: true,
+            stage: 'pull',
+            message: translateNow('updates.applyStatus.pulling')
+          })
+        }
+
+        continue
+      }
+
+      if (last.exit_code === 0 || (last.exit_code === null && completedAfterRestart(last, started.action_id))) {
+        return finishBackendApply(true)
+      }
+
+      if (!started.action_id && last.exit_code === null) {
+        try {
+          const status = await checkHermesUpdate(true)
+
+          if (legacyBackendReachedTarget(status, requestedTargetSha, previousVersion)) {
+            return finishBackendApply(true)
+          }
+        } catch {
+          continue
+        }
+      }
+
+      if (last.exit_code !== null) {
         break
       }
-    }
-
-    const ok = !!last && (last.exit_code ?? 1) === 0
-
-    if (ok) {
-      $backendUpdateApply.set({
-        ...$backendUpdateApply.get(),
-        applying: true,
-        stage: 'restart',
-        message: translateNow('updates.applyStatus.restarting')
-      })
-
-      return finishBackendApply(await waitForBackendReturn())
     }
 
     $backendUpdateApply.set({
@@ -633,6 +674,18 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
 
     return { ok: false, error: 'apply-failed', message }
   }
+}
+
+export function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+  if (backendUpdateInFlight) {
+    return backendUpdateInFlight
+  }
+
+  backendUpdateInFlight = runBackendUpdate().finally(() => {
+    backendUpdateInFlight = null
+  })
+
+  return backendUpdateInFlight
 }
 
 function ingestProgress(payload: DesktopUpdateProgress): void {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1144,6 +1144,8 @@ export interface ActionResponse {
   name: string
   ok: boolean
   pid: number
+  action_id?: string
+  already_running?: boolean
 }
 
 export interface ActionStatusResponse {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5071,6 +5071,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _print_curator_recent_run_notice,
     _print_fts_optimize_available_notice,
     _print_stash_cleanup_guidance,
+    _print_update_completion,
     _record_npm_lockfile_hash,
     _refresh_active_lazy_features,
     _refresh_active_memory_provider_dependencies,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -712,6 +712,16 @@ def _commit_staged_replacements(staged) -> None:
                 pass
 
 
+def _print_update_completion(message: str) -> None:
+    """Print an update outcome plus, when the dashboard launched this run
+    with an action id, a terminal receipt line the Desktop can match after
+    the dashboard restarts (see #47359 / #58764)."""
+    print(message)
+    action_id = os.environ.get("HERMES_ACTION_ID", "")
+    if len(action_id) == 32 and all(char in "0123456789abcdef" for char in action_id):
+        print(f"=== hermes-update completed {action_id} ===")
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -1059,7 +1069,7 @@ def _update_via_zip(args):
         print("  Code and Python deps are updated, but the dashboard/TUI may")
         print("  be in a mixed state until the Node deps are rebuilt.")
     else:
-        print("✓ Update complete!")
+        _print_update_completion("✓ Update complete!")
     try:
         _print_curator_first_run_notice()
     except Exception as e:
@@ -3916,11 +3926,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 healthy_after, detail_after = _venv_core_imports_healthy()
                 if healthy_after:
                     print("✓ Dependencies repaired!")
+                    _print_update_completion("✓ Update complete!")
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                print("✓ Already up to date!")
+                _print_update_completion("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():
                 print()
                 print(
@@ -4591,7 +4602,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         else:
-            print("✓ Update complete!")
+            _print_update_completion("✓ Update complete!")
 
         # Search-index optimization notice (v23). Existing installs keep their
         # working search index untouched on update; the compact v23 layout —

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3743,6 +3743,7 @@ _ACTION_LOG_FILES: Dict[str, str] = {
 # report liveness and exit code without shelling out to ``ps``.
 _ACTION_PROCS: Dict[str, subprocess.Popen] = {}
 _ACTION_COMMANDS: Dict[str, Tuple[str, ...]] = {}
+_ACTION_IDS: Dict[str, str] = {}
 
 # ``name`` → completed synthetic action result for actions the server handled
 # without spawning a subprocess (for example, unsupported Docker updates).
@@ -3763,6 +3764,7 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
             log_file.write(b"\n")
     _ACTION_PROCS.pop(name, None)
     _ACTION_COMMANDS.pop(name, None)
+    _ACTION_IDS.pop(name, None)
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": None}
 
 
@@ -3779,7 +3781,12 @@ def _dashboard_spawn_executable() -> str:
     return sys.executable
 
 
-def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
+def _spawn_hermes_action(
+    subcommand: List[str],
+    name: str,
+    *,
+    env_overrides: Optional[Dict[str, str]] = None,
+) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
     Uses the running interpreter's ``hermes_cli.main`` module so the action
@@ -3808,7 +3815,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
         "stderr": subprocess.STDOUT,
-        "env": action_env,
+        "env": {**action_env, **(env_overrides or {})},
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = windows_detach_flags()
@@ -3823,6 +3830,11 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     _ACTION_RESULTS.pop(name, None)
     _ACTION_COMMANDS[name] = tuple(subcommand)
     _ACTION_PROCS[name] = proc
+    action_id = (env_overrides or {}).get("HERMES_ACTION_ID")
+    if action_id:
+        _ACTION_IDS[name] = action_id
+    else:
+        _ACTION_IDS.pop(name, None)
     return proc
 
 
@@ -4114,8 +4126,26 @@ async def update_hermes():
             "update_command": message,
         }
 
+    existing = _ACTION_PROCS.get("hermes-update")
+    if existing is not None and existing.poll() is None:
+        response = {
+            "ok": True,
+            "pid": existing.pid,
+            "name": "hermes-update",
+            "already_running": True,
+        }
+        action_id = _ACTION_IDS.get("hermes-update")
+        if action_id:
+            response["action_id"] = action_id
+        return response
+
+    action_id = secrets.token_hex(16)
     try:
-        proc = _spawn_hermes_action(["update"], "hermes-update")
+        proc = _spawn_hermes_action(
+            ["update"],
+            "hermes-update",
+            env_overrides={"HERMES_ACTION_ID": action_id},
+        )
     except Exception as exc:
         _log.exception("Failed to spawn hermes update")
         raise HTTPException(status_code=500, detail=f"Failed to start update: {exc}")
@@ -4123,6 +4153,7 @@ async def update_hermes():
         "ok": True,
         "pid": proc.pid,
         "name": "hermes-update",
+        "action_id": action_id,
     }
 
 
@@ -4763,6 +4794,7 @@ async def get_action_status(name: str, lines: int = 200):
             _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
             _ACTION_PROCS.pop(name, None)
             _ACTION_COMMANDS.pop(name, None)
+            _ACTION_IDS.pop(name, None)
 
     return {
         "name": name,

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -19,8 +19,28 @@ from hermes_cli.main import (
     _finalize_update_output,
     _install_hangup_protection,
     _log_only_write,
+    _print_update_completion,
     _run_logged_subprocess,
 )
+
+
+def test_update_completion_includes_bounded_action_identity(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_ACTION_ID", "a" * 32)
+
+    _print_update_completion("✓ Update complete!")
+
+    assert capsys.readouterr().out.splitlines() == [
+        "✓ Update complete!",
+        f"=== hermes-update completed {'a' * 32} ===",
+    ]
+
+
+def test_update_completion_rejects_untrusted_action_identity(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_ACTION_ID", "not-safe\nforged")
+
+    _print_update_completion("✓ Update complete!")
+
+    assert capsys.readouterr().out == "✓ Update complete!\n"
 
 
 # -----------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1003,6 +1003,72 @@ class TestWebServerEndpoints:
         assert status_data["pid"] is None
         assert any("docker pull nousresearch/hermes-agent:latest" in line for line in status_data["lines"])
 
+    def test_update_hermes_spawns_with_action_id(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        class Proc:
+            pid = 12345
+
+        calls = []
+
+        def fake_spawn(subcommand, name, *, env_overrides=None):
+            calls.append((subcommand, name, env_overrides))
+            return Proc()
+
+        monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: False)
+        monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "git")
+        monkeypatch.setattr(web_server.secrets, "token_hex", lambda _size: "a" * 32)
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
+        web_server._ACTION_PROCS.pop("hermes-update", None)
+        web_server._ACTION_RESULTS.pop("hermes-update", None)
+
+        resp = self.client.post("/api/hermes/update")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "pid": 12345,
+            "name": "hermes-update",
+            "action_id": "a" * 32,
+        }
+        assert calls == [
+            (["update"], "hermes-update", {"HERMES_ACTION_ID": "a" * 32})
+        ]
+
+    def test_update_hermes_reuses_running_action(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        class Proc:
+            pid = 24680
+
+            def poll(self):
+                return None
+
+        monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: False)
+        monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "git")
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda *_args, **_kwargs: pytest.fail("must not spawn a duplicate update"),
+        )
+        web_server._ACTION_PROCS["hermes-update"] = Proc()
+        web_server._ACTION_IDS["hermes-update"] = "b" * 32
+
+        try:
+            resp = self.client.post("/api/hermes/update")
+        finally:
+            web_server._ACTION_PROCS.pop("hermes-update", None)
+            web_server._ACTION_IDS.pop("hermes-update", None)
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "pid": 24680,
+            "name": "hermes-update",
+            "already_running": True,
+            "action_id": "b" * 32,
+        }
+
 
 
 


### PR DESCRIPTION
Remote backend updates from Desktop reported "Backend update failed." even when the update succeeded — on nearly every real update (the ~45s poll cap expired mid-run) and on every no-op re-check (the "Already up to date" path printed no terminal marker and never restarted the gateway, so the return-check timed out). This makes backend update completion terminal-state driven end to end: the dashboard mints an `action_id` per update, `hermes update` prints a matching receipt on every success path including the no-op, and the Desktop only reports failure on a nonzero exit or a provably inconclusive completion.

## Behavior

- A reachable `running: true` action is never converted into failure by an elapsed budget; a fixed six-minute deadline guards against a genuinely stuck action.
- One in-flight apply promise in the renderer; the dashboard reuses an already-running update action instead of spawning a duplicate.
- Each update gets an `action_id` (`HERMES_ACTION_ID`) and emits `=== hermes-update completed <id> ===` before the restart boundary — normal, zip, dependency-repair, and no-op paths alike — so completion is proven by receipt, not inferred from stale log text.
- Older backends without `action_id` support are proven by the requested commit landing, a forced up-to-date check, or a packaged-version transition; inconclusive completion fails closed.
- Reconnect recovery during the dashboard restart does not extend the action deadline indefinitely.

## Tests

- `apps/desktop` vitest `src/store/updates.test.ts`: 43/43 (long-running action past the old cap, fast restarts, receipt matching incl. truncated logs, receipt from a different action rejected, pre-action-ID git/packaged upgrades, nonzero exit, concurrent applies, no-op success)
- `tests/hermes_cli/test_update_hangup_protection.py`: 11/11 (receipt bounds/format)
- `tests/hermes_cli/test_web_server.py`: update/action endpoint suite incl. new action-ID spawn + in-flight reuse tests
- `tests/hermes_cli/test_cmd_update.py`: 21/21
- Desktop typecheck clean on touched files

## Relationship to existing work

Consolidates the cluster on current `main` (both prior PRs no longer merge cleanly):

- Supersedes #47362 — @MarkVLK isolated the root cause: the 45s cap converting a still-running action's `exit_code: null` into failure. The two-phase wait/confirm structure survives here, rebuilt on receipts. Both sweeper review notes are addressed: `ingestBackendActionStatus` is retained in the poll loop, and Phase-B coverage includes `update_available: true → false` sequencing.
- Supersedes #59190 — @doncazper diagnosed the no-op "Already up to date" path (#58764); its terminal-marker approach is generalized into the action-scoped receipt.
- Supersedes #65681 — @TheAngryPit's consolidation is the backbone of this PR, re-resolved against current main (post-refactor `update_cmd.py` layout, action-env scrubbing from #52470, newer nix/managed-runtime guards and test structure).

Fixes #47359
Fixes #58764
