### PR TITLE
fix(ollama): probe /api/show under the model's full tag for :cloud models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3797,8 +3797,19 @@ def ollama_model_supports_thinking(
     if not server_url:
         return None
 
-    bare_model = _strip_ollama_cloud_suffix((model or "").strip())
-    if not bare_model:
+    # Try the model id as configured FIRST, then the :cloud-stripped form.
+    # A local Ollama serving a Cloud model registers it under the full tag, so
+    # asking for the bare name makes the daemon look up "<model>:latest" and
+    # answer 404 — which used to be indistinguishable from "no thinking cap"
+    # and silently suppressed reasoning for every glm-*/kimi-*:cloud model.
+    # The stripped form stays in the list because models.dev-sourced ids can
+    # carry a :cloud suffix the server itself does not know.
+    requested = (model or "").strip()
+    candidates = []
+    for name in (requested, _strip_ollama_cloud_suffix(requested)):
+        if name and name not in candidates:
+            candidates.append(name)
+    if not candidates:
         return None
 
     token = str(api_key or "").strip()
@@ -3806,12 +3817,13 @@ def ollama_model_supports_thinking(
 
     try:
         with httpx.Client(timeout=timeout, headers=headers) as client:
-            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
-            if resp.status_code != 200:
-                return None
-            caps = resp.json().get("capabilities")
-            if isinstance(caps, list):
-                return "thinking" in caps
+            for name in candidates:
+                resp = client.post(f"{server_url}/api/show", json={"name": name})
+                if resp.status_code != 200:
+                    continue
+                caps = resp.json().get("capabilities")
+                if isinstance(caps, list):
+                    return "thinking" in caps
     except Exception:
         return None
     return None

--- a/tests/plugins/model_providers/test_ollama_cloud_profile.py
+++ b/tests/plugins/model_providers/test_ollama_cloud_profile.py
@@ -216,6 +216,103 @@ class TestOllamaModelSupportsThinking:
             ollama_model_supports_thinking("x", "https://ollama.com/v1", "key") is None
         )
 
+    def test_cloud_suffix_model_is_probed_under_its_full_tag(self, monkeypatch):
+        """A :cloud model must not be probed by its stripped name only.
+
+        Ollama registers a Cloud model under the full tag, so asking for the
+        bare name makes the daemon look up "<model>:latest" and answer 404 —
+        indistinguishable from "no thinking capability". That silently
+        disabled reasoning for every glm-*/kimi-*:cloud model even though
+        they advertise ["thinking", "completion", "tools"].
+        """
+        import httpx
+
+        from hermes_cli.models import ollama_model_supports_thinking
+
+        asked = []
+
+        class _Resp:
+            def __init__(self, status, payload):
+                self.status_code = status
+                self._payload = payload
+
+            def json(self):
+                return self._payload
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def post(self, url, json=None, **k):
+                name = (json or {}).get("name")
+                asked.append(name)
+                if name == "glm-5.2:cloud":
+                    return _Resp(200, {"capabilities": ["thinking", "completion", "tools"]})
+                return _Resp(404, {"error": "model 'glm-5.2:latest' not found"})
+
+        monkeypatch.setattr(httpx, "Client", _Client)
+
+        assert (
+            ollama_model_supports_thinking(
+                "glm-5.2:cloud", "https://ollama.com/v1", "key"
+            )
+            is True
+        )
+        assert "glm-5.2:cloud" in asked
+
+    def test_stripped_name_still_probed_when_full_tag_unknown(self, monkeypatch):
+        """models.dev ids can carry a :cloud suffix the server does not know.
+
+        The stripped form must stay in the candidate list, otherwise this
+        fix would trade one blind spot for another.
+        """
+        import httpx
+
+        from hermes_cli.models import ollama_model_supports_thinking
+
+        asked = []
+
+        class _Resp:
+            def __init__(self, status, payload):
+                self.status_code = status
+                self._payload = payload
+
+            def json(self):
+                return self._payload
+
+        class _Client:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def post(self, url, json=None, **k):
+                name = (json or {}).get("name")
+                asked.append(name)
+                if name == "kimi-k2.6":
+                    return _Resp(200, {"capabilities": ["thinking", "completion"]})
+                return _Resp(404, {"error": "not found"})
+
+        monkeypatch.setattr(httpx, "Client", _Client)
+
+        assert (
+            ollama_model_supports_thinking(
+                "kimi-k2.6:cloud", "https://ollama.com/v1", "key"
+            )
+            is True
+        )
+        assert asked == ["kimi-k2.6:cloud", "kimi-k2.6"]
+
     def test_exception_returns_none(self, monkeypatch):
         from hermes_cli.models import ollama_model_supports_thinking
 


