### PR TITLE
fix(desktop): never show bogus commit-behind count on shallow clones

### DIFF
--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -4,9 +4,14 @@ import { test } from 'vitest'
 
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 
-// FAIL-BEFORE: pre-fix the function did `Number.parseInt(countStr) || 0`
-// unconditionally, so a shallow checkout with no merge-base surfaced the bogus
-// rev-list count (e.g. 12104). This asserts the new shallow/no-merge-base branch.
+// FAIL-BEFORE: pre-fix `shouldCountCommits` returned `!(isShallow && !hasMergeBase)`,
+// so a SHALLOW checkout that happened to share a merge-base with the tip STILL ran
+// `rev-list --count` and surfaced the bogus thousands-of-commits number
+// (e.g. the real-world 4650 a shallow pin reported). The CLI's banner.py already
+// compares tip SHAs for ANY shallow clone — this aligns the desktop with that.
+// A shallow checkout must ALWAYS skip the count and fall back to a SHA compare,
+// regardless of whether a merge-base exists.
+
 test('shallow checkout with no merge-base does NOT trust the bogus rev-list count', () => {
   assert.equal(
     resolveBehindCount({
@@ -20,6 +25,33 @@ test('shallow checkout with no merge-base does NOT trust the bogus rev-list coun
   )
 })
 
+// The previously-missing case: shallow + merge-base was the live bug (4650).
+test('shallow checkout WITH a merge-base does NOT trust the bogus rev-list count', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '4650',
+      currentSha: 'aaa',
+      targetSha: 'bbb',
+      isShallow: true,
+      hasMergeBase: true
+    }),
+    1
+  )
+})
+
+test('shallow checkout behind by a bogus count but identical SHA reports up-to-date', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '4650',
+      currentSha: 'abc',
+      targetSha: 'abc',
+      isShallow: true,
+      hasMergeBase: true
+    }),
+    0
+  )
+})
+
 test('shallow checkout with no merge-base but identical SHA reports up-to-date', () => {
   assert.equal(
     resolveBehindCount({
@@ -30,19 +62,6 @@ test('shallow checkout with no merge-base but identical SHA reports up-to-date',
       hasMergeBase: false
     }),
     0
-  )
-})
-
-test('shallow checkout WITH a merge-base keeps the exact count (reliable)', () => {
-  assert.equal(
-    resolveBehindCount({
-      countStr: '3',
-      currentSha: 'aaa',
-      targetSha: 'bbb',
-      isShallow: true,
-      hasMergeBase: true
-    }),
-    3
   )
 })
 
@@ -86,15 +105,15 @@ test('non-numeric count falls back to 0 (defensive, unchanged behaviour)', () =>
 })
 
 // shouldCountCommits gates the expensive `rev-list --count` in checkUpdates().
-// FAIL-BEFORE: in the shallow + no-merge-base case the caller ran rev-list
-// unconditionally and discarded the bogus result; this predicate lets the
-// caller SKIP the whole-ancestry enumeration in exactly that case (#51922).
-test('shallow checkout with no merge-base SKIPS the rev-list count', () => {
+// Any shallow checkout (installer / binary / desktop pin) must skip it — the
+// local history is truncated, so the count is never meaningful. Only full
+// clones run it.
+test('shallow checkout SKIPS the rev-list count (no merge-base)', () => {
   assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: false }), false)
 })
 
