### PR TITLE
fix(gateway): await in-flight streamed final send before duplicate-resend decision

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -80,6 +80,17 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 # transport cannot block the session-stall watcher pass (notify-only path;
 # on timeout the latch stays clear and the next tick retries).
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
+# Bound on waiting for the stream consumer's final-delivery attempt before
+# the gateway decides whether to send its own "final" response. The base
+# timeout keeps the common (no flood control) case fast; when the consumer
+# reports a final-delivery attempt still in flight (GatewayStreamConsumer.
+# final_delivery_in_progress), the wait extends up to the max — Telegram
+# flood control can mandate retry_after waits of 30-90s, and abandoning the
+# wait early lets the gateway race a send that's still in progress (#gateway
+# final-send flood race, 2026-08-05 incident: duplicate 4070-char message
+# after a 37s Telegram flood-control retry outlived the old 5s wait).
+_STREAM_FINAL_WAIT_BASE_TIMEOUT_SECONDS = 5.0
+_STREAM_FINAL_WAIT_MAX_TIMEOUT_SECONDS = 90.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
@@ -5634,6 +5645,51 @@ class TurnRunner:
             # True preserves the skip-db behaviour for the standard runtime.
             "agent_persisted": (ctx.result_holder[0].get("agent_persisted", True) if ctx.result_holder[0] else True),
         }
+
+
+async def _await_stream_task_before_final_decision(stream_task, stream_consumer) -> None:
+    """Wait for the stream consumer's task before any duplicate-send decision.
+
+    A flat short timeout here races an in-flight platform flood-control
+    retry: Telegram can mandate a ``retry_after`` wait of 30-90s on the
+    consumer's final send/edit, and giving up early leaves
+    ``final_response_sent`` / ``final_content_delivered`` False (the attempt
+    hasn't resolved yet) — the caller then sends its own "final" response,
+    and if the abandoned send still reaches the platform, the user gets a
+    duplicate. Extend the wait, bounded, only while the consumer reports an
+    active final-delivery attempt (``final_delivery_in_progress``); never
+    treat "in flight" itself as delivered — only a completed send sets the
+    flags the caller checks afterward.
+
+    Uses ``asyncio.wait`` rather than ``asyncio.wait_for``: the latter
+    cancels the awaited task on timeout and waits for it to fully unwind
+    *before* raising ``TimeoutError``, so by the time a caller's except
+    clause runs, the consumer's cancellation handling (and
+    ``final_delivery_in_progress``) has already completed — the in-flight
+    check would always see it as False. ``asyncio.wait`` just reports
+    done/pending on timeout without touching the task, so the flag reflects
+    genuinely live state when checked.
+    """
+    done, _ = await asyncio.wait(
+        {stream_task}, timeout=_STREAM_FINAL_WAIT_BASE_TIMEOUT_SECONDS,
+    )
+    if stream_task in done:
+        return
+    if stream_consumer is not None and getattr(
+        stream_consumer, "final_delivery_in_progress", False,
+    ):
+        remaining = (
+            _STREAM_FINAL_WAIT_MAX_TIMEOUT_SECONDS
+            - _STREAM_FINAL_WAIT_BASE_TIMEOUT_SECONDS
+        )
+        done, _ = await asyncio.wait({stream_task}, timeout=remaining)
+        if stream_task in done:
+            return
+    stream_task.cancel()
+    try:
+        await stream_task
+    except asyncio.CancelledError:
+        pass
 
 
 
@@ -23812,10 +23868,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _stream_consumer:
                 _stream_consumer.finish()
             if stream_task:
-                try:
-                    await asyncio.wait_for(stream_task, timeout=5.0)
-                except (asyncio.TimeoutError, asyncio.CancelledError):
-                    stream_task.cancel()
+                await _await_stream_task_before_final_decision(stream_task, _stream_consumer)
 
         _elapsed = time.time() - _start
         if not _run_still_current():
@@ -25336,13 +25389,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _sc = stream_consumer_holder[0]
                     if _sc and stream_task:
                         try:
-                            await asyncio.wait_for(stream_task, timeout=5.0)
-                        except (asyncio.TimeoutError, asyncio.CancelledError):
-                            stream_task.cancel()
-                            try:
-                                await stream_task
-                            except asyncio.CancelledError:
-                                pass
+                            await _await_stream_task_before_final_decision(stream_task, _sc)
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
                     # The queued branch needs raw ``result`` for interruption,
@@ -25547,14 +25594,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except asyncio.CancelledError:
                         pass
                 else:
