### PR TITLE
fix(cli): finalize one-shot Relay roots on every exit

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -415,6 +415,7 @@ def _run_agent(
     # raises on a provider/config error. The one-shot exit path hard-exits via
     # os._exit and skips finalizers, so an un-closed connection here would leak.
     agent = None
+    relay_session_id = None
     try:
         # Read the effective fallback chain from profile config so oneshot
         # workers honour the same merge semantics as interactive CLI and
@@ -454,6 +455,10 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
+        # Relay keys its root conversation to the session id at turn entry.
+        # Compression may rotate ``agent.session_id`` during the turn without
+        # acquiring a second Relay root, so retain the id that owns the lease.
+        relay_session_id = getattr(agent, "session_id", None)
         result = agent.run_conversation(prompt)
         return (result.get("final_response") or "", result)
     finally:
@@ -461,6 +466,20 @@ def _run_agent(
         # NOT cli.py:_run_cleanup — oneshot has no _active_agent_ref and must
         # close the agent explicitly because the hard-exit path skips finalizers.
         if agent is not None:
+            # ``run_conversation`` ends the Relay turn but intentionally keeps
+            # the root conversation resumable. One-shot has no later turn, and
+            # os._exit skips atexit, so close that root before tearing down the
+            # agent resources that own its remaining lifecycle work.
+            try:
+                from hermes_cli.lifecycle import finalize_session
+
+                finalize_session(
+                    session_id=relay_session_id,
+                    platform=getattr(agent, "platform", None) or "cli",
+                    reason="shutdown",
+                )
+            except Exception:
+                logging.debug("oneshot session finalization failed", exc_info=True)
             try:
                 session_messages = getattr(agent, "_session_messages", None)
                 if isinstance(session_messages, list):

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -216,6 +216,110 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+@pytest.mark.parametrize("run_fails", [False, True], ids=["success", "failure"])
+def test_oneshot_finalizes_relay_session_before_resource_cleanup(monkeypatch, run_fails):
+    """One-shot must close its Relay root before the hard-exit cleanup path."""
+    from hermes_cli import (
+        config,
+        lifecycle,
+        mcp_startup,
+        models,
+        oneshot,
+        runtime_provider,
+        tools_config,
+    )
+
+    events = []
+    finalize_calls = []
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            self.session_id = "oneshot-session"
+            self.platform = "cli"
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+            self._session_messages = []
+
+        def run_conversation(self, _prompt):
+            events.append("run")
+            # Compression rotates the DB session id, but the Relay root remains
+            # keyed to the id captured when the turn started.
+            self.session_id = "compression-child"
+            if run_fails:
+                raise RuntimeError("agent failed")
+            return {"final_response": "ok", "failed": False, "partial": False}
+
+        def shutdown_memory_provider(self, _messages=None):
+            events.append("memory")
+
+        def close(self):
+            events.append("agent_close")
+
+    class FakeSessionDB:
+        def close(self):
+            events.append("db_close")
+
+    def fake_finalize_session(**kwargs):
+        finalize_calls.append(kwargs)
+        events.append("finalize")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=FakeAgent),
+    )
+    monkeypatch.setattr(lifecycle, "finalize_session", fake_finalize_session)
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", FakeSessionDB)
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {"model": {"default": "m"}},
+    )
+    monkeypatch.setattr(
+        models,
+        "detect_provider_for_model",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "k",
+            "base_url": "u",
+            "provider": "p",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        tools_config,
+        "_get_platform_tools",
+        lambda *_args, **_kwargs: set(),
+    )
+    monkeypatch.setattr(
+        mcp_startup,
+        "ensure_mcp_discovery_before_agent_build",
+        lambda **_kwargs: None,
+    )
+
+    if run_fails:
+        with pytest.raises(RuntimeError, match="agent failed"):
+            oneshot._run_agent("finish this")
+    else:
+        text, result = oneshot._run_agent("finish this")
+        assert text == "ok"
+        assert not result.get("failed")
+    assert finalize_calls == [
+        {
+            "session_id": "oneshot-session",
+            "platform": "cli",
+            "reason": "shutdown",
+        }
+    ]
+    assert events == ["run", "finalize", "memory", "agent_close", "db_close"]
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None
@@ -282,7 +386,6 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert argv == [str(tsx), "src/entry.tsx"]
     assert cwd == tui_dir
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

One-shot mode ends the Relay turn but deliberately retains the resumable root conversation. Because the one-shot entrypoint then exits with `os._exit`, no later lifecycle boundary closes that root, so telemetry can contain session/turn start and turn end events without a matching session end.

This change captures the Relay-owning session ID immediately before `run_conversation()` and finalizes it from `_run_agent()`'s existing `finally` block, before memory, agent, and session-store teardown. Finalization exceptions are contained, and the existing hard-exit `finally` from #43055 remains unchanged.

Capturing the entry ID matters: context compression may rotate `agent.session_id` during the turn, while the Relay lease remains keyed to the ID used when the turn began. The same `finally` placement also closes the root when `run_conversation()` raises.

This patch was already in progress when the overlapping #79533 was opened. At its current head, #79533 forwards the final result session ID into process cleanup for the ordinary successful path. This patch instead finalizes at the owner call site, preserves the existing `run_oneshot() -> int` contract, and also covers exception exits and compression-driven session-ID rotation.

This change does not add telemetry fields, destinations, or configuration, and it does not alter Relay subscriber-flush behavior. The separate concurrent async-loop deadlock discussed on #77915 remains out of scope.

## Related Issue

Fixes #79471

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/oneshot.py`: retain the session ID that owns the Relay lease and finalize it before one-shot agent resources are torn down.
- `tests/hermes_cli/test_tui_resume_flow.py`: cover success and exception exits, compression-style session-ID rotation, exactly-once finalization, and cleanup ordering.

## How to Test

1. For RED proof, apply only the regression-test hunk to unmodified `main` and run `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py -k oneshot_finalizes_relay_session_before_resource_cleanup -q`; both cases fail because no session finalizer is called.
2. Apply this change and run:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_lifecycle.py tests/cli/test_single_query_session_finalize.py tests/hermes_cli/test_relay_shared_metrics.py tests/hermes_cli/test_relay_shared_metrics_runtime.py
   ```
3. Confirm both success and exception cases finalize `oneshot-session` exactly once before memory/agent/DB cleanup, even after the fake agent rotates its live ID to `compression-child`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (overlap with #79533 is disclosed above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing behavior or configuration changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python lifecycle change; Windows footgun check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- Related lifecycle suite after rebasing onto current `upstream/main`: **138 passed, 0 failed**.
- `/Users/lesterliang/.hermes/hermes-agent/venv/bin/ruff check --no-cache hermes_cli/oneshot.py tests/hermes_cli/test_tui_resume_flow.py`: passed.
- `scripts/check-windows-footguns.py`: passed.
- `git diff --check`: passed.
- Full `scripts/run_tests.sh`: 20 failures across 13 files, plus 4 collection errors in 1 file. All 14 affected files also fail on unmodified `upstream/main` at `0531aad55` in the same macOS environment; none references either file changed by this PR.
- GitHub Actions: all required checks passed, including all 8 Python test slices, Ruff enforcement, Windows footguns, e2e, attribution, lockfile, and supply-chain checks.
