### PR TITLE
fix(desktop): end hands-free voice chat after follow-up idle

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $voicePlayback } from '@/store/voice-playback'
+import { $voiceFollowUpIdleSeconds, DEFAULT_FOLLOW_UP_IDLE_SECONDS } from '@/store/voice-prefs'
 
 import { useVoiceConversation } from './use-voice-conversation'
 
@@ -160,6 +161,7 @@ describe('useVoiceConversation playback rearm', () => {
     cleanup()
     vi.clearAllMocks()
     mocks.resetSpeechMocks()
+    $voiceFollowUpIdleSeconds.set(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
     $voicePlayback.set({
       audioElement: null,
       messageId: null,
@@ -167,6 +169,92 @@ describe('useVoiceConversation playback rearm', () => {
       source: null,
       status: 'idle'
     })
+  })
+
+  it('arms the follow-up idle window from voice.follow_up_idle_seconds', async () => {
+    $voiceFollowUpIdleSeconds.set(45)
+    const hook = renderRearmConversation('reply-idle-cfg', 'Hello back')
+
+    hook.rerender({ enabled: true })
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(1))
+
+    expect(mocks.handle.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idleSilenceMs: 45_000
+      })
+    )
+  })
+
+  it('ends the voice conversation when follow-up idle elapses with no speech', async () => {
+    const onStopWord = vi.fn()
+    mocks.handle.stop.mockResolvedValueOnce({
+      audio: new Blob(['silence'], { type: 'audio/webm' }),
+      heardSpeech: false
+    })
+
+    const hook = renderHook(
+      ({ enabled }) =>
+        useVoiceConversation({
+          busy: false,
+          consumePendingResponse: vi.fn(),
+          enabled,
+          onStopWord,
+          onSubmit: async () => undefined,
+          onTranscribeAudio: async () => 'should not run',
+          pendingResponse: () => null
+        }),
+      { initialProps: { enabled: false } }
+    )
+
+    hook.rerender({ enabled: true })
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      mocks.triggerSilence()
+    })
+
+    await waitFor(() => expect(onStopWord).toHaveBeenCalledTimes(1))
+    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    expect(hook.result.current.status).toBe('idle')
+  })
+
+  it('re-arms after silent idle when follow_up_idle_seconds is 0 (legacy)', async () => {
+    $voiceFollowUpIdleSeconds.set(0)
+    mocks.handle.stop.mockResolvedValueOnce({
+      audio: new Blob(['silence'], { type: 'audio/webm' }),
+      heardSpeech: false
+    })
+
+    const onStopWord = vi.fn()
+    const hook = renderHook(
+      ({ enabled }) =>
+        useVoiceConversation({
+          busy: false,
+          consumePendingResponse: vi.fn(),
+          enabled,
+          onStopWord,
+          onSubmit: async () => undefined,
+          onTranscribeAudio: async () => 'should not run',
+          pendingResponse: () => null
+        }),
+      { initialProps: { enabled: false } }
+    )
+
+    hook.rerender({ enabled: true })
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(1))
+    expect(mocks.handle.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idleSilenceMs: 12_000
+      })
+    )
+
+    await act(async () => {
+      mocks.triggerSilence()
+    })
+
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
+    expect(onStopWord).not.toHaveBeenCalled()
+    expect(hook.result.current.status).toBe('listening')
   })
 
   it('re-arms the microphone after normal streaming playback completes', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
@@ -185,6 +185,55 @@ describe('useVoiceConversation playback rearm', () => {
     )
   })
 