-                    try:
-                        await asyncio.wait_for(stream_task, timeout=5.0)
-                    except (asyncio.TimeoutError, asyncio.CancelledError):
-                        stream_task.cancel()
-                        try:
-                            await stream_task
-                        except asyncio.CancelledError:
-                            pass
+                    await _await_stream_task_before_final_decision(
+                        stream_task, stream_consumer_holder[0],
+                    )
             
             # Unconditional abort + bounded wait for the streaming-TTS
             # consumer (#60671 hardening).  Covers cancellation / exception

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -261,6 +261,12 @@ class GatewayStreamConsumer:
         # streaming, even if the final edit (cursor removal etc.)
         # subsequently failed.
         self._final_content_delivered = False
+        # True for the duration of the got_done final-delivery attempt below
+        # (send/edit calls that may block on a platform flood-control retry).
+        # The gateway's duplicate-send decision waits on this instead of
+        # abandoning an in-flight send after a flat short timeout — see
+        # ``final_delivery_in_progress`` (#gateway-final-send-flood-race).
+        self._final_delivery_in_progress = False
         # Exact cleaned payload of the turn-final delivery that set the flags
         # above.  The gateway compares this against the completed
         # ``final_response`` before trusting the flags: a *successful* finalize
@@ -361,6 +367,18 @@ class GatewayStreamConsumer:
         """True when the final response content reached the user, even if
         the subsequent cosmetic edit (cursor removal) failed."""
         return self._final_content_delivered
+
+    @property
+    def final_delivery_in_progress(self) -> bool:
+        """True while a final-delivery send/edit attempt is still unresolved.
+
+        A platform flood-control retry can hold this send for tens of
+        seconds. Callers deciding whether to send their own duplicate
+        "final" response must wait this out (bounded) rather than checking
+        ``final_response_sent`` / ``final_content_delivered`` while they are
+        still guaranteed False because the attempt hasn't returned yet.
+        """
+        return self._final_delivery_in_progress
 
     async def _notify_before_finalize(self) -> None:
         """Run the pre-finalize hook exactly once, swallowing hook errors."""
@@ -812,6 +830,17 @@ class GatewayStreamConsumer:
                 # so trailing text that was waiting for a potential open
                 # tag is not lost.
                 if got_done:
+                    # From here on this iteration only finalizes and returns
+                    # (whole-response send/edit, overflow-chunk tail, or the
+                    # got_done block below) — every exit path can block on a
+                    # platform flood-control retry. Set for the rest of this
+                    # run() call (cleared in the outer finally) so the
+                    # gateway's duplicate-send decision (gateway/run.py) can
+                    # wait out an in-flight attempt instead of racing it —
+                    # final_response_sent / final_content_delivered are
+                    # still guaranteed False here because the attempt hasn't
+                    # returned yet.
+                    self._final_delivery_in_progress = True
                     self._flush_think_buffer()
 
                     # Intentional-silence suppression.  When the agent chose
@@ -1164,6 +1193,10 @@ class GatewayStreamConsumer:
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
         finally:
+            # run() is exiting for good on every path through this finally
+            # (normal return, cancellation, or exception) — nothing further
+            # will attempt final delivery, so clear the in-flight marker.
+            self._final_delivery_in_progress = False
             # Safety net: if run() exits (normal return, cancellation, or
             # exception) while a _FLUSH barrier is still queued or was consumed
             # but not yet signaled, wake any waiters now. Without this a caller

