### PR TITLE
fix(agent): bound synchronous tool execution with a configurable ceiling

### DIFF
--- a/agent/relay_tools.py
+++ b/agent/relay_tools.py
@@ -7,6 +7,7 @@ import contextvars
 import inspect
 import json
 import logging
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -111,12 +112,39 @@ def _json_equal(left: Any, right: Any) -> bool:
         return left == right
 
 
+def _tool_execution_ceiling_seconds() -> float:
+    """Upper bound for one synchronous tool execution, in seconds.
+
+    The concurrent tool path is bounded by HERMES_CONCURRENT_TOOL_TIMEOUT_S,
+    but the sequential path has no deadline at all: a tool whose awaitable
+    never resolves wedges the conversation turn forever with no log output
+    (observed in production with a stuck skill_view; the turn thread parks in
+    the event-loop selector and the session's ended_at/end_reason stay NULL).
+    The default sits above every stock per-tool budget (web_extract 360s,
+    typical terminal timeouts) so it only fires on genuinely wedged tools.
+    Set HERMES_TOOL_EXECUTION_CEILING_S=0 to disable.
+    """
+    raw = os.getenv("HERMES_TOOL_EXECUTION_CEILING_S", "").strip()
+    if not raw:
+        return 420.0
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "invalid HERMES_TOOL_EXECUTION_CEILING_S=%r; using 420s", raw
+        )
+        return 420.0
+
+
 def _run_awaitable(value: Any) -> Any:
     if not inspect.isawaitable(value):
         return value
     try:
         asyncio.get_running_loop()
     except RuntimeError:
+        ceiling = _tool_execution_ceiling_seconds()
+        if ceiling > 0:
+            return asyncio.run(asyncio.wait_for(value, timeout=ceiling))
         return asyncio.run(value)
     raise RuntimeError(
         "Synchronous Hermes Relay tool execution cannot run on an active event-loop thread"

--- a/tests/agent/test_relay_run_awaitable_ceiling.py
+++ b/tests/agent/test_relay_run_awaitable_ceiling.py
@@ -1,0 +1,53 @@
+"""Tests for the synchronous tool-execution ceiling in relay_tools._run_awaitable.
+
+The sequential tool path has no batch deadline (unlike the concurrent path's
+HERMES_CONCURRENT_TOOL_TIMEOUT_S), so a tool whose awaitable never resolves
+used to wedge the conversation turn forever. _run_awaitable now bounds every
+synchronous execution with a configurable ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent import relay_tools
+
+
+def test_completed_awaitable_returns_value(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_EXECUTION_CEILING_S", raising=False)
+
+    async def _quick():
+        return "done"
+
+    assert relay_tools._run_awaitable(_quick()) == "done"
+
+
+def test_non_awaitable_passes_through():
+    assert relay_tools._run_awaitable("plain") == "plain"
+
+
+def test_wedged_awaitable_raises_timeout(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+
+    async def _never():
+        await asyncio.Event().wait()
+
+    with pytest.raises(TimeoutError):
+        relay_tools._run_awaitable(_never())
+
+
+def test_ceiling_zero_disables_bound(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0")
+
+    async def _quick():
+        return 42
+
+    # With the ceiling disabled the awaitable still runs to completion.
+    assert relay_tools._run_awaitable(_quick()) == 42
+
+
+def test_invalid_ceiling_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "not-a-number")
+    assert relay_tools._tool_execution_ceiling_seconds() == 420.0


### PR DESCRIPTION
> **Disclosure:** This PR was drafted by an AI assistant (Claude) working through a real,
> interactive troubleshooting session on my self-hosted deployment. The fix was applied and
> validated in production there before submission.

## What does this PR do?

Bounds every synchronous tool execution with a configurable ceiling
(`HERMES_TOOL_EXECUTION_CEILING_S`, default 420s, `0` disables), closing a gap where the
sequential tool path (`execute_tool_calls_sequential` and the segmented executor's sequential
segments) has no deadline at all: a tool whose awaitable never resolves parks the conversation
turn in the event-loop selector **forever** — no log line, no error, `ended_at`/`end_reason`
stay NULL, and the client spins on "ruminating…" indefinitely. The concurrent path already has
`HERMES_CONCURRENT_TOOL_TIMEOUT_S`; this gives the synchronous funnel an equivalent backstop.

## Related Issue

Fixes #79568

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/relay_tools.py` — new `_tool_execution_ceiling_seconds()` (env-read, default 420.0,
  warns and falls back on invalid values); `_run_awaitable` wraps the awaitable in
  `asyncio.wait_for` when the ceiling is > 0.
- `tests/agent/test_relay_run_awaitable_ceiling.py` — 5 new tests: normal completion,
  non-awaitable passthrough, wedged awaitable raises `TimeoutError`, ceiling `0` disables the
  bound, invalid env falls back to the default.

## How to Test

1. `pytest tests/agent/test_relay_run_awaitable_ceiling.py -v` (5 passed; also executed inside
   the official `nousresearch/hermes-agent:v2026.8.3` container venv, Python 3.13.5).
2. Manual: monkey-patch any tool's execute to `await asyncio.Event().wait()`, invoke it on the
   sequential path with `HERMES_TOOL_EXECUTION_CEILING_S=5` — the tool fails visibly in ~5s and
   the turn continues, instead of hanging forever.
3. Production validation (my deployment, linux/amd64, Debian 12 host): a naturally wedged
   `skill_view` that previously hung the turn permanently instead surfaced as
   `tool skill_view failed (420.11s)`; the turn issued its next API call and completed with
   `finish_reason=stop`.

Platforms tested: Linux (Docker, linux/amd64). No platform-specific APIs touched
(stdlib `asyncio.wait_for` / `os.getenv` only).

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for duplicate PRs (none touch `_run_awaitable` or sequential-path deadlines)
- [x] Only related commits included (single commit, single concern)
- [x] New tests pass (5/5 in the release container venv); full suite not run locally —
  the change is additive and behind an env-tunable default
- [x] Test coverage added for the change
- [x] Cross-platform considered: stdlib-only, no Unix assumptions
- [ ] Documentation: env var could be added to the configuration reference — happy to include
  if maintainers point me at the right page

## Screenshots / Logs

Before (production, silent forever-hang; timestamps CEST):

```
14:05:32 WARNING ... concurrent tool batch timed out after 120.0s; 4 tool(s) still running: ...
(no further output from this session, ever — no next API call, no error; ended_at=NULL)
```

After (same workload, fix applied):

```
17:12:44 TimeoutError
17:12:44 INFO ... tool skill_view failed (420.11s): Error executing tool 'skill_view':
17:14:56 INFO ... API call #3 ...
17:16:04 INFO ... Turn ended: reason=text_response(finish_reason=stop)
```
