### PR TITLE
feat(buzz): implement edit_message and delete_message so replies can stream

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -664,6 +664,81 @@ class BuzzAdapter(BasePlatformAdapter):
             return False
         return True
 
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Edit a previously sent message.
+
+        Implementing this is what lets the gateway stream a reply on Buzz: the
+        stream consumer sends a first partial message and then re-edits that one
+        message as tokens arrive.  Without it the adapter inherits the base
+        stub, which returns ``success=False``, and the whole answer is delivered
+        in one block when the turn finishes.
+
+        ``buzz-cli`` reports a NEW event id for the edit itself, but the edit
+        TARGET stays the original id, and the stream consumer holds a single
+        ``message_id`` across the whole stream.  So this returns the id it was
+        given, not the one the CLI reports; returning the CLI's id would make
+        every edit after the first address a message that was never sent.
+
+        ``finalize`` is a no-op here.  Buzz edits carry no lifecycle state, the
+        same as Telegram, Slack and Discord.
+        """
+        if not message_id:
+            return SendResult(success=False, error="Buzz edit needs a message id")
+        if not content:
+            return SendResult(success=False, error="Empty message")
+        args = ["messages", "edit", "--event", str(message_id), "--content", "-"]
+        code, out, err = await self._run_cli(args, input_text=content)
+        if code != 0:
+            return SendResult(
+                success=False,
+                error=_cli_error_message(err, code),
+                retryable=code == 2,
+            )
+        try:
+            data = json.loads(out or "{}")
+        except ValueError:
+            data = {}
+        edit_event_id = data.get("event_id")
+        if edit_event_id:
+            # The edit is itself an event on the relay and comes back on our own
+            # subscription; mark it seen so the de-dupe does not treat our own
+            # edit as inbound traffic.
+            self._mark_seen(str(chat_id), str(edit_event_id))
+        return SendResult(
+            success=bool(data.get("accepted", True)),
+            message_id=str(message_id),
+            raw_response=data,
+        )
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent message.
+
+        Used by the stream consumer's fresh-final cleanup path, which replaces a
+        long-lived preview with a completed reply rather than editing in place.
+        """
+        if not message_id:
+            return False
+        code, out, _err = await self._run_cli(
+            ["messages", "delete", "--event", str(message_id)]
+        )
+        if code != 0:
+            return False
+        try:
+            data = json.loads(out or "{}")
+        except ValueError:
+            return True
+        event_id = data.get("event_id")
+        if event_id:
+            self._mark_seen(str(chat_id), str(event_id))
+        return bool(data.get("accepted", True))
+
     async def send_image(
         self,
         chat_id: str,

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -538,3 +538,131 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+# ── Editing and deleting (streaming) ──────────────────────────────────
+
+
+class TestBuzzAdapterEdit:
+
+    @pytest.mark.asyncio
+    async def test_edit_targets_the_original_event_and_uses_stdin(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "partial answer")
+        assert result.success is True
+
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "edit"]
+        assert args[args.index("--event") + 1] == "orig1"
+        # Content travels via stdin (--content -), never argv, same as send
+        assert args[args.index("--content") + 1] == "-"
+        assert stdin_text == "partial answer"
+
+    @pytest.mark.asyncio
+    async def test_edit_returns_the_original_id_not_the_cli_event_id(self):
+        """The stream consumer re-edits ONE message id for the whole stream.
+
+        buzz-cli reports a fresh event id for each edit; returning that would
+        make the second edit address a message that was never sent.
+        """
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1"})
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert result.message_id == "orig1"
+
+    @pytest.mark.asyncio
+    async def test_edit_marks_its_own_event_seen(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1"})
+        adapter._run_cli = cli
+
+        await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert "edit1" in adapter._channel_state[CHANNEL]["seen"]
+
+    @pytest.mark.asyncio
+    async def test_edit_accepts_finalize_without_changing_behaviour(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", {"accepted": True, "event_id": "edit1"})
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "text", finalize=True)
+        assert result.success is True
+        assert len(cli.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_edit_without_a_message_id_never_calls_the_cli(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "", "text")
+        assert result.success is False
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_edit_with_empty_content_never_calls_the_cli(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        result = await adapter.edit_message(CHANNEL, "orig1", "")
+        assert result.success is False
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_edit_relay_error_is_retryable_but_bad_input_is_not(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", "", code=2, stderr="relay unreachable")
+        adapter._run_cli = cli
+        relay_failure = await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert relay_failure.success is False
+        assert relay_failure.retryable is True
+
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "edit", "", code=1, stderr="bad input")
+        adapter._run_cli = cli
+        input_failure = await adapter.edit_message(CHANNEL, "orig1", "text")
+        assert input_failure.success is False
+        assert input_failure.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_delete_targets_the_event(self):
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "delete", {"accepted": True, "event_id": "del1"})
+        adapter._run_cli = cli
+
+        assert await adapter.delete_message(CHANNEL, "orig1") is True
+        assert cli.calls[0][0] == ["messages", "delete", "--event", "orig1"]
+
+    @pytest.mark.asyncio
+    async def test_delete_failure_returns_false(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "delete", "", code=2, stderr="relay unreachable")
+        adapter._run_cli = cli
+
+        assert await adapter.delete_message(CHANNEL, "orig1") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_without_a_message_id_never_calls_the_cli(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        assert await adapter.delete_message(CHANNEL, "") is False
+        assert cli.calls == []


### PR DESCRIPTION
## What

Implements `edit_message` and `delete_message` on the Buzz platform adapter.

## Why

The gateway already streams. Its consumer sends a first partial message and re-edits that message as tokens arrive, falling back to the `send` + `edit_message` path when an adapter does not support native drafts (`gateway/platforms/base.py`: "Stream consumers fall back to the edit-based path").

The Buzz adapter never implemented `edit_message`, so it inherited the base stub that returns `success=False, error="Not supported"`. The result is that a Buzz reply arrives as one block when the turn finishes, however long the turn took. On a slow model that is a minute of silence and then a wall of text.

`buzz-cli` already exposes `messages edit` and `messages delete`, so no new mechanism, dependency, config key or env var is needed.

## The detail worth reviewing

`buzz-cli` reports a **new** event id for each edit, but the edit **target** stays the original id, and the stream consumer holds a single `message_id` for the whole stream.

So `edit_message` returns the id it was **given**, not the one the CLI reports. Returning the CLI's id would make every edit after the first address a message that was never sent, and the stream would appear to stop updating after one token. This is called out in the docstring so it does not get "cleaned up" later.

`delete_message` is included because the consumer's fresh-final cleanup path calls it when it replaces a preview rather than editing in place.

## How tested

Ten new cases in `tests/gateway/test_buzz_adapter.py`, in the existing `_ScriptedCli` idiom:

- the edit targets the original event id, and content travels via stdin (`--content -`), never argv, matching `send`
- the returned `message_id` is the original, not the CLI's new event id
- the adapter's own edit event is marked seen, so echo suppression still holds
- `finalize=True` is accepted and inert, matching Telegram, Slack and Discord
- an empty `message_id` and an empty `content` each fail without invoking the CLI at all
- exit 2 is retryable, exit 1 is not
- delete targets the event, reports failure, and no-ops without an id

```
tests/gateway/test_buzz_adapter.py .................................  33 passed
tests/gateway/test_buzz_adapter.py + test_buzz_websocket.py           37 passed
```

Negative control: reverting only the adapter change while keeping the tests takes the file from 33 passed to **6 failed, 27 passed**, so the tests genuinely exercise the new code rather than passing vacuously.

## Platforms

Buzz only. No other adapter is touched, and the change is inert for anyone not running Buzz.

## Note

Found while running a self-hosted Buzz relay with a Hermes gateway. Happy to adjust the shape if maintainers would rather this went through `supports_draft_streaming` / `send_draft` instead of the edit path.