+  it('does not let a short follow-up idle window truncate an in-progress listen', async () => {
+    // Reviewer finding on #79574: voice.follow_up_idle_seconds must only govern
+    // the no-speech follow-up window (idleSilenceMs, handled by useMicRecorder),
+    // never the hard cap on an already-in-progress listen/utterance. A short
+    // idle setting (5s here) must not cut off active speech before the
+    // independent per-listen turn timeout (60s) elapses.
+    vi.useFakeTimers()
+
+    try {
+      $voiceFollowUpIdleSeconds.set(5)
+
+      const hook = renderHook(
+        ({ enabled }) =>
+          useVoiceConversation({
+            busy: false,
+            consumePendingResponse: vi.fn(),
+            enabled,
+            onSubmit: async () => undefined,
+            onTranscribeAudio: async () => 'still talking',
+            pendingResponse: () => null
+          }),
+        { initialProps: { enabled: false } }
+      )
+
+      hook.rerender({ enabled: true })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+      // The follow-up idle setting still reaches the mic recorder's own
+      // no-speech detector...
+      expect(mocks.handle.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idleSilenceMs: 5_000
+        })
+      )
+
+      // ...but it must NOT shrink the per-listen turn timeout. At the 5s mark
+      // (the configured follow-up idle) the listen must still be alive — no
+      // forced stop/transcribe of the in-progress utterance.
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(mocks.handle.stop).not.toHaveBeenCalled()
+
+      // The independent hard cap (60s) still protects against a stuck listen.
+      await vi.advanceTimersByTimeAsync(55_000)
+      expect(mocks.handle.stop).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('ends the voice conversation when follow-up idle elapses with no speech', async () => {
     const onStopWord = vi.fn()
     mocks.handle.stop.mockResolvedValueOnce({
@@ -226,6 +275,7 @@ describe('useVoiceConversation playback rearm', () => {
     })
 
     const onStopWord = vi.fn()
+
     const hook = renderHook(
       ({ enabled }) =>
         useVoiceConversation({

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -13,6 +13,7 @@ import {
 import { isVoiceStopCommand } from '@/lib/voice-stop-word'
 import { notify, notifyError } from '@/store/notifications'
 import { $voicePlayback } from '@/store/voice-playback'
+import { $voiceFollowUpIdleSeconds } from '@/store/voice-prefs'
 
 import { useMicRecorder } from './use-mic-recorder'
 
@@ -44,6 +45,13 @@ interface VoiceConversationOptions {
 /** How long a barge-triggered interrupt may take to settle before we submit
  *  the captured utterance anyway. */
 const INTERRUPT_SETTLE_TIMEOUT_MS = 5_000
+
+/** Legacy no-speech cycle length when `voice.follow_up_idle_seconds` is 0
+ *  (always-rearm mode). */
+const LEGACY_IDLE_SILENCE_MS = 12_000
+
+/** Hard cap on a single listen cycle when follow-up idle is disabled. */
+const LEGACY_TURN_TIMEOUT_MS = 60_000
 
 export function useVoiceConversation({
   busy,
@@ -147,8 +155,22 @@ export function useVoiceConversation({
 
       try {
         const result = await handle.stop()
+        const followUpIdleSeconds = $voiceFollowUpIdleSeconds.get()
+        const endOnIdle = followUpIdleSeconds > 0
 
+        // No speech in the follow-up window (or mic unavailable). With
+        // voice.follow_up_idle_seconds > 0, end the voice conversation so a
+        // hands-free multi-turn loop can't stay armed forever. With 0, keep
+        // the legacy always-rearm behavior.
         if (!result || (!result.heardSpeech && !forceTranscribe) || !onTranscribeAudio) {
+          if (endOnIdle) {
+            dropSpeechSession()
+            setStatus('idle')
+            onStopWordRef.current?.()
+
+            return
+          }
+
           if (enabledRef.current && !mutedRef.current && !busyRef.current && statusRef.current !== 'speaking') {
             pendingStartRef.current = true
           }
@@ -162,7 +184,10 @@ export function useVoiceConversation({
           const transcript = (await onTranscribeAudio(result.audio)).trim()
 
           if (!transcript) {
-            if (enabledRef.current) {
+            // Speech energy was detected but STT returned nothing — give one
+            // more listen cycle rather than killing the conversation on a
+            // transcription miss.
+            if (enabledRef.current && !mutedRef.current && !busyRef.current) {
               pendingStartRef.current = true
             }
 
@@ -233,11 +258,18 @@ export function useVoiceConversation({
     }
 
     try {
-      // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
+      // Follow-up window from voice.follow_up_idle_seconds. When > 0, wait that
+      // long for the user to start speaking; no speech ends the conversation
+      // in handleTurn. When 0, keep the legacy short idle cycle + always-rearm.
+      const followUpIdleSeconds = $voiceFollowUpIdleSeconds.get()
+      const followUpIdleMs = followUpIdleSeconds > 0 ? Math.round(followUpIdleSeconds * 1000) : 0
+      const idleSilenceMs = followUpIdleMs > 0 ? followUpIdleMs : LEGACY_IDLE_SILENCE_MS
+      const turnTimeoutMs = followUpIdleMs > 0 ? followUpIdleMs : LEGACY_TURN_TIMEOUT_MS
+
       await handle.start({
         silenceLevel: 0.075,
         silenceMs: 1_250,
-        idleSilenceMs: 12_000,
+        idleSilenceMs,
         onError: error => {
           notifyError(error, voiceCopy.microphoneFailed)
           pendingStartRef.current = false
@@ -246,13 +278,10 @@ export function useVoiceConversation({
         onSilence: () => void handleTurn()
       })
       setStatus('listening')
-      // Clear any prior turn-timeout before arming a fresh one. Each listen
-      // cycle reassigns turnTimeoutRef; without clearing first, a stale 60s
-      // timer from an earlier cycle survives and later fires handleTurn() in
-      // the middle of a new listen, cutting it short (or, after enough idle
-      // re-listens, wedging the loop into a state it doesn't re-arm from).
+      // Clear any prior turn-timeout before arming a fresh one so a stale timer
+      // can't fire mid-listen after a re-arm.
       clearTurnTimeout()
-      turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), 60_000)
+      turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), turnTimeoutMs)
     } catch (error) {
       notifyError(error, voiceCopy.couldNotStartSession)
       pendingStartRef.current = false

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -50,8 +50,18 @@ const INTERRUPT_SETTLE_TIMEOUT_MS = 5_000
  *  (always-rearm mode). */
 const LEGACY_IDLE_SILENCE_MS = 12_000
 
-/** Hard cap on a single listen cycle when follow-up idle is disabled. */
-const LEGACY_TURN_TIMEOUT_MS = 60_000
+/**
+ * Hard cap on a single listen cycle, independent of `voice.follow_up_idle_seconds`.
+ *
+ * This bounds how long one in-progress listen (mic capture of the user's live
+ * utterance) may run before we force-stop and transcribe whatever was
+ * captured — it protects against a stuck/never-silent mic, not against the
+ * user taking a while to start talking. `follow_up_idle_seconds` governs a
+ * *different* thing (how long to wait for speech to begin before ending the
+ * conversation) and must never shrink this cap: doing so would let a short
+ * follow-up idle setting truncate an utterance that's still being spoken.
+ */
+const TURN_TIMEOUT_MS = 60_000
 
 export function useVoiceConversation({
   busy,
@@ -261,10 +271,12 @@ export function useVoiceConversation({
       // Follow-up window from voice.follow_up_idle_seconds. When > 0, wait that
       // long for the user to start speaking; no speech ends the conversation
       // in handleTurn. When 0, keep the legacy short idle cycle + always-rearm.
+      // The per-listen turn timeout (TURN_TIMEOUT_MS) is intentionally NOT
+      // derived from follow-up idle: it bounds an in-progress utterance, and a
+      // short follow_up_idle_seconds must not truncate active speech.
       const followUpIdleSeconds = $voiceFollowUpIdleSeconds.get()
       const followUpIdleMs = followUpIdleSeconds > 0 ? Math.round(followUpIdleSeconds * 1000) : 0
       const idleSilenceMs = followUpIdleMs > 0 ? followUpIdleMs : LEGACY_IDLE_SILENCE_MS
-      const turnTimeoutMs = followUpIdleMs > 0 ? followUpIdleMs : LEGACY_TURN_TIMEOUT_MS
 
       await handle.start({
         silenceLevel: 0.075,
@@ -281,7 +293,7 @@ export function useVoiceConversation({
       // Clear any prior turn-timeout before arming a fresh one so a stale timer
       // can't fire mid-listen after a re-arm.
       clearTurnTimeout()
-      turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), turnTimeoutMs)
+      turnTimeoutRef.current = window.setTimeout(() => void handleTurn(), TURN_TIMEOUT_MS)
     } catch (error) {
       notifyError(error, voiceCopy.couldNotStartSession)
       pendingStartRef.current = false

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -18,6 +18,7 @@ import {
 } from '@/store/session'
 import {
   applyAutoSpeakFromConfig,
+  applyFollowUpIdleFromConfig,
   applyThinkingSoundFromConfig,
   applyVoiceStopPhraseFromConfig
 } from '@/store/voice-prefs'
@@ -147,6 +148,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         applyAutoSpeakFromConfig(config)
         applyVoiceStopPhraseFromConfig(config)
         applyThinkingSoundFromConfig(config)
+        applyFollowUpIdleFromConfig(config)
       } catch {
         // Config is nice-to-have; chat still works without it.
       }

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -17,6 +17,7 @@ import {
 } from '@/store/session'
 import {
   applyAutoSpeakFromConfig,
+  applyFollowUpIdleFromConfig,
   applyThinkingSoundFromConfig,
   applyVoiceStopPhraseFromConfig
 } from '@/store/voice-prefs'
@@ -113,6 +114,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         applyAutoSpeakFromConfig(config)
         applyVoiceStopPhraseFromConfig(config)
         applyThinkingSoundFromConfig(config)
+        applyFollowUpIdleFromConfig(config)
       } catch {
         // Config is nice-to-have; chat still works without it.
       }

--- a/apps/desktop/src/store/voice-prefs.test.ts
+++ b/apps/desktop/src/store/voice-prefs.test.ts
@@ -5,7 +5,14 @@ vi.mock('@/hermes', () => ({
   saveHermesConfig: vi.fn(async () => undefined)
 }))
 
-import { $voiceStopPhrase, applyVoiceStopPhraseFromConfig } from './voice-prefs'
+import {
+  $voiceFollowUpIdleSeconds,
+  $voiceStopPhrase,
+  applyFollowUpIdleFromConfig,
+  applyVoiceStopPhraseFromConfig,
+  DEFAULT_FOLLOW_UP_IDLE_SECONDS,
+  parseFollowUpIdleSeconds
+} from './voice-prefs'
 
 describe('applyVoiceStopPhraseFromConfig', () => {
   it('defaults to "stop" when the key is absent (backend default applies)', () => {
@@ -34,5 +41,30 @@ describe('applyVoiceStopPhraseFromConfig', () => {
   it('malformed entries are skipped; all-blank list disables', () => {
     applyVoiceStopPhraseFromConfig({ voice: { stop_phrases: ['  ', ''] } })
     expect($voiceStopPhrase.get()).toBeNull()
+  })
+})
+
+describe('parseFollowUpIdleSeconds / applyFollowUpIdleFromConfig', () => {
+  it('defaults to 60 seconds when the key is absent', () => {
+    expect(parseFollowUpIdleSeconds(undefined)).toBe(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
+    applyFollowUpIdleFromConfig({ voice: {} })
+    expect($voiceFollowUpIdleSeconds.get()).toBe(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
+  })
+
+  it('accepts 0 as the legacy always-rearm mode', () => {
+    expect(parseFollowUpIdleSeconds(0)).toBe(0)
+    applyFollowUpIdleFromConfig({ voice: { follow_up_idle_seconds: 0 } })
+    expect($voiceFollowUpIdleSeconds.get()).toBe(0)
+  })
+
+  it('accepts a custom positive window', () => {
+    applyFollowUpIdleFromConfig({ voice: { follow_up_idle_seconds: 90 } })
+    expect($voiceFollowUpIdleSeconds.get()).toBe(90)
+  })
+
+  it('falls back to the default for negative or non-numeric values', () => {
+    expect(parseFollowUpIdleSeconds(-1)).toBe(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
+    expect(parseFollowUpIdleSeconds('nope')).toBe(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
+    expect(parseFollowUpIdleSeconds(Number.NaN)).toBe(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
   })
 })

--- a/apps/desktop/src/store/voice-prefs.ts
+++ b/apps/desktop/src/store/voice-prefs.ts
@@ -48,6 +48,35 @@ export function applyThinkingSoundFromConfig(
   $thinkingSoundEnabled.set(config?.voice?.thinking_sound !== false)
 }
 
+// `voice.follow_up_idle_seconds` — how long a desktop hands-free voice chat
+// waits for the next utterance after the agent speaks. No speech ends the
+// voice conversation so multi-turn can't stay armed forever. 0 keeps the
+// legacy always-rearm loop. Default 60 matches config_defaults.
+export const DEFAULT_FOLLOW_UP_IDLE_SECONDS = 60
+export const $voiceFollowUpIdleSeconds = atom<number>(DEFAULT_FOLLOW_UP_IDLE_SECONDS)
+
+/** Normalize a config value to a non-negative finite number of seconds. */
+export function parseFollowUpIdleSeconds(raw: unknown): number {
+  if (raw === undefined || raw === null || raw === '') {
+    return DEFAULT_FOLLOW_UP_IDLE_SECONDS
+  }
+
+  const value = typeof raw === 'number' ? raw : Number(raw)
+
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_FOLLOW_UP_IDLE_SECONDS
+  }
+
+  return value
+}
+
+/** Seed the follow-up idle window from a loaded config payload. */
+export function applyFollowUpIdleFromConfig(
+  config: { voice?: { follow_up_idle_seconds?: unknown } | null } | null | undefined
+) {
+  $voiceFollowUpIdleSeconds.set(parseFollowUpIdleSeconds(config?.voice?.follow_up_idle_seconds))
+}
+
 /**
  * Flip the preference and persist it. Optimistic — the atom updates instantly and
  * reverts if the config write fails. Read-modify-writes the whole record (the

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -350,6 +350,7 @@ export interface HermesConfig {
     auto_tts?: boolean
     stop_phrases?: unknown
     thinking_sound?: unknown
+    follow_up_idle_seconds?: number
   }
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -349,6 +349,7 @@ export interface HermesConfig {
     auto_tts?: boolean
     stop_phrases?: unknown
     thinking_sound?: unknown
+    follow_up_idle_seconds?: number
   }
 }
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1568,6 +1568,11 @@ DEFAULT_CONFIG = {
         # voice chat instead of being sent to the agent. Case-insensitive,
         # surrounding punctuation ignored. Set [] to disable.
         "stop_phrases": ["stop"],
+        # Desktop hands-free multi-turn: seconds to wait for the user to start
+        # speaking after the agent finishes. No speech in this window ends the
+        # voice conversation (wake word can start a new one). 0 = legacy
+        # always-rearm behavior. Does not affect messaging session_reset.
+        "follow_up_idle_seconds": 60,
     },
 
     # "Hey Hermes" hands-free wake word. Always-on, on-device hotword

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2017,6 +2017,11 @@ DEFAULT_CONFIG = {
         # voice chat instead of being sent to the agent. Case-insensitive,
         # surrounding punctuation ignored. Set [] to disable.
         "stop_phrases": ["stop"],
+        # Desktop hands-free multi-turn: seconds to wait for the user to start
+        # speaking after the agent finishes. No speech in this window ends the
+        # voice conversation (wake word can start a new one). 0 = legacy
+        # always-rearm behavior. Does not affect messaging session_reset.
+        "follow_up_idle_seconds": 60,
     },
 
     # "Hey Hermes" hands-free wake word. Always-on, on-device hotword

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1887,6 +1887,7 @@ voice:
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
+  follow_up_idle_seconds: 60    # Desktop hands-free: end voice chat if no speech starts in this window; 0 = always re-arm
 ```
 
 Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2187,6 +2187,7 @@ voice:
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
+  follow_up_idle_seconds: 60    # Desktop hands-free: end voice chat if no speech starts in this window; 0 = always re-arm
 ```
 
 Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -161,7 +161,9 @@ Both `silence_threshold` and `silence_duration` are configurable in `config.yaml
 
 ### Ending a voice chat by voice
 
-Say **"stop"** — and nothing else — to end the voice conversation hands-free. The match is deliberately strict: the whole utterance (case-insensitive, surrounding punctuation ignored) must equal a configured phrase, so "stop doing that and try X instead" still reaches the agent normally. Customize the phrase list with `voice.stop_phrases` in `config.yaml` (e.g. `["stop", "goodbye hermes"]`), or set it to `[]` to disable. A voice chat also ends on its own after three consecutive silent cycles (no speech detected).
+Say **"stop"** — and nothing else — to end the voice conversation hands-free. The match is deliberately strict: the whole utterance (case-insensitive, surrounding punctuation ignored) must equal a configured phrase, so "stop doing that and try X instead" still reaches the agent normally. Customize the phrase list with `voice.stop_phrases` in `config.yaml` (e.g. `["stop", "goodbye hermes"]`), or set it to `[]` to disable.
+
+On **desktop**, a hands-free multi-turn voice chat also ends on its own if you do not start speaking within `voice.follow_up_idle_seconds` (default **60**) after the agent finishes. That closes only the voice conversation — it does not reset messaging sessions — and the wake word can start a new one. Set `voice.follow_up_idle_seconds: 0` to keep the legacy always-rearm loop. On **CLI**, a voice chat still ends after three consecutive silent cycles (no speech detected).
 
 **Typing** a bare stop phrase while a voice chat is active works the same way on every surface (CLI, TUI, desktop): the message ends the voice chat instead of being sent to the agent. Outside a voice chat, typed "stop" is an ordinary message.
 
@@ -416,6 +418,7 @@ voice:
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop
   stop_phrases: ["stop"]           # Saying exactly one of these ends the voice chat; [] disables
+  follow_up_idle_seconds: 60       # Desktop: end multi-turn voice chat if no speech starts in this window; 0 = always re-arm
 
 # Speech-to-Text
 stt:

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -161,7 +161,9 @@ Both `silence_threshold` and `silence_duration` are configurable in `config.yaml
 
 ### Ending a voice chat by voice
 
-Say **"stop"** — and nothing else — to end the voice conversation hands-free. The match is deliberately strict: the whole utterance (case-insensitive, surrounding punctuation ignored) must equal a configured phrase, so "stop doing that and try X instead" still reaches the agent normally. Customize the phrase list with `voice.stop_phrases` in `config.yaml` (e.g. `["stop", "goodbye hermes"]`), or set it to `[]` to disable. A voice chat also ends on its own after three consecutive silent cycles (no speech detected).
+Say **"stop"** — and nothing else — to end the voice conversation hands-free. The match is deliberately strict: the whole utterance (case-insensitive, surrounding punctuation ignored) must equal a configured phrase, so "stop doing that and try X instead" still reaches the agent normally. Customize the phrase list with `voice.stop_phrases` in `config.yaml` (e.g. `["stop", "goodbye hermes"]`), or set it to `[]` to disable.
+
+On **desktop**, a hands-free multi-turn voice chat also ends on its own if you do not start speaking within `voice.follow_up_idle_seconds` (default **60**) after the agent finishes. That closes only the voice conversation — it does not reset messaging sessions — and the wake word can start a new one. Set `voice.follow_up_idle_seconds: 0` to keep the legacy always-rearm loop. On **CLI**, a voice chat still ends after three consecutive silent cycles (no speech detected).
 
 **Typing** a bare stop phrase while a voice chat is active works the same way on every surface (CLI, TUI, desktop): the message ends the voice chat instead of being sent to the agent. Outside a voice chat, typed "stop" is an ordinary message.
 
@@ -434,6 +436,7 @@ voice:
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop
   stop_phrases: ["stop"]           # Saying exactly one of these ends the voice chat; [] disables
+  follow_up_idle_seconds: 60       # Desktop: end multi-turn voice chat if no speech starts in this window; 0 = always re-arm
 
 # Speech-to-Text
 stt:


### PR DESCRIPTION
## Summary
Desktop hands-free multi-turn voice chats re-armed the mic forever after silence, so a wake-word session could keep listening unintentionally.

This adds `voice.follow_up_idle_seconds` (default `60`):
- after the agent finishes speaking, wait that long for the user to start talking
- no speech ends only the voice conversation (wake word can start again)
- `0` keeps the legacy always-rearm loop
- does not touch messaging `session_reset`

## Test plan
- [x] `vitest` desktop UI: `voice-prefs.test.ts` + `use-voice-conversation-rearm.test.tsx` (17 tests)
- [ ] Wake → one turn → stay silent for 60s → voice chat ends, wake still works
- [ ] Wake → reply within the window → multi-turn continues
- [ ] `voice.follow_up_idle_seconds: 0` keeps always-rearm
- [ ] Empty STT after speech energy still retries one listen cycle
- [ ] Telegram/Discord session idle behavior unchanged

## Config
```yaml
voice:
  follow_up_idle_seconds: 60  # desktop; 0 = legacy
```