### PR TITLE
fix(buzz): honor the reactions setting for the "seen" reaction

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -25,11 +25,12 @@ Configuration in config.yaml::
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
+            reactions: true            # false = no "seen" reaction on inbound messages
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
     BUZZ_CLI_PATH, BUZZ_CREDENTIALS_FILE, BUZZ_ALLOWED_USERS,
-    BUZZ_ALLOW_ALL_USERS
+    BUZZ_ALLOW_ALL_USERS, BUZZ_REACTIONS
 
 The only secret is BUZZ_PRIVATE_KEY (nsec or hex) — it belongs in
 ``~/.hermes/.env``.  It is passed to the CLI via the subprocess
@@ -638,6 +639,16 @@ class BuzzAdapter(BasePlatformAdapter):
         """Buzz has no typing indicator API — no-op."""
         pass
 
+    def _reactions_enabled(self) -> bool:
+        """Check if message reactions are enabled via config/env.
+
+        Same contract as the Discord adapter and the generic hook in
+        ``gateway/platforms/base.py``: ``<PLATFORM>_REACTIONS``, default on.
+        Buzz shipped without this gate, so the "seen" reaction fired even for
+        a deployment that had turned reactions off on every other platform.
+        """
+        return os.getenv("BUZZ_REACTIONS", "true").lower() not in {"false", "0", "no"}
+
     async def send_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Add a reaction to a message via buzz-cli.
 
@@ -1245,7 +1256,8 @@ class BuzzAdapter(BasePlatformAdapter):
         # Add a "seen" reaction after dispatching — signals to the user that
         # their message was received and is being processed.
         try:
-            await self.send_reaction(chat_id, message_id, "👀")
+            if self._reactions_enabled():
+                await self.send_reaction(chat_id, message_id, "👀")
         except Exception:
             logger.debug("Buzz: reaction failed for message %s", message_id[:12], exc_info=True)
 
@@ -1316,6 +1328,8 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
+    if "reactions" in extra and not os.getenv("BUZZ_REACTIONS"):
+        os.environ["BUZZ_REACTIONS"] = str(extra["reactions"]).lower()
     return None
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -23,6 +24,7 @@ check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
 _env_enablement = _buzz_mod._env_enablement
+_apply_yaml_config = _buzz_mod._apply_yaml_config
 _standalone_send = _buzz_mod._standalone_send
 
 # Real key pair (Chip's public identity — public information, not a secret)
