### PR TITLE
fix(file-ops): stop reading truncated UTF-8 samples as binary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -242,7 +242,11 @@ def file_ops(mock_env):
     return ShellFileOperations(mock_env)
 
 
-def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMock:
+def make_real_subprocess_env(
+    cwd: str,
+    include_stderr: bool = False,
+    lossy_utf8: bool = False,
+) -> MagicMock:
     """Mock env whose execute() runs the command in a real subprocess.
 
     For tests that need the generated shell scripts to actually run
@@ -250,17 +254,26 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     intercepted by a bare MagicMock.  ``include_stderr`` folds stderr
     into ``output`` for tests that surface shell error text; leave it
     off for tests that parse structured stdout (e.g. find results).
+
+    ``lossy_utf8`` decodes exactly like ``LocalEnvironment`` does
+    (``encoding="utf-8", errors="replace"`` — see environments/local.py),
+    so undecodable bytes arrive as U+FFFD instead of raising.  Needed by
+    the tests that pin how ``_is_likely_binary`` reacts to those.
     """
     env = MagicMock()
     env.cwd = cwd
 
     def execute(command, **kwargs):
+        decode_kwargs = (
+            {"encoding": "utf-8", "errors": "replace"} if lossy_utf8 else {}
+        )
         completed = subprocess.run(
             command,
             shell=True,
             text=True,
             capture_output=True,
             input=kwargs.get("stdin_data"),
+            **decode_kwargs,
         )
         output = completed.stdout
         if include_stderr:
@@ -328,6 +341,20 @@ class TestShellFileOpsHelpers:
         assert file_ops._is_likely_binary("code.py") is False
         assert file_ops._is_likely_binary("readme.md") is False
 
+    def test_is_likely_binary_ignores_truncated_char_at_sample_end(self, file_ops):
+        """A U+FFFD produced by the probe's own byte cut is not evidence.
+
+        The sample comes from ``head -c 1000`` — a byte cut.  When it lands
+        inside a multibyte codepoint the terminal's errors="replace" decode
+        leaves a trailing U+FFFD.  That artifact belongs to the probe, not
+        to the file.
+        """
+        assert file_ops._is_likely_binary("szene.fountain", "Renie sagt: h�") is False
+
+    def test_is_likely_binary_still_flags_undecodable_bytes_in_body(self, file_ops):
+        """The real guard stays: lossy bytes mid-sample mean don't touch it."""
+        assert file_ops._is_likely_binary("blob.txt", "head��tail") is True
+
 
     def test_cwd_fallback_to_slash(self):
         env = MagicMock(spec=[])  # no cwd attribute
@@ -362,6 +389,72 @@ class TestShellFileOpsHelpers:
         assert "\x1b]" not in result.content
         assert "\x07" not in result.content
         assert "1|print('ok')" in result.content
