### PR TITLE
fix(telegram): assign observed group context once

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1566,6 +1566,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
                 if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
                     bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
+                if plat == Platform.TELEGRAM and "observe_unmentioned_group_exclude_patterns" in platform_cfg:
+                    bridged["observe_unmentioned_group_exclude_patterns"] = platform_cfg[
+                        "observe_unmentioned_group_exclude_patterns"
+                    ]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1194,6 +1194,147 @@ def _message_timestamps_enabled(user_config: Optional[dict]) -> bool:
     return bool(mt)
 
 
+def _is_addressed_gateway_user_row(message: Dict[str, Any]) -> bool:
+    """Return whether a transcript user row proves an addressed gateway turn.
+
+    Platform message identity is the primary boundary. The provider sidecar is
+    a fallback for gateway turns restored from stores that omit that identity.
+    Ambiguous synthetic/legacy user rows deliberately do not consume pending
+    observations: retaining extra context is safer than silently losing real
+    group conversation.
+    """
+
+    return bool(
+        message.get("platform_message_id")
+        or message.get("message_id")
+        or message.get("api_content") is not None
+    )
+
+
+def _merge_gateway_adjacent_user_sidecars(messages: List[Dict[str, Any]]) -> int:
+    """Merge adjacent text user turns without discarding provider sidecars.
+
+    Generic alternation repair intentionally drops ``api_content`` after a
+    content merge. Gateway replay cannot do that when the sidecar is the exact
+    observed-context wrapper already sent for an addressed turn. Merge those
+    effective provider bytes first; the generic repair can then handle the
+    remaining ordinary adjacency safely.
+    """
+
+    merged: List[Dict[str, Any]] = []
+    repairs = 0
+    for message in messages:
+        if (
+            merged
+            and message.get("role") == "user"
+            and merged[-1].get("role") == "user"
+            and (
+                merged[-1].get("api_content") is not None
+                or message.get("api_content") is not None
+            )
+        ):
+            previous = merged[-1]
+            previous_content = previous.get("content", "")
+            current_content = message.get("content", "")
+            previous_api = previous.get("api_content", previous_content)
+            current_api = message.get("api_content", current_content)
+            if all(
+                isinstance(value, str)
+                for value in (
+                    previous_content,
+                    current_content,
+                    previous_api,
+                    current_api,
+                )
+            ):
+                previous["content"] = (
+                    f"{previous_content}\n\n{current_content}"
+                    if previous_content and current_content
+                    else previous_content or current_content
+                )
+                previous["api_content"] = (
+                    f"{previous_api}\n\n{current_api}"
+                    if previous_api and current_api
+                    else previous_api or current_api
+                )
+                repairs += 1
+                continue
+        merged.append(message)
+
+    if repairs:
+        messages[:] = merged
+    return repairs
+
+
+def _api_content_text_parts(api_content: Any) -> List[str]:
+    if isinstance(api_content, str):
+        return [api_content]
+    if isinstance(api_content, list):
+        return [
+            str(part.get("text", ""))
+            for part in api_content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+    return []
+
+
+def _sidecar_commits_observed_values(
+    api_content: Any,
+    observed_values: List[str],
+) -> bool:
+    """Match historical values while ignoring timestamp presentation changes."""
+
+    from gateway.message_timestamps import strip_leading_message_timestamps
+
+    header = f"{_OBSERVED_GROUP_CONTEXT_HEADER}\n"
+    committed_suffix = f"\n\n{_CURRENT_ADDRESSED_MESSAGE_HEADER}\n"
+    for text in _api_content_text_parts(api_content):
+        if not text.startswith(header):
+            continue
+        remainder = text[len(header):]
+        for index, raw_value in enumerate(observed_values):
+            if remainder.startswith(raw_value):
+                remainder = remainder[len(raw_value):]
+            else:
+                clean_remainder, _ = strip_leading_message_timestamps(remainder)
+                if clean_remainder == remainder or not clean_remainder.startswith(raw_value):
+                    break
+                remainder = clean_remainder[len(raw_value):]
+
+            if index == len(observed_values) - 1:
+                if remainder.startswith(committed_suffix):
+                    return True
+                break
+            if not remainder.startswith("\n"):
+                break
+            remainder = remainder[1:]
+    return False
+
+
+def _committed_observed_version_count(
+    versions: List[tuple[tuple[str, str], str]],
+    api_content: Any,
+) -> int:
+    """Return the historical-version prefix committed by ``api_content``.
+
+    Each candidate cut is projected to the latest value per Telegram message id
+    as it existed at that point. This keeps later human edits pending without
+    letting them obscure an earlier provider snapshot.
+    """
+
+    projection: Dict[tuple[str, str], str] = {}
+    last_matching_index = 0
+    for index, (key, raw_value) in enumerate(versions, start=1):
+        projection.pop(key, None)
+        projection[key] = raw_value
+        if _sidecar_commits_observed_values(
+            api_content,
+            list(projection.values()),
+        ):
+            last_matching_index = index
+    return last_matching_index
+
+
 def _build_gateway_agent_history(
     history: List[Dict[str, Any]],
     *,
@@ -1220,7 +1361,17 @@ def _build_gateway_agent_history(
 
     _msg_tz = _get_msg_tz()
     agent_history: List[Dict[str, Any]] = []
-    observed_group_context: List[str] = []
+    # Observed rows are assigned to the *next* addressed turn.  Earlier rows
+    # already live exactly once in that turn's api_content sidecar and must not
+    # be selected again. Dict insertion order deduplicates Telegram message
+    # ids and keeps the newest human edit available before assignment. Bot
+    # edits are rejected at Telegram ingress while authoritative sender/edit
+    # metadata is still available. Rows without a platform id stay fail-open
+    # and independent.
+    pending_observed: Dict[tuple[str, str], str] = {}
+    pending_observed_versions: List[tuple[tuple[str, str], str, str]] = []
+    observed_content_by_id: Dict[str, str] = {}
+    unkeyed_observed_seq = 0
     separate_observed_context = _uses_telegram_observed_group_context(channel_prompt)
 
     for msg in history or []:
@@ -1237,12 +1388,81 @@ def _build_gateway_agent_history(
         if role == "system":
             continue
 
-        content = msg.get("content")
+        raw_content = msg.get("content")
+        content = raw_content
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
-        if separate_observed_context and msg.get("observed") and role == "user" and content:
-            observed_group_context.append(str(content).strip())
+        if separate_observed_context and msg.get("observed") and role == "user":
+            if not content:
+                # Empty synthetic rows carry no model context.  Dropping the
+                # entire row also avoids leaking a bare Telegram message id.
+                continue
+            normalized_content = str(content).strip()
+            normalized_raw_content = str(raw_content).strip()
+            message_id = str(msg.get("message_id") or "").strip()
+            if message_id:
+                # Telegram retransmits and restored adapter caches may append
+                # the same passive row again after an addressed boundary. Keep
+                # genuine human corrections (same id, different raw content),
+                # but never redeliver an identical id/content pair. Timestamp
+                # rendering is presentation and must not change this identity.
+                if observed_content_by_id.get(message_id) == normalized_raw_content:
+                    continue
+                observed_content_by_id[message_id] = normalized_raw_content
+                key = ("message", message_id)
+            else:
+                unkeyed_observed_seq += 1
+                key = ("row", str(unkeyed_observed_seq))
+            # Telegram human edits reuse message_id. Keep only the latest
+            # version available at this addressed-turn boundary.
+            pending_observed.pop(key, None)
+            pending_observed[key] = normalized_content
+            pending_observed_versions.append(
+                (key, normalized_raw_content, normalized_content)
+            )
             continue
+
+        if (
+            separate_observed_context
+            and role == "user"
+            and _is_addressed_gateway_user_row(msg)
+        ):
+            # A proven gateway user row is an addressed turn. Consume only the
+            # pending prefix whose exact observed wrapper was durably persisted
+            # on this row. Passive rows may have arrived after the provider
+            # snapshot but before this user row's crash-safe write; transcript
+            # position alone must not assign those later observations backward.
+            committed_count = _committed_observed_version_count(
+                [(key, raw) for key, raw, _ in pending_observed_versions],
+                msg.get("api_content"),
+            )
+            if committed_count:
+                committed_projection: Dict[tuple[str, str], str] = {}
+                for key, raw, _ in pending_observed_versions[:committed_count]:
+                    committed_projection.pop(key, None)
+                    committed_projection[key] = raw
+                del pending_observed_versions[:committed_count]
+
+                suffix_projection: Dict[tuple[str, str], str] = {}
+                for key, raw, _ in pending_observed_versions:
+                    suffix_projection.pop(key, None)
+                    suffix_projection[key] = raw
+                reverted_keys = {
+                    key
+                    for key, raw in suffix_projection.items()
+                    if committed_projection.get(key) == raw
+                }
+                if reverted_keys:
+                    pending_observed_versions[:] = [
+                        version
+                        for version in pending_observed_versions
+                        if version[0] not in reverted_keys
+                    ]
+
+                pending_observed.clear()
+                for key, _, rendered in pending_observed_versions:
+                    pending_observed.pop(key, None)
+                    pending_observed[key] = rendered
 
         # Rich agent messages (tool_calls, tool results) must be passed through
         # intact so the API sees valid assistant→tool sequences.
@@ -1275,6 +1495,19 @@ def _build_gateway_agent_history(
             entry = _build_replay_entry(role, content, msg, preserve_timestamp=(role == "user"))
             agent_history.append(entry)
 
+    # Repair provider role alternation only after structurally hidden observed
+    # rows have been removed.  Repairing the raw transcript first can merge
+    # passive chatter into an addressed/API-wrapped user turn.
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    repair_count = _merge_gateway_adjacent_user_sidecars(agent_history)
+    repair_count += repair_message_sequence(None, agent_history)
+    if repair_count:
+        logger.info(
+            "Repaired %d gateway message-alternation violation(s) after context partitioning",
+            repair_count,
+        )
+
     # Strip interrupted tool-call tails so the LLM doesn't re-execute
     # tools that were killed mid-flight.
     agent_history = strip_interrupted_tool_tails(agent_history)
@@ -1295,29 +1528,56 @@ def _build_gateway_agent_history(
         agent_history, now=time.time()
     )
 
-    observed_context = "\n".join(observed_group_context).strip() or None
+    observed_context = "\n".join(pending_observed.values()).strip() or None
     return agent_history, observed_context
+
+
+def _build_gateway_hygiene_history(
+    history: List[Dict[str, Any]],
+    *,
+    channel_prompt: Optional[str] = None,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]], bool]:
+    """Build safe replay and token-estimate inputs for pre-turn hygiene.
+
+    Passive Telegram observations must not be compressed as ordinary durable
+    user turns.  The estimate includes their once-only pending text so hygiene
+    does not undercount, while the replay list remains safe to compress.  A
+    pending flag lets the caller defer pre-turn compression until the live turn
+    can attach that text without dropping or duplicating it.
+    """
+
+    replay, pending = _build_gateway_agent_history(
+        history,
+        channel_prompt=channel_prompt,
+    )
+    estimate = list(replay)
+    if pending:
+        estimate.append({"role": "user", "content": pending})
+    return replay, estimate, pending is not None
 
 
 def _select_cached_agent_history(
     persisted_history: List[Dict[str, Any]],
     live_history: Any,
 ) -> List[Dict[str, Any]]:
-    """Prefer a cached agent's live in-memory transcript over a shorter
-    persisted one.
+    """Prefer a genuinely longer canonical live transcript.
 
-    Guards the FTS write-corruption case (#50502): when message writes fail
-    silently through corrupt FTS triggers, the next turn reloads a stale/empty
-    ``conversation_history`` from disk even though the same cached ``AIAgent``
-    still holds the full live ``_session_messages``. Replacing the live
-    transcript with that shorter persisted copy causes immediate same-session
-    amnesia. When the live transcript is strictly longer, keep it.
-
-    Returns ``persisted_history`` unchanged unless the live copy is a longer
-    list, in which case a copy of the live transcript is returned.
+    The cached agent keeps provider-facing messages, while the persisted path
+    has already passed through structural filtering and role-alternation repair.
+    Normalize a deep copy of the live list before comparing lengths; otherwise
+    adjacent user rows (including formerly observed wrappers) make memory look
+    newer solely because it is malformed and bypass the cleaned projection.
     """
-    if isinstance(live_history, list) and len(live_history) > len(persisted_history):
-        return list(live_history)
+    if not isinstance(live_history, list):
+        return persisted_history
+
+    from copy import deepcopy
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    canonical_live = deepcopy(live_history)
+    repair_message_sequence(None, canonical_live)
+    if len(canonical_live) > len(persisted_history):
+        return canonical_live
     return persisted_history
 
 
@@ -16466,7 +16726,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _lease_state.lease_generation = run_generation
 
         # Load conversation history from transcript
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        # Keep structurally hidden rows intact until
+        # _build_gateway_agent_history() partitions them.  Generic user-role
+        # repair before that boundary can merge observed Telegram chatter into
+        # an addressed/API-wrapped turn.
+        history = await self.async_session_store.load_transcript(
+            session_entry.session_id,
+            repair_alternation=False,
+        )
+        hygiene_replay_history, hygiene_estimate_history, hygiene_has_pending = (
+            _build_gateway_hygiene_history(
+                history,
+                channel_prompt=event.channel_prompt,
+            )
+        )
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -16483,7 +16756,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         #    by 30-50% on code/JSON-heavy sessions, but that just
         #    means hygiene fires a bit early — safe and harmless.
         # -----------------------------------------------------------------
-        if history and len(history) >= 4:
+        if hygiene_estimate_history and len(hygiene_estimate_history) >= 4:
             from agent.model_metadata import (
                 estimate_messages_tokens_rough,
                 get_model_context_length_async,
@@ -16651,7 +16924,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 _warn_token_threshold = int(_hyg_context_length * 0.95)
 
-                _msg_count = len(history)
+                _msg_count = len(hygiene_estimate_history)
 
                 # Prefer actual API-reported tokens from the last turn
                 # (stored in session entry) over the rough char-based estimate.
@@ -16660,7 +16933,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _approx_tokens = _stored_tokens
                     _token_source = "actual"
                 else:
-                    _approx_tokens = estimate_messages_tokens_rough(history)
+                    _approx_tokens = estimate_messages_tokens_rough(
+                        hygiene_estimate_history
+                    )
                     _token_source = "estimated"
                     # Note: rough estimates overestimate by 30-50% for code/JSON-heavy
                     # sessions, but that just means hygiene fires a bit early — which
@@ -16687,6 +16962,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _approx_tokens >= _compress_token_threshold
                     or _msg_count >= _HARD_MSG_LIMIT
                 )
+
+                if _needs_compress and hygiene_has_pending:
+                    # The pending observed block belongs exactly once to the
+                    # current addressed turn. Pre-turn in-place hygiene cannot
+                    # commit it without either dropping it or materializing it as
+                    # an ordinary user row, so let the normal agent preflight see
+                    # and compress the fully wrapped current request instead.
+                    logger.info(
+                        "Session hygiene: deferring pre-turn compression for %s; "
+                        "Telegram observed context is pending assignment",
+                        session_entry.session_id,
+                    )
+                    _needs_compress = False
 
                 if _needs_compress:
                     # Use the persistent DB-backed cooldown (same as the
@@ -16744,7 +17032,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # its full message list to _compress_context — the
                             # gateway now matches.
                             _hyg_msgs = [
-                                m for m in history
+                                m for m in hygiene_replay_history
                                 if m.get("role") in {"user", "assistant", "tool"}
                             ]
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3377,12 +3377,21 @@ class SessionStore:
             logger.debug("Failed to rewrite transcript in DB: %s", e)
             return False
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(
+        self,
+        session_id: str,
+        *,
+        repair_alternation: bool = True,
+    ) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed
         in spec 002 — pre-DB sessions on existing disks have already been
         migrated (their DB row holds the full message history).
+
+        Gateway callers that carry structurally hidden rows (for example
+        Telegram ``observed=True`` context) may request the raw sequence and
+        partition those rows before repairing provider-role alternation.
         """
         if not self._db:
             return []
@@ -3392,7 +3401,8 @@ class SessionStore:
             # would otherwise re-trigger the pre-request repair on every
             # request forever — heal it once at the restore boundary.
             return self._db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                session_id,
+                repair_alternation=repair_alternation,
             )
         except Exception as e:
             logger.debug("Could not load messages from DB: %s", e)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7797,6 +7797,56 @@ class TelegramAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false").lower() in {"true", "1", "yes", "on"}
 
+    def _telegram_observed_exclude_patterns(self) -> List[str]:
+        """Return operator-configured regexes for passive group observations."""
+
+        configured = self.config.extra.get(
+            "observe_unmentioned_group_exclude_patterns",
+            [],
+        )
+        if isinstance(configured, str):
+            configured = [configured]
+        if not isinstance(configured, (list, tuple)):
+            return []
+        return [str(pattern) for pattern in configured if str(pattern)]
+
+    def _telegram_should_exclude_observed_event(self, event: MessageEvent) -> bool:
+        """Match passive content filters, failing open on invalid regexes.
+
+        Patterns only apply to transport-verified bot authors and run against
+        the original message text before sender attribution. Human observations
+        always survive. A match drops the whole synthetic observed row, so no
+        empty message-id metadata remains. Invalid operator patterns retain
+        content rather than risking silent loss of real conversation.
+        """
+
+        if not getattr(event.source, "is_bot", False):
+            return False
+
+        text = str(event.text or "")
+        for pattern in self._telegram_observed_exclude_patterns():
+            try:
+                if re.search(pattern, text):
+                    return True
+            except re.error as exc:
+                logger.warning(
+                    "[%s] Invalid Telegram observed-context exclude regex %r; "
+                    "keeping message: %s",
+                    getattr(self, "name", "telegram"),
+                    pattern,
+                    exc,
+                )
+        return False
+
+    @staticmethod
+    def _telegram_update_is_edit(update: Update) -> bool:
+        """Return whether Telegram delivered an edited message update."""
+
+        return bool(
+            getattr(update, "edited_message", None)
+            or getattr(update, "edited_channel_post", None)
+        )
+
     def _telegram_guest_mode(self) -> bool:
         """Return whether non-allowlisted groups may trigger via direct @mention."""
         configured = self.config.extra.get("guest_mode")
@@ -8605,6 +8655,7 @@ class TelegramAdapter(BasePlatformAdapter):
         msg_type: MessageType,
         update_id: Optional[int] = None,
         event: Optional[MessageEvent] = None,
+        edited: bool = False,
     ) -> None:
         """Append skipped group chatter to the target session without dispatching."""
         store = getattr(self, "_session_store", None)
@@ -8612,6 +8663,28 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         try:
             event = event or self._build_message_event(message, msg_type, update_id=update_id)
+            if edited and event.source.is_bot:
+                logger.info(
+                    "[%s] Ignoring edited bot message in Telegram observed context: "
+                    "chat=%s message_id=%s",
+                    getattr(self, "name", "telegram"),
+                    getattr(getattr(message, "chat", None), "id", "unknown"),
+                    event.message_id or "unknown",
+                )
+                return
+            if self._telegram_should_exclude_observed_event(event):
+                original_text = str(event.text or "")
+                logger.info(
+                    "[%s] Filtered passive Telegram bot observation: "
+                    "chat=%s message_id=%s from=%s original_text=%r truncated=%s",
+                    getattr(self, "name", "telegram"),
+                    getattr(getattr(message, "chat", None), "id", "unknown"),
+                    event.message_id or "unknown",
+                    getattr(event.source, "user_id", None) or "unknown",
+                    original_text[:1000],
+                    len(original_text) > 1000,
+                )
+                return
             shared_source = self._telegram_group_observe_shared_source(event.source)
             session_entry = store.get_or_create_session(shared_source)
             entry = {
@@ -8803,7 +8876,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
+                self._observe_unmentioned_group_message(
+                    msg,
+                    MessageType.TEXT,
+                    update_id=update.update_id,
+                    edited=self._telegram_update_is_edit(update),
+                )
             return
         await self._ensure_forum_commands(update.message)
 
@@ -8861,7 +8939,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+                self._observe_unmentioned_group_message(
+                    msg,
+                    MessageType.LOCATION,
+                    update_id=update.update_id,
+                    edited=self._telegram_update_is_edit(update),
+                )
             return
 
         venue = getattr(msg, "venue", None)
@@ -9054,29 +9137,44 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if not self._is_user_authorized_from_message(msg):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
                     _event.text = self._clean_bot_trigger_text(_m.caption)
+                _edited = self._telegram_update_is_edit(update)
+                if _edited and _event.source.is_bot:
+                    # Let the common ingress guard log and reject this before
+                    # downloading/caching cumulative bot progress media.
+                    self._observe_unmentioned_group_message(
+                        _m,
+                        _event.message_type,
+                        update_id=update.update_id,
+                        event=_event,
+                        edited=True,
+                    )
+                    return
                 await self._cache_observed_media(_m, _event)
                 self._observe_unmentioned_group_message(
-                    _m, _event.message_type, update_id=update.update_id, event=_event
+                    _m,
+                    _event.message_type,
+                    update_id=update.update_id,
+                    event=_event,
+                    edited=_edited,
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -331,6 +331,28 @@ class TestLoadGatewayConfig:
         assert config.default_reset_policy.mode == "idle"
         assert config.default_reset_policy.idle_minutes == 30
 
+    def test_telegram_observed_exclude_patterns_bridge_to_platform_extra(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "telegram:\n"
+            "  observe_unmentioned_group_messages: true\n"
+            "  observe_unmentioned_group_exclude_patterns:\n"
+            "    - '^summary:'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.extra["observe_unmentioned_group_messages"] is True
+        assert telegram.extra["observe_unmentioned_group_exclude_patterns"] == [
+            "^summary:"
+        ]
+
 
     def test_slack_ignored_channels_config_sets_env_bridge(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -22,6 +23,7 @@ def _make_adapter(
     group_allowed_chats=None,
     guest_mode=None,
     observe_unmentioned_group_messages=None,
+    observe_unmentioned_group_exclude_patterns=None,
     bot_username="hermes_bot",
 ):
     from plugins.platforms.telegram.adapter import TelegramAdapter
@@ -65,6 +67,10 @@ def _make_adapter(
         extra["guest_mode"] = guest_mode
     if observe_unmentioned_group_messages is not None:
         extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
+    if observe_unmentioned_group_exclude_patterns is not None:
+        extra["observe_unmentioned_group_exclude_patterns"] = (
+            observe_unmentioned_group_exclude_patterns
+        )
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -99,6 +105,7 @@ def _group_message(
     entities=None,
     caption=None,
     caption_entities=None,
+    from_user_is_bot=False,
 ):
     reply_to_message = None
     if reply_to_bot:
@@ -112,7 +119,12 @@ def _group_message(
         message_thread_id=thread_id,
         is_topic_message=thread_id is not None,
         chat=SimpleNamespace(id=chat_id, type="group", title="Test Group", is_forum=thread_id is not None),
-        from_user=SimpleNamespace(id=from_user_id, full_name=from_user_name, first_name=from_user_name.split()[0]),
+        from_user=SimpleNamespace(
+            id=from_user_id,
+            full_name=from_user_name,
+            first_name=from_user_name.split()[0],
+            is_bot=from_user_is_bot,
+        ),
         reply_to_message=reply_to_message,
         date=None,
     )
@@ -184,6 +196,212 @@ def test_unmentioned_group_messages_can_be_observed_without_dispatching():
         assert store.sources[0].chat_type == "group"
         assert store.sources[0].user_id is None
         assert store.sources[0].user_name is None
+
+    asyncio.run(_run())
+
+
+def test_observed_bot_edit_is_ignored_before_persistence():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        edited_message = _group_message(
+            "progress step 1 + step 2",
+            from_user_id=222,
+            from_user_name="Helper Bot",
+            from_user_is_bot=True,
+        )
+        update = SimpleNamespace(
+            update_id=1002,
+            message=None,
+            edited_message=edited_message,
+            edited_channel_post=None,
+            effective_message=edited_message,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert store.messages == []
+
+    asyncio.run(_run())
+
+
+def test_observed_human_edit_is_kept_as_real_content():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        edited_message = _group_message(
+            "corrected human content",
+            from_user_id=222,
+            from_user_name="Alice",
+        )
+        update = SimpleNamespace(
+            update_id=1003,
+            message=None,
+            edited_message=edited_message,
+            edited_channel_post=None,
+            effective_message=edited_message,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert len(store.messages) == 1
+        assert "corrected human content" in store.messages[0][1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_observed_human_media_edit_is_retained_from_effective_message():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        adapter._cache_observed_media = AsyncMock()
+        edited_message = _group_photo_message(caption="corrected human caption")
+        edited_message.from_user.is_bot = False
+        update = SimpleNamespace(
+            update_id=1006,
+            message=None,
+            edited_message=edited_message,
+            edited_channel_post=None,
+            effective_message=edited_message,
+        )
+
+        await adapter._handle_media_message(update, SimpleNamespace())
+
+        adapter._cache_observed_media.assert_awaited_once()
+        assert len(store.messages) == 1
+        assert "corrected human caption" in store.messages[0][1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_observed_bot_media_edit_is_dropped_before_caching():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        adapter._cache_observed_media = AsyncMock()
+        edited_message = _group_photo_message(caption="cumulative bot progress")
+        edited_message.from_user.is_bot = True
+        update = SimpleNamespace(
+            update_id=1007,
+            message=None,
+            edited_message=edited_message,
+            edited_channel_post=None,
+            effective_message=edited_message,
+        )
+
+        await adapter._handle_media_message(update, SimpleNamespace())
+
+        adapter._cache_observed_media.assert_not_awaited()
+        assert store.messages == []
+
+    asyncio.run(_run())
+
+
+def test_observed_exclude_pattern_drops_the_whole_bot_synthetic_row(caplog):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+            observe_unmentioned_group_exclude_patterns=[
+                r"^✓ Context compaction complete",
+            ],
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        update = SimpleNamespace(
+            update_id=1003,
+            message=_group_message(
+                "✓ Context compaction complete — continuing turn...",
+                from_user_id=222,
+                from_user_name="Helper Bot",
+                from_user_is_bot=True,
+            ),
+            effective_message=None,
+        )
+
+        with caplog.at_level(logging.INFO):
+            await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert store.messages == []
+        assert "Filtered passive Telegram bot observation" in caplog.text
+        assert "message_id=42" in caplog.text
+        assert "✓ Context compaction complete — continuing turn..." in caplog.text
+
+    asyncio.run(_run())
+
+
+def test_observed_exclude_pattern_never_drops_human_content():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+            observe_unmentioned_group_exclude_patterns=[r"^🔎 "],
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        update = SimpleNamespace(
+            update_id=1008,
+            message=_group_message("🔎 menschlicher Lupenbericht"),
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert len(store.messages) == 1
+        assert "🔎 menschlicher Lupenbericht" in store.messages[0][1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_invalid_observed_exclude_pattern_fails_open_and_keeps_content():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+            observe_unmentioned_group_exclude_patterns=["[invalid"],
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        update = SimpleNamespace(
+            update_id=1004,
+            message=_group_message("real human content"),
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        assert len(store.messages) == 1
+        assert "real human content" in store.messages[0][1]["content"]
 
     asyncio.run(_run())
 

--- a/tests/gateway/test_telegram_observed_context_lifecycle.py
+++ b/tests/gateway/test_telegram_observed_context_lifecycle.py
@@ -1,0 +1,554 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from gateway.run import (
+    _build_gateway_agent_history,
+    _build_gateway_hygiene_history,
+    _select_cached_agent_history,
+    _wrap_current_message_with_observed_context,
+)
+from gateway.session import SessionStore
+
+
+OBSERVED_PROMPT = "This channel uses observed Telegram group context."
+OBSERVED_HEADER = "[Observed Telegram group context"
+
+
+def _provider_wire(history, current):
+    messages = history + [{"role": "user", "content": current}]
+    return "\n".join(
+        str(message.get("api_content") or message.get("content") or "")
+        for message in messages
+    )
+
+
+def test_hygiene_uses_canonical_replay_and_defers_when_observations_are_pending():
+    first_wrapper = _wrap_current_message_with_observed_context("ASK_B", "OBS_A")
+    history = [
+        {"role": "user", "content": "OBS_A", "observed": True, "message_id": "1"},
+        {"role": "user", "content": "ASK_B", "api_content": first_wrapper},
+        {"role": "assistant", "content": "ANSWER_B"},
+        {
+            "role": "user",
+            "content": "human draft",
+            "observed": True,
+            "message_id": "2",
+        },
+        {
+            "role": "user",
+            "content": "human correction",
+            "observed": True,
+            "message_id": "2",
+        },
+    ]
+
+    replay, estimate, has_pending = _build_gateway_hygiene_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert has_pending is True
+    assert len(estimate) == len(replay) + 1
+    assert estimate[-1] == {"role": "user", "content": "human correction"}
+    assert "human draft" not in _provider_wire(replay, estimate[-1])
+
+
+def test_three_turn_provider_history_contains_each_observation_once():
+    raw_history = []
+    observations = ["OBS_A", "OBS_C", "OBS_E"]
+    addressed = ["ASK_B", "ASK_D", "ASK_F"]
+
+    for index, (observed, current_text) in enumerate(
+        zip(observations, addressed),
+        start=1,
+    ):
+        raw_history.append({
+            "role": "user",
+            "content": observed,
+            "observed": True,
+            "message_id": str(index),
+        })
+        agent_history, observed_context = _build_gateway_agent_history(
+            raw_history,
+            channel_prompt=OBSERVED_PROMPT,
+        )
+        api_current = _wrap_current_message_with_observed_context(
+            current_text,
+            observed_context,
+        )
+        wire = _provider_wire(agent_history, api_current)
+
+        for delivered in observations[:index]:
+            assert wire.count(delivered) == 1
+
+        raw_history.extend([
+            {
+                "role": "user",
+                "content": current_text,
+                "api_content": api_current,
+            },
+            {"role": "assistant", "content": f"ANSWER_{index}"},
+        ])
+
+
+def test_interleaved_observation_after_turn_snapshot_remains_pending():
+    first_wrapper = _wrap_current_message_with_observed_context("ASK_B", "OBS_A")
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "OBS_C",
+            "observed": True,
+            "message_id": "20",
+        },
+        {
+            "role": "user",
+            "content": "ASK_B",
+            "api_content": first_wrapper,
+        },
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context == "OBS_C"
+
+
+def test_interleaved_human_edit_preserves_only_the_new_correction():
+    committed = _wrap_current_message_with_observed_context(
+        "ASK", "OBS_A\nOBS_B_OLD"
+    )
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "OBS_B_OLD",
+            "observed": True,
+            "message_id": "20",
+        },
+        {
+            "role": "user",
+            "content": "OBS_B_NEW",
+            "observed": True,
+            "message_id": "20",
+        },
+        {"role": "user", "content": "ASK", "api_content": committed},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context == "OBS_B_NEW"
+
+
+def test_timestamp_projection_change_does_not_redeliver_committed_observation():
+    committed = _wrap_current_message_with_observed_context("ASK", "OBS_T")
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_T",
+            "observed": True,
+            "message_id": "10",
+            "timestamp": 0,
+        },
+        {"role": "user", "content": "ASK", "api_content": committed},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+        inject_timestamps=True,
+    )
+
+    assert observed_context is None
+
+
+def test_edit_before_snapshot_commits_the_latest_version():
+    committed = _wrap_current_message_with_observed_context(
+        "ASK", "OBS_A\nOBS_B_NEW"
+    )
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "OBS_B_OLD",
+            "observed": True,
+            "message_id": "20",
+        },
+        {
+            "role": "user",
+            "content": "OBS_B_NEW",
+            "observed": True,
+            "message_id": "20",
+        },
+        {"role": "user", "content": "ASK", "api_content": committed},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context is None
+
+
+def test_historical_timestamp_and_timezone_do_not_change_observation_identity():
+    committed = _wrap_current_message_with_observed_context(
+        "ASK", "[Thu 1970-01-01 00:00:00 UTC] OBS_T"
+    )
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_T",
+            "observed": True,
+            "message_id": "10",
+            "timestamp": 0,
+        },
+        {"role": "user", "content": "ASK", "api_content": committed},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+        inject_timestamps=False,
+    )
+
+    assert observed_context is None
+
+
+def test_cyclic_edit_commits_the_last_matching_historical_cut():
+    committed = _wrap_current_message_with_observed_context("ASK", "OBS_A")
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "OBS_B",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {"role": "user", "content": "ASK", "api_content": committed},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context is None
+
+
+def test_multi_id_cyclic_edit_does_not_redeliver_reverted_content():
+    committed = _wrap_current_message_with_observed_context(
+        "ASK", "A_OLD\nB_STABLE"
+    )
+    history = [
+        {
+            "role": "user",
+            "content": "A_OLD",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "B_STABLE",
+            "observed": True,
+            "message_id": "20",
+        },
+        {
+            "role": "user",
+            "content": "A_TEMP",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "A_OLD",
+            "observed": True,
+            "message_id": "10",
+        },
+        {"role": "user", "content": "ASK", "api_content": committed},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context is None
+
+
+def test_identical_observation_retransmit_after_assignment_is_not_redelivered():
+    first_wrapper = _wrap_current_message_with_observed_context("ASK_A", "OBS_X")
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_X",
+            "observed": True,
+            "message_id": "10",
+        },
+        {"role": "user", "content": "ASK_A", "api_content": first_wrapper},
+        {"role": "assistant", "content": "ANSWER_A"},
+        {
+            "role": "user",
+            "content": "OBS_X",
+            "observed": True,
+            "message_id": "10",
+        },
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context is None
+
+
+def test_ambiguous_synthetic_user_row_does_not_consume_real_observation():
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {"role": "user", "content": "[internal continuation marker]"},
+        {"role": "assistant", "content": "internal acknowledgement"},
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context == "OBS_A"
+
+
+def test_observations_are_assigned_once_across_api_content_replay():
+    first_wrapper = _wrap_current_message_with_observed_context("ASK_B", "OBS_A")
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "ASK_B",
+            "api_content": first_wrapper,
+        },
+        {"role": "assistant", "content": "ANSWER_B"},
+        {
+            "role": "user",
+            "content": "OBS_C",
+            "observed": True,
+            "message_id": "20",
+        },
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+    current = _wrap_current_message_with_observed_context("ASK_D", observed_context)
+    wire = _provider_wire(agent_history, current)
+
+    assert observed_context == "OBS_C"
+    assert wire.count("OBS_A") == 1
+    assert wire.count("OBS_C") == 1
+    assert wire.count(OBSERVED_HEADER) == 2
+
+
+def test_human_edits_keep_the_latest_content_before_assignment():
+    history = [
+        {
+            "role": "user",
+            "content": "human draft",
+            "observed": True,
+            "message_id": "25",
+        },
+        {
+            "role": "user",
+            "content": "human corrected",
+            "observed": True,
+            "message_id": "25",
+        },
+    ]
+
+    _, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context == "human corrected"
+
+
+def test_human_edit_after_assignment_is_delivered_as_a_correction():
+    first_wrapper = _wrap_current_message_with_observed_context(
+        "ASK_B", "human initial"
+    )
+    history = [
+        {
+            "role": "user",
+            "content": "human initial",
+            "observed": True,
+            "message_id": "20",
+        },
+        {"role": "user", "content": "ASK_B", "api_content": first_wrapper},
+        {"role": "assistant", "content": "ANSWER_B"},
+        {
+            "role": "user",
+            "content": "human correction",
+            "observed": True,
+            "message_id": "20",
+        },
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context == "human correction"
+    wire = _provider_wire(agent_history, observed_context)
+    assert wire.count("human initial") == 1
+    assert wire.count("human correction") == 1
+
+
+def test_repair_preserves_api_content_when_addressed_turns_are_adjacent():
+    first_wrapper = _wrap_current_message_with_observed_context("ASK_B", "OBS_A")
+    second_wrapper = _wrap_current_message_with_observed_context("ASK_D", "OBS_C")
+    history = [
+        {
+            "role": "user",
+            "content": "OBS_A",
+            "observed": True,
+            "message_id": "10",
+        },
+        {
+            "role": "user",
+            "content": "ASK_B",
+            "api_content": first_wrapper,
+            "message_id": "11",
+        },
+        {
+            "role": "user",
+            "content": "OBS_C",
+            "observed": True,
+            "message_id": "20",
+        },
+        {
+            "role": "user",
+            "content": "ASK_D",
+            "api_content": second_wrapper,
+            "message_id": "21",
+        },
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    assert observed_context is None
+    assert len(agent_history) == 1
+    assert agent_history[0]["content"] == "ASK_B\n\nASK_D"
+    assert agent_history[0]["api_content"] == f"{first_wrapper}\n\n{second_wrapper}"
+
+
+def test_observed_rows_are_partitioned_before_user_alternation_repair():
+    history = [
+        {"role": "user", "content": "ASK_B", "message_id": "31"},
+        {
+            "role": "user",
+            "content": "OBS_C",
+            "observed": True,
+            "message_id": "30",
+        },
+        {
+            "role": "user",
+            "content": "ASK_D",
+            "message_id": "32",
+            "api_content": _wrap_current_message_with_observed_context(
+                "ASK_D", "OBS_C"
+            ),
+        },
+        {"role": "assistant", "content": "ANSWER_D"},
+        {
+            "role": "user",
+            "content": "OBS_E",
+            "observed": True,
+            "message_id": "40",
+        },
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(
+        history,
+        channel_prompt=OBSERVED_PROMPT,
+    )
+
+    user_messages = [m for m in agent_history if m.get("role") == "user"]
+    assert len(user_messages) == 1
+    assert user_messages[0]["content"] == "ASK_B\n\nASK_D"
+    assert "OBS_C" not in user_messages[0]["content"]
+    assert observed_context == "OBS_E"
+
+
+def test_session_store_can_load_raw_transcript_without_alternation_repair():
+    db = SimpleNamespace(get_messages_as_conversation=Mock(return_value=[]))
+    store = object.__new__(SessionStore)
+    store._db = db
+
+    store.load_transcript("session-1", repair_alternation=False)
+
+    db.get_messages_as_conversation.assert_called_once_with(
+        "session-1",
+        repair_alternation=False,
+    )
+
+
+def test_cached_history_is_repaired_before_length_fallback_selection():
+    persisted = [{"role": "user", "content": "ASK_A\n\nASK_B"}]
+    live = [
+        {"role": "user", "content": "ASK_A"},
+        {"role": "user", "content": "ASK_B"},
+    ]
+
+    selected = _select_cached_agent_history(persisted, live)
+
+    assert selected is persisted
+    assert live == [
+        {"role": "user", "content": "ASK_A"},
+        {"role": "user", "content": "ASK_B"},
+    ]

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -143,9 +143,14 @@ telegram:
     - "-1001234567890"
   require_mention: true
   observe_unmentioned_group_messages: true
+  # Optional: drop whole bot-authored passive rows whose original text matches.
+  observe_unmentioned_group_exclude_patterns:
+    - '^✓ Context compaction complete'
 ```
 
-With this mode enabled, unmentioned group messages from explicitly allowlisted chats/topics are appended to the shared chat/topic session transcript as observed context, but they do not dispatch the agent. `allowed_chats` gates where the bot responds; `group_allowed_chats` authorizes the shared group session used for observed context, so use the same chat IDs for this mode. A later `@botname` mention, reply to the bot, or configured mention pattern in that same allowlisted chat/topic can use that observed context. The triggered message is also tagged with `[nickname|user_id]` and gets a per-turn safety prompt so the model treats prior observed lines as context, not instructions addressed to the bot.
+With this mode enabled, unmentioned group messages from explicitly allowlisted chats/topics are appended to the shared chat/topic session transcript as observed context, but they do not dispatch the agent. `allowed_chats` gates where the bot responds; `group_allowed_chats` authorizes the shared group session used for observed context, so use the same chat IDs for this mode. A later `@botname` mention, reply to the bot, or configured mention pattern in that same allowlisted chat/topic can use that observed context. Each observed message is assigned exactly once to the next addressed turn. Human edits keep the newest version available before assignment. Edited messages authored by bots are dropped before persistence so cumulative progress UI cannot inflate later prompts; normal bot messages and final replies with their own message IDs remain available. The triggered message is also tagged with `[nickname|user_id]` and gets a per-turn safety prompt so the model treats prior observed lines as context, not instructions addressed to the bot.
+
+`observe_unmentioned_group_exclude_patterns` is optional and only applies to transport-verified bot authors. Each regex matches against the original message text before sender attribution; human-authored observations are always retained. A match drops the whole synthetic observation, including its metadata, and emits a bounded local INFO audit entry with the source message ID and original-text preview. Invalid regexes fail open and keep the message; use narrow patterns because real conversational bot content should be retained when in doubt.
 
 Equivalent environment variable:
 


### PR DESCRIPTION
Passive Telegram group observations were selected again on every addressed turn even after their original `api_content` wrapper had been persisted. That made old observations accumulate across requests and could trigger unnecessary context compression.

This change:

- partitions observed rows before generic role-alternation repair;
- assigns each observation once to the next proven addressed turn;
- preserves historical provider sidecars, including recovery merges with adjacent user turns;
- canonicalizes cached and preflight-hygiene history instead of trusting a longer malformed copy;
- keeps human edits by Telegram message ID while dropping bot-authored edited progress messages before persistence and media caching;
- adds an optional, fail-open regex filter that drops matching passive rows whole.

Existing contaminated sessions are not rewritten by this forward fix.

Tests:

- `103 passed` on the clean upstream worktree (`test_telegram_observed_context_lifecycle.py`, `test_telegram_group_gating.py`, `test_config.py`)
- `259 passed` on the complete local Telegram overlay
- Ruff, `compileall`, and `git diff --check` passed