### PR TITLE
feat: install manifest + update.channel config + bundled-mode update refusal

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2383,6 +2383,18 @@ DEFAULT_CONFIG = {
         "backup_count": 3,     # Number of rotated backup files to keep
     },
 
+    # Update pipeline settings.
+    "update": {
+        # Which releases `hermes update` tracks on source (git) installs:
+        #   auto   — defer to the install manifest (.hermes-install.json);
+        #            effectively "main" for every pre-existing install.
+        #   main   — git pull origin main (today's behavior).
+        #   stable — check out the latest tagged release instead of main.
+        # Bundled desktop installs ignore this and always track stable —
+        # their updates arrive through the desktop app's own updater.
+        "channel": "auto",
+    },
+
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches
     # curated model lists for OpenRouter and Nous Portal from this URL,
     # falling back to the in-repo snapshot on network failure.  Lets us

--- a/hermes_cli/install_manifest.py
+++ b/hermes_cli/install_manifest.py
@@ -1,0 +1,181 @@
+"""Install-manifest plumbing for bundled desktop installs.
+
+``.hermes-install.json`` is a small, code-scoped marker written next to the
+managed checkout (the parent of ``hermes_cli/`` — same anchoring rationale as
+``.install_method`` in ``hermes_cli/config.py``: it describes *the running
+code*, not ``$HERMES_HOME``, so two installs sharing one data directory can't
+poison each other).
+
+It records where a checkout came from and where its updates come from:
+
+    {
+      "schemaVersion": 1,
+      "installMode": "bundled" | "source",
+      "channel": "stable" | "main",
+      "pinnedCommit": "<sha>",       # optional
+      "pinnedTag": "v0.17.0"         # optional, bundled installs only
+    }
+
+Semantics
+---------
+* ``installMode: "source"`` — the checkout is user-managed; ``hermes update``
+  (git pull / tag checkout / ZIP fallback) owns updates. **Absence of the file
+  means source mode** — every install that exists today is a source install,
+  so back-compat is total and nothing needs migrating.
+* ``installMode: "bundled"`` — the checkout was materialized from payloads
+  shipped inside the desktop installer. The desktop app owns updates (it
+  re-materializes the checkout offline after the app itself updates), so
+  ``hermes update`` refuses and points at the in-app updater.
+* ``channel`` — ``"main"`` tracks the git main branch (source mode only);
+  ``"stable"`` tracks tagged releases. The effective channel resolution lives
+  in :func:`resolve_update_channel`; ``update.channel`` in config.yaml can
+  override for source installs, while bundled installs are always stable.
+
+Pure-stdlib leaf module: no imports from hermes_cli.config (config imports
+would drag the full config machinery into every consumer; the desktop
+bootstrap and install scripts also write this file without Python).
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+INSTALL_MANIFEST_NAME = ".hermes-install.json"
+INSTALL_MANIFEST_SCHEMA_VERSION = 1
+
+MODE_SOURCE = "source"
+MODE_BUNDLED = "bundled"
+_VALID_MODES = (MODE_SOURCE, MODE_BUNDLED)
+
+CHANNEL_MAIN = "main"
+CHANNEL_STABLE = "stable"
+_VALID_CHANNELS = (CHANNEL_MAIN, CHANNEL_STABLE)
+
+# Sentinel accepted in config.yaml's ``update.channel``: defer to the manifest.
+CHANNEL_AUTO = "auto"
+
+
+def _default_manifest() -> dict:
+    """The implicit manifest for a checkout with no ``.hermes-install.json``.
+
+    Source mode on the main channel — i.e. exactly today's behavior, so
+    pre-manifest installs (all of them) are unaffected.
+    """
+    return {
+        "schemaVersion": INSTALL_MANIFEST_SCHEMA_VERSION,
+        "installMode": MODE_SOURCE,
+        "channel": CHANNEL_MAIN,
+    }
+
+
+def install_manifest_path(project_root: Optional[Path] = None) -> Path:
+    """Path of the manifest for the running code's install tree."""
+    root = project_root if project_root is not None else Path(__file__).parent.parent
+    return Path(root).resolve() / INSTALL_MANIFEST_NAME
+
+
+def read_install_manifest(project_root: Optional[Path] = None) -> dict:
+    """Read and sanitize the install manifest.
+
+    Never raises: a missing, unreadable, or malformed file — or one with
+    out-of-vocabulary ``installMode``/``channel`` values (e.g. written by a
+    FUTURE Hermes with a bigger vocabulary) — degrades to the source/main
+    default rather than bricking update logic. Unknown extra keys are
+    preserved so round-tripping a future manifest doesn't strip fields.
+    """
+    path = install_manifest_path(project_root)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _default_manifest()
+    except (OSError, ValueError) as exc:
+        logger.warning("Unreadable install manifest at %s (%s); assuming source install", path, exc)
+        return _default_manifest()
+
+    if not isinstance(raw, dict):
+        logger.warning("Install manifest at %s is not a JSON object; assuming source install", path)
+        return _default_manifest()
+
+    manifest = dict(raw)
+    if manifest.get("installMode") not in _VALID_MODES:
+        manifest["installMode"] = MODE_SOURCE
+    if manifest.get("channel") not in _VALID_CHANNELS:
+        manifest["channel"] = CHANNEL_MAIN if manifest["installMode"] == MODE_SOURCE else CHANNEL_STABLE
+    manifest.setdefault("schemaVersion", INSTALL_MANIFEST_SCHEMA_VERSION)
+    return manifest
+
+
+def write_install_manifest(
+    manifest: dict,
+    project_root: Optional[Path] = None,
+) -> Path:
+    """Atomically write the manifest (tmp + rename); returns the path written.
+
+    Validates mode/channel up front — writing garbage is worse than raising,
+    because every reader silently degrades garbage to source/main and the
+    caller's intent (e.g. marking an install bundled) would be quietly lost.
+    """
+    if manifest.get("installMode") not in _VALID_MODES:
+        raise ValueError(f"invalid installMode: {manifest.get('installMode')!r}")
+    if manifest.get("channel") not in _VALID_CHANNELS:
+        raise ValueError(f"invalid channel: {manifest.get('channel')!r}")
+
+    payload = dict(manifest)
+    payload.setdefault("schemaVersion", INSTALL_MANIFEST_SCHEMA_VERSION)
+
+    path = install_manifest_path(project_root)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def is_bundled_install(project_root: Optional[Path] = None) -> bool:
+    """True when the running checkout was materialized from desktop payloads."""
+    return read_install_manifest(project_root).get("installMode") == MODE_BUNDLED
+
+
+def resolve_update_channel(
+    config: Optional[dict] = None,
+    project_root: Optional[Path] = None,
+) -> str:
+    """Effective update channel for this install.
+
+    Resolution order:
+    1. Bundled installs are ALWAYS ``stable`` — the desktop app re-materializes
+       from tagged release payloads; a config override can't change what the
+       installer ships. (Ejecting flips the manifest to source mode first.)
+    2. ``update.channel`` in config.yaml (``stable`` / ``main``) when set to a
+       real channel; ``auto``/empty/unknown fall through.
+    3. The manifest's own channel (source default: ``main``).
+    """
+    manifest = read_install_manifest(project_root)
+    if manifest.get("installMode") == MODE_BUNDLED:
+        return CHANNEL_STABLE
+
+    configured: Any = None
+    if isinstance(config, dict):
+        update_cfg = config.get("update")
+        if isinstance(update_cfg, dict):
+            configured = update_cfg.get("channel")
+    if isinstance(configured, str) and configured.strip().lower() in _VALID_CHANNELS:
+        return configured.strip().lower()
+
+    return manifest.get("channel", CHANNEL_MAIN)
+
+
+def format_bundled_update_message() -> str:
+    """Refusal text for ``hermes update`` on a bundled install."""
+    return (
+        "✗ This Hermes install is managed by the Hermes desktop app.\n"
+        "\n"
+        "The desktop app updates the agent together with itself — use the\n"
+        "in-app updater (Settings → Check for updates) instead of `hermes update`.\n"
+        "\n"
+        "To manage this checkout yourself with `hermes update` (git-based\n"
+        "updates), eject it from desktop management first. Ejecting keeps the\n"
+        "desktop app auto-updating itself, but leaves the agent checkout to you."
+    )

