### PR TITLE
fix(compression): cap lease lifetime so a wedged live holder cannot block session writes forever

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -616,6 +616,14 @@ class _CompressionActivityHeartbeat:
 
 
 class _CompressionLockLeaseRefresher:
+    # Default cap on how long one lease may be renewed, as a multiple of its
+    # TTL, with a generous absolute floor. Must comfortably exceed any
+    # legitimate compression run (chunked summaries of huge sessions, slow
+    # local aux models with 300s+ per-call timeouts, transient retries), so
+    # the floor sits well above the gateway hygiene waiter's 600s ceiling.
+    _MAX_LIFETIME_TTL_MULTIPLE = 6.0
+    _MAX_LIFETIME_FLOOR_SECONDS = 1800.0
+
     def __init__(
         self,
         db: Any,
@@ -623,6 +631,7 @@ class _CompressionLockLeaseRefresher:
         holder: str,
         ttl_seconds: float,
         refresh_interval_seconds: float | None = None,
+        max_lifetime_seconds: float | None = None,
     ) -> None:
         self._db = db
         self._session_id = session_id
@@ -639,6 +648,31 @@ class _CompressionLockLeaseRefresher:
         self._max_consecutive_failures = max(
             1, int(self._ttl_seconds / self._refresh_interval_seconds)
         )
+        # Hard cap on total lease lifetime. The refresher only stops when the
+        # owner calls stop() - but an owner wedged inside a summary call that
+        # never returns (dead aux provider, per-chunk read timeout that resets
+        # on trickling bytes) never calls it, and a live-PID holder is exempt
+        # from dead-PID reclaim. Without this cap such a holder renews forever
+        # and append_message fails with CompressionSessionBusyError until a
+        # human deletes the lock row (observed in production: 45+ minutes of
+        # blocked writes). Once the cap trips we stop renewing, the lease
+        # expires by TTL, writes resume, and the zombie compression - if it
+        # ever returns - fails its lease check at publication and aborts
+        # without forking the session.
+        try:
+            max_lifetime = float(max_lifetime_seconds) if max_lifetime_seconds is not None else None
+        except (TypeError, ValueError):
+            max_lifetime = None
+        if max_lifetime is None or not math.isfinite(max_lifetime) or max_lifetime <= 0:
+            max_lifetime = max(
+                self._MAX_LIFETIME_TTL_MULTIPLE * self._ttl_seconds,
+                self._MAX_LIFETIME_FLOOR_SECONDS,
+            )
+        # A cap below one TTL is not honorable: the lease outlives the last
+        # renewal by up to a full TTL anyway, so floor the cap there.
+        self._max_lifetime_seconds = max(max_lifetime, float(self._ttl_seconds))
+        # Seam for tests; production always uses the monotonic clock.
+        self._monotonic = time.monotonic
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=self._run,
@@ -671,6 +705,7 @@ class _CompressionLockLeaseRefresher:
         # by the TTL the acquirer set — the lock can never be held past its TTL
         # by a stuck refresher.
         consecutive_failures = 0
+        started_at = self._monotonic()
         # First refresh happens immediately, not one interval late. Everything
         # between try_acquire() and start() (the rotation-ownership lookup, the
         # durable-breaker re-read, thread startup) is charged against the very
@@ -682,6 +717,24 @@ class _CompressionLockLeaseRefresher:
                 first = False
                 if self._stop.is_set():
                     break