--- a/tests/gateway/test_final_send_flood_race.py
+++ b/tests/gateway/test_final_send_flood_race.py
@@ -1,0 +1,252 @@
+"""Regression coverage for the gateway final-send flood-control race.
+
+Incident (2026-08-05 15:15 ET, Telegram group, 4070-char final response
+delivered twice):
+
+    15:15:10 MarkdownV2 edit failed, falling back to plain text: Flood
+             control exceeded. Retry in 37 seconds
+    15:15:10 Telegram flood control, waiting 37.0s
+    15:15:10 Telegram flood control on send (attempt 1/3), retrying in
+             37.0s: Flood control exceeded
+    15:15:15 gateway.platforms.base: Sending response (4070 chars) to
+             -1003725014629
+    15:15:15 Telegram flood control on send (attempt 1/3), retrying in
+             32.0s
+
+The stream consumer's finalize edit hit Telegram flood control (fast,
+"Retry in 37 seconds") and fell back to a fresh ``send()`` — and *that*
+send hit flood control too, entering a retry sleep governed by Telegram's
+own ``retry_after`` (37s). Meanwhile ``gateway/run.py`` only waited a flat
+5 seconds (``asyncio.wait_for(stream_task, timeout=5.0)``) for the whole
+final-delivery attempt before giving up, cancelling the consumer's task,
+and falling through to the duplicate-send decision with
+``final_response_sent`` / ``final_content_delivered`` still False (the
+attempt hadn't resolved yet). The gateway then sent its own "final"
+response — and because the abandoned send can still reach the platform
+after being locally cancelled/abandoned, the user got the answer twice.
+
+The fix (``gateway/run.py``: ``_await_stream_task_before_final_decision``;
+``gateway/stream_consumer.py``: ``GatewayStreamConsumer.
+final_delivery_in_progress``) extends the wait, bounded, whenever the
+consumer reports a final-delivery attempt still in flight, instead of
+racing a fixed short timeout against an arbitrarily long platform-mandated
+retry.
+
+Determinism: the mocked flood-controlled ``send()`` does not sleep for a
+fixed duration and race that duration against a scaled timeout (that was
+the source of the original flakiness — two independently-timed waits
+compared against each other under real scheduling jitter). Instead it
+blocks on an ``asyncio.Event`` (``send_release``) that only the test
+controls, and signals ``send_started`` the instant it begins blocking.
+The test awaits ``send_started`` (no timing guess needed — this resolves
+the moment the send is genuinely in flight), lets the gateway's *base*
+timeout genuinely elapse (a single one-sided sleep, safe because nothing
+else is racing it — the send cannot complete on its own), and only then
+sets ``send_release``. Resolution after that point is driven by the event
+loop waking the extended ``wait_for`` on task completion, not by more
+sleeping.
+"""
+
+import asyncio
+import importlib
+import time
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.stream_consumer import _DONE, GatewayStreamConsumer, StreamConsumerConfig
+
+FULL_RESPONSE = "y" * 200
+
+
+class FloodyFallbackAdapter(BasePlatformAdapter):
+    """Telegram-shaped adapter reproducing the incident's exact call shape.
+
+    The cosmetic finalize edit ("MarkdownV2 edit failed... Retry in 37
+    seconds") always fails with flood control immediately — matching the
+    incident, where the edit failure itself resolved fast and it was the
+    *fallback* send that entered the long retry sleep. ``FALLBACK_ON_
+    FINAL_EDIT_FLOOD`` + ``RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK`` route
+    that fallback through a fresh ``send()`` call, which blocks on
+    ``send_release`` until the test lets it through — modeling a
+    flood-controlled retry that's still in flight when the gateway's
+    duplicate-send decision runs. ``asyncio.shield`` models the fact that
+    a request already reached Telegram: a local ``cancel()`` of the
+    waiting task cannot un-send it, so delivery still completes once
+    ``send_release`` is set even if the gateway gave up waiting.
+    """
+
+    REQUIRES_EDIT_FINALIZE = True
+    FALLBACK_ON_FINAL_EDIT_FLOOD = True
+    RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+        self.edits = []
+        self.deleted = set()
+        self._next_id = 0
+        self.send_started = asyncio.Event()
+        self.send_release = asyncio.Event()
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    def _mint_id(self) -> str:
+        self._next_id += 1
+        return f"m-{self._next_id}"
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        async def _deliver():
+            self.send_started.set()
+            await self.send_release.wait()
+            message_id = self._mint_id()
+            self.sent.append({"chat_id": chat_id, "content": content, "message_id": message_id})
+            return SendResult(success=True, message_id=message_id)
+
+        return await asyncio.shield(_deliver())
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None,
+    ) -> SendResult:
+        if not finalize:
+            self.edits.append(
+                {"chat_id": chat_id, "message_id": message_id, "content": content, "finalize": finalize}
+            )
+            return SendResult(success=True, message_id=message_id)
+        self.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content, "finalize": True}
+        )
+        return SendResult(
+            success=False,
+            error="Flood control exceeded. Retry in 37 seconds",
+            retry_after=37.0,
+        )
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.deleted.add(str(message_id))
+        return True
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    def visible_full_response_messages(self):
+        """Messages still visible in the chat carrying the exact final text."""
+        return [
+            m for m in self.sent
+            if m["content"] == FULL_RESPONSE and m["message_id"] not in self.deleted
+        ]
+
+
+def _make_consumer(adapter):
+    consumer = GatewayStreamConsumer(adapter, "chat-1", StreamConsumerConfig(cursor=" ▉"))
+    # Streaming already showed the complete answer (a real preview message
+    # exists and matches the final text exactly) — only the cosmetic
+    # finalize edit is left to run. Setting this up directly (rather than
+    # depending on exactly how a delta callback and the completion sentinel
+    # happen to interleave through a background thread) keeps the test
+    # deterministic: it exercises got_done's finalize/fallback handling in
+    # run() every time.
+    consumer._message_id = "preview-stale"
+    consumer._last_sent_text = FULL_RESPONSE
+    consumer._already_sent = True
+    consumer._accumulated = FULL_RESPONSE
+    consumer._message_created_ts = time.monotonic() - 1000.0
+    consumer._queue.put(_DONE)
+    return consumer
+
+
+async def _legacy_wait_then_decide(stream_task, base_timeout: float):
+    """Pre-fix gateway/run.py logic: flat short timeout, then cancel and give up.
+
+    This is the literal control flow every call site used to run (only the
+    numeric timeout is shrunk for test speed — the shape is unchanged: no
+    extension, no in-flight check).
+    """
+    try:
+        await asyncio.wait_for(stream_task, timeout=base_timeout)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        stream_task.cancel()
+        try:
+            await stream_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _run_flood_race(monkeypatch, *, base_timeout: float, max_timeout: float):
+    gateway_run = importlib.import_module("gateway.run")
+
+    adapter = FloodyFallbackAdapter()
+    consumer = _make_consumer(adapter)
+    stream_task = asyncio.create_task(consumer.run())
+
+    # Resolves the instant the flood-controlled send actually starts
+    # blocking — no timing guess, no race.
+    await adapter.send_started.wait()
+
+    helper = getattr(gateway_run, "_await_stream_task_before_final_decision", None)
+    if helper is not None:
+        monkeypatch.setattr(gateway_run, "_STREAM_FINAL_WAIT_BASE_TIMEOUT_SECONDS", base_timeout)
+        monkeypatch.setattr(gateway_run, "_STREAM_FINAL_WAIT_MAX_TIMEOUT_SECONDS", max_timeout)
+        decision_task = asyncio.create_task(helper(stream_task, consumer))
+    else:
+        decision_task = asyncio.create_task(_legacy_wait_then_decide(stream_task, base_timeout))
+
+    # One-sided wait: guarantees the base timeout has genuinely elapsed.
+    # Nothing races this — the send cannot complete on its own, it is
+    # blocked on send_release, which we haven't set yet.
+    await asyncio.sleep(base_timeout + 0.05)
+
+    # Now let the "flood-controlled" send resolve. Fixed code is still
+    # inside its extended wait at this point (bounded by max_timeout) and
+    # will observe completion via the event loop, not more sleeping.
+    # Unpatched code has already given up and moved on.
+    adapter.send_release.set()
+
+    await decision_task
+
+    already_confirmed = bool(consumer.final_response_sent or consumer.final_content_delivered)
+    if not already_confirmed:
+        # Mimic the real outer caller: it only performs its own "normal
+        # final send" when the gateway did not confirm streamed delivery —
+        # exactly the decision that races the in-flight fallback send.
+        await adapter.send(chat_id="chat-1", content=FULL_RESPONSE, metadata=None)
+
+    # Let the (now-released) shielded delivery finish landing.
+    for _ in range(200):
+        if adapter.sent:
+            break
+        await asyncio.sleep(0.01)
+
+    return adapter, already_confirmed
+
+
+@pytest.mark.asyncio
+async def test_flood_controlled_finalize_delivers_final_response_once(monkeypatch):
+    """The completed answer must reach the chat exactly once even when the
+    stream consumer's flood-controlled fallback send is still in flight at
+    the moment the gateway decides whether to send its own final response.
+    """
+    adapter, already_confirmed = await _run_flood_race(
+        monkeypatch, base_timeout=0.05, max_timeout=1.0,
+    )
+
+    visible = adapter.visible_full_response_messages()
+    assert len(visible) == 1, (
+        f"final response visible in {len(visible)} separate messages "
+        f"(expected exactly 1): {visible!r}; all sends={adapter.sent!r}"
+    )
+    assert already_confirmed is True, (
+        "gateway did not wait for the in-flight fallback send to resolve "
+        "before deciding whether to send its own duplicate final response"
+    )


