### PR TITLE
fix(desktop): show raft and other missing messaging platforms in sidebar

### DIFF
--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -69,6 +69,13 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   api_server: { Icon: Globe, color: '#64748B', kind: 'generic' },
   weixin: { Icon: SiWechat, color: '#07C160', kind: 'brand' },
   qqbot: { Icon: SiQq, color: '#EB1923', kind: 'brand' },
+  raft: { color: '#141111', kind: 'brand', monogram: 'R' },
+  google_chat: { color: '#4285F4', kind: 'brand', monogram: 'G' },
+  line: { color: '#06C755', kind: 'brand', monogram: 'L' },
+  teams: { color: '#6264A7', kind: 'brand', monogram: 'T' },
+  irc: { color: '#6B7280', kind: 'generic', monogram: 'I' },
+  simplex: { color: '#2B4D7A', kind: 'generic', monogram: 'X' },
+  ntfy: { color: '#EA580C', kind: 'generic', monogram: 'n' },
   yuanbao: { Icon: SiBilibili, color: '#FB7299', kind: 'brand' }
 }
 

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -15,6 +15,13 @@ const SOURCE_LABELS: Record<string, string> = {
   mattermost: 'Mattermost',
   photon: 'Photon',
   qqbot: 'QQ',
+  raft: 'Raft',
+  google_chat: 'Google Chat',
+  line: 'LINE',
+  teams: 'Teams',
+  irc: 'IRC',
+  simplex: 'Simplex',
+  ntfy: 'ntfy',
   signal: 'Signal',
   slack: 'Slack',
   sms: 'SMS',
@@ -69,7 +76,14 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'qqbot',
   'yuanbao',
   'dingtalk',
-  'feishu'
+  'feishu',
+  'raft',
+  'google_chat',
+  'line',
+  'teams',
+  'irc',
+  'simplex',
+  'ntfy'
 ]
 const MESSAGING_SOURCE_IDS = new Set(MESSAGING_SESSION_SOURCE_IDS)
 


### PR DESCRIPTION
## 问题

Desktop 侧边栏的 messaging 平台区（`MESSAGING_SESSION_SOURCE_IDS`）缺少 `raft`、`google_chat`、`line`、`teams`、`irc`、`simplex`、`ntfy`。这些平台的会话被 `isMessagingSource()` 过滤，导致即使 gateway 适配器正常工作（消息收发、会话记录都正常），侧边栏也永远不显示对应平台分区——用户只能在 CLI 或会话搜索里找到这些会话。

## 修改

- `apps/desktop/src/lib/session-source.ts`：`SOURCE_LABELS` 增加 7 个平台标签；`MESSAGING_SESSION_SOURCE_IDS` 增加 7 个平台 ID
- `apps/desktop/src/app/messaging/platform-icon.tsx`：`PLATFORM_ICONS` 增加对应图标（monogram 风格，使用品牌色；raft 使用官方 logo 主色 #141111）

## 验证

本地构建（`hermes desktop --build-only --force-build`）通过；重启桌面 app 后侧边栏出现 Raft 分区与会话条目。其他平台标签/图标为纯常量声明，无行为风险。