### PR TITLE
fix(tts): honor configured voice for local providers, legacy kittentts compat

### DIFF
--- a/tests/tools/test_tts_kittentts.py
+++ b/tests/tools/test_tts_kittentts.py
@@ -1,6 +1,8 @@
 """Tests for the KittenTTS local provider in tools/tts_tool.py."""
 
 import json
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -129,3 +131,217 @@ class TestDispatcherBranch:
         assert result["success"] is False
         assert "kittentts" in result["error"].lower()
         assert "hermes setup tts" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Voice selection contract (#79459)
+# ---------------------------------------------------------------------------
+
+class TestKittenTtsVoiceSelection:
+    def test_top_level_tts_voice_used_when_no_provider_voice(
+        self, tmp_path, mock_kittentts_module
+    ):
+        """``tts.voice`` (the plugin-dispatch key) must reach kittentts when
+        ``tts.kittentts.voice`` is unset, instead of silently rendering the
+        provider default (#79459)."""
+        from tools.tts_tool import _generate_kittentts
+
+        fake_model, _ = mock_kittentts_module
+        config = {"voice": "Luna"}
+        _generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert fake_model.generate.call_args.kwargs["voice"] == "Luna"
+
+    def test_provider_voice_beats_top_level_voice(self, tmp_path, mock_kittentts_module):
+        from tools.tts_tool import _generate_kittentts
+
+        fake_model, _ = mock_kittentts_module
+        config = {"voice": "Jasper", "kittentts": {"voice": "Luna"}}
+        _generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert fake_model.generate.call_args.kwargs["voice"] == "Luna"
+
+    def test_unknown_voice_raises_with_available_list(self, tmp_path, mock_kittentts_module):
+        """A voice absent from the model's voice table must fail loudly with
+        the valid choices — never silently render a different voice."""
+        from tools.tts_tool import _generate_kittentts
+
+        fake_model, _ = mock_kittentts_module
+        inner = MagicMock()
+        inner.all_voice_names = ["expr-voice-2-f", "expr-voice-2-m"]
+        inner.voice_aliases = {"Jasper": "expr-voice-2-m"}
+        fake_model.model = inner
+
+        config = {"kittentts": {"voice": "Zoltan"}}
+        with pytest.raises(RuntimeError) as excinfo:
+            _generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+
+        msg = str(excinfo.value)
+        assert "Zoltan" in msg
+        assert "expr-voice-2-f" in msg
+        # alias must be accepted as a valid choice too
+        assert "Jasper" in msg
+        fake_model.generate.assert_not_called()
+
+    def test_known_alias_voice_passes_validation(self, tmp_path, mock_kittentts_module):
+        from tools.tts_tool import _generate_kittentts
+
+        fake_model, _ = mock_kittentts_module
+        inner = MagicMock()
+        inner.all_voice_names = ["expr-voice-2-m"]
+        inner.voice_aliases = {"Jasper": "expr-voice-2-m"}
+        fake_model.model = inner
+
+        config = {"kittentts": {"voice": "Jasper"}}
+        _generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert fake_model.generate.call_args.kwargs["voice"] == "Jasper"
+
+
+# ---------------------------------------------------------------------------
+# Legacy library compatibility (#79459): PyPI 0.1.x expects local file
+# paths and has no clean_text kwarg.
+# ---------------------------------------------------------------------------
+
+class _LegacyKittenModel:
+    """Mimics kittentts 0.1.3: ctor takes local paths, generate(text, voice, speed)."""
+
+    instances = []
+
+    def __init__(self, model_path=None, voices_path=None):
+        if model_path is not None and "/" in str(model_path):
+            # ort.InferenceSession on a HF repo id
+            raise RuntimeError(
+                "[ONNXRuntimeError] : 3 : NO_SUCHFILE : Load model from "
+                f"{model_path} failed"
+            )
+        self.model_path = model_path
+        self.voices_path = voices_path
+        self.available_voices = ["expr-voice-2-f", "expr-voice-2-m"]
+        self.last_generate = None
+        _LegacyKittenModel.instances.append(self)
+
+    def generate(self, text, voice="expr-voice-2-m", speed=1.0):
+        self.last_generate = {"text": text, "voice": voice, "speed": speed}
+        return [0.0] * 24000
+
+
+@pytest.fixture
+def legacy_kittentts(monkeypatch):
+    from tools import tts_tool
+
+    _LegacyKittenModel.instances = []
+    monkeypatch.setattr(tts_tool, "_import_kittentts", lambda: _LegacyKittenModel)
+    # Stub soundfile (not installed in CI venv).
+    fake_sf = MagicMock()
+    fake_sf.write = lambda path, audio, samplerate: (
+        __import__("pathlib").Path(path).write_bytes(b"RIFF fake")
+    )
+    monkeypatch.setitem(sys.modules, "soundfile", fake_sf)
+    yield
+
+
+class TestKittenTtsLegacyCompatibility:
+    def test_repo_id_resolved_to_local_paths_for_legacy_library(
+        self, tmp_path, monkeypatch, legacy_kittentts
+    ):
+        """When the installed kittentts cannot handle HF repo ids, hermes
+        resolves the repo via huggingface_hub and passes explicit local
+        paths to the constructor."""
+        from tools import tts_tool
+
+        local_model = tmp_path / "model.onnx"
+        local_voices = tmp_path / "voices.npz"
+        local_model.write_bytes(b"m")
+        local_voices.write_bytes(b"v")
+        monkeypatch.setattr(
+            tts_tool,
+            "_resolve_kittentts_model_files",
+            lambda name: (str(local_model), str(local_voices)),
+        )
+
+        config = {
+            "kittentts": {
+                "model": "KittenML/kitten-tts-nano-0.8-int8",
+                "voice": "expr-voice-2-f",
+            }
+        }
+        result = tts_tool._generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert result == str(tmp_path / "out.wav")
+        inst = _LegacyKittenModel.instances[-1]
+        assert inst.model_path == str(local_model)
+        assert inst.voices_path == str(local_voices)
+        # legacy generate() has no clean_text kwarg — must not receive it
+        assert inst.last_generate["voice"] == "expr-voice-2-f"
+
+    def test_legacy_voice_validation_uses_available_voices_attr(
+        self, tmp_path, monkeypatch, legacy_kittentts
+    ):
+        from tools import tts_tool
+
+        # Let construction succeed via resolved local paths (no "/" in the
+        # fake names so the legacy ctor accepts them), then the voice check
+        # must reject 'Jasper' using the legacy available_voices attribute.
+        monkeypatch.setattr(
+            tts_tool, "_resolve_kittentts_model_files", lambda name: ("model.onnx", "voices.npz")
+        )
+        config = {"kittentts": {"voice": "Jasper"}}  # not in legacy voice table
+        with pytest.raises(RuntimeError) as excinfo:
+            tts_tool._generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+        assert "expr-voice-2-f" in str(excinfo.value)
+
+    def test_unresolvable_failure_surfaces_upgrade_hint(self, monkeypatch):
+        """Constructor failure + impossible resolution = actionable error."""
+        from tools.tts_tool import _construct_kittentts_model
+
+        def broken_ctor(model_name=None, model_path=None, voices_path=None):
+            raise RuntimeError("NO_SUCHFILE")
+
+        monkeypatch.setattr(
+            "tools.tts_tool._resolve_kittentts_model_files", lambda name: None
+        )
+        with pytest.raises(RuntimeError) as excinfo:
+            _construct_kittentts_model(broken_ctor, "KittenML/kitten-tts-nano-0.8-int8")
+        assert "kittentts-0.8.1" in str(excinfo.value)
+
+
+class TestResolveKittenTtsModelFiles:
+    def test_non_repo_name_returns_none(self):
+        from tools.tts_tool import _resolve_kittentts_model_files
+
+        assert _resolve_kittentts_model_files("local-model") is None
+        assert _resolve_kittentts_model_files("") is None
+
+    def test_resolves_repo_layout_via_hf_hub(self, tmp_path, monkeypatch):
+        from tools import tts_tool
+
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps({"type": "ONNX2", "model_file": "model.onnx", "voices": "voices.npz"}),
+            encoding="utf-8",
+        )
+        files = {
+            "config.json": str(config_path),
+            "model.onnx": str(tmp_path / "model.onnx"),
+            "voices.npz": str(tmp_path / "voices.npz"),
+        }
+        fake_hub = types.SimpleNamespace(
+            hf_hub_download=lambda repo_id, filename, **kw: files[filename]
+        )
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+        resolved = tts_tool._resolve_kittentts_model_files("KittenML/kitten-tts-nano-0.8-int8")
+        assert resolved == (str(tmp_path / "model.onnx"), str(tmp_path / "voices.npz"))
+
+    def test_repo_without_model_file_returns_none(self, tmp_path, monkeypatch):
+        from tools import tts_tool
+
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({"type": "unknown"}), encoding="utf-8")
+        fake_hub = types.SimpleNamespace(
+            hf_hub_download=lambda repo_id, filename, **kw: str(config_path)
+        )
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+        assert tts_tool._resolve_kittentts_model_files("KittenML/legacy-model") is None

