### PR TITLE
docs(mcp): document chrome-devtools-mcp real-profile setup (--autoConnect / --userDataDir)

### DIFF
--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -207,6 +207,67 @@ mcp_servers:
       resources: false
 ```
 
+## Use `chrome-devtools-mcp` with your real Chrome profile
+
+`chrome-devtools-mcp` launches Chrome with an **isolated, blank profile** by default
+(`$HOME/.cache/chrome-devtools-mcp/chrome-profile`). This is intentional: the MCP server
+gets full control of the browser, so it starts from a clean slate instead of touching your
+daily browsing data. The side effect is that authenticated sites (Gmail, GitHub, dashboards,
+etc.) start logged out.
+
+If your workflows need your existing cookies and sessions, point the server at your real
+Chrome instead:
+
+### Option A — `--autoConnect` (recommended)
+
+Attaches to your already-running Chrome (v144+) with all your cookies, extensions, and
+sessions, without starting a separate instance:
+
+1. In Chrome, open `chrome://inspect/#remote-debugging` and follow the dialog to enable
+   remote debugging (allow incoming debugging connections).
+2. Add the server (the name `chrome-devtools` is just a label — use any name you like,
+   e.g. `chrome-devtools-win` if you already have a Windows entry):
+
+```bash
+# macOS / Linux
+hermes mcp add chrome-devtools --command npx --args -y chrome-devtools-mcp@latest --autoConnect --no-usage-statistics
+
+# Windows
+hermes mcp add chrome-devtools --command cmd.exe --args /c npx -y chrome-devtools-mcp@latest --autoConnect --no-usage-statistics
+```
+
+3. Start a fresh Hermes session or run `/reload-mcp`.
+
+The server connects to your running Chrome — the default profile when you have several —
+and asks for your permission via a dialog before taking control. Keep Chrome running while
+you use the MCP tools.
+
+### Option B — `--userDataDir`
+
+Points the server at a specific Chrome user data directory instead of the blank default.
+Use the **parent directory** that contains your profiles (e.g. `.../Chrome/User Data`),
+not an individual profile folder like `Default`:
+
+```bash
+# macOS
+hermes mcp add chrome-devtools --command npx --args -y chrome-devtools-mcp@latest --userDataDir "$HOME/Library/Application Support/Google/Chrome" --no-usage-statistics
+
+# Linux (Chromium / Chrome under ~/.config)
+hermes mcp add chrome-devtools --command npx --args -y chrome-devtools-mcp@latest --userDataDir "$HOME/.config/google-chrome" --no-usage-statistics
+
+# Windows (uses your real profile path via %LOCALAPPDATA%)
+hermes mcp add chrome-devtools --command cmd.exe --args /c npx -y chrome-devtools-mcp@latest --userDataDir "%LOCALAPPDATA%\Google\Chrome\User Data" --no-usage-statistics
+```
+
+Caveats:
+
+- A profile directory can only be used by one Chrome instance at a time. Close all Chrome
+  windows and background processes before starting the MCP server against the same
+  directory, otherwise the launch fails with a profile-in-use error.
+- The MCP server has full control over the browser it drives, so any profile you attach is
+  readable by your agent. Only attach profiles you're comfortable exposing to your MCP
+  tools.
+
 ## What does filtering actually affect?
 
 There are two categories of MCP-exposed functionality in Hermes:


### PR DESCRIPTION
## What changed and why

`chrome-devtools-mcp` launches Chrome with an isolated, blank profile by default
(`$HOME/.cache/chrome-devtools-mcp/chrome-profile`), so authenticated sites start logged
out. This was reported in #52954 — users trying to automate authenticated workflows
(Gmail, GitHub, dashboards) hit a wall because the docs never mentioned the flags that
attach the server to the user's real Chrome.

This PR adds a **"Use `chrome-devtools-mcp` with your real Chrome profile"** section to the
MCP guide documenting the two existing flags that solve it:

- **`--autoConnect`** (recommended) — attaches to the user's already-running Chrome
  (v144+) with all cookies, extensions, and sessions, via the
  `chrome://inspect/#remote-debugging` flow.
- **`--userDataDir`** — points the server at the user's Chrome user data directory
  (the parent dir containing profiles, not the individual profile folder like `Default`).

The section covers per-OS command variants (the `cmd.exe /c` wrapper required on
Windows, matching the existing house style in this guide), the profile-in-use caveat,
and a data-exposure note.

## Files changed

- `website/docs/guides/use-mcp-with-hermes.md` (+61 lines)

## Verification

- Docs-only change; no code paths affected.
- All commands follow the existing patterns already in the guide (e.g. the
  `chrome-devtools-win` Windows example at line 146).
- Cross-vendor review (Gemini 3.1 Pro + GPT-OSS 120B): round 1 flagged a Windows
  command-syntax blocker (fixed), round 2 flagged a macOS/Linux label error (fixed);
  final round: no remaining blockers.

## Notes

- **Open question:** whether the FAQ page (`website/docs/reference/faq.md`) should also
  get a short pointer to this section — happy to add if maintainers prefer.
- The zh-Hans i18n copy is translated separately per repo convention.

Closes #52954
