### PR TITLE
fix(cli): finalize Relay session in one-shot cleanup (#79471)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -134,7 +134,7 @@ def _exit_after_oneshot(rc: object) -> None:
 _oneshot_cleanup_done = False
 
 
-def _cleanup_oneshot_runtime() -> None:
+def _cleanup_oneshot_runtime(session_id: str | None = None) -> None:
     """Best-effort process-global cleanup before one-shot hard exit.
 
     ``run_oneshot`` owns the agent-local cleanup (memory provider, agent.close,
@@ -171,6 +171,22 @@ def _cleanup_oneshot_runtime() -> None:
         shutdown_cached_clients()
     except Exception:
         pass
+    # Finalize the Relay conversation so one-shot runs emit a balanced
+    # session-end event instead of leaving the root session open in exported
+    # telemetry (#79471). Best-effort and late in the sequence: the hard
+    # exit below is the safety boundary, so a failure here must not fall
+    # through to interpreter finalization.
+    if session_id:
+        try:
+            from hermes_cli.lifecycle import finalize_session
+
+            finalize_session(
+                session_id=session_id,
+                platform="cli",
+                reason="oneshot_complete",
+            )
+        except Exception:
+            pass
 
 
 def _run_and_exit_oneshot(
@@ -181,10 +197,11 @@ def _run_and_exit_oneshot(
     toolsets: object = None,
     usage_file: object = None,
 ) -> None:
+    session_id: str | None = None
     try:
         from hermes_cli.oneshot import run_oneshot
 
-        rc = run_oneshot(
+        rc, session_id = run_oneshot(
             prompt,
             model=model,
             provider=provider,
@@ -213,7 +230,7 @@ def _run_and_exit_oneshot(
             pass
         rc = 1
     try:
-        _cleanup_oneshot_runtime()
+        _cleanup_oneshot_runtime(session_id)
     finally:
         # The hard exit is the safety boundary for #43055. Even an interrupt
         # during best-effort cleanup must not fall back into interpreter

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,7 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
-) -> int:
+) -> tuple[int, str | None]:
     """Execute a single prompt and print only the final content block.
 
     Args:
@@ -190,6 +190,7 @@ def run_oneshot(
 
     Returns the exit code.  The caller owns process termination.
     """
+    session_id: str | None = None
     # Silence every stdlib logger for the duration.  AIAgent, tools, and
     # provider adapters all log to stderr through the root logger; file
     # handlers added by setup_logging() keep working (they're attached to
@@ -208,12 +209,12 @@ def run_oneshot(
             "hermes -z: --provider requires --model (or HERMES_INFERENCE_MODEL). "
             "Pass both explicitly, or neither to use your configured defaults.\n"
         )
-        return 2
+        return 2, None
 
     explicit_toolsets, toolsets_error = _validate_explicit_toolsets(toolsets)
     if toolsets_error:
         sys.stderr.write(toolsets_error)
-        return 2
+        return 2, None
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
@@ -273,9 +274,10 @@ def run_oneshot(
         _write_usage_file(usage_file, result, failure=str(failure))
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
-        return 1
+        return 1, None
 
     _write_usage_file(usage_file, result)
+    session_id = result.get("session_id") or None
 
     # Model text can contain lone UTF-16 surrogates (invalid in UTF-8). Writing
     # those to a real stdout TextIO raises UnicodeEncodeError and aborts with
@@ -293,14 +295,14 @@ def run_oneshot(
         real_stdout.flush()
 
     if (result.get("failed") or result.get("partial")) and not (response or "").strip():
-        return 2
+        return 2, session_id
 
     if not (response or "").strip():
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
-        return 1
+        return 1, session_id
 
-    return 0
+    return 0, session_id
 
 
 def _create_session_db_for_oneshot():

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -188,7 +188,9 @@ def run_oneshot(
             run — even when the run fails — so pipelines can account for
             spend per invocation.
 
-    Returns the exit code.  The caller owns process termination.
+    Returns a ``(exit_code, session_id)`` tuple. ``session_id`` is the run's
+    session id (for Relay lifecycle finalization) or None when the run never
+    bound one. The caller owns process termination.
     """
     session_id: str | None = None
     # Silence every stdlib logger for the duration.  AIAgent, tools, and

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,7 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
-) -> int:
+) -> tuple[int, str | None]:
     """Execute a single prompt and print only the final content block.
 
     Args:
@@ -190,6 +190,7 @@ def run_oneshot(
 
     Returns the exit code.  The caller owns process termination.
     """
