### PR TITLE
fix(desktop): release update modal for boot recovery

### DIFF
--- a/apps/desktop/src/app/updates-overlay.test.tsx
+++ b/apps/desktop/src/app/updates-overlay.test.tsx
@@ -1,0 +1,86 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { BootFailureOverlay } from '@/components/boot-failure-overlay'
+import { $desktopBoot } from '@/store/boot'
+import { $desktopOnboarding } from '@/store/onboarding'
+import { $backendUpdateApply, $backendUpdateStatus, $updateOverlayOpen, $updateOverlayTarget } from '@/store/updates'
+
+import { UpdatesOverlay } from './updates-overlay'
+
+beforeEach(() => {
+  $desktopBoot.set({
+    error: null,
+    fakeMode: false,
+    message: 'ready',
+    phase: 'renderer.ready',
+    progress: 100,
+    running: false,
+    timestamp: Date.now(),
+    visible: false
+  })
+  $desktopOnboarding.set({
+    configured: true,
+    flow: { status: 'idle' },
+    mode: 'oauth',
+    providers: null,
+    reason: null,
+    requested: false,
+    firstRunSkipped: false,
+    manual: false,
+    localEndpoint: false
+  })
+  $backendUpdateStatus.set({
+    behind: 1,
+    commits: [],
+    fetchedAt: Date.now(),
+    supported: true,
+    updateAvailable: true
+  })
+  $backendUpdateApply.set({
+    applying: true,
+    stage: 'restart',
+    message: 'Restarting backend…',
+    percent: null,
+    error: null,
+    command: null,
+    log: []
+  })
+  $updateOverlayTarget.set('backend')
+  $updateOverlayOpen.set(true)
+})
+
+afterEach(() => {
+  cleanup()
+  $updateOverlayOpen.set(false)
+})
+
+describe('UpdatesOverlay recovery ownership', () => {
+  it('releases its modal lock when a hard boot failure takes over', async () => {
+    render(
+      <>
+        <UpdatesOverlay />
+        <BootFailureOverlay />
+      </>
+    )
+
+    await waitFor(() => expect(window.document.body.style.pointerEvents).toBe('none'))
+
+    await act(async () => {
+      $desktopBoot.set({
+        ...$desktopBoot.get(),
+        error: 'Your remote gateway session has expired.',
+        message: 'Desktop boot failed',
+        phase: 'renderer.error',
+        running: false,
+        visible: true
+      })
+    })
+
+    await waitFor(() => expect($updateOverlayOpen.get()).toBe(false))
+    await waitFor(() => expect(window.document.body.style.pointerEvents).not.toBe('none'))
+
+    fireEvent.click(screen.getByRole('button', { name: /gateway settings/i }))
+    expect(await screen.findByRole('button', { name: /back/i })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -20,6 +20,7 @@ import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
 import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
 import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
 import { cn } from '@/lib/utils'
+import { $desktopBoot } from '@/store/boot'
 import {
   $backendUpdateApply,
   $backendUpdateChecking,
@@ -45,6 +46,7 @@ function totalItems(groups: readonly CommitGroup[]) {
 export function UpdatesOverlay() {
   const open = useStore($updateOverlayOpen)
   const target = useStore($updateOverlayTarget)
+  const boot = useStore($desktopBoot)
 
   const clientStatus = useStore($updateStatus)
   const clientChecking = useStore($updateChecking)
@@ -59,12 +61,23 @@ export function UpdatesOverlay() {
   const apply = isBackend ? backendApply : clientApply
   const check = isBackend ? checkBackendUpdates : checkUpdates
   const install = isBackend ? applyBackendUpdate : applyUpdates
+  const bootFailureOwnsScreen = Boolean(boot.error) && !boot.running
+
+  // A hard boot failure owns the recovery surface. Merely drawing that surface
+  // above this dialog is insufficient: Radix's modal still disables pointer
+  // events and traps focus everywhere outside its content. Close the lower
+  // modal while leaving the update action itself free to finish in the store.
+  useEffect(() => {
+    if (open && bootFailureOwnsScreen) {
+      setUpdateOverlayOpen(false)
+    }
+  }, [bootFailureOwnsScreen, open])
 
   useEffect(() => {
-    if (open && !status && !checking) {
+    if (open && !bootFailureOwnsScreen && !status && !checking) {
       void check()
     }
-  }, [check, checking, open, status])
+  }, [bootFailureOwnsScreen, check, checking, open, status])
 
   const behind = status?.behind ?? 0
   const updateAvailable = status?.updateAvailable || behind > 0
@@ -100,7 +113,7 @@ export function UpdatesOverlay() {
   }
 
   return (
-    <Dialog onOpenChange={handleClose} open={open}>
+    <Dialog onOpenChange={handleClose} open={open && !bootFailureOwnsScreen}>
       {/* This dialog has no inputs, so Radix's default autofocus would land on
           the close button and trigger its tooltip immediately on open. */}
       <DialogContent


### PR DESCRIPTION
## What does this PR do?

Fixes recovery controls becoming non-interactive when a remote gateway update is followed by a hard boot or reauthentication failure.

The boot-failure surface already renders above the update dialog, but the still-open Radix modal continues disabling pointer events and trapping focus outside its own content. When boot recovery takes ownership, the update dialog now closes immediately and clears its open flag while leaving the in-flight update action state untouched.

## Related Issue

No linked issue; reproduced from the Desktop remote-gateway update flow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Make `UpdatesOverlay` yield modal ownership to a hard boot-failure recovery surface.
- Prevent update checks from starting while boot recovery owns the screen.
- Add a stacked-overlay regression test that verifies Radix releases the body pointer lock and the Gateway settings action is clickable without restarting Desktop.

## How to Test

1. Connect Desktop to a remote OAuth gateway and open the backend update dialog.
2. Start the update, then let reconnect surface an expired-session boot failure.
3. Verify Gateway settings and the other recovery actions work immediately without restarting Desktop.

Automated verification:

- `npx vitest run src/app/updates-overlay.test.tsx src/components/boot-failure-overlay.test.tsx src/store/updates.test.ts`
- `npm run typecheck`
- `npx eslint src/app/updates-overlay.tsx src/app/updates-overlay.test.tsx`
- `npx prettier --check src/app/updates-overlay.tsx src/app/updates-overlay.test.tsx`

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] Searched open and closed PRs and issues for duplicates
- [x] PR contains only changes related to this fix
- [ ] Full Python pytest suite — not applicable to this Desktop-only renderer change
- [x] Added regression coverage
- [x] Tested on Linux

### Documentation & Housekeeping

- [x] Documentation changes are not required
- [x] No config keys changed
- [x] No architecture or workflow documentation changed
- [x] Considered cross-platform impact; the fix is renderer-only and uses shared modal/boot state
- [x] No tool descriptions or schemas changed