### PR TITLE
refactor(agent): extract model-routing + retry-status mixins from run_agent.py (shard s1)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/plugins/agent/mixins/model_routing_mixin.py
+++ b/plugins/agent/mixins/model_routing_mixin.py
@@ -1,0 +1,90 @@
+"""Model-routing URL / provider classification helpers for AIAgent.
+
+Extracted verbatim from ``run_agent.py`` (godfile shard plan s1, cluster
+c23 — 7 methods, 28/28 move agreement). The methods read ``self.*`` state
+maintained by ``AIAgent.__init__`` / the ``base_url`` property
+(``_base_url_lower``, ``_base_url_hostname``, ``provider``, ``model``,
+``api_mode``); those class attributes stay on ``AIAgent`` and resolve
+through the MRO.
+
+``base_url_hostname`` / ``base_url_host_matches`` are shared module
+helpers also used by methods that remain in ``run_agent.py``, so they are
+imported here from ``utils`` exactly as ``run_agent.py`` imports them.
+"""
+
+from utils import base_url_host_matches, base_url_hostname
+
+
+class ModelRoutingMixin:
+    def _is_direct_openai_url(self, base_url: str = None) -> bool:
+        """Return True when a base URL targets OpenAI's native API."""
+        if base_url is not None:
+            hostname = base_url_hostname(base_url)
+        else:
+            hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
+                getattr(self, "_base_url_lower", "")
+            )
+        return hostname == "api.openai.com"
+
+    def _is_azure_openai_url(self, base_url: str = None) -> bool:
+        """Return True when a base URL targets Azure OpenAI.
+
+        Azure OpenAI exposes an OpenAI-compatible endpoint at
+        ``{resource}.openai.azure.com/openai/v1`` that accepts the
+        standard ``openai`` Python client.  Unlike api.openai.com it
+        does NOT support the Responses API — gpt-5.x models are served
+        on the regular ``/chat/completions`` path — so routing decisions
+        must treat Azure separately from direct OpenAI.
+        """
+        if base_url is not None:
+            url = str(base_url).lower()
+        else:
+            url = getattr(self, "_base_url_lower", "") or ""
+        return "openai.azure.com" in url
+
+    def _is_github_copilot_url(self, base_url: str = None) -> bool:
+        """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""
+        if base_url is not None:
+            hostname = base_url_hostname(base_url)
+        else:
+            hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
+                getattr(self, "_base_url_lower", "")
+            )
+        if not hostname:
+            return False
+        return hostname == "api.githubcopilot.com" or hostname.endswith(".githubcopilot.com")
+
+    def _is_openrouter_url(self) -> bool:
+        """Return True when the base URL targets OpenRouter."""
+        return base_url_host_matches(self._base_url_lower, "openrouter.ai")
+
+    def _is_copilot_url(self) -> bool:
+        """Return True when the base URL targets GitHub Copilot or GitHub Models."""
+        return (
+            "api.githubcopilot.com" in self._base_url_lower
+            or "models.github.ai" in self._base_url_lower
+        )
+
+    def _is_copilot_provider(self) -> bool:
+        """True when the active provider is GitHub Copilot, however spelled.
+
+        ``self.provider`` is not always the normalized slug: ``/model`` and
+        profile configs can leave the alias ``github-copilot`` (or ``github``)
+        in place — a single session log can show both ``provider=copilot`` and
+        ``provider=github-copilot`` for the same account. A bare
+        ``provider == "copilot"`` gate silently skips credential recovery for
+        the alias spellings, so this is the single owner of the check; the
+        Copilot base URL is accepted as a fallback signal.
+        """
+        if (self.provider or "").strip().lower() in {"copilot", "github-copilot", "github"}:
+            return True
+        return self._is_copilot_url()
+
+    def _is_codex_backend(self) -> bool:
+        """Return True for the ChatGPT OAuth Codex Responses backend."""
+        return (
+            getattr(self, "api_mode", None) == "codex_responses"
+            and getattr(self, "_base_url_hostname", "") == "chatgpt.com"
+            and "/backend-api/codex"
+            in (getattr(self, "_base_url_lower", "") or "")
+        )

--- a/plugins/agent/mixins/retry_status_mixin.py
+++ b/plugins/agent/mixins/retry_status_mixin.py
@@ -1,0 +1,117 @@
+"""Buffered retry/fallback status emission helpers for AIAgent.
+
+Extracted verbatim from ``run_agent.py`` (godfile shard plan s1, cluster
+c18 — 5 methods, 20/20 move agreement). The buffered helpers defer noisy
+retry chatter (rate-limit retries, fallback switches) until the turn
+outcome is known; on success the buffer is dropped, on terminal failure it
+is flushed. Emission is delegated back through the MRO to
+``AIAgent._emit_status`` / ``_emit_warning`` / ``_vprint``; the buffer
+itself lives on the instance (``self._retry_status_buffer``,
+``self._pending_fallback_notice``), initialized lazily here.
+"""
+
+
+class RetryStatusMixin:
+    # ── Buffered retry/fallback status ────────────────────────────────────
+    # Retry and fallback chains were flooding the CLI/gateway with status
+    # noise that users found confusing: a single transient 429 could produce
+    # 10+ "Provider/Endpoint/Retrying in 5s..." lines before the request
+    # eventually succeeded.  The buffered helpers below capture these
+    # status messages instead of emitting them immediately.  They are
+    # flushed (shown to the user) ONLY when every retry and fallback has
+    # been exhausted; on success they are silently dropped.  Backend logs
+    # (agent.log) are unaffected — every individual emission site still
+    # writes to ``logger.warning`` / ``logger.info`` for diagnosis.
+
+    def _buffer_status(self, message: str) -> None:
+        """Buffer a retry/fallback status message.
+
+        Stored as a (kind, text) tuple where ``kind`` is one of:
+        - ``"status"``  -> replays via ``_emit_status``
+        - ``"vprint"``  -> replays via ``_vprint(force=True)``
+        - ``"warn"``    -> replays via ``_emit_warning``
+        Used to defer noisy retry chatter until we know whether the
+        turn ultimately recovered or failed.
+        """
+        try:
+            buf = getattr(self, "_retry_status_buffer", None)
+            if buf is None:
+                buf = []
+                self._retry_status_buffer = buf
+            buf.append(("status", message))
+        except Exception:
+            # Never break the retry loop on a buffer hiccup.
+            pass
+
+    def _buffer_vprint(self, message: str) -> None:
+        """Buffer a vprint(force=True) retry/fallback line."""
+        try:
+            buf = getattr(self, "_retry_status_buffer", None)
+            if buf is None:
+                buf = []
+                self._retry_status_buffer = buf
+            buf.append(("vprint", message))
+        except Exception:
+            pass
+
+    def _clear_status_buffer(self) -> None:
+        """Drop buffered retry messages — call on successful recovery."""
+        try:
+            buf = getattr(self, "_retry_status_buffer", None)
+            if buf:
+                buf.clear()
+        except Exception:
+            pass
+
+    def _emit_pending_fallback_notice(self) -> None:
+        """Surface the one-shot fallback-switch notice on successful recovery.
+
+        A provider/model switch is a durable state change operators must see,
+        unlike transient retry chatter that ``_clear_status_buffer`` drops.
+        ``try_activate_fallback`` records the switch in
+        ``self._pending_fallback_notice``; this emits it exactly once via
+        ``_emit_status`` and then clears it, so a successful fallback still
+        produces one visible notice.  On terminal failure the buffered switch
+        line is flushed instead (and this notice discarded) — see
+        ``_flush_status_buffer`` — so the user always sees the switch once.
+        """
+        try:
+            notice = getattr(self, "_pending_fallback_notice", None)
+            if notice:
+                # Clear before emitting so a (swallowed) callback error can't
+                # leave the notice set for a stale re-emit on a later turn.
+                self._pending_fallback_notice = None
+                self._emit_status(notice)
+        except Exception:
+            # Never break the conversation loop on a notice hiccup.
+            pass
+
+    def _flush_status_buffer(self) -> None:
+        """Emit buffered retry messages — call on terminal failure.
+
+        Surfaces the full retry/fallback trace so the user can see what
+        was tried before the turn gave up.
+        """
+        try:
+            # The buffered trace already carries the fallback switch line, so
+            # drop any one-shot fallback notice to avoid a stale duplicate
+            # leaking into a later successful turn.
+            self._pending_fallback_notice = None
+            buf = getattr(self, "_retry_status_buffer", None)
+            if not buf:
+                return
+            # Drain first so a callback exception doesn't double-emit.
+            messages = list(buf)
+            buf.clear()
+            for kind, msg in messages:
+                try:
+                    if kind == "status":
+                        self._emit_status(msg)
+                    elif kind == "warn":
+                        self._emit_warning(msg)
+                    else:
+                        self._vprint(f"{self.log_prefix}{msg}", force=True)
+                except Exception:
+                    pass
+        except Exception:
+            pass

--- a/run_agent.py
+++ b/run_agent.py
@@ -221,6 +221,8 @@ from agent.tool_dispatch_helpers import (
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
+from plugins.agent.mixins.model_routing_mixin import ModelRoutingMixin
+from plugins.agent.mixins.retry_status_mixin import RetryStatusMixin
 
 
 # Internal flags that mark a message as ephemeral empty-response/prefill
@@ -409,7 +411,7 @@ class _StreamErrorEvent(Exception):
         }
 
 
-class AIAgent:
+class AIAgent(ModelRoutingMixin, RetryStatusMixin):
     """
     AI Agent with tool calling capabilities.
 