--- a/tests/tools/test_tts_kittentts.py
+++ b/tests/tools/test_tts_kittentts.py
@@ -232,6 +232,9 @@ def legacy_kittentts(monkeypatch):
 
     _LegacyKittenModel.instances = []
     monkeypatch.setattr(tts_tool, "_import_kittentts", lambda: _LegacyKittenModel)
+    # Reset the module-level model cache so every test constructs through
+    # its own monkeypatched resolution/constructor stubs.
+    monkeypatch.setattr(tts_tool, "_kittentts_model_cache", {})
     # Stub soundfile (not installed in CI venv).
     fake_sf = MagicMock()
     fake_sf.write = lambda path, audio, samplerate: (
@@ -257,7 +260,7 @@ class TestKittenTtsLegacyCompatibility:
         monkeypatch.setattr(
             tts_tool,
             "_resolve_kittentts_model_files",
-            lambda name: (str(local_model), str(local_voices)),
+            lambda name: (str(local_model), str(local_voices), {}),
         )
 
         config = {
@@ -282,14 +285,75 @@ class TestKittenTtsLegacyCompatibility:
 
         # Let construction succeed via resolved local paths (no "/" in the
         # fake names so the legacy ctor accepts them), then the voice check
-        # must reject 'Jasper' using the legacy available_voices attribute.
+        # must reject an explicit 'Jasper' when the resolution carried no
+        # alias metadata.
         monkeypatch.setattr(
-            tts_tool, "_resolve_kittentts_model_files", lambda name: ("model.onnx", "voices.npz")
+            tts_tool,
+            "_resolve_kittentts_model_files",
+            lambda name: ("model.onnx", "voices.npz", {}),
         )
         config = {"kittentts": {"voice": "Jasper"}}  # not in legacy voice table
         with pytest.raises(RuntimeError) as excinfo:
             tts_tool._generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
         assert "expr-voice-2-f" in str(excinfo.value)
+
+    def test_legacy_default_voice_normalized_via_repo_aliases(
+        self, tmp_path, monkeypatch, legacy_kittentts
+    ):
+        """The no-config default (Jasper) must keep working on the legacy
+        0.1.x stack: the repo config.json voice_aliases mapping carried by
+        the HF resolution normalizes it to a raw voice the model accepts,
+        instead of the validation rejecting it (review on #79581)."""
+        from tools import tts_tool
+
+        aliases = {"Jasper": "expr-voice-2-m", "Luna": "expr-voice-2-f"}
+        monkeypatch.setattr(
+            tts_tool,
+            "_resolve_kittentts_model_files",
+            lambda name: ("model.onnx", "voices.npz", aliases),
+        )
+        # No voice configured anywhere -> DEFAULT_KITTENTTS_VOICE (Jasper)
+        result = tts_tool._generate_kittentts("Hi", str(tmp_path / "out.wav"), {})
+
+        assert result == str(tmp_path / "out.wav")
+        inst = _LegacyKittenModel.instances[-1]
+        assert inst.last_generate["voice"] == "expr-voice-2-m"
+
+    def test_legacy_configured_alias_normalized_before_generate(
+        self, tmp_path, monkeypatch, legacy_kittentts
+    ):
+        """An explicitly configured alias voice is normalized too, so users
+        can keep alias names across library versions."""
+        from tools import tts_tool
+
+        aliases = {"Luna": "expr-voice-2-f"}
+        monkeypatch.setattr(
+            tts_tool,
+            "_resolve_kittentts_model_files",
+            lambda name: ("model.onnx", "voices.npz", aliases),
+        )
+        config = {"kittentts": {"voice": "Luna"}}
+        tts_tool._generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+
+        assert _LegacyKittenModel.instances[-1].last_generate["voice"] == "expr-voice-2-f"
+
+    def test_legacy_alias_mapping_to_unknown_voice_still_fails(
+        self, tmp_path, monkeypatch, legacy_kittentts
+    ):
+        """Alias normalization must not mask misconfiguration: an alias whose
+        target is absent from the loaded model still fails loudly."""
+        from tools import tts_tool
+
+        aliases = {"Mystery": "expr-voice-9-z"}  # target not in available_voices
+        monkeypatch.setattr(
+            tts_tool,
+            "_resolve_kittentts_model_files",
+            lambda name: ("model.onnx", "voices.npz", aliases),
+        )
+        config = {"kittentts": {"voice": "Mystery"}}
+        with pytest.raises(RuntimeError) as excinfo:
+            tts_tool._generate_kittentts("Hi", str(tmp_path / "out.wav"), config)
+        assert "expr-voice-9-z" in str(excinfo.value)
 
     def test_unresolvable_failure_surfaces_upgrade_hint(self, monkeypatch):
         """Constructor failure + impossible resolution = actionable error."""
@@ -318,7 +382,14 @@ class TestResolveKittenTtsModelFiles:
 
         config_path = tmp_path / "config.json"
         config_path.write_text(
-            json.dumps({"type": "ONNX2", "model_file": "model.onnx", "voices": "voices.npz"}),
+            json.dumps(
+                {
+                    "type": "ONNX2",
+                    "model_file": "model.onnx",
+                    "voices": "voices.npz",
+                    "voice_aliases": {"Jasper": "expr-voice-2-m", "Empty": ""},
+                }
+            ),
             encoding="utf-8",
         )
         files = {
@@ -332,7 +403,31 @@ class TestResolveKittenTtsModelFiles:
         monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
 
         resolved = tts_tool._resolve_kittentts_model_files("KittenML/kitten-tts-nano-0.8-int8")
-        assert resolved == (str(tmp_path / "model.onnx"), str(tmp_path / "voices.npz"))
+        assert resolved == (
+            str(tmp_path / "model.onnx"),
+            str(tmp_path / "voices.npz"),
+            {"Jasper": "expr-voice-2-m"},  # empty-valued entries dropped
+        )
+
+    def test_resolves_repo_without_aliases_field(self, tmp_path, monkeypatch):
+        from tools import tts_tool
+
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps({"type": "ONNX2", "model_file": "model.onnx"}),
+            encoding="utf-8",
+        )
+        files = {
+            "config.json": str(config_path),
+            "model.onnx": str(tmp_path / "model.onnx"),
+        }
+        fake_hub = types.SimpleNamespace(
+            hf_hub_download=lambda repo_id, filename, **kw: files[filename]
+        )
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+        resolved = tts_tool._resolve_kittentts_model_files("KittenML/legacy-model")
+        assert resolved == (str(tmp_path / "model.onnx"), None, {})
 
     def test_repo_without_model_file_returns_none(self, tmp_path, monkeypatch):
         from tools import tts_tool

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -63,7 +63,7 @@ class TestResolvePiperVoicePath:
 
     def test_empty_voice_falls_back_to_default_name(self, tmp_path):
         (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx").write_bytes(b"model")
-        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}", encoding="utf-8")
         result = _resolve_piper_voice_path("", tmp_path)
         assert result.endswith(f"{DEFAULT_PIPER_VOICE}.onnx")
 
@@ -111,7 +111,7 @@ class TestGeneratePiperTts:
     def _prepare_voice_files(self, tmp_path, voice=DEFAULT_PIPER_VOICE):
         model = tmp_path / f"{voice}.onnx"
         model.write_bytes(b"model")
-        (tmp_path / f"{voice}.onnx.json").write_text("{}")
+        (tmp_path / f"{voice}.onnx.json").write_text("{}", encoding="utf-8")
         return model
 
     def test_loads_voice_and_writes_wav(self, tmp_path, monkeypatch):
@@ -180,6 +180,52 @@ class TestGeneratePiperTts:
         assert _StubPiperVoice.loaded == [str(model)]
 
 
+class TestPiperVoiceSelectionFallback:
+    """Voice resolution contract (#79459): provider key wins, the shared
+    top-level ``tts.voice`` is the fallback, garbage falls back to the
+    default — but never silently substitutes a *different* cached voice."""
+
+    def _prepare_named_voice(self, tmp_path, voice):
+        model = tmp_path / f"{voice}.onnx"
+        model.write_bytes(b"model")
+        (tmp_path / f"{voice}.onnx.json").write_text("{}", encoding="utf-8")
+        return model
+
+    def test_top_level_tts_voice_used_when_no_piper_voice(self, tmp_path, monkeypatch):
+        """``tts.voice`` (the plugin-dispatch key) must reach piper when
+        ``tts.piper.voice`` is unset — previously piper fell through to the
+        lessac default and rendered the wrong voice silently (#79459)."""
+        model = self._prepare_named_voice(tmp_path, "en_US-ryan-medium")
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        config = {"voice": "en_US-ryan-medium", "piper": {"voices_dir": str(tmp_path)}}
+        tts_tool._generate_piper_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert _StubPiperVoice.loaded == [str(model)]
+
+    def test_piper_voice_beats_top_level_voice(self, tmp_path, monkeypatch):
+        ryan = self._prepare_named_voice(tmp_path, "en_US-ryan-medium")
+        self._prepare_named_voice(tmp_path, DEFAULT_PIPER_VOICE)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        config = {
+            "voice": DEFAULT_PIPER_VOICE,
+            "piper": {"voice": "en_US-ryan-medium", "voices_dir": str(tmp_path)},
+        }
+        tts_tool._generate_piper_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert _StubPiperVoice.loaded == [str(ryan)]
+
+    def test_non_string_voice_falls_back_to_default(self, tmp_path, monkeypatch):
+        default = self._prepare_named_voice(tmp_path, DEFAULT_PIPER_VOICE)
+        monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
+
+        config = {"voice": 42, "piper": {"voice": None, "voices_dir": str(tmp_path)}}
+        tts_tool._generate_piper_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert _StubPiperVoice.loaded == [str(default)]
+
+
 # ---------------------------------------------------------------------------
 # text_to_speech_tool end-to-end (provider == "piper")
 # ---------------------------------------------------------------------------
@@ -188,7 +234,7 @@ class TestTextToSpeechToolWithPiper:
     def test_dispatches_to_piper(self, tmp_path, monkeypatch):
         model = tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx"
         model.write_bytes(b"model")
-        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}")
+        (tmp_path / f"{DEFAULT_PIPER_VOICE}.onnx.json").write_text("{}", encoding="utf-8")
 
         monkeypatch.setattr(tts_tool, "_import_piper", lambda: _StubPiperVoice)
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -53,7 +53,7 @@ import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Any, Iterator, Optional
+from typing import Callable, Dict, Any, Iterator, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -2624,7 +2624,18 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
     import wave
 
     piper_config = tts_config.get("piper") or {} if isinstance(tts_config, dict) else {}
-    voice_name = piper_config.get("voice") or DEFAULT_PIPER_VOICE
+    # Provider-specific key wins; the shared top-level ``tts.voice`` (the key
+    # the plugin-provider dispatch path reads) is honored as a fallback, so
+    # users switching between plugin and built-in backends keep their voice
+    # instead of silently rendering the provider default (#79459).
+    voice_name = (
+        piper_config.get("voice")
+        or (tts_config.get("voice") if isinstance(tts_config, dict) else None)
+        or DEFAULT_PIPER_VOICE
+    )
+    if not isinstance(voice_name, str) or not voice_name.strip():
+        voice_name = DEFAULT_PIPER_VOICE
+    logger.info("[Piper] Voice requested: %s", voice_name)
     download_dir = Path(piper_config.get("voices_dir") or _get_piper_voices_dir()).expanduser()
     download_dir.mkdir(parents=True, exist_ok=True)
     use_cuda = bool(piper_config.get("use_cuda", False))
@@ -2720,6 +2731,108 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 # Module-level cache for KittenTTS model instance
 _kittentts_model_cache: Dict[str, Any] = {}
 
+# Install hint shared by KittenTTS error paths: the GitHub wheel resolves
+# Hugging Face repo ids internally, the legacy PyPI releases (0.1.x) do not.
+_KITTENTTS_WHEEL_HINT = (
+    "pip install https://github.com/KittenML/KittenTTS/releases/download/"
+    "0.8.1/kittentts-0.8.1-py3-none-any.whl"
+)
+
+
+def _resolve_kittentts_model_files(model_name: str) -> Optional[Tuple[str, Optional[str]]]:
+    """Resolve a Hugging Face repo id to cached local (model, voices) paths.
+
+    Returns None when *model_name* is not a repo id, ``huggingface_hub`` is
+    unavailable, or the repo layout doesn't expose a ``config.json`` with a
+    ``model_file`` entry (as the 0.8-era KittenML repos do). Callers treat
+    None as "resolution not possible" and surface the original error.
+    """
+    if not isinstance(model_name, str) or "/" not in model_name:
+        return None
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        return None
+    try:
+        config_path = hf_hub_download(repo_id=model_name, filename="config.json")
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        model_file = config.get("model_file")
+        if not model_file:
+            return None
+        local_model = hf_hub_download(repo_id=model_name, filename=str(model_file))
+        voices_file = config.get("voices")
+        local_voices = (
+            hf_hub_download(repo_id=model_name, filename=str(voices_file))
+            if voices_file
+            else None
+        )
+        return str(local_model), (str(local_voices) if local_voices else None)
+    except Exception as exc:
+        logger.warning(
+            "[KittenTTS] Hugging Face resolution failed for '%s': %s",
+            model_name, exc,
+        )
+        return None
+
+
+def _construct_kittentts_model(KittenTTS, model_name: str):
+    """Construct a KittenTTS model across library generations.
+
+    Newer releases (>=0.8) resolve Hugging Face repo ids internally. The
+    legacy PyPI releases (0.1.x) treat the constructor argument as a local
+    file path and fail with ``NO_SUCHFILE`` on repo ids (#79459); for those
+    the repo is resolved to cached local files via ``huggingface_hub`` and
+    explicit paths are passed instead.
+    """
+    try:
+        return KittenTTS(model_name)
+    except Exception as first_exc:
+        resolved = _resolve_kittentts_model_files(model_name)
+        if resolved is None:
+            raise RuntimeError(
+                f"KittenTTS could not load model '{model_name}': {first_exc}. "
+                "Older kittentts releases (PyPI 0.1.x) cannot resolve Hugging "
+                f"Face repo ids — upgrade with: {_KITTENTTS_WHEEL_HINT}"
+            ) from first_exc
+        local_model, local_voices = resolved
+        logger.info("[KittenTTS] Resolved '%s' -> %s", model_name, local_model)
+        try:
+            return KittenTTS(model_path=local_model, voices_path=local_voices)
+        except Exception as second_exc:
+            raise RuntimeError(
+                f"KittenTTS failed to load the locally resolved model for "
+                f"'{model_name}' ({local_model}): {second_exc}. Your kittentts "
+                "version may be too old for this model — upgrade with: "
+                f"{_KITTENTTS_WHEEL_HINT}"
+            ) from second_exc
+
+
+def _kittentts_voice_table(model) -> Optional[List[str]]:
+    """Best-effort enumeration of the voices the loaded model accepts.
+
+    Newer libraries expose ``model.model.all_voice_names`` plus
+    ``voice_aliases``; the legacy 0.1.x releases expose
+    ``model.available_voices``. Returns None when no table can be
+    determined — voice validation is then skipped rather than guessed.
+    """
+    names: set = set()
+    try:
+        inner = getattr(model, "model", None)
+        if inner is not None:
+            all_names = getattr(inner, "all_voice_names", None)
+            if isinstance(all_names, (list, tuple)):
+                names.update(all_names)
+            aliases = getattr(inner, "voice_aliases", None)
+            if isinstance(aliases, dict):
+                names.update(aliases.keys())
+        legacy = getattr(model, "available_voices", None)
+        if isinstance(legacy, (list, tuple)):
+            names.update(legacy)
+    except Exception:
+        return None
+    return sorted(names) or None
+
 
 def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate speech using KittenTTS local ONNX model.
@@ -2736,23 +2849,54 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
         Path to the saved audio file.
     """
     KittenTTS = _import_kittentts()
-    kt_config = tts_config.get("kittentts", {})
-    model_name = kt_config.get("model", DEFAULT_KITTENTTS_MODEL)
-    voice = kt_config.get("voice", DEFAULT_KITTENTTS_VOICE)
+    kt_config = tts_config.get("kittentts", {}) if isinstance(tts_config, dict) else {}
+    if not isinstance(kt_config, dict):
+        kt_config = {}
+    model_name = kt_config.get("model") or DEFAULT_KITTENTTS_MODEL
+    # Provider-specific key wins; the shared top-level ``tts.voice`` is the
+    # fallback (same contract as the plugin-provider dispatch path), so a
+    # voice configured once survives a switch to this built-in backend
+    # instead of silently rendering the default (#79459).
+    voice = (
+        kt_config.get("voice")
+        or (tts_config.get("voice") if isinstance(tts_config, dict) else None)
+        or DEFAULT_KITTENTTS_VOICE
+    )
+    if not isinstance(voice, str) or not voice.strip():
+        voice = DEFAULT_KITTENTTS_VOICE
     speed = kt_config.get("speed", 1.0)
     clean_text = kt_config.get("clean_text", True)
 
     # Use cached model instance if available
     def _load_kittentts_model():
         logger.info("[KittenTTS] Loading model: %s", model_name)
-        m = KittenTTS(model_name)
+        m = _construct_kittentts_model(KittenTTS, model_name)
         logger.info("[KittenTTS] Model loaded successfully")
         return m
 
     model = _tts_cache_get_or_load(_kittentts_model_cache, model_name, _load_kittentts_model)
 
-    # Generate audio (returns numpy array at 24kHz)
-    audio = model.generate(text, voice=voice, speed=speed, clean_text=clean_text)
+    # Unknown voices must fail loudly with the list of valid choices —
+    # never silently render a different voice (#79459). Validation is
+    # skipped when the library exposes no voice table.
+    voice_table = _kittentts_voice_table(model)
+    if voice_table and voice not in voice_table:
+        raise RuntimeError(
+            f"KittenTTS voice '{voice}' is not available in model "
+            f"'{model_name}'. Available voices: {', '.join(voice_table)}"
+        )
+
+    # Generate audio (returns numpy array at 24kHz). ``clean_text`` only
+    # exists on newer kittentts releases; the legacy 0.1.x generate()
+    # signature is (text, voice, speed), so retry without the kwarg when
+    # the library rejects it.
+    try:
+        audio = model.generate(text, voice=voice, speed=speed, clean_text=clean_text)
+    except TypeError as exc:
+        if "clean_text" not in str(exc):
+            raise
+        logger.info("[KittenTTS] generate() has no clean_text parameter — omitted")
+        audio = model.generate(text, voice=voice, speed=speed)
 
     # Save as WAV
     import soundfile as sf

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2739,13 +2739,19 @@ _KITTENTTS_WHEEL_HINT = (
 )
 
 
-def _resolve_kittentts_model_files(model_name: str) -> Optional[Tuple[str, Optional[str]]]:
-    """Resolve a Hugging Face repo id to cached local (model, voices) paths.
+def _resolve_kittentts_model_files(
+    model_name: str,
+) -> Optional[Tuple[str, Optional[str], Dict[str, str]]]:
+    """Resolve a Hugging Face repo id to cached local (model, voices, aliases).
 
     Returns None when *model_name* is not a repo id, ``huggingface_hub`` is
     unavailable, or the repo layout doesn't expose a ``config.json`` with a
     ``model_file`` entry (as the 0.8-era KittenML repos do). Callers treat
     None as "resolution not possible" and surface the original error.
+
+    The third element carries the repo's ``voice_aliases`` mapping (e.g.
+    ``{"Jasper": "expr-voice-2-m"}``) so callers can normalize alias names
+    for legacy libraries that only accept raw voice names.
     """
     if not isinstance(model_name, str) or "/" not in model_name:
         return None
@@ -2767,7 +2773,13 @@ def _resolve_kittentts_model_files(model_name: str) -> Optional[Tuple[str, Optio
             if voices_file
             else None
         )
-        return str(local_model), (str(local_voices) if local_voices else None)
+        raw_aliases = config.get("voice_aliases")
+        aliases = (
+            {k: str(v) for k, v in raw_aliases.items() if isinstance(k, str) and v}
+            if isinstance(raw_aliases, dict)
+            else {}
+        )
+        return str(local_model), (str(local_voices) if local_voices else None), aliases
     except Exception as exc:
         logger.warning(
             "[KittenTTS] Hugging Face resolution failed for '%s': %s",
@@ -2776,17 +2788,20 @@ def _resolve_kittentts_model_files(model_name: str) -> Optional[Tuple[str, Optio
         return None
 
 
-def _construct_kittentts_model(KittenTTS, model_name: str):
+def _construct_kittentts_model(KittenTTS, model_name: str) -> Tuple[Any, Dict[str, str]]:
     """Construct a KittenTTS model across library generations.
 
-    Newer releases (>=0.8) resolve Hugging Face repo ids internally. The
-    legacy PyPI releases (0.1.x) treat the constructor argument as a local
-    file path and fail with ``NO_SUCHFILE`` on repo ids (#79459); for those
-    the repo is resolved to cached local files via ``huggingface_hub`` and
-    explicit paths are passed instead.
+    Newer releases (>=0.8) resolve Hugging Face repo ids internally and
+    understand alias voice names natively, so they come back with an empty
+    alias map. The legacy PyPI releases (0.1.x) treat the constructor
+    argument as a local file path and fail with ``NO_SUCHFILE`` on repo ids
+    (#79459); for those the repo is resolved to cached local files via
+    ``huggingface_hub`` and explicit paths are passed instead, together with
+    the repo's ``voice_aliases`` mapping so alias names can be normalized to
+    the raw voice names the legacy ``generate()`` accepts.
     """
     try:
-        return KittenTTS(model_name)
+        return KittenTTS(model_name), {}
     except Exception as first_exc:
         resolved = _resolve_kittentts_model_files(model_name)
         if resolved is None:
@@ -2795,10 +2810,10 @@ def _construct_kittentts_model(KittenTTS, model_name: str):
                 "Older kittentts releases (PyPI 0.1.x) cannot resolve Hugging "
                 f"Face repo ids — upgrade with: {_KITTENTTS_WHEEL_HINT}"
             ) from first_exc
-        local_model, local_voices = resolved
+        local_model, local_voices, aliases = resolved
         logger.info("[KittenTTS] Resolved '%s' -> %s", model_name, local_model)
         try:
-            return KittenTTS(model_path=local_model, voices_path=local_voices)
+            return KittenTTS(model_path=local_model, voices_path=local_voices), aliases
         except Exception as second_exc:
             raise RuntimeError(
                 f"KittenTTS failed to load the locally resolved model for "
@@ -2867,14 +2882,27 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
     speed = kt_config.get("speed", 1.0)
     clean_text = kt_config.get("clean_text", True)
 
-    # Use cached model instance if available
+    # Use cached model instance if available. The loader also returns the
+    # repo voice-alias map (non-empty only on the legacy HF-resolution
+    # path), so alias names can be normalized before validation.
     def _load_kittentts_model():
         logger.info("[KittenTTS] Loading model: %s", model_name)
-        m = _construct_kittentts_model(KittenTTS, model_name)
+        m, alias_map = _construct_kittentts_model(KittenTTS, model_name)
         logger.info("[KittenTTS] Model loaded successfully")
-        return m
+        return m, alias_map
 
-    model = _tts_cache_get_or_load(_kittentts_model_cache, model_name, _load_kittentts_model)
+    model, alias_map = _tts_cache_get_or_load(
+        _kittentts_model_cache, model_name, _load_kittentts_model
+    )
+
+    # Newer libraries resolve alias names (Jasper, Luna, ...) internally;
+    # the legacy 0.1.x generate() only accepts raw voice names, so map the
+    # alias through the repo metadata carried by the HF resolution. This
+    # keeps the documented no-config default (Jasper) working on the very
+    # legacy package this fallback exists for.
+    if alias_map and voice in alias_map:
+        logger.info("[KittenTTS] Voice alias '%s' -> '%s'", voice, alias_map[voice])
+        voice = alias_map[voice]
 
     # Unknown voices must fail loudly with the list of valid choices —
     # never silently render a different voice (#79459). Validation is

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -114,6 +114,10 @@ MiniMax TTS selects its region, endpoint, and credential together:
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
 
+**Voice selection**: For the built-in `piper` and `kittentts` providers the provider-specific key (`tts.piper.voice`, `tts.kittentts.voice`) wins. The shared top-level `tts.voice` key — the same key plugin providers read — is honored as a fallback, so switching backends keeps your configured voice instead of silently rendering the provider default. Requesting a voice the loaded model doesn't offer fails with an error listing the available choices rather than substituting another voice.
+
+**KittenTTS package version**: `hermes setup tts` installs the KittenTTS 0.8.1 wheel, which resolves Hugging Face model ids (e.g., `KittenML/kitten-tts-nano-0.8-int8`) on its own. The legacy PyPI releases (`pip install kittentts`, 0.1.x) cannot resolve repo ids; Hermes falls back to resolving the model files itself, but upgrading to the wheel is recommended.
+
 ### Gemini Persona Prompts
 
 Gemini TTS can follow natural-language performance direction. Set `tts.gemini.persona_prompt_file` to a local Markdown or text file that describes the voice persona. The file can include Gemini-style sections such as `AUDIO PROFILE`, `SCENE`, `DIRECTOR'S NOTES`, `SAMPLE CONTEXT`, and `TRANSCRIPT`.


### PR DESCRIPTION
## What does this PR do?

Makes the local TTS providers (`piper`, `kittentts`) actually honor the configured voice, and fixes the KittenTTS `NO_SUCHFILE` dead-end on legacy library versions — per the expected behavior in #79459: *the configured voice is used, or a hard error is raised; never a silent default substitution*.

Three changes, each verified against real libraries (see How to Test):

1. **Top-level `tts.voice` fallback** — the plugin-provider dispatch path reads the shared top-level `tts.voice` key, but the built-in `piper`/`kittentts` providers only read their own subsection keys. A user who configured `tts.voice` (or switches from a plugin backend) silently got the provider default voice. The provider-specific key still wins; the top-level key is now the fallback before the provider default.
2. **KittenTTS HF repo-id resolution** — kittentts 0.8.1 (what `hermes setup tts` installs) resolves Hugging Face repo ids internally, but the legacy PyPI releases (`pip install kittentts` = 0.1.x, the reporter's version) treat the constructor argument as a local file path and die with `NO_SUCHFILE`. Hermes now falls back to resolving the repo (`config.json` → `model_file`/`voices`) via `huggingface_hub` and constructs with explicit local paths; if that's impossible the error is actionable (wheel upgrade hint) instead of `NO_SUCHFILE`.
3. **Loud voice validation + legacy `generate()` compat** — when the loaded model exposes a voice table (`all_voice_names` + `voice_aliases` on 0.8.x, `available_voices` on 0.1.x), an unknown voice raises with the full list of valid choices. Also, `clean_text` is no longer passed unconditionally — legacy `generate(text, voice, speed)` rejects the kwarg with `TypeError`.

## Related Issue

Fixes #79459

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation
- [ ] 🧪 Tests only
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/tts_tool.py`
  - `_generate_piper_tts`: voice resolution = `tts.piper.voice` → `tts.voice` → default (non-string garbage falls back to default); logs the requested voice
  - `_generate_kittentts`: same voice resolution chain for `tts.kittentts.voice`
  - `_construct_kittentts_model`: generation-aware constructor (repo-id first, HF-resolved local paths second, actionable error third)
  - `_resolve_kittentts_model_files`: `huggingface_hub` repo → cached local `(model, voices)` paths
  - `_kittentts_voice_table`: best-effort voice enumeration across library generations; unknown voices raise with the choices listed
  - `generate()` call retries without `clean_text` when the library rejects it
- `tests/tools/test_tts_piper.py`: 3 new voice-resolution tests (+ encoding footgun fixes on 4 `write_text` calls)
- `tests/tools/test_tts_kittentts.py`: 10 new tests — voice fallback/precedence, loud unknown-voice error with alias acceptance, legacy-library constructor fallback, upgrade-hint error, `_resolve_kittentts_model_files` repo layouts
- `website/docs/user-guide/features/tts.md`: "Voice selection" and "KittenTTS package version" notes

Notes on the issue's two diagnoses, verified independently on Linux before fixing:
- Piper 1.6.0's `download_voices` does **not** silently substitute lessac (invalid names 404 → hermes already raised). The reproducible voice-selection gap was the top-level-key inconsistency above.
- The KittenTTS `NO_SUCHFILE` repro is real for PyPI 0.1.3 (still what `pip install kittentts` gives); the 0.8.1 wheel hermes installs is unaffected.

## How to Test

1. `pytest tests/tools/test_tts_piper.py tests/tools/test_tts_kittentts.py -q` → 31 passed
2. Piper (real `piper-tts` 1.6.0, WSL): with `tts.voice: en_US-ryan-medium` and **no** `tts.piper.voice`, generate twice (ryan via top-level key, lessac explicitly) → outputs are byte-distinct; provider key over top-level key renders ryan
3. KittenTTS 0.8.1 (WSL): top-level `tts.voice: Luna` renders Luna; `voice: Zoltan` fails with `Available voices: Bella, Bruno, Hugo, Jasper, Kiki, Leo, Luna, Rosie`
4. KittenTTS 0.1.3 (WSL): raw ctor with the repo id raises the original `NO_SUCHFILE`; with this PR, hermes resolves the repo to `~/.cache/huggingface/.../kitten_tts_nano_v0_8.onnx` (24 MB) and passes local paths to the constructor — the repo-id dead-end is gone

## Checklist - Code

- [x] I have read the Contributing Guide
- [x] My commits follow the Conventional Commits format
- [x] I have searched for existing PRs and confirmed this is not a duplicate
- [x] This PR only contains changes relevant to the stated issue
- [ ] `pytest tests/ -q` passes locally — not run to full completion on Windows: the full `tests/tools/` directory has pre-existing environment issues unrelated to this change (`test_search_hidden_dirs.py` collection needs a missing binary; a network-bound test hangs). Every TTS-related suite (123 tests incl. plugin dispatch/picker/registration) is green
- [x] I have added tests for my changes (bug fixes require tests)
- [x] I have tested this on my platform (Windows 11 dev + WSL end-to-end with real piper-tts 1.6.0 / kittentts 0.8.1 / kittentts 0.1.3)

## Checklist - Documentation & Housekeeping

- [x] I have updated the documentation accordingly (`website/docs/user-guide/features/tts.md`)
- [ ] I have updated `cli-config.yaml.example` — N/A (no new config keys; existing per-provider keys unchanged)
- [ ] I have updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I have considered cross-platform impact — voice resolution and HF cache paths are platform-neutral; no Windows-specific code added
- [ ] I have updated tool descriptions/schemas — N/A (no schema change)
