### PR TITLE
fix(gateway): stop flood-controlled progress edits from re-sending

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3971,6 +3971,19 @@ class TurnRunner:
                             adapter.name,
                         )
                         return True
+                    if "flood" in (getattr(result, "error", "") or "").lower() or (
+                        "retry after" in (getattr(result, "error", "") or "").lower()
+                    ):
+                        # Sibling of the flood branch in the main edit path:
+                        # flood control is transient, so keep can_edit and
+                        # leave the buffer intact for a later retry rather
+                        # than splitting into fresh sends. Those extra API
+                        # calls are what escalate the penalty (#76494).
+                        logger.info(
+                            "[%s] Overflow edit flood control, backing off",
+                            adapter.name,
+                        )
+                        return True
                     can_edit = False
                     # Fall back to the existing non-edit behavior below.
                     return False
@@ -4085,14 +4098,28 @@ class TurnRunner:
                         if "flood" in _err or "retry after" in _err:
                             # Flood control hit — backoff but keep editing.
                             # Only disable edits for non-recoverable errors.
+                            #
+                            # Do NOT fall through to the send() below. The
+                            # penalty is charged per API call against this
+                            # chat, so answering a flood-controlled edit with
+                            # a fresh send is the exact burst that makes
+                            # Telegram escalate the retry-after — a ~50s
+                            # back-off compounds into multi-thousand-second
+                            # bans while the agent keeps completing turns
+                            # nobody can see (#76494). Resetting
+                            # _last_edit_ts above is the whole remedy: the
+                            # throttle at the top of the loop waits out
+                            # _PROGRESS_EDIT_INTERVAL and the next tick edits
+                            # the same bubble. Same contract as the
+                            # `retryable` branch above.
                             logger.info(
                                 "[%s] Progress edit flood control, backing off",
                                 adapter.name,
                             )
                             _last_edit_ts = time.monotonic()