@@ -1081,110 +1083,6 @@ class AIAgent:
             except Exception:
                 logger.debug("thinking_callback error in _emit_wait_notice", exc_info=True)
 
-    # ── Buffered retry/fallback status ────────────────────────────────────
-    # Retry and fallback chains were flooding the CLI/gateway with status
-    # noise that users found confusing: a single transient 429 could produce
-    # 10+ "Provider/Endpoint/Retrying in 5s..." lines before the request
-    # eventually succeeded.  The buffered helpers below capture these
-    # status messages instead of emitting them immediately.  They are
-    # flushed (shown to the user) ONLY when every retry and fallback has
-    # been exhausted; on success they are silently dropped.  Backend logs
-    # (agent.log) are unaffected — every individual emission site still
-    # writes to ``logger.warning`` / ``logger.info`` for diagnosis.
-
-    def _buffer_status(self, message: str) -> None:
-        """Buffer a retry/fallback status message.
-
-        Stored as a (kind, text) tuple where ``kind`` is one of:
-        - ``"status"``  -> replays via ``_emit_status``
-        - ``"vprint"``  -> replays via ``_vprint(force=True)``
-        - ``"warn"``    -> replays via ``_emit_warning``
-        Used to defer noisy retry chatter until we know whether the
-        turn ultimately recovered or failed.
-        """
-        try:
-            buf = getattr(self, "_retry_status_buffer", None)
-            if buf is None:
-                buf = []
-                self._retry_status_buffer = buf
-            buf.append(("status", message))
-        except Exception:
-            # Never break the retry loop on a buffer hiccup.
-            pass
-
-    def _buffer_vprint(self, message: str) -> None:
-        """Buffer a vprint(force=True) retry/fallback line."""
-        try:
-            buf = getattr(self, "_retry_status_buffer", None)
-            if buf is None:
-                buf = []
-                self._retry_status_buffer = buf
-            buf.append(("vprint", message))
-        except Exception:
-            pass
-
-    def _clear_status_buffer(self) -> None:
-        """Drop buffered retry messages — call on successful recovery."""
-        try:
-            buf = getattr(self, "_retry_status_buffer", None)
-            if buf:
-                buf.clear()
-        except Exception:
-            pass
-
-    def _emit_pending_fallback_notice(self) -> None:
-        """Surface the one-shot fallback-switch notice on successful recovery.
-
-        A provider/model switch is a durable state change operators must see,
-        unlike transient retry chatter that ``_clear_status_buffer`` drops.
-        ``try_activate_fallback`` records the switch in
-        ``self._pending_fallback_notice``; this emits it exactly once via
-        ``_emit_status`` and then clears it, so a successful fallback still
-        produces one visible notice.  On terminal failure the buffered switch
-        line is flushed instead (and this notice discarded) — see
-        ``_flush_status_buffer`` — so the user always sees the switch once.
-        """
-        try:
-            notice = getattr(self, "_pending_fallback_notice", None)
-            if notice:
-                # Clear before emitting so a (swallowed) callback error can't
-                # leave the notice set for a stale re-emit on a later turn.
-                self._pending_fallback_notice = None
-                self._emit_status(notice)
-        except Exception:
-            # Never break the conversation loop on a notice hiccup.
-            pass
-
-    def _flush_status_buffer(self) -> None:
-        """Emit buffered retry messages — call on terminal failure.
-
-        Surfaces the full retry/fallback trace so the user can see what
-        was tried before the turn gave up.
-        """
-        try:
-            # The buffered trace already carries the fallback switch line, so
-            # drop any one-shot fallback notice to avoid a stale duplicate
-            # leaking into a later successful turn.
-            self._pending_fallback_notice = None
-            buf = getattr(self, "_retry_status_buffer", None)
-            if not buf:
-                return
-            # Drain first so a callback exception doesn't double-emit.
-            messages = list(buf)
-            buf.clear()
-            for kind, msg in messages:
-                try:
-                    if kind == "status":
-                        self._emit_status(msg)
-                    elif kind == "warn":
-                        self._emit_warning(msg)
-                    else:
-                        self._vprint(f"{self.log_prefix}{msg}", force=True)
-                except Exception:
-                    pass
-        except Exception:
-            pass
-
     def _disable_codex_reasoning_replay(
         self,
         messages: Optional[List[Dict[str, Any]]] = None,
@@ -1324,44 +1222,6 @@ class AIAgent:
         from agent.conversation_compression import replay_compression_warning
         replay_compression_warning(self)
 
-    def _is_direct_openai_url(self, base_url: str = None) -> bool:
-        """Return True when a base URL targets OpenAI's native API."""
-        if base_url is not None:
-            hostname = base_url_hostname(base_url)
-        else:
-            hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
-                getattr(self, "_base_url_lower", "")
-            )
-        return hostname == "api.openai.com"
-
-    def _is_azure_openai_url(self, base_url: str = None) -> bool:
-        """Return True when a base URL targets Azure OpenAI.
-
-        Azure OpenAI exposes an OpenAI-compatible endpoint at
-        ``{resource}.openai.azure.com/openai/v1`` that accepts the
-        standard ``openai`` Python client.  Unlike api.openai.com it
-        does NOT support the Responses API — gpt-5.x models are served
-        on the regular ``/chat/completions`` path — so routing decisions
-        must treat Azure separately from direct OpenAI.
-        """
-        if base_url is not None:
-            url = str(base_url).lower()
-        else:
-            url = getattr(self, "_base_url_lower", "") or ""
-        return "openai.azure.com" in url
-
-    def _is_github_copilot_url(self, base_url: str = None) -> bool:
-        """Return True when a base URL targets GitHub Copilot's OpenAI-compatible API."""
-        if base_url is not None:
-            hostname = base_url_hostname(base_url)
-        else:
-            hostname = getattr(self, "_base_url_hostname", "") or base_url_hostname(
-                getattr(self, "_base_url_lower", "")
-            )
-        if not hostname:
-            return False
-        return hostname == "api.githubcopilot.com" or hostname.endswith(".githubcopilot.com")
-
     def _resolved_api_call_timeout(self) -> float:
         """Resolve the effective per-call request timeout in seconds.
 
@@ -1494,41 +1354,6 @@ class AIAgent:
             "or switch to a different model/provider in your fallback chain. "
             "Some ChatGPT Codex accounts do not support `gpt-5.4-codex`. "
             "See hermes-agent#21444 for symptom history."
-        )
-
-    def _is_openrouter_url(self) -> bool:
-        """Return True when the base URL targets OpenRouter."""
-        return base_url_host_matches(self._base_url_lower, "openrouter.ai")
-
-    def _is_copilot_url(self) -> bool:
-        """Return True when the base URL targets GitHub Copilot or GitHub Models."""
-        return (
-            "api.githubcopilot.com" in self._base_url_lower
-            or "models.github.ai" in self._base_url_lower
-        )
-
-    def _is_copilot_provider(self) -> bool:
-        """True when the active provider is GitHub Copilot, however spelled.
-
-        ``self.provider`` is not always the normalized slug: ``/model`` and
-        profile configs can leave the alias ``github-copilot`` (or ``github``)
-        in place — a single session log can show both ``provider=copilot`` and
-        ``provider=github-copilot`` for the same account. A bare
-        ``provider == "copilot"`` gate silently skips credential recovery for
-        the alias spellings, so this is the single owner of the check; the
-        Copilot base URL is accepted as a fallback signal.
-        """
-        if (self.provider or "").strip().lower() in {"copilot", "github-copilot", "github"}:
-            return True
-        return self._is_copilot_url()
-
-    def _is_codex_backend(self) -> bool:
-        """Return True for the ChatGPT OAuth Codex Responses backend."""
-        return (
-            getattr(self, "api_mode", None) == "codex_responses"
-            and getattr(self, "_base_url_hostname", "") == "chatgpt.com"
-            and "/backend-api/codex"
-            in (getattr(self, "_base_url_lower", "") or "")
         )
 
     def _anthropic_prompt_cache_policy(

--- a/tests/run_agent/test_model_routing_mixin_extraction.py
+++ b/tests/run_agent/test_model_routing_mixin_extraction.py
@@ -1,0 +1,110 @@
+"""Regression tests for the model-routing mixin extraction (shard s1, c23).
+
+The 7 URL / provider classification helpers moved VERBATIM from
+``run_agent.py`` into ``plugins.agent.mixins.model_routing_mixin``.
+These tests pin the pure classification behavior and the MRO wiring
+(``AIAgent`` must still expose the exact same function objects, so
+callers inside run_agent.py keep working without any change).
+"""
+
+from __future__ import annotations
+
+import run_agent
+from plugins.agent.mixins.model_routing_mixin import ModelRoutingMixin
+
+MOVED = (
+    "_is_direct_openai_url",
+    "_is_azure_openai_url",
+    "_is_github_copilot_url",
+    "_is_openrouter_url",
+    "_is_copilot_url",
+    "_is_copilot_provider",
+    "_is_codex_backend",
+)
+
+
+def _bare_agent(**attrs):
+    """Object.__new__-based bare adapter (no __init__ side effects)."""
+    agent = object.__new__(run_agent.AIAgent)
+    for key, value in attrs.items():
+        setattr(agent, key, value)
+    return agent
+
+
+def test_methods_are_wired_through_mro():
+    for name in MOVED:
+        assert getattr(run_agent.AIAgent, name) is getattr(ModelRoutingMixin, name), name
+
+
+def test_is_direct_openai_url():
+    agent = _bare_agent(_base_url_lower="https://api.openai.com/v1", _base_url_hostname="api.openai.com")
+    assert agent._is_direct_openai_url() is True
+    agent = _bare_agent(_base_url_lower="https://api.openai.com/v1", _base_url_hostname="api.openai.com")
+    assert agent._is_direct_openai_url("https://api.openai.com/v1") is True
+    agent = _bare_agent(_base_url_lower="https://other.example.com/v1", _base_url_hostname="other.example.com")
+    assert agent._is_direct_openai_url() is False
+    # Explicit base_url argument wins over instance state.
+    agent = _bare_agent(_base_url_lower="https://other.example.com/v1", _base_url_hostname="other.example.com")
+    assert agent._is_direct_openai_url("https://api.openai.com/v1") is True
+
+
+def test_is_azure_openai_url():
+    agent = _bare_agent(_base_url_lower="https://my-resource.openai.azure.com/openai/v1")
+    assert agent._is_azure_openai_url() is True
+    agent = _bare_agent(_base_url_lower="https://api.openai.com/v1")
+    assert agent._is_azure_openai_url() is False
+    agent = _bare_agent(_base_url_lower="")
+    assert agent._is_azure_openai_url("https://res.openai.azure.com/") is True
+
+
+def test_is_github_copilot_url():
+    agent = _bare_agent(_base_url_lower="https://api.githubcopilot.com/chat/completions", _base_url_hostname="api.githubcopilot.com")
+    assert agent._is_github_copilot_url() is True
+    agent = _bare_agent(_base_url_lower="https://api.openai.com/v1", _base_url_hostname="api.openai.com")
+    assert agent._is_github_copilot_url() is False
+    # Subdomain hosts count.
+    agent = _bare_agent(_base_url_lower="", _base_url_hostname="")
+    assert agent._is_github_copilot_url("https://copilot-proxy.githubcopilot.com/v1") is True
+    # No hostname at all -> False, never an exception.
+    agent = _bare_agent(_base_url_lower="", _base_url_hostname="")
+    assert agent._is_github_copilot_url() is False
+
+
+def test_is_openrouter_url():
+    agent = _bare_agent(_base_url_lower="https://openrouter.ai/api/v1")
+    assert agent._is_openrouter_url() is True
+    agent = _bare_agent(_base_url_lower="https://api.openai.com/v1")
+    assert agent._is_openrouter_url() is False
+
+
+def test_is_copilot_url():
+    agent = _bare_agent(_base_url_lower="https://api.githubcopilot.com/chat/completions")
+    assert agent._is_copilot_url() is True
+    agent = _bare_agent(_base_url_lower="https://models.github.ai/v1")
+    assert agent._is_copilot_url() is True
+    agent = _bare_agent(_base_url_lower="https://api.openai.com/v1")
+    assert agent._is_copilot_url() is False
+
+
+def test_is_copilot_provider_spellings_and_url_fallback():
+    for spelling in ("copilot", "github-copilot", "github", "  Copilot  "):
+        agent = _bare_agent(provider=spelling, _base_url_lower="https://api.openai.com/v1")
+        assert agent._is_copilot_provider() is True, spelling
+    agent = _bare_agent(provider="anthropic", _base_url_lower="https://api.githubcopilot.com/v1")
+    assert agent._is_copilot_provider() is True  # URL fallback signal
+    agent = _bare_agent(provider="anthropic", _base_url_lower="https://api.openai.com/v1")
+    assert agent._is_copilot_provider() is False
+    agent = _bare_agent(provider=None, _base_url_lower="https://api.openai.com/v1")
+    assert agent._is_copilot_provider() is False  # None provider must not raise
+
+
+def test_is_codex_backend():
+    agent = _bare_agent(api_mode="codex_responses", _base_url_hostname="chatgpt.com",
+                        _base_url_lower="https://chatgpt.com/backend-api/codex")
+    assert agent._is_codex_backend() is True
+    agent = _bare_agent(api_mode="responses", _base_url_hostname="chatgpt.com",
+                        _base_url_lower="https://chatgpt.com/backend-api/codex")
+    assert agent._is_codex_backend() is False
+    agent = _bare_agent(api_mode="codex_responses", _base_url_hostname="api.openai.com",
+                        _base_url_lower="https://api.openai.com/v1")
+    assert agent._is_codex_backend() is False

--- a/tests/run_agent/test_retry_status_mixin_extraction.py
+++ b/tests/run_agent/test_retry_status_mixin_extraction.py
@@ -1,0 +1,116 @@
+"""Regression tests for the retry-status mixin extraction (shard s1, c18).
+
+The 5 buffered retry/fallback status helpers moved VERBATIM from
+``run_agent.py`` into ``plugins.agent.mixins.retry_status_mixin``.
+Tests pin the buffering semantics (accumulate, flush on terminal
+failure, drop on success, one-shot fallback notice) and the MRO wiring.
+"""
+
+from __future__ import annotations
+
+import run_agent
+from plugins.agent.mixins.retry_status_mixin import RetryStatusMixin
+
+MOVED = (
+    "_buffer_status",
+    "_buffer_vprint",
+    "_clear_status_buffer",
+    "_emit_pending_fallback_notice",
+    "_flush_status_buffer",
+)
+
+
+def _bare_agent(**attrs):
+    """Object.__new__-based bare adapter (no __init__ side effects)."""
+    agent = object.__new__(run_agent.AIAgent)
+    agent.log_prefix = ""
+    agent._emit_status = lambda msg: None
+    agent._emit_warning = lambda msg: None
+    agent._vprint = lambda msg, force=False: None
+    for key, value in attrs.items():
+        setattr(agent, key, value)
+    return agent
+
+
+def test_methods_are_wired_through_mro():
+    for name in MOVED:
+        assert getattr(run_agent.AIAgent, name) is getattr(RetryStatusMixin, name), name
+
+
+def test_buffer_status_accumulates_then_flushes():
+    agent = _bare_agent()
+    emitted = []
+    agent._emit_status = lambda msg: emitted.append(("status", msg))
+
+    agent._buffer_status("\u23f3 Retrying in 5s...")
+    agent._buffer_status("\u26a0\ufe0f Fallback attempt 2...")
+    assert emitted == []  # deferred until flush
+
+    agent._flush_status_buffer()
+    assert emitted == [("status", "\u23f3 Retrying in 5s..."), ("status", "\u26a0\ufe0f Fallback attempt 2...")]
+
+    # Buffer drained: a second flush emits nothing.
+    agent._flush_status_buffer()
+    assert emitted == [("status", "\u23f3 Retrying in 5s..."), ("status", "\u26a0\ufe0f Fallback attempt 2...")]
+
+
+def test_buffer_vprint_flush_uses_log_prefix():
+    agent = _bare_agent(log_prefix="[agent] ")
+    vprinted = []
+    agent._vprint = lambda msg, force=False: vprinted.append((msg, force))
+
+    agent._buffer_vprint("retry detail line")
+    agent._flush_status_buffer()
+    assert vprinted == [("[agent] retry detail line", True)]
+
+
+def test_flush_emits_warning_kind():
+    agent = _bare_agent()
+    warned = []
+    agent._emit_warning = lambda msg: warned.append(msg)
+
+    agent._buffer_status("status line")
+    # Simulate a warn-kind entry by poking the buffer directly (private shape
+    # is (kind, text) tuples appended by _buffer_status/_buffer_vprint).
+    buf = getattr(agent, "_retry_status_buffer")
+    buf.append(("warn", "warning line"))
+    agent._flush_status_buffer()
+    assert warned == ["warning line"]
+
+
+def test_clear_status_buffer_drops_silently():
+    agent = _bare_agent()
+    emitted = []
+    agent._emit_status = lambda msg: emitted.append(msg)
+
+    agent._buffer_status("doomed retry")
+    agent._clear_status_buffer()
+    agent._flush_status_buffer()
+    assert emitted == []
+
+
+def test_emit_pending_fallback_notice_emits_once_then_clears():
+    agent = _bare_agent()
+    emitted = []
+    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._pending_fallback_notice = "Switched provider X -> Y"
+
+    agent._emit_pending_fallback_notice()
+    assert emitted == ["Switched provider X -> Y"]
+    # Cleared after emission: a second call emits nothing.
+    agent._emit_pending_fallback_notice()
+    assert emitted == ["Switched provider X -> Y"]
+
+
+def test_flush_discards_pending_fallback_notice():
+    agent = _bare_agent()
+    emitted = []
+    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._pending_fallback_notice = "Switched provider X -> Y"
+
+    agent._buffer_status("gave up after retries")
+    agent._flush_status_buffer()
+    # The buffered trace carries the switch line already; the one-shot notice
+    # must be dropped so it cannot leak into a later successful turn.
+    assert agent._pending_fallback_notice is None
+    assert emitted == ["gave up after retries"]


### PR DESCRIPTION
## Godfile kill — run_agent.py shard s1

Extracts the model_routing_mixin, retry_status_mixin into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 438 added / 178 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069 #79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701 #78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715 #78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729 #78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743 #78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757 #78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771 #78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785 #78786 #78787 #78788 #78789 #78790

Part of #78639
Part of #78647