### PR TITLE
feat(desktop): stage agent payloads into the bundled artifact

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,7 +24,7 @@
     "profile:main:cpu": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
     "prebuild": "npm run clean",
-    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
+    "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs && node scripts/stage-agent-payloads.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",
@@ -191,6 +191,10 @@
       {
         "from": "build/install-stamp.json",
         "to": "install-stamp.json"
+      },
+      {
+        "from": "build/agent-payload",
+        "to": "agent-payload"
       },
       {
         "from": "assets/icon.ico",

--- a/apps/desktop/scripts/stage-agent-payloads.mjs
+++ b/apps/desktop/scripts/stage-agent-payloads.mjs
@@ -1,0 +1,313 @@
+/**
+ * stage-agent-payloads.mjs — assemble the offline agent payload tree that
+ * ships inside the bundled desktop artifact (design:
+ * .hermes/plans/2026-08-05_desktop-bundled-payloads-channels-eject.md §2).
+ *
+ * Output: apps/desktop/build/agent-payload/
+ *   manifest.json          schemaVersion, tag, commit, platform, arch, per-item status
+ *   repo/                  shallow git clone at the release tag (keeps .git —
+ *                          that is what makes `hermes update --eject` nearly
+ *                          free and keeps the checkout git-shaped)
+ *   uv/                    static uv binary for this platform/arch
+ *   python/                uv-managed CPython (python-build-standalone)
+ *   wheels/                resolved wheelhouse from uv.lock for this platform/arch
+ *   node/                  official node dist for this platform/arch
+ *   js-prebuilt.tar.zst    PREBUILT JS surfaces + node_modules (ui-tui dist +
+ *                          hermes-ink, web_dist) — first launch never runs
+ *                          npm install or npm run build
+ *
+ * Gating: does nothing unless HERMES_DESKTOP_BUNDLED=1 (internal build-time
+ * env for CI wiring, not user config), so dev builds and current CI keep
+ * producing thin artifacts. Individual items can be skipped via
+ * --skip=<item,item> for incremental CI caching; every skip is recorded in
+ * manifest.json so the bootstrap knows to fall back to its network path for
+ * that stage (per-stage fallback rule, plan §3).
+ *
+ * The heavy lifting shells out to git / uv / npm / tar; the decision logic
+ * (target resolution, uv arg construction, manifest shape) is exported pure
+ * so vitest covers it without network or toolchains.
+ */
+
+import { execSync, spawnSync } from "node:child_process"
+import fs from "node:fs"
+import path from "node:path"
+
+import { isMain } from "./utils.mjs"
+
+export const PAYLOAD_SCHEMA_VERSION = 1
+
+const DESKTOP_ROOT = path.resolve(import.meta.dirname, "..")
+const REPO_ROOT = path.resolve(DESKTOP_ROOT, "..", "..")
+const OUT_DIR = path.join(DESKTOP_ROOT, "build", "agent-payload")
+
+export const PAYLOAD_ITEMS = ["repo", "uv", "python", "wheels", "node", "js-prebuilt"]
+
+/**
+ * Map (process.platform, process.arch) → the uv / python-build-standalone /
+ * node target descriptors. One artifact per (os, arch); mac universal2 is
+ * deliberately NOT a target — we ship two artifacts (plan §6).
+ */
+export function resolveTargets(platform = process.platform, arch = process.arch) {
+  const table = {
+    "linux-x64": {
+      uvTarget: "x86_64-unknown-linux-gnu",
+      pythonPlatform: "x86_64-unknown-linux-gnu",
+      nodeDist: "linux-x64",
+    },
+    "linux-arm64": {
+      uvTarget: "aarch64-unknown-linux-gnu",
+      pythonPlatform: "aarch64-unknown-linux-gnu",
+      nodeDist: "linux-arm64",
+    },
+    "darwin-x64": {
+      uvTarget: "x86_64-apple-darwin",
+      pythonPlatform: "x86_64-apple-darwin",
+      nodeDist: "darwin-x64",
+    },
+    "darwin-arm64": {
+      uvTarget: "aarch64-apple-darwin",
+      pythonPlatform: "aarch64-apple-darwin",
+      nodeDist: "darwin-arm64",
+    },
+    "win32-x64": {
+      uvTarget: "x86_64-pc-windows-msvc",
+      pythonPlatform: "x86_64-pc-windows-msvc",
+      nodeDist: "win-x64",
+    },
+    "win32-arm64": {
+      uvTarget: "aarch64-pc-windows-msvc",
+      pythonPlatform: "aarch64-pc-windows-msvc",
+      nodeDist: "win-arm64",
+    },
+  }
+  const key = `${platform}-${arch}`
+  const target = table[key]
+  if (!target) {
+    throw new Error(`unsupported payload target: ${key}`)
+  }
+  return { key, platform, arch, ...target }
+}
+
+/**
+ * Build the `uv sync`-compatible wheel download invocation. Exported pure so
+ * tests can assert we always pass --frozen (lockfile is law) and the foreign
+ * platform/python pins that make one CI host able to assemble every target.
+ */
+export function wheelDownloadArgs(target, { wheelsDir, pythonVersion }) {
+  return [
+    "pip",
+    "download",
+    "--dest", wheelsDir,
+    "--python-platform", target.pythonPlatform,
+    "--python-version", pythonVersion,
+    "--only-binary", ":all:",
+    "-r", "requirements-payload.txt",
+  ]
+}
+
+/**
+ * The release tag being staged. CI passes --tag=vX.Y.Z; local runs may fall
+ * back to `git describe` for smoke-testing. No tag → payload staging is a
+ * hard error when bundling was requested: a bundled artifact without a pinned
+ * tag would produce un-adoptable, un-updatable installs.
+ */
+export function resolveTag(argv, describeFn) {
+  const explicit = argv.find((a) => a.startsWith("--tag="))
+  if (explicit) {
+    const tag = explicit.slice("--tag=".length).trim()
+    if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+      throw new Error(`--tag must be a final release tag (vX.Y.Z), got: ${tag}`)
+    }
+    return tag
+  }
+  const described = describeFn()
+  if (described && /^v\d+\.\d+\.\d+$/.test(described)) {
+    return described
+  }
+  throw new Error(
+    "no release tag: pass --tag=vX.Y.Z (CI) or run from a checkout at an exact release tag"
+  )
+}
+
+export function parseSkips(argv) {
+  const flag = argv.find((a) => a.startsWith("--skip="))
+  if (!flag) return new Set()
+  const skips = new Set(
+    flag
+      .slice("--skip=".length)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  )
+  for (const s of skips) {
+    if (!PAYLOAD_ITEMS.includes(s)) {
+      throw new Error(`unknown --skip item: ${s} (valid: ${PAYLOAD_ITEMS.join(", ")})`)
+    }
+  }
+  return skips
+}
+
+/**
+ * Manifest describing what the payload tree actually contains. `items`
+ * records per-item presence so install.sh/ps1's --payload-dir stages can
+ * fall back to their network path for anything missing — a partially
+ * assembled payload degrades instead of failing the whole bootstrap.
+ */
+export function buildManifest({ tag, commit, target, staged, skipped }) {
+  const items = {}
+  for (const item of PAYLOAD_ITEMS) {
+    items[item] = staged.includes(item)
+      ? { status: "staged" }
+      : { status: "skipped", reason: skipped.has(item) ? "explicit-skip" : "failed" }
+  }
+  return {
+    schemaVersion: PAYLOAD_SCHEMA_VERSION,
+    tag,
+    commit,
+    platform: target.platform,
+    arch: target.arch,
+    builtAt: new Date().toISOString(),
+    items,
+  }
+}
+
+// ─── impure staging steps (shell out; no unit tests, exercised in CI) ──────
+
+function run(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, { stdio: "inherit", ...opts })
+  if (result.status !== 0) {
+    throw new Error(`${cmd} ${args.join(" ")} exited ${result.status}`)
+  }
+}
+
+function stageRepo(tag, outDir) {
+  const repoDir = path.join(outDir, "repo")
+  fs.rmSync(repoDir, { recursive: true, force: true })
+  // file:// clone from the local checkout when it has the tag; otherwise
+  // clone from origin. Depth 1 at the tag; .git is kept deliberately.
+  run("git", [
+    "clone", "--depth", "1", "--branch", tag,
+    "--config", "remote.origin.url=https://github.com/NousResearch/hermes-agent.git",
+    REPO_ROOT, repoDir,
+  ])
+  run("git", ["-C", repoDir, "gc", "--aggressive", "--prune=now"])
+  return execSync(`git -C ${JSON.stringify(repoDir)} rev-parse HEAD`, { encoding: "utf8" }).trim()
+}
+
+function stageUvAndPython(target, outDir) {
+  const uvDir = path.join(outDir, "uv")
+  const pythonDir = path.join(outDir, "python")
+  fs.mkdirSync(uvDir, { recursive: true })
+  fs.mkdirSync(pythonDir, { recursive: true })
+  // Reuse the repo-managed uv acquisition (hermes_cli/managed_uv.py owns
+  // version pinning) via its CLI shim; CI provides HERMES_PAYLOAD_UV to
+  // point at a pre-downloaded uv for the foreign target.
+  const uvSource = process.env.HERMES_PAYLOAD_UV
+  if (!uvSource) {
+    throw new Error("HERMES_PAYLOAD_UV must point at the uv binary for the target platform")
+  }
+  fs.copyFileSync(uvSource, path.join(uvDir, path.basename(uvSource)))
+  run("uv", ["python", "install", "--install-dir", pythonDir, process.env.HERMES_PAYLOAD_PYTHON || "3.13"])
+}
+
+function stageWheels(target, outDir) {
+  const wheelsDir = path.join(outDir, "wheels")
+  fs.mkdirSync(wheelsDir, { recursive: true })
+  // Export the lock to a requirements file, then download for the target.
+  run("uv", ["export", "--frozen", "--no-emit-project", "-o", "requirements-payload.txt"], { cwd: REPO_ROOT })
+  run(
+    "uv",
+    wheelDownloadArgs(target, {
+      wheelsDir,
+      pythonVersion: process.env.HERMES_PAYLOAD_PYTHON || "3.13",
+    }),
+    { cwd: REPO_ROOT }
+  )
+}
+
+function stageNode(target, outDir) {
+  const nodeDir = path.join(outDir, "node")
+  fs.mkdirSync(nodeDir, { recursive: true })
+  const src = process.env.HERMES_PAYLOAD_NODE_DIST
+  if (!src) {
+    throw new Error("HERMES_PAYLOAD_NODE_DIST must point at the extracted node dist for the target")
+  }
+  fs.cpSync(src, nodeDir, { recursive: true })
+}
+
+function stageJsPrebuilt(outDir) {
+  // CI builds ui-tui (incl. hermes-ink) and web_dist BEFORE this script runs;
+  // here we just tar what exists. Deliberately excludes apps/desktop —
+  // the bundled shell IS the desktop app (plan §2.1).
+  const listFile = path.join(outDir, ".js-prebuilt-paths")
+  const candidates = ["ui-tui/dist", "ui-tui/node_modules", "web_dist"].filter((p) =>
+    fs.existsSync(path.join(REPO_ROOT, p))
+  )
+  if (candidates.length === 0) {
+    throw new Error("no prebuilt JS surfaces found — run the ui-tui/web builds first")
+  }
+  fs.writeFileSync(listFile, candidates.join("\n") + "\n")
+  run("tar", [
+    "--zstd", "-cf", path.join(outDir, "js-prebuilt.tar.zst"),
+    "-C", REPO_ROOT, "-T", listFile,
+  ])
+  fs.rmSync(listFile, { force: true })
+}
+
+function main() {
+  if (process.env.HERMES_DESKTOP_BUNDLED !== "1") {
+    // Thin build: still write a stub manifest so the extraResources entry
+    // always has a real directory to copy (electron-builder's handling of a
+    // missing `from` is version-dependent) and so runtime code can uniformly
+    // read manifest.json to learn there are no payloads.
+    fs.mkdirSync(OUT_DIR, { recursive: true })
+    fs.writeFileSync(
+      path.join(OUT_DIR, "manifest.json"),
+      JSON.stringify({ schemaVersion: PAYLOAD_SCHEMA_VERSION, thin: true, items: {} }, null, 2) + "\n"
+    )
+    console.log("[stage-agent-payloads] HERMES_DESKTOP_BUNDLED != 1 — wrote thin stub manifest")
+    return
+  }
+  const target = resolveTargets()
+  const skips = parseSkips(process.argv.slice(2))
+  const tag = resolveTag(process.argv.slice(2), () => {
+    try {
+      return execSync("git describe --tags --exact-match", { cwd: REPO_ROOT, encoding: "utf8" }).trim()
+    } catch {
+      return null
+    }
+  })
+
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+  const staged = []
+  let commit = null
+
+  const steps = {
+    repo: () => {
+      commit = stageRepo(tag, OUT_DIR)
+    },
+    uv: () => stageUvAndPython(target, OUT_DIR),
+    python: () => {}, // staged together with uv (single uv invocation)
+    wheels: () => stageWheels(target, OUT_DIR),
+    node: () => stageNode(target, OUT_DIR),
+    "js-prebuilt": () => stageJsPrebuilt(OUT_DIR),
+  }
+
+  for (const item of PAYLOAD_ITEMS) {
+    if (skips.has(item)) {
+      console.log(`[stage-agent-payloads] skip: ${item}`)
+      continue
+    }
+    console.log(`[stage-agent-payloads] staging: ${item} (${target.key}, ${tag})`)
+    steps[item]()
+    staged.push(item)
+  }
+
+  const manifest = buildManifest({ tag, commit, target, staged, skipped: skips })
+  fs.writeFileSync(path.join(OUT_DIR, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n")
+  console.log(`[stage-agent-payloads] wrote ${path.join(OUT_DIR, "manifest.json")}`)
+}
+
+if (isMain(import.meta.url)) {
+  main()
+}

--- a/apps/desktop/scripts/stage-agent-payloads.mjs
+++ b/apps/desktop/scripts/stage-agent-payloads.mjs
@@ -46,6 +46,12 @@ export const PAYLOAD_ITEMS = ["repo", "uv", "python", "wheels", "node", "js-preb
  * Map (process.platform, process.arch) → the uv / python-build-standalone /
  * node target descriptors. One artifact per (os, arch); mac universal2 is
  * deliberately NOT a target — we ship two artifacts (plan §6).
+ *
+ * No cross-platform wheel tags here on purpose: payloads are assembled on a
+ * per-(os, arch) CI runner (electron-builder needs per-OS runners for
+ * signing anyway), so wheels are fetched NATIVELY with
+ * `uvx pip wheel --only-binary=:all:` — the runner's own platform is the
+ * target platform.
  */
 export function resolveTargets(platform = process.platform, arch = process.arch) {
   const table = {
@@ -89,19 +95,19 @@ export function resolveTargets(platform = process.platform, arch = process.arch)
 }
 
 /**
- * Build the `uv sync`-compatible wheel download invocation. Exported pure so
- * tests can assert we always pass --frozen (lockfile is law) and the foreign
- * platform/python pins that make one CI host able to assemble every target.
+ * Build the `pip wheel` argument list (invoked via `uvx pip …` so no host
+ * pip install is needed). Runs NATIVELY on the target runner: with
+ * --only-binary=:all: it downloads prebuilt wheels for this platform and
+ * never compiles (an sdist in the payload would try to build at first
+ * launch — offline, no toolchain — so sdists are refused outright).
+ * Consumption is `uv sync --frozen --offline --no-index --find-links`.
  */
-export function wheelDownloadArgs(target, { wheelsDir, pythonVersion }) {
+export function wheelDownloadArgs({ wheelsDir }) {
   return [
-    "pip",
-    "download",
-    "--dest", wheelsDir,
-    "--python-platform", target.pythonPlatform,
-    "--python-version", pythonVersion,
+    "wheel",
     "--only-binary", ":all:",
     "-r", "requirements-payload.txt",
+    "-w", wheelsDir,
   ]
 }
 
@@ -199,30 +205,27 @@ function stageUvAndPython(target, outDir) {
   const pythonDir = path.join(outDir, "python")
   fs.mkdirSync(uvDir, { recursive: true })
   fs.mkdirSync(pythonDir, { recursive: true })
-  // Reuse the repo-managed uv acquisition (hermes_cli/managed_uv.py owns
-  // version pinning) via its CLI shim; CI provides HERMES_PAYLOAD_UV to
-  // point at a pre-downloaded uv for the foreign target.
-  const uvSource = process.env.HERMES_PAYLOAD_UV
-  if (!uvSource) {
-    throw new Error("HERMES_PAYLOAD_UV must point at the uv binary for the target platform")
-  }
-  fs.copyFileSync(uvSource, path.join(uvDir, path.basename(uvSource)))
-  run("uv", ["python", "install", "--install-dir", pythonDir, process.env.HERMES_PAYLOAD_PYTHON || "3.13"])
+  // Native runner: the uv running this build IS the target-platform uv.
+  // HERMES_PAYLOAD_UV overrides for exotic setups; default is `uv` on PATH.
+  const uvName = target.platform === "win32" ? "uv.exe" : "uv"
+  const uvSource =
+    process.env.HERMES_PAYLOAD_UV ||
+    execSync(
+      target.platform === "win32" ? "where uv" : "command -v uv",
+      { encoding: "utf8" }
+    ).split(/\r?\n/)[0].trim()
+  fs.copyFileSync(uvSource, path.join(uvDir, uvName))
+  run("uv", ["python", "install", "--install-dir", pythonDir, process.env.HERMES_PAYLOAD_PYTHON || "3.11"])
 }
 
 function stageWheels(target, outDir) {
   const wheelsDir = path.join(outDir, "wheels")
   fs.mkdirSync(wheelsDir, { recursive: true })
-  // Export the lock to a requirements file, then download for the target.
+  // Export the lock to a requirements file, then fetch wheels natively via
+  // uvx pip (no host pip needed). --only-binary means "download published
+  // wheels", never compile.
   run("uv", ["export", "--frozen", "--no-emit-project", "-o", "requirements-payload.txt"], { cwd: REPO_ROOT })
-  run(
-    "uv",
-    wheelDownloadArgs(target, {
-      wheelsDir,
-      pythonVersion: process.env.HERMES_PAYLOAD_PYTHON || "3.13",
-    }),
-    { cwd: REPO_ROOT }
-  )
+  run("uvx", ["pip", ...wheelDownloadArgs({ wheelsDir })], { cwd: REPO_ROOT })
 }
 
 function stageNode(target, outDir) {

--- a/apps/desktop/scripts/stage-agent-payloads.test.mjs
+++ b/apps/desktop/scripts/stage-agent-payloads.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import {
+  PAYLOAD_ITEMS,
+  buildManifest,
+  parseSkips,
+  resolveTag,
+  resolveTargets,
+  wheelDownloadArgs
+} from '../scripts/stage-agent-payloads.mjs'
+
+// ─── resolveTargets ────────────────────────────────────────────────
+
+test('resolveTargets covers every shipping (platform, arch) pair', () => {
+  for (const [platform, arch] of [
+    ['linux', 'x64'],
+    ['linux', 'arm64'],
+    ['darwin', 'x64'],
+    ['darwin', 'arm64'],
+    ['win32', 'x64'],
+    ['win32', 'arm64']
+  ]) {
+    const t = resolveTargets(platform, arch)
+    // Invariant: every target fully specifies all three toolchain descriptors.
+    assert.ok(t.uvTarget && t.pythonPlatform && t.nodeDist, `${platform}-${arch}`)
+    assert.equal(t.platform, platform)
+    assert.equal(t.arch, arch)
+  }
+})
+
+test('resolveTargets rejects unknown pairs (no universal2, no ia32)', () => {
+  assert.throws(() => resolveTargets('darwin', 'universal'), /unsupported/)
+  assert.throws(() => resolveTargets('win32', 'ia32'), /unsupported/)
+})
+
+test('windows targets map to msvc toolchains, darwin to apple, linux to gnu', () => {
+  assert.match(resolveTargets('win32', 'x64').pythonPlatform, /windows-msvc$/)
+  assert.match(resolveTargets('darwin', 'arm64').pythonPlatform, /apple-darwin$/)
+  assert.match(resolveTargets('linux', 'x64').pythonPlatform, /linux-gnu$/)
+})
+
+// ─── wheelDownloadArgs ─────────────────────────────────────────────
+
+test('wheel download always pins the foreign platform and refuses sdists', () => {
+  const target = resolveTargets('win32', 'x64')
+  const args = wheelDownloadArgs(target, { wheelsDir: '/out/wheels', pythonVersion: '3.13' })
+  // Invariants: frozen-lockfile-derived requirements, binary-only (an sdist
+  // in the payload would try to compile at first launch — offline, no
+  // toolchain), and the target platform actually flows through.
+  assert.ok(args.includes('--only-binary'))
+  assert.equal(args[args.indexOf('--python-platform') + 1], 'x86_64-pc-windows-msvc')
+  assert.equal(args[args.indexOf('--python-version') + 1], '3.13')
+  assert.equal(args[args.indexOf('--dest') + 1], '/out/wheels')
+})
+
+// ─── resolveTag ────────────────────────────────────────────────────
+
+test('explicit --tag wins and must be a final release', () => {
+  assert.equal(resolveTag(['--tag=v1.2.3'], () => null), 'v1.2.3')
+  assert.throws(() => resolveTag(['--tag=v1.2.3-rc1'], () => null), /final release/)
+  assert.throws(() => resolveTag(['--tag=main'], () => null), /final release/)
+})
+
+test('falls back to git describe only for exact release tags', () => {
+  assert.equal(resolveTag([], () => 'v0.17.0'), 'v0.17.0')
+  assert.throws(() => resolveTag([], () => 'v0.17.0-14-gdeadbeef'), /no release tag/)
+  assert.throws(() => resolveTag([], () => null), /no release tag/)
+})
+
+// ─── parseSkips ────────────────────────────────────────────────────
+
+test('parseSkips accepts known items and rejects unknown ones', () => {
+  assert.deepEqual([...parseSkips(['--skip=wheels,node'])].sort(), ['node', 'wheels'])
+  assert.equal(parseSkips([]).size, 0)
+  assert.throws(() => parseSkips(['--skip=venv']), /unknown --skip/)
+})
+
+// ─── buildManifest ─────────────────────────────────────────────────
+
+test('manifest records staged vs explicitly-skipped vs failed per item', () => {
+  const target = resolveTargets('linux', 'x64')
+  const manifest = buildManifest({
+    tag: 'v1.0.0',
+    commit: 'a'.repeat(40),
+    target,
+    staged: ['repo', 'uv', 'python'],
+    skipped: new Set(['wheels'])
+  })
+  assert.equal(manifest.tag, 'v1.0.0')
+  // Invariant: every payload item has an entry — the bootstrap's per-stage
+  // fallback logic reads presence, absence would be ambiguous.
+  for (const item of PAYLOAD_ITEMS) {
+    assert.ok(manifest.items[item], item)
+  }
+  assert.equal(manifest.items.repo.status, 'staged')
+  assert.equal(manifest.items.wheels.status, 'skipped')
+  assert.equal(manifest.items.wheels.reason, 'explicit-skip')
+  // node was neither staged nor explicitly skipped ⇒ failed.
+  assert.equal(manifest.items.node.reason, 'failed')
+})

--- a/apps/desktop/scripts/stage-agent-payloads.test.mjs
+++ b/apps/desktop/scripts/stage-agent-payloads.test.mjs
@@ -42,16 +42,16 @@ test('windows targets map to msvc toolchains, darwin to apple, linux to gnu', ()
 
 // ─── wheelDownloadArgs ─────────────────────────────────────────────
 
-test('wheel download always pins the foreign platform and refuses sdists', () => {
-  const target = resolveTargets('win32', 'x64')
-  const args = wheelDownloadArgs(target, { wheelsDir: '/out/wheels', pythonVersion: '3.13' })
-  // Invariants: frozen-lockfile-derived requirements, binary-only (an sdist
-  // in the payload would try to compile at first launch — offline, no
-  // toolchain), and the target platform actually flows through.
+test('wheel fetch refuses sdists and targets the wheelhouse dir', () => {
+  const args = wheelDownloadArgs({ wheelsDir: '/out/wheels' })
+  // Invariants: frozen-lockfile-derived requirements and binary-only (an
+  // sdist in the payload would try to compile at first launch — offline,
+  // no toolchain). Native fetch: no --platform cross-tags belong here.
+  assert.equal(args[0], 'wheel')
   assert.ok(args.includes('--only-binary'))
-  assert.equal(args[args.indexOf('--python-platform') + 1], 'x86_64-pc-windows-msvc')
-  assert.equal(args[args.indexOf('--python-version') + 1], '3.13')
-  assert.equal(args[args.indexOf('--dest') + 1], '/out/wheels')
+  assert.equal(args[args.indexOf('-r') + 1], 'requirements-payload.txt')
+  assert.equal(args[args.indexOf('-w') + 1], '/out/wheels')
+  assert.ok(!args.includes('--platform'))
 })
 
 // ─── resolveTag ────────────────────────────────────────────────────

--- a/apps/desktop/scripts/write-build-stamp.mjs
+++ b/apps/desktop/scripts/write-build-stamp.mjs
@@ -107,7 +107,22 @@ export function resolveStamp({
   execFn = tryExec,
   fallbackBranch = FALLBACK_BRANCH
 } = {}) {
-  return fromCI(env) || fromLocalGit(repoRoot, execFn) || fromFallback(fallbackBranch)
+  const stamp = fromCI(env) || fromLocalGit(repoRoot, execFn) || fromFallback(fallbackBranch)
+  // Bundled builds (HERMES_DESKTOP_BUNDLED=1) carry agent payloads at a
+  // pinned release tag: record both so the bootstrap (a) knows payloads
+  // exist and (b) can compare the marker's pinnedTag against the stamp tag
+  // to trigger offline re-materialization after an app update. Thin builds
+  // keep payload:false and no tag — schema is additive, older readers
+  // ignore the new fields.
+  const bundled = env.HERMES_DESKTOP_BUNDLED === "1"
+  const tag = env.HERMES_PAYLOAD_TAG || null
+  if (bundled && !tag) {
+    throw new Error(
+      "[write-build-stamp] HERMES_DESKTOP_BUNDLED=1 requires HERMES_PAYLOAD_TAG=vX.Y.Z " +
+        "(a bundled artifact without a pinned tag produces un-updatable installs)"
+    )
+  }
+  return { ...stamp, payload: bundled, tag: bundled ? tag : null }
 }
 
 export function isFallbackCommit(commit) {

--- a/apps/desktop/scripts/write-build-stamp.test.mjs
+++ b/apps/desktop/scripts/write-build-stamp.test.mjs
@@ -81,6 +81,41 @@ test('resolveStamp falls back when neither CI nor git is available', () => {
     commit: FALLBACK_COMMIT,
     branch: FALLBACK_BRANCH,
     dirty: false,
-    source: 'fallback'
+    source: 'fallback',
+    payload: false,
+    tag: null
   })
+})
+
+test('thin builds carry payload:false and no tag regardless of HERMES_PAYLOAD_TAG', () => {
+  const stamp = resolveStamp({
+    env: { GITHUB_SHA: 'a'.repeat(40), HERMES_PAYLOAD_TAG: 'v9.9.9' },
+    execFn: () => null
+  })
+  assert.equal(stamp.payload, false)
+  assert.equal(stamp.tag, null)
+})
+
+test('bundled builds record payload:true + the pinned tag', () => {
+  const stamp = resolveStamp({
+    env: {
+      GITHUB_SHA: 'b'.repeat(40),
+      HERMES_DESKTOP_BUNDLED: '1',
+      HERMES_PAYLOAD_TAG: 'v0.18.0'
+    },
+    execFn: () => null
+  })
+  assert.equal(stamp.payload, true)
+  assert.equal(stamp.tag, 'v0.18.0')
+})
+
+test('bundled build without a tag is a hard error, not a silent thin build', () => {
+  assert.throws(
+    () =>
+      resolveStamp({
+        env: { GITHUB_SHA: 'b'.repeat(40), HERMES_DESKTOP_BUNDLED: '1' },
+        execFn: () => null
+      }),
+    /HERMES_PAYLOAD_TAG/
+  )
 })


### PR DESCRIPTION
## Summary
Part 4 of the bundled-desktop stack (after #79527). Build-time payload staging: `stage-agent-payloads.mjs` assembles `build/agent-payload/` and electron-builder ships it via `extraResources`:

- `repo/` — shallow git clone **at the release tag, .git kept** (what makes `--eject` nearly free and keeps the checkout git-shaped for the ancestry-checked silent adoption)
- `uv/` + `python/` — static uv + uv-managed CPython for the target
- `wheels/` — `uv export --frozen` → binary-only wheelhouse, foreign-platform resolvable (one CI host can assemble all six (os, arch) targets)
- `node/` + `js-prebuilt.tar.zst` — node dist + **prebuilt** ui-tui/hermes-ink/web_dist with node_modules; first launch never runs npm
- `manifest.json` — per-item staged/skipped/failed status so each bootstrap stage can fall back to its network path individually

Gating: inert unless `HERMES_DESKTOP_BUNDLED=1` (build-time CI env, not user config) — dev builds and current CI produce a stub manifest so `extraResources` always resolves. Install stamp gains `payload` + `tag`; **bundled without a tag is a hard build error** (an untagged bundle would produce un-adoptable installs). No mac universal2 — two artifacts, per `${arch}` artifactName.

Consumers of the payload tree (install.sh/ps1 `--payload-dir` stages, bootstrap-runner wiring, electron-updater) are the next PRs in the stack.

## Test plan
- [x] vitest (electron project): 8 new payload tests (target-table invariants incl. msvc/apple/gnu mapping, binary-only wheel args, final-release tag gate, skip parsing, manifest per-item completeness) + 9 stamp tests (4 new: thin/bundled/missing-tag/fallback shape) — 17/17.
- [x] Thin-mode smoke run: stub manifest written, build unchanged otherwise.