### PR TITLE
fix(gateway): match skill paths with the platform separator

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -922,16 +922,20 @@ def _collect_gateway_skill_entries(
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
         _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
+        _hub_dir = os.path.join(str((SKILLS_DIR / ".hub").resolve()), "")
         # Build set of allowed directory prefixes: local skills dir + any
         # user-configured ``skills.external_dirs``. Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
+        # with the platform separator so ``/my-skills`` does not also match
+        # ``/my-skills-extra``. The separator must come from ``os.path`` and
+        # not be a hardcoded ``/``: ``skill_md_path`` is a plain ``str(Path)``
+        # (:func:`agent.skill_commands.get_skill_commands`), so on Windows it
+        # is backslash-separated and no skill would match at all.
         # Without this widening, external skills are visible in
         # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
         # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
+        _allowed_prefixes = [os.path.join(_skills_dir, "")]
         _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
+            os.path.join(str(d), "") for d in get_external_skills_dirs()
         )
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
@@ -939,6 +943,11 @@ def _collect_gateway_skill_entries(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
+            # Compare both sides in the same convention: the prefixes above
+            # use the platform separator, while ``skill_md_path`` can reach
+            # this filter mixed (``C:\...\skills/foo/SKILL.md``) from callers
+            # that assemble it as a string rather than through ``Path``.
+            skill_path = os.path.normpath(skill_path)
             if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
                 continue
             if skill_path.startswith(_hub_dir):

--- a/tests/hermes_cli/test_gateway_skill_menu_separator.py
+++ b/tests/hermes_cli/test_gateway_skill_menu_separator.py
@@ -1,0 +1,103 @@
+"""Gateway slash menu must match skill paths with the platform separator.
+
+``_collect_gateway_skill_entries`` admits a skill only when its
+``skill_md_path`` starts with one of the allowed directory prefixes.  Those
+prefixes were terminated with a hardcoded ``"/"`` (#18741), while
+``skill_md_path`` is stored as a plain ``str(Path)``
+(:func:`agent.skill_commands.get_skill_commands`), which is
+backslash-separated on Windows.  Every comparison was therefore ``False``
+there and the Telegram menu lost its entire skill tier.  ``/skill-name``
+dispatch does not use this filter and kept working, so the loss was
+silent.
+
+The #8110 regression test does not cover this: it hand-builds
+``skill_md_path`` with f-string ``/`` separators, so the first separator
+after the skills dir is a forward slash on every platform.  The tests below
+build the paths the way production does, with the platform separator.  On
+POSIX both spellings are the same string, so these tests discriminate on
+Windows only: there they fail against ``main`` and pass with the fix.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli.commands import telegram_menu_commands
+
+
+def _skill_entry(root: Path, name: str) -> dict[str, str]:
+    """Build a ``get_skill_commands`` entry with native separators."""
+    skill_dir = os.path.join(str(root), name)
+    return {
+        "name": name,
+        "description": f"The {name} skill",
+        "skill_md_path": os.path.join(skill_dir, "SKILL.md"),
+        "skill_dir": skill_dir,
+    }
+
+
+def test_native_separator_skill_paths_reach_the_menu(tmp_path, monkeypatch):
+    """Local and external skills are admitted; a prefix sibling is not."""
+    local_dir = tmp_path / "skills"
+    local_dir.mkdir()
+    external_dir = tmp_path / "my-skills"
+    external_dir.mkdir()
+    lookalike_dir = tmp_path / "my-skills-extra"
+    lookalike_dir.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    fake_cmds = {
+        "/local-one": _skill_entry(local_dir, "local-one"),
+        "/morning-briefing": _skill_entry(external_dir, "morning-briefing"),
+        "/lookalike-skill": _skill_entry(lookalike_dir, "lookalike-skill"),
+    }
+
+    with (
+        patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+        patch("tools.skills_tool.SKILLS_DIR", local_dir),
+        patch(
+            "agent.skill_utils.get_external_skills_dirs",
+            return_value=[external_dir],
+        ),
+    ):
+        menu, _ = telegram_menu_commands(max_commands=100)
+
+    menu_names = {n for n, _ in menu}
+    assert "local_one" in menu_names, (
+        "a local skill path built with the platform separator must appear"
+    )
+    assert "morning_briefing" in menu_names, (
+        "an external skill path built with the platform separator must appear"
+    )
+    assert "lookalike_skill" not in menu_names, (
+        "prefix-match sibling directories must still be rejected"
+    )
+
+
+def test_hub_skills_stay_excluded_with_native_separators(tmp_path, monkeypatch):
+    """The ``.hub`` exclusion survives the separator fix."""
+    local_dir = tmp_path / "skills"
+    hub_dir = local_dir / ".hub"
+    hub_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    fake_cmds = {
+        "/local-one": _skill_entry(local_dir, "local-one"),
+        "/hub-installed": _skill_entry(hub_dir, "hub-installed"),
+    }
+
+    with (
+        patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+        patch("tools.skills_tool.SKILLS_DIR", local_dir),
+        patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+    ):
+        menu, _ = telegram_menu_commands(max_commands=100)
+
+    menu_names = {n for n, _ in menu}
+    assert "local_one" in menu_names, "the local skill must still appear"
+    assert "hub_installed" not in menu_names, (
+        "hub-installed skills must not reach the gateway menu"
+    )


### PR DESCRIPTION
## What does this PR do?

On Windows the Telegram slash-command menu contains no skills at all. The bot registers only the core command set, on every profile, with no error in the logs. `/skill-name` dispatch keeps working because it does not go through this filter, which is what makes the failure hard to spot: the skills are loaded, `hermes skills list` shows them, the agent can run them, only the menu is empty.

`_collect_gateway_skill_entries` (`hermes_cli/commands.py`) admits a skill only when its `skill_md_path` starts with one of the allowed directory prefixes:

```python
_allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
_allowed_prefixes.extend(str(d).rstrip("/") + "/" for d in get_external_skills_dirs())
...
if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
    continue
```

Every prefix is terminated with a hardcoded `"/"` (added in #18741 so that `/my-skills` cannot also admit `/my-skills-extra`). But `skill_md_path` is stored as a plain `str(Path)` (`agent/skill_commands.py`), which is backslash separated on Windows, so the comparison is

```
"C:\\Users\\me\\.hermes\\skills\\writer\\SKILL.md".startswith("C:\\Users\\me\\.hermes\\skills/")
```

which is always `False`. The `continue` fires for every entry and the whole skill tier is dropped. The same applies to the `.hub` exclusion prefix a few lines below.

The fix normalizes both sides instead of assuming a separator: each prefix is terminated with `os.path.join(..., "")`, which appends the platform separator and leaves an already terminated path alone, and `skill_md_path` goes through `os.path.normpath` before the comparison, so a path assembled as a string rather than through `Path` is still compared in the same convention. The normalization runs after the existing empty-string guard, since `os.path.normpath("")` returns `"."`.

Behaviour on POSIX is unchanged. `posixpath.join(p, "")` is the same string as `p.rstrip("/") + "/"` for every prefix these lines can produce, including `/`, and `posixpath.normpath` is the identity on the `str(Path)` values `get_skill_commands` stores. The `/my-skills` vs `/my-skills-extra` boundary from #18741 and the `.hub` exclusion both keep working, and both are asserted in the new tests.

**On the pathlib rule in CONTRIBUTING (cross-platform rule 7).** `Path.is_relative_to` is the obvious alternative and it does fix the separator problem, but it compares purely lexically: `PureWindowsPath(r"C:\...\skills\..\evil\SKILL.md").is_relative_to(r"C:\...\skills")` is `True`. `os.path.normpath` collapses the `..` first, so that path is rejected. Keeping the string comparison also keeps the diff at four lines inside a hot loop that runs for every skill on every gateway start.

## Related Issue

I did not find an open issue for this specific cause, so there is nothing to close here.

* #8108 reports the same user-visible symptom (a gateway that comes up with the core command set only). This is a Windows-specific path to it, not necessarily the same report, so this PR does not claim to fix that issue.
* #18741 introduced the slash-terminated prefixes. This restores that intent on Windows rather than reverting it.

**Overlap with #78676, please read before merging either.** #78676 (opened a day before this one) refactors this same block to `Path.is_relative_to` helpers to fix a symlinked `HERMES_HOME`. That refactor also fixes this Windows bug as a side effect. I checked out that branch on Windows 11 and ran the regression test from this PR against it unmodified: **2 passed**, and its own gateway test set is green there too (87 passed, 1 skipped). The two PRs touch the same lines, so whichever lands first, the other needs a rebase.

If you prefer #78676, say so and I will drop the code change here and re-send `tests/hermes_cli/test_gateway_skill_menu_separator.py` alone, rebased on top of it: that PR fixes the Windows behaviour implicitly and does not currently test it, so the regression test is worth keeping either way. If you prefer the minimal fix here, #78676 rebases cleanly on top of it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `hermes_cli/commands.py`: `_allowed_prefixes` and `_hub_dir` are terminated with `os.path.join(..., "")` instead of `rstrip("/") + "/"`, and `skill_path` is run through `os.path.normpath` before the prefix comparison. Four lines changed, no control flow moved.
* `tests/hermes_cli/test_gateway_skill_menu_separator.py`: new regression test, two cases.

One commit, two files.

## How to Test

Reproduce the comparison without a Windows machine, on any platform:

```python
import ntpath
sk = r"C:\Users\me\.hermes\skills"
p  = r"C:\Users\me\.hermes\skills\writer\SKILL.md"

p.startswith(sk.rstrip("/") + "/")                    # main today  -> False
ntpath.normpath(p).startswith(ntpath.join(sk, ""))    # this PR     -> True

# boundary from #18741 still holds
ntpath.normpath(r"C:\x\my-skills-extra\s\SKILL.md").startswith(ntpath.join(r"C:\x\my-skills", ""))  # -> False
```

On a Windows host:

1. Install a skill under `~/.hermes/skills/` and start the Telegram gateway.
2. Before the fix the skill tier is missing from the slash menu while `hermes skills list` and `/skill-name` both work.
3. After the fix the skill appears in the menu.

Automated:

```
pytest tests/hermes_cli/test_gateway_skill_menu_separator.py -q
```

Note that pytest is not run on Windows in CI. The only Windows job is `installer-tests.yml`, which runs the PowerShell installer tests, so these tests cannot go red there. They are written to run everywhere rather than be skipped, but on POSIX the two path spellings are the same string, so they only discriminate on Windows. The module docstring says so, and the snippet above is the platform-independent proof. Verified manually on Windows 11, Python 3.13:

* with `hermes_cli/commands.py` reverted to main and the new test in place: `2 failed`, `AssertionError: assert 'local_one' in {'agents', 'approvals', ...}`;
* with the fix: `2 passed` for the new file, and `89 passed` across it plus `tests/hermes_cli/test_commands.py`, `tests/hermes_cli/test_discord_skill_clamp_warning.py`, `tests/gateway/test_telegram_forum_commands.py`, `tests/gateway/test_discord_slash_commands.py`, `tests/gateway/test_reload_skills_discord_resync.py`, `tests/gateway/test_discord_slash_auth.py`;
* blast radius, every other test file touching `skill_md_path`, `SKILLS_DIR` or `get_external_skills_dirs` (`tests/tools/test_skills_tool.py`, `test_skills_tool_discovery_cache.py`, `test_skills_sync.py`, `tests/agent/test_skill_utils.py`, `test_external_skills.py`, `test_external_skills_dirs_cache.py`, `tests/hermes_cli/test_skills_config.py`, `tests/test_tui_gateway_server.py`): `615 passed, 4 failed`. The four failures are pre-existing Windows failures in `tools/skills_tool.py`, `tools/skills_sync.py` and `agent/skill_utils.py`; they reproduce identically with this change reverted and none of them touch `hermes_cli/commands.py`.

Discord is not affected: `discord_skill_commands_by_category` filters through `Path.relative_to`, not this string comparison.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31055716732

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate. Nearest match is #78676, disclosed above; #39632 fixes a different failure of the same filter (resolved vs unresolved paths) and is orthogonal, since `realpath` alone still leaves a backslash path compared against a slash-terminated prefix.
- [x] My PR contains **only** changes related to this fix: one commit, the source change and its test
- [ ] I've run `pytest tests/ -q`. Not honestly checkable here: the full suite on a Windows host has pre-existing failures unrelated to this change. I ran the affected files plus the blast radius listed above and reported the exact numbers.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.13

### Documentation & Housekeeping

- [x] Documentation: N/A, the reasoning lives in the code comment and the test docstring
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered per the compatibility guide, see the pathlib note above. `scripts/check-windows-footguns.py --all` and `ruff check` are both clean.
- [x] Tool descriptions/schemas: N/A

