### PR TITLE
feat: --payload-dir offline staging in install.sh / install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -43,6 +43,13 @@ param(
     [switch]$NonInteractive,
     [switch]$Json,
 
+    # --- Offline payload tree (desktop bundled artifact) ---
+    # Points at the agent-payload/ directory shipped in the bundled desktop
+    # app's resources (see apps/desktop/scripts/stage-agent-payloads.mjs).
+    # Stages that normally hit the network source locally from it instead;
+    # anything missing falls back to the stage's normal network path.
+    [string]$PayloadDir = "",
+
     # Print the paths this install would use, as JSON, and exit without
     # touching anything. The first question on any "installer says a path
     # doesn't exist" report is which paths it actually resolved -- especially
@@ -4000,17 +4007,138 @@ function Stage-Node             {
     }
 }
 function Stage-SystemPackages   { Install-SystemPackages }
-function Stage-Repository       { Install-Repository }
+function Stage-Repository       { if (-not (Invoke-PayloadStageRepository)) { Install-Repository } }
 function Stage-Venv             { Resolve-UvCmd; Install-Venv }
-function Stage-Dependencies     { Resolve-UvCmd; Install-Dependencies }
-function Stage-NodeDeps         { Install-NodeDeps }
+function Stage-Dependencies     { Resolve-UvCmd; if (-not (Invoke-PayloadStageWheels)) { Install-Dependencies } }
+function Stage-NodeDeps         { if (-not (Invoke-PayloadStageJs)) { Install-NodeDeps } }
 function Stage-Desktop          { Install-DesktopVoiceDeps; Install-Desktop }
 function Stage-Path             { Set-PathVariable }
 function Stage-ConfigTemplates  { Copy-ConfigTemplates }
 function Stage-PlatformSdks     { Resolve-UvCmd; Install-PlatformSdks }
-function Stage-BootstrapMarker  { Write-BootstrapMarker }
+function Stage-BootstrapMarker  { Write-BootstrapMarker; Write-InstallModeManifest }
 function Stage-Configure        { Invoke-SetupWizard }
 function Stage-Gateway          { Start-GatewayIfConfigured }
