### PR TITLE
feat(desktop): bundled runtime — payload bootstrap, tag invalidation, silent adoption

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -662,7 +662,7 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
 // a repair/update path and must not let an old packaged app detach the checkout
 // back to the commit baked into that app. All-zero fallback stamps are never
 // passed as -Commit/--commit — only the branch is used (#50823 / #50864 review).
-function buildPinArgs(installStamp, { pinCommit = true } = {}) {
+function buildPinArgs(installStamp, { pinCommit = true, payloadDir = null } = {}) {
   const args = []
 
   if (pinCommit && installStamp && isPinnedCommit(installStamp.commit)) {
@@ -673,10 +673,14 @@ function buildPinArgs(installStamp, { pinCommit = true } = {}) {
     args.push('-Branch', installStamp.branch)
   }
 
+  if (payloadDir) {
+    args.push('-PayloadDir', payloadDir)
+  }
+
   return args
 }
 
-function buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit = true }) {
+function buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit = true, payloadDir = null }) {
   const args = ['--dir', activeRoot, '--hermes-home', hermesHome]
 
   if (installStamp && installStamp.branch) {
@@ -687,15 +691,19 @@ function buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit = t
     args.push('--commit', installStamp.commit)
   }
 
+  if (payloadDir) {
+    args.push('--payload-dir', payloadDir)
+  }
+
   return args
 }
 
-async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, activeRoot, installStamp, pinCommit }) {
+async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, activeRoot, installStamp, pinCommit, payloadDir = null }) {
   const isPosix = installerKind === 'posix'
 
   const args = isPosix
-    ? ['--manifest', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit })]
-    : ['-Manifest', ...buildPinArgs(installStamp, { pinCommit })]
+    ? ['--manifest', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit, payloadDir })]
+    : ['-Manifest', ...buildPinArgs(installStamp, { pinCommit, payloadDir })]
 
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
@@ -761,7 +769,8 @@ async function runStage({
   activeRoot,
   abortSignal,
   installStamp,
-  pinCommit
+  pinCommit,
+  payloadDir = null
 }) {
   const startedAt = Date.now()
   emit({ type: 'stage', name: stage.name, state: 'running' })
@@ -774,9 +783,9 @@ async function runStage({
         stage.name,
         '--non-interactive',
         '--json',
-        ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit })
+        ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit, payloadDir })
       ]
-    : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs(installStamp, { pinCommit })]
+    : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs(installStamp, { pinCommit, payloadDir })]
 
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
@@ -865,6 +874,7 @@ async function runBootstrap(opts) {
     logRoot,
     onEvent,
     abortSignal,
+    payloadDir = null, // resources/agent-payload dir for bundled builds (bundled-runtime.resolvePayload)
     writeMarker // callback to write the bootstrap-complete marker; main.ts provides
   } = opts
 
