### PR TITLE
fix(tui): make terminal path tests platform-independent

### DIFF
--- a/tests/tui_gateway/test_entry_import_off_main_thread.py
+++ b/tests/tui_gateway/test_entry_import_off_main_thread.py
@@ -25,8 +25,11 @@ thread, so an in-process import would not reproduce the bug).
 
 import subprocess
 import sys
+from pathlib import Path
 
-REPO_ROOT = "."
+# Derive from __file__ so the test is not cwd-dependent (works regardless of
+# where pytest is invoked from). Sibling tests use the identical pattern.
+REPO_ROOT = str(Path(__file__).resolve().parents[2])
 
 
 def _spawn_worker_import_entry():
@@ -50,8 +53,12 @@ def _spawn_worker_import_entry():
         "    sys.stdout.write('IMPORT_FAILED: ' + errs[0] + '\\n')\n"
         "    sys.exit(2)\n"
         "# main thread of this process still installs SIGPIPE handler\n"
-        "h = signal.getsignal(signal.SIGPIPE)\n"
-        "sys.stdout.write('OK handler_installed=' + str(h is signal.SIG_IGN or callable(h)) + '\\n')\n"
+        "# SIGPIPE is POSIX-only; guard so the probe works on Windows.\n"
+        "if hasattr(signal, 'SIGPIPE'):\n"
+        "    h = signal.getsignal(signal.SIGPIPE)\n"
+        "    sys.stdout.write('OK handler_installed=' + str(h is signal.SIG_IGN or callable(h)) + '\\n')\n"
+        "else:\n"
+        "    sys.stdout.write('OK no_sigpipe_on_platform\\n')\n"
         "sys.exit(0)\n"
     )
     proc = subprocess.run(


### PR DESCRIPTION
## Summary

Makes the terminal TUI gateway path tests platform-independent. The only genuine Windows failure risk in `tests/tui_gateway/` (found by a 50-file cross-platform audit) was in `test_entry_import_off_main_thread.py`:

1. **`signal.SIGPIPE` is POSIX-only.** The test probes it in a spawned subprocess; on Windows `SIGPIPE` is absent, the child dies with `AttributeError`, and `assert rc == 0` fails. Guarded behind `hasattr(signal, 'SIGPIPE')` with a `no_sigpipe` branch that preserves the `rc == 0` / `'OK'` contract.
2. **`REPO_ROOT = '.'` was cwd-dependent.** The test silently depended on pytest being invoked from the repo root. Replaced with `Path(__file__).resolve().parents[2]` (same pattern as `test_slash_worker_sys_path` / `test_compute_host`).

## Why

The Windows TestDriver path needs these tests to pass on non-POSIX platforms; the SIGPIPE probe guaranteed a failure there. Hardcoded Unix fixture strings in ~9 other TUI tests were audited and left unchanged (mock-only, do not fail on Windows).

## Verification

- 41 TUI path tests pass on Linux (`test_entry_import_off_main_thread`, `test_entry_sys_path`, `test_project_tree`, `test_session_images_dir`, `test_subprocess_encoding`, `test_slash_worker_ansi`, `test_slash_worker_sys_path`).
- Full `tests/tui_gateway/` suite: 342 passed.
- cwd-independence confirmed by running from `/tmp` (`1 passed`).
- Windows path simulated (SIGPIPE-absent child): `rc=0`, `'OK no_sigpipe_on_platform'`.

Refs: #79497