-                        else:
-                            can_edit = False
-                        _flood_result = await adapter.send(
+                            continue
+                        can_edit = False
+                        _fallback_result = await adapter.send(
                             chat_id=ctx.source.chat_id,
                             content=msg,
                             reply_to=ctx._progress_reply_to,
@@ -4100,10 +4127,10 @@ class TurnRunner:
                         )
                         if (
                             ctx._cleanup_progress
-                            and getattr(_flood_result, "success", False)
-                            and getattr(_flood_result, "message_id", None)
+                            and getattr(_fallback_result, "success", False)
+                            and getattr(_fallback_result, "message_id", None)
                         ):
-                            ctx._cleanup_msg_ids.append(str(_flood_result.message_id))
+                            ctx._cleanup_msg_ids.append(str(_fallback_result.message_id))
                 else:
                     if can_edit:
                         # First tool: send all accumulated text as new message

--- a/tests/gateway/test_run_progress_flood_control.py
+++ b/tests/gateway/test_run_progress_flood_control.py
@@ -1,0 +1,239 @@
+"""Tests for flood-control handling in the gateway's tool-progress loop.
+
+When a progress-bubble edit is rejected with Telegram flood control, the
+gateway used to answer it with a fresh ``adapter.send()`` into the same
+chat.  That extra API call is charged against the same penalty the edit
+just hit, so Telegram escalates the retry-after: a ~50s back-off compounds
+into multi-thousand-second bans during which nothing reaches the chat while
+the agent keeps completing turns (#76494).
+
+The contract these tests pin: a flood-controlled edit backs off and keeps
+editing — it never answers with another message.  Failures that are
+genuinely not recoverable still fall back to sending, because that is the
+only way the user sees progress once editing is broken.
+"""
+
+import importlib
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+# The progress loop throttles edits to _PROGRESS_EDIT_INTERVAL (1.5s) and it
+# is a local in the production function, so it cannot be monkeypatched.
+#
+# Timing matters here in a way that is easy to get wrong: an event that lands
+# while the throttle is still closed is drained into the pending buffer and
+# the loop then goes back to waiting on the queue — no edit is attempted until
+# something else wakes it.  So the second event must arrive *after* the
+# throttle has already expired, which is why the gap below exceeds 1.5s
+# rather than being the "obvious" short sleep.
+_THROTTLE_EXPIRY_GAP = 2.0
+_EDIT_SETTLE_WAIT = 0.8
+
+
+class _EditFailingAdapter(BasePlatformAdapter):
+    """Records sends/edits and fails every edit with a caller-supplied error."""
+
+    def __init__(self, edit_error: str, retryable: bool = False):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self._edit_error = edit_error
+        self._edit_retryable = retryable
+        self.sent = []
+        self.edits = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content})
+        return SendResult(success=True, message_id=f"msg-{len(self.sent)}")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append({"message_id": message_id, "content": content})
+        return SendResult(
+            success=False,
+            error=self._edit_error,
+            retryable=self._edit_retryable,
+        )
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class _TwoToolAgent:
+    """Emits one tool event to open the bubble, then a second to force an edit."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+        self._interrupt_requested = False
+
+    @property
+    def is_interrupted(self) -> bool:
+        return self._interrupt_requested
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        # First event: no bubble exists yet, so the loop sends one and
+        # remembers its message_id.
+        self.tool_progress_callback("tool.started", "web_search", "opening bubble", {})
+        time.sleep(_THROTTLE_EXPIRY_GAP)
+        # Second event: a bubble now exists and the throttle has expired, so
+        # the loop edits it immediately — and the adapter rejects that edit.
+        self.tool_progress_callback("tool.started", "web_search", "forces an edit", {})
+        time.sleep(_EDIT_SETTLE_WAIT)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+async def _run_with_edit_error(monkeypatch, tmp_path, session_id, edit_error, retryable=False):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _TwoToolAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = _EditFailingAdapter(edit_error, retryable=retryable)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id=session_id,
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+    return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_flood_controlled_edit_does_not_resend_into_the_same_chat(monkeypatch, tmp_path):
+    """The reported escalation: a flood-controlled edit must not answer with a send.
+
+    Telegram charges the penalty per API call against the chat, so the
+    fallback send is what turns a ~50s back-off into an hours-long ban.
+    """
+    adapter, _ = await _run_with_edit_error(
+        monkeypatch,
+        tmp_path,
+        "sess-flood",
+        "Too Many Requests: retry after 50",
+    )
+
+    assert adapter.edits, "test bug: the loop never attempted an edit, so nothing was exercised"
+    assert len(adapter.sent) == 1, (
+        "flood-controlled edit triggered an extra send into the same chat "
+        f"({len(adapter.sent)} sends) — this is the burst that escalates the "
+        "retry-after into a multi-hour ban"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flood_wording_without_retry_after_is_also_treated_as_flood(monkeypatch, tmp_path):
+    """Both spellings the adapters surface ('flood', 'retry after') take the branch."""
+    adapter, _ = await _run_with_edit_error(
+        monkeypatch,
+        tmp_path,
+        "sess-flood-wording",
+        "Flood control exceeded",
+    )
+
+    assert adapter.edits, "test bug: the loop never attempted an edit"
+    assert len(adapter.sent) == 1, (
+        "a 'Flood control exceeded' edit failure still fell through to a send"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flood_controlled_edit_keeps_editing_enabled(monkeypatch, tmp_path):
+    """Flood is transient, so can_edit must survive it and later ticks still edit.
+
+    Disabling edits would silently downgrade the whole turn to one message
+    per tool call, which is the pre-v0.9 behavior users opted out of.
+    """
+    adapter, _ = await _run_with_edit_error(
+        monkeypatch,
+        tmp_path,
+        "sess-flood-keeps-editing",
+        "Too Many Requests: retry after 50",
+    )
+
+    assert len(adapter.edits) >= 1, "test bug: no edit was attempted at all"
+    assert len(adapter.sent) == 1, (
+        "editing was disabled by flood control — subsequent progress fell back "
+        "to sending new messages instead of retrying the edit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_flood_edit_failure_still_falls_back_to_send(monkeypatch, tmp_path):
+    """The legitimate fallback survives: when editing is truly broken, send.
+
+    This is the branch the flood fix must not take away — without it a
+    chat whose bubble was deleted would show no progress at all.
+    """
+    adapter, _ = await _run_with_edit_error(
+        monkeypatch,
+        tmp_path,
+        "sess-not-flood",
+        "Bad Request: message to edit not found",
+    )
+
+    assert adapter.edits, "test bug: the loop never attempted an edit"
+    assert len(adapter.sent) >= 2, (
+        "a non-recoverable edit failure no longer falls back to sending — "
+        "progress would silently stop reaching the chat"
+    )


### PR DESCRIPTION
## Summary

A Telegram progress bubble that fails to edit with flood control is answered with a **fresh `adapter.send()` into the same chat**. Telegram charges the penalty per API call against that chat, so the fallback send is the burst that makes it escalate the retry-after — the reporter's log shows `51.0s` compounding into `10,323.0s`. During the ban the agent keeps completing turns normally (`response ready: time=2854.6s`) while nothing reaches the user, so Hermes looks hung.

This stops the progress loop from answering a flood-controlled edit with another message. The back-off it already performs becomes the whole remedy.

Closes #76494.

## Root cause

`gateway/run.py`, progress-drain loop. On a failed progress edit the code branches three ways, but only two of them return:

```python
if getattr(result, "retryable", False):
    continue                              # transient → no send ✅
if "flood" in _err or "retry after" in _err:
    # Flood control hit — backoff but keep editing.
    _last_edit_ts = time.monotonic()      # back-off is real…
else:
    can_edit = False
_flood_result = await adapter.send(...)   # …but control falls through here ❌
```

The comment states the intent — *"backoff but keep editing"* — and the back-off works: resetting `_last_edit_ts` makes the throttle at the top of the loop wait out `_PROGRESS_EDIT_INTERVAL`. But control then falls through unconditionally to `adapter.send()`, which is the API call the back-off exists to avoid. The `retryable` branch immediately above already shows the correct shape.

That `send()` is right for the `else` branch — once editing is permanently broken (bubble deleted, permissions lost), a new message is the only way progress reaches the user. It is wrong for flood control, which is transient by definition.

**Sibling path:** `_roll_progress_overflow_if_needed()` has the same defect by a different route. It handles `retryable` and then treats *everything else, including flood*, as non-recoverable — permanently setting `can_edit = False` and letting the caller fall through to sends. That path fires whenever progress text overflows a bubble, so fixing only the main path leaves the escalation reachable on any sufficiently chatty turn. Its own docstring already authorizes the fix: *"Returns True when it delivered/split the current buffer, or when a transient edit failure left the buffer and message identity intact for a later retry."*

## Changes

- `gateway/run.py` — flood branch in the progress-drain loop now `continue`s instead of falling through to `adapter.send()`; the back-off it already performs is the remedy.
- `gateway/run.py` — same treatment in `_roll_progress_overflow_if_needed()`: flood keeps `can_edit` and returns `True`, matching the documented "transient failure, buffer intact" contract.
- `gateway/run.py` — renamed `_flood_result` → `_fallback_result` at the send site. After this change that variable can never hold a flood result and the old name would mislead. Same hunk, no behavior change.
- `tests/gateway/test_run_progress_flood_control.py` — new; drives the real `GatewayRunner._run_agent` through a `BasePlatformAdapter` whose edits fail, using the harness pattern from `test_run_progress_interrupt.py`.

Not included: honoring the server-supplied `retry_after` as the back-off duration (rather than `_PROGRESS_EDIT_INTERVAL`), and the per-chat rate gate across status callbacks / streaming previews / final answer that the issue also mentions. Both are real, both are wider than this bug, and neither is needed to stop the self-inflicted escalation.

## Validation

| | Before | After |
|---|---|---|
| Flood-controlled progress edit | extra `send()` into the throttled chat | back-off only, no send |
| `can_edit` after flood | preserved (main path) / **disabled** (overflow path) | preserved on both |
| Overflow roll under flood | splits into fresh sends | buffer kept, retried later |
| Non-recoverable edit failure | falls back to `send()` | falls back to `send()` (unchanged) |
| Transient/`retryable` failure | `continue` | `continue` (unchanged) |
| tests/gateway/test_run_progress_flood_control.py | — | 4 passed |
| tests/gateway/ (full) | 3 pre-existing failures | same 3, unchanged |
| Mutation check | — | 3 flood tests fail on `main`, pass with fix ✅ |
| ruff | clean | clean |
| check-windows-footguns.py | clean | clean |

The three `tests/gateway/` failures (`test_api_server.py::test_health_detailed_returns_ok`, `test_readiness.py`, `test_systemd_notify.py::test_notify_supports_systemd_abstract_socket`) reproduce identically on clean `main` with this branch's `gateway/run.py` stashed — they are macOS-environment failures (e.g. the systemd test binds a Linux abstract socket, `\0`-prefixed, which macOS has no equivalent for). Not touched by this change.

The mutation check is the load-bearing one: with `gateway/run.py` stashed, the three flood tests fail with `assert 2 == 1` — they observe the extra send directly. The fourth test (`test_non_flood_edit_failure_still_falls_back_to_send`) passes on both sides by design; it is the guard proving this fix does not take away the legitimate fallback.

Tested on: macOS 15 (Darwin 25.5.0), Python 3.13.

<!--
NOTE: the tests wait out _PROGRESS_EDIT_INTERVAL (1.5s) because it is a local
in the production function and cannot be monkeypatched, so the file takes ~12s.
That is documented in a module comment so it does not get "optimized" away.
-->
