### PR TITLE
fix(agent): bound the concurrent start-order gate wait

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -97,6 +97,11 @@ _DEFAULT_IMAGE_PARALLEL_REQUESTS = 4
 # Keep this above the stock auxiliary.web_extract timeout (360s) so the batch
 # guard does not preempt a slow-but-valid summarization attempt.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
+# Upper bound a concurrent worker will wait at the start-order gate for all
+# earlier-ordered tools to advance before proceeding out of order. Long enough
+# to cover slow-but-legitimate authorization (e.g. an approval round-trip),
+# short enough that one wedged dispatch cannot starve the batch forever.
+_START_ORDER_GATE_TIMEOUT_S = 120.0
 
 
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
@@ -806,12 +811,35 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     def _begin_in_order(order: int, callback=None) -> None:
         nonlocal next_start_order
         with start_condition:
-            start_condition.wait_for(lambda: order == next_start_order)
+            # Bounded wait: a tool that wedges during its dispatch must not
+            # park every later-ordered worker forever. Without the timeout,
+            # one blocking dispatch starves the whole batch (the parked tools
+            # then get falsely reported as "timed out" by the batch deadline
+            # despite never having started) and the parked threads leak
+            # permanently after the batch is abandoned — f.cancel() cannot
+            # cancel running threads and nothing ever notifies the condition
+            # again. On expiry, proceed out of order: the worst case is
+            # interleaved approval prompts, strictly better than permanent
+            # starvation. The >= predicate (rather than ==) lets one worker's
+            # timeout-jump release every skipped worker immediately instead
+            # of each burning its own full timeout; max() keeps the counter
+            # monotonic when workers advance out of order.
+            in_order = start_condition.wait_for(
+                lambda: next_start_order >= order,
+                timeout=_START_ORDER_GATE_TIMEOUT_S,
+            )
+            if not in_order:
+                logger.warning(
+                    "start-order gate timed out (order=%d next=%d); "
+                    "proceeding out of order",
+                    order,
+                    next_start_order,
+                )
             try:
                 if callback is not None:
                     callback()
             finally:
-                next_start_order += 1
+                next_start_order = max(next_start_order, order + 1)
                 start_condition.notify_all()
 
     # Touch activity before launching workers so the gateway knows


### PR DESCRIPTION
> **Disclosure:** This PR was drafted by an AI assistant (Claude) working through a real,
> interactive troubleshooting session on my self-hosted deployment. The fix was applied and
> validated in production there before submission.

## What does this PR do?

Bounds `_begin_in_order`'s start-order wait (new `_START_ORDER_GATE_TIMEOUT_S = 120.0`). The
gate currently parks each concurrent tool worker on a **timeout-less** `Condition.wait_for`
until every earlier-ordered tool has advanced through its dispatch. When one tool wedges during
dispatch, three failures compound:

1. every later-ordered worker is starved and never starts;
2. the batch deadline then **falsely reports those never-started tools as "timed out"**
   (sub-second `read_file`/`search_files` calls get blamed with zero work done, and the model
   retries against that false failure information);
3. after the batch is abandoned, the parked workers **leak permanently** — `f.cancel()` cannot
   cancel running threads, the per-thread interrupt flag is never polled inside `wait_for`, and
   nothing ever notifies the condition again (confirmed by a `faulthandler` all-threads dump
   taken after batch abandonment, workers still parked at the gate).

On expiry the worker logs a warning and proceeds out of order — worst case is interleaved
approval prompts, strictly better than permanent starvation. The `>=` predicate lets one
worker's timeout-jump release every skipped worker immediately (an earlier `==` variant we ran
in production worked but released stragglers one full timeout apart), and `max()` keeps the
counter monotonic under out-of-order advancement.

## Related Issue

Fixes #79569

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/tool_executor.py` — module constant `_START_ORDER_GATE_TIMEOUT_S = 120.0`;
  `_begin_in_order` waits with that timeout on predicate `next_start_order >= order`, warns on
  expiry, and advances via `next_start_order = max(next_start_order, order + 1)`.

## How to Test

1. Deterministic: in a batch of parallel-safe tools, make the first-dispatched tool block during
   dispatch (e.g. patch its authorization callback to sleep forever). Without this PR, no other
   tool in the batch ever starts and all are reported "timed out" by the batch deadline; with
   it, each remaining worker starts after ≤120s and produces its real result.
2. Production validation (my deployment): a batch of 7 tools fully wedged at order 0 — with the
   fix, the log shows `start-order gate timed out (order=3 next=0); proceeding out of order`,
   after which both `web_search` calls completed in ~3s of real work, `skill_view` and
   `search_files` returned real results, and the turn completed with `finish_reason=stop`.
   The identical workload previously ended in the batch reporting every tool timed out and the
   session wedging.
3. Healthy-path regression: ordering semantics are unchanged when no dispatch blocks (counter
   advances 0,1,2,… exactly as before; `>=` is equivalent to `==` in that case). Verified by
   normal multi-tool turns before/after in the same deployment.

Platforms tested: Linux (Docker, linux/amd64). Stdlib `threading` only.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for duplicate PRs (none touch `_begin_in_order`)
- [x] Only related commits included (single commit, single concern)
- [ ] New unit test not included: `_begin_in_order` is a closure inside
  `execute_tool_calls_concurrent` with no existing seam for isolated testing; validated via the
  deterministic repro in "How to Test" and in production. Happy to add a harness test if
  maintainers can point at a preferred pattern for exercising the concurrent executor.
- [x] Cross-platform considered: stdlib-only, no Unix assumptions

## Screenshots / Logs

Before (production; sub-second local tools blamed, then batch wedged):

```
17:31:44 WARNING ... concurrent tool batch timed out after 120.0s; 3 tool(s) still running: web_extract, search_files, read_file
(read_file/search_files complete in ≤0.5s on the same paths when run alone)
```

After (same workload, fix applied):

```
17:07:44 WARNING ... start-order gate timed out (order=3 next=0); proceeding out of order
17:07:47 INFO ... tool web_search completed (123.24s, 19983 chars)   <- ~3s of real work once released
17:09:47 INFO ... tool skill_view completed (243.39s, 6532 chars)
17:09:48 INFO ... tool search_files completed (244.01s, 1246 chars)
17:16:04 INFO ... Turn ended: reason=text_response(finish_reason=stop)
```