@@ -42,6 +44,7 @@ _ENV_VARS = (
     "BUZZ_HOME_CHANNEL",
     "BUZZ_ALLOWED_USERS",
     "BUZZ_ALLOW_ALL_USERS",
+    "BUZZ_REACTIONS",
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
@@ -538,3 +541,77 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+# ── Reactions gate ────────────────────────────────────────────────────────
+
+
+class TestBuzzReactionsGate:
+    """The "seen" reaction must honor the per-platform reactions setting.
+
+    These drive the real ``_dispatch_message`` rather than calling the gate
+    helper directly: a correct helper whose call site never consults it would
+    pass a helper-only test while still reacting to every message.
+    """
+
+    async def _dispatch(self, adapter):
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        # Stub the base-class entry point (session plumbing outside this
+        # change); the wiring under test is the REAL _dispatch_message body,
+        # its gate, and whether send_reaction is reached.
+        adapter.handle_message = fake_handle_message
+        adapter._message_handler = fake_handle_message
+        adapter._channel_names[CHANNEL] = "general"
+        reacted = []
+
+        async def fake_reaction(chat_id, message_id, emoji):
+            reacted.append((chat_id, message_id, emoji))
+            return True
+
+        adapter.send_reaction = fake_reaction
+        await adapter._dispatch_message(
+            text="hello",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="alice",
+            message_id="evt1",
+            created_at=1000,
+        )
+        return handled, reacted
+
+    @pytest.mark.asyncio
+    async def test_seen_reaction_fires_by_default(self):
+        handled, reacted = await self._dispatch(_make_adapter())
+        assert reacted == [(CHANNEL, "evt1", "👀")]
+        assert len(handled) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["false", "0", "no"])
+    async def test_reactions_disabled_suppresses_the_seen_reaction(self, monkeypatch, value):
+        monkeypatch.setenv("BUZZ_REACTIONS", value)
+        handled, reacted = await self._dispatch(_make_adapter())
+        assert reacted == []
+        # The gate must only suppress the reaction, never the dispatch itself.
+        assert len(handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_true_still_reacts(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_REACTIONS", "true")
+        _handled, reacted = await self._dispatch(_make_adapter())
+        assert len(reacted) == 1
+
+    def test_config_yaml_reactions_key_bridges_to_env(self):
+        _apply_yaml_config({}, {"extra": {"relay_url": "https://x", "reactions": False}})
+        assert os.environ.get("BUZZ_REACTIONS") == "false"
+
+    def test_env_wins_over_config(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_REACTIONS", "false")
+        _apply_yaml_config({}, {"extra": {"relay_url": "https://x", "reactions": True}})
+        assert os.environ.get("BUZZ_REACTIONS") == "false"
+
+    def test_absent_config_key_sets_nothing(self):
+        _apply_yaml_config({}, {"extra": {"relay_url": "https://x"}})
+        assert os.environ.get("BUZZ_REACTIONS") is None


### PR DESCRIPTION
## What

Gives the Buzz adapter the `_reactions_enabled()` gate every other adapter with a reaction feature already has, and a `reactions:` config key to drive it.

## Why

The Buzz adapter adds a "seen" 👀 reaction to every inbound message it dispatches. Unlike Discord (whose `_reactions_enabled()` reads `DISCORD_REACTIONS`, fed by the per-platform `reactions:` config key, and which the generic processing hooks in `gateway/platforms/base.py` also consult), Buzz has no gate at all. A deployment that sets `reactions: false` on every platform still gets reacted at on Buzz, with no way to turn it off.

## Shape

Config-first, mirroring the Discord adapter exactly:

```yaml
buzz:
  extra:
    reactions: false   # default true; unset = today's behaviour
```

- `_apply_yaml_config` bridges the key to `BUZZ_REACTIONS` with the same `not os.getenv(...)` guard as the sibling keys (`require_mention`, `allow_all_users`), so an explicit env var still wins and the value is internal, per the AGENTS.md env-var policy.
- The gate uses the same truthiness set as Discord's (`not in {"false", "0", "no"}`), so behaviour is consistent across adapters. If #79253's `env_var_enabled` migration lands, this gate is one more one-line call site for it.
- Default on: an unset config is byte-identical to today.

## How tested

Six new cases (ten with parametrize expansion) in `tests/gateway/test_buzz_adapter.py`:

- the suppression cases drive the **real `_dispatch_message`**, not the gate helper, and assert both that `send_reaction` is not reached and that the message handler still is, so the gate cannot silently swallow dispatch
- default-on fires the reaction; explicit `true` fires; `false`/`0`/`no` suppress
- the config key bridges to the env var; an explicit env var wins over config; an absent key sets nothing

```
tests/gateway/test_buzz_adapter.py                       31 passed
+ tests/gateway/test_buzz_websocket.py                   35 passed
adapter change reverted, tests kept                      4 failed, 27 passed
```

The wiring-not-helper test shape is deliberate: in our deployment an earlier version of this gate shipped with a correct helper whose call site never consulted it, and a helper-only test stayed green.

## Platforms

Buzz only.

## Related

Sibling per-adapter reactions work: #78898 (Discord), #78899 (Slack), #78905 (Feishu), #78907 (Matrix), and #79253 (shared `env_var_enabled`). This fills the same gap for the one adapter that has no gate at all, and follows the currently-merged idiom rather than the pending helper migration.
