### PR TITLE
feat(mcp): add Tendem to the MCP catalog (remote HTTP + native OAuth)

### DIFF
--- a/optional-mcps/tendem/manifest.yaml
+++ b/optional-mcps/tendem/manifest.yaml
@@ -1,0 +1,54 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: tendem
+description: Delegate tasks to vetted human experts - research, writing, analysis, and data work.
+source: https://github.com/Toloka/tendem-mcp
+
+# Tendem ships a hosted remote MCP server with native MCP OAuth 2.0 over
+# Streamable HTTP. Hermes's MCP client + mcp_oauth_manager handle discovery,
+# PKCE, token exchange, and refresh - nothing to clone, install, or run
+# locally, so this entry needs no `install:` block.
+transport:
+  type: http
+  url: https://mcp.tendem.ai/mcp?utm_hash=736745e8ff
+
+auth:
+  # No `provider:` - this is native MCP OAuth (case 1), not a third-party
+  # provider like Google. The MCP client triggers the browser flow on the
+  # first probe / first connect.
+  #
+  # Headless / CI users who would rather not do a browser flow can instead
+  # configure the server by hand with an `Authorization: ApiKey <token>`
+  # header, using a token from https://agent.tendem.ai/tokens.
+  type: oauth
+
+# Tool selection at install time:
+# The server exposes 11 tools covering one task lifecycle - create, scope by
+# chat, read the contract, approve, poll, fetch the result. Spend only ever
+# happens through `approve_task`, and only against a price the caller has
+# already read from `get_contract`, so the mutating tools are not pruned
+# here: pruning them would leave a task stuck mid-lifecycle. `default_enabled`
+# is left unset so the install-time checklist starts with everything
+# pre-checked and users prune what they don't want.
+
+post_install: |
+  On first connection, Hermes will open a browser to sign in to Tendem.
+  After auth, restart your Hermes session so the Tendem tools are loaded.
+
+  How the lifecycle works: `create_task` submits the request in plain
+  language, Tendem's orchestrator scopes it over `read_chat`/`send_message`,
+  and `get_contract` returns the agreed scope plus a price. Nothing is
+  charged until `approve_task` - surface the scope and the price to your
+  user and get an explicit go-ahead first. Poll with
+  `get_task(task_id, wait_for_change_seconds=30)` rather than busy-looping,
+  then collect markdown + files with `get_task_result`.
+
+  Good for work that wants a human in the loop: research and competitive
+  analysis, fact-checking, copywriting and editing, design review,
+  presentation polish, data cleaning and list building. Data scraping is
+  declined by policy.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure tendem


### PR DESCRIPTION
## What does this PR do?

Adds a single catalog entry, `optional-mcps/tendem/manifest.yaml`, so Hermes users can `hermes mcp install tendem` instead of hand-writing an `mcp_servers` block.

Tendem is a hybrid AI + human task service exposed as a remote MCP server. Hermes submits a task in plain language, Tendem's orchestrator scopes it over chat and quotes a transparent price, and after explicit approval a vetted human expert executes it and returns verified results as markdown plus files. It covers the work an agent alone can't reliably close out — research and competitive analysis, fact-checking, copywriting and editing, design review, presentation polish, data cleaning and list building. Data scraping is declined by policy.

Why this shape: the server ships native MCP OAuth 2.0 over Streamable HTTP, so the entry is the same low-risk kind as `linear` — no `install:` block, no clone, no `bootstrap`, no third-party auth provider, nothing running locally. The supply-chain pin policy has nothing to bite on here because no code is fetched or executed on the user's machine.

Fit is uncertain by design — the catalog is Nous-approved and there is no community submission tier — so treat this as a proposal and close it if a human-in-the-loop service isn't wanted in the catalog.

## Related Issue

No existing issue; searched open and closed PRs and issues for "tendem" and found none.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/tendem/manifest.yaml` (new, only file changed): `manifest_version: 1`, `transport.type: http` pointing at `https://mcp.tendem.ai/mcp`, `auth.type: oauth` (native MCP OAuth, no `provider:`), no `tools.default_enabled`, and a `post_install` note covering the create → scope → approve → poll → fetch lifecycle and the spend-approval step.

Reference: https://github.com/Toloka/tendem-mcp — also listed in the official MCP registry as `io.github.Toloka/tendem-mcp` (v1.0.1). Tools exposed: `create_task`, `get_task`, `get_contract`, `approve_task`, `cancel_task`, `get_task_result`, `list_tasks`, `read_chat`, `send_message`, `get_account`, `get_file_upload_url`.

## How to Test

1. `hermes mcp catalog` — the `tendem` row appears as `available`.
2. `hermes mcp install tendem` — no clone or bootstrap runs; a browser opens for Tendem OAuth on first connect, then the tool checklist lists the 11 tools above.
3. Start a new session and ask Hermes to create a small task; `get_contract` should return scope + price before anything is approved or charged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` — not run; this PR adds only a data manifest and touches no Python
- [ ] I've added tests for my changes — N/A, `tests/hermes_cli/test_mcp_catalog.py` covers manifest loading generically
- [x] I've tested on my platform: macOS 15 (manifest schema validated against the `linear` entry; YAML parses)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, `website/docs/user-guide/features/mcp.md` documents the catalog generically and needs no per-entry edit
- [x] I've updated `cli-config.yaml.example` — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact — remote HTTP + OAuth only, nothing platform-specific
- [x] I've updated tool descriptions/schemas — N/A, no Hermes tool behavior changed