+    session_id: str | None = None
     # Silence every stdlib logger for the duration.  AIAgent, tools, and
     # provider adapters all log to stderr through the root logger; file
     # handlers added by setup_logging() keep working (they're attached to
@@ -208,12 +209,12 @@ def run_oneshot(
             "hermes -z: --provider requires --model (or HERMES_INFERENCE_MODEL). "
             "Pass both explicitly, or neither to use your configured defaults.\n"
         )
-        return 2
+        return 2, None
 
     explicit_toolsets, toolsets_error = _validate_explicit_toolsets(toolsets)
     if toolsets_error:
         sys.stderr.write(toolsets_error)
-        return 2
+        return 2, None
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
@@ -273,9 +274,10 @@ def run_oneshot(
         _write_usage_file(usage_file, result, failure=str(failure))
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
-        return 1
+        return 1, None
 
     _write_usage_file(usage_file, result)
+    session_id = result.get("session_id") or None
 
     if response:
         real_stdout.write(response)
@@ -284,14 +286,14 @@ def run_oneshot(
         real_stdout.flush()
 
     if (result.get("failed") or result.get("partial")) and not (response or "").strip():
-        return 2
+        return 2, session_id
 
     if not (response or "").strip():
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
-        return 1
+        return 1, session_id
 
-    return 0
+    return 0, session_id
 
 
 def _create_session_db_for_oneshot():

--- a/tests/hermes_cli/test_oneshot_relay_finalize.py
+++ b/tests/hermes_cli/test_oneshot_relay_finalize.py
@@ -1,0 +1,57 @@
+"""Tests for one-shot Relay session finalization (#79471).
+
+One-shot mode hard-exits via os._exit, so the Relay conversation was never
+finalized: exported telemetry got session start + turn lifecycle but no
+session end. The cleanup path must finalize the conversation before exit.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.main import _cleanup_oneshot_runtime
+
+
+def _run_cleanup(session_id):
+    calls = []
+    manager = SimpleNamespace(
+        invoke_hook=lambda name, **kwargs: calls.append(("plugin", name, kwargs)) or []
+    )
+    with patch(
+        "hermes_cli.observability.observe_lifecycle",
+        lambda name, **kwargs: calls.append(("builtin", name, kwargs)),
+    ), patch("hermes_cli.plugins.invoke_hook", manager.invoke_hook), patch(
+        "hermes_cli.main._oneshot_cleanup_done", False
+    ), patch(
+        "tools.terminal_tool.cleanup_all_environments", MagicMock()
+    ) as cleanup_term, patch(
+        "tools.async_delegation.interrupt_all", MagicMock()
+    ) as cleanup_deleg, patch(
+        "tools.browser_tool._emergency_cleanup_all_sessions", MagicMock()
+    ) as cleanup_browser, patch(
+        "tools.mcp_tool.shutdown_mcp_servers", MagicMock()
+    ) as cleanup_mcp, patch(
+        "agent.auxiliary_client.shutdown_cached_clients", MagicMock()
+    ) as cleanup_aux:
+        _cleanup_oneshot_runtime(session_id)
+    return calls, cleanup_term, cleanup_deleg, cleanup_browser, cleanup_mcp, cleanup_aux
+
+
+def test_cleanup_oneshot_runtime_finalizes_relay_session():
+    calls, ct, cd, cb, cm, ca = _run_cleanup("session-1")
+
+    assert ct.call_count == 1
+    assert cd.call_count == 1
+    assert cb.call_count == 1
+    assert cm.call_count == 1
+    assert ca.call_count == 1
+    builtin = [c for c in calls if c[0] == "builtin"]
+    assert builtin
+    assert builtin[0][1] == "on_session_finalize"
+    assert builtin[0][2]["session_id"] == "session-1"
+    assert builtin[0][2]["platform"] == "cli"
+    assert builtin[0][2]["reason"] == "oneshot_complete"
+
+
+def test_cleanup_oneshot_runtime_without_session_id_skips_finalize():
+    calls, *_ = _run_cleanup(None)
+    assert not [c for c in calls if c[0] == "builtin"]

--- a/tests/hermes_cli/test_oneshot_surrogate.py
+++ b/tests/hermes_cli/test_oneshot_surrogate.py
@@ -19,7 +19,8 @@ def test_oneshot_replaces_lone_surrogate_and_exits_zero():
             dirty,
             {"final_response": dirty, "failed": False, "partial": False, "completed": True},
         )
-        raise SystemExit(oneshot.run_oneshot("hello"))
+        code, _ = oneshot.run_oneshot("hello")
+        raise SystemExit(code)
         """
     )
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -113,7 +113,8 @@ def test_oneshot_subprocess_exits_without_teardown_abort():
         from hermes_cli.main import _exit_after_oneshot
 
         oneshot._run_agent = lambda *args, **kwargs: ("ok", {"final_response": "ok"})
-        _exit_after_oneshot(oneshot.run_oneshot("hello"))
+        rc, _session_id = oneshot.run_oneshot("hello")
+        _exit_after_oneshot(rc)
         """
     )
 


### PR DESCRIPTION
## Summary

One-shot mode (`hermes -z` / `--oneshot`) hard-exits via `os._exit`, so the Relay conversation was never finalized: exported telemetry contains session start + turn lifecycle but **no session end** — the root session stays open (#79471).

`_cleanup_oneshot_runtime()` already mirrors `cli.py:_run_cleanup()` for the other process-global clients (terminal, delegation, browser, MCP, auxiliary), but never finalizes the Relay conversation.

## Fix

- **`hermes_cli/main.py`**: `_cleanup_oneshot_runtime(session_id)` now calls `hermes_cli.lifecycle.finalize_session(session_id=..., platform="cli", reason="oneshot_complete")` — the same chokepoint `cli.py` single-query and the TUI gateway already use — before the hard exit.
- **`hermes_cli/oneshot.py`**: `run_oneshot()` returns `(rc, session_id)` so the session id reaches the cleanup path; `_run_agent`'s result dict already carries it (`turn_finalizer.py` sets `"session_id": agent.session_id`).

## Safety

- Best-effort and guarded (`try/except Exception: pass`), mirroring `cli.py:_notify_session_finalize` (cli.py:1286-1294).
- No Relay host → `finalize_conversation` no-ops via `for_profile(create=False)` → `None`; `close_session` on an unknown session is a no-op. Safe for installs without Relay.
- The `#43055` hard-exit safety boundary is preserved: the `finally` block still runs `os._exit`; a finalization failure never falls through to interpreter finalization.
- `run_oneshot`'s only caller is `_run_and_exit_oneshot` (verified; `tui_gateway/methods_session.py` imports the unrelated `agent.oneshot`).

## Tests

`tests/hermes_cli/test_oneshot_relay_finalize.py`:
- `test_cleanup_oneshot_runtime_finalizes_relay_session` — proves `finalize_session` fires with session_id/platform/reason; all other cleanup clients still called.
- `test_cleanup_oneshot_runtime_without_session_id_skips_finalize` — no session id → no finalize (idempotent no-op).

**RED proof**: with the fix stashed, the test fails (`TypeError: _cleanup_oneshot_runtime() takes 0 positional arguments`). GREEN with the fix: `2 passed`.
Regression: `543 passed` across oneshot/lifecycle/TUI-gateway suites.

## Validation

- `python3 -m pytest tests/hermes_cli/test_oneshot_relay_finalize.py -q` → `2 passed`
- `PYTHONPATH= python3 -m pytest tests/hermes_cli/test_oneshot_usage_file.py tests/agent/test_oneshot.py tests/hermes_cli/test_lifecycle.py tests/test_tui_gateway_ws.py tests/tui_gateway/test_gateway_owned_session_reap.py tests/test_tui_gateway_server.py -q` → `543 passed`
- `python3 scripts/check-windows-footguns.py --diff main` → clean
- `git diff --check` → clean