--- a/hermes_cli/install_manifest.py
+++ b/hermes_cli/install_manifest.py
@@ -12,6 +12,7 @@ It records where a checkout came from and where its updates come from:
       "schemaVersion": 1,
       "installMode": "bundled" | "source",
       "channel": "stable" | "main",
+      "manageStyle": "adopted" | "auto-adopted" | "ejected",  # optional
       "pinnedCommit": "<sha>",       # optional
       "pinnedTag": "v0.17.0"         # optional, bundled installs only
     }
@@ -30,6 +31,19 @@ Semantics
   ``"stable"`` tracks tagged releases. The effective channel resolution lives
   in :func:`resolve_update_channel`; ``update.channel`` in config.yaml can
   override for source installs, while bundled installs are always stable.
+* ``manageStyle`` — provenance: HOW the install got into its current mode,
+  where ``installMode`` says where it is now. Vocabulary:
+
+  - ``"adopted"`` — user chose bundled explicitly (fresh installer run).
+  - ``"auto-adopted"`` — a pristine legacy checkout was silently migrated
+    into the bundled path by the desktop app at launch. Kept distinct from
+    ``"adopted"`` so a bad auto-adoption cohort can be bulk-reverted without
+    touching anyone who consented.
+  - ``"ejected"`` — user ran ``hermes update --eject``. STICKY opt-out:
+    auto-adoption must never touch a checkout that says ejected, even though
+    its ``installMode`` is plain ``"source"``.
+  - absent — legacy checkout that predates manifests (or a plain source
+    install); the only state auto-adoption may consider.
 
 Pure-stdlib leaf module: no imports from hermes_cli.config (config imports
 would drag the full config machinery into every consumer; the desktop
@@ -53,6 +67,11 @@ _VALID_MODES = (MODE_SOURCE, MODE_BUNDLED)
 CHANNEL_MAIN = "main"
 CHANNEL_STABLE = "stable"
 _VALID_CHANNELS = (CHANNEL_MAIN, CHANNEL_STABLE)
+
+STYLE_ADOPTED = "adopted"
+STYLE_AUTO_ADOPTED = "auto-adopted"
+STYLE_EJECTED = "ejected"
+_VALID_STYLES = (STYLE_ADOPTED, STYLE_AUTO_ADOPTED, STYLE_EJECTED)
 
 # Sentinel accepted in config.yaml's ``update.channel``: defer to the manifest.
 CHANNEL_AUTO = "auto"
@@ -104,6 +123,17 @@ def read_install_manifest(project_root: Optional[Path] = None) -> dict:
         manifest["installMode"] = MODE_SOURCE
     if manifest.get("channel") not in _VALID_CHANNELS:
         manifest["channel"] = CHANNEL_MAIN if manifest["installMode"] == MODE_SOURCE else CHANNEL_STABLE
+    # Unknown manageStyle values are DROPPED, not defaulted: an absent style
+    # means "adoption may consider this checkout", and inventing one would
+    # either wrongly block adoption or (worse) erase an eject opt-out written
+    # by a future vocabulary. EXCEPTION: anything that *smells* ejected stays
+    # ejected — the opt-out must survive vocabulary drift in both directions.
+    style = manifest.get("manageStyle")
+    if style is not None and style not in _VALID_STYLES:
+        if isinstance(style, str) and "eject" in style.lower():
+            manifest["manageStyle"] = STYLE_EJECTED
+        else:
+            del manifest["manageStyle"]
     manifest.setdefault("schemaVersion", INSTALL_MANIFEST_SCHEMA_VERSION)
     return manifest
 
@@ -122,6 +152,8 @@ def write_install_manifest(
         raise ValueError(f"invalid installMode: {manifest.get('installMode')!r}")
     if manifest.get("channel") not in _VALID_CHANNELS:
         raise ValueError(f"invalid channel: {manifest.get('channel')!r}")
+    if manifest.get("manageStyle") is not None and manifest["manageStyle"] not in _VALID_STYLES:
+        raise ValueError(f"invalid manageStyle: {manifest.get('manageStyle')!r}")
 
     payload = dict(manifest)
     payload.setdefault("schemaVersion", INSTALL_MANIFEST_SCHEMA_VERSION)
@@ -136,6 +168,16 @@ def write_install_manifest(
 def is_bundled_install(project_root: Optional[Path] = None) -> bool:
     """True when the running checkout was materialized from desktop payloads."""
     return read_install_manifest(project_root).get("installMode") == MODE_BUNDLED
+
+
+def is_ejected(project_root: Optional[Path] = None) -> bool:
+    """True when the user explicitly ejected this checkout from desktop management.
+
+    The sticky opt-out signal for auto-adoption: an ejected checkout must
+    never be silently re-adopted into the bundled path, even though its
+    ``installMode`` is plain ``source``.
+    """
+    return read_install_manifest(project_root).get("manageStyle") == STYLE_EJECTED
 
 
 def resolve_update_channel(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9127,6 +9127,17 @@ def cmd_update(args):
         print(recommended_update_command_for_method(install_method))
         sys.exit(1)
 
+    # Bundled desktop installs are materialized from payloads shipped inside
+    # the desktop app; the app's own updater re-materializes the checkout
+    # after updating itself. `hermes update` mutating that checkout would
+    # desync it from the shell's stamped tag, so refuse and point at the
+    # in-app updater (or eject, which flips the install to source mode).
+    from hermes_cli.install_manifest import format_bundled_update_message, is_bundled_install
+
+    if is_bundled_install(PROJECT_ROOT):
+        print(format_bundled_update_message())
+        sys.exit(1)
+
     if getattr(args, "check", False):
         # --check honors --branch so the "any new commits?" answer matches
         # what a subsequent `hermes update --branch=<x>` would actually pull.

--- a/tests/hermes_cli/test_install_manifest.py
+++ b/tests/hermes_cli/test_install_manifest.py
@@ -1,0 +1,159 @@
+"""Tests for hermes_cli/install_manifest.py — bundled-install manifest plumbing."""
+
+import json
+
+import pytest
+
+from hermes_cli.install_manifest import (
+    CHANNEL_MAIN,
+    CHANNEL_STABLE,
+    INSTALL_MANIFEST_NAME,
+    MODE_BUNDLED,
+    MODE_SOURCE,
+    format_bundled_update_message,
+    install_manifest_path,
+    is_bundled_install,
+    read_install_manifest,
+    resolve_update_channel,
+    write_install_manifest,
+)
+
+
+def _write_raw(tmp_path, payload):
+    (tmp_path / INSTALL_MANIFEST_NAME).write_text(
+        payload if isinstance(payload, str) else json.dumps(payload),
+        encoding="utf-8",
+    )
+
+
+class TestReadInstallManifest:
+    def test_absent_file_means_source_main(self, tmp_path):
+        """The back-compat contract: no manifest ⇒ source install on main."""
+        manifest = read_install_manifest(tmp_path)
+        assert manifest["installMode"] == MODE_SOURCE
+        assert manifest["channel"] == CHANNEL_MAIN
+
+    def test_malformed_json_degrades_to_source(self, tmp_path):
+        _write_raw(tmp_path, "{not json")
+        assert read_install_manifest(tmp_path)["installMode"] == MODE_SOURCE
+
+    def test_non_object_json_degrades_to_source(self, tmp_path):
+        _write_raw(tmp_path, '["bundled"]')
+        assert read_install_manifest(tmp_path)["installMode"] == MODE_SOURCE
+
+    def test_unknown_mode_degrades_to_source(self, tmp_path):
+        """A future vocabulary must not brick an older reader."""
+        _write_raw(tmp_path, {"installMode": "quantum", "channel": "stable"})
+        manifest = read_install_manifest(tmp_path)
+        assert manifest["installMode"] == MODE_SOURCE
+        assert manifest["channel"] == CHANNEL_STABLE
+
+    def test_unknown_channel_defaults_by_mode(self, tmp_path):
+        _write_raw(tmp_path, {"installMode": "bundled", "channel": "nightly"})
+        assert read_install_manifest(tmp_path)["channel"] == CHANNEL_STABLE
+        _write_raw(tmp_path, {"installMode": "source", "channel": "nightly"})
+        assert read_install_manifest(tmp_path)["channel"] == CHANNEL_MAIN
+
+    def test_extra_keys_preserved(self, tmp_path):
+        _write_raw(
+            tmp_path,
+            {"installMode": "bundled", "channel": "stable", "pinnedTag": "v0.17.0", "futureKey": 7},
+        )
+        manifest = read_install_manifest(tmp_path)
+        assert manifest["pinnedTag"] == "v0.17.0"
+        assert manifest["futureKey"] == 7
+
+
+class TestWriteInstallManifest:
+    def test_roundtrip(self, tmp_path):
+        write_install_manifest(
+            {"installMode": MODE_BUNDLED, "channel": CHANNEL_STABLE, "pinnedTag": "v1.2.3"},
+            tmp_path,
+        )
+        manifest = read_install_manifest(tmp_path)
+        assert manifest["installMode"] == MODE_BUNDLED
+        assert manifest["pinnedTag"] == "v1.2.3"
+        assert manifest["schemaVersion"] == 1
+
+    def test_rejects_invalid_mode(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_install_manifest({"installMode": "quantum", "channel": "stable"}, tmp_path)
+        assert not install_manifest_path(tmp_path).exists()
+
+    def test_rejects_invalid_channel(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_install_manifest({"installMode": "source", "channel": "nightly"}, tmp_path)
+
+    def test_atomic_no_tmp_leftover(self, tmp_path):
+        write_install_manifest({"installMode": MODE_SOURCE, "channel": CHANNEL_MAIN}, tmp_path)
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+
+class TestIsBundledInstall:
+    def test_default_is_not_bundled(self, tmp_path):
+        assert not is_bundled_install(tmp_path)
+
+    def test_bundled_manifest_detected(self, tmp_path):
+        write_install_manifest({"installMode": MODE_BUNDLED, "channel": CHANNEL_STABLE}, tmp_path)
+        assert is_bundled_install(tmp_path)
+
+
+class TestResolveUpdateChannel:
+    def test_default_install_is_main(self, tmp_path):
+        assert resolve_update_channel(None, tmp_path) == CHANNEL_MAIN
+
+    def test_bundled_is_always_stable_even_with_config_main(self, tmp_path):
+        write_install_manifest({"installMode": MODE_BUNDLED, "channel": CHANNEL_STABLE}, tmp_path)
+        config = {"update": {"channel": "main"}}
+        assert resolve_update_channel(config, tmp_path) == CHANNEL_STABLE
+
+    def test_config_overrides_manifest_on_source(self, tmp_path):
+        write_install_manifest({"installMode": MODE_SOURCE, "channel": CHANNEL_MAIN}, tmp_path)
+        assert resolve_update_channel({"update": {"channel": "stable"}}, tmp_path) == CHANNEL_STABLE
+
+    def test_config_auto_defers_to_manifest(self, tmp_path):
+        write_install_manifest({"installMode": MODE_SOURCE, "channel": CHANNEL_STABLE}, tmp_path)
+        assert resolve_update_channel({"update": {"channel": "auto"}}, tmp_path) == CHANNEL_STABLE
+
+    def test_config_garbage_defers_to_manifest(self, tmp_path):
+        assert resolve_update_channel({"update": {"channel": 42}}, tmp_path) == CHANNEL_MAIN
+        assert resolve_update_channel({"update": "stable"}, tmp_path) == CHANNEL_MAIN
+
+
+class TestDefaultConfigContract:
+    def test_update_channel_key_exists_and_is_valid(self):
+        """update.channel must exist in DEFAULT_CONFIG with an accepted value."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        channel = DEFAULT_CONFIG["update"]["channel"]
+        assert channel in ("auto", CHANNEL_MAIN, CHANNEL_STABLE)
+
+
+class TestCmdUpdateRefusal:
+    def test_cmd_update_refuses_on_bundled(self, monkeypatch, capsys):
+        """cmd_update exits 1 with the bundled message before touching git."""
+        import hermes_cli.install_manifest as im
+        from hermes_cli import main as hermes_main
+
+        monkeypatch.setattr(im, "is_bundled_install", lambda root=None: True)
+        # Neutralize the earlier refusal branches so we reach the bundled check.
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+        monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda root=None: "git")
+
+        class Args:
+            check = False
+            gateway = False
+            branch = None
+
+        with pytest.raises(SystemExit) as excinfo:
+            hermes_main.cmd_update(Args())
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "desktop app" in out
+        assert "eject" in out
+
+    def test_message_mentions_in_app_updater(self):
+        msg = format_bundled_update_message()
+        assert "hermes update" in msg
+        assert "eject" in msg

--- a/tests/hermes_cli/test_install_manifest.py
+++ b/tests/hermes_cli/test_install_manifest.py
@@ -10,9 +10,13 @@ from hermes_cli.install_manifest import (
     INSTALL_MANIFEST_NAME,
     MODE_BUNDLED,
     MODE_SOURCE,
+    STYLE_ADOPTED,
+    STYLE_AUTO_ADOPTED,
+    STYLE_EJECTED,
     format_bundled_update_message,
     install_manifest_path,
     is_bundled_install,
+    is_ejected,
     read_install_manifest,
     resolve_update_channel,
     write_install_manifest,
@@ -97,6 +101,51 @@ class TestIsBundledInstall:
     def test_bundled_manifest_detected(self, tmp_path):
         write_install_manifest({"installMode": MODE_BUNDLED, "channel": CHANNEL_STABLE}, tmp_path)
         assert is_bundled_install(tmp_path)
+
+
+class TestManageStyle:
+    def test_absent_by_default(self, tmp_path):
+        assert "manageStyle" not in read_install_manifest(tmp_path)
+        assert not is_ejected(tmp_path)
+
+    def test_valid_styles_roundtrip(self, tmp_path):
+        for style in (STYLE_ADOPTED, STYLE_AUTO_ADOPTED, STYLE_EJECTED):
+            write_install_manifest(
+                {"installMode": MODE_SOURCE, "channel": CHANNEL_MAIN, "manageStyle": style},
+                tmp_path,
+            )
+            assert read_install_manifest(tmp_path)["manageStyle"] == style
+
+    def test_ejected_is_sticky_signal(self, tmp_path):
+        write_install_manifest(
+            {"installMode": MODE_SOURCE, "channel": CHANNEL_MAIN, "manageStyle": STYLE_EJECTED},
+            tmp_path,
+        )
+        assert is_ejected(tmp_path)
+
+    def test_unknown_style_dropped_not_defaulted(self, tmp_path):
+        """A future vocabulary must not wrongly block (or force) adoption."""
+        _write_raw(
+            tmp_path,
+            {"installMode": "source", "channel": "main", "manageStyle": "quantum"},
+        )
+        assert "manageStyle" not in read_install_manifest(tmp_path)
+
+    def test_eject_smelling_future_style_stays_ejected(self, tmp_path):
+        """The opt-out survives vocabulary drift: 'force-ejected' etc. reads as ejected."""
+        _write_raw(
+            tmp_path,
+            {"installMode": "source", "channel": "main", "manageStyle": "force-ejected"},
+        )
+        assert read_install_manifest(tmp_path)["manageStyle"] == STYLE_EJECTED
+        assert is_ejected(tmp_path)
+
+    def test_write_rejects_invalid_style(self, tmp_path):
+        with pytest.raises(ValueError):
+            write_install_manifest(
+                {"installMode": MODE_SOURCE, "channel": CHANNEL_MAIN, "manageStyle": "quantum"},
+                tmp_path,
+            )
 
 
 class TestResolveUpdateChannel:


### PR DESCRIPTION
## Summary
Part 1/3 of the bundled-desktop-install stack (design: bundled installers carry agent payloads; existing git installs unaffected).

Adds `.hermes-install.json` — a code-scoped install manifest (same anchoring rationale as `.install_method`) recording `installMode: source|bundled` and `channel: main|stable`:

- **Absent file ⇒ source/main**: every existing install keeps today's update behavior exactly. Malformed/future-vocabulary manifests also degrade to source/main instead of bricking.
- `update.channel` added to DEFAULT_CONFIG (`auto|main|stable`, default `auto` = defer to manifest). No config version bump (new key, deep-merge).
- `cmd_update` refuses on bundled installs (same pattern as the docker/nix refusals) pointing at the in-app updater / `--eject` (lands in PR 3 of the stack).

## Test plan
- [x] `tests/hermes_cli/test_install_manifest.py` — 20 tests: absent/malformed/future-schema degradation, atomic write, channel resolution precedence (bundled always stable; config overrides manifest on source; garbage config defers), refusal exit path.
- CI for the full suite.

### manageStyle (added after review discussion)
Provenance — *how* the install got into its mode, where `installMode` says where it is now:
- `ejected` — sticky opt-out: silent auto-adoption (future PR) must never touch it, even though installMode is plain `source`.
- `auto-adopted` vs `adopted` — distinguishes silently-migrated users from ones who chose bundled, so a bad auto-adoption cohort can be bulk-reverted without touching consenting users.
- Unknown future styles are dropped on read (absent = adoptable), EXCEPT eject-smelling values which stay `ejected` — the opt-out survives vocabulary drift in both directions.