+
+    def test_read_file_raw_reads_utf8_split_by_the_sample_byte_cut(self, tmp_path):
+        """German prose stays readable when byte 1000 lands inside a char.
+
+        Real-world repro: a .fountain screenplay whose umlaut straddles the
+        ``head -c 1000`` boundary was reported as "Binary file — cannot
+        display as text" by both read_file and patch, so the agent could
+        neither read nor edit it.
+        """
+        target = tmp_path / "szene.fountain"
+        content = "x" * 999 + "ä" + "\n\nRENIE\n    Wo ist Stephen?\n"
+        target.write_bytes(content.encode("utf-8"))
+        # Pin the premise: the cut really does split the 'ä'.
+        assert len(content.encode("utf-8")[:1000].decode("utf-8", "replace")) == 1000
+
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), lossy_utf8=True)
+        )
+        result = ops.read_file_raw(str(target))
+
+        assert result.error is None
+        assert result.is_binary is False
+        assert result.content == content
+
+    def test_read_file_raw_refuses_a_bad_byte_sitting_on_the_sample_cut(self, tmp_path):
+        """A real undecodable byte at the cut is not a truncation artifact.
+
+        Both produce a single trailing U+FFFD, so the decoded sample alone
+        cannot tell them apart. Reading this file as text would put U+FFFD
+        into the content and a write-back would destroy the original byte —
+        exactly the corruption the binary guard exists to prevent.
+        """
+        target = tmp_path / "sabotage.txt"
+        target.write_bytes(b"a" * 999 + b"\xff" + b"tail\n" * 50)
+
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), lossy_utf8=True)
+        )
+        result = ops.read_file_raw(str(target))
+
+        assert result.is_binary is True
+        assert result.content in (None, "")
+
+    def test_read_file_raw_refuses_a_bad_byte_the_file_ends_on(self, tmp_path):
+        """Nothing was cut off, so the marker cannot be a cut artifact."""
+        target = tmp_path / "ends_badly.txt"
+        target.write_bytes(b"a" * 999 + b"\xff")
+
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), lossy_utf8=True)
+        )
+
+        assert ops.read_file_raw(str(target)).is_binary is True
+
+    def test_read_file_raw_still_refuses_a_file_with_undecodable_bytes(self, tmp_path):
+        """The corruption guard survives: lossy content is read-only."""
+        target = tmp_path / "mixed.txt"
+        target.write_bytes(b"header\n" + b"\xff\xfe\xff\xfe" + b"tail\n" * 40)
+
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), lossy_utf8=True)
+        )
+        result = ops.read_file_raw(str(target))
+
+        assert result.is_binary is True
+        assert "Binary file" in result.error
 
     def test_read_file_raw_strips_leaked_terminal_fence_markers(self, mock_env):
         leaked = (

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,7 +903,21 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # Except at the very end: callers sample with ``head -c N``, a
+            # BYTE cut, so a multibyte codepoint straddling the limit decodes
+            # to a trailing U+FFFD that the probe itself created. Judging the
+            # file by that artifact made ordinary UTF-8 prose both unreadable
+            # and unpatchable whenever byte N landed inside an umlaut \u2014 which
+            # non-ASCII text hits constantly. Only U+FFFD in the body is
+            # evidence of genuinely undecodable bytes.
+            probe = content_sample[:1000]
+            body = probe.rstrip("\ufffd")
+            if "\ufffd" in body:
+                return True
+            if body != probe and self._cut_marker_is_a_real_bad_byte(
+                path, probe
+            ):
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')
@@ -911,6 +925,30 @@ class ShellFileOperations(FileOperations):
         
         return False
     
+    def _cut_marker_is_a_real_bad_byte(self, path: str, probe: str) -> bool:
+        """Decide whether a U+FFFD on the sample's cut is genuine.
+
+        A trailing marker has two possible causes and the decoded text
+        cannot tell them apart: the byte cut split a codepoint (harmless,
+        the probe's own doing), or an undecodable byte happens to sit on
+        the cut (real, and reading the file would corrupt it on write-back).
+
+        So look past the boundary. Four more bytes is the most a UTF-8
+        codepoint can need: a split one completes and its marker vanishes,
+        while a bad byte moves into the body where it is unmistakable. If
+        the longer read returns nothing new the file simply ended there —
+        nothing was cut off, so the marker was never an artifact.
+        """
+        result = self._exec(
+            f"head -c 1004 {self._escape_shell_arg(path)} 2>/dev/null"
+        )
+        if result.exit_code != 0:
+            return True  # can't confirm it's harmless — stay read-only
+        extended = _strip_terminal_fence_leaks(result.stdout)
+        if extended == probe:
+            return True
+        return "�" in extended.rstrip("�")
+
     def _is_image(self, path: str) -> bool:
         """Check if file is an image we can return as base64."""
         ext = os.path.splitext(path)[1].lower()


### PR DESCRIPTION
## The bug

`read_file` and `read_file_raw` probe a file with `head -c 1000` before deciding whether it is text. That is a **byte** cut, so a multibyte codepoint straddling the limit decodes (`errors="replace"`) to a trailing U+FFFD — an artifact the probe itself created.

`_is_likely_binary` treated any U+FFFD in the sample as proof of undecodable bytes, so those files came back as `Binary file — cannot display as text` from **both** `read_file` and `patch`. The file was then neither readable nor editable, with no way for the agent to recover.

Non-ASCII text hits this constantly — byte 1000 only has to land inside an umlaut. It surfaced on a German screenplay, where the agent worked around the block by stripping every en dash from the prose.

Reproducer against the current code, no fixtures needed:

```python
from tools.environments.local import LocalEnvironment
# any UTF-8 file whose byte 1000 falls inside a multibyte codepoint
s = LocalEnvironment().execute(f"head -c 1000 '{path}'").get("output", "")
assert "�" in s   # -> the file is rejected as binary
```

## The fix

A marker **on the cut itself** is ambiguous, and the decoded sample cannot resolve it: a split codepoint and a genuinely undecodable byte sitting on the boundary both leave exactly one trailing U+FFFD. Stripping the tail unconditionally would let real corruption through, so the check looks past the boundary instead of guessing.

Four more bytes is the most a UTF-8 codepoint can need:

- a split codepoint completes and its marker vanishes → text;
- a bad byte moves into the body, where it is unmistakable → binary;
- a read that returns nothing new means the file ended there, so nothing was cut off and the marker was never an artifact → binary.

Only that second read can clear a file; anything unresolved stays read-only. The extra `head` runs solely in the ambiguous case.

The corruption guard this check exists for is therefore intact — lossy content still makes a file read-only, so a read/edit/write round-trip cannot replace the original bytes with mojibake. The `>30%` non-printable ratio that catches real binaries is unchanged.

The other `head -c` probes were checked and are unaffected: `_detect_file_line_ending` only looks for `\r\n` vs `\n`, `_file_has_bom` compares an exact 3-byte prefix, and `file_tools.py`'s guard is extension-only.

## Tests

`tests/tools/test_file_operations.py` gains coverage for the split-codepoint case and for both ways a marker on the cut can be genuine (a bad byte followed by more content, and a file that ends on one). `make_real_subprocess_env` gained a `lossy_utf8` flag so the fixture decodes the way `LocalEnvironment` actually does (`encoding="utf-8", errors="replace"`).

Green: every test file that touches `file_operations` — 207 tests.

Pre-existing failures in `tests/tools/` are unrelated and reproduce on a clean tree (`test_approval.py`, `test_clipboard.py` — `prompt_toolkit` is not installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)