### PR TITLE
Add emem to optional-mcps catalog

### DIFF
--- a/optional-mcps/emem/manifest.yaml
+++ b/optional-mcps/emem/manifest.yaml
@@ -1,0 +1,40 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: emem
+description: Signed geospatial facts and verifiable citations for real-world locations.
+source: https://github.com/Vortx-AI/emem
+
+# emem is a public remote MCP server over Streamable HTTP. It needs no local
+# install, API key, or account for the selected public tools.
+transport:
+  type: http
+  url: https://emem.dev/mcp
+
+auth:
+  type: none
+
+# emem's public endpoint advertises a 15-tool core and has a broader advanced
+# surface available on demand. Keep the initial Hermes default focused on the
+# main place-based workflow. Users can opt into additional tools with
+# `hermes mcp configure emem`.
+tools:
+  default_enabled:
+    - emem_ask
+    - emem_locate
+    - emem_recall
+    - emem_memory_token
+    - emem_verify_receipt
+
+post_install: |
+  emem is ready to use without authentication. Start a new Hermes session
+  after installation, then ask a place-based question such as:
+
+    Is Helsinki-Vantaa Airport low-lying? Show the signed evidence.
+
+  The selected default tools resolve locations, retrieve signed geospatial
+  facts, create citation tokens, and verify receipts. To enable additional
+  emem tools, run:
+
+    hermes mcp configure emem

--- a/optional-mcps/emem/manifest.yaml
+++ b/optional-mcps/emem/manifest.yaml
@@ -3,38 +3,49 @@
 manifest_version: 1
 
 name: emem
-description: Signed geospatial facts and verifiable citations for real-world locations.
-source: https://github.com/Vortx-AI/emem
+description: Recall signed, citeable facts about real-world locations.
+source: https://emem.dev
 
-# emem is a public remote MCP server over Streamable HTTP. It needs no local
-# install, API key, or account for the selected public tools.
+# emem is an open protocol (Apache 2.0) serving cryptographically signed,
+# content-addressed geospatial facts over a remote Streamable HTTP MCP
+# server. Stateless, no session negotiation, nothing to install locally.
+# Every fact carries an ed25519 signature and a content address; receipts
+# verify offline against the responder's public key and an append-only
+# transparency log (RFC 6962 inclusion/consistency proofs).
 transport:
   type: http
-  url: https://emem.dev/mcp
+  url: https://emem.dev/mcp/full
 
-auth:
-  type: none
+# No auth: the public responder is open-read. Writes to /memories/* are
+# key-scoped server-side; no credentials are held by Hermes.
 
-# emem's public endpoint advertises a 15-tool core and has a broader advanced
-# surface available on demand. Keep the initial Hermes default focused on the
-# main place-based workflow. Users can opt into additional tools with
-# `hermes mcp configure emem`.
+# Tool selection at install time:
+# The full surface is ~105 tools. The curated default below covers the
+# working loop (locate a place, recall facts, cite them, verify a claim)
+# plus the common one-shot recalls. Everything else stays available but
+# unchecked; users opt in via `hermes mcp configure emem`.
 tools:
   default_enabled:
-    - emem_ask
-    - emem_locate
-    - emem_recall
-    - emem_memory_token
-    - emem_verify_receipt
+    - emem_tools            # map of the surface, start here
+    - emem_locate           # canonical cell64 address for a place
+    - emem_at               # one-shot signed facts at a place
+    - emem_ask              # free-text answer backed by signed receipts
+    - emem_recall           # signed facts at a cell64, auto-materializing
+    - emem_ndvi
+    - emem_forest
+    - emem_water
+    - emem_weather
+    - emem_elevation
+    - emem_verify           # claim -> verdict + evidence + signed receipt
+    - emem_memory_token     # mint a resolvable citation handle
+    - emem_memory_token_resolve
+    - emem_echo_verify      # grade a value against the fact it cites
+    - emem_verify_receipt   # offline receipt verification
 
 post_install: |
-  emem is ready to use without authentication. Start a new Hermes session
-  after installation, then ask a place-based question such as:
-
-    Is Helsinki-Vantaa Airport low-lying? Show the signed evidence.
-
-  The selected default tools resolve locations, retrieve signed geospatial
-  facts, create citation tokens, and verify receipts. To enable additional
-  emem tools, run:
-
+  No authentication needed. Try:
+    "Locate JSCA Stadium Ranchi and recall the signed NDVI fact there."
+  Facts return with a fact_cid and an emem:fact: citation token any agent
+  can resolve to the byte-identical signed object. Re-run the tool
+  checklist any time with:
     hermes mcp configure emem


### PR DESCRIPTION
## What

Catalog entry for **emem** — a remote MCP server (Streamable HTTP, `auth: none`, nothing to install) serving cryptographically signed, content-addressed facts about real-world locations. Open protocol, Apache 2.0, pure Rust. Same remote-HTTP pattern as the `linear` entry.

## Why

Agents making claims about the physical world currently can't cite or verify them. Every emem fact carries an ed25519 signature, a BLAKE3 content address, and a resolvable `emem:fact:` citation token any agent resolves to the byte-identical signed object. Receipts verify offline against an append-only transparency log (RFC 6962 inclusion/consistency proofs). Geo-AI teams are already building on Hermes (e.g. the AutoGeoAI4Sci fork); this gives them and everyone else a verifiable ground layer.

## Tool curation

Full surface is ~105 tools. `tools.default_enabled` is trimmed to 15 covering the working loop (locate → recall → cite → verify) plus common one-shot recalls (NDVI, forest, water, weather, elevation). Everything else stays opt-in via `hermes mcp configure emem`, per the pre-prune pattern the docs describe.

## Validation

Manifest parses clean through `hermes_cli.mcp_catalog._parse_manifest`:

```
PARSE OK | emem | http https://emem.dev/mcp/full | auth: none | 15 default tools
```

Live round-trip against the endpoint (stateless JSON-RPC, no session negotiation):

```
emem_locate {"place": "Eiffel Tower, Paris"}
  -> cell64: defi.zb5f7.dumU.suqU

emem_ndvi {"place": "Eiffel Tower, Paris"}
  -> band: indices.ndvi
     value: 0.3236
     fact_cids: 16 signed facts (polygon aggregation)
     responder_pubkey_b32: 777er3yihgifqmv5hmc2wwmyszgddzderzhsx6rex4yoakwomvka
```

Tool discovery confirms all 15 curated default tool names present in the 105-tool surface.

## Duplicate check

Searched open and merged issues/PRs for emem, geospatial, and signed-facts entries; no prior catalog entry covers this.

## Disclosure

Maintainer of emem here. Happy to adjust the manifest to whatever catalog review wants — narrower default set, description wording, anything.
