### PR TITLE
fix(computer-use): merge refs+content_refs in _ref_map for cua-driver 0.17

### DIFF
--- a/tools/computer_use/browser_route.py
+++ b/tools/computer_use/browser_route.py
@@ -60,36 +60,44 @@ def _ref_map(payload: Dict[str, Any]) -> Dict[str, Set[str]]:
     cua-driver has emitted both mapping and list representations while the
     semantic snapshot contract evolved.  Accept both without weakening the
     capability rule: a ref with no declared action remains readable only.
+
+    cua-driver >= 0.17 splits the semantic_v2 payload: action-bearing refs
+    live in the ``refs`` array while ``content_refs`` carries every node
+    with empty action lists.  Merge both sources (plus the legacy
+    snapshot.refs forms) so click/pointer/type refs stay usable.
     """
     normalized: Dict[str, Set[str]] = {}
-    snapshot = payload.get("snapshot")
-    # semantic_v2 carries the authoritative action-bearing entries in
-    # ``content_refs``; some transitional builds also emitted a ``refs`` list
-    # or map. Prefer the richer live shape, then accept both older forms.
-    raw = payload.get("content_refs")
-    if not raw:
-        raw = payload.get("refs")
-    if raw is None and isinstance(snapshot, dict):
-        raw = snapshot.get("refs")
-    if isinstance(raw, dict):
-        entries: Iterable[tuple[Optional[str], Any]] = raw.items()
-    elif isinstance(raw, list):
-        entries = ((None, item) for item in raw)
-    else:
-        entries = ()
 
-    for key, value in entries:
-        if isinstance(value, dict):
-            ref = value.get("ref") or key
-            actions = value.get("actions")
+    def absorb(raw: Any) -> None:
+        if isinstance(raw, dict):
+            entries: Iterable[tuple[Optional[str], Any]] = raw.items()
+        elif isinstance(raw, list):
+            entries = ((None, item) for item in raw)
         else:
-            ref = key
-            actions = None
-        if not isinstance(ref, str) or not ref:
-            continue
-        normalized[ref] = {
-            action for action in (actions or []) if isinstance(action, str)
-        }
+            return
+        for key, value in entries:
+            if isinstance(value, dict):
+                ref = value.get("ref") or key
+                actions = value.get("actions")
+            else:
+                ref = key
+                actions = None
+            if not isinstance(ref, str) or not ref:
+                continue
+            action_set = {
+                action for action in (actions or []) if isinstance(action, str)
+            }
+            # Merge, never drop: content_refs entries carry empty action
+            # lists and must not clobber the same ref declared in ``refs``.
+            normalized[ref] = normalized.get(ref, set()) | action_set
+
+    # 0.17 authoritative action refs; older builds emit only ``refs``; some
+    # transitional builds emit a mapping. Absorb every shape.
+    absorb(payload.get("refs"))
+    absorb(payload.get("content_refs"))
+    snapshot = payload.get("snapshot")
+    if isinstance(snapshot, dict):
+        absorb(snapshot.get("refs"))
     return normalized
 
 


### PR DESCRIPTION
## Summary

Fixes typed-browser mutations (`cua_browser_click` / `cua_browser_type` / `cua_browser_pointer`) failing with `browser_ref_stale` on every ref after upgrading cua-driver to >= 0.17.

## Root cause

cua-driver >= 0.17 splits the `semantic_v2` snapshot payload into two lists:

- `refs` — action-bearing entries with `actions: ["click", "pointer", ...]` (the authoritative interactive refs)
- `content_refs` — every node in the tree, but **with empty `actions: []`**

`_ref_map()` in `tools/computer_use/browser_route.py` only absorbed `content_refs` (preferring it over `refs`), so every ref was registered with an **empty action set**. `_require_ref()` then rejected all mutations with `browser_ref_stale`. Navigation and snapshot reads still worked because they don't need action refs — which made this easy to miss: the browser works until you click.

Observed live on macOS with cua-driver 0.17.0 (upgraded from 0.1.9 via `hermes computer-use install --upgrade`).

## Fix

Merge all three payload shapes instead of picking one:

- `refs` (0.17 authoritative, action-bearing)
- `content_refs` (0.17 content nodes; empty actions must not clobber)
- `snapshot.refs` (legacy fallback)

Actions are combined with set union, so an empty `content_refs` entry can never drop the actions declared in `refs`. The old behavior for pre-0.17 drivers (refs-only list, transitional dict shape) is preserved.

## Verification

- Unit-tested `_ref_map` against 4 payload shapes:
  1. 0.17 split format (`refs` with actions + `content_refs` with empty actions) → refs keep `click/pointer` ✅
  2. legacy `refs`-only list ✅
  3. transitional `refs`-as-dict ✅
  4. `snapshot.refs` fallback + empty payload ✅
- End-to-end on a live driver-owned isolated Chromium (cua-driver 0.17.0): bind → snapshot → navigate to github.com search → click a repo link → page navigated to the repo ✅

## Test plan for reviewers

```python
import sys
sys.path.insert(0, '.')
from tools.computer_use.browser_route import _ref_map

# 0.17 split format
payload = {
    'refs': [{'ref': 'p1:1', 'actions': ['click', 'pointer']}],
    'content_refs': [{'ref': 'p1:1', 'actions': []}, {'ref': 'p1:2', 'actions': []}],
}
assert _ref_map(payload)['p1:1'] == {'click', 'pointer'}
assert _ref_map(payload)['p1:2'] == set()
```

Requires cua-driver >= 0.17 for the live end-to-end reproduction; the unit-level check above runs on any version.
