### PR TITLE
feat: hermes update --eject — take over a desktop-bundled install

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9127,6 +9127,15 @@ def cmd_update(args):
         print(recommended_update_command_for_method(install_method))
         sys.exit(1)
 
+    # --eject runs BEFORE the bundled-install refusal below: ejecting is the
+    # one update operation that must work on a bundled install (it's the way
+    # out of desktop management). On source installs it's a channel setter /
+    # no-op.
+    if getattr(args, "eject", False):
+        from hermes_cli.update_cmd import cmd_update_eject
+
+        sys.exit(cmd_update_eject(args))
+
     # Bundled desktop installs are materialized from payloads shipped inside
     # the desktop app; the app's own updater re-materializes the checkout
     # after updating itself. `hermes update` mutating that checkout would

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -73,4 +73,27 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--eject",
+        action="store_true",
+        default=False,
+        help=(
+            "Take over update management of a desktop-bundled install: mark "
+            "the checkout as source-managed (git updates via `hermes update`) "
+            "and fetch full git history. The desktop app keeps updating "
+            "itself, but no longer touches the agent checkout. No effect on "
+            "installs that are already source-managed."
+        ),
+    )
+    update_parser.add_argument(
+        "--channel",
+        default=None,
+        choices=("stable", "main"),
+        metavar="CHANNEL",
+        help=(
+            "With --eject: which releases the ejected install tracks — "
+            "'stable' (tagged releases) or 'main' (git main branch, the "
+            "pre-eject desktop cadence is 'stable'). Defaults to 'main'."
+        ),
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3773,6 +3773,7 @@ def cmd_update_eject(args) -> int:
         CHANNEL_MAIN,
         CHANNEL_STABLE,
         MODE_SOURCE,
+        STYLE_EJECTED,
         install_manifest_path,
         read_install_manifest,
         write_install_manifest,
@@ -3792,6 +3793,10 @@ def cmd_update_eject(args) -> int:
         if getattr(args, "channel", None):
             manifest["installMode"] = MODE_SOURCE
             manifest["channel"] = channel
+            # Deliberately NOT marking ejected here: this shorthand runs on
+            # checkouts that were never desktop-managed (or already ejected —
+            # in which case the existing style is preserved below). A plain
+            # channel switch is not an adoption opt-out.
             write_install_manifest(manifest, project_root)
             print(f"✓ Install is already source-managed; channel set to '{channel}'.")
         else:
@@ -3842,6 +3847,9 @@ def cmd_update_eject(args) -> int:
 
     manifest["installMode"] = MODE_SOURCE
     manifest["channel"] = channel
+    # Sticky opt-out: auto-adoption must never silently pull an ejected
+    # checkout back into the bundled path.
+    manifest["manageStyle"] = STYLE_EJECTED
     # The tag pin describes the *bundled* payload provenance; keep it for
     # forensics but it no longer governs updates once mode is source.
     write_install_manifest(manifest, project_root)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3757,6 +3757,106 @@ def _normalize_managed_eol(git_cmd, repo_root):
         # Never let line-ending cleanup block an update.
         pass
 
+def cmd_update_eject(args) -> int:
+    """Implement ``hermes update --eject``.
+
+    Flips a desktop-bundled checkout to source management: unshallows the
+    git history (bundled payload clones are depth-1), fetches tags, and
+    rewrites the install manifest to ``installMode: source`` with the chosen
+    channel. After this, ``hermes update`` owns the checkout and the desktop
+    app's bootstrap skips its agent stages (it refuses to overwrite a
+    source-mode checkout).
+
+    Returns a process exit code.
+    """
+    from hermes_cli.install_manifest import (
+        CHANNEL_MAIN,
+        CHANNEL_STABLE,
+        MODE_SOURCE,
+        install_manifest_path,
+        read_install_manifest,
+        write_install_manifest,
+    )
+
+    project_root = _m().PROJECT_ROOT
+    manifest = read_install_manifest(project_root)
+    channel = getattr(args, "channel", None) or CHANNEL_MAIN
+    if channel not in (CHANNEL_MAIN, CHANNEL_STABLE):
+        print(f"✗ Unknown channel '{channel}' — use 'stable' or 'main'.")
+        return 1
+
+    if manifest.get("installMode") != "bundled":
+        # Already source-managed. Still honor an explicit --channel request so
+        # `hermes update --eject --channel stable` is a one-shot way to switch,
+        # but don't touch git history.
+        if getattr(args, "channel", None):
+            manifest["installMode"] = MODE_SOURCE
+            manifest["channel"] = channel
+            write_install_manifest(manifest, project_root)
+            print(f"✓ Install is already source-managed; channel set to '{channel}'.")
+        else:
+            print("✓ Nothing to eject — this install is already source-managed.")
+            print("  (Only desktop-bundled installs need ejecting.)")
+        return 0
+
+    git_dir = project_root / ".git"
+    if not git_dir.exists():
+        print("✗ Cannot eject: the checkout is not a git repository.")
+        print("  Reinstall from source instead:")
+        print("  curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash")
+        return 1
+
+    git_cmd = ["git"]
+    if sys.platform == "win32":
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+
+    is_shallow = (
+        subprocess.run(
+            git_cmd + ["rev-parse", "--is-shallow-repository"],
+            cwd=project_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        ).stdout.strip()
+        == "true"
+    )
+
+    print("⚕ Ejecting from desktop-managed updates...")
+    fetch_args = ["fetch", "--tags", "origin"]
+    if is_shallow:
+        print("→ Fetching full git history (this can take a minute)...")
+        fetch_args.insert(1, "--unshallow")
+    else:
+        print("→ Fetching tags...")
+    fetch_result = subprocess.run(
+        git_cmd + fetch_args,
+        cwd=project_root,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    if fetch_result.returncode != 0:
+        stderr = (fetch_result.stderr or "").strip()
+        print("✗ git fetch failed — eject aborted; the install is unchanged.")
+        if stderr:
+            print(f"  {stderr.splitlines()[0]}")
+        return 1
+
+    manifest["installMode"] = MODE_SOURCE
+    manifest["channel"] = channel
+    # The tag pin describes the *bundled* payload provenance; keep it for
+    # forensics but it no longer governs updates once mode is source.
+    write_install_manifest(manifest, project_root)
+
+    print("✓ Ejected. This checkout is now source-managed.")
+    print(f"  • Update channel: {channel}"
+          + (" (tagged releases)" if channel == CHANNEL_STABLE else " (git main)"))
+    print("  • Update with: hermes update")
+    print("  • The desktop app will keep updating itself, but will no longer")
+    print("    modify this checkout. Expect the app and agent versions to")
+    print("    drift apart until you update the agent yourself.")
+    print(f"  • Manifest: {install_manifest_path(project_root)}")
+    return 0
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""

--- a/tests/hermes_cli/test_update_eject.py
+++ b/tests/hermes_cli/test_update_eject.py
@@ -1,0 +1,148 @@
+"""Tests for ``hermes update --eject`` (hermes_cli/update_cmd.py::cmd_update_eject).
+
+Uses real git repos (not mocks) per the repo's E2E-validation preference:
+a local "origin" plus a depth-1 clone reproduce exactly what a bundled
+desktop payload checkout looks like.
+"""
+
+import subprocess
+
+import pytest
+
+from hermes_cli.install_manifest import (
+    CHANNEL_MAIN,
+    CHANNEL_STABLE,
+    MODE_BUNDLED,
+    MODE_SOURCE,
+    read_install_manifest,
+    write_install_manifest,
+)
+from hermes_cli.update_cmd import cmd_update_eject
+
+
+def _git(cwd, *args):
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True, text=True, encoding="utf-8",
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def bundled_checkout(tmp_path):
+    """A depth-1 clone of a local origin, manifest-marked as bundled."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-b", "main")
+    _git(origin, "config", "user.email", "test@example.com")
+    _git(origin, "config", "user.name", "test")
+    for i in range(3):
+        (origin / f"f{i}.txt").write_text(f"content {i}\n")
+        _git(origin, "add", ".")
+        _git(origin, "commit", "-m", f"commit {i}")
+    _git(origin, "tag", "v0.1.0")
+
+    checkout = tmp_path / "checkout"
+    subprocess.run(
+        ["git", "clone", "--depth", "1", f"file://{origin}", str(checkout)],
+        capture_output=True, text=True, check=True,
+    )
+    write_install_manifest(
+        {"installMode": MODE_BUNDLED, "channel": CHANNEL_STABLE, "pinnedTag": "v0.1.0"},
+        checkout,
+    )
+    return checkout
+
+
+class _Args:
+    def __init__(self, channel=None):
+        self.eject = True
+        self.channel = channel
+
+
+def _patch_project_root(monkeypatch, root):
+    import hermes_cli.main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", root)
+
+
+class TestEjectBundled:
+    def test_eject_unshallows_and_flips_mode(self, bundled_checkout, monkeypatch, capsys):
+        _patch_project_root(monkeypatch, bundled_checkout)
+        assert _git(bundled_checkout, "rev-parse", "--is-shallow-repository") == "true"
+
+        rc = cmd_update_eject(_Args())
+
+        assert rc == 0
+        assert _git(bundled_checkout, "rev-parse", "--is-shallow-repository") == "false"
+        manifest = read_install_manifest(bundled_checkout)
+        assert manifest["installMode"] == MODE_SOURCE
+        assert manifest["channel"] == CHANNEL_MAIN  # default eject channel
+        # Provenance pin survives for forensics.
+        assert manifest["pinnedTag"] == "v0.1.0"
+        # Full history + tags are now available.
+        assert _git(bundled_checkout, "rev-list", "--count", "HEAD") == "3"
+        assert "v0.1.0" in _git(bundled_checkout, "tag", "--list")
+        assert "Ejected" in capsys.readouterr().out
+
+    def test_eject_with_stable_channel(self, bundled_checkout, monkeypatch):
+        _patch_project_root(monkeypatch, bundled_checkout)
+        rc = cmd_update_eject(_Args(channel="stable"))
+        assert rc == 0
+        assert read_install_manifest(bundled_checkout)["channel"] == CHANNEL_STABLE
+
+    def test_failed_fetch_leaves_manifest_untouched(self, bundled_checkout, monkeypatch, capsys):
+        """Eject must be atomic-ish: no mode flip if git fetch fails."""
+        _patch_project_root(monkeypatch, bundled_checkout)
+        _git(bundled_checkout, "remote", "set-url", "origin", "file:///nonexistent/repo")
+
+        rc = cmd_update_eject(_Args())
+
+        assert rc == 1
+        manifest = read_install_manifest(bundled_checkout)
+        assert manifest["installMode"] == MODE_BUNDLED
+        assert "aborted" in capsys.readouterr().out
+
+    def test_missing_git_dir_refuses(self, tmp_path, monkeypatch, capsys):
+        root = tmp_path / "nogit"
+        root.mkdir()
+        write_install_manifest(
+            {"installMode": MODE_BUNDLED, "channel": CHANNEL_STABLE}, root
+        )
+        _patch_project_root(monkeypatch, root)
+
+        rc = cmd_update_eject(_Args())
+
+        assert rc == 1
+        assert read_install_manifest(root)["installMode"] == MODE_BUNDLED
+        assert "not a git repository" in capsys.readouterr().out
+
+
+class TestEjectOnSourceInstalls:
+    def test_noop_without_channel(self, tmp_path, monkeypatch, capsys):
+        root = tmp_path / "src"
+        root.mkdir()
+        _patch_project_root(monkeypatch, root)
+
+        rc = cmd_update_eject(_Args())
+
+        assert rc == 0
+        assert "already source-managed" in capsys.readouterr().out
+        # No manifest is created by a pure no-op eject... actually one may be
+        # absent entirely; reading it must still say source/main.
+        manifest = read_install_manifest(root)
+        assert manifest["installMode"] == MODE_SOURCE
+
+    def test_channel_switch_shorthand(self, tmp_path, monkeypatch):
+        """--eject --channel stable on a source install just sets the channel."""
+        root = tmp_path / "src"
+        root.mkdir()
+        _patch_project_root(monkeypatch, root)
+
+        rc = cmd_update_eject(_Args(channel="stable"))
+
+        assert rc == 0
+        manifest = read_install_manifest(root)
+        assert manifest["installMode"] == MODE_SOURCE
+        assert manifest["channel"] == CHANNEL_STABLE

--- a/tests/hermes_cli/test_update_eject.py
+++ b/tests/hermes_cli/test_update_eject.py
@@ -14,6 +14,8 @@ from hermes_cli.install_manifest import (
     CHANNEL_STABLE,
     MODE_BUNDLED,
     MODE_SOURCE,
+    STYLE_EJECTED,
+    is_ejected,
     read_install_manifest,
     write_install_manifest,
 )
@@ -79,6 +81,9 @@ class TestEjectBundled:
         manifest = read_install_manifest(bundled_checkout)
         assert manifest["installMode"] == MODE_SOURCE
         assert manifest["channel"] == CHANNEL_MAIN  # default eject channel
+        # Sticky opt-out for silent auto-adoption.
+        assert manifest["manageStyle"] == STYLE_EJECTED
+        assert is_ejected(bundled_checkout)
         # Provenance pin survives for forensics.
         assert manifest["pinnedTag"] == "v0.1.0"
         # Full history + tags are now available.
@@ -146,3 +151,6 @@ class TestEjectOnSourceInstalls:
         manifest = read_install_manifest(root)
         assert manifest["installMode"] == MODE_SOURCE
         assert manifest["channel"] == CHANNEL_STABLE
+        # A channel switch on a never-desktop-managed checkout is NOT an
+        # adoption opt-out — the checkout stays adoptable.
+        assert not is_ejected(root)


### PR DESCRIPTION
## Summary
Part 3/3. `hermes update --eject` — the escape hatch from desktop-managed (bundled) installs back to git-based updates:

- Unshallows the payload clone (`git fetch --unshallow --tags`), flips the manifest to `installMode: source` with `--channel stable|main` (default main).
- Runs **before** the bundled-mode refusal from PR 1 — eject is the one update op that must work on a bundled install.
- Failed fetch aborts without touching the manifest (no half-ejected state).
- On already-source installs: `--eject --channel X` is a channel-switch shorthand; bare `--eject` is a friendly no-op.
- `pinnedTag` survives eject for provenance; it no longer governs updates.

The other half of the eject contract (desktop bootstrap refusing to overwrite a source-mode checkout) lands with the payload-materialization work.

## Test plan
- [x] E2E with real git repos (local origin + depth-1 clone, no mocks): unshallow verified via rev-list count + tag visibility, mode flip, fetch-failure atomicity, no-git-dir refusal, channel shorthand.