-test('shallow checkout WITH a merge-base still runs the count', () => {
-  assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: true }), true)
+test('shallow checkout SKIPS the rev-list count (with merge-base — the live bug)', () => {
+  assert.equal(shouldCountCommits({ isShallow: true, hasMergeBase: true }), false)
 })
 
 test('full (non-shallow) clone always runs the count', () => {

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -1,22 +1,35 @@
 // Whether `git rev-list HEAD..origin/<branch> --count` produces a meaningful
-// number worth computing. On a SHALLOW checkout (installer clones with
-// --depth 1) the local history often shares no merge-base with the freshly
-// fetched origin tip, so the count enumerates the entire remote ancestry and
-// returns a bogus huge number (e.g. 12104) — see #51922. resolveBehindCount
-// discards that bogus count in favour of a SHA compare, so the caller should
-// SKIP the expensive rev-list entirely in that case rather than run it and
-// throw the result away.
-function shouldCountCommits({ isShallow, hasMergeBase }) {
-  return !(isShallow && !hasMergeBase)
+// number worth computing. On a SHALLOW checkout (installer and most binary /
+// desktop installs clone with --depth 1) the local history is truncated, so
+// `rev-list --count` enumerates the entire remote ancestry and returns a bogus
+// huge number (e.g. 12104, and in practice thousands — see #51922 and the
+// real-world 4650 a shallow pin reported). The CLI's banner.py makes the same
+// decision: ANY shallow checkout skips the count and falls back to a SHA
+// compare, surfacing a generic "update available" instead of a scary,
+// unactionable commit distance. Full clones (developers / Docker dev images)
+// keep the exact count path unchanged.
+function shouldCountCommits({ isShallow, hasMergeBase }: { isShallow: boolean; hasMergeBase?: boolean }) {
+  // Previously this was `!(isShallow && !hasMergeBase)`, which still trusted
+  // the count whenever a shallow clone happened to share a merge-base with the
+  // tip — that path produces the bogus 4650. Shallow history is never reliable
+  // to count across (the local boundary is artificial), so treat every shallow
+  // checkout as binary and compare tip SHAs instead.
+  return !isShallow
 }
 
 // Resolve how many commits the local checkout is behind origin for the desktop
-// update indicator. When the count isn't meaningful (shallow + no merge-base)
-// fall back to a binary up-to-date check by SHA, exactly like the official-SSH
-// path in checkUpdates() and the CLI guard in hermes_cli/banner.py. Full clones
-// (developers / Docker dev images) keep the exact count path unchanged.
-function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase }) {
-  if (!shouldCountCommits({ isShallow, hasMergeBase })) {
+// update indicator. On a shallow checkout we have no reliable history to count
+// across, so we fall back to a binary up-to-date check by SHA — exactly like
+// the official-SSH path in checkUpdates() and the CLI guard in
+// hermes_cli/banner.py. Full clones keep the exact count path unchanged.
+function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase }: {
+  countStr: string
+  currentSha: string
+  targetSha: string
+  isShallow: boolean
+  hasMergeBase?: boolean
+}) {
+  if (isShallow) {
     if (currentSha && targetSha && currentSha === targetSha) {
       return 0
     }


### PR DESCRIPTION
## Summary

A shallow `hermes-agent` checkout that shares a merge-base with `origin/main` still runs `git rev-list HEAD..origin/<branch> --count` in `checkUpdates()`, and surfaces the raw (real but alarming) commit distance in the desktop update pill — e.g. **4650 commits behind** on a shallow pin that simply hadn't been updated.

`apps/desktop/electron/update-count.ts` only skipped the count when `isShallow && !hasMergeBase`. The shallow-with-merge-base case fell through to the count and produced the bogus large number.

This aligns the desktop with the already-correct CLI guard in `hermes_cli/banner.py`: **any** shallow checkout skips the count and falls back to a tip-SHA compare, showing a generic "update available" instead of a scary, unactionable number. Full clones keep the exact-count path unchanged.

- `shouldCountCommits` → `return !isShallow`
- `resolveBehindCount` → binary SHA compare when `isShallow`, else the parsed count

## Test plan

- Updated `update-count.test.ts`: it previously asserted the buggy shallow+merge-base behavior (count kept); now asserts shallow always resolves via SHA compare. Added the missing shallow+merge-base case that produced the 4650.
- `vitest run electron/update-count.test.ts` → 11/11 pass.
- `tsc -p apps/desktop/tsconfig.electron.json --noEmit` → clean.

## Root cause reference

First reported as the desktop update pill showing "4650 updates" on a shallow install. Mirrors desktop note in `banner.py` (shallow clones compare tip SHAs, never count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)