### PR TITLE
fix(computer-use): scope Windows desktop capture

### DIFF
--- a/tests/computer_use/test_cua_desktop_capture.py
+++ b/tests/computer_use/test_cua_desktop_capture.py
@@ -1,0 +1,141 @@
+"""Regression tests for whole-desktop capture routing."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tools.computer_use.cua_backend import CuaDriverBackend
+
+
+_ONE_PIXEL_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+AcAAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+def _backend():
+    backend = object.__new__(CuaDriverBackend)
+    backend._session_id = "test-session"
+    backend._session = SimpleNamespace(
+        _has_tool=lambda name: False,
+        capabilities_discovered=True,
+    )
+    backend._active_pid = None
+    backend._active_window_id = None
+    backend._last_app = None
+    backend._last_target = None
+    backend._snapshot_tokens = {}
+    return backend
+
+
+def test_windows_whole_screen_uses_scoped_desktop_capture_without_uia(monkeypatch):
+    backend = _backend()
+    capture_calls = []
+    lifecycle_calls = []
+    backend._session.call_tool = lambda name, args: (
+        lifecycle_calls.append((name, args)) or {"isError": False}
+    )
+
+    def fake_capture_tool(name, args):
+        capture_calls.append((name, args))
+        if name == "start_session":
+            return {"isError": False}
+        assert name == "get_desktop_state"
+        return {
+            "images": [],
+            "structuredContent": {
+                "screenshot_png_b64": _ONE_PIXEL_PNG,
+                "screenshot_mime_type": "image/png",
+            },
+            "isError": False,
+        }
+
+    monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "win32")
+    monkeypatch.setattr(backend, "_call_capture_tool", fake_capture_tool)
+    monkeypatch.setattr(
+        backend,
+        "_load_windows",
+        lambda: (_ for _ in ()).throw(AssertionError("desktop capture must not enumerate UIA windows")),
+    )
+
+    result = backend.capture(mode="som", app="screen")
+
+    assert capture_calls[0][0] == "start_session"
+    desktop_session = capture_calls[0][1]["session"]
+    assert desktop_session.startswith("test-session-desktop-")
+    assert capture_calls[0][1]["capture_scope"] == "desktop"
+    assert capture_calls[1] == (
+        "get_desktop_state",
+        {"session": desktop_session},
+    )
+    assert lifecycle_calls == [
+        ("end_session", {"session": desktop_session}),
+        ("start_session", {"session": "test-session"}),
+    ]
+    assert result.mode == "vision"
+    assert result.app == "screen"
+    assert result.window_title == "Desktop"
+    assert result.png_b64 == _ONE_PIXEL_PNG
+    assert result.elements == []
+    assert result.width == 1
+    assert result.height == 1
+
+
+def test_windows_whole_screen_restores_primary_session_after_capture_failure(monkeypatch):
+    backend = _backend()
+    lifecycle_calls = []
+    backend._session.call_tool = lambda name, args: (
+        lifecycle_calls.append((name, args)) or {"isError": False}
+    )
+
+    def fake_capture_tool(name, args):
+        if name == "start_session":
+            return {"isError": False}
+        raise RuntimeError("desktop capture failed")
+
+    monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "win32")
+    monkeypatch.setattr(backend, "_call_capture_tool", fake_capture_tool)
+
+    with pytest.raises(RuntimeError, match="desktop capture failed"):
+        backend.capture(mode="vision", app="screen")
+
+    desktop_session = lifecycle_calls[0][1]["session"]
+    assert lifecycle_calls == [
+        ("end_session", {"session": desktop_session}),
+        ("start_session", {"session": "test-session"}),
+    ]
+
+
+def test_application_capture_keeps_window_path(monkeypatch):
+    backend = _backend()
+    monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "win32")
+    monkeypatch.setattr(
+        backend,
+        "_load_windows",
+        lambda: [{
+            "app_name": "Hermes",
+            "title": "Hermes",
+            "pid": 123,
+            "window_id": 456,
+            "off_screen": False,
+            "z_index": 10,
+        }],
+    )
+    monkeypatch.setattr(
+        backend,
+        "_call_capture_tool",
+        lambda name, args: {
+            "images": [_ONE_PIXEL_PNG],
+            "image_mime_types": ["image/png"],
+            "data": "AXWindow \"Hermes\"",
+            "structuredContent": {"elements": []},
+            "isError": False,
+        },
+    )
+
+    result = backend.capture(mode="vision", app="Hermes")
+
+    assert result.app == "Hermes"
+    assert result.png_b64 == _ONE_PIXEL_PNG
+    assert result.width == 1
+    assert result.height == 1

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2229,6 +2229,79 @@ class CuaDriverBackend(ComputerUseBackend):
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
         `get_window_state` (ax/som) or `screenshot` (vision).
         """