### PR DESCRIPTION
## Incident

2026-08-05 15:15 ET, Telegram group — a 4070-char final response was delivered twice.

```
15:15:10 MarkdownV2 edit failed, falling back to plain text: Flood control exceeded. Retry in 37 seconds
15:15:10 Telegram flood control, waiting 37.0s
15:15:10 Telegram flood control on send (attempt 1/3), retrying in 37.0s: Flood control exceeded
15:15:15 gateway.platforms.base: Sending response (4070 chars) to -1003725014629
15:15:15 Telegram flood control on send (attempt 1/3), retrying in 32.0s
```

## Mechanism

`gateway/run.py` waited a flat 5 seconds (`asyncio.wait_for(stream_task, timeout=5.0)`) for the stream consumer's finalize/fallback send before deciding whether to send its own "final" response, then cancelled the consumer's task on timeout and moved on. Telegram's own `retry_after` can mandate waits far longer than 5s (37s here). So the gateway routinely gave up while the send was still in flight: `final_response_sent` / `final_content_delivered` were still `False` (the attempt hadn't resolved yet), suppression never triggered, and the gateway sent its own "final" response. If the abandoned send still reached the platform after being locally cancelled, the user got the answer twice.

## Fix

- `GatewayStreamConsumer` (`gateway/stream_consumer.py`) now tracks `final_delivery_in_progress` for the duration of the `got_done` finalize/fallback sequence (cleared in the outer `finally`, so every exit path — normal return, cancellation, exception — resets it).
- `gateway/run.py`'s new `_await_stream_task_before_final_decision` waits a short base timeout first (unchanged latency for the common, non-flood case), and only when the consumer reports an attempt still in flight extends the wait up to 90s before giving up. It uses `asyncio.wait` rather than `asyncio.wait_for` — `wait_for` cancels the awaited task on timeout and waits for it to fully unwind *before* raising `TimeoutError`, so by the time a caller's except clause runs, the consumer's own cancellation handling has already reset the in-flight flag; checking it there would always see `False`. `asyncio.wait` just reports done/pending on timeout without touching the task, so the flag reflects genuinely live state.
- Never suppresses on "in flight" alone — only a completed send sets the flags the gateway checks. If the in-flight send ultimately fails, the gateway resend still happens (lost-message safety over duplicate-message risk).
- Applied at all three call sites that raced this decision (the two in the main agent-run path, plus the proxy-relay path `_run_agent_via_proxy`).

