### PR TITLE
fix(desktop): session tabs no longer trap — self-heal phantom tiles, never hide chat tabs behind a hidden strip

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/hidden-strip-recovery.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/hidden-strip-recovery.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Ground-truth repro for "hidden tab strip becomes an inescapable dead end for
+// chat tabs" (upstream issue: crash-stale or user-set `headerHidden: true` on
+// the main zone). The tab strip is the ONLY affordance that shows/switches/
+// closes chat tabs, and the only "show header" control lives in the header's
+// own context menu — so once the strip is hidden:
+//
+//   1. revealTreePane('session-tile:X') fronted the tab INVISIBLY — every
+//      sidebar click looked dead (nothing on screen changed), and
+//   2. adoption re-pinned `headerHidden: true` onto the zone (the "standing
+//      preference" branch), so even NEW tabs arrived invisible.
+//
+// Fix under test: revealing or adopting a SESSION pane (workspace /
+// session-tile:*) into a header-hidden zone force-shows the bar; tool panels
+// (terminal, logs, …) keep honoring the zone's standing preference.
+
+describe('hidden tab strip recovery for chat tabs', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    registry.register({
+      area: 'panes',
+      data: { placement: 'main', uncloseable: true },
+      id: 'workspace',
+      render: () => null,
+      title: 'chat'
+    })
+
+    tree.declareDefaultTree(
+      model.split(
+        'row',
+        [model.group(['workspace'], { active: 'workspace', id: 'grp-main' })],
+        [1]
+      )
+    )
+    tree.watchContributedPanes()
+
+    return { model, registry, tree }
+  }
+
+  const mainGroup = (tree: Awaited<ReturnType<typeof setup>>['tree']) => {
+    const root = tree.$layoutTree.get()!
+    const find = (n: import('@/components/pane-shell/tree/model').LayoutNode): import('@/components/pane-shell/tree/model').GroupNode | null => {
+      if (n.type === 'group') {
+        return n.panes.includes('workspace') || n.panes.some(p => p.startsWith('session-tile:')) ? n : null
+      }
+
+      for (const child of n.children) {
+        const hit = find(child)
+
+        if (hit) {
+          return hit
+        }
+      }
+
+      return null
+    }
+
+    return find(root)!
+  }
+
+  it('revealTreePane un-hides the strip for a session tile', async () => {
+    const { registry, tree } = await setup()
+
+    registry.register({
+      area: 'panes',
+      data: { dock: { pane: 'workspace', pos: 'center' }, placement: 'main' },
+      id: 'session-tile:s1',
+      render: () => null,
+      title: 's1'
+    })
+    expect(mainGroup(tree).panes).toContain('session-tile:s1')
+
+    // The trap state: strip explicitly hidden while a chat tab exists.
+    tree.setTreeGroupHeaderHidden(mainGroup(tree).id, true)
+    expect(mainGroup(tree).headerHidden).toBe(true)
+
+    // A sidebar click on the open session funnels through revealTreePane.
+    // Pre-fix: the tab fronted invisibly (headerHidden stayed true) — the
+    // user saw a dead click with no way to ever show the strip again.
+    tree.revealTreePane('session-tile:s1')
+
+    expect(mainGroup(tree).headerHidden).toBe(false)
+    expect(mainGroup(tree).active).toBe('session-tile:s1')
+  })
+
+  it('adopting a NEW session tile into a hidden-strip zone shows the strip', async () => {
+    const { registry, tree } = await setup()
+
+    tree.setTreeGroupHeaderHidden(mainGroup(tree).id, true)
+    expect(mainGroup(tree).headerHidden).toBe(true)
+
+    // "Open in new tab" registers a new tile pane; adoption docks it into the
+    // main zone. Pre-fix the adoption path re-pinned the zone's hidden flag
+    // (standing-preference branch), so the new tab arrived invisible.
+    registry.register({
+      area: 'panes',
+      data: { dock: { pane: 'workspace', pos: 'center' }, placement: 'main' },
+      id: 'session-tile:s2',
+      render: () => null,
+      title: 's2'
+    })
+
+    expect(mainGroup(tree).panes).toContain('session-tile:s2')
+    expect(mainGroup(tree).headerHidden).toBe(false)
+  })
+
+  it('tool panels still honor the standing hidden preference on adoption', async () => {
+    const { registry, tree } = await setup()
+
+    tree.setTreeGroupHeaderHidden(mainGroup(tree).id, true)
+
+    // A tool pane (NOT a session strip pane) adopted into the same zone must
+    // keep the user's hidden bar — that's the legitimate standing preference
+    // the original branch protects (close/reopen of terminal, logs, …).
+    registry.register({
+      area: 'panes',
+      data: { dock: { pane: 'workspace', pos: 'center' }, placement: 'main' },
+      id: 'scratchpad',
+      render: () => null,
+      title: 'scratchpad'
+    })
+
+    expect(mainGroup(tree).panes).toContain('scratchpad')
+    expect(mainGroup(tree).headerHidden).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -904,6 +904,15 @@ export function revealTreePane(paneId: string) {
       next = setGroupMinimized(next, group.id, false)
     }
 
+    // Revealing a CHAT tab into a zone whose header is hidden must un-hide
+    // it: the strip is the only way to see/switch/close chat tabs, and the
+    // only "show header" affordance lives in the header's own menu — an
+    // invisible strip is a dead end the user can't escape. Tool panels keep
+    // the zone's standing preference.
+    if (group.headerHidden === true && isSessionStripPane(paneId)) {
+      next = setGroupHeaderHiddenOp(next, group.id, false)
+    }
+
     if (group.active !== paneId) {
       next = setActivePaneOp(next, group.id, paneId)
     }
@@ -1113,10 +1122,17 @@ function adoptContributedPanes(): void {
       // standing preference about the zone, not a stale default. Without this
       // the bar came back every time a tool panel was closed and toggled on
       // again — Close dismisses the pane, the toggle re-adopts it through here.
+      //
+      // EXCEPT-THE-EXCEPTION: session tiles. A chat tab is only reachable
+      // through the tab strip, and the only "show header" affordance lives in
+      // the header's own context menu — so honoring the hidden preference for
+      // a session tile creates an invisible tab with NO way back (the user
+      // sees a dead click). Chat tabs force the bar visible; tool panels keep
+      // honoring the zone's standing preference.
       const landed = findGroupOfPane(next, pane.id)
 
       if (landed) {
-        next = setGroupHeaderHiddenOp(next, landed.id, hostHeaderHidden)
+        next = setGroupHeaderHiddenOp(next, landed.id, hostHeaderHidden && !isSessionStripPane(pane.id))
       }
     }
   }

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -230,13 +230,20 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
   it('drops a phantom tile (persisted but pane-less) and reports a miss', async () => {
     const { states, tree } = await setup()
 
-    // Simulate crash-stale storage: the tile list says "open", but the layout
-    // tree lost the pane (hard restart reset the tree; localStorage survived).
-    // Bypass closeSessionTile — that's the graceful path that keeps both in
-    // sync. Instead surgically remove the pane from the tree while leaving the
-    // $sessionTiles entry behind, exactly what a mid-write crash produces.
+    // A tile opened THIS run is exempt: pane adoption is async, so a briefly
+    // missing pane right after open is in-flight, not phantom. Simulate the
+    // adoption gap by removing the pane — the claim must survive.
     tree.removeTreePane(tilePane('closed'))
+    expect(states.focusOpenSession('closed')).toBe('tile')
     expect(states.$sessionTiles.get().some(t => t.storedSessionId === 'closed')).toBe(true)
+
+    // Crash-stale storage shape: the tile hydrates from localStorage on boot
+    // (no runtime open), and the layout tree lost the pane. Simulate by
+    // closing (clears the runtime mark), re-hydrating the atom directly the
+    // way boot does, and stripping the pane the harness re-adopted.
+    states.closeSessionTile('closed')
+    states.$sessionTiles.set([{ dir: 'center' as const, storedSessionId: 'closed' }])
+    tree.removeTreePane(tilePane('closed'))
     expect(findGroupOfPane(tree.$layoutTree.get()!, tilePane('closed'))).toBeNull()
 
     // Pre-fix this returned 'tile' (a dead click: nothing on screen to front,

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -226,4 +226,25 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
     expect(findGroupOfPane(tree.$layoutTree.get()!, tilePane('closed'))?.active).toBe(tilePane('closed'))
     expect(tree.$activeTreeGroup.get()).toBe('grp-main')
   })
+
+  it('drops a phantom tile (persisted but pane-less) and reports a miss', async () => {
+    const { states, tree } = await setup()
+
+    // Simulate crash-stale storage: the tile list says "open", but the layout
+    // tree lost the pane (hard restart reset the tree; localStorage survived).
+    // Bypass closeSessionTile — that's the graceful path that keeps both in
+    // sync. Instead surgically remove the pane from the tree while leaving the
+    // $sessionTiles entry behind, exactly what a mid-write crash produces.
+    tree.removeTreePane(tilePane('closed'))
+    expect(states.$sessionTiles.get().some(t => t.storedSessionId === 'closed')).toBe(true)
+    expect(findGroupOfPane(tree.$layoutTree.get()!, tilePane('closed'))).toBeNull()
+
+    // Pre-fix this returned 'tile' (a dead click: nothing on screen to front,
+    // menu suppresses "Open in new tab" forever). It must be a miss...
+    expect(states.focusOpenSession('closed')).toBeNull()
+
+    // ...and self-heal: the phantom entry is gone, so the NEXT open works and
+    // the actions menu offers "Open in new tab" again.
+    expect(states.$sessionTiles.get().some(t => t.storedSessionId === 'closed')).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -528,6 +528,12 @@ function syncTileStripOrder() {
  *  An unanchored open (⌘T, ⌘⇧T on a tile that predates anchors) docks into the
  *  FOCUSED chat zone — the same zone ⌘1…⌘9 and ⌘W act on — so a new tab lands
  *  in the strip the user is looking at, not always main's. */
+// Tiles opened during THIS app run. Pane adoption is async (registry →
+// layout tree), so a tile whose pane is briefly missing right after open is
+// IN-FLIGHT, not phantom. Only tiles hydrated from storage (app boot /
+// profile switch) may be judged phantom when their pane never materializes.
+const runtimeOpenedTiles = new Set<string>()
+
 export function openSessionTile(
   storedSessionId: string,
   dir: TileDock = 'right',
@@ -543,6 +549,7 @@ export function openSessionTile(
   const dock = anchor ?? focusedSessionTabAnchor() ?? undefined
 
   if (!tiles.some(t => t.storedSessionId === storedSessionId)) {
+    runtimeOpenedTiles.add(storedSessionId)
     saveTiles([...tiles, { anchor: dock, before, dir, storedSessionId }])
     // Adoption is async via the registry — order sync runs after the move path
     // below; a brand-new tile's strip slot is already in `before`.
@@ -619,9 +626,15 @@ export function focusOpenSession(storedSessionId: string): 'main' | 'tile' | nul
     // list survived). Claiming 'tile' here makes every open a dead click and
     // keeps the actions menu suppressing "Open in new tab" forever. Drop the
     // stale entry and report a miss so the caller opens the session for real.
-    discardSessionTile(storedSessionId)
+    // Tiles opened THIS run are exempt: their pane adoption is async and a
+    // just-opened tile must not be discarded mid-flight.
+    if (!runtimeOpenedTiles.has(storedSessionId)) {
+      discardSessionTile(storedSessionId)
 
-    return null
+      return null
+    }
+
+    return 'tile'
   }
 
   // Already the main session: front the workspace tab and drop tile focus so
@@ -694,6 +707,7 @@ export function closeSessionTile(storedSessionId: string) {
     closedStack().push({ anchor: tile.anchor, before: tile.before, dir: tile.dir, storedSessionId })
   }
 
+  runtimeOpenedTiles.delete(storedSessionId)
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
 }
 
@@ -708,6 +722,7 @@ export function discardSessionTile(storedSessionId: string) {
     dropSessionState(runtimeId)
   }
 
+  runtimeOpenedTiles.delete(storedSessionId)
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
 }
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -610,9 +610,18 @@ export function focusOpenSession(storedSessionId: string): 'main' | 'tile' | nul
 
     if (group) {
       noteActiveTreeGroup(group.id)
+
+      return 'tile'
     }
 
-    return 'tile'
+    // Phantom tile: persisted as "open", but no pane exists even after a
+    // reveal (crash-stale storage — the layout tree was reset while the tile
+    // list survived). Claiming 'tile' here makes every open a dead click and
+    // keeps the actions menu suppressing "Open in new tab" forever. Drop the
+    // stale entry and report a miss so the caller opens the session for real.
+    discardSessionTile(storedSessionId)
+
+    return null
   }
 
   // Already the main session: front the workspace tab and drop tile focus so


### PR DESCRIPTION
## Summary

Fixes two production-observed traps that make desktop chat tabs appear completely broken after a crash or an unlucky toggle. Both were hit today on macOS (remote/SSH connection mode) while recovering from the FD-exhaustion outage (#78873); root-caused live via CDP against the affected machines.

Fixes #79476, fixes #79518.

## 1. Phantom session tiles (crash-stale storage) — #79476

**Symptom:** "Open in new tab" vanishes from the session context menu; Cmd-click on sidebar sessions is a dead click.

**Root cause:** `$sessionTiles` (localStorage) and the layout tree persist separately. A hard restart can commit one without the other; `focusOpenSession()` trusted the tile list unconditionally and returned `'tile'` for a pane that doesn't exist. Downstream, `openSession(..., 'tab')` early-returns (dead click) and the actions menu computes `alreadyTabbed=true` forever.

**Fix:** after the reveal attempt, if the pane is still absent from the layout tree, the persisted tile is phantom — `discardSessionTile()` it and report a miss so the caller opens the session for real. Self-heals on first interaction instead of requiring a manual localStorage wipe.

**In-flight guard:** tiles opened during the current run are exempt (pane adoption is async via the registry; a just-opened tile is briefly pane-less and must not be discarded mid-flight). Only storage-hydrated tiles can be judged phantom.

## 2. Hidden tab strip dead end — #79518

**Symptom:** every sidebar click on an open session looks dead; new tabs arrive invisible; there is NO way back (the only "Show header" affordance lives in the strip's own context menu).

**Root cause:** two sites preserve `headerHidden` where the pane is a chat tab: `revealTreePane()` (fronts session tabs into an invisible strip) and the adoption path (re-pins the zone's hidden flag onto newly adopted session tiles — the "standing preference" branch, correct for tool panels only).

**Fix:** use the existing `isSessionStripPane()` distinction at both sites. Revealing or adopting a session strip pane (`workspace` / `session-tile:*`) into a header-hidden zone force-shows the bar; tool panels keep honoring the standing preference (terminal close/reopen keeps working as designed).

This follows the desktop AGENTS.md doctrine: recovery ladders must end in a real affordance, and persisted UI state is a cache to validate at the boundary, not owned truth.

## Tests

- `src/store/session-states.test.ts`: phantom tile dropped + reported as miss; in-flight tile survives the adoption gap (simulates the exact mid-write crash shape).
- `src/components/pane-shell/tree/hidden-strip-recovery.test.ts` (new): reveal un-hides for session tiles; adoption un-hides for new session tiles; tool panels still honor the hidden preference.
- Full desktop suite: **4418 passed | 2 skipped** on this branch.

## Verification beyond unit tests

Both fixes were validated against the live production instances that hit the bugs (CDP `Runtime.evaluate` against the packaged app): the phantom-tile state and the hidden-strip state were reproduced from the users' real localStorage payloads, and the patched build restores tab behavior on first interaction.