@@ -938,7 +948,8 @@ async function runBootstrap(opts) {
       hermesHome,
       activeRoot,
       installStamp,
-      pinCommit
+      pinCommit,
+      payloadDir
     })
 
     emit({
@@ -967,7 +978,8 @@ async function runBootstrap(opts) {
         activeRoot,
         abortSignal,
         installStamp,
-        pinCommit
+        pinCommit,
+        payloadDir
       })
 
       if (ev.state === 'failed') {
@@ -999,7 +1011,11 @@ async function runBootstrap(opts) {
 
     const markerPayload = {
       pinnedCommit,
-      pinnedBranch: installStamp ? installStamp.branch : null
+      pinnedBranch: installStamp ? installStamp.branch : null,
+      // Bundled builds: record which payload tag this bootstrap materialized.
+      // main.ts compares this against the (possibly newer) stamp tag at
+      // launch to decide offline re-materialization after an app update.
+      pinnedTag: installStamp && (installStamp as any).payload === true ? (installStamp as any).tag || null : null
     }
 
     const marker = typeof writeMarker === 'function' ? writeMarker(markerPayload) : markerPayload

--- a/apps/desktop/electron/bundled-runtime.test.ts
+++ b/apps/desktop/electron/bundled-runtime.test.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  type AdoptionFacts,
+  adoptionManifest,
+  decideAdoption,
+  executeAdoptionCheckout,
+  gatherGitFacts,
+  type GitRunner,
+  needsRematerialization,
+  payloadArgs,
+  resolvePayload
+} from '../electron/bundled-runtime'
+
+// ─── resolvePayload ────────────────────────────────────────────────
+
+const readerFor = (manifest: unknown) => (p: string) => {
+  if (!p.endsWith('manifest.json')) {throw new Error('ENOENT')}
+
+  return JSON.stringify(manifest)
+}
+
+test('resolvePayload returns null for dev runs, thin stubs, and garbage', () => {
+  assert.equal(resolvePayload(null), null)
+  assert.equal(resolvePayload(undefined), null)
+  assert.equal(resolvePayload('/res', readerFor({ schemaVersion: 1, thin: true, items: {} })), null)
+  assert.equal(
+    resolvePayload('/res', () => {
+      throw new Error('ENOENT')
+    }),
+    null
+  )
+  assert.equal(resolvePayload('/res', readerFor('not-an-object')), null)
+  // Manifest with items but nothing actually staged ⇒ null (all-skipped payload).
+  assert.equal(
+    resolvePayload('/res', readerFor({ tag: 'v1.0.0', items: { repo: { status: 'skipped' } } })),
+    null
+  )
+})
+
+test('resolvePayload returns dir + tag for a real payload', () => {
+  const p = resolvePayload('/res', readerFor({ tag: 'v1.2.3', items: { repo: { status: 'staged' } } }))
+  assert.ok(p)
+  assert.match(p.dir, /agent-payload$/)
+  assert.equal(p.tag, 'v1.2.3')
+})
+
+test('payloadArgs maps installer kind, empty for null payload', () => {
+  const p = { dir: '/res/agent-payload', tag: 'v1.0.0', items: {} }
+  assert.deepEqual(payloadArgs('posix', p), ['--payload-dir', '/res/agent-payload'])
+  assert.deepEqual(payloadArgs('powershell', p), ['-PayloadDir', '/res/agent-payload'])
+  assert.deepEqual(payloadArgs('posix', null), [])
+})
+
+// ─── needsRematerialization ────────────────────────────────────────
+
+const bundledStamp = { payload: true, tag: 'v2.0.0' }
+const bundledManifest = { installMode: 'bundled' }
+
+test('fires only on bundled-mode checkouts when the stamp tag moved', () => {
+  assert.equal(needsRematerialization({ pinnedTag: 'v1.0.0' }, bundledStamp, bundledManifest), true)
+  assert.equal(needsRematerialization({ pinnedTag: 'v2.0.0' }, bundledStamp, bundledManifest), false)
+})
+
+test('never fires for thin builds, missing markers, or non-bundled checkouts', () => {
+  assert.equal(needsRematerialization({ pinnedTag: 'v1.0.0' }, { payload: false, tag: null }, bundledManifest), false)
+  assert.equal(needsRematerialization({ pinnedTag: 'v1.0.0' }, null, bundledManifest), false)
+  assert.equal(needsRematerialization(null, bundledStamp, bundledManifest), false)
+  // Ejected / source-managed: user owns updates.
+  assert.equal(needsRematerialization({ pinnedTag: 'v1.0.0' }, bundledStamp, { installMode: 'source' }), false)
+  // Legacy checkout without a manifest: only adoption may touch it.
+  assert.equal(needsRematerialization({ pinnedTag: 'v1.0.0' }, bundledStamp, null), false)
+})
+
+// ─── decideAdoption ────────────────────────────────────────────────
+
+const pristine: AdoptionFacts = {
+  stampHasPayload: true,
+  stampTag: 'v2.0.0',
+  installManifest: null,
+  gitCheckoutExists: true,
+  workingTreeClean: true,
+  currentBranch: 'main',
+  headIsAncestorOfTag: true,
+  recentManualUpdateDays: null
+}
+
+test('a pristine legacy checkout adopts', () => {
+  assert.deepEqual(decideAdoption(pristine), { adopt: true })
+})
+
+test('every non-pristine variation refuses, with a reason', () => {
+  const cases: Array<[Partial<AdoptionFacts>, RegExp]> = [
+    [{ stampHasPayload: false }, /thin build/],
+    [{ stampTag: null }, /thin build/],
+    [{ installManifest: { installMode: 'source', manageStyle: 'ejected' } }, /ejected/],
+    [{ installManifest: { installMode: 'bundled', manageStyle: 'adopted' } }, /already bundled/],
+    [{ installManifest: { installMode: 'source', manageStyle: 'auto-adopted' } }, /manageStyle/],
+    [{ gitCheckoutExists: false }, /no git checkout/],
+    [{ workingTreeClean: false }, /not clean/],
+    [{ currentBranch: 'ethie/my-branch' }, /not main/],
+    [{ currentBranch: null }, /not main/],
+    [{ recentManualUpdateDays: 3 }, /cohabiting/],
+    [{ headIsAncestorOfTag: false }, /not an ancestor/],
+    [{ headIsAncestorOfTag: null }, /deferring/]
+  ]
+
+  for (const [override, reason] of cases) {
+    const decision = decideAdoption({ ...pristine, ...override })
+    assert.equal(decision.adopt, false, JSON.stringify(override))
+    assert.match((decision as { adopt: false; reason: string }).reason, reason)
+  }
+})
+
+test('a plain source manifest without manageStyle stays adoptable', () => {
+  // install.sh writes {installMode: source, channel: main} with NO style on
+  // network installs — those users are exactly the silent-adoption cohort.
+  const decision = decideAdoption({ ...pristine, installManifest: { installMode: 'source' } })
+  assert.deepEqual(decision, { adopt: true })
+})
+
+test('a stale manual update (>= 30d) no longer blocks', () => {
+  assert.deepEqual(decideAdoption({ ...pristine, recentManualUpdateDays: 45 }), { adopt: true })
+})
+
+test('adoptionManifest is bundled/stable/auto-adopted at the tag', () => {
+  assert.deepEqual(adoptionManifest('v2.0.0'), {
+    schemaVersion: 1,
+    installMode: 'bundled',
+    channel: 'stable',
+    manageStyle: 'auto-adopted',
+    pinnedTag: 'v2.0.0'
+  })
+})
+
+// ─── gatherGitFacts ────────────────────────────────────────────────
+
+function fakeGit(responses: Record<string, { code: number; stdout: string }>): GitRunner & { calls: string[] } {
+  const calls: string[] = []
+
+  const runner = ((args: string[], _cwd: string) => {
+    const key = args.join(' ')
+    calls.push(key)
+
+    for (const [prefix, result] of Object.entries(responses)) {
+      if (key.startsWith(prefix)) {return result}
+    }
+
+    return { code: 0, stdout: '' }
+  }) as GitRunner & { calls: string[] }
+
+  runner.calls = calls
+
+  return runner
+}
+
+const cleanMainRepo = {
+  'rev-parse --git-dir': { code: 0, stdout: '.git\n' },
+  'status --porcelain -uno': { code: 0, stdout: '' },
+  'rev-parse --abbrev-ref HEAD': { code: 0, stdout: 'main\n' },
+  'rev-parse --is-shallow-repository': { code: 0, stdout: 'false\n' },
+  'fetch origin tag v2.0.0': { code: 0, stdout: '' },
+  'merge-base --is-ancestor': { code: 0, stdout: '' }
+}
+
+test('clean main checkout at an ancestor of the tag ⇒ fully adoptable facts', () => {
+  const git = fakeGit(cleanMainRepo)
+  const facts = gatherGitFacts('/root', 'v2.0.0', git)
+  assert.deepEqual(facts, {
+    gitCheckoutExists: true,
+    workingTreeClean: true,
+    currentBranch: 'main',
+    headIsAncestorOfTag: true
+  })
+})
+
+test('merge-base exit 1 means not-ancestor; other exits mean unknown', () => {
+  const notAncestor = gatherGitFacts(
+    '/root',
+    'v2.0.0',
+    fakeGit({ ...cleanMainRepo, 'merge-base --is-ancestor': { code: 1, stdout: '' } })
+  )
+
+  assert.equal(notAncestor.headIsAncestorOfTag, false)
+
+  const broken = gatherGitFacts(
+    '/root',
+    'v2.0.0',
+    fakeGit({ ...cleanMainRepo, 'merge-base --is-ancestor': { code: 128, stdout: '' } })
+  )
+
+  assert.equal(broken.headIsAncestorOfTag, null)
+})
+
+test('offline fetch leaves ancestry unknown (defer), not false', () => {
+  const facts = gatherGitFacts(
+    '/root',
+    'v2.0.0',
+    fakeGit({ ...cleanMainRepo, 'fetch origin tag v2.0.0': { code: 128, stdout: '' } })
+  )
+
+  assert.equal(facts.headIsAncestorOfTag, null)
+})
+
+test('shallow checkouts unshallow first; failed unshallow defers', () => {
+  const git = fakeGit({
+    ...cleanMainRepo,
+    'rev-parse --is-shallow-repository': { code: 0, stdout: 'true\n' },
+    'fetch --unshallow origin main': { code: 0, stdout: '' }
+  })
+
+  const facts = gatherGitFacts('/root', 'v2.0.0', git)
+  assert.equal(facts.headIsAncestorOfTag, true)
+  assert.ok(git.calls.some(c => c.startsWith('fetch --unshallow')))
+
+  const offline = gatherGitFacts(
+    '/root',
+    'v2.0.0',
+    fakeGit({
+      ...cleanMainRepo,
+      'rev-parse --is-shallow-repository': { code: 0, stdout: 'true\n' },
+      'fetch --unshallow origin main': { code: 128, stdout: '' }
+    })
+  )
+
+  assert.equal(offline.headIsAncestorOfTag, null)
+})
+
+test('dirty or off-main checkouts never touch the network', () => {
+  const dirty = fakeGit({ ...cleanMainRepo, 'status --porcelain -uno': { code: 0, stdout: ' M cli.py\n' } })
+  gatherGitFacts('/root', 'v2.0.0', dirty)
+  assert.ok(!dirty.calls.some(c => c.startsWith('fetch')))
+
+  const offMain = fakeGit({ ...cleanMainRepo, 'rev-parse --abbrev-ref HEAD': { code: 0, stdout: 'dev\n' } })
+  gatherGitFacts('/root', 'v2.0.0', offMain)
+  assert.ok(!offMain.calls.some(c => c.startsWith('fetch')))
+})
+
+test('not a git repo ⇒ all-negative facts, no further probes', () => {
+  const git = fakeGit({ 'rev-parse --git-dir': { code: 128, stdout: '' } })
+  const facts = gatherGitFacts('/root', 'v2.0.0', git)
+  assert.equal(facts.gitCheckoutExists, false)
+  assert.equal(git.calls.length, 1)
+})
+
+// ─── executeAdoptionCheckout ───────────────────────────────────────
+
+test('adoption executes exactly one checkout -B main at the tag commit', () => {
+  const git = fakeGit({ 'checkout -B main v2.0.0^{commit}': { code: 0, stdout: '' } })
+  assert.equal(executeAdoptionCheckout('/root', 'v2.0.0', git), true)
+  assert.deepEqual(git.calls, ['checkout -B main v2.0.0^{commit}'])
+
+  const failing = fakeGit({ 'checkout -B main': { code: 1, stdout: '' } })
+  assert.equal(executeAdoptionCheckout('/root', 'v2.0.0', failing), false)
+})

--- a/apps/desktop/electron/bundled-runtime.ts
+++ b/apps/desktop/electron/bundled-runtime.ts
@@ -1,0 +1,279 @@
+// bundled-runtime.ts — decision logic for the bundled desktop runtime:
+// payload discovery, marker-tag invalidation (when does an app update force
+// offline re-materialization?), and silent adoption eligibility for pristine
+// legacy checkouts.
+//
+// Design: .hermes/plans/2026-08-05_desktop-bundled-payloads-channels-eject.md
+// (§1.4 adoption, §4.3 bundled update flow).
+//
+// Everything here is pure (dependencies injected) so vitest covers the whole
+// decision surface; the impure executors live in main.ts / bootstrap-runner.
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+// ─── payload discovery ──────────────────────────────────────────────────────
+
+export interface PayloadInfo {
+  dir: string
+  tag: string | null
+  items: Record<string, { status: string }>
+}
+
+/**
+ * Resolve the agent-payload directory shipped in the packaged app's
+ * resources. Returns null for thin builds (stub manifest with thin:true),
+ * dev runs (no resourcesPath), or unreadable manifests — every caller treats
+ * null as "behave exactly like today's network bootstrap".
+ */
+export function resolvePayload(
+  resourcesPath: string | null | undefined,
+  readFile: (p: string) => string = p => fs.readFileSync(p, 'utf8')
+): PayloadInfo | null {
+  if (!resourcesPath) {
+    return null
+  }
+
+  const dir = path.join(resourcesPath, 'agent-payload')
+
+  let parsed
+
+  try {
+    parsed = JSON.parse(readFile(path.join(dir, 'manifest.json')))
+  } catch {
+    return null
+  }
+
+  if (!parsed || typeof parsed !== 'object' || parsed.thin === true) {
+    return null
+  }
+
+  const items = parsed.items && typeof parsed.items === 'object' ? parsed.items : {}
+  const hasAny = Object.values(items).some((v: any) => v && v.status === 'staged')
+
+  if (!hasAny) {
+    return null
+  }
+
+  return { dir, tag: typeof parsed.tag === 'string' ? parsed.tag : null, items }
+}
+
+/** Installer argv addition for a payload-backed bootstrap. */
+export function payloadArgs(installerKind: 'posix' | 'powershell', payload: PayloadInfo | null): string[] {
+  if (!payload) {
+    return []
+  }
+
+  return installerKind === 'posix' ? ['--payload-dir', payload.dir] : ['-PayloadDir', payload.dir]
+}
+
+// ─── marker-tag invalidation ────────────────────────────────────────────────
+
+/**
+ * Does the completed-bootstrap marker need invalidating because the app
+ * updated to a build carrying NEWER payloads?
+ *
+ * True only when this build ships payloads (stamp.payload) with a real tag,
+ * the checkout's install manifest says installMode:bundled (it opted into
+ * desktop-managed materialization), AND the marker's pinnedTag differs.
+ *
+ * Deliberately false for everything else:
+ * - no install manifest (legacy checkout) — ONLY the adoption flow, with its
+ *   pristineness gates, may move a legacy checkout. Re-materializing here
+ *   would be silent adoption without consent checks.
+ * - installMode:source (ejected / user-managed) — the user owns updates.
+ * - thin builds, missing marker (normal bootstrap-needed logic owns that).
+ */
+export function needsRematerialization(
+  marker: { pinnedTag?: string | null } | null,
+  stamp: { payload?: boolean; tag?: string | null } | null,
+  installManifest?: { installMode?: string } | null
+): boolean {
+  if (!stamp || stamp.payload !== true || !stamp.tag) {
+    return false
+  }
+
+  if (!marker) {
+    return false
+  }
+
+  if (!installManifest || installManifest.installMode !== 'bundled') {
+    return false
+  }
+
+  return marker.pinnedTag !== stamp.tag
+}
+
+// ─── silent adoption (plan §1.4) ────────────────────────────────────────────
+
+export interface AdoptionFacts {
+  // From the packaged build:
+  stampHasPayload: boolean
+  stampTag: string | null
+  // From the checkout:
+  installManifest: { installMode?: string; manageStyle?: string } | null
+  gitCheckoutExists: boolean
+  workingTreeClean: boolean
+  currentBranch: string | null
+  headIsAncestorOfTag: boolean | null // null = could not determine (offline, fetch failed)
+  // From update-state:
+  recentManualUpdateDays: number | null // null = never / unknown
+}
+
+export type AdoptionDecision =
+  | { adopt: true }
+  | { adopt: false; reason: string }
+
+export const RECENT_MANUAL_UPDATE_WINDOW_DAYS = 30
+
+/**
+ * Should this launch silently adopt the checkout into the bundled path?
+ *
+ * The bias is "when unsure, don't adopt": every ambiguous or unverifiable
+ * input returns adopt:false with a reason (logged, never shown to the user —
+ * failure to adopt is silent and retried at a later launch/release).
+ */
+export function decideAdoption(facts: AdoptionFacts): AdoptionDecision {
+  if (!facts.stampHasPayload || !facts.stampTag) {
+    return { adopt: false, reason: 'thin build (no payloads)' }
+  }
+
+  const manifest = facts.installManifest
+
+  if (manifest) {
+    if (manifest.manageStyle === 'ejected') {
+      return { adopt: false, reason: 'checkout is ejected (sticky opt-out)' }
+    }
+
+    if (manifest.installMode === 'bundled') {
+      return { adopt: false, reason: 'already bundled' }
+    }
+
+    if (manifest.manageStyle) {
+      return { adopt: false, reason: `manageStyle=${manifest.manageStyle} present` }
+    }
+
+    // A manifest with installMode:source but NO manageStyle is a deliberate
+    // source install (written by install.sh without payloads) — legacy
+    // checkouts have no manifest at all. Both are adoptable per plan §1.4
+    // only when style is absent; mode source alone doesn't opt out, the
+    // remaining pristine checks decide.
+  }
+
+  if (!facts.gitCheckoutExists) {
+    return { adopt: false, reason: 'no git checkout' }
+  }
+
+  if (!facts.workingTreeClean) {
+    return { adopt: false, reason: 'working tree not clean' }
+  }
+
+  if (facts.currentBranch !== 'main') {
+    return { adopt: false, reason: `on branch ${facts.currentBranch || '<detached>'}, not main` }
+  }
+
+  if (
+    facts.recentManualUpdateDays !== null &&
+    facts.recentManualUpdateDays < RECENT_MANUAL_UPDATE_WINDOW_DAYS
+  ) {
+    return {
+      adopt: false,
+      reason: `manual hermes update ${facts.recentManualUpdateDays}d ago (cohabiting CLI user)`
+    }
+  }
+
+  if (facts.headIsAncestorOfTag !== true) {
+    return {
+      adopt: false,
+      reason:
+        facts.headIsAncestorOfTag === null
+          ? 'ancestry unknown (offline or fetch failed) — deferring'
+          : 'HEAD not an ancestor of the release tag (local commits or ahead of release)'
+    }
+  }
+
+  return { adopt: true }
+}
+
+/**
+ * The manifest to write after a successful adoption. auto-adopted is kept
+ * distinct from adopted so a bad auto-adoption cohort can be bulk-reverted
+ * without touching users who chose bundled explicitly.
+ */
+export function adoptionManifest(tag: string) {
+  return {
+    schemaVersion: 1,
+    installMode: 'bundled',
+    channel: 'stable',
+    manageStyle: 'auto-adopted',
+    pinnedTag: tag
+  }
+}
+
+// ─── adoption fact-gathering + execution ────────────────────────────────────
+
+export type GitRunner = (args: string[], cwd: string) => { code: number; stdout: string }
+
+/**
+ * Gather the git-side AdoptionFacts for a checkout. Network is touched only
+ * for the ancestry probe (a tag-scoped fetch; --unshallow first when the
+ * checkout is a depth-1 installer clone). Every failure degrades to the
+ * "don't adopt" side of the fact: null ancestry, dirty tree, etc.
+ */
+export function gatherGitFacts(
+  activeRoot: string,
+  tag: string,
+  git: GitRunner
+): Pick<AdoptionFacts, 'gitCheckoutExists' | 'workingTreeClean' | 'currentBranch' | 'headIsAncestorOfTag'> {
+  const probe = git(['rev-parse', '--git-dir'], activeRoot)
+
+  if (probe.code !== 0) {
+    return { gitCheckoutExists: false, workingTreeClean: false, currentBranch: null, headIsAncestorOfTag: null }
+  }
+
+  // -uno: untracked files don't block adoption (mirrors write-build-stamp's
+  // dirty probe and install.sh's lockfile-churn tolerance is upstream of us —
+  // npm churn shows as tracked modifications, which DO block. Conservative.)
+  const status = git(['status', '--porcelain', '-uno'], activeRoot)
+  const workingTreeClean = status.code === 0 && status.stdout.trim() === ''
+
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], activeRoot)
+  const currentBranch = branch.code === 0 ? branch.stdout.trim() : null
+
+  let headIsAncestorOfTag: boolean | null = null
+
+  if (workingTreeClean && currentBranch === 'main') {
+    const shallow = git(['rev-parse', '--is-shallow-repository'], activeRoot)
+
+    if (shallow.code === 0 && shallow.stdout.trim() === 'true') {
+      const unshallow = git(['fetch', '--unshallow', 'origin', 'main'], activeRoot)
+
+      if (unshallow.code !== 0) {
+        return { gitCheckoutExists: true, workingTreeClean, currentBranch, headIsAncestorOfTag: null }
+      }
+    }
+
+    const fetch = git(['fetch', 'origin', 'tag', tag], activeRoot)
+
+    if (fetch.code === 0) {
+      const ancestor = git(['merge-base', '--is-ancestor', 'HEAD', `${tag}^{commit}`], activeRoot)
+
+      // merge-base --is-ancestor: 0 = yes, 1 = no, anything else = error.
+      headIsAncestorOfTag = ancestor.code === 0 ? true : ancestor.code === 1 ? false : null
+    }
+  }
+
+  return { gitCheckoutExists: true, workingTreeClean, currentBranch, headIsAncestorOfTag }
+}
+
+/**
+ * Execute an adoption the decision already approved: fast-forward main to
+ * the release tag. Returns true on success; on any failure the caller leaves
+ * the checkout in source mode (the reflog preserves the previous state, and
+ * checkout -B is itself atomic per-ref — no partial adoption state exists).
+ * The caller re-runs the bootstrap afterwards so venv/js re-materialize from
+ * payloads, then writes adoptionManifest().
+ */
+export function executeAdoptionCheckout(activeRoot: string, tag: string, git: GitRunner): boolean {
+  return git(['checkout', '-B', 'main', `${tag}^{commit}`], activeRoot).code === 0
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -49,6 +49,14 @@ import { shouldLatchBackendStartFailure, shouldLatchRemoteReauthFailure } from '
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
+import { needsRematerialization, resolvePayload } from './bundled-runtime'
+import {
+  adoptionManifest,
+  decideAdoption,
+  executeAdoptionCheckout,
+  gatherGitFacts,
+  type GitRunner
+} from './bundled-runtime'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
 import {
   authModeFromStatus,
@@ -3613,6 +3621,102 @@ function readBootstrapMarker() {
   return readJson(BOOTSTRAP_COMPLETE_MARKER)
 }
 
+// ─── Silent adoption of pristine legacy checkouts (plan §1.4) ───────────────
+//
+// Runs once per launch, BEFORE backend resolution reads the marker/manifest:
+// a bundled build meeting a pristine legacy checkout (no install manifest,
+// clean tree, on main, HEAD an ancestor of the payload tag) fast-forwards it
+// to the release tag and marks it bundled/auto-adopted. Every ambiguous
+// input skips silently — failure to adopt just means the checkout keeps
+// booting through the legacy path, and we retry at a future launch/release.
+// Runs at launch (fresh process, backend not yet spawned) and NEVER inside
+// `hermes update` — the update process executes post-pull steps from
+// pre-pull modules, so it only ever stages; fresh processes apply.
+
+const INSTALL_MANIFEST_PATH = path.join(ACTIVE_HERMES_ROOT, '.hermes-install.json')
+
+const adoptionGitRunner: GitRunner = (args, cwd) => {
+  try {
+    const stdout = execFileSync('git', ['-c', 'windows.appendAtomically=false', ...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 120_000,
+      ...hiddenWindowsChildOptions()
+    })
+
+    return { code: 0, stdout: String(stdout) }
+  } catch (err: any) {
+    return { code: typeof err?.status === 'number' ? err.status : -1, stdout: String(err?.stdout || '') }
+  }
+}
+
+/** Days since the checkout's last fetch (FETCH_HEAD mtime) — conservative
+ * proxy for "someone is actively running hermes update here". null = never. */
+function daysSinceLastFetch(activeRoot: string): number | null {
+  try {
+    const st = fs.statSync(path.join(activeRoot, '.git', 'FETCH_HEAD'))
+
+    return (Date.now() - st.mtimeMs) / 86_400_000
+  } catch {
+    return null
+  }
+}
+
+function maybeAutoAdopt() {
+  try {
+    const stamp = INSTALL_STAMP as any
+
+    // Thin builds can never adopt — skip before spawning any git probes
+    // (this is every dev run and every current CI build).
+    if (stamp?.payload !== true || !stamp?.tag) {
+      return false
+    }
+
+    const facts = {
+      stampHasPayload: stamp?.payload === true,
+      stampTag: stamp?.tag || null,
+      installManifest: readJson(INSTALL_MANIFEST_PATH),
+      recentManualUpdateDays: daysSinceLastFetch(ACTIVE_HERMES_ROOT),
+      ...gatherGitFacts(ACTIVE_HERMES_ROOT, stamp?.tag || '', adoptionGitRunner)
+    }
+
+    const decision = decideAdoption(facts)
+
+    if (!decision.adopt) {
+      if (facts.stampHasPayload) {
+        rememberLog(`[adopt] not adopting: ${(decision as any).reason}`)
+      }
+
+      return false
+    }
+
+    rememberLog(`[adopt] pristine legacy checkout — fast-forwarding to ${stamp.tag} (reflog is the undo)`)
+
+    if (!executeAdoptionCheckout(ACTIVE_HERMES_ROOT, stamp.tag, adoptionGitRunner)) {
+      rememberLog('[adopt] checkout failed; staying in source mode')
+
+      return false
+    }
+
+    writeFileAtomic(
+      INSTALL_MANIFEST_PATH,
+      JSON.stringify(adoptionManifest(stamp.tag), null, 2) + '\n',
+      'utf8'
+    )
+    // Do NOT touch the bootstrap marker here: its pinnedTag still names the
+    // previous materialization, so needsRematerialization() now fires and the
+    // normal bootstrap path re-materializes venv/js offline from payloads.
+    rememberLog('[adopt] adopted into the bundled path (manageStyle: auto-adopted)')
+
+    return true
+  } catch (err: any) {
+    rememberLog(`[adopt] error (staying source): ${err?.message || err}`)
+
+    return false
+  }
+}
+
 // Marker-independent: is the canonical install at ACTIVE_HERMES_ROOT actually
 // runnable right now? A complete CLI install (`install.sh --include-desktop`)
 // or a DMG launch over a prior CLI install satisfies this WITHOUT the desktop
@@ -3648,6 +3752,10 @@ function writeBootstrapMarker(payload) {
     schemaVersion: BOOTSTRAP_MARKER_SCHEMA_VERSION,
     pinnedCommit: payload.pinnedCommit || null,
     pinnedBranch: payload.pinnedBranch || null,
+    // Bundled builds: which payload tag this bootstrap materialized (null on
+    // thin/network bootstraps). Compared against the stamp tag at launch to
+    // trigger offline re-materialization after an app update.
+    pinnedTag: payload.pinnedTag || null,
     completedAt: new Date().toISOString(),
     desktopVersion: app.getVersion()
   }
@@ -3874,6 +3982,14 @@ function createActiveBackend(backendArgs) {
 }
 
 function resolveHermesBackend(backendArgs) {
+  // 0. Bundled builds: consider silently adopting a pristine legacy checkout
+  //    into the bundled path (plan §1.4). Must run before anything below
+  //    reads the marker / install manifest — adoption rewrites both. No-op
+  //    on thin builds and every non-pristine checkout; a successful adoption
+  //    leaves the marker's pinnedTag stale on purpose so the
+  //    re-materialization branch below re-runs the (now offline) bootstrap.
+  maybeAutoAdopt()
+
   // 1. Explicit override -- HERMES_DESKTOP_HERMES_ROOT points at a developer
   //    checkout. Honour it as-is (no bootstrap; the user is driving).
   const overrideRoot = process.env.HERMES_DESKTOP_HERMES_ROOT && path.resolve(process.env.HERMES_DESKTOP_HERMES_ROOT)
@@ -3908,7 +4024,29 @@ function resolveHermesBackend(backendArgs) {
   //    bootstrap when the runtime itself is unusable.
   const activeRuntime = activeRuntimeState()
 
-  if (activeRuntime.shouldUseActiveRuntime && !bootstrapRepairRequested) {
+  // Bundled builds: if the app updated (stamp tag ≠ marker pinnedTag), the
+  // runtime on disk was materialized from the PREVIOUS release's payloads.
+  // Re-run the bootstrap — it sources offline from the new payloads and the
+  // install.sh/ps1 repository stage refuses ejected (source-mode) checkouts,
+  // so a user-managed agent is never touched (needsRematerialization also
+  // short-circuits on installMode:source to skip the pointless re-run).
+  const rematerializationNeeded =
+    activeRuntime.shouldUseActiveRuntime &&
+    !bootstrapRepairRequested &&
+    needsRematerialization(
+      readBootstrapMarker(),
+      INSTALL_STAMP as any,
+      readJson(path.join(ACTIVE_HERMES_ROOT, '.hermes-install.json'))
+    )
+
+  if (rematerializationNeeded) {
+    rememberLog(
+      `[bootstrap] app updated to payload tag ${(INSTALL_STAMP as any).tag}; ` +
+        're-materializing the agent runtime offline from bundled payloads'
+    )
+  }
+
+  if (activeRuntime.shouldUseActiveRuntime && !bootstrapRepairRequested && !rematerializationNeeded) {
     if (!activeRuntime.hasValidMarker) {
       rememberLog(
         `[bootstrap] Active Hermes runtime at ${ACTIVE_HERMES_ROOT} is usable but the bootstrap marker is missing or stale; skipping first-run bootstrap.`
@@ -3927,7 +4065,9 @@ function resolveHermesBackend(backendArgs) {
   //    do NOT write a bootstrap marker; the user did this themselves and we
   //    don't want to take ownership of an install we didn't perform.
   //    HERMES_DESKTOP_IGNORE_EXISTING=1 forces the bootstrap path for testing.
-  if (process.env.HERMES_DESKTOP_IGNORE_EXISTING !== '1') {
+  //    Skipped when re-materialization is pending: the PATH hermes typically
+  //    points into the very ACTIVE_HERMES_ROOT venv we're about to refresh.
+  if (process.env.HERMES_DESKTOP_IGNORE_EXISTING !== '1' && !rematerializationNeeded) {
     let hermesCommand = null
     const hermesOverride = process.env.HERMES_DESKTOP_HERMES
 
@@ -3998,7 +4138,7 @@ function resolveHermesBackend(backendArgs) {
   // 5. Last-ditch: pip-installed hermes_cli module via system Python.
   //    Same rationale as #4 -- the user installed this; we use it but don't
   //    take ownership.
-  const python = findSystemPython()
+  const python = rematerializationNeeded ? null : findSystemPython()
 
   if (python) {
     // Same smoke-test rationale as step 4: a system Python in the
@@ -4110,6 +4250,10 @@ async function ensureRuntime(backend) {
       hermesHome: HERMES_HOME,
       logRoot: path.join(HERMES_HOME, 'logs'),
       abortSignal: bootstrapAbortController.signal,
+      // Bundled builds carry an agent-payload tree in resources; the install
+      // stages source from it offline (per-item fallback to network). Thin
+      // builds resolve null and bootstrap exactly as before.
+      payloadDir: (resolvePayload(process.resourcesPath) || ({} as any)).dir || null,
       onEvent: ev => {
         // Tee every bootstrap event to (a) the desktop log for forensics
         // and (b) the renderer for live progress UI. Either may be absent;


### PR DESCRIPTION
## Summary
Part 6 (top of the stack, after #79573). The Electron side of bundled installs: payload-backed bootstrap, app-update-driven re-materialization, and **silent adoption** of pristine legacy checkouts.

New `electron/bundled-runtime.ts` — pure decision core, all deps injected:
- `resolvePayload`: finds `resources/agent-payload`; thin stubs, dev runs, garbage, all-skipped payloads → null (**thin builds collapse every new path to a no-op — today's behavior byte-for-byte**).
- `needsRematerialization`: app updated (stamp tag ≠ marker pinnedTag) **and** the checkout's manifest says `installMode: bundled`. Deliberately false for legacy checkouts (only adoption, with its consent gates, may move those) and source/ejected (user owns updates).
- `decideAdoption` (plan §1.4): adopt only when the checkout has no `manageStyle`, clean tree, on `main`, no recent manual update (FETCH_HEAD mtime < 30d = cohabiting CLI user), and **HEAD is an ancestor of the payload tag** — answered by real `git fetch origin tag <tag>` (+ `--unshallow` for depth-1 installer clones) + `merge-base --is-ancestor`. Offline/ambiguous ⇒ defer silently, retry next launch. Every refusal carries a logged reason.
- Adoption executes as `git checkout -B main <tag>^{commit}` (reflog = undo) + `manageStyle: auto-adopted` (distinct from `adopted` so a bad cohort can be bulk-reverted without touching consenting users).

Wiring:
- `main.ts`: `maybeAutoAdopt()` at backend-resolution start (fresh process, backend not spawned — never inside `hermes update`, which runs post-pull steps on pre-pull code). Adoption leaves the marker's pinnedTag stale **on purpose**: the re-materialization branch then re-runs the bootstrap, offline, from payloads. Tag mismatch also bypasses resolver steps 4–5 (PATH hermes / system python point into the venv being refreshed).
- `bootstrap-runner.ts`: threads `payloadDir` into every install.sh/ps1 invocation (`--payload-dir` / `-PayloadDir` from #79573); marker gains `pinnedTag` on bundled builds.

Not in this PR: electron-updater feed/publish config (needs the release-pipeline decisions — tag cadence, update host) and the Windows Tauri-handoff retirement; both are follow-ups once bundled builds actually ship.

## Test plan
- [x] 17 new vitest tests on the decision core: thin-build null paths, re-materialization matrix (6 cases), the full adoption refusal table (12 variations, each asserting the reason), git fact-gathering incl. offline-defers-not-false, unshallow flow, dirty/off-main never touching network, and single-command adoption execution.
- [x] `npm run typecheck` (3 tsconfigs) + lint: 0 errors.
- [x] electron project: 966 passed / desktop ui: 3489 passed — no regressions.
- Real packaged-app adoption/re-materialization e2e needs a bundled artifact from CI (can't produce one on this host).