### PR DESCRIPTION
## What does this PR do?

`ollama_model_supports_thinking()` strips the `:cloud` suffix before calling `/api/show`. A local Ollama registers a Cloud model under its **full tag**, so the daemon resolves the bare name to `"<model>:latest"` and answers 404:

```console
$ curl -s localhost:11434/api/show -d '{"name":"glm-5.2"}'
{"error":"model 'glm-5.2:latest' not found"}          # HTTP 404

$ curl -s localhost:11434/api/show -d '{"name":"glm-5.2:cloud"}'
{"capabilities":["thinking","completion","tools"]}    # HTTP 200
```

The probe treats any non-200 as an unusable answer and returns `None`, which callers read as *"no thinking capability"*. Reasoning was therefore suppressed for every `glm-*`/`kimi-*:cloud` model that in fact advertises it — and because the failure mode is a silent `None` rather than an error, nothing surfaces to the user.

The fix tries the model id **as configured** first, then the stripped form. The stripped candidate is deliberately kept: models.dev-sourced ids can carry a `:cloud` suffix the server itself does not know, so neither spelling regresses.

## Related Issue

No existing issue — found while debugging why `agent.reasoning_effort` had no effect with `glm-5.2:cloud` on a local daemon.

Related but distinct (deliberately **not** duplicated here):

- #70022 / #70023 — oneshot never resolves `reasoning_config`. Different layer (`hermes_cli/oneshot.py`); #70023 already covers it.
- #71299 — `_supports_reasoning_extra_body()` gating for custom providers. Different condition (model-prefix allowlist), same call site downstream of this probe.
- #63315 — capability gating inside the custom provider profile. Complementary: that PR decides *what to do* with capabilities, this one makes the probe return them at all.
- #75872 — closed as redundant; the analysis there (named custom provider resolves to `provider="custom"`, `CustomProfile` already emits top-level `reasoning_effort`) matches what I observed and is what led me to this probe instead.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `ollama_model_supports_thinking()` now probes a candidate list (configured id, then `:cloud`-stripped id) and only gives up when every candidate fails. Non-200 responses `continue` instead of aborting the probe.
- `tests/plugins/model_providers/test_ollama_cloud_profile.py` — two regression tests in `TestOllamaModelSupportsThinking`.

## How to Test

Reproduce the bug (before this patch), with any Ollama Cloud thinking model pulled locally:

1. `curl -s localhost:11434/api/show -d '{"name":"glm-5.2:cloud"}'` → `capabilities` includes `thinking`.
2. `curl -s localhost:11434/api/show -d '{"name":"glm-5.2"}'` → HTTP 404.
3. `python -c "from hermes_cli.models import ollama_model_supports_thinking as p; print(p('glm-5.2:cloud','http://127.0.0.1:11434/v1'))"` → `None` (should be `True`).

After this patch step 3 returns `True`, while models without the capability still return `False`:

```
glm-5.2:cloud          -> True
deepseek-v4-pro:cloud  -> True
gemma2:2b              -> False
qwen2.5-coder:7b       -> False
```

Automated:

```console
pytest tests/plugins/model_providers/test_ollama_cloud_profile.py -q     # 22 passed
pytest tests/ -k "ollama or thinking or reasoning" -q                    # 637 passed, 4 skipped
```

Both new tests fail on the previous implementation, so they pin the regression rather than merely describing it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