+            elapsed = self._monotonic() - started_at
+            if elapsed >= self._max_lifetime_seconds:
+                # The owner never released us and the cap has passed: assume
+                # the compression is wedged, not slow. Stop renewing so the
+                # lease expires by TTL and blocked session writes resume; a
+                # worker that later returns fails its holder-qualified lease
+                # check at publication and aborts without forking the session.
+                logger.warning(
+                    "compression lease for session %s held for %.0fs "
+                    "(cap %.0fs) without completing; stopping the lease "
+                    "refresher so the lock expires by TTL (%.0fs) and "
+                    "session writes can resume",
+                    self._session_id,
+                    elapsed,
+                    self._max_lifetime_seconds,
+                    self._ttl_seconds,
+                )
+                break
             try:
                 refreshed = self._db.refresh_compression_lock(
                     self._session_id,
@@ -1504,6 +1557,7 @@ def compress_context(
     except (TypeError, ValueError):
         _lock_ttl = 300.0
     _lock_refresh_interval = getattr(agent, "_compression_lock_refresh_interval", None)
+    _lock_max_lifetime = getattr(agent, "_compression_lock_max_lifetime_seconds", None)
     _lock_refresher: Optional[_CompressionLockLeaseRefresher] = None
     if _lock_db is not None and _lock_sid:
         _lock_holder = _compression_lock_holder(agent)
@@ -1699,6 +1753,7 @@ def compress_context(
                 _lock_holder,
                 _lock_ttl,
                 _lock_refresh_interval,
+                max_lifetime_seconds=_lock_max_lifetime,
             )
             _lock_refresher.start()
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -1708,3 +1708,92 @@ def test_lease_refresher_stops_on_persistent_raise() -> None:
     _no_sleep(refresher)
     refresher._run()  # must not propagate
     assert db.calls == refresher._max_consecutive_failures
+
+
+def test_lease_refresher_stops_renewing_after_max_lifetime() -> None:
+    """A holder that never calls stop() must not renew the lease forever.
+
+    Regression for the wedged-holder incident: a compression worker stuck
+    inside a summary call (dead aux provider) keeps its refresher alive
+    indefinitely - the dead-PID reclaim never fires because the process is
+    alive, so append_message fails with CompressionSessionBusyError until a
+    human deletes the lock row. The lifetime cap must stop renewals so the
+    lease expires by TTL on its own.
+    """
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    db = _FlakyRefreshDB([])  # every refresh succeeds - a healthy-looking zombie
+    refresher = _CompressionLockLeaseRefresher(
+        db,
+        "sess",
+        "holder",
+        ttl_seconds=10.0,
+        refresh_interval_seconds=2.0,
+        max_lifetime_seconds=100.0,
+    )
+    _no_sleep(refresher)
+    # Scripted clock: 3 ticks inside the cap, then the cap is exceeded.
+    clock = iter([0.0, 10.0, 50.0, 99.0, 150.0, 151.0, 152.0])
+    refresher._monotonic = lambda: next(clock)
+    refresher._run()
+
+    # Ticks at 10/50/99s refreshed; the 150s reading tripped the cap before
+    # any further renewal. Successful renewals must never make the loop
+    # immortal - only the cap (or stop()) may end it.
+    assert db.calls == 3, (
+        f"expected renewals to stop at the lifetime cap after 3 ticks, "
+        f"got {db.calls} refresh calls"
+    )
+
+
+def test_lease_refresher_max_lifetime_defaults_are_bounded() -> None:
+    """The default cap derives from the TTL with an absolute floor, and an
+    explicit cap below one TTL is raised to the TTL (a smaller cap is not
+    honorable - the lease outlives the final renewal by up to a full TTL)."""
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    db = _FlakyRefreshDB([])
+    # Default: max(6 * ttl, 1800) - the floor dominates for the default 300s TTL.
+    r1 = _CompressionLockLeaseRefresher(db, "s", "h", ttl_seconds=300.0)
+    assert r1._max_lifetime_seconds == max(
+        r1._MAX_LIFETIME_TTL_MULTIPLE * 300.0, r1._MAX_LIFETIME_FLOOR_SECONDS
+    )
+    # A huge TTL scales the cap proportionally instead of being outlived by it.
+    r2 = _CompressionLockLeaseRefresher(db, "s", "h", ttl_seconds=3600.0)
+    assert r2._max_lifetime_seconds >= 6.0 * 3600.0
+    # An explicit cap below the TTL is floored at the TTL.
+    r3 = _CompressionLockLeaseRefresher(
+        db, "s", "h", ttl_seconds=60.0, max_lifetime_seconds=5.0
+    )
+    assert r3._max_lifetime_seconds == 60.0
+    # Garbage values fall back to the derived default instead of raising.
+    r4 = _CompressionLockLeaseRefresher(
+        db, "s", "h", ttl_seconds=60.0, max_lifetime_seconds="soon"
+    )
+    assert r4._max_lifetime_seconds == max(
+        r4._MAX_LIFETIME_TTL_MULTIPLE * 60.0, r4._MAX_LIFETIME_FLOOR_SECONDS
+    )
+
+
+def test_lease_refresher_keeps_renewing_under_max_lifetime() -> None:
+    """The cap must not fire early: a clock inside the cap never ends the loop,
+    only the external stop does (the pre-cap behavior is unchanged)."""
+    from agent.conversation_compression import _CompressionLockLeaseRefresher
+
+    db = _FlakyRefreshDB([])
+    refresher = _CompressionLockLeaseRefresher(
+        db,
+        "sess",
+        "holder",
+        ttl_seconds=10.0,
+        refresh_interval_seconds=2.0,
+        max_lifetime_seconds=1000.0,
+    )
+    refresher._monotonic = lambda: 0.0  # time never advances
+    refresher._stop.wait = lambda _i: db.calls >= 5  # type: ignore[assignment]
+    refresher._run()
+
+    assert db.calls >= 5, (
+        "refresher stopped before the external stop signal even though the "
+        f"lifetime cap was never reached (calls: {db.calls})"
+    )


### PR DESCRIPTION
## What does this PR do?

Bounds the total lifetime of a compression lock lease so a **live but wedged** compression worker cannot block session writes forever.

`_CompressionLockLeaseRefresher._run()` currently exits only when (a) the owner calls `stop()` or (b) refreshes fail `ttl/interval` consecutive times. A worker stuck inside its auxiliary summary call (dead aux provider; or an HTTP read timeout that resets on every trickled byte and so never fires) does neither: the DB is healthy, every renewal succeeds, and `_release_lock()` is never reached. The lease is then renewed indefinitely and every `append_message` on the session fails with `CompressionSessionBusyError`, which the gateway surfaces as the misleading "session storage could not be written - check disk space / permissions" turn abort.

None of the adjacent fixes cover this case:
- dead-PID reclaim (#70247, #74568 / #74569) never fires - the holder process is alive;
- raising the append-side busy-wait (#77386 / #77410 / #77799) cannot help - no finite wait outlasts a lease that is actively renewed every tick;
- treating `CompressionSessionBusyError` as recoverable (#73785) retries into the same held lock.

The fix gives the refresher a hard cap on total lease lifetime: once `monotonic() - start` exceeds the cap, it logs a WARNING and stops renewing, and the lease expires by TTL on its own. Session writes resume without human intervention. A zombie worker that eventually returns fails its holder-qualified lease check at publication ("Compression lease lost before publication") and aborts cleanly - i.e. this uses the revocation path the publication check was already built for, so there is no risk of forking the session lineage.

Cap default: `max(6 * ttl, 1800s)` (30 min with the default 300s TTL) - generously above the gateway hygiene waiter's 600s ceiling and any aux-timeout x retries budget, so legitimate slow compressions (chunked summaries of huge sessions, slow local models) are unaffected. Overridable via `agent._compression_lock_max_lifetime_seconds`, same pattern as the existing `_compression_lock_ttl_seconds` / `_compression_lock_refresh_interval` knobs. An explicit cap below one TTL is floored at the TTL (a smaller cap is not honorable - the lease outlives the final renewal by up to a full TTL anyway).

## Production incident motivating this (2026-08-04, macOS gateway)

- `auxiliary.compression` had no working provider (openrouter: payment error; nous: not authenticated). The summary call hung. The hygiene waiter gave up (`Session hygiene compression ... made no progress for 358.9s (total wait 360.0s, ceiling 600.0s); continuing without compression`) but the abandoned worker thread kept holding the lease.
- `errors.log` filled with `Session DB append_message failed: Session '...' is being compressed by another writer` for **45+ minutes**; every turn in that chat aborted with the disk-space/permissions message (disk had 40 GB free, permissions fine).
- Live observation of the lock row: `expires_at` advancing +60s per tick (refresh interval 60s, TTL 300s), holder `pid=...` alive, `acquired_at` 45 minutes in the past.
- Recovery required manually deleting the `compression_locks` row; appends resumed immediately.

## Related Issue

Related: #74568 (dead-PID variant of the same user-visible failure), #77386 (misleading disk-full dialog on this error path), #73785, #70247. I could not file a dedicated issue for the live-PID variant from this environment; happy to open one as a follow-up if maintainers prefer a linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: `_CompressionLockLeaseRefresher` gains `max_lifetime_seconds` (validated; garbage/non-finite/non-positive values fall back to the derived default; floored at one TTL) and a monotonic-clock lifetime check in `_run()` that stops renewals with a WARNING once the cap is exceeded. A `_monotonic` seam keeps the tests deterministic. The instantiation site passes the new agent knob through.
- `tests/agent/test_compression_concurrent_fork.py`: three new tests alongside the existing refresher suite - renewals stop at the cap with a scripted clock; default/floor/garbage-value derivation; and a no-early-fire guard proving pre-cap behavior is unchanged.

## How to Test

1. `python -m pytest tests/agent/test_compression_concurrent_fork.py -k lease_refresher -q` - 11 passed (8 pre-existing + 3 new).
2. `python -m pytest tests/agent/test_compression_concurrent_fork.py -q` - full file, 51 passed.
3. Manual repro of the incident: configure `auxiliary.compression` against a provider that accepts connections but never responds, trigger compression on a large session, and observe that (before this patch) `compression_locks.expires_at` slides forever while `append_message` fails; with the patch, renewals stop at the cap, the lease expires by TTL, and appends resume.

https://claude.ai/code/session_01CuSmXbQwfJNG3EaGdw4gMe
