### PR TITLE
fix(web): show Telegram session context in chat list

### DIFF
--- a/web/src/components/ChatSessionList.tsx
+++ b/web/src/components/ChatSessionList.tsx
@@ -27,6 +27,7 @@ import { useSearchParams } from "react-router";
 
 import { useI18n } from "@/i18n";
 import { api, type SessionInfo } from "@/lib/api";
+import { telegramThreadLabel } from "@/lib/session-labels";
 import { cn, timeAgo } from "@/lib/utils";
 
 const SESSION_LIMIT = 30;
@@ -181,6 +182,7 @@ export function ChatSessionList({
       <div className="flex flex-col gap-0.5">
         {sessions.map((s) => {
           const isActive = s.id === activeSessionId;
+          const telegramLabel = telegramThreadLabel(s);
           return (
             <ListItem
               key={s.id}
@@ -205,7 +207,12 @@ export function ChatSessionList({
                     <span>{s.message_count} msgs</span>
                   </>
                 )}
-                {s.source && s.source !== "cli" && (
+                {telegramLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span className="truncate">{telegramLabel}</span>
+                  </>
+                ) : s.source && s.source !== "cli" && (
                   <>
                     <span aria-hidden>·</span>
                     <span className="truncate">{s.source}</span>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1886,6 +1886,11 @@ export interface StatusResponse {
 export interface SessionInfo {
   id: string;
   source: string | null;
+  chat_id?: string | null;
+  chat_type?: string | null;
+  thread_id?: string | number | null;
+  display_name?: string | null;
+  origin_json?: string | null;
   model: string | null;
   title: string | null;
   started_at: number;

--- a/web/src/lib/session-labels.test.ts
+++ b/web/src/lib/session-labels.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { telegramThreadLabel } from "@/lib/session-labels";
+import type { SessionInfo } from "@/lib/api";
+
+function session(overrides: Partial<SessionInfo>): SessionInfo {
+  return {
+    id: "s1",
+    source: null,
+    model: null,
+    title: null,
+    started_at: 0,
+    ended_at: null,
+    last_active: 0,
+    is_active: false,
+    message_count: 0,
+    tool_call_count: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    preview: null,
+    ...overrides,
+  };
+}
+
+describe("telegramThreadLabel", () => {
+  it("ignores non-Telegram sessions", () => {
+    expect(telegramThreadLabel(session({ source: "cli" }))).toBeNull();
+  });
+
+  it("shows Telegram DM display context", () => {
+    expect(
+      telegramThreadLabel(
+        session({
+          source: "telegram",
+          display_name: "Frank van Puffelen",
+          chat_type: "dm",
+        }),
+      ),
+    ).toBe("telegram · Frank van Puffelen");
+  });
+
+  it("prefers topic names from origin metadata", () => {
+    expect(
+      telegramThreadLabel(
+        session({
+          source: "telegram",
+          display_name: "Home",
+          thread_id: 123,
+          chat_type: "group",
+          origin_json: JSON.stringify({ chat_topic: "Daily video jobs" }),
+        }),
+      ),
+    ).toBe("telegram · Home · Daily video jobs");
+  });
+
+  it("falls back to thread id when topic metadata is absent", () => {
+    expect(
+      telegramThreadLabel(
+        session({
+          source: "telegram",
+          display_name: "Home",
+          thread_id: 456,
+          chat_type: "group",
+        }),
+      ),
+    ).toBe("telegram · Home · thread 456");
+  });
+
+  it("does not throw on malformed origin metadata", () => {
+    expect(
+      telegramThreadLabel(
+        session({
+          source: "telegram",
+          display_name: "Home",
+          chat_type: "group",
+          origin_json: "not json",
+        }),
+      ),
+    ).toBe("telegram · Home");
+  });
+
+  it("shows only the platform when no display or thread context exists", () => {
+    expect(
+      telegramThreadLabel(
+        session({
+          source: "telegram",
+          chat_type: "group",
+        }),
+      ),
+    ).toBe("telegram");
+  });
+});

--- a/web/src/lib/session-labels.ts
+++ b/web/src/lib/session-labels.ts
@@ -1,0 +1,24 @@
+import type { SessionInfo } from "@/lib/api";
+
+export function telegramThreadLabel(session: SessionInfo): string | null {
+  if (session.source !== "telegram") return null;
+
+  let topic: string | null = null;
+  try {
+    const origin = session.origin_json ? JSON.parse(session.origin_json) : null;
+    const rawTopic = origin?.chat_topic ?? origin?.topic_name ?? null;
+    if (typeof rawTopic === "string" && rawTopic.trim()) topic = rawTopic.trim();
+  } catch {
+    // Best-effort display only; malformed origin JSON should not break the list.
+  }
+
+  const parts = ["telegram"];
+  const who = session.display_name?.trim();
+  if (who) parts.push(who);
+  if (topic) {
+    parts.push(topic);
+  } else if (session.thread_id !== null && session.thread_id !== undefined && `${session.thread_id}`) {
+    parts.push(`thread ${session.thread_id}`);
+  }
+  return parts.join(" · ");
+}


### PR DESCRIPTION
## Summary
- show Telegram chat/thread context in the dashboard chat session switcher instead of only `telegram`
- surface Telegram metadata fields on the frontend `SessionInfo` type
- add unit coverage for DM, topic-name, thread-id, and malformed-origin fallbacks

## Test plan
- `npm --workspace web run check`
- `npm --workspace web run build`

## Notes
This restores visibility for Telegram-origin conversations/topics after the recent desktop/web upgrade. The backend already includes the relevant fields (`chat_type`, `thread_id`, `display_name`, `origin_json`) in session rows; this patch only formats them in the chat session list.