### Sibling flood paths checked

- `gateway/stream_consumer.py`'s `_fallback_flood_retry_delay` users (`_send_fallback_final`, `_send_empty_fallback_final`) are unaffected — they already bound their own retry sleep to `_max_fallback_flood_retry_seconds` (5s) and bail out early on long waits, deliberately leaving final delivery to the gateway. That's the correct pattern; this fix makes the gateway side honor it properly.
- `gateway/run.py`'s progress-edit flood path (~line 4085-4106, inside `send_progress_messages`) is unaffected — it's cancelled harmlessly in the `finally` block alongside `progress_task`; it only ever sends non-critical progress/status messages, never the final answer, so there's no duplicate-content risk there.

## Tests

New: `tests/gateway/test_final_send_flood_race.py::test_flood_controlled_finalize_delivers_final_response_once`

Drives the real `GatewayStreamConsumer` and the real gateway helper directly. The mocked flood-controlled `send()` blocks on an `asyncio.Event` (`send_release`) that only the test controls, and signals `send_started` the instant it begins blocking — this replaced an earlier sleep-duration-vs-scaled-timeout version that was flaky under scheduling jitter. The test awaits `send_started` (no timing guess), lets the gateway's base timeout genuinely elapse via a one-sided sleep (nothing races it, since the send cannot complete on its own), then releases the send — resolution after that is driven by the event loop waking the extended wait on task completion, not more sleeping.

**Before fix** (`git stash` the fix, keep the test) — 3/3 runs, always fails with the duplicate:
```
AssertionError: final response visible in 2 separate messages (expected exactly 1): [...{'message_id': 'm-1'}, {'message_id': 'm-2'}]
assert 2 == 1
1 failed in 0.91s-1.27s
```

**After fix** — 5/5 runs, passes:
```
tests/gateway/test_final_send_flood_race.py::test_flood_controlled_finalize_delivers_final_response_once PASSED
1 passed in 0.83s-1.03s
```

Full suite run (`/home/deploy/.hermes/hermes-agent/venv/bin/python -m pytest`):
```
tests/gateway/test_final_send_flood_race.py .
tests/gateway/test_telegram_final_delivery.py ....
tests/gateway/test_duplicate_reply_suppression.py .........
tests/gateway/test_stale_finalize_suppression.py .........
tests/gateway/test_send_retry.py .............
35 passed in 2.90s
```
Also ran `tests/gateway/test_stream_consumer.py` (66 passed) to confirm no regression in the consumer's broader finalize/fallback logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)