### PR TITLE
CXronjob : reject non-string script/action without crashing

### DIFF
--- a/tests/tools/test_cronjob_nonstrings.py
+++ b/tests/tools/test_cronjob_nonstrings.py
@@ -1,0 +1,40 @@
+"""cronjob script/action must tolerate non-string JSON without crashing."""
+
+from __future__ import annotations
+
+import json
+
+from tools.cronjob_tools import _validate_cron_script_path, cronjob
+
+
+def test_validate_script_path_rejects_non_string_without_crash():
+    for bad in (42, ["collect.py"], {"path": "x"}):
+        err = _validate_cron_script_path(bad)
+        assert err is not None, bad
+        assert "must be a string" in err
+
+
+def test_validate_script_path_null_and_blank_clear_field():
+    assert _validate_cron_script_path(None) is None
+    assert _validate_cron_script_path("") is None
+    assert _validate_cron_script_path("   ") is None
+
+
+def test_cronjob_non_string_action_returns_tool_error():
+    result = json.loads(cronjob(action=123))
+    assert result.get("success") is False
+    assert "action must be a string" in result["error"]
+
+
+def test_cronjob_create_with_non_string_script_returns_tool_error(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="30m",
+            prompt="ping health",
+            script=99,
+        )
+    )
+    assert result.get("success") is False
+    assert "must be a string" in result["error"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -522,8 +522,17 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     Returns an error string if blocked, else None (valid).
     """
-    if not script or not script.strip():
-        return None  # empty/None = clearing the field, always OK
+    # Empty / None clears the field. Non-strings (JSON int/list fillers) must
+    # not AttributeError on ``.strip()`` at this security boundary.
+    if script is None or script == "":
+        return None
+    if not isinstance(script, str):
+        return (
+            f"Script path must be a string relative to ~/.hermes/scripts/. "
+            f"Got {type(script).__name__}."
+        )
+    if not script.strip():
+        return None  # whitespace-only = clearing the field, always OK
 
     from hermes_constants import get_hermes_home
 
@@ -734,6 +743,13 @@ def cronjob(
     del task_id  # unused but kept for handler signature compatibility
 
     try:
+        # Strict providers may send int/list fillers for ``action``; bare
+        # ``.strip()`` AttributeErrors before any action dispatch.
+        if action is not None and not isinstance(action, str):
+            return tool_error(
+                f"action must be a string, got {type(action).__name__}.",
+                success=False,
+            )
         normalized = (action or "").strip().lower()
 
         if normalized == "create":


### PR DESCRIPTION
## Summary
- `_validate_cron_script_path` called `.strip()` on raw `script` at the API security boundary.
- Int/list fillers raise `AttributeError` mid-tool instead of a clean rejection.
- Require a real string for script paths (null/blank still clear the field).
- Same guard for `action` before dispatch — non-string action no longer crashes on `.strip()`.