+        # Windows exposes the desktop backdrop as Progman/WorkerW. Those
+        # shell windows are valid list_windows entries but their UIA tree can
+        # block indefinitely. Use cua-driver's vision-only desktop path in an
+        # explicitly scoped child session instead. The primary auto session
+        # remains window-scoped for normal application capture and input.
+        is_whole_screen = (
+            pid is None
+            and window_id is None
+            and isinstance(app, str)
+            and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS
+        )
+        if is_whole_screen and sys.platform == "win32":
+            desktop_session_id = f"{self._session_id}-desktop-{uuid.uuid4().hex[:8]}"
+            desktop_started = False
+            try:
+                self._call_capture_tool(
+                    "start_session",
+                    {
+                        "session": desktop_session_id,
+                        "capture_scope": "desktop",
+                    },
+                )
+                desktop_started = True
+                desktop_out = self._call_capture_tool(
+                    "get_desktop_state",
+                    {"session": desktop_session_id},
+                )
+                png_b64, image_mime_type = _image_from_tool_result(desktop_out)
+                if not png_b64:
+                    return self._failed_capture(
+                        mode,
+                        "<cua-driver get_desktop_state returned no screenshot>",
+                    )
+                width = height = 0
+                try:
+                    raw = base64.b64decode(png_b64, validate=False)
+                    width, height = _image_dimensions_from_bytes(raw)
+                    png_bytes_len = len(raw)
+                except Exception:
+                    png_bytes_len = len(png_b64) * 3 // 4
+                return CaptureResult(
+                    # get_desktop_state is vision-only: do not claim AX/SOM
+                    # semantics when the caller used the default SOM mode.
+                    mode="vision",
+                    width=width,
+                    height=height,
+                    png_b64=png_b64,
+                    elements=[],
+                    app="screen",
+                    window_title="Desktop",
+                    png_bytes_len=png_bytes_len,
+                    image_mime_type=image_mime_type,
+                )
+            finally:
+                if desktop_started:
+                    try:
+                        self._session.call_tool(
+                            "end_session",
+                            {"session": desktop_session_id},
+                        )
+                    except Exception as exc:
+                        logger.debug("cua-driver desktop session cleanup failed: %s", exc)
+                # CuaMcpSession tracks the most recently declared identity for
+                # ended-session recovery. Restore the primary run identity
+                # after the short-lived desktop child session.
+                try:
+                    self._session.call_tool(
+                        "start_session",
+                        {"session": self._session_id},
+                    )
+                except Exception as exc:
+                    logger.debug("cua-driver primary session restore failed: %s", exc)
+
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         # Surface 3 of NousResearch/hermes-agent#47072: read the canonical
         # `structuredContent.windows` array directly. Pre-fix the wrapper


### PR DESCRIPTION
## Summary
- Route Windows whole-screen capture requests through a short-lived `capture_scope="desktop"` cua-driver session instead of selecting `Progman` / `WorkerW` and walking UIA.
- Return the desktop screenshot as vision-only output, since `get_desktop_state` does not provide AX/SOM elements.
- Add regression coverage for scoped desktop capture, cleanup/primary-session restoration on failure, and normal app capture staying on the window path.

## Why
On Windows, `computer_use(action="capture", app="screen")` can resolve the shell desktop window (`Progman` / `WorkerW`) and then call `get_window_state`. Live logs from this machine show the failure mode:

```text
get_window_state timed out after 4s (UIA provider unresponsive on hwnd ..., class 'Progman')
```

cua-driver already exposes the correct full-display path via `get_desktop_state`, but that tool is locked behind desktop capture scope. This PR uses an explicit scoped child session for the desktop-only call, then ends that child session and restores the primary run session.

This is related to, but distinct from, #62690 / #62697. That PR handles macOS when no Finder desktop window is enumerated. This PR handles Windows where a desktop shell window is enumerated but walking its UIA tree can hang.

An earlier Windows-focused implementation is tracked in #60081. We cross-link it here so the maintainers can reconcile the two Windows implementations. This PR keeps the scope-lifecycle behavior explicit with a short-lived desktop child session, rather than mutating the primary session scope.

## Verification
- `python -m pytest tests/computer_use/test_cua_desktop_capture.py tests/computer_use/test_cua_no_overlay.py tests/computer_use/test_cua_perf_knobs.py tests/computer_use/test_cua_atexit_teardown.py -q -n 0` -> 18 passed
- Manual Windows handler check returned `capture mode=vision 3840x2160 app=screen window='Desktop'` through the formal `handle_computer_use` path.