+
+# ─── Offline payload support (-PayloadDir; desktop bundled artifact) ───────
+# Mirror of install.sh's payload_* helpers. Each network-touching stage
+# first tries the payload; a $false return means "fall back to the normal
+# network path". Keep the two scripts in lockstep.
+
+function Get-PayloadManifest {
+    if (-not $PayloadDir) { return $null }
+    $manifestPath = Join-Path $PayloadDir "manifest.json"
+    if (-not (Test-Path $manifestPath)) { return $null }
+    try { return (Get-Content $manifestPath -Raw | ConvertFrom-Json) } catch { return $null }
+}
+
+function Test-PayloadHas {
+    param([string]$Item)
+    $m = Get-PayloadManifest
+    if (-not $m -or -not $m.items) { return $false }
+    $entry = $m.items.PSObject.Properties[$Item]
+    return ($null -ne $entry -and $entry.Value.status -eq "staged")
+}
+
+function Get-PayloadTag {
+    $m = Get-PayloadManifest
+    if ($m -and $m.tag) { return [string]$m.tag }
+    return ""
+}
+
+function Test-PayloadRefusesSourceCheckout {
+    # The eject contract: never overwrite a checkout whose .hermes-install.json
+    # says installMode source. Missing manifest is NOT a refusal.
+    $manifestPath = Join-Path $InstallDir ".hermes-install.json"
+    if (-not (Test-Path $manifestPath)) { return $false }
+    try {
+        $m = Get-Content $manifestPath -Raw | ConvertFrom-Json
+        return ($m.installMode -eq "source")
+    } catch { return $false }
+}
+
+function Invoke-PayloadStageRepository {
+    if (-not (Test-PayloadHas "repo")) { return $false }
+    if ((Test-Path $InstallDir) -and (Test-PayloadRefusesSourceCheckout)) {
+        Write-Info "Existing checkout is source-managed (ejected) - leaving it alone"
+        return $true
+    }
+    $tag = Get-PayloadTag
+    Write-Info "Materializing Hermes Agent from bundled payload ($tag)..."
+    $payloadRepo = Join-Path $PayloadDir "repo"
+    if (Test-Path (Join-Path $InstallDir ".git")) {
+        $payloadHead = (& git -C $payloadRepo rev-parse HEAD 2>$null)
+        if (-not $payloadHead) { return $false }
+        & git -C $InstallDir fetch $payloadRepo HEAD 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { return $false }
+        & git -C $InstallDir checkout -B main $payloadHead 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { return $false }
+        & git -C $InstallDir reset --hard $payloadHead 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { return $false }
+    } else {
+        if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
+        $parent = Split-Path $InstallDir -Parent
+        if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+        Copy-Item -Recurse $payloadRepo $InstallDir
+    }
+    Write-Success "Checkout materialized offline at $tag"
+    return $true
+}
+
+function Invoke-PayloadStageWheels {
+    if (-not (Test-PayloadHas "wheels")) { return $false }
+    Write-Info "Installing Python dependencies from bundled wheelhouse..."
+    $wheels = Join-Path $PayloadDir "wheels"
+    Push-Location $InstallDir
+    try {
+        & $script:UvCmd sync --frozen --offline --no-index --find-links $wheels --inexact
+        if ($LASTEXITCODE -ne 0) { return $false }
+    } finally { Pop-Location }
+    Write-Success "Python dependencies installed offline"
+    return $true
+}
+
+function Invoke-PayloadStageJs {
+    if (-not (Test-PayloadHas "js-prebuilt")) { return $false }
+    $archive = Join-Path $PayloadDir "js-prebuilt.tar.zst"
+    if (-not (Test-Path $archive)) { return $false }
+    Write-Info "Unpacking prebuilt JS surfaces (no npm needed)..."
+    # Windows 10 1803+ ships bsdtar as tar.exe with zstd support.
+    & tar --zstd -xf $archive -C $InstallDir 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { return $false }
+    Write-Success "Prebuilt JS surfaces unpacked"
+    return $true
+}
+
+function Write-InstallModeManifest {
+    # Decide + write .hermes-install.json at install completion. NEVER
+    # overwrites an ejected manifest — the opt-out is sticky.
+    if (-not (Test-Path $InstallDir)) { return }
+    $manifestPath = Join-Path $InstallDir ".hermes-install.json"
+    if (Test-Path $manifestPath) {
+        try {
+            $existing = Get-Content $manifestPath -Raw | ConvertFrom-Json
+            if ($existing.manageStyle -eq "ejected") {
+                Write-Info "Install manifest says ejected - preserving it"
+                return
+            }
+        } catch { }
+    }
+    $payload = ($PayloadDir -and (Test-PayloadHas "repo") -and -not (Test-PayloadRefusesSourceCheckout))
+    $obj = [ordered]@{ schemaVersion = 1 }
+    if ($payload) {
+        $obj.installMode = "bundled"
+        $obj.channel = "stable"
+        $obj.manageStyle = "adopted"
+        $tag = Get-PayloadTag
+        if ($tag) { $obj.pinnedTag = $tag }
+    } else {
+        $obj.installMode = "source"
+        $obj.channel = "main"
+    }
+    $tmp = "$manifestPath.tmp"
+    ($obj | ConvertTo-Json) + "`n" | Set-Content -Path $tmp -Encoding utf8
+    Move-Item -Force $tmp $manifestPath
+}
 
 function Get-InstallStage {
     param([string]$Name)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,7 @@ STAGE_NAME=""
 JSON_OUTPUT=false
 NON_INTERACTIVE=false
 INCLUDE_DESKTOP=false
+PAYLOAD_DIR=""
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -151,6 +152,10 @@ while [[ $# -gt 0 ]]; do
             HERMES_HOME="$2"
             shift 2
             ;;
+        --payload-dir|-PayloadDir)
+            PAYLOAD_DIR="$2"
+            shift 2
+            ;;
         --ensure)
             ENSURE_DEPS="$2"
             shift 2
@@ -181,6 +186,10 @@ while [[ $# -gt 0 ]]; do
             echo "                   default (non-root):  ~/.hermes/hermes-agent"
             echo "                   default (root, Linux): /usr/local/lib/hermes-agent"
             echo "  --hermes-home PATH  Data directory (default: ~/.hermes, or \$HERMES_HOME)"
+            echo "  --payload-dir PATH  Offline payload tree (desktop bundled artifact)."
+            echo "                   Stages source locally from it — repo snapshot, uv,"
+            echo "                   python, wheels, node, prebuilt JS — and fall back to"
+            echo "                   their normal network path for anything missing."
             echo "  -h, --help     Show this help"
             echo ""
             echo "Notes:"
@@ -345,6 +354,174 @@ emit_stage_json() {
     else
         printf '{"ok":%s,"stage":"%s","skipped":%s}\n' "$ok" "$stage" "$skipped"
     fi
+}
+
+# ============================================================================
+# Offline payload support (--payload-dir; desktop bundled artifact)
+#
+# The bundled desktop app ships an agent-payload/ tree in its resources
+# (assembled by apps/desktop/scripts/stage-agent-payloads.mjs). Each install
+# stage that normally hits the network first checks whether the payload can
+# satisfy it locally; anything missing/unusable falls back to the stage's
+# normal network path (per-stage fallback — a partial payload degrades
+# instead of failing the bootstrap).
+# ============================================================================
+
+# payload_has ITEM — true iff a usable payload dir was given AND its
+# manifest.json marks ITEM as staged. Grep-based on the known manifest shape
+# (jq is not a prerequisite at bootstrap time): items are objects like
+#   "wheels": { "status": "staged" }
+payload_has() {
+    local item="$1"
+    [ -n "$PAYLOAD_DIR" ] && [ -f "$PAYLOAD_DIR/manifest.json" ] || return 1
+    # Allow whitespace/newlines between the key and its status; reject
+    # anything not literally marked staged (skipped/failed ⇒ network path).
+    tr -d '\n\r\t ' < "$PAYLOAD_DIR/manifest.json" \
+        | grep -q "\"$item\":{\"status\":\"staged\"" || return 1
+    return 0
+}
+
+# payload_tag — the pinned release tag from manifest.json ("" if absent).
+payload_tag() {
+    [ -n "$PAYLOAD_DIR" ] && [ -f "$PAYLOAD_DIR/manifest.json" ] || { echo ""; return; }
+    tr -d '\n\r\t ' < "$PAYLOAD_DIR/manifest.json" \
+        | sed -n 's/.*"tag":"\([^"]*\)".*/\1/p'
+}
+
+# payload_refuses_source_checkout — the eject contract (plan §4.3): a payload
+# materialization must never overwrite a checkout the user manages. True
+# (refuse) iff an existing checkout's .hermes-install.json says the install
+# is source-managed. A missing manifest is NOT a refusal — pre-manifest
+# checkouts are handled by the repository stage's normal update path, and
+# silent adoption decides separately (in the desktop app) whether to migrate
+# them.
+payload_refuses_source_checkout() {
+    local manifest="$INSTALL_DIR/.hermes-install.json"
+    [ -f "$manifest" ] || return 1
+    tr -d '\n\r\t ' < "$manifest" | grep -q '"installMode":"source"'
+}
+
+# payload_stage_repo — materialize the checkout from the payload's shallow
+# clone (which keeps .git, so the result is git-shaped: eject stays cheap
+# and `hermes update` premises hold). Returns 1 to signal "fall back".
+payload_stage_repo() {
+    payload_has repo || return 1
+    if [ -d "$INSTALL_DIR/.git" ] || [ -d "$INSTALL_DIR" ]; then
+        if payload_refuses_source_checkout; then
+            log_info "Existing checkout is source-managed (ejected) — leaving it alone"
+            # Deliberate success: the stage is satisfied by the user's own
+            # checkout; the desktop boots whatever is checked out.
+            return 0
+        fi
+    fi
+    log_info "Materializing Hermes Agent from bundled payload ($(payload_tag))..."
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+    if [ -d "$INSTALL_DIR/.git" ]; then
+        # Existing bundled/legacy checkout: fetch from the payload clone and
+        # hard-reset to its HEAD. file-protocol fetch, no network.
+        local payload_head
+        payload_head=$(git -C "$PAYLOAD_DIR/repo" rev-parse HEAD) || return 1
+        git -C "$INSTALL_DIR" fetch "$PAYLOAD_DIR/repo" HEAD || return 1
+        git -C "$INSTALL_DIR" checkout -B main "$payload_head" || return 1
+        git -C "$INSTALL_DIR" reset --hard "$payload_head" || return 1
+    else
+        rm -rf "$INSTALL_DIR"
+        cp -R "$PAYLOAD_DIR/repo" "$INSTALL_DIR" || return 1
+    fi
+    log_success "Checkout materialized offline at $(payload_tag)"
+}
+
+# payload_stage_wheels VENVDIR — offline dependency sync from the wheelhouse.
+# Returns 1 to signal "fall back to network uv sync".
+payload_stage_wheels() {
+    payload_has wheels || return 1
+    log_info "Installing Python dependencies from bundled wheelhouse..."
+    (
+        cd "$INSTALL_DIR"
+        $UV_CMD sync --frozen --offline --no-index \
+            --find-links "$PAYLOAD_DIR/wheels" --inexact
+    ) || return 1
+    log_success "Python dependencies installed offline"
+}
+
+# payload_stage_js — unpack prebuilt JS surfaces (ui-tui dist + node_modules,
+# web_dist). tar.zst; zstd support probes tar first, falls back to unzstd.
+payload_stage_js() {
+    payload_has js-prebuilt || return 1
+    [ -f "$PAYLOAD_DIR/js-prebuilt.tar.zst" ] || return 1
+    log_info "Unpacking prebuilt JS surfaces (no npm needed)..."
+    if tar --zstd -tf "$PAYLOAD_DIR/js-prebuilt.tar.zst" >/dev/null 2>&1; then
+        tar --zstd -xf "$PAYLOAD_DIR/js-prebuilt.tar.zst" -C "$INSTALL_DIR" || return 1
+    elif command -v unzstd >/dev/null 2>&1; then
+        unzstd -c "$PAYLOAD_DIR/js-prebuilt.tar.zst" | tar -xf - -C "$INSTALL_DIR" || return 1
+    else
+        log_warn "No zstd support available for js-prebuilt payload"
+        return 1
+    fi
+    log_success "Prebuilt JS surfaces unpacked"
+}
+
+# payload_stage_runtimes — seed the Hermes-managed uv ($HERMES_HOME/bin/uv)
+# and node ($HERMES_HOME/node) from the payload BEFORE install_uv/check_node
+# probe for them: both helpers prefer an existing managed runtime, so seeding
+# first turns their network path into a no-op. Failures are non-fatal — the
+# helpers just proceed to their normal download.
+payload_stage_runtimes() {
+    [ -n "$PAYLOAD_DIR" ] || return 0
+    if payload_has uv && [ ! -x "$HERMES_HOME/bin/uv" ]; then
+        local uv_src
+        uv_src=$(find "$PAYLOAD_DIR/uv" -maxdepth 1 -type f -name 'uv*' 2>/dev/null | head -1)
+        if [ -n "$uv_src" ]; then
+            mkdir -p "$HERMES_HOME/bin"
+            cp "$uv_src" "$HERMES_HOME/bin/uv" && chmod +x "$HERMES_HOME/bin/uv" \
+                && log_success "uv seeded from bundled payload" \
+                || log_warn "Could not seed uv from payload (will download)"
+        fi
+    fi
+    if payload_has node && [ ! -x "$HERMES_HOME/node/bin/node" ] && [ -d "$PAYLOAD_DIR/node" ]; then
+        rm -rf "$HERMES_HOME/node.payload-tmp"
+        if cp -R "$PAYLOAD_DIR/node" "$HERMES_HOME/node.payload-tmp" 2>/dev/null; then
+            rm -rf "$HERMES_HOME/node"
+            mv "$HERMES_HOME/node.payload-tmp" "$HERMES_HOME/node"
+            log_success "Node.js seeded from bundled payload"
+        else
+            rm -rf "$HERMES_HOME/node.payload-tmp"
+            log_warn "Could not seed node from payload (will download)"
+        fi
+    fi
+    if payload_has python && [ -d "$PAYLOAD_DIR/python" ] && [ ! -d "$HERMES_HOME/python-payload" ]; then
+        # uv discovers managed pythons via UV_PYTHON_INSTALL_DIR; seed the
+        # payload interpreter and export for the venv/python-deps stages.
+        cp -R "$PAYLOAD_DIR/python" "$HERMES_HOME/python-payload" 2>/dev/null \
+            && log_success "CPython seeded from bundled payload" \
+            || log_warn "Could not seed python from payload (uv will download)"
+    fi
+    if [ -d "$HERMES_HOME/python-payload" ]; then
+        export UV_PYTHON_INSTALL_DIR="$HERMES_HOME/python-payload"
+    fi
+    return 0
+}
+
+# write_install_manifest_file MODE CHANNEL STYLE TAG — the .hermes-install.json
+# consumed by hermes_cli/install_manifest.py. Atomic (tmp+mv), same discipline
+# as write_bootstrap_marker.
+write_install_manifest_file() {
+    local mode="$1" channel="$2" style="$3" tag="$4"
+    local manifest_path="$INSTALL_DIR/.hermes-install.json"
+    local tmp_path="$manifest_path.tmp"
+    local style_line=""
+    if [ -n "$style" ]; then
+        style_line="  \"manageStyle\": \"$style\",
+"
+    fi
+    local tag_line=""
+    if [ -n "$tag" ]; then
+        tag_line="  \"pinnedTag\": \"$tag\",
+"
+    fi
+    printf '{\n%s%s  "channel": "%s",\n  "installMode": "%s",\n  "schemaVersion": 1\n}\n' \
+        "$style_line" "$tag_line" "$channel" "$mode" > "$tmp_path"
+    mv -f "$tmp_path" "$manifest_path"
 }
 
 prompt_yes_no() {
@@ -2573,6 +2750,24 @@ write_bootstrap_marker() {
     mv -f "$tmp_path" "$marker_path"
 }
 
+# write_install_mode_manifest — decide + write .hermes-install.json at the
+# end of an install. Bundled when this run materialized from a payload (and
+# the checkout isn't an ejected one we left alone); otherwise source/main.
+# NEVER overwrites an existing ejected manifest — the opt-out is sticky.
+write_install_mode_manifest() {
+    [ -d "$INSTALL_DIR" ] || return 0
+    local existing="$INSTALL_DIR/.hermes-install.json"
+    if [ -f "$existing" ] && tr -d '\n\r\t ' < "$existing" | grep -q '"manageStyle":"ejected"'; then
+        log_info "Install manifest says ejected — preserving it"
+        return 0
+    fi
+    if [ -n "$PAYLOAD_DIR" ] && payload_has repo && ! payload_refuses_source_checkout; then
+        write_install_manifest_file "bundled" "stable" "adopted" "$(payload_tag)"
+    else
+        write_install_manifest_file "source" "main" "" ""
+    fi
+}
+
 print_success() {
     echo ""
     echo -e "${GREEN}${BOLD}"
@@ -3187,6 +3382,7 @@ run_stage_body() {
             print_banner
             detect_os
             resolve_install_layout
+            payload_stage_runtimes
             install_uv
             check_python
             check_git
@@ -3198,12 +3394,13 @@ run_stage_body() {
             detect_os
             resolve_install_layout
             check_git
-            clone_repo
+            payload_stage_repo || clone_repo
             ;;
         venv)
             detect_os
             resolve_install_layout
             require_install_dir
+            payload_stage_runtimes
             install_uv
             check_python
             setup_venv
@@ -3212,16 +3409,18 @@ run_stage_body() {
             detect_os
             resolve_install_layout
             require_install_dir
+            payload_stage_runtimes
             install_uv
             check_python
-            install_deps
+            payload_stage_wheels || install_deps
             ;;
         node-deps)
             detect_os
             resolve_install_layout
             require_install_dir
+            payload_stage_runtimes
             check_node
-            install_node_deps
+            payload_stage_js || install_node_deps
             ;;
         path)
             detect_os
@@ -3264,6 +3463,7 @@ run_stage_body() {
             resolve_install_layout
             print_success
             write_bootstrap_marker
+            write_install_mode_manifest
             # Code-scoped stamp: write next to the install tree, not into
             # $HERMES_HOME. $HERMES_HOME is a shared data dir (it can be
             # bind-mounted into a Docker gateway too), so a stamp there gets
@@ -3326,6 +3526,7 @@ main() {
 
     detect_os
     resolve_install_layout
+    payload_stage_runtimes
     install_uv
     check_python
     check_git
@@ -3333,10 +3534,10 @@ main() {
     check_network_prerequisites
     install_system_packages
 
-    clone_repo
+    payload_stage_repo || clone_repo
     setup_venv
-    install_deps
-    install_node_deps
+    payload_stage_wheels || install_deps
+    payload_stage_js || install_node_deps
     setup_path
     copy_config_templates
     run_setup_wizard
@@ -3350,6 +3551,7 @@ main() {
     print_success
 
     write_bootstrap_marker
+    write_install_mode_manifest
 
     # Code-scoped stamp: write next to the install tree, not into $HERMES_HOME.
     # $HERMES_HOME is a shared data dir (it can be bind-mounted into a Docker

--- a/tests/test_install_sh_payload_dir.py
+++ b/tests/test_install_sh_payload_dir.py
@@ -1,0 +1,250 @@
+"""E2E tests for install.sh --payload-dir offline staging (plan §3).
+
+Exercise the real shell functions against real fixtures — a git "payload
+repo" clone, a manifest.json in the shape stage-agent-payloads.mjs writes —
+never asserting on install.sh's text. Mirrors the pattern of
+test_install_sh_bootstrap_marker.py.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+# Functions the payload test-harness needs, extracted from install.sh by name.
+_FUNCS = (
+    "payload_has",
+    "payload_tag",
+    "payload_refuses_source_checkout",
+    "payload_stage_repo",
+    "write_install_manifest_file",
+    "write_install_mode_manifest",
+)
+
+
+def _extract_functions_script():
+    parts = [
+        f"eval \"$(sed -n '/^{name}()/,/^}}/p' {INSTALL_SH})\"" for name in _FUNCS
+    ]
+    return "\n".join(parts)
+
+
+def run_payload_snippet(body, *, payload_dir="", install_dir=""):
+    """Run a bash snippet with install.sh's payload functions defined."""
+    script = f"""
+set -e
+PAYLOAD_DIR={str(payload_dir)!r}
+INSTALL_DIR={str(install_dir)!r}
+{_extract_functions_script()}
+log_info() {{ echo "INFO: $*" >&2; }}
+log_warn() {{ echo "WARN: $*" >&2; }}
+log_error() {{ echo "ERROR: $*" >&2; }}
+log_success() {{ echo "OK: $*" >&2; }}
+{body}
+"""
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    )
+
+
+def make_payload(tmp_path, *, items=("repo",), tag="v0.1.0", commits=2):
+    """Build a payload dir shaped like stage-agent-payloads.mjs output."""
+    payload = tmp_path / "agent-payload"
+    payload.mkdir(exist_ok=True)
+    manifest = {
+        "schemaVersion": 1,
+        "tag": tag,
+        "items": {i: {"status": "staged"} for i in items},
+    }
+    (payload / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    if "repo" in items:
+        repo = payload / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+        for i in range(commits):
+            (repo / f"f{i}.txt").write_text(f"payload {i}\n")
+            _git(repo, "add", ".")
+            _git(repo, "-c", "user.email=t@t", "-c", "user.name=t",
+                 "commit", "-q", "-m", f"c{i}")
+    return payload
+
+
+def _git(cwd, *args):
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"git {args}: {result.stderr}"
+    return result.stdout.strip()
+
+
+class TestPayloadHas:
+    def test_staged_item_detected(self, tmp_path):
+        payload = make_payload(tmp_path, items=("repo", "wheels"))
+        r = run_payload_snippet("payload_has wheels && echo YES", payload_dir=payload)
+        assert "YES" in r.stdout
+
+    def test_missing_item_and_skipped_status_rejected(self, tmp_path):
+        payload = make_payload(tmp_path, items=("repo",))
+        manifest = json.loads((payload / "manifest.json").read_text())
+        manifest["items"]["wheels"] = {"status": "skipped", "reason": "explicit-skip"}
+        (payload / "manifest.json").write_text(json.dumps(manifest))
+        r = run_payload_snippet(
+            "payload_has wheels && echo YES || echo NO", payload_dir=payload
+        )
+        assert "NO" in r.stdout
+
+    def test_no_payload_dir_is_false(self, tmp_path):
+        r = run_payload_snippet("payload_has repo && echo YES || echo NO")
+        assert "NO" in r.stdout
+
+    def test_thin_stub_manifest_is_false(self, tmp_path):
+        payload = tmp_path / "agent-payload"
+        payload.mkdir()
+        (payload / "manifest.json").write_text(
+            json.dumps({"schemaVersion": 1, "thin": True, "items": {}})
+        )
+        r = run_payload_snippet("payload_has repo && echo YES || echo NO", payload_dir=payload)
+        assert "NO" in r.stdout
+
+
+class TestPayloadTag:
+    def test_reads_tag(self, tmp_path):
+        payload = make_payload(tmp_path, tag="v2.3.4")
+        r = run_payload_snippet("payload_tag", payload_dir=payload)
+        assert r.stdout.strip() == "v2.3.4"
+
+
+class TestPayloadStageRepo:
+    def test_fresh_materialization_is_git_shaped(self, tmp_path):
+        """Fresh install: repo copied with .git so eject/update premises hold."""
+        payload = make_payload(tmp_path)
+        install_dir = tmp_path / "hermes-agent"
+        r = run_payload_snippet(
+            "payload_stage_repo", payload_dir=payload, install_dir=install_dir
+        )
+        assert r.returncode == 0, r.stderr
+        assert (install_dir / ".git").is_dir()
+        assert (install_dir / "f0.txt").read_text() == "payload 0\n"
+        payload_head = _git(payload / "repo", "rev-parse", "HEAD")
+        assert _git(install_dir, "rev-parse", "HEAD") == payload_head
+
+    def test_existing_checkout_updated_via_file_fetch(self, tmp_path):
+        """Existing bundled checkout: fetched + hard-reset to payload HEAD, offline."""
+        payload = make_payload(tmp_path, commits=3)
+        install_dir = tmp_path / "hermes-agent"
+        # Simulate an older bundled install: clone payload repo then rewind.
+        subprocess.run(
+            ["git", "clone", "-q", str(payload / "repo"), str(install_dir)],
+            check=True, capture_output=True,
+        )
+        _git(install_dir, "reset", "--hard", "-q", "HEAD~2")
+        assert not (install_dir / "f2.txt").exists()
+
+        r = run_payload_snippet(
+            "payload_stage_repo", payload_dir=payload, install_dir=install_dir
+        )
+        assert r.returncode == 0, r.stderr
+        assert (install_dir / "f2.txt").exists()
+        assert _git(install_dir, "rev-parse", "HEAD") == _git(
+            payload / "repo", "rev-parse", "HEAD"
+        )
+
+    def test_refuses_source_managed_checkout(self, tmp_path):
+        """The eject contract: a source-mode checkout is never overwritten."""
+        payload = make_payload(tmp_path)
+        install_dir = tmp_path / "hermes-agent"
+        install_dir.mkdir()
+        (install_dir / ".hermes-install.json").write_text(
+            json.dumps({"schemaVersion": 1, "installMode": "source",
+                        "channel": "main", "manageStyle": "ejected"})
+        )
+        (install_dir / "user-file.txt").write_text("precious\n")
+
+        r = run_payload_snippet(
+            "payload_stage_repo && echo STAGE-OK",
+            payload_dir=payload, install_dir=install_dir,
+        )
+        # Succeeds (stage satisfied) but leaves the checkout alone.
+        assert "STAGE-OK" in r.stdout
+        assert (install_dir / "user-file.txt").read_text() == "precious\n"
+        assert not (install_dir / "f0.txt").exists()
+
+    def test_no_repo_item_falls_back(self, tmp_path):
+        payload = make_payload(tmp_path, items=("wheels",))
+        r = run_payload_snippet(
+            "payload_stage_repo && echo STAGED || echo FALLBACK",
+            payload_dir=payload, install_dir=tmp_path / "x",
+        )
+        assert "FALLBACK" in r.stdout
+
+
+class TestWriteInstallModeManifest:
+    def test_bundled_manifest_after_payload_install(self, tmp_path):
+        payload = make_payload(tmp_path, tag="v1.0.0")
+        install_dir = tmp_path / "hermes-agent"
+        install_dir.mkdir()
+        r = run_payload_snippet(
+            "write_install_mode_manifest",
+            payload_dir=payload, install_dir=install_dir,
+        )
+        assert r.returncode == 0, r.stderr
+        manifest = json.loads((install_dir / ".hermes-install.json").read_text())
+        assert manifest["installMode"] == "bundled"
+        assert manifest["channel"] == "stable"
+        assert manifest["manageStyle"] == "adopted"
+        assert manifest["pinnedTag"] == "v1.0.0"
+        assert manifest["schemaVersion"] == 1
+
+    def test_source_manifest_without_payload(self, tmp_path):
+        install_dir = tmp_path / "hermes-agent"
+        install_dir.mkdir()
+        r = run_payload_snippet(
+            "write_install_mode_manifest", install_dir=install_dir
+        )
+        assert r.returncode == 0, r.stderr
+        manifest = json.loads((install_dir / ".hermes-install.json").read_text())
+        assert manifest["installMode"] == "source"
+        assert manifest["channel"] == "main"
+        assert "manageStyle" not in manifest
+
+    def test_ejected_manifest_is_never_overwritten(self, tmp_path):
+        """Sticky opt-out: even a payload install preserves ejected."""
+        payload = make_payload(tmp_path)
+        install_dir = tmp_path / "hermes-agent"
+        install_dir.mkdir()
+        original = {
+            "schemaVersion": 1, "installMode": "source",
+            "channel": "stable", "manageStyle": "ejected",
+        }
+        (install_dir / ".hermes-install.json").write_text(json.dumps(original))
+        r = run_payload_snippet(
+            "write_install_mode_manifest",
+            payload_dir=payload, install_dir=install_dir,
+        )
+        assert r.returncode == 0, r.stderr
+        after = json.loads((install_dir / ".hermes-install.json").read_text())
+        assert after["manageStyle"] == "ejected"
+        assert after["installMode"] == "source"
+
+
+class TestManifestReadableByPython:
+    def test_shell_written_manifest_parses_via_install_manifest_module(self, tmp_path):
+        """Cross-language contract: install.sh's writer ↔ Python's reader."""
+        from hermes_cli.install_manifest import read_install_manifest
+
+        payload = make_payload(tmp_path, tag="v3.0.0")
+        install_dir = tmp_path / "hermes-agent"
+        install_dir.mkdir()
+        run_payload_snippet(
+            "write_install_mode_manifest",
+            payload_dir=payload, install_dir=install_dir,
+        )
+        manifest = read_install_manifest(install_dir)
+        assert manifest["installMode"] == "bundled"
+        assert manifest["channel"] == "stable"
+        assert manifest["manageStyle"] == "adopted"
+        assert manifest["pinnedTag"] == "v3.0.0"


### PR DESCRIPTION
## Summary
Part 5 of the bundled-desktop stack (after #79554). `--payload-dir` / `-PayloadDir` in install.sh + install.ps1: every network-touching stage sources from the bundled payload tree when its manifest marks the item staged, and **falls back per-item** to the normal network path otherwise — a partial payload degrades, never bricks.

| stage | payload path |
|---|---|
| prerequisites | seed managed uv (`$HERMES_HOME/bin/uv`), node (`$HERMES_HOME/node`), CPython (`UV_PYTHON_INSTALL_DIR`) before the probes — their network path becomes a no-op |
| repository | fresh: copy payload clone (.git kept — checkout stays git-shaped, eject stays cheap). existing: file-protocol `git fetch` + `checkout -B main` + hard reset, fully offline |
| python-deps | `uv sync --frozen --offline --no-index --find-links wheels/` |
| node-deps | untar `js-prebuilt.tar.zst` (prebuilt ui-tui/web_dist + node_modules) — npm never runs |
| complete / bootstrap-marker | write `.hermes-install.json`: bundled/stable/adopted from a payload, source/main otherwise |

**The eject contract lands here (both scripts):** the repository stage refuses to overwrite a checkout whose manifest says `installMode: source` — reports satisfied and leaves the user's checkout alone — and an `ejected` manifest is never overwritten at completion. Stage names and the JSON frame protocol are untouched, so the desktop bootstrap-runner drives these stages unchanged.

## Test plan
- [x] 13 E2E tests (`tests/test_install_sh_payload_dir.py`), real git fixtures + real extracted shell functions, incl.: fresh materialization is git-shaped at payload HEAD; existing-checkout offline update; **source-managed checkout untouched (user file survives)**; ejected manifest sticky through a payload install; thin stub manifest ⇒ fallback; cross-language contract (shell-written manifest ↔ `hermes_cli.install_manifest` reader).
- [x] Existing install.sh suites green (bootstrap marker, install-method stamp, lockfile churn, no-initial-commit, pythonpath): 15/15.
- [x] `bash -n` + PowerShell 7.6 parser: both scripts syntax-clean.
- install.ps1 payload paths are Windows-runtime-verified only by CI/desktop e2e — mirrored 1:1 from the tested bash